### PR TITLE
Bump the @version pragmas to 3.6

### DIFF
--- a/scl/syslog-ng.conf
+++ b/scl/syslog-ng.conf
@@ -3,7 +3,7 @@
 # single file called /var/log/messages.
 #
 
-@version: 3.5
+@version: 3.6
 @include "scl.conf"
 
 source s_local {

--- a/tests/functional/test_file_source.py
+++ b/tests/functional/test_file_source.py
@@ -3,7 +3,7 @@ from log import *
 from messagegen import *
 from messagecheck import *
 
-config = """@version: 3.5
+config = """@version: 3.6
 
 options { ts_format(iso); chain_hostnames(no); keep_hostname(yes); threaded(yes); };
 

--- a/tests/functional/test_filters.py
+++ b/tests/functional/test_filters.py
@@ -3,7 +3,7 @@ from log import *
 from messagegen import *
 from messagecheck import *
 
-config = """@version: 3.5
+config = """@version: 3.6
 
 options { ts_format(iso); chain_hostnames(no); keep_hostname(yes); threaded(yes); };
 

--- a/tests/functional/test_input_drivers.py
+++ b/tests/functional/test_input_drivers.py
@@ -3,7 +3,7 @@ from log import *
 from messagegen import *
 from messagecheck import *
 
-config = """@version: 3.5
+config = """@version: 3.6
 
 options { ts_format(iso); chain_hostnames(no); keep_hostname(yes); threaded(yes); };
 

--- a/tests/functional/test_performance.py
+++ b/tests/functional/test_performance.py
@@ -3,7 +3,7 @@ from log import *
 from messagegen import *
 from messagecheck import *
 
-config = """@version: 3.5
+config = """@version: 3.6
 
 options { ts_format(iso); chain_hostnames(no); keep_hostname(yes); threaded(yes); };
 

--- a/tests/functional/test_sql.py
+++ b/tests/functional/test_sql.py
@@ -4,7 +4,7 @@ from messagegen import *
 from messagecheck import *
 from control import flush_files, stop_syslogng
 
-config = """@version: 3.5
+config = """@version: 3.6
 
 options { ts_format(iso); chain_hostnames(no); keep_hostname(yes); threaded(yes); };
 


### PR DESCRIPTION
Since the default version was switched to 3.6 earlier, bump the @version
of the default config and the in the func-tests too.

Signed-off-by: Gergely Nagy algernon@balabit.hu
