### PR TITLE
csvparser: escape related flags are incorrectly processed

### DIFF
--- a/modules/csvparser/csvparser-grammar.ym
+++ b/modules/csvparser/csvparser-grammar.ym
@@ -79,7 +79,10 @@ parser_csv_opts
         ;
 
 parser_csv_opt
-        : KW_FLAGS '(' parser_csv_flags ')'     { log_csv_parser_set_flags((LogColumnParser *) last_parser, $3); }
+        : KW_FLAGS '(' parser_csv_flags ')'     {
+                                                  guint32 flags = log_csv_parser_normalize_escape_flags((LogColumnParser *) last_parser, $3);
+                                                  log_csv_parser_set_flags((LogColumnParser *) last_parser, flags);
+                                                }
         | KW_DELIMITERS '(' string ')'          { log_csv_parser_set_delimiters((LogColumnParser *) last_parser, $3); free($3); }
         | KW_QUOTES '(' string ')'              { log_csv_parser_set_quotes((LogColumnParser *) last_parser, $3); free($3); }
         | KW_QUOTE_PAIRS '(' string ')'         { log_csv_parser_set_quote_pairs((LogColumnParser *) last_parser, $3); free($3); }

--- a/modules/csvparser/csvparser.h
+++ b/modules/csvparser/csvparser.h
@@ -34,6 +34,7 @@
 #define LOG_CSV_PARSER_GREEDY             0x0010
 #define LOG_CSV_PARSER_DROP_INVALID       0x0020
 
+#define LOG_CSV_PARSER_FLAGS_DEFAULT  ((LOG_CSV_PARSER_STRIP_WHITESPACE) | (LOG_CSV_PARSER_ESCAPE_NONE))
 
 void log_csv_parser_set_flags(LogColumnParser *s, guint32 flags);
 void log_csv_parser_set_delimiters(LogColumnParser *s, const gchar *delimiters);
@@ -41,6 +42,9 @@ void log_csv_parser_set_quotes(LogColumnParser *s, const gchar *quotes);
 void log_csv_parser_set_quote_pairs(LogColumnParser *s, const gchar *quote_pairs);
 void log_csv_parser_set_null_value(LogColumnParser *s, const gchar *null_value);
 LogColumnParser *log_csv_parser_new(void);
-gint log_csv_parser_lookup_flag(const gchar *flag);
+guint32 log_csv_parser_lookup_flag(const gchar *flag);
+guint32 log_csv_parser_normalize_escape_flags(LogColumnParser *s, guint32 new_flag);
+
+guint32 log_csv_parser_get_flags(LogColumnParser *s);
 
 #endif


### PR DESCRIPTION
The problem is that escape related flags just simply overwrite
default flags and overwritten by non-escape flags.
This patch is do the following in order to avoid undesired owerwrites:

If new flag is an escape flag (and does not contain any other flags),
previously set flags, without escape flags, are appended to that new flag.

If new flag does not contain escape flags, escape flags from previously
set flags are appended to that new flag.

Otherwise new flag is overwrite previously set flags.

Please note, that this solution is not the best( adding a new escape-mode()
argument would be better than this workaround ).

Signed-off-by: Budai Laszlo lbudai@balabit.hu
