### PR TITLE
Makefile.am: Use the -no-install libtool flag for tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,7 @@ TEST_CFLAGS		= -I$(top_srcdir)/libtest
 TEST_LDADD		= $(top_builddir)/libtest/libsyslog-ng-test.a \
 			  $(top_builddir)/lib/libsyslog-ng.la \
 			  $(TOOL_DEPS_LIBS)
+test_ldflags		= -no-install
 
 PREOPEN_SYSLOGFORMAT	= -dlpreopen ${top_builddir}/modules/syslogformat/libsyslogformat.la
 PREOPEN_BASICFUNCS	= -dlpreopen ${top_builddir}/modules/basicfuncs/libbasicfuncs.la
@@ -38,6 +39,8 @@ local-check: current_tests=$(foreach subdir,${check_subdir} ${check_subdir}_test
 local-check:
 	${AM_v_at}${MAKE} check check_PROGRAMS="${current_tests} ${subdir_tests}" \
 				TESTS="${current_tests} ${subdir_tests}"
+
+${check_PROGRAMS}: LDFLAGS+="${test_ldflags}"
 
 noinst_LIBRARIES	=
 noinst_DATA		=


### PR DESCRIPTION
When building test programs (anything in ${check_PROGRAMS}) add
-no-install to the list of LDFLAGS, so that libtool stops generating a
useless wrapper for them. This makes debugging the check programs
easier, and also avoids a lot of shell launching for no good reason.

Signed-off-by: Gergely Nagy algernon@balabit.hu
