### PR TITLE
logthrdestdrv: threaded_dest_driver_start() should fail with no queue

### DIFF
--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -130,6 +130,11 @@ log_threaded_dest_driver_start(LogPipe *s)
   self->queue = log_dest_driver_acquire_queue(&self->super,
                                               self->format.persist_name(self));
 
+  if (self->queue == NULL)
+    {
+      return FALSE;
+    }
+
   stats_lock();
   stats_register_counter(0, self->stats_source | SCS_DESTINATION, self->super.super.id,
                          self->format.stats_instance(self),


### PR DESCRIPTION
When log_dest_driver_acquire_queue() fails to acquire the queue,
destination driver should not be started.

Signed-off-by: Budai Laszlo lbudai@balabit.hu
