### PR TITLE
system-source: Fix the uname() call on Solaris

### DIFF
--- a/modules/system-source/system-source.c
+++ b/modules/system-source/system-source.c
@@ -192,7 +192,7 @@ system_generate_system(CfgLexer *lexer, gint type, const gchar *name,
 
   sysblock = g_string_sized_new(1024);
 
-  if (uname(&u) != 0)
+  if (uname(&u) == -1)
     {
       msg_error("system(): Cannot get information about the running kernel",
                 evt_tag_errno("error", errno),


### PR DESCRIPTION
On Solaris, uname() can return any positive value, and that indicates
success. Pretty much everywhere else, only 0 does. Thankfully, -1
signals failure everywhere, so check for that.

This makes system() work on Solaris again.

Signed-off-by: Gergely Nagy algernon@balabit.hu
