### PR TITLE
affile: affile_open_file() refactoring

### DIFF
--- a/modules/affile/affile-common.h
+++ b/modules/affile/affile-common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -20,15 +20,20 @@
  * COPYING for details.
  *
  */
-  
-#ifndef AFDFILE_COMMON_H_INCLUDED
-#define AFDFILE_COMMON_H_INCLUDED
+
+#ifndef AFFILE_COMMON_H_INCLUDED
+#define AFFILE_COMMON_H_INCLUDED
 
 #include "file-perms.h"
 
-gboolean affile_open_file(gchar *name, gint flags,
-                          const FilePermOptions *perm_options,
-                          gboolean create_dirs, gboolean privileged,
-                          gboolean is_pipe, gint *fd);
+typedef struct _FileOpenOptions
+{
+  gboolean create_dirs:1,
+           needs_privileges:1,
+           is_pipe:1;
+  gint open_flags;
+} FileOpenOptions;
+
+gboolean affile_open_file(gchar *name, FileOpenOptions *open_opts, FilePermOptions *perm_opts, gint *fd);
 
 #endif

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -42,6 +42,9 @@
 #include <errno.h>
 #include <time.h>
 #include <stdlib.h>
+
+#define DEFAULT_DW_REOPEN_FLAGS (O_WRONLY | O_CREAT | O_NOCTTY | O_NONBLOCK | O_LARGEFILE)
+#define DEFAULT_DW_REOPEN_FLAGS_PIPE (O_RDWR | O_NOCTTY | O_NONBLOCK | O_LARGEFILE)
 
 /*
  * Threading notes:
@@ -144,9 +147,15 @@ affile_dw_reap(gpointer s)
 }
 
 static gboolean
+_affile_dw_reopen_file(AFFileDestWriter *self, gchar *name, gint *fd)
+{
+  return affile_open_file(name, &self->owner->file_open_options, &self->owner->file_perm_options, fd);
+}
+
+static gboolean
 affile_dw_reopen(AFFileDestWriter *self)
 {
-  int fd, flags;
+  int fd;
   struct stat st;
 
   self->last_open_stamp = self->last_msg_stamp;
@@ -161,17 +170,10 @@ affile_dw_reopen(AFFileDestWriter *self)
       unlink(self->filename);
     }
 
-  if (self->owner->is_pipe)
-    flags = O_RDWR | O_NOCTTY | O_NONBLOCK | O_LARGEFILE;
-  else
-    flags = O_WRONLY | O_CREAT | O_NOCTTY | O_NONBLOCK | O_LARGEFILE | O_APPEND;
-
-
-  if (affile_open_file(self->filename, flags, &self->owner->file_perm_options,
-                       self->owner->create_dirs, FALSE, self->owner->is_pipe, &fd))
+  if (_affile_dw_reopen_file(self, self->filename, &fd))
     {
       log_writer_reopen(self->writer,
-                        self->owner->is_pipe
+                        self->owner->file_open_options.is_pipe
                         ? log_proto_text_client_new(log_transport_pipe_new(fd), &self->owner->writer_options.proto_options.super)
                         : log_proto_file_writer_new(log_transport_file_new(fd), &self->owner->writer_options.proto_options.super,
                                                     self->owner->writer_options.flush_lines,
@@ -209,7 +211,7 @@ affile_dw_init(LogPipe *s)
       guint32 flags;
 
       flags = LW_FORMAT_FILE |
-        (self->owner->is_pipe ? 0 : LW_SOFT_FLOW_CONTROL);
+        (self->owner->file_open_options.is_pipe ? 0 : LW_SOFT_FLOW_CONTROL);
 
       self->writer = log_writer_new(flags);
     }
@@ -217,7 +219,7 @@ affile_dw_init(LogPipe *s)
                          s,
                          &self->owner->writer_options,
                          STATS_LEVEL1,
-                         self->owner->is_pipe ? SCS_PIPE : SCS_FILE,
+                         self->owner->file_open_options.is_pipe ? SCS_PIPE : SCS_FILE,
                          self->owner->super.super.id,
                          self->filename);
   log_writer_set_queue(self->writer, log_dest_driver_acquire_queue(&self->owner->super, affile_dw_format_persist_name(self)));
@@ -345,7 +347,7 @@ affile_dd_set_create_dirs(LogDriver *s, gboolean create_dirs)
 {
   AFFileDestDriver *self = (AFFileDestDriver *) s;
   
-  self->create_dirs = create_dirs;
+  self->file_open_options.create_dirs = create_dirs;
 }
 
 void 
@@ -428,7 +430,7 @@ affile_dd_init(LogPipe *s)
     return FALSE;
 
   if (cfg->create_dirs)
-    self->create_dirs = TRUE;
+    self->file_open_options.create_dirs = TRUE;
   if (self->time_reap == -1)
     self->time_reap = cfg->time_reap;
   
@@ -714,6 +716,9 @@ affile_dd_new_instance(gchar *filename)
       self->filename_is_a_template = TRUE;
     }
   self->time_reap = -1;
+  self->file_open_options.is_pipe = FALSE;
+  self->file_open_options.needs_privileges = FALSE;
+  self->file_open_options.open_flags = DEFAULT_DW_REOPEN_FLAGS;
   g_static_mutex_init(&self->lock);
   return self;
 }
@@ -728,6 +733,8 @@ LogDriver *
 afpipe_dd_new(gchar *filename)
 {
   AFFileDestDriver *self = affile_dd_new_instance(filename);
-  self->is_pipe = TRUE;
+  self->file_open_options.is_pipe = TRUE;
+  self->file_open_options.open_flags = DEFAULT_DW_REOPEN_FLAGS_PIPE;
+
   return &self->super.super;
 }

--- a/modules/affile/affile-dest.h
+++ b/modules/affile/affile-dest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 
 #include "driver.h"
 #include "logwriter.h"
-#include "file-perms.h"
+#include "affile-common.h"
 
 typedef struct _AFFileDestWriter AFFileDestWriter;
 
@@ -36,12 +36,11 @@ typedef struct _AFFileDestDriver
   GStaticMutex lock;
   LogTemplate *filename_template;
   AFFileDestWriter *single_writer;
-  gboolean is_pipe:1,
-    filename_is_a_template:1,
+  gboolean filename_is_a_template:1,
     template_escape:1,
-    create_dirs:1,
     use_fsync:1;
   FilePermOptions file_perm_options;
+  FileOpenOptions file_open_options;
   TimeZoneInfo *local_time_zone_info;
   LogWriterOptions writer_options;
   GHashTable *writer_hash;

--- a/modules/affile/affile-source.h
+++ b/modules/affile/affile-source.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2012 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -26,8 +26,8 @@
 
 #include "driver.h"
 #include "logreader.h"
-#include "file-perms.h"
 #include "logproto/logproto-regexp-multiline-server.h"
+#include "affile-common.h"
 
 
 enum
@@ -44,10 +44,9 @@ typedef struct _AFFileSourceDriver
   LogReader *reader;
   LogReaderOptions reader_options;
   FilePermOptions file_perm_options;
+  FileOpenOptions file_open_options;
   gint pad_size;
   gint follow_freq;
-  gboolean is_pipe:1,
-    is_privileged:1;
   gint multi_line_mode;
   MultiLineRegexp *multi_line_prefix, *multi_line_garbage;
   /* state information to follow a set of files using a wildcard expression */


### PR DESCRIPTION
This splits up the large affile_open_file() function into smaller, more
readable private functions, that makes it easier to understand the
control flow.

Signed-off-by: Budai Laszlo lbudai@balabit.hu
