### PR TITLE
redis: Fix the host() and port() options

### DIFF
--- a/modules/redis/redis-parser.c
+++ b/modules/redis/redis-parser.c
@@ -31,6 +31,8 @@ int redis_parse(CfgLexer *lexer, LogDriver **instance, gpointer arg);
 static CfgLexerKeyword redis_keywords[] = {
   { "redis",			KW_REDIS },
   { "command",			KW_COMMAND },
+  { "host",			KW_HOST },
+  { "port",			KW_PORT },
   { NULL }
 };
 


### PR DESCRIPTION
The host() and port() options were not declared in the parser, only in
the grammar, thus using them led to a syntax error. Declare them for the
parser too.

Reported-by: Otto Berger otto@bergerdata.de
Signed-off-by: Gergely Nagy algernon@balabit.hu
