### PR TITLE
coverage: Removed running of firefox in coverage collector script

### DIFF
--- a/tests/collect-cov.sh
+++ b/tests/collect-cov.sh
@@ -7,4 +7,3 @@ lcov --extract coverage.info "${top_srcdir}/*" --output-file coverage.info
 lcov --remove coverage.info "${top_srcdir}/modules/afmongodb/libmongo-client/*" --output-file coverage.info
 lcov --remove coverage.info "${top_srcdir}/modules/afamqp/rabbitmq-c/*" --output-file coverage.info
 genhtml coverage.info --output-directory coverage.html
-firefox  coverage.html/index.html


### PR DESCRIPTION
Because it prevents coverage generation on a non-desktop machine...
