### PR TITLE
syslogformat: Only set PROGRAM to kernel when the message is local

### DIFF
--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -933,7 +933,8 @@ log_msg_parse_legacy(const MsgFormatOptions *parse_options,
       /* Different format */
 
       /* A kernel message? Use 'kernel' as the program name. */
-      if ((self->flags & LF_INTERNAL) == 0 && ((self->pri & LOG_FACMASK) == LOG_KERN))
+      if ((self->flags & LF_INTERNAL) == 0 && ((self->pri & LOG_FACMASK) == LOG_KERN &&
+                                               (self->flags & LF_LOCAL) != 0))
         {
           log_msg_set_value(self, LM_V_PROGRAM, "kernel", 6);
         }


### PR DESCRIPTION
When the message is not local, do not override - or set - the value of
PROGRAM, there's other ways to do that. Doing an unconditional setting
breaks setups where kernel messages are forwarded between syslog-ng
instances:

The first syslog-ng sees "<4>Some message..." on /proc/kmsg, sets
PROGRAM to "kernel", and sends it over on tcp as "<4>kernel: Some
message...". The second syslog-ng sees that, from the facility it sees
that it's a kernel message, and sets PROGRAM to kernel again.

But when a message is from the kernel, we don't parse the rest, we don't
extract the program, we treat the rest of the message as MESSAGE, so in
this case, we'd end up with "<4>kernel: kernel: Some message", and each
hop would add another "kernel: ".

If we only set this when the message is local, we avoid this. The
downside is, that on the remote end, PROGRAM will not be set.

Reported-by: Matyas Koszik koszik@atw.hu
Signed-off-by: Gergely Nagy algernon@balabit.hu
