### PR TITLE
Link to SSL-using modules to libsyslog-ng-crypto too

### DIFF
--- a/modules/afmongodb/Makefile.am
+++ b/modules/afmongodb/Makefile.am
@@ -27,7 +27,7 @@ modules_afmongodb_libafmongodb_la_SOURCES	=	\
 	modules/afmongodb/afmongodb-parser.h		\
 	${DUMMY_C}
 modules_afmongodb_libafmongodb_la_LIBADD	=	\
-	$(MODULE_DEPS_LIBS) $(LIBMONGO_LIBS)
+	$(MODULE_DEPS_LIBS) $(CRYPTO_LIBS) $(LIBMONGO_LIBS)
 modules_afmongodb_libafmongodb_la_LDFLAGS	=	\
 	$(MODULE_LDFLAGS)
 modules_afmongodb_libafmongodb_la_DEPENDENCIES	=	\

--- a/modules/afsmtp/Makefile.am
+++ b/modules/afsmtp/Makefile.am
@@ -12,7 +12,7 @@ modules_afsmtp_libafsmtp_la_SOURCES	=	\
 	modules/afsmtp/afsmtp-parser.c		\
 	modules/afsmtp/afsmtp-parser.h
 modules_afsmtp_libafsmtp_la_LIBADD	=	\
-	$(LIBESMTP_LIBS) $(MODULE_DEPS_LIBS)
+	$(LIBESMTP_LIBS) $(MODULE_DEPS_LIBS) $(CRYPTO_LIBS)
 modules_afsmtp_libafsmtp_la_LDFLAGS	=	\
 	$(MODULE_LDFLAGS)
 modules_afsmtp_libafsmtp_la_DEPENDENCIES=	\

--- a/modules/afsql/Makefile.am
+++ b/modules/afsql/Makefile.am
@@ -15,7 +15,7 @@ modules_afsql_libafsql_la_CPPFLAGS	=	\
 	-I$(top_builddir)/modules/afsql
 modules_afsql_libafsql_la_LIBADD	= 	\
 	$(MODULE_DEPS_LIBS) $(LIBDBI_LIBS)	\
-	$(OPENSSL_LIBS)
+	$(CRYPTO_LIBS) $(OPENSSL_LIBS)
 modules_afsql_libafsql_la_LDFLAGS	=	\
 	$(MODULE_LDFLAGS)
 modules_afsql_libafsql_la_DEPENDENCIES	=	\


### PR DESCRIPTION
Since OpenSSL needs some initialization to work properly, link afql to
libsyslog-ng-crypto to do that. If we don't do this, then loading
afsql (or any other module that uses OpenSSL) before anything that uses
libsyslog-ng-crypto (like afsocket) will fail and result in a
segmentation fault.

Affected modules are: afsql, afmongodb and afsmtp.

Reported-by: Imre Lazar imre@balabit.hu
Signed-off-by: Gergely Nagy algernon@balabit.hu
