### PR TITLE
syslog-ng-ctl/Makefile.am: Include more files in make dist

### DIFF
--- a/syslog-ng-ctl/Makefile.am
+++ b/syslog-ng-ctl/Makefile.am
@@ -4,7 +4,11 @@ sbin_PROGRAMS			+= syslog-ng-ctl/syslog-ng-ctl
 
 syslog_ng_ctl_syslog_ng_ctl_SOURCES		= 	\
 	syslog-ng-ctl/syslog-ng-ctl.c			\
+	syslog-ng-ctl/control-client.h			\
 	syslog-ng-ctl/control-client.c
+
+EXTRA_DIST					+=	\
+	syslog-ng-ctl/control-client-unix.c
 
 syslog_ng_ctl_syslog_ng_ctl_LDADD		= lib/libsyslog-ng.la lib/libsyslog-ng-crypto.la @BASE_LIBS@ @GLIB_LIBS@ @RESOLV_LIBS@
 


### PR DESCRIPTION
make dist requires control-client.h and control-client-unix.c to be
included as well, add them to the appropriate variables.

Signed-off-by: Gergely Nagy algernon@balabit.hu
