### PR TITLE
Make modules that link to crypto libs depend on them too

### DIFF
--- a/modules/afmongodb/Makefile.am
+++ b/modules/afmongodb/Makefile.am
@@ -31,7 +31,7 @@ modules_afmongodb_libafmongodb_la_LIBADD	=	\
 modules_afmongodb_libafmongodb_la_LDFLAGS	=	\
 	$(MODULE_LDFLAGS)
 modules_afmongodb_libafmongodb_la_DEPENDENCIES	=	\
-	$(MODULE_DEPS_LIBS) ${lmc_EXTRA_DEPS}
+	$(MODULE_DEPS_LIBS) $(CRYPTO_LIBS) ${lmc_EXTRA_DEPS}
 
 modules/afmongodb modules/afmongodb/ mod-afmongodb mod-mongodb: \
 	modules/afmongodb/libafmongodb.la

--- a/modules/afsmtp/Makefile.am
+++ b/modules/afsmtp/Makefile.am
@@ -16,7 +16,7 @@ modules_afsmtp_libafsmtp_la_LIBADD	=	\
 modules_afsmtp_libafsmtp_la_LDFLAGS	=	\
 	$(MODULE_LDFLAGS)
 modules_afsmtp_libafsmtp_la_DEPENDENCIES=	\
-	$(MODULE_DEPS_LIBS)
+	$(MODULE_DEPS_LIBS) $(CRYPTO_LIBS)
 
 modules/afsmtp modules/afsmtp/ mod-afsmtp mod-smtp: \
 	modules/afsmtp/libafsmtp.la

--- a/modules/afsql/Makefile.am
+++ b/modules/afsql/Makefile.am
@@ -19,7 +19,7 @@ modules_afsql_libafsql_la_LIBADD	= 	\
 modules_afsql_libafsql_la_LDFLAGS	=	\
 	$(MODULE_LDFLAGS)
 modules_afsql_libafsql_la_DEPENDENCIES	=	\
-	$(MODULE_DEPS_LIBS)
+	$(MODULE_DEPS_LIBS) $(CRYPTO_LIBS)
 
 modules/afsql modules/afsql/ mod-afsql mod-sql:	\
 	modules/afsql/libafsql.la


### PR DESCRIPTION
Just linking to $(CRYPTO_LIBS) fails in a clean, parallel build, because
the dependency is missing. This patch adds them.

Reported-by: Peter Czanik czanik@balabit.hu
Signed-off-by: Gergely Nagy algernon@balabit.hu
