### PR TITLE
value-pairs: Ignore empty values in SDATA too

### DIFF
--- a/lib/value-pairs.c
+++ b/lib/value-pairs.c
@@ -225,6 +225,9 @@ vp_msg_nvpairs_foreach(NVHandle handle, gchar *name,
   gboolean inc;
   SBTHGString *sb;
 
+  if (value_len == 0)
+    return FALSE;
+
   inc = (name[0] == '.' && (vp->scopes & VPS_DOT_NV_PAIRS)) ||
     (name[0] != '.' && (vp->scopes & VPS_NV_PAIRS)) ||
     (log_msg_is_handle_sdata(handle) && (vp->scopes & VPS_SDATA));


### PR DESCRIPTION
The value-pairs framework ignored empty values when they were explicitly
specified as such, but when they came through via SDATA or any other
means, it treated them as empty strings, and allowed them through. This
was inconsistent, and a waste too.

This patch corrects that behaviour, and empty-valued SDATA members will
not pass through anymore.

Reported-by: Lucas McLane lucas@clicksecurity.com
Signed-off-by: Gergely Nagy algernon@balabit.hu
