### PR TITLE
value-pairs: Handle SDATA enterprise IDs correctly

### DIFF
--- a/modules/json/tests/test_json.c
+++ b/modules/json/tests/test_json.c
@@ -16,6 +16,8 @@ test_format_json(void)
                          "{\"kernel\":{\"SUBSYSTEM\":\"pci\",\"DEVICE\":{\"type\":\"pci\",\"name\":\"0000:02:00.0\"}},\"MSGID\":\"801\",\"MESSAGE\":\"test\"}");
   assert_template_format("$(format-json .foo=bar)", "{\"_foo\":\"bar\"}");
   assert_template_format("$(format-json --scope rfc3164,rfc3164)", "{\"PROGRAM\":\"syslog-ng\",\"PRIORITY\":\"err\",\"PID\":\"23323\",\"MESSAGE\":\"árvíztűrőtükörfúrógép\",\"HOST\":\"bzorp\",\"FACILITY\":\"local3\",\"DATE\":\"Feb 11 18:58:35\"}");
+  assert_template_format("$(format-json sdata.win@18372.4.fruit=\"pear\" sdata.win@18372.4.taste=\"good\")",
+                         "{\"sdata\":{\"win@18372.4\":{\"taste\":\"good\",\"fruit\":\"pear\"}}}");
 }
 
 void


### PR DESCRIPTION
RFC5424 SDATA IDs are of the form "[win@18372.4 foo=bar]", which
translates to "sdata.win@18372.4.foo=bar" internally. In this case, we
should not split the "4" into a separate object, but treat it as part of
the sdata ID.

To do this, the name splitting was enhanced, and instead of splitting by
every dot, it will look for @ too, and only split a token off after
that, if a dot is followed by a non-number. A test case to verify the
behaviour is also included.

Signed-off-by: Tibor Benke btibi@balabit.hu
Signed-off-by: Gergely Nagy algernon@balabit.hu
