### PR TITLE
configure.ac: Correctly detect newer json-c too

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -697,7 +697,11 @@ dnl json headers/libraries
 dnl ***************************************************************************
 if test "x$enable_json" = "xyes" || test "x$enable_json" = "xauto"; then
    _with_json="yes"
-   PKG_CHECK_MODULES(JSON_C, json >= $JSON_C_MIN_VERSION,, [JSON_C_LIBS=""; _with_json="no"])
+   PKG_CHECK_MODULES(JSON_C, json-c >= $JSON_C_MIN_VERSION,, [JSON_C_LIBS=""; _with_json="no"])
+   if test "x$_with_json" = "xno"; then
+     _with_json="yes"
+     PKG_CHECK_MODULES(JSON_C, json >= $JSON_C_MIN_VERSION,, [JSON_C_LIBS=""; _with_json="no"])
+   fi
 
    if test "x$enable_json" = "xyes" && test "x$_with_json" = "xno"; then
       AC_MSG_ERROR([Could not find json-c, and json support was explicitly enabled.])


### PR DESCRIPTION
Newer json-c had the pkg-config module renamed from json to json-c, and
while a compatiliby shim is available, we should not rely on that, but
detect json-c AND json as well.

To do that, we try the newer json-c first, and fall back to json if it
is not found.

Reported-by: Fabien Wernli cpan@faxm0dem.org
Signed-off-by: Gergely Nagy algernon@balabit.hu
