### PR TITLE
logproto: Fix the framed server free method

### DIFF
--- a/lib/logproto/logproto-framed-server.c
+++ b/lib/logproto/logproto-framed-server.c
@@ -270,6 +270,8 @@ log_proto_framed_server_free(LogProtoServer *s)
 {
   LogProtoFramedServer *self = (LogProtoFramedServer *) s;
   g_free(self->buffer);
+
+  log_proto_server_free_method(s);
 }
 
 LogProtoServer *


### PR DESCRIPTION
The LogProtoFramedServer free method did not call the free_method of its
super class, which resulted in memory & FD leaks when using a syslog()
source. This patch corrects that.

Reported-by: Andras Mitzki micek@balabit.hu
Signed-off-by: Gergely Nagy algernon@balabit.hu
