### PR TITLE
mainloop: Deinit the dns thread cache when reverting the config

### DIFF
--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -120,6 +120,7 @@ app_startup(void)
   iv_init();
   g_thread_init(NULL);
   dns_cache_global_init();
+  dns_cache_thread_init();
   afinter_global_init();
   child_manager_init();
   alarm_init();
@@ -162,6 +163,7 @@ app_shutdown(void)
   child_manager_deinit();
   g_list_foreach(application_hooks, (GFunc) g_free, NULL);
   g_list_free(application_hooks);
+  dns_cache_thread_deinit();
   dns_cache_global_deinit();
   msg_deinit();
   iv_deinit();

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -219,7 +219,6 @@ cfg_init(GlobalConfig *cfg)
   log_tags_reinit_stats(cfg);
 
   dns_cache_set_params(cfg->dns_cache_size, cfg->dns_cache_expire, cfg->dns_cache_expire_failed, cfg->dns_cache_hosts);
-  dns_cache_thread_init();
   hostname_reinit(cfg->custom_domain);
   host_resolve_options_init(&cfg->host_resolve_options, cfg);
   log_proto_register_builtin_plugins(cfg);
@@ -229,7 +228,6 @@ cfg_init(GlobalConfig *cfg)
 gboolean
 cfg_deinit(GlobalConfig *cfg)
 {
-  dns_cache_thread_deinit();
   return cfg_tree_stop(&cfg->tree);
 }
 

--- a/tests/unit/test_dnscache.c
+++ b/tests/unit/test_dnscache.c
@@ -20,7 +20,6 @@ test_expiration(void)
   gboolean positive;
 
   dns_cache_set_params(50000, 3, 1, NULL);
-  dns_cache_thread_init();
 
   for (i = 0; i < 10000; i++)
     {
@@ -107,7 +106,6 @@ test_expiration(void)
           exit(1);
         }
     }
-  dns_cache_thread_deinit();
 }
 
 void
@@ -120,7 +118,6 @@ test_dns_cache_benchmark(void)
   gint i;
 
   dns_cache_set_params(50000, 600, 300, NULL);
-  dns_cache_thread_init();
 
   for (i = 0; i < 10000; i++)
     {
@@ -143,7 +140,6 @@ test_dns_cache_benchmark(void)
     }
   g_get_current_time(&end);
   printf("DNS cache speed: %12.3f iters/sec\n", i * 1e6 / g_time_val_diff(&end, &start));
-  dns_cache_thread_deinit();
 }
 
 int


### PR DESCRIPTION
When reloading the configuration and the new config fails to initialize,
syslog-ng reverts to the old config. But by that time,
dns_cache_thread_init() has already been called (when trying to init the
new config), and dns_cache_thread_deinit() never got called. So when we
tried to cfg_init() the old config, it called dns_cache_thread_init()
again, and triggered an assertion.

Reported-by: Andras Mitzki micek@balabit.hu
Signed-off-by: Gergely Nagy algernon@balabit.hu
