### PR TITLE
pdbtool: Initialize module_path

### DIFF
--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -1158,6 +1158,8 @@ main(int argc, char *argv[])
   log_tags_global_init();
   pattern_db_global_init();
 
+  module_path = get_installation_path_for(MODULE_PATH);
+
   configuration = cfg_new(VERSION_VALUE);
 
   if (!g_option_context_parse(ctx, &argc, &argv, &error))


### PR DESCRIPTION
With the reloc patch that went in a while ago, module_path has to be
explicitly initialized, otherwise it will remain empty. And if it
remains empty, and we try to split it, GLib will spew warnings at us.

This patch adds the initialisation.

Reported-by: Andras Mitzki micek@balabit.hu
Signed-off-by: Gergely Nagy algernon@balabit.hu
