### PR TITLE
messages: Add a timestamp to internal messages in debug mode

### DIFF
--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -891,9 +891,11 @@ cfg_tree_compile_node(CfgTree *self, LogExprNode *node,
   if (debug_flag)
     {
       gchar buf[32];
+      gchar timebuf[128];
 
       indent++;
-      fprintf(stderr, "%.*sCompiling %s %s [%s] at [%s]\n",
+      fprintf(stderr, "[%s] %.*sCompiling %s %s [%s] at [%s]\n",
+              get_cached_current_time(timebuf),
               indent * 2, "                   ",
               node->name ? : "#unnamed",
               log_expr_node_get_layout_name(node->layout),

--- a/lib/messages.c
+++ b/lib/messages.c
@@ -118,13 +118,23 @@ msg_limit_internal_message(const gchar *msg)
   return TRUE;
 }
 
+static void
+msg_send_formatted_message_to_stderr(const char *msg)
+{
+  gchar tmtime[128];
+
+  if (G_UNLIKELY(debug_flag))
+    fprintf(stderr, "[%s] %s\n", get_cached_current_time(tmtime), msg);
+  else
+    fprintf(stderr, "%s\n", msg);
+}
 
 static void
 msg_send_formatted_message(int prio, const char *msg)
 {
   if (G_UNLIKELY(log_stderr || (msg_post_func == NULL && (prio & 0x7) <= EVT_PRI_WARNING)))
     {
-      fprintf(stderr, "%s\n", msg);
+      msg_send_formatted_message_to_stderr(msg);
     }
   else
     {

--- a/lib/timeutils.c
+++ b/lib/timeutils.c
@@ -233,6 +233,17 @@ cached_gmtime(time_t *when, struct tm *tm)
     }
 }
 
+gchar *
+get_cached_current_time(gchar buf[128])
+{
+  struct tm tm;
+  time_t now = cached_g_current_time_sec();
+
+  cached_localtime(&now, &tm);
+  strftime(buf, 64, "%Y-%m-%dT%H:%M:%S%z", &tm);
+  return buf;
+}
+
 /**
  * get_local_timezone_ofs:
  * @when: time in UTC

--- a/lib/timeutils.h
+++ b/lib/timeutils.h
@@ -31,6 +31,7 @@
 time_t cached_mktime(struct tm *tm);
 void cached_localtime(time_t *when, struct tm *tm);
 void cached_gmtime(time_t *when, struct tm *tm);
+gchar *get_cached_current_time(gchar buf[128]);
 
 long get_local_timezone_ofs(time_t when);
 void clean_time_cache();


### PR DESCRIPTION
When running in debug mode, and sending messages to stderr anyway, add a
timestamp to ease debugging. This also changes cfg_tree_compile_node()
to add a timestamp too in similar cases.

Based on a patch by Viktor Juhasz jviktor@balabit.hu.

Signed-off-by: Gergely Nagy algernon@balabit.hu
