### PR TITLE
filter: Fix the match() filter grammar

### DIFF
--- a/lib/filter/filter-expr-grammar.ym
+++ b/lib/filter/filter-expr-grammar.ym
@@ -191,7 +191,7 @@ filter_re
 	| KW_HOST    { last_re_filter = filter_re_new(LM_V_HOST); } filter_re_params
 	| KW_MESSAGE { last_re_filter = filter_re_new(LM_V_MESSAGE); } filter_re_params
         | KW_SOURCE  { last_re_filter = filter_source_new();  } filter_re_params
-	: KW_MATCH   { last_re_filter = filter_match_new(); } filter_match_params
+	| KW_MATCH   { last_re_filter = filter_match_new(); } filter_match_params
 	;
 
 filter_re_params


### PR DESCRIPTION
In the filter_re rule, the match() filter's grammar was written with a
":" at the start of the line instead of a "|", therefore yacc did not
consider it part of the rule. This patch corrects that.

Reported-by: Andras Mitzki micek@balabit.hu
Signed-off-by: Gergely Nagy algernon@balabit.hu
