### PR TITLE
pdbtool: If a test message has no program attribute, warn when verbose

### DIFF
--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -743,6 +743,12 @@ pdbtool_test(int argc, char *argv[])
         {
           example = examples->data;
 
+          if (!example->program && verbose_flag)
+            {
+              printf ("Warnning, message has no 'program' attribute: message='%s'\n",
+                      example->message);
+            }
+
           if (example->message && example->program)
             {
               PDBInput input;


### PR DESCRIPTION
When encountering a test message that has no program attribute, warn
about it when verbose mode is on. The rationale for only doing it in
verbose mode is that there are valid reasons for having no program
attribute for a test (to temporarily disable it, for example), and we
don't want to needlessly spew a lot of warnings at the user.

Reported-by: Fabien Wernli bugzilla.balabit@faxm0dem.org
Signed-off-by: Gergely Nagy algernon@balabit.hu
