### PR TITLE
doc/Makefile.am: Always include the manpages in the tarball

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -27,15 +27,19 @@ XSL_STYLESHEET = /usr/share/xml/docbook/stylesheet/docbook-xsl/manpages/docbook.
 sysconfdir_e = $(shell echo "${sysconfdir}" | sed -e "s,-,\\\\\\\\-,g")
 prefix_e = $(shell echo "${prefix}" | sed -e "s,-,\\\\\\\\-,g")
 
-if ENABLE_MAN_PAGES
-man_MANS	+= \
+manpages	= \
 		doc/man/syslog-ng.8 \
 		doc/man/syslog-ng.conf.5 \
 		doc/man/pdbtool.1 \
 		doc/man/loggen.1 \
 		doc/man/syslog-ng-ctl.1
 
+if ENABLE_MAN_PAGES
+man_MANS	+= ${manpages}
+
 doc/man/%: doc/man/%.xml
 	$(AM_V_GEN)$(XSLTPROC) --xinclude --output $@ ${XSL_STYLESHEET} $<
 	$(AM_V_at)sed -e 's,/opt/syslog\\*-ng/etc,$(sysconfdir_e),g' -e 's,/opt/syslog\\*-ng/,$(prefix_e)/,g' <$@ >$@.tmp && mv $@.tmp $@
+else
+EXTRA_DIST	+= ${manpages}
 endif


### PR DESCRIPTION
Whether man page building is enabled or not, include them in the
tarball. This means that you won't be able to build a tarball from git
unless you build the man pages too, but it also means that if you do a
make dist from a tarball, without xsltproc installed, they will still be
included.

Reported-by: Peter Czanik czanik@balabit.hu
Signed-off-by: Gergely Nagy algernon@balabit.hu
