### PR TITLE
control: Fix the test_control_cmds test to be deterministic

### DIFF
--- a/lib/control/tests/test_control_cmds.c
+++ b/lib/control/tests/test_control_cmds.c
@@ -67,6 +67,7 @@ test_stats()
   GString *reply = NULL;
   GString *command = g_string_sized_new(128);
   StatsCounterItem *counter = NULL;
+  gchar **stats_result;
 
   stats_lock();
   stats_register_counter(0, SCS_CENTER, "id", "received", SC_TYPE_PROCESSED, &counter);
@@ -75,10 +76,10 @@ test_stats()
   g_string_assign(command,"STATS");
 
   reply = control_connection_send_stats(command);
-  assert_string(reply->str, "SourceName;SourceId;SourceInstance;State;Type;Number\n"
-                            "center;id;received;a;processed;0\nglobal;payload_reallocs;;a;processed;0\n"
-                            "global;msg_clones;;a;processed;0\n"
-                            "global;sdata_updates;;a;processed;0\n", "Bad reply");
+  stats_result = g_strsplit(reply->str, "\n", 2);
+  assert_string(stats_result[0], "SourceName;SourceId;SourceInstance;State;Type;Number",
+                "Bad reply");
+  g_strfreev(stats_result);
   g_string_free(reply, TRUE);
 
   g_string_free(command, TRUE);


### PR DESCRIPTION
The order in which stats are generated is not deterministic, therefore
testing whether the generated stats are the same as a pre-determined
list will sooner or later fail. There are two things we can test: that
the first line is the stats header, and that the number of returned
lines are of the expected number. In this case, I believe it is enough
if we test the header only.

Reported-by: Andras Mitzki micek@balabit.hu
Signed-off-by: Gergely Nagy algernon@balabit.hu
