### PR TITLE
run-id: Added implementation of run_id.

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -81,6 +81,7 @@ pkginclude_HEADERS			+= \
 	lib/pragma-parser.h		\
 	lib/reloc.h			\
 	lib/rcptid.h			\
+	lib/run-id.h			\
 	lib/scratch-buffers.h		\
 	lib/serialize.h			\
 	lib/service-management.h	\
@@ -157,6 +158,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	lib/pragma-parser.c		\
 	lib/rcptid.c			\
 	lib/reloc.c			\
+	lib/run-id.c			\
 	lib/scratch-buffers.c		\
 	lib/serialize.c			\
 	lib/service-management.c	\

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -34,6 +34,7 @@
 #include "reloc.h"
 #include "service-management.h"
 #include "persist-state.h"
+#include "run-id.h"
 
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -169,7 +170,9 @@ main_loop_initialize_state(GlobalConfig *cfg, const gchar *persist_filename)
   if (!persist_state_start(cfg->state))
     return FALSE;
 
+  run_id_init(cfg->state);
   success = cfg_init(cfg);
+
   if (success)
     persist_state_commit(cfg->state);
   else

--- a/lib/run-id.c
+++ b/lib/run-id.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2013 Viktor Juhasz
+ * Copyright (c) 2013 Viktor Tusa
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "run-id.h"
+#include "persistable-state-header.h"
+#include "str-format.h"
+
+int cached_run_id = 0;
+
+typedef struct _RunIDState
+{
+  PersistableStateHeader header;
+  gint run_id;
+} RunIDState;
+
+void
+run_id_init(PersistState* state)
+{
+  gsize size;
+  guint8 version;
+  PersistEntryHandle handle;
+  RunIDState* run_id_state;
+
+  handle = persist_state_lookup_entry(state, "runid", &size, &version);
+
+  if (handle == 0)
+    {
+      handle = persist_state_alloc_entry(state, "runid", sizeof(RunIDState) );
+    }
+
+  run_id_state = persist_state_map_entry(state, handle);
+
+  run_id_state->run_id++;
+  cached_run_id = run_id_state->run_id;
+
+  persist_state_unmap_entry(state, handle);
+};
+
+int
+run_id_get(void)
+{
+  return cached_run_id;
+};
+
+gboolean
+run_id_is_same_run(gint other_id)
+{
+  return cached_run_id != other_id;
+};
+
+void
+run_id_append_formatted_id(GString *str)
+{
+  if (cached_run_id)
+    format_uint32_padded(str, 0, 0, 10, cached_run_id);
+};
+
+void
+run_id_deinit(void)
+{
+  cached_run_id = 0;
+};

--- a/lib/run-id.h
+++ b/lib/run-id.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2013 Viktor Juhasz
+ * Copyright (c) 2013 Viktor Tusa
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef _RUN_ID_H
+#define _RUN_ID_H
+#include "persist-state.h"
+
+void run_id_init(PersistState *state);
+void run_id_deinit(void);
+int run_id_get(void);
+gboolean run_id_is_same_run(gint other_run_id);
+void run_id_append_formatted_id(GString* str);
+
+#endif

--- a/lib/template/templates.c
+++ b/lib/template/templates.c
@@ -34,6 +34,7 @@
 #include "plugin-types.h"
 #include "str-format.h"
 #include "rcptid.h"
+#include "run-id.h"
 
 #include <time.h>
 #include <string.h>
@@ -64,6 +65,7 @@ enum
   M_LOGHOST,
   M_SYSUPTIME,
   M_RCPTID,
+  M_RUNID,
 
   /* only touch this section if you want to add three macros, one w/o
    * prefix, and a R_ and S_ prefixed macro that relates one of the
@@ -228,6 +230,7 @@ LogMacroDef macros[] =
         { "SEQNUM", M_SEQNUM },
         { "CONTEXT_ID", M_CONTEXT_ID },
         { "RCPTID", M_RCPTID },
+        { "RUNID", M_RUNID },
 
         /* values that have specific behaviour with older syslog-ng config versions */
         { "MSG", M_MESSAGE },
@@ -470,6 +473,12 @@ log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOpt
     case M_RCPTID:
       {
         rcptid_append_formatted_id(result, msg->rcptid);
+        break;
+      }
+
+    case M_RUNID:
+      {
+        run_id_append_formatted_id(result);
         break;
       }
 

--- a/lib/tests/Makefile.am
+++ b/lib/tests/Makefile.am
@@ -8,7 +8,8 @@ lib_tests_TESTS		= \
 	lib/tests/test_reloc		\
 	lib/tests/test_hostname		\
 	lib/tests/test_rcptid		\
-	lib/tests/test_lexer
+	lib/tests/test_lexer        \
+	lib/tests/test_runid
 
 check_PROGRAMS		+= ${lib_tests_TESTS}
 
@@ -67,6 +68,11 @@ lib_tests_test_rcptid_LDADD	= \
 lib_tests_test_lexer_CFLAGS	=	\
 	$(TEST_CFLAGS)
 lib_tests_test_lexer_LDADD	=	\
+	$(TEST_LDADD)
+
+lib_tests_test_runid_CFLAGS	=	\
+	$(TEST_CFLAGS)
+lib_tests_test_runid_LDADD	=	\
 	$(TEST_LDADD)
 
 CLEANFILES				+= \

--- a/lib/tests/test_runid.c
+++ b/lib/tests/test_runid.c
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2013 Viktor Juhasz
+ * Copyright (c) 2013 Viktor Tusa
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "libtest/testutils.h"
+#include "lib/run-id.h"
+#include "lib/apphook.h"
+#include <unistd.h>
+
+#define RUN_ID_FIRST 1
+
+PersistState*
+create_persist_state(void)
+{
+  PersistState* state;
+
+  unlink("test_run_id.persist");
+  state = persist_state_new("test_run_id.persist");
+  persist_state_start(state);
+  return state;
+};
+
+void
+destroy_persist_state(PersistState* state)
+{
+  persist_state_cancel(state);
+  persist_state_free(state);
+  unlink("test_run_id.persist");
+};
+
+void
+test_run_id__first_run__run_id_is_one(void)
+{
+  PersistState *state;
+
+  state = create_persist_state();
+
+  run_id_init(state);
+
+  assert_gint(run_id_get(), RUN_ID_FIRST, "Newly initialized run id is not the first id!");
+
+  destroy_persist_state(state);
+};
+
+void
+test_run_id__second_run__run_id_is_two(void)
+{
+  PersistState *state;
+
+  state = create_persist_state();
+
+  run_id_init(state);
+  persist_state_commit(state);
+  persist_state_free(state);
+
+  state = persist_state_new("test_run_id.persist");
+  persist_state_start(state);
+  run_id_init(state);
+  assert_gint(run_id_get(), RUN_ID_FIRST + 1, "Running run_id_init twice is not the second id!");
+
+  destroy_persist_state(state);
+};
+
+void
+test_run_id__second_run_but_with_non_commit__run_id_is_one(void)
+{
+  PersistState *state;
+
+  state = create_persist_state();
+
+  run_id_init(state);
+  persist_state_cancel(state);
+  persist_state_free(state);
+
+  state = persist_state_new("test_run_id.persist");
+  persist_state_start(state);
+  run_id_init(state);
+  assert_gint(run_id_get(), RUN_ID_FIRST, "Not committing persist state still increases run_id");
+
+  destroy_persist_state(state);
+};
+
+void
+test_run_id__is_same_run__differs_when_not_same_run(void)
+{
+  PersistState *state;
+
+  state = create_persist_state();
+
+  run_id_init(state);
+  int prev_run_id = run_id_get();
+  persist_state_cancel(state);
+  persist_state_free(state);
+
+  state = persist_state_new("test_run_id.persist");
+  persist_state_start(state);
+  run_id_init(state);
+  assert_false(run_id_is_same_run(prev_run_id), "Run_id_is_same_run returned true when the run differs");
+
+  destroy_persist_state(state);
+};
+
+void
+test_run_id_macro__macro_has_the_same_value_as_run_id(void)
+{
+  PersistState *state;
+  GString* res = g_string_sized_new(0);
+
+  state = create_persist_state();
+  run_id_init(state);
+
+  run_id_append_formatted_id(res);
+  assert_string(res->str, "1", "Run id is formatted incorrectly");
+
+  destroy_persist_state(state);
+  g_string_free(res, TRUE);
+};
+
+void
+test_run_id_macro__macro_is_empty_if_run_id_is_not_inited(void)
+{
+  GString* res = g_string_sized_new(0);
+
+  run_id_deinit();
+
+  run_id_append_formatted_id(res);
+  assert_string(res->str, "", "Run id is not empty if it is not inited");
+
+  g_string_free(res, TRUE);
+};
+
+
+int
+main()
+{
+  app_startup();
+  test_run_id__first_run__run_id_is_one();
+  test_run_id__second_run__run_id_is_two();
+  test_run_id__second_run_but_with_non_commit__run_id_is_one();
+  test_run_id__is_same_run__differs_when_not_same_run();
+  test_run_id_macro__macro_has_the_same_value_as_run_id();
+  test_run_id_macro__macro_is_empty_if_run_id_is_not_inited();
+  app_shutdown();
+  return 0;
+};


### PR DESCRIPTION
run_id is changed every time when syslog-ng is restarted but not when it is
reloaded. The actual value is stored in the persist file. A macro named RUNID
is available for using its value.
