### PR TITLE
driver: Fix a memory leak in log_driver_free()

### DIFF
--- a/lib/driver.c
+++ b/lib/driver.c
@@ -91,6 +91,10 @@ log_driver_free(LogPipe *s)
     {
       log_driver_plugin_free((LogDriverPlugin *) l->data);
     }
+  if (self->plugins)
+    {
+      g_list_free(self->plugins);
+    }
   if (self->group)
     g_free(self->group);
   if (self->id)


### PR DESCRIPTION
After freeing up the members of self->plugins, free self->plugins itself
too.

Signed-off-by: Gergely Nagy algernon@balabit.hu
