### PR TITLE
dbparser: Validate the current time when ticking

### DIFF
--- a/modules/dbparser/dbparser.c
+++ b/modules/dbparser/dbparser.c
@@ -118,6 +118,8 @@ log_db_parser_timer_tick(gpointer s)
   LogDBParser *self = (LogDBParser *) s;
 
   pattern_db_timer_tick(self->db);
+  iv_validate_now();
+  self->tick.expires = iv_now;
   self->tick.expires.tv_sec++;
   iv_timer_register(&self->tick);
 }


### PR DESCRIPTION
The tick timer did not validate the current time, which could result in
non-deterministic behaviour when the time changed between two ticks.

Signed-off-by: Juhasz Viktor jviktor@balabit.hu
