### PR TITLE
logmsg: Do not use NULL template_options parameter for log_macro_expand.

### DIFF
--- a/lib/logmsg.c
+++ b/lib/logmsg.c
@@ -381,7 +381,7 @@ log_msg_get_macro_value(LogMessage *self, gint id, gssize *value_len)
     }
   g_string_truncate(value, 0);
 
-  log_macro_expand(value, id, FALSE, NULL, LTZ_LOCAL, 0, NULL, self);
+  log_macro_expand_simple(value, id, self);
   if (value_len)
     *value_len = value->len;
   return value->str;

--- a/lib/template/templates.c
+++ b/lib/template/templates.c
@@ -245,6 +245,8 @@ LogMacroDef macros[] =
 GHashTable *macro_hash;
 GTimeVal app_uptime;
 
+static LogTemplateOptions template_options_for_macro_expand;
+
 static void
 result_append(GString *result, const gchar *sstr, gssize len, gboolean escape)
 {
@@ -642,6 +644,12 @@ log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOpt
       }
     }
   return TRUE;
+}
+
+gboolean
+log_macro_expand_simple(GString *result, gint id, LogMessage *msg)
+{
+  return log_macro_expand(result, id, FALSE, &template_options_for_macro_expand, LTZ_LOCAL, 0, NULL, msg);
 }
 
 guint
@@ -1555,6 +1563,7 @@ log_template_global_init(void)
 
   /* init the uptime (SYSUPTIME macro) */
   g_get_current_time(&app_uptime);
+  log_template_options_defaults(&template_options_for_macro_expand);
 
   macro_hash = g_hash_table_new(g_str_hash, g_str_equal);
   for (i = 0; macros[i].name; i++)

--- a/lib/template/templates.h
+++ b/lib/template/templates.h
@@ -213,6 +213,7 @@ void log_template_append_format_recursive(LogTemplate *self, const LogTemplateIn
 /* low level macro functions */
 guint log_macro_lookup(gchar *macro, gint len);
 gboolean log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOptions *opts, gint tz, gint32 seq_num, const gchar *context_id, LogMessage *msg);
+gboolean log_macro_expand_simple(GString *result, gint id, LogMessage *msg);
 
 LogTemplate *log_template_new(GlobalConfig *cfg, gchar *name);
 LogTemplate *log_template_ref(LogTemplate *s);

--- a/lib/tests/test_log_message.c
+++ b/lib/tests/test_log_message.c
@@ -143,6 +143,24 @@ test_log_message(void)
   MSG_TESTCASE(test_rcptid_is_automatically_assigned_to_a_newly_created_log_message);
 }
 
+void
+test_log_msg_get_value_with_time_related_macro(void)
+{
+  LogMessage *msg;
+  gssize value_len;
+  NVHandle handle;
+  const char *date_value;
+
+  msg = log_msg_new_empty();
+  msg->timestamps[LM_TS_STAMP].tv_sec = 1389783444;
+
+  handle = log_msg_get_value_handle("ISODATE");
+  date_value = log_msg_get_value(msg, handle, &value_len);
+  assert_string(date_value, "2014-01-15T10:57:23-00:00", "ISODATE macro value does not match!");
+
+  log_msg_unref(msg);
+}
+
 int
 main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
 {
@@ -151,6 +169,8 @@ main(int argc G_GNUC_UNUSED, char *argv[] G_GNUC_UNUSED)
   init_and_load_syslogformat_module();
 
   test_log_message();
+  test_log_msg_get_value_with_time_related_macro();
+
   app_shutdown();
   return 0;
 }


### PR DESCRIPTION
In case of time-related macros, it uses the members of the
LogTemplateOptions\* structure, but it results in a NULL pointer
dereference. Instead of spraying the log_macro_expand code with NULL checks,
we pass an initialized options structure to the function.
