### PR TITLE
run-id: Fixed run_id_is_same_run functionality.

### DIFF
--- a/lib/run-id.c
+++ b/lib/run-id.c
@@ -69,7 +69,7 @@ run_id_get(void)
 gboolean
 run_id_is_same_run(gint other_id)
 {
-  return cached_run_id != other_id;
+  return cached_run_id == other_id;
 };
 
 void

--- a/lib/tests/test_runid.c
+++ b/lib/tests/test_runid.c
@@ -110,7 +110,7 @@ test_run_id__is_same_run__differs_when_not_same_run(void)
 
   run_id_init(state);
   int prev_run_id = run_id_get();
-  persist_state_cancel(state);
+  persist_state_commit(state);
   persist_state_free(state);
 
   state = persist_state_new("test_run_id.persist");


### PR DESCRIPTION
The test and the code was obviously bad.

Signed-off-by: Tusa Viktor tusavik@gmail.com
