### PR TITLE
persist-state: Clean up the temporary file upon destroy

### DIFF
--- a/lib/persist-state.c
+++ b/lib/persist-state.c
@@ -873,6 +873,7 @@ _destroy(PersistState *self)
     close(self->fd);
   if (self->current_map)
     munmap(self->current_map, self->current_size);
+  unlink(self->temp_filename);
 
   g_mutex_free(self->mapped_lock);
   g_cond_free(self->mapped_release_cond);

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -80,6 +80,3 @@ tests_unit_test_persist_state_LDADD	= \
 tests_unit_test_value_pairs_LDADD	= \
 	$(TEST_LDADD) $(unit_test_extra_modules)
 
-CLEANFILES				+= \
-	test_values.persist		   \
-	test_values.persist-

--- a/tests/unit/test_persist_state.c
+++ b/tests/unit/test_persist_state.c
@@ -124,6 +124,33 @@ test_values(void)
   cancel_and_destroy_persist_state(state);
 }
 
+void
+test_persist_state_temp_file_cleanup_on_cancel()
+{
+  PersistState *state = clean_and_create_persist_state_for_test("test_persist_state_temp_file_cleanup_on_cancel.persist");
+
+  cancel_and_destroy_persist_state(state);
+
+  assert_true(access("test_persist_state_temp_file_cleanup_on_cancel.persist", F_OK) != 0,
+              "persist file is removed on destroy()");
+  assert_true(access("test_persist_state_temp_file_cleanup_on_cancel.persist-", F_OK) != 0,
+              "backup persist file is removed on destroy()");
+}
+
+void
+test_persist_state_temp_file_cleanup_on_commit_destroy()
+{
+  PersistState *state = clean_and_create_persist_state_for_test("test_persist_state_temp_file_cleanup_on_commit_destroy.persist");
+
+  commit_and_destroy_persist_state(state);
+
+  assert_true(access("test_persist_state_temp_file_cleanup_on_commit_destroy.persist", F_OK) != 0,
+              "persist file is removed on destroy(), even after commit");
+  assert_true(access("test_persist_state_temp_file_cleanup_on_commit_destroy.persist-", F_OK) != 0,
+              "backup persist file is removed on destroy(), even after commit");
+}
+
+
 int
 main(int argc, char *argv[])
 {
@@ -133,6 +160,8 @@ main(int argc, char *argv[])
   app_startup();
   test_values();
   test_persist_state_remove_entry();
+  test_persist_state_temp_file_cleanup_on_cancel();
+  test_persist_state_temp_file_cleanup_on_commit_destroy();
 
   return 0;
 }


### PR DESCRIPTION
When destroying a persist state, unlink the temporary file too, as to
not leave junk behind. Added test cases for both the commit() +
destroy() and the cancel() + destroy() cases. With this fixed, the
persist files created during make check need not be in CLEANFILES.

Signed-off-by: Gergely Nagy algernon@balabit.hu
