### PR TITLE
Makefile: Fix make dist in certain edge cases

### DIFF
--- a/modules/afamqp/Makefile.am
+++ b/modules/afamqp/Makefile.am
@@ -3,6 +3,8 @@ DIST_SUBDIRS				+= modules/afamqp/rabbitmq-c
 CLEAN_SUBDIRS 				+= @LIBRABBITMQ_SUBDIRS@
 
 if ENABLE_AMQP
+AMQP_DUMMY_C_DEPS			 =	\
+	modules/afamqp/rabbitmq-c/librabbitmq/librabbitmq.la
 module_LTLIBRARIES			+= modules/afamqp/libafamqp.la
 
 modules_afamqp_libafamqp_la_CFLAGS	= 	\
@@ -24,11 +26,6 @@ modules_afamqp_libafamqp_la_DEPENDENCIES=	\
 	$(MODULE_DEPS_LIBS)			\
 	modules/afamqp/rabbitmq-c/librabbitmq/librabbitmq.la
 
-BUILT_SOURCES				+=	\
-		modules/afamqp/dummy.c
-
-modules/afamqp/dummy.c: modules/afamqp/rabbitmq-c/librabbitmq/librabbitmq.la
-	$(AM_V_GEN) touch $@
 modules/afamqp/rabbitmq-c/librabbitmq/librabbitmq.la:
 	${MAKE} -C modules/afamqp/rabbitmq-c
 modules/afamqp modules/afamqp/ mod-afamqp mod-amqp: \
@@ -37,10 +34,14 @@ else
 modules/afamqp modules/afamqp/ mod-afamqp mod-amqp:
 endif
 
+modules/afamqp/dummy.c: ${AMQP_DUMMY_C_DEPS}
+	$(AM_V_GEN) touch $@
+
 BUILT_SOURCES				+=	\
 		modules/afamqp/afamqp-grammar.y \
 		modules/afamqp/afamqp-grammar.c \
-		modules/afamqp/afamqp-grammar.h
+		modules/afamqp/afamqp-grammar.h \
+		modules/afamqp/dummy.c
 
 EXTRA_DIST				+=	\
 		modules/afamqp/afamqp-grammar.ym \

--- a/modules/afmongodb/Makefile.am
+++ b/modules/afmongodb/Makefile.am
@@ -2,11 +2,8 @@ DIST_SUBDIRS 					+= modules/afmongodb/libmongo-client
 
 if LIBMONGO_INTERNAL
 CLEAN_SUBDIRS					+= @LIBMONGO_SUBDIRS@
-DUMMY_C						= modules/afmongodb/dummy.c
 lmc_EXTRA_DEPS					= modules/afmongodb/libmongo-client/src/libmongo-client.la
 
-modules/afmongodb/dummy.c: modules/afmongodb/libmongo-client/src/libmongo-client.la
-	$(AM_V_GEN) touch $@
 modules/afmongodb/libmongo-client/src/libmongo-client.la:
 	${MAKE} -C modules/afmongodb/libmongo-client
 endif
@@ -39,11 +36,14 @@ else
 modules/afmongodb modules/afmongodb/ mod-afmongodb mod-mongodb:
 endif
 
+modules/afmongodb/dummy.c: ${lmc_EXTRA_DEPS}
+	$(AM_V_GEN) touch $@
+
 BUILT_SOURCES					+=	\
 	modules/afmongodb/afmongodb-grammar.y		\
 	modules/afmongodb/afmongodb-grammar.c		\
 	modules/afmongodb/afmongodb-grammar.h		\
-	${DUMMY_C}
+	modules/afmongodb/dummy.c
 EXTRA_DIST					+=	\
 	modules/afmongodb/afmongodb-grammar.ym		\
 	modules/afmongodb/libmongo-client/configure.gnu


### PR DESCRIPTION
Due to the way internal modules were built, if both mongodb and
libmongo-client was disabled, make dist failed. When amqp was explicitly
disabled, make dist failed.

The reason being, we use a dummy.c to trigger building the bundled
libraries, but the dummy.c files were not created if mongodb/amqp were
disabled. Now we create them anyway, just don't recurse into the
directory when the module is disabled.

Signed-off-by: Gergely Nagy algernon@balabit.hu
