### PR TITLE
pathutils: Fixed pathutils functions.

### DIFF
--- a/lib/pathutils.c
+++ b/lib/pathutils.c
@@ -28,11 +28,11 @@
 gboolean
 is_file_directory(const char *filename)
 {
-  return g_file_test(filename, G_FILE_TEST_EXISTS | G_FILE_TEST_IS_DIR);
+  return g_file_test(filename, G_FILE_TEST_EXISTS) && g_file_test(filename, G_FILE_TEST_IS_DIR);
 };
 
 gboolean
 is_file_regular(const char *filename)
 {
-  return g_file_test(filename, G_FILE_TEST_EXISTS | G_FILE_TEST_IS_REGULAR);
+  return g_file_test(filename, G_FILE_TEST_EXISTS) && g_file_test(filename, G_FILE_TEST_IS_REGULAR);
 };

--- a/lib/tests/Makefile.am
+++ b/lib/tests/Makefile.am
@@ -10,7 +10,8 @@ lib_tests_TESTS		= \
 	lib/tests/test_rcptid		\
 	lib/tests/test_lexer        \
 	lib/tests/test_str_format   \
-	lib/tests/test_runid
+	lib/tests/test_runid        \
+	lib/tests/test_pathutils
 
 check_PROGRAMS		+= ${lib_tests_TESTS}
 
@@ -79,6 +80,11 @@ lib_tests_test_runid_LDADD	=	\
 lib_tests_test_str_format_CFLAGS	=	\
 	$(TEST_CFLAGS)
 lib_tests_test_str_format_LDADD	=	\
+	$(TEST_LDADD)
+
+lib_tests_test_pathutils_CFLAGS	=	\
+	$(TEST_CFLAGS)
+lib_tests_test_pathutils_LDADD	=	\
 	$(TEST_LDADD)
 
 CLEANFILES				+= \

--- a/lib/tests/test_pathutils.c
+++ b/lib/tests/test_pathutils.c
@@ -1,0 +1,24 @@
+#include "pathutils.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include "libtest/testutils.h"
+#include <unistd.h>
+
+void
+test_is_directory_return_false_in_case_of_regular_file(void)
+{
+  int fd = open("test.file", O_CREAT, 0644);
+  write(fd, "a", 1);
+  close(fd);
+
+  assert_false(is_file_directory("test.file"), "File is not a directory!");
+
+  unlink("test.file");
+}
+
+int
+main()
+{
+  test_is_directory_return_false_in_case_of_regular_file();
+}


### PR DESCRIPTION
g_file_test flags has an "or" relation instead of the incorrectly
assumed "and" relation. Wrote a unittest, too.
