### PR TITLE
str-format: Fixed format_hex_string_with_delimiter.

### DIFF
--- a/lib/str-format.c
+++ b/lib/str-format.c
@@ -228,7 +228,7 @@ format_hex_string_with_delimiter(gpointer data, gsize data_len, gchar *result, g
   gint pos = 0;
   guchar *str = (guchar *) data;
 
-  for (i = 0; i < data_len && result_len - pos >= 2; i++)
+  for (i = 0; i < data_len && result_len - pos >= 3; i++)
     {
       if ( (delimiter != 0) && (i < data_len - 1))
       {

--- a/lib/tests/test_str_format.c
+++ b/lib/tests/test_str_format.c
@@ -3,8 +3,8 @@
 
 void test_format_hex_string__single_byte__perfect()
 {
-   gchar expected_output[2] = "40";
-   gchar output[2];
+   gchar expected_output[3] = "40";
+   gchar output[3];
    gchar input[1] = "@";
    //Act
    format_hex_string(input, sizeof(input), output, sizeof(output));
@@ -14,8 +14,8 @@ void test_format_hex_string__single_byte__perfect()
 
 void test_format_hex_string__two_bytes__perfect()
 {
-   gchar expected_output[4] = "4041";
-   gchar output[4];
+   gchar expected_output[5] = "4041";
+   gchar output[5];
    gchar input[2] = "@A";
    //Act
    format_hex_string(input, sizeof(input), output, sizeof(output));
@@ -25,8 +25,8 @@ void test_format_hex_string__two_bytes__perfect()
 
 void test_format_hex_string_with_delimiter__single_byte__perfect()
 {
-   gchar expected_output[2] = "40";
-   gchar output[2];
+   gchar expected_output[3] = "40";
+   gchar output[3];
    gchar input[1] = "@";
    //Act
    format_hex_string_with_delimiter(input, sizeof(input), output, sizeof(output), ' ');
@@ -36,8 +36,8 @@ void test_format_hex_string_with_delimiter__single_byte__perfect()
 
 void test_format_hex_string_with_delimiter__two_bytes__perfect()
 {
-   gchar expected_output[5] = "40 41";
-   gchar output[5];
+   gchar expected_output[6] = "40 41";
+   gchar output[6];
    gchar input[2] = "@A";
    //Act
    format_hex_string_with_delimiter(input, sizeof(input), output, sizeof(output), ' ');


### PR DESCRIPTION
g_snprintf adds a terminating NULL character, which was not considered.
We need more space for this extra character, so the result length
check should also be tweaked.

Signed-off-by: Viktor Tusa tusa@balabit.hu
