### PR TITLE
json-parser: Fix cloning when no marker is set

### DIFF
--- a/modules/json/json-parser.c
+++ b/modules/json/json-parser.c
@@ -246,7 +246,8 @@ json_parser_clone(LogPipe *s)
 
   cloned = json_parser_new(s->cfg);
   json_parser_set_prefix(cloned, self->prefix);
-  json_parser_set_marker(cloned, self->marker);
+  if (self->marker)
+    json_parser_set_marker(cloned, self->marker);
   json_parser_set_extract_prefix(cloned, self->extract_prefix);
 
   return &cloned->super;


### PR DESCRIPTION
When cloning a json-parser, only clone the marker if it is set in the
original, otherwise we may end up crashing trying to strlen(NULL).

Reported-by: Fabien Wernli bugzilla.balabit@faxm0dem.org
Signed-off-by: Gergely Nagy algernon@balabit.hu
