### PR TITLE
tfgeoip: Handle the failed lookup case gracefully

### DIFF
--- a/modules/tfgeoip/tfgeoip.c
+++ b/modules/tfgeoip/tfgeoip.c
@@ -68,7 +68,8 @@ tf_geoip(LogMessage *msg, gint argc, GString *argv[], GString *result)
     }
 
   country = GeoIP_country_code_by_name(local_state->gi, argv[0]->str);
-  g_string_append(result, country);
+  if (country)
+    g_string_append(result, country);
 
   return TRUE;
 }


### PR DESCRIPTION
When a GeoIP lookup fails, do not try to use the result, as trying to
append NULL to a GString results in a GLib warning, which is not nice.

Reported-by: Fabien Wernli
Signed-off-by: Gergely Nagy algernon@balabit.hu
