### PR TITLE
system(): Don't use /dev/klog in a FreeBSD jail

### DIFF
--- a/modules/system-source/system-source.c
+++ b/modules/system-source/system-source.c
@@ -41,6 +41,11 @@
 #include <systemd/sd-daemon.h>
 #endif
 
+#if __FreeBSD__
+#include <sys/sysctl.h>
+#include <inttypes.h>
+#endif
+
 static void
 system_sysblock_add_unix_dgram_driver(GString *sysblock, const gchar *path,
                                       const gchar *perms, const gchar *recvbuf_size)
@@ -113,6 +118,27 @@ system_sysblock_add_pipe(GString *sysblock, const gchar *path, gint pad_size)
     g_string_append_printf(sysblock, " pad_size(%d)", pad_size);
   g_string_append(sysblock, ");\n");
 }
+
+#if __FreeBSD__
+static gboolean
+system_freebsd_is_jailed(void)
+{
+  int r;
+  int32_t is_jailed;
+  size_t len = 4;
+
+  r = sysctlbyname("security.jail.jailed", &is_jailed, &len, NULL, 0);
+  if (r != 0)
+    return FALSE;
+  return !!is_jailed;
+}
+#else
+static gboolean
+system_freebsd_is_jailed(void)
+{
+  return FALSE;
+}
+#endif
 
 static void
 system_sysblock_add_freebsd_klog(GString *sysblock, const gchar *release)
@@ -265,7 +291,8 @@ system_generate_system(CfgLexer *lexer, gint type, const gchar *name,
       system_sysblock_add_unix_dgram(sysblock, "/var/run/log", NULL, NULL);
       system_sysblock_add_unix_dgram(sysblock, "/var/run/logpriv", "0600", NULL);
 
-      system_sysblock_add_freebsd_klog(sysblock, u.release);
+      if (!system_freebsd_is_jailed())
+        system_sysblock_add_freebsd_klog(sysblock, u.release);
     }
   else if (strcmp(u.sysname, "GNU/kFreeBSD") == 0)
     {


### PR DESCRIPTION
When figuring out what to expand system() to, check whether we're in a
jail when running on FreeBSD, and don't include /dev/klog if we are.
This fixes #93.

Signed-off-by: Gergely Nagy algernon@balabit.hu
