### PR TITLE
syslog-ng.pc.in: Add scldir and datarootdir

### DIFF
--- a/syslog-ng.pc.in
+++ b/syslog-ng.pc.in
@@ -5,6 +5,8 @@ libdir=@libdir@
 includedir=@includedir@
 toolsdir=@datadir@/tools
 moduledir=@expanded_moduledir@
+scldir=@datadir@/include/scl
+datarootdir=@datarootdir@
 
 Name: syslog-ng-dev
 Description: Dev package for syslog-ng module


### PR DESCRIPTION
The former is primarily for syslog-ng-incubator, the latter is to
silence config.status and for correctness' sake.

Signed-off-by: Gergely Nagy algernon@balabit.hu
