### PR TITLE
value-pairs: Get rid of magic casting that breaks strict aliasing

### DIFF
--- a/lib/value-pairs.c
+++ b/lib/value-pairs.c
@@ -407,6 +407,7 @@ vp_walker_stack_unwind_until (vp_walk_stack_t **stack, vp_walk_state_t *state,
                               const gchar *name)
 {
   vp_walk_stack_t *t;
+  GTrashStack *tstack = (GTrashStack *)&((*stack)->stackp);
 
   if (!stack)
     return NULL;
@@ -415,11 +416,11 @@ vp_walker_stack_unwind_until (vp_walk_stack_t **stack, vp_walk_state_t *state,
   if (strncmp(name, (*stack)->prefix, (*stack)->prefix_len) == 0)
     return *stack;
 
-  while ((t = g_trash_stack_pop((GTrashStack **)stack)) != NULL)
+  while ((t = g_trash_stack_pop((GTrashStack **)&tstack)) != NULL)
     {
       if (strncmp(name, t->prefix, t->prefix_len) != 0)
         {
-          vp_walk_stack_t *p = g_trash_stack_peek((GTrashStack **)stack);
+          vp_walk_stack_t *p = g_trash_stack_peek((GTrashStack **)&tstack);
 
           if (p)
             state->obj_end(t->key, t->prefix, &t->data,
@@ -436,7 +437,7 @@ vp_walker_stack_unwind_until (vp_walk_stack_t **stack, vp_walk_state_t *state,
       else
         {
           /* This one matched, put it back, PUT IT BACK! */
-          g_trash_stack_push((GTrashStack **)stack, t);
+          g_trash_stack_push((GTrashStack **)&tstack, t);
           break;
         }
     }
@@ -449,10 +450,11 @@ vp_walker_stack_unwind_all(vp_walk_stack_t **stack,
                            vp_walk_state_t *state)
 {
   vp_walk_stack_t *t;
+  GTrashStack *tstack = (GTrashStack *)&((*stack)->stackp);
 
-  while ((t = g_trash_stack_pop((GTrashStack **)stack)) != NULL)
+  while ((t = g_trash_stack_pop((GTrashStack **)&tstack)) != NULL)
     {
-      vp_walk_stack_t *p = g_trash_stack_peek((GTrashStack **)stack);
+      vp_walk_stack_t *p = g_trash_stack_peek((GTrashStack **)&tstack);
 
       if (p)
         state->obj_end(t->key, t->prefix, &t->data,
@@ -474,13 +476,14 @@ vp_walker_stack_push (vp_walk_stack_t **stack,
                       gchar *key, gchar *prefix)
 {
   vp_walk_stack_t *nt = g_new(vp_walk_stack_t, 1);
+  GTrashStack *tstack = (GTrashStack *)&((*stack)->stackp);
 
   nt->key = key;
   nt->prefix = prefix;
   nt->prefix_len = strlen(nt->prefix);
   nt->data = NULL;
 
-  g_trash_stack_push((GTrashStack **)stack, nt);
+  g_trash_stack_push((GTrashStack **)&tstack, nt);
   return nt;
 }
 


### PR DESCRIPTION
We used to cast custom pointers to GTrashStack**, which broke strict
aliasing in certain scenarios, leading to pretty much unpredictable
behaviour. That behaviour manifested itself in a live-lock. With this
patch, the intent does not change, but strict aliasing is not broken
either.

Reported-by: Fabien Wernli bugzilla.balabit@faxm0dem.org
Signed-off-by: Gergely Nagy algernon@balabit.hu
