### PR TITLE
afmongodb: Mark host() and port() obsolete

### DIFF
--- a/modules/afmongodb/afmongodb-parser.c
+++ b/modules/afmongodb/afmongodb-parser.c
@@ -36,8 +36,8 @@ static CfgLexerKeyword afmongodb_keywords[] = {
   { "username",			KW_USERNAME },
   { "password",			KW_PASSWORD },
   { "safe_mode",		KW_SAFE_MODE },
-  { "host",                     KW_HOST },
-  { "port",                     KW_PORT },
+  { "host",                     KW_HOST, 0, KWS_OBSOLETE, "Use the servers() option instead of host() and port()" },
+  { "port",                     KW_PORT, 0, KWS_OBSOLETE, "Use the servers() option instead of host() and port()" },
   { "path",                     KW_PATH },
   { NULL }
 };


### PR DESCRIPTION
The host() and port() options should have been marked obsolete a while
ago, fix that now, and suggest using servers() instead. This fixes #92.

Reported-by: Andras Mitzki micek@balabit.hu
Signed-off-by: Gergely Nagy algernon@madhouse-project.org
