### PR TITLE
afamqp: Make the username() and password() options mandatory

### DIFF
--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -497,6 +497,14 @@ afamqp_dd_init(LogPipe *s)
   if (!log_dest_driver_init_method(s))
     return FALSE;
 
+  if (!self->user || !self->password)
+    {
+      msg_error("Error initializing AMQP destination: username and password MUST be set!",
+                evt_tag_str("driver", self->super.super.super.id),
+                NULL);
+      return FALSE;
+    }
+
   log_template_options_init(&self->template_options, cfg);
 
   msg_verbose("Initializing AMQP destination",


### PR DESCRIPTION
For the destination to work, we need both username() and password()
supplied, otherwise the underlying library will crash. If either of
those is unset, fail the driver initialization. This fixes #80.

Signed-off-by: Gergely Nagy algernon@balabit.hu
