### PR TITLE
basicfuncs: Handle empty environment variables when using $(env)

### DIFF
--- a/modules/basicfuncs/misc-funcs.c
+++ b/modules/basicfuncs/misc-funcs.c
@@ -51,7 +51,12 @@ tf_env(LogMessage *msg, gint argc, GString *argv[], GString *result)
 
   for (i = 0; i < argc; i++)
     {
-      g_string_append(result, getenv(argv[i]->str));
+      char *val = getenv(argv[i]->str);
+
+      if (!val)
+        continue;
+
+      g_string_append(result, val);
       if (i < argc - 1)
         g_string_append_c(result, ' ');
     }


### PR DESCRIPTION
When using the $(env) template function, if the environment variable is
empty or non-existent, don't try to add a NULL string to the result.
This fixes a Glib warning, which, under some cases, would turn into a
crash. (Fixes BugZilla#277)

Reported-by: Nick Alcock nix@esperi.org.uk
Signed-off-by: Gergely Nagy algernon@madhouse-project.org
