### PR TITLE
patterndb: Fix test_patterndb crash when testing outside-of-rule db look...

### DIFF
--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -69,8 +69,12 @@ create_pattern_db(gchar *pdb)
 void
 clean_pattern_db(void)
 {
-  g_ptr_array_foreach(messages, (GFunc) log_msg_unref, NULL);
-  g_ptr_array_free(messages, TRUE);
+  if (messages)
+    {
+      g_ptr_array_foreach(messages, (GFunc) log_msg_unref, NULL);
+      g_ptr_array_free(messages, TRUE);
+    }
+  messages = NULL;
   pattern_db_free(patterndb);
   patterndb = NULL;
 


### PR DESCRIPTION
...ups.

First test_patterndb_tags_outside_of_rule() nulls out the messages pointer,
then it calls clean_pattern_db(), which unconditionally dereferences it.

This will never work.

Guard the use of messages in clean_pattern_db() with a nullity check.

Signed-off-by: Nick Alcock nix@esperi.org.uk
