### PR TITLE
F/facility range

### DIFF
--- a/lib/filter/filter-expr-grammar.ym
+++ b/lib/filter/filter-expr-grammar.ym
@@ -267,14 +267,17 @@ filter_fac_list
 	;
 
 filter_fac
-        : facility_string			{ $$ = 1 << ($1 >> 3); }
+	: facility_string LL_DOTDOT facility_string
+	  {
+	    $$ = syslog_make_range($1 >> 3, $3 >> 3);
+	  }
+        | facility_string			{ $$ = 1 << ($1 >> 3); }
 	;
 
 filter_level_list
 	: filter_level filter_level_list	{ $$ = $1 | $2; }
 	| filter_level				{ $$ = $1; }
 	;
-
 
 filter_level
 	: level_string LL_DOTDOT level_string


### PR DESCRIPTION
This branch implements range support in the facility filter, like that:

facility(local0..local6)

This actually fixes a docbug by implementing it, although only the example uses the previously unsupported syntax, the general description is O.K. Here is the documentation link:

https://www.balabit.com/sites/default/files/documents/syslog-ng-ose-3.3-guides/en/syslog-ng-ose-v3.3-guide-admin-en/html/reference_filters.html#filter-facility
