### PR TITLE
plugin.c: Use G_MODULE_BIND_LAZY instead of G_MODULE_BIND_LOCAL

### DIFF
--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -309,7 +309,7 @@ plugin_dlopen_module(const gchar *module_name, const gchar *module_path)
             evt_tag_str("filename", plugin_module_name),
             NULL);
 
-  mod = g_module_open(plugin_module_name, G_MODULE_BIND_LOCAL);
+  mod = g_module_open(plugin_module_name, G_MODULE_BIND_LAZY);
   g_free(plugin_module_name);
   if (!mod)
     {


### PR DESCRIPTION
When we have a situation where we load a syslog-ng module, linked
against a certain library, and that module tries to load a plugin that
requires the library the module is linked against, but the plugin isn't,
using BIND_LOCAL will result in symbol lookup errors. Not using it will
correctly resolve the symbols previously loaded.

This is needed to be able to load Lua, Perl, etc modules.

On some exotic platforms (like AIX), where the linker tends to act
strangely, this may cause problems. If it does, we should likely use
BIND_LOCAL there.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
