### PR TITLE
logproto: Added suffix based multiline mode.

### DIFF
--- a/lib/logproto/logproto-regexp-multiline-server.c
+++ b/lib/logproto/logproto-regexp-multiline-server.c
@@ -23,29 +23,47 @@
 
 #include <string.h>
 
-static gint
-_find_regexp(regex_t *re, const guchar *str, gsize len)
+static int
+_find_regexp(regex_t *re, const guchar *str, gsize len, regmatch_t *matches, gint matches_num)
 {
   gint rc;
   gchar *buf;
-  regmatch_t matches[1];
 
   if (!re)
     return -1;
 
   APPEND_ZERO(buf, str, len);
-  rc = regexec(re, buf, sizeof(matches) / sizeof(matches[0]), matches, 0);
-  if (rc == 0)
-    return matches[0].rm_so;
-  return -1;
-
+  rc = regexec(re, buf, matches_num, matches, 0);
+  return rc;
 }
 
 static gboolean
 _regexp_matches(regex_t *re, const guchar *str, gsize len)
 {
-  return _find_regexp(re, str, len) >= 0;
+  regmatch_t match;
+  if (_find_regexp(re, str, len, &match, 1) != 0)
+    return FALSE;
+  return match.rm_so >= 0;
 }
+
+gint
+log_proto_prefix_garbage_multiline_get_offset_of_garbage(LogProtoREMultiLineServer *self, const guchar* line, gsize line_len)
+{
+  regmatch_t match;
+  if (_find_regexp(self->garbage, line, line_len, &match, 1) != 0)
+    return -1;
+  return match.rm_so;
+};
+
+gint
+log_proto_prefix_suffix_multiline_get_offset_of_garbage(LogProtoREMultiLineServer *self, const guchar* line, gsize line_len)
+{
+  regmatch_t match;
+  if (_find_regexp(self->garbage, line, line_len, &match, 1) != 0)
+    return -1;
+  return match.rm_eo;
+};
+
 
 static gint
 _accumulate_initial_line(LogProtoREMultiLineServer *self,
@@ -53,9 +71,7 @@ _accumulate_initial_line(LogProtoREMultiLineServer *self,
                                                    gsize line_len,
                                                    gssize consumed_len)
 {
-  gint offset_of_garbage;
-
-  offset_of_garbage = _find_regexp(self->garbage, line, line_len);
+  gint offset_of_garbage = self->get_offset_of_garbage(self, line, line_len);
   if (offset_of_garbage >= 0)
     return LPT_CONSUME_PARTIALLY(line_len - offset_of_garbage) | LPT_EXTRACTED;
   else
@@ -69,9 +85,7 @@ _accumulate_continuation_line(LogProtoREMultiLineServer *self,
                                                         gsize line_len,
                                                         gssize consumed_len)
 {
-  gint offset_of_garbage;
-
-  offset_of_garbage = _find_regexp(self->garbage, line, line_len);
+  gint offset_of_garbage = self->get_offset_of_garbage(self, line, line_len);
   if (offset_of_garbage >= 0)
     return LPT_CONSUME_PARTIALLY(line_len - offset_of_garbage) | LPT_EXTRACTED;
   else if (_regexp_matches(self->prefix, line, line_len))
@@ -125,16 +139,16 @@ log_proto_regexp_multiline_server_init(LogProtoREMultiLineServer *self,
                                        LogTransport *transport,
                                        const LogProtoServerOptions *options,
                                        regex_t *prefix,
-                                       regex_t *garbage)
+                                       regex_t *garbage_or_suffix)
 {
   log_proto_text_server_init(&self->super, transport, options);
   self->super.accumulate_line = log_proto_regexp_multiline_accumulate_line;
   self->prefix = prefix;
-  self->garbage = garbage;
+  self->garbage = garbage_or_suffix;
 }
 
 LogProtoServer *
-log_proto_regexp_multiline_server_new(LogTransport *transport,
+log_proto_prefix_garbage_multiline_server_new(LogTransport *transport,
                                       const LogProtoServerOptions *options,
                                       regex_t *prefix,
                                       regex_t *garbage)
@@ -142,5 +156,19 @@ log_proto_regexp_multiline_server_new(LogTransport *transport,
   LogProtoREMultiLineServer *self = g_new0(LogProtoREMultiLineServer, 1);
 
   log_proto_regexp_multiline_server_init(self, transport, options, prefix, garbage);
+  self->get_offset_of_garbage = log_proto_prefix_garbage_multiline_get_offset_of_garbage;
+  return &self->super.super.super;
+}
+
+LogProtoServer *
+log_proto_prefix_suffix_multiline_server_new(LogTransport *transport,
+                                      const LogProtoServerOptions *options,
+                                      regex_t *prefix,
+                                      regex_t *suffix)
+{
+  LogProtoREMultiLineServer *self = g_new0(LogProtoREMultiLineServer, 1);
+
+  log_proto_regexp_multiline_server_init(self, transport, options, prefix, suffix);
+  self->get_offset_of_garbage = log_proto_prefix_suffix_multiline_get_offset_of_garbage;
   return &self->super.super.super;
 }

--- a/lib/logproto/logproto-regexp-multiline-server.h
+++ b/lib/logproto/logproto-regexp-multiline-server.h
@@ -31,6 +31,7 @@ struct _LogProtoREMultiLineServer
   /* these are borrowed */
   regex_t *prefix;
   regex_t *garbage;
+  gint (*get_offset_of_garbage)(LogProtoREMultiLineServer *self, const guchar* line, gsize line_len);
 };
 
 /* LogProtoREMultiLineServer
@@ -40,14 +41,19 @@ struct _LogProtoREMultiLineServer
  * zero or more lines starting with whitespace. A record is terminated
  * when we reach a line that starts with non-whitespace, or EOF.
  */
-LogProtoServer *log_proto_regexp_multiline_server_new(LogTransport *transport,
+LogProtoServer *log_proto_prefix_garbage_multiline_server_new(LogTransport *transport,
                                                       const LogProtoServerOptions *options,
                                                       regex_t *prefix,
                                                       regex_t *garbage);
+LogProtoServer *log_proto_prefix_suffix_multiline_server_new(LogTransport *transport,
+                                                      const LogProtoServerOptions *options,
+                                                      regex_t *prefix,
+                                                      regex_t *suffix);
+
 void log_proto_regexp_multiline_server_init(LogProtoREMultiLineServer *self,
                                             LogTransport *transport,
                                             const LogProtoServerOptions *options,
                                             regex_t *prefix,
-                                            regex_t *garbage);
+                                            regex_t *garbage_or_suffix);
 
 #endif

--- a/lib/logproto/tests/test-regexp-multiline-server.c
+++ b/lib/logproto/tests/test-regexp-multiline-server.c
@@ -22,7 +22,7 @@ test_lines_separated_with_prefix(gboolean input_is_stream)
 {
   LogProtoServer *proto;
 
-  proto = log_proto_regexp_multiline_server_new(
+  proto = log_proto_prefix_garbage_multiline_server_new(
             /* 32 bytes max line length, which means that the complete
              * multi-line block plus one additional line must fit into 32
              * bytes. */
@@ -51,7 +51,7 @@ test_lines_separated_with_prefix_and_garbage(gboolean input_is_stream)
 {
   LogProtoServer *proto;
 
-  proto = log_proto_regexp_multiline_server_new(
+  proto = log_proto_prefix_garbage_multiline_server_new(
             /* 32 bytes max line length, which means that the complete
              * multi-line block plus one additional line must fit into 32
              * bytes. */
@@ -76,11 +76,38 @@ test_lines_separated_with_prefix_and_garbage(gboolean input_is_stream)
 }
 
 static void
+test_lines_separated_with_prefix_and_suffix(gboolean input_is_stream)
+{
+  LogProtoServer *proto;
+
+  proto = log_proto_prefix_suffix_multiline_server_new(
+            /* 32 bytes max line length, which means that the complete
+             * multi-line block plus one additional line must fit into 32
+             * bytes. */
+            (0 && input_is_stream ? log_transport_mock_stream_new : log_transport_mock_records_new)(
+              "prefix first suffix garbage\n"
+              "prefix multi\n"
+              "suffix garbage\n"
+              "prefix final\n", -1,
+              LTM_PADDING,
+              LTM_EOF),
+            get_inited_proto_server_options(),
+            compile_regex("^prefix"), compile_regex("suffix"));
+
+  assert_proto_server_fetch(proto, "prefix first suffix", -1);
+  assert_proto_server_fetch(proto, "prefix multi\nsuffix", -1);
+
+  log_proto_server_free(proto);
+
+};
+
+
+static void
 test_lines_separated_with_garbage(gboolean input_is_stream)
 {
   LogProtoServer *proto;
 
-  proto = log_proto_regexp_multiline_server_new(
+  proto = log_proto_prefix_garbage_multiline_server_new(
             /* 32 bytes max line length, which means that the complete
              * multi-line block plus one additional line must fit into 32
              * bytes. */
@@ -109,7 +136,7 @@ test_first_line_without_prefix(gboolean input_is_stream)
 {
   LogProtoServer *proto;
 
-  proto = log_proto_regexp_multiline_server_new(
+  proto = log_proto_prefix_garbage_multiline_server_new(
             /* 32 bytes max line length, which means that the complete
              * multi-line block plus one additional line must fit into 32
              * bytes. */
@@ -143,7 +170,7 @@ test_input_starts_with_continuation(gboolean input_is_stream)
 
   proto_server_options.max_msg_size = 32;
 
-  proto = log_proto_regexp_multiline_server_new(
+  proto = log_proto_prefix_garbage_multiline_server_new(
             /* 32 bytes max line length */
             (input_is_stream ? log_transport_mock_stream_new : log_transport_mock_records_new)
             (
@@ -167,7 +194,7 @@ test_multiline_at_eof(gboolean input_is_stream)
 
   proto_server_options.max_msg_size = 32;
 
-  proto = log_proto_regexp_multiline_server_new(
+  proto = log_proto_prefix_garbage_multiline_server_new(
             /* 32 bytes max line length */
             (input_is_stream ? log_transport_mock_stream_new : log_transport_mock_records_new)
             (
@@ -193,6 +220,8 @@ test_log_proto_regexp_multiline_server(void)
   PROTO_TESTCASE(test_lines_separated_with_prefix, TRUE);
   PROTO_TESTCASE(test_lines_separated_with_prefix_and_garbage, FALSE);
   PROTO_TESTCASE(test_lines_separated_with_prefix_and_garbage, TRUE);
+  PROTO_TESTCASE(test_lines_separated_with_prefix_and_suffix, FALSE);
+  PROTO_TESTCASE(test_lines_separated_with_prefix_and_suffix, TRUE);
   PROTO_TESTCASE(test_lines_separated_with_garbage, FALSE);
   PROTO_TESTCASE(test_lines_separated_with_garbage, TRUE);
   PROTO_TESTCASE(test_first_line_without_prefix, FALSE);

--- a/modules/affile/affile-parser.c
+++ b/modules/affile/affile-parser.c
@@ -40,7 +40,8 @@ static CfgLexerKeyword affile_keywords[] = {
   { "follow_freq",        KW_FOLLOW_FREQ,  },
   { "multi_line_mode",    KW_MULTI_LINE_MODE, 0x0305  },
   { "multi_line_prefix",  KW_MULTI_LINE_PREFIX, 0x0305 },
-  { "multi_line_garbage", KW_MULTI_LINE_PREFIX, 0x0305 },
+  { "multi_line_garbage", KW_MULTI_LINE_GARBAGE, 0x0305 },
+  { "multi_line_suffix",  KW_MULTI_LINE_GARBAGE, 0x0305 },
   { NULL }
 };
 

--- a/modules/affile/affile-source.c
+++ b/modules/affile/affile-source.c
@@ -55,7 +55,11 @@ affile_sd_set_multi_line_mode(LogDriver *s, const gchar *mode)
   if (strcasecmp(mode, "indented") == 0)
     self->multi_line_mode = MLM_INDENTED;
   else if (strcasecmp(mode, "regexp") == 0)
-    self->multi_line_mode = MLM_REGEXP;
+    self->multi_line_mode = MLM_PREFIX_GARBAGE;
+  else if (strcasecmp(mode, "prefix-garbage") == 0)
+    self->multi_line_mode = MLM_PREFIX_GARBAGE;
+  else if (strcasecmp(mode, "prefix-suffix") == 0)
+    self->multi_line_mode = MLM_PREFIX_SUFFIX;
   else if (strcasecmp(mode, "none") == 0)
     self->multi_line_mode = MLM_NONE;
   else
@@ -253,8 +257,10 @@ affile_sd_construct_proto(AFFileSourceDriver *self, gint fd)
         {
         case MLM_INDENTED:
           return log_proto_indented_multiline_server_new(transport, proto_options);
-        case MLM_REGEXP:
-          return log_proto_regexp_multiline_server_new(transport, proto_options, self->multi_line_prefix, self->multi_line_garbage);
+        case MLM_PREFIX_GARBAGE:
+          return log_proto_prefix_garbage_multiline_server_new(transport, proto_options, self->multi_line_prefix, self->multi_line_garbage);
+        case MLM_PREFIX_SUFFIX:
+          return log_proto_prefix_suffix_multiline_server_new(transport, proto_options, self->multi_line_prefix, self->multi_line_garbage);
         default:
           return log_proto_text_server_new(transport, proto_options);
         }
@@ -350,10 +356,9 @@ affile_sd_init(LogPipe *s)
 
   log_reader_options_init(&self->reader_options, cfg, self->super.super.group);
 
-  if (self->multi_line_mode != MLM_REGEXP && (self->multi_line_prefix || self->multi_line_garbage))
+  if ((self->multi_line_mode != MLM_PREFIX_GARBAGE && self->multi_line_mode != MLM_PREFIX_SUFFIX ) && (self->multi_line_prefix || self->multi_line_garbage))
     {
-      msg_error("multi-line-prefix() and/or multi-line-garbage() specified but multi-line-mode() is not 'regexp', please set multi-line-mode() properly",
-                NULL);
+      msg_error("multi-line-prefix() and/or multi-line-garbage() specified but multi-line-mode() is not regexp based (prefix-garbage or prefix-suffix), please set multi-line-mode() properly", NULL);
       return FALSE;
     }
 

--- a/modules/affile/affile-source.h
+++ b/modules/affile/affile-source.h
@@ -32,7 +32,8 @@ enum
 {
   MLM_NONE,
   MLM_INDENTED,
-  MLM_REGEXP,
+  MLM_PREFIX_GARBAGE,
+  MLM_PREFIX_SUFFIX,
 };
 
 typedef struct _AFFileSourceDriver


### PR DESCRIPTION
Suffix-based multiline is very similar to prefix-garbage based, except it
appends the garbage part to the message as well. With this way, the user can
workaround the absence of multi-line timeout feature.

The only difference in config that the user should use
multi-line-mode(regexp-suffix) in the config. multi-line-prefix() and
multi-line-garbage() options remained the same.

Requested-by: Evan Rempel erempel@uvic.ca
Signed-off-by: Tusa Viktor tusavik@gmail.com
