### PR TITLE
logproto: Added suffix based multiline mode.

### DIFF
--- a/lib/logproto/logproto-regexp-multiline-server.h
+++ b/lib/logproto/logproto-regexp-multiline-server.h
@@ -35,7 +35,7 @@ void multi_line_regexp_free(MultiLineRegexp *self);
  * zero or more lines starting with whitespace. A record is terminated
  * when we reach a line that starts with non-whitespace, or EOF.
  */
-LogProtoServer *log_proto_regexp_multiline_server_new(LogTransport *transport,
+LogProtoServer *log_proto_prefix_garbage_multiline_server_new(LogTransport *transport,
                                                       const LogProtoServerOptions *options,
                                                       MultiLineRegexp *prefix,
                                                       MultiLineRegexp *garbage);
@@ -44,5 +44,9 @@ void log_proto_regexp_multiline_server_init(LogProtoREMultiLineServer *self,
                                             const LogProtoServerOptions *options,
                                             MultiLineRegexp *prefix,
                                             MultiLineRegexp *garbage);
+LogProtoServer *log_proto_prefix_suffix_multiline_server_new(LogTransport *transport,
+                                                      const LogProtoServerOptions *options,
+                                                      MultiLineRegexp *prefix,
+                                                      MultiLineRegexp *suffix);
 
 #endif

--- a/lib/logproto/tests/test-regexp-multiline-server.c
+++ b/lib/logproto/tests/test-regexp-multiline-server.c
@@ -12,7 +12,7 @@ test_lines_separated_with_prefix(gboolean input_is_stream)
 {
   LogProtoServer *proto;
 
-  proto = log_proto_regexp_multiline_server_new(
+  proto = log_proto_prefix_garbage_multiline_server_new(
             /* 32 bytes max line length, which means that the complete
              * multi-line block plus one additional line must fit into 32
              * bytes. */
@@ -41,7 +41,7 @@ test_lines_separated_with_prefix_and_garbage(gboolean input_is_stream)
 {
   LogProtoServer *proto;
 
-  proto = log_proto_regexp_multiline_server_new(
+  proto = log_proto_prefix_garbage_multiline_server_new(
             /* 32 bytes max line length, which means that the complete
              * multi-line block plus one additional line must fit into 32
              * bytes. */
@@ -66,11 +66,38 @@ test_lines_separated_with_prefix_and_garbage(gboolean input_is_stream)
 }
 
 static void
+test_lines_separated_with_prefix_and_suffix(gboolean input_is_stream)
+{
+  LogProtoServer *proto;
+
+  proto = log_proto_prefix_suffix_multiline_server_new(
+            /* 32 bytes max line length, which means that the complete
+             * multi-line block plus one additional line must fit into 32
+             * bytes. */
+            (0 && input_is_stream ? log_transport_mock_stream_new : log_transport_mock_records_new)(
+              "prefix first suffix garbage\n"
+              "prefix multi\n"
+              "suffix garbage\n"
+              "prefix final\n", -1,
+              LTM_PADDING,
+              LTM_EOF),
+            get_inited_proto_server_options(),
+            multi_line_regexp_compile("^prefix", NULL), multi_line_regexp_compile("suffix", NULL));
+
+  assert_proto_server_fetch(proto, "prefix first suffix", -1);
+  assert_proto_server_fetch(proto, "prefix multi\nsuffix", -1);
+
+  log_proto_server_free(proto);
+
+};
+
+
+static void
 test_lines_separated_with_garbage(gboolean input_is_stream)
 {
   LogProtoServer *proto;
 
-  proto = log_proto_regexp_multiline_server_new(
+  proto = log_proto_prefix_garbage_multiline_server_new(
             /* 32 bytes max line length, which means that the complete
              * multi-line block plus one additional line must fit into 32
              * bytes. */
@@ -99,7 +126,7 @@ test_first_line_without_prefix(gboolean input_is_stream)
 {
   LogProtoServer *proto;
 
-  proto = log_proto_regexp_multiline_server_new(
+  proto = log_proto_prefix_garbage_multiline_server_new(
             /* 32 bytes max line length, which means that the complete
              * multi-line block plus one additional line must fit into 32
              * bytes. */
@@ -130,6 +157,8 @@ test_log_proto_regexp_multiline_server(void)
   PROTO_TESTCASE(test_lines_separated_with_prefix, TRUE);
   PROTO_TESTCASE(test_lines_separated_with_prefix_and_garbage, FALSE);
   PROTO_TESTCASE(test_lines_separated_with_prefix_and_garbage, TRUE);
+  PROTO_TESTCASE(test_lines_separated_with_prefix_and_suffix, FALSE);
+  PROTO_TESTCASE(test_lines_separated_with_prefix_and_suffix, TRUE);
   PROTO_TESTCASE(test_lines_separated_with_garbage, FALSE);
   PROTO_TESTCASE(test_lines_separated_with_garbage, TRUE);
   PROTO_TESTCASE(test_first_line_without_prefix, FALSE);

--- a/modules/affile/affile-parser.c
+++ b/modules/affile/affile-parser.c
@@ -40,7 +40,8 @@ static CfgLexerKeyword affile_keywords[] = {
   { "follow_freq",        KW_FOLLOW_FREQ,  },
   { "multi_line_mode",    KW_MULTI_LINE_MODE, 0x0305  },
   { "multi_line_prefix",  KW_MULTI_LINE_PREFIX, 0x0305 },
-  { "multi_line_garbage", KW_MULTI_LINE_PREFIX, 0x0305 },
+  { "multi_line_garbage", KW_MULTI_LINE_GARBAGE, 0x0305 },
+  { "multi_line_suffix",  KW_MULTI_LINE_GARBAGE, 0x0306 },
   { NULL }
 };
 

--- a/modules/affile/affile-source.c
+++ b/modules/affile/affile-source.c
@@ -60,7 +60,11 @@ affile_sd_set_multi_line_mode(LogDriver *s, const gchar *mode)
   if (strcasecmp(mode, "indented") == 0)
     self->multi_line_mode = MLM_INDENTED;
   else if (strcasecmp(mode, "regexp") == 0)
-    self->multi_line_mode = MLM_REGEXP;
+    self->multi_line_mode = MLM_PREFIX_GARBAGE;
+  else if (strcasecmp(mode, "prefix-garbage") == 0)
+    self->multi_line_mode = MLM_PREFIX_GARBAGE;
+  else if (strcasecmp(mode, "prefix-suffix") == 0)
+    self->multi_line_mode = MLM_PREFIX_SUFFIX;
   else if (strcasecmp(mode, "none") == 0)
     self->multi_line_mode = MLM_NONE;
   else
@@ -239,8 +243,10 @@ affile_sd_construct_proto(AFFileSourceDriver *self, gint fd)
         {
         case MLM_INDENTED:
           return log_proto_indented_multiline_server_new(transport, proto_options);
-        case MLM_REGEXP:
-          return log_proto_regexp_multiline_server_new(transport, proto_options, self->multi_line_prefix, self->multi_line_garbage);
+        case MLM_PREFIX_GARBAGE:
+          return log_proto_prefix_garbage_multiline_server_new(transport, proto_options, self->multi_line_prefix, self->multi_line_garbage);
+        case MLM_PREFIX_SUFFIX:
+          return log_proto_prefix_suffix_multiline_server_new(transport, proto_options, self->multi_line_prefix, self->multi_line_garbage);
         default:
           return log_proto_text_server_new(transport, proto_options);
         }
@@ -336,10 +342,9 @@ affile_sd_init(LogPipe *s)
 
   log_reader_options_init(&self->reader_options, cfg, self->super.super.group);
 
-  if (self->multi_line_mode != MLM_REGEXP && (self->multi_line_prefix || self->multi_line_garbage))
+  if ((self->multi_line_mode != MLM_PREFIX_GARBAGE && self->multi_line_mode != MLM_PREFIX_SUFFIX ) && (self->multi_line_prefix || self->multi_line_garbage))
     {
-      msg_error("multi-line-prefix() and/or multi-line-garbage() specified but multi-line-mode() is not 'regexp', please set multi-line-mode() properly",
-                NULL);
+      msg_error("multi-line-prefix() and/or multi-line-garbage() specified but multi-line-mode() is not regexp based (prefix-garbage or prefix-suffix), please set multi-line-mode() properly", NULL);
       return FALSE;
     }
 

--- a/modules/affile/affile-source.h
+++ b/modules/affile/affile-source.h
@@ -34,7 +34,8 @@ enum
 {
   MLM_NONE,
   MLM_INDENTED,
-  MLM_REGEXP,
+  MLM_PREFIX_GARBAGE,
+  MLM_PREFIX_SUFFIX,
 };
 
 typedef struct _AFFileSourceDriver


### PR DESCRIPTION
Suffix-based multiline is very similar to prefix-garbage based, except it
appends the garbage part to the message as well. With this way, the user can
workaround the absence of multi-line timeout feature.

The differences: The old multi-line-mode(regexp) is still usable, but there is a new alias
for it, multi-line-mode(prefix-garbage). And the entirely new mode is
multi-line-mode(prefix-suffix). The user can use multi-line-suffix() instead of multi-line-garbage().

Requested-by: Evan Rempel erempel@uvic.ca
Signed-off-by: Tusa Viktor tusavik@gmail.com
