### PR TITLE
libtest: Install the library, headers and pkg-config file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1272,6 +1272,7 @@ AC_OUTPUT(dist.conf
           Makefile
 	  syslog-ng.spec
 	  syslog-ng.pc
+          libtest/syslog-ng-test.pc
 	  scripts/update-patterndb
           )
 

--- a/libtest/Makefile.am
+++ b/libtest/Makefile.am
@@ -1,4 +1,10 @@
-noinst_LIBRARIES		   += libtest/libsyslog-ng-test.a
+libtestdir			    =	\
+	$(pkglibdir)/libtest
+libtestincludedir		    =	\
+	$(pkgincludedir)/libtest
+
+libtest_LIBRARIES		    =	\
+	libtest/libsyslog-ng-test.a
 
 libtest_libsyslog_ng_test_a_SOURCES =   \
 	libtest/libtest.c		\
@@ -12,3 +18,13 @@ libtest_libsyslog_ng_test_a_SOURCES =   \
 	libtest/proto_lib.h		\
 	libtest/mock-transport.c	\
 	libtest/mock-transport.h
+
+libtestinclude_HEADERS		    =	\
+	libtest/testutils.h		\
+	libtest/msg_parse_lib.h		\
+	libtest/template_lib.h		\
+	libtest/proto_lib.h		\
+	libtest/mock-transport.h
+
+pkgconfig_DATA			   +=	\
+	libtest/syslog-ng-test.pc

--- a/libtest/syslog-ng-test.pc.in
+++ b/libtest/syslog-ng-test.pc.in
@@ -1,0 +1,13 @@
+# Package Information for pkg-config
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+pkglibdir=@libdir@/syslog-ng
+includedir=@includedir@
+
+Name: syslog-ng-test
+Description: Test helper package for syslog-ng modules
+Version: @VERSION@
+Requires.private: glib-2.0 syslog-ng
+Libs: -L${pkglibdir}/libtest -lsyslog-ng-test
+Cflags: -I${includedir}/syslog-ng/libtest


### PR DESCRIPTION
This opens up the possibility of using the testing framework in external modules, too.
