### PR TITLE
system-source: A tool to expand system()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -103,6 +103,7 @@ help:
 .PHONY: help populate-makefiles
 
 include Mk/lex-rules.am
+include Mk/Makefile.am
 include libtest/Makefile.am
 include lib/Makefile.am
 include modules/Makefile.am
@@ -115,4 +116,3 @@ include contrib/Makefile.am
 include scl/Makefile.am
 include debian/Makefile.am
 include tgz2build/Makefile.am
-include Mk/Makefile.am

--- a/modules/system-source/Makefile.am
+++ b/modules/system-source/Makefile.am
@@ -11,6 +11,9 @@ modules_system_source_libsystem_source_la_LDFLAGS	=	\
 modules_system_source_libsystem_source_la_DEPENDENCIES	=	\
 	$(MODULE_DEPS_LIBS)
 
+tools_SCRIPTS						+=	\
+	modules/system-source/system-expand
+
 modules/system-source modules/system-source/ mod-system-source: \
 	modules/system-source/libsystem-source.la
 .PHONY: modules/system-source/ mod-system-source

--- a/modules/system-source/system-expand
+++ b/modules/system-source/system-expand
@@ -1,0 +1,69 @@
+#! /bin/sh
+
+set -e
+
+cfg="$(mktemp)"
+out="$(mktemp)"
+
+create_config () {
+        local cfg="$1"
+        cat >"${cfg}" <<EOF
+@version: 3.6
+@include "scl.conf"
+source s_system {
+# ----- Cut here -----
+system();
+# ----- Cut here -----
+};
+EOF
+}
+
+process_config () {
+        local cfg="$1"
+        local out="$2"
+
+        syslog-ng -f "${cfg}" \
+                  --syntax-only \
+                  --preprocess-into="${out}" \
+                  --no-caps \
+                  >/dev/null 2>/dev/null
+}
+
+extract_system_source () {
+        local out="$1"
+        local IFS_SAVE="${IFS}"
+        IFS="
+"
+        local print=0
+
+        echo "## system() expands to:"
+        echo
+        for line in $(cat "${out}"); do
+                case "${line}" in
+                        "# ----- Cut here -----")
+                                if test ${print} -eq 0; then
+                                        print=1
+                                else
+                                        print=0
+                                fi
+                                ;;
+                        *)
+                                if test ${print} -eq 1; then
+                                        echo "${line}"
+                                fi
+                                ;;
+                esac
+        done
+}
+
+cleanup () {
+        local cfg="$1"
+        local out="$2"
+
+        rm -f "${cfg}" "${out}"
+}
+
+create_config "${cfg}"
+process_config "${cfg}" "${out}"
+extract_system_source "${out}"
+cleanup "${cfg}" "${out}"


### PR DESCRIPTION
When system() was turned into a C module, it became harder to figure out
what it expands to. This patch adds a small and simple tool that will
create a temporary syslog-ng config file, and extract the part system()
expanded to. This fixes #94.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
