### PR TITLE
Install internal ivykis headers when necessary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -805,6 +805,7 @@ dnl ***************************************************************************
 dnl ivykis headers/libraries
 dnl ***************************************************************************
 
+INTERNAL_IVYKIS_CFLAGS=""
 if test "x$with_ivykis" = "xinternal"; then
 	if test -f "$srcdir/lib/ivykis/src/iv_main_posix.c"; then
 		AC_CONFIG_SUBDIRS([lib/ivykis])
@@ -815,6 +816,7 @@ if test "x$with_ivykis" = "xinternal"; then
 		IVYKIS_LIBS="-Wl,--whole-archive -L\$(top_builddir)/lib/ivykis/src -livykis  -Wl,--no-whole-archive"
 		IVYKIS_CFLAGS="-I\$(top_srcdir)/lib/ivykis/src/include -I\$(top_builddir)/lib/ivykis/src/include"
 		IVYKIS_SUBDIRS=lib/ivykis
+                INTERNAL_IVYKIS_CFLAGS="-I\${includedir}/syslog-ng/ivykis"
 
 		# LIBS to use when libtool is not applicable (when linking the main syslog-ng executable in mixed linking mode)
 		IVYKIS_NO_LIBTOOL_LIBS="-Wl,--whole-archive -L\$(top_builddir)/lib/ivykis/src/.libs -livykis -Wl,--no-whole-archive"
@@ -1267,6 +1269,8 @@ AC_SUBST(CURRDATE)
 AC_SUBST(RELEASE_TAG)
 AC_SUBST(SNAPSHOT_VERSION)
 AC_SUBST(SOURCE_REVISION)
+AC_SUBST(with_ivykis)
+AC_SUBST(INTERNAL_IVYKIS_CFLAGS)
 
 AC_OUTPUT(dist.conf
           Makefile

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -19,6 +19,14 @@ lib/ivykis/src/libivykis.la:
 	${MAKE} -C lib/ivykis
 
 CLEAN_SUBDIRS				+= @IVYKIS_SUBDIRS@
+
+install-ivykis:
+	${MAKE} -C lib/ivykis/src \
+		install-includeHEADERS \
+		install-nodist_includeHEADERS \
+		includedir="${pkgincludedir}/ivykis"
+
+INSTALL_EXEC_HOOKS			+= install-ivykis
 endif
 
 # this is intentionally formatted so conflicts are less likely to arise. one name in every line.

--- a/syslog-ng.pc.in
+++ b/syslog-ng.pc.in
@@ -7,10 +7,11 @@ includedir=@includedir@
 toolsdir=@datadir@/tools
 moduledir=@expanded_moduledir@
 scldir=@datadir@/include/scl
+ivykis=@with_ivykis@
 
 Name: syslog-ng-dev
 Description: Dev package for syslog-ng module
 Version: @VERSION@
 Requires: glib-2.0
 Libs: -L${libdir} @GLIB_LIBS@ -lsyslog-ng
-Cflags: -I${includedir}/syslog-ng
+Cflags: -I${includedir}/syslog-ng @INTERNAL_IVYKIS_CFLAGS@


### PR DESCRIPTION
When building with an internal ivykis, and it gets linked into libsyslog-ng, install the headers to `${pkgincludedir}/ivykis`, adjust the `CFLAGS` in the pkg-config control file accordingly, and note the fact with an `ivykis=internal` entry in the same file.

This makes it possible to not only detect a syslog-ng with an embedded ivykis, but to build against such a thing, too. This fixes #124.
