### PR TITLE
lib/Makefile.am: Uninstall ivykis headers when needed

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -26,7 +26,14 @@ install-ivykis:
 		install-nodist_includeHEADERS \
 		includedir="${pkgincludedir}/ivykis"
 
+uninstall-ivykis:
+	${MAKE} -C lib/ivykis/src \
+		uninstall-includeHEADERS \
+		uninstall-nodist_includeHEADERS \
+		includedir="${pkgincludedir}/ivykis"
+
 INSTALL_EXEC_HOOKS			+= install-ivykis
+UNINSTALL_HOOKS				+= uninstall-ivykis
 endif
 
 # this is intentionally formatted so conflicts are less likely to arise. one name in every line.


### PR DESCRIPTION
When we installed the ivykis headers (if using the internal ivykis), we
should uninstall them too. This hooks up an uninstall hook that does
just that.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
