### PR TITLE
contrib/upstart: Added ctrl/pid and conf to upstart

### DIFF
--- a/contrib/upstart/syslog-ng.conf.upstart
+++ b/contrib/upstart/syslog-ng.conf.upstart
@@ -2,7 +2,7 @@
 #
 # syslog-ng is an replacement for the traditional syslog daemon, logging messages from applications
 
-description	"system logging daemon"
+description "system logging daemon"
 
 start on filesystem
 stop on runlevel [06]
@@ -10,4 +10,23 @@ stop on runlevel [06]
 expect fork
 respawn
 
-exec syslog-ng --process-mode=background
+script
+  CONF="/etc/syslog-ng/syslog-ng.conf"
+  CTRL="/var/lib/syslog-ng/syslog-ng.ctl"
+  OPTS=""
+
+  # Allow override of command/conf and opts by /etc/default/syslog-ng
+  if [ -f /etc/default/$UPSTART_JOB ]; then
+    . /etc/default/$UPSTART_JOB
+  fi
+
+  if ! [ -r "$CONF" ] ; then
+    echo "Could not read ${CONF}: exiting"
+    exit 1
+  fi
+
+  exec /usr/sbin/syslog-ng --process-mode=background \
+        -f $CONF -c $CTRL \
+        -p /var/run/syslog-ng.pid $OPTS
+
+end script


### PR DESCRIPTION
Hi, this PR update a bit the upstart configuration in contrib directory,

Added, pid and conf/controll and allow override by a default file, and check if configuration file
is present.

Partial-Bug: LP [#1330475](https://bugs.launchpad.net/ubuntu/+source/syslog-ng/+bug/1330475)
