### PR TITLE
logthrdestdrv: mainloop refactoring was to be able to use the same infra...

### DIFF
--- a/lib/logthrdestdrv.c
+++ b/lib/logthrdestdrv.c
@@ -23,7 +23,6 @@
  */
 
 #include "logthrdestdrv.h"
-#include "mainloop-worker.h"
 
 void
 log_threaded_dest_driver_suspend(LogThrDestDriver *self)
@@ -115,7 +114,7 @@ log_threaded_dest_driver_start_thread(LogThrDestDriver *self)
 {
   main_loop_create_worker_thread(log_threaded_dest_driver_worker_thread_main,
                                  log_threaded_dest_driver_stop_thread,
-                                 self);
+                                 self, &self->worker_options);
 }
 
 
@@ -215,6 +214,8 @@ void
 log_threaded_dest_driver_init_instance(LogThrDestDriver *self, GlobalConfig *cfg)
 {
   log_dest_driver_init_instance(&self->super, cfg);
+
+  self->worker_options.is_output_thread = TRUE;
 
   self->writer_thread_wakeup_cond = g_cond_new();
   self->suspend_mutex = g_mutex_new();

--- a/lib/logthrdestdrv.h
+++ b/lib/logthrdestdrv.h
@@ -29,6 +29,7 @@
 #include "driver.h"
 #include "stats/stats-registry.h"
 #include "logqueue.h"
+#include "mainloop-worker.h"
 
 typedef struct _LogThrDestDriver LogThrDestDriver;
 
@@ -68,6 +69,7 @@ struct _LogThrDestDriver
   gint stats_source;
 
   void (*queue_method) (LogThrDestDriver *s);
+  WorkerOptions worker_options;
 };
 
 gboolean log_threaded_dest_driver_deinit_method(LogPipe *s);

--- a/lib/mainloop-worker.h
+++ b/lib/mainloop-worker.h
@@ -49,6 +49,11 @@ typedef struct _WorkerBatchCallback
   gpointer user_data;
 } WorkerBatchCallback;
 
+typedef struct _WorkerOptions
+{
+  gboolean is_output_thread;
+} WorkerOptions;
+
 static inline void
 worker_batch_callback_init(WorkerBatchCallback *self)
 {
@@ -67,10 +72,10 @@ gint main_loop_worker_get_thread_id(void);
 void main_loop_worker_job_start(void);
 void main_loop_worker_job_complete(void);
 
-void main_loop_worker_thread_start(void);
+void main_loop_worker_thread_start(void *cookie);
 void main_loop_worker_thread_stop(void);
 
-void main_loop_create_worker_thread(WorkerThreadFunc func, WorkerExitNotificationFunc terminate_func, gpointer data);
+void main_loop_create_worker_thread(WorkerThreadFunc func, WorkerExitNotificationFunc terminate_func, gpointer data, WorkerOptions *worker_options);
 
 void main_loop_worker_sync_call(void (*func)(void));
 

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -975,7 +975,7 @@ afsql_dd_stop_thread(gpointer s)
 static void
 afsql_dd_start_thread(AFSqlDestDriver *self)
 {
-  main_loop_create_worker_thread(afsql_dd_database_thread, afsql_dd_stop_thread, self);
+  main_loop_create_worker_thread(afsql_dd_database_thread, afsql_dd_stop_thread, self, &self->worker_options);
 }
 
 
@@ -1243,6 +1243,7 @@ afsql_dd_new(GlobalConfig *cfg)
   AFSqlDestDriver *self = g_new0(AFSqlDestDriver, 1);
 
   log_dest_driver_init_instance(&self->super, cfg);
+
   self->super.super.super.init = afsql_dd_init;
   self->super.super.super.deinit = afsql_dd_deinit;
   self->super.super.super.queue = afsql_dd_queue;
@@ -1274,6 +1275,8 @@ afsql_dd_new(GlobalConfig *cfg)
 
   self->db_thread_wakeup_cond = g_cond_new();
   self->db_thread_mutex = g_mutex_new();
+
+  self->worker_options.is_output_thread = TRUE;
   return &self->super.super;
 }
 

--- a/modules/afsql/afsql.h
+++ b/modules/afsql/afsql.h
@@ -26,6 +26,7 @@
 
 #include "driver.h"
 #include <dbi/dbi.h>
+#include "mainloop-worker.h"
 
 enum
 {
@@ -110,6 +111,7 @@ typedef struct _AFSqlDestDriver
   dbi_conn dbi_ctx;
   GHashTable *validated_tables;
   guint32 failed_message_counter;
+  WorkerOptions worker_options;
 } AFSqlDestDriver;
 
 


### PR DESCRIPTION
...structure

for worker threads and io threads.

threadid allows LogQueueFifo to scale properly for input threads.
LogQueueFifo uses a fix size array for input threads, but threadid allocation
for threaded destination make this method wrong.

https://github.com/balabit/syslog-ng/issues/85

The solution is, that the worker threads get threadid from range 65-128,
and the input threads (ivykis worker threads) get id from range 1-64 as before.

Signed-off-by: Juhász Viktor jviktor@balabit.hu
