### PR TITLE
mainloop-io-worker: take care that the worker-threads option can set the...

### DIFF
--- a/lib/mainloop-io-worker.c
+++ b/lib/mainloop-io-worker.c
@@ -84,7 +84,10 @@ get_processor_count(void)
 void
 main_loop_io_worker_init(void)
 {
-  main_loop_io_workers.max_threads = MIN(MAX(MAIN_LOOP_MIN_WORKER_THREADS, get_processor_count()), MAIN_LOOP_MAX_WORKER_THREADS);
+  if (main_loop_io_workers.max_threads == 0)
+    {
+      main_loop_io_workers.max_threads = MIN(MAX(MAIN_LOOP_MIN_WORKER_THREADS, get_processor_count()), MAIN_LOOP_MAX_WORKER_THREADS);
+    }
 
   main_loop_io_workers.thread_start = (void (*)(void *)) main_loop_worker_thread_start;
   main_loop_io_workers.thread_stop = (void (*)(void *)) main_loop_worker_thread_stop;


### PR DESCRIPTION
... max_threads,

therefore we should set it to default if it isn't set by command line option

Signed-off-by: Juhász Viktor viktor.juhasz@balabit.com
