### PR TITLE
afsmtp_dd_free: do not free the str String in dd_free,

### DIFF
--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -502,7 +502,6 @@ afsmtp_dd_free(LogPipe *d)
   log_template_unref(self->body_tmpl);
   g_free(self->body);
   g_free(self->subject);
-  g_string_free(self->str, TRUE);
 
   l = self->rcpt_tos;
   while (l)


### PR DESCRIPTION
because it is already free in thread deinit

Signed-off-by: Juhász Viktor viktor.juhasz@balabit.com
