### PR TITLE
logreader: Memory leak fix.

### DIFF
--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -533,7 +533,8 @@ log_reader_set_peer_addr(LogReader *s, GSockAddr *peer_addr)
 {
   LogReader *self = (LogReader *) s;
 
-  self->peer_addr = g_sockaddr_ref(peer_addr);
+  if (self->peer_addr != peer_addr)
+    self->peer_addr = g_sockaddr_ref(peer_addr);
 }
 
 LogReader *


### PR DESCRIPTION
The log_reader_set_peer_addr() function is called with every reload. If
peer_addr is set, it will be ref'd again.

Configuration to reproduce:
 1) syslog-ng creates a TCP source
 2) connect to it with netcat (and don't close the connection)
 3) reload syslog-ng
 4) send SIGTERM to syslog-ng

Signed-off-by: Tibor Benke ihrwein@gmail.com
