### PR TITLE
afsocket: Memory leak fix

### DIFF
--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -533,6 +533,7 @@ log_reader_set_peer_addr(LogReader *s, GSockAddr *peer_addr)
 {
   LogReader *self = (LogReader *) s;
 
+  g_sockaddr_unref(self->peer_addr);
   self->peer_addr = g_sockaddr_ref(peer_addr);
 }
 

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -92,6 +92,7 @@ afsocket_sc_init(LogPipe *s)
       proto = log_proto_server_factory_construct(self->owner->proto_factory, transport, &self->owner->reader_options.proto_options.super);
       self->reader = log_reader_new(s->cfg);
       log_reader_reopen(self->reader, proto, poll_fd_events_new(self->sock));
+      log_reader_set_peer_addr(self->reader, self->peer_addr);
     }
   log_reader_set_options(self->reader, s,
                          &self->owner->reader_options,
@@ -99,7 +100,6 @@ afsocket_sc_init(LogPipe *s)
                          self->owner->transport_mapper->stats_source,
                          self->owner->super.super.id,
                          afsocket_sc_stats_instance(self));
-  log_reader_set_peer_addr(self->reader, self->peer_addr);
   log_pipe_append((LogPipe *) self->reader, s);
   if (log_pipe_init((LogPipe *) self->reader))
     {


### PR DESCRIPTION
If the configuration stays the same during a reload, log_reader_set_peer_addr()
is already called.

Signed-off-by: Tibor Benke ihrwein@gmail.com
