### PR TITLE
ack_tracker: keep AckTracker parent class 64 bit aligned

### DIFF
--- a/lib/ack_tracker.h
+++ b/lib/ack_tracker.h
@@ -35,6 +35,7 @@ struct _AckTracker
   Bookmark* (*request_bookmark)(AckTracker *self);
   void (*track_msg)(AckTracker *self, LogMessage *msg);
   void (*manage_msg_ack)(AckTracker *self, LogMessage *msg, gboolean acked);
+  void *padding; /* keep this structure 64bit aligned */
 };
 
 struct _AckRecord


### PR DESCRIPTION
AckTracker is a parent "class" for LateAckTracker which contains a RingBuffer.
RingBuffer has a pointer member which points to the memory where the AckRecord
slots (containing Bookmark) are stored.
When the AckTracker is unaligned then the RingBuffer within LateAckTracker
will also be unaligned and that can lead to SIGBUS on Sparc and IA64 platforms.

Signed-off-by: Budai Laszlo Laszlo.Budai@balabit.com
