### PR TITLE
bookmark: eliminate paddings (while keeping alignment well)

### DIFF
--- a/lib/ack_tracker.h
+++ b/lib/ack_tracker.h
@@ -35,7 +35,6 @@ struct _AckTracker
   Bookmark* (*request_bookmark)(AckTracker *self);
   void (*track_msg)(AckTracker *self, LogMessage *msg);
   void (*manage_msg_ack)(AckTracker *self, LogMessage *msg, gboolean acked);
-  void *padding; /* keep this structure 64bit aligned */
 };
 
 struct _AckRecord

--- a/lib/bookmark.h
+++ b/lib/bookmark.h
@@ -28,11 +28,12 @@
 #include "syslog-ng.h"
 #include "persist-state.h"
 
-#define MAX_BOOKMARK_DATA_LENGTH (128-4*sizeof(void *)) /* Bookmark structure should be aligned (ie. HPUX-11v2 ia64) */
+#define MAX_BOOKMARK_DATA_LENGTH (128)
 
 typedef struct _BookmarkContainer
 {
-  char other_state[MAX_BOOKMARK_DATA_LENGTH];
+  /* Bookmark structure should be aligned (ie. HPUX-11v2 ia64) */
+  gint64 other_state[MAX_BOOKMARK_DATA_LENGTH/sizeof(gint64)];
 } BookmarkContainer;
 
 struct _Bookmark
@@ -40,9 +41,7 @@ struct _Bookmark
   PersistState *persist_state;
   void (*save)(Bookmark *self);
   void (*destroy)(Bookmark *self);
-  void *padding;
   BookmarkContainer container;
-  /* take care of the size of the structure because of the required alignment on some platforms (see comment above) */
 };
 
 static inline void
@@ -51,7 +50,6 @@ bookmark_init(Bookmark *self)
   self->persist_state = NULL;
   self->save = NULL;
   self->destroy = NULL;
-  self->padding = NULL;
 }
 
 #endif


### PR DESCRIPTION
Using those paddings was a mistake: it makes code too breakable.
If we want to avoid bus error(or any other alignment issues)
on some stricter architectures(eg.:Sparc, IA64) what we have to do is
keep Bookmark aligned. For that reason we should choose carefully the
internal representation of the Bookmark.

Signed-off-by: Budai Laszlo Laszlo.Budai@balabit.com
