### PR TITLE
affile, afsocket: Properly call the LogSrcDriver queue method

### DIFF
--- a/modules/affile/affile-source.c
+++ b/modules/affile/affile-source.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2013 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -326,7 +326,7 @@ affile_sd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options,
   
   log_msg_set_value(msg, filename_handle, self->filename->str, self->filename->len);
 
-  log_pipe_forward_msg(s, msg, path_options);
+  log_src_driver_queue_method(s, msg, path_options, user_data);
 }
 
 static gboolean

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -684,8 +684,6 @@ afsocket_sd_init_instance(AFSocketSourceDriver *self,
   self->super.super.super.init = afsocket_sd_init_method;
   self->super.super.super.deinit = afsocket_sd_deinit_method;
   self->super.super.super.free_fn = afsocket_sd_free_method;
-  /* NULL behaves as if log_pipe_forward_msg was specified */
-  self->super.super.super.queue = NULL;
   self->super.super.super.notify = afsocket_sd_notify;
   self->setup_addresses = afsocket_sd_setup_addresses_method;
   self->socket_options = socket_options;


### PR DESCRIPTION
Since both the affile and afsocket sources are descendants of
LogSrcDriver, they both should call log_src_driver_queue_method(), so
that it can set the SOURCE macro appropriately, and do its other tasks.

The socket source was explicitly setting the queue method to NULL, for a
fallback to log_pipe_forward_msg(), while the file source was setting
its own properties, and failed to call the parents queue method.

The other sources were unaffected. This closes #186.

Reported-by: Fabien Wernli
Signed-off-by: Gergely Nagy algernon@madhouse-project.org
