### PR TITLE
modules: Do not count inserted/sent messages as stored ones.

### DIFF
--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -465,7 +465,6 @@ afamqp_worker_insert(LogThrDestDriver *s)
 
   if (success)
     {
-      stats_counter_inc(s->stored_messages);
       step_sequence_number(&self->seq_num);
       log_msg_ack(msg, &path_options, AT_PROCESSED);
       log_msg_unref(msg);

--- a/modules/afstomp/afstomp.c
+++ b/modules/afstomp/afstomp.c
@@ -333,7 +333,6 @@ afstomp_worker_insert(LogThrDestDriver *s)
 
   if (success)
     {
-      stats_counter_inc(self->super.stored_messages);
       step_sequence_number(&self->seq_num);
       log_msg_ack(msg, &path_options, AT_PROCESSED);
       log_msg_unref(msg);

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -243,7 +243,6 @@ redis_worker_insert(LogThrDestDriver *s)
 
   if (success)
     {
-      stats_counter_inc(self->super.stored_messages);
       step_sequence_number(&self->seq_num);
       log_msg_ack(msg, &path_options, AT_PROCESSED);
       log_msg_unref(msg);


### PR DESCRIPTION
Stored messages are for only queued messages inside syslog-ng.
