### PR TITLE
F/parse cim json messages in system

### DIFF
--- a/modules/system-source/system-source.c
+++ b/modules/system-source/system-source.c
@@ -220,18 +220,10 @@ system_sysblock_add_linux(GString *sysblock)
   system_sysblock_add_linux_kmsg(sysblock);
 }
 
-gboolean
-system_generate_system(CfgLexer *lexer, gint type, const gchar *name,
-                       CfgArgs *args, gpointer user_data)
+static gboolean
+system_generate_system_transports(GString *sysblock)
 {
-  gchar buf[256];
-  GString *sysblock;
   struct utsname u;
-  gboolean result;
-  
-  g_snprintf(buf, sizeof(buf), "source confgen system");
-
-  sysblock = g_string_sized_new(1024);
 
   if (uname(&u) < 0)
     {
@@ -288,8 +280,68 @@ system_generate_system(CfgLexer *lexer, gint type, const gchar *name,
                 NULL);
       return FALSE;
     }
+  g_string_append(sysblock, "\n");
+  return TRUE;
+}
 
+static gboolean
+_is_json_parser_available(GlobalConfig *cfg)
+{
+  return plugin_find(cfg, LL_CONTEXT_PARSER, "json-parser") != NULL;
+}
+
+static void
+system_generate_cim_parser(GlobalConfig *cfg, GString *sysblock)
+{
+  if (cfg_is_config_version_older(cfg, 0x0307))
+    {
+      msg_warning_once("WARNING: Starting with " VERSION_3_7 ", the system() source performs JSON parsing of messages starting with the '@cim:' prefix. No additional action is needed",
+                       NULL);
+      return;
+    }
+
+  if (!_is_json_parser_available(cfg))
+    {
+      msg_warning_once("system(): json-parser() is missing, skipping the automatic JSON parsing of messages submitted via syslog(3), Please install the json module",
+                       NULL);
+      return;
+    }
+
+  g_string_append(sysblock,
+                  "    parser {\n"
+                  "        json-parser(prefix('.cim.') marker('@cim:'));\n"
+                  "    };\n");
+}
+
+static gboolean
+system_generate_system(CfgLexer *lexer, gint type, const gchar *name,
+                       CfgArgs *args, gpointer user_data)
+{
+  gchar buf[256];
+  GString *sysblock;
+  gboolean result = FALSE;
+  GlobalConfig *cfg = (GlobalConfig *) user_data;
+
+  g_snprintf(buf, sizeof(buf), "source confgen system");
+
+  sysblock = g_string_sized_new(1024);
+
+  g_string_append(sysblock,
+                  "channel {\n"
+                  "    source {\n");
+
+  if (!system_generate_system_transports(sysblock))
+    {
+      goto exit;
+    }
+
+  g_string_append(sysblock, "    }; # source\n");
+
+  system_generate_cim_parser(cfg, sysblock);
+
+  g_string_append(sysblock, "}; # channel\n");
   result = cfg_lexer_include_buffer(lexer, buf, sysblock->str, sysblock->len);
+ exit:
   g_string_free(sysblock, TRUE);
   return result;
 }
@@ -300,7 +352,7 @@ system_source_module_init(GlobalConfig *cfg, CfgArgs *args)
   cfg_lexer_register_block_generator(cfg->lexer,
                                      cfg_lexer_lookup_context_type_by_name("source"),
                                      "system", system_generate_system,
-                                     NULL, NULL);
+                                     cfg, NULL);
 
   return TRUE;
 }


### PR DESCRIPTION
This branch adds a JSON parser to all locally received messages through the system() driver. It depends at least on the f/msg-warning-refactor branch.

It contains our final conclusion on how to cope with a missing json parser.

Please merge.
