### PR TITLE
system-source: Bump the version in system-expand

### DIFF
--- a/modules/system-source/system-expand
+++ b/modules/system-source/system-expand
@@ -8,7 +8,7 @@ out="$(mktemp)"
 create_config () {
         local cfg="$1"
         cat >"${cfg}" <<EOF
-@version: 3.6
+@version: 3.7
 @include "scl.conf"
 source s_system {
 # ----- Cut here -----


### PR DESCRIPTION
Bump the version in system-expand, so new 3.7 features will be included
in the expanded system() when running the program.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
