### PR TITLE
lib/compat/time.h: CLOCK_MONOTONIC compatibility

### DIFF
--- a/lib/compat/Makefile.am
+++ b/lib/compat/Makefile.am
@@ -7,8 +7,9 @@ compatinclude_HEADERS		= 	\
 	lib/compat/lfs.h		\
 	lib/compat/pio.h		\
 	lib/compat/socket.h		\
-	lib/compat/string.h
-	
+	lib/compat/string.h		\
+	lib/compat/time.h
+
 compat_sources			= 	\
 	lib/compat/getutent.c		\
 	lib/compat/inet_aton.c		\

--- a/lib/compat/time.h
+++ b/lib/compat/time.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2014 Gergely Nagy <algernon@madhouse-project.org>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef COMPAT_TIME_H_INCLUDED
+#define COMPAT_TIME_H_INCLUDED
+
+#include "compat/compat.h"
+#include <time.h>
+
+#ifndef CLOCK_MONOTONIC
+#define CLOCK_MONOTONIC CLOCK_REALTIME
+#endif
+
+#endif

--- a/lib/timeutils.h
+++ b/lib/timeutils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2010 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2002-2014 BalaBit IT Ltd, Budapest, Hungary
  * Copyright (c) 1998-2010 Balázs Scheidler
  *
  * This library is free software; you can redistribute it and/or
@@ -26,7 +26,7 @@
 #define TIMEUTILS_H_INCLUDED
 
 #include "syslog-ng.h"
-#include <time.h>
+#include "compat/time.h"
 
 time_t cached_mktime(struct tm *tm);
 void cached_localtime(time_t *when, struct tm *tm);


### PR DESCRIPTION
Instead of using CLOCK_MONOTONIC unconditionally, define it to
CLOCK_REALTIME if it is not already defined. This definition goes into
lib/compat/time.h, which is included instead of <time.h> in
lib/timeutils.h, which is in turn included by all users that use
CLOCK_MONOTONIC.

This fixes #174.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
