### PR TITLE
value-pairs: Support string list in key() and exclude()

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1185,14 +1185,14 @@ vp_option
         }
         vp_rekey_options
         ')' { value_pairs_add_transforms(last_value_pairs, last_vp_transset); } ')'
-	| KW_KEY '(' string ')'		         { value_pairs_add_glob_pattern(last_value_pairs, $3, TRUE); free($3);  }
+	| KW_KEY '(' string_list ')'		         { value_pairs_add_glob_patterns(last_value_pairs, $3, TRUE); }
         | KW_REKEY '(' string
         {
           last_vp_transset = value_pairs_transform_set_new($3);
           free($3);
         }
         vp_rekey_options ')'                     { value_pairs_add_transforms(last_value_pairs, last_vp_transset); }
-	| KW_EXCLUDE '(' string ')'	         { value_pairs_add_glob_pattern(last_value_pairs, $3, FALSE); free($3); }
+        | KW_EXCLUDE '(' string_list ')'         { value_pairs_add_glob_patterns(last_value_pairs, $3, FALSE); }
 	| KW_SCOPE '(' vp_scope_list ')'
 	;
 

--- a/lib/value-pairs.c
+++ b/lib/value-pairs.c
@@ -154,6 +154,19 @@ value_pairs_add_glob_pattern(ValuePairs *vp, const gchar *pattern,
   vp->patterns[i] = p;
 }
 
+void
+value_pairs_add_glob_patterns(ValuePairs *vp, GList *patterns, gboolean include)
+{
+  GList *l = patterns;
+
+  while (l)
+    {
+      value_pairs_add_glob_pattern(vp, (gchar *)l->data, include);
+      l = g_list_next (l);
+    }
+  string_list_free(patterns);
+}
+
 gboolean
 value_pairs_add_pair(ValuePairs *vp, const gchar *key, LogTemplate *value)
 {
@@ -909,9 +922,16 @@ vp_cmdline_parse_exclude(const gchar *option_name, const gchar *value,
 {
   gpointer *args = (gpointer *) data;
   ValuePairs *vp = (ValuePairs *) args[1];
+  gchar **excludes;
+  gint i;
 
   vp_cmdline_parse_rekey_finish (data);
-  value_pairs_add_glob_pattern(vp, value, FALSE);
+
+  excludes = g_strsplit(value, ",", -1);
+  for (i = 0; excludes[i] != NULL; i++)
+    value_pairs_add_glob_pattern(vp, excludes[i], FALSE);
+  g_strfreev(excludes);
+
   return TRUE;
 }
 
@@ -930,9 +950,16 @@ vp_cmdline_parse_key(const gchar *option_name, const gchar *value,
 {
   gpointer *args = (gpointer *) data;
   ValuePairs *vp = (ValuePairs *) args[1];
+  gchar **keys;
+  gint i;
 
   vp_cmdline_start_key(data, value);
-  value_pairs_add_glob_pattern(vp, value, TRUE);
+
+  keys = g_strsplit(value, ",", -1);
+  for (i = 0; keys[i] != NULL; i++)
+    value_pairs_add_glob_pattern(vp, keys[i], TRUE);
+  g_strfreev(keys);
+
   return TRUE;
 }
 

--- a/lib/value-pairs.h
+++ b/lib/value-pairs.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2011-2013 BalaBit IT Ltd, Budapest, Hungary
- * Copyright (c) 2011-2013 Gergely Nagy <algernon@balabit.hu>
+ * Copyright (c) 2011-2014 BalaBit IT Ltd, Budapest, Hungary
+ * Copyright (c) 2011-2014 Gergely Nagy <algernon@balabit.hu>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -45,6 +45,7 @@ typedef gboolean (*VPWalkCallbackFunc)(const gchar *name,
 
 gboolean value_pairs_add_scope(ValuePairs *vp, const gchar *scope);
 void value_pairs_add_glob_pattern(ValuePairs *vp, const gchar *pattern, gboolean include);
+void value_pairs_add_glob_patterns(ValuePairs *vp, GList *patterns, gboolean include);
 gboolean value_pairs_add_pair(ValuePairs *vp, const gchar *key, LogTemplate *value);
 
 void value_pairs_add_transforms(ValuePairs *vp, gpointer vpts);


### PR DESCRIPTION
This adds support to value-pairs for using multiple elements in the
key() and exclude() options. This makes it easier to wrap them in an SCL
block. Same feature was added to the command-line parser too.

These partially address #219.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
