### PR TITLE
geoip: Fix local state initialisation

### DIFF
--- a/modules/tfgeoip/tfgeoip.c
+++ b/modules/tfgeoip/tfgeoip.c
@@ -44,7 +44,7 @@ TLS_BLOCK_END;
 
 #define local_state __tls_deref(geoip_state)
 
-static void
+static inline void
 tf_geoip_init(void)
 {
   if (!local_state)
@@ -58,6 +58,8 @@ static gboolean
 tf_geoip(LogMessage *msg, gint argc, GString *argv[], GString *result)
 {
   const char *country;
+
+  tf_geoip_init();
 
   if (argc != 1)
     {
@@ -83,7 +85,6 @@ static Plugin tfgeoip_plugins[] =
 gboolean
 tfgeoip_module_init(GlobalConfig *cfg, CfgArgs *args)
 {
-  tf_geoip_init();
   plugin_register(cfg, tfgeoip_plugins, G_N_ELEMENTS(tfgeoip_plugins));
   return TRUE;
 }


### PR DESCRIPTION
When running with threaded(yes), local state was never initialised,
because we did that at module load time, which happens in a different
thread. Instead, we now initialise the local state on each function
call, unless already initialised.

This fixes #228.

Reported-by: Fabien Wernli
Signed-off-by: Gergely Nagy algernon@madhouse-project.org
