### PR TITLE
afsocket: syslog-ng receives credentials via UDS only on FreeBSD and on ...

### DIFF
--- a/modules/afsocket/unix-credentials.c
+++ b/modules/afsocket/unix-credentials.c
@@ -24,9 +24,11 @@
 #include "syslog-ng.h"
 #include "unix-credentials.h"
 
+
 void
 socket_set_pass_credentials(gint fd)
 {
+#if defined(CRED_PASS_SUPPORTED)
 #if defined(LOCAL_CREDS) || defined(SO_PASSCRED)
   static gint one = 1;
 #endif
@@ -36,6 +38,7 @@ socket_set_pass_credentials(gint fd)
 #else
 #ifdef SO_PASSCRED
   setsockopt(fd, SOL_SOCKET, SO_PASSCRED, &one, sizeof(one));
+#endif
 #endif
 #endif
 }

--- a/modules/afsocket/unix-credentials.h
+++ b/modules/afsocket/unix-credentials.h
@@ -29,20 +29,23 @@
 
 #include "syslog-ng.h"
 
-#if HAVE_STRUCT_UCRED
-#define cred_t struct ucred
-#define cred_get(c,x) (c->x)
-#else
+#if defined(__linux__)
+# if HAVE_STRUCT_UCRED
+# define CRED_PASS_SUPPORTED
+# define cred_t struct ucred
+# define cred_get(c,x) (c->x)
+# endif
+#else if defined(__FreeBSD__)
 # if HAVE_STRUCT_CMSGCRED
+#  define CRED_PASS_SUPPORTED
+#  define SCM_CREDENTIALS SCM_CREDS
 #  define cred_t struct cmsgcred
 #  define cred_get(c,x) (c->cmcred_##x)
 # endif
 #endif
 
-#ifndef SCM_CREDENTIALS
-#define SCM_CREDENTIALS SCM_CREDS
-#endif
-
+#if defined(CRED_PASS_SUPPORTED)
 void socket_set_pass_credentials(gint fd);
+#endif
 
 #endif


### PR DESCRIPTION
...Linux

Signed-off-by: Budai Laszlo Laszlo.Budai@balabit.com
