### PR TITLE
systemd-journald: remove reference to non-existing header file

### DIFF
--- a/modules/systemd-journal/Makefile.am
+++ b/modules/systemd-journal/Makefile.am
@@ -7,13 +7,11 @@ modules_systemd_journal_libsdjournal_la_SOURCES = \
 	modules/systemd-journal/systemd-journal-parser.c \
 	modules/systemd-journal/systemd-journal-parser.h \
 	modules/systemd-journal/systemd-journal-plugin.c \
-	modules/systemd-journal/journal-interface.h \
 	modules/systemd-journal/journal-reader.c \
 	modules/systemd-journal/journal-reader.h \
 	modules/systemd-journal/journald-subsystem.c \
 	modules/systemd-journal/journald-subsystem.h \
-	modules/systemd-journal/journald-helper.c \
-	modules/systemd-journal/journald-helper.h
+	modules/systemd-journal/journald-helper.c
 
 
 BUILT_SOURCES += modules/systemd-journal/systemd-journal-grammar.y \


### PR DESCRIPTION
Signed-off-by: Juhász Viktor viktor.juhasz@balabit.com
