### PR TITLE
systemd-journal: if prefix is set, do not set prefixed key as link to th...

### DIFF
--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -194,13 +194,16 @@ __handle_data(gchar *key, gchar *value, gpointer user_data)
     }
   else
     {
-      NVHandle handle = log_msg_get_value_handle(key);
-      log_msg_set_value(msg, handle, value, value_len);
-      if (options->prefix)
+      if (!options->prefix)
+        {
+          NVHandle handle = log_msg_get_value_handle(key);
+          log_msg_set_value(msg, handle, value, value_len);
+        }
+      else
         {
           gchar *prefixed_key = g_strdup_printf("%s%s", options->prefix, key);
           NVHandle prefixed_handle = log_msg_get_value_handle(prefixed_key);
-          log_msg_set_value_indirect(msg, prefixed_handle, handle, 0, 0, value_len);
+          log_msg_set_value(msg, prefixed_handle, value, value_len);
           g_free(prefixed_key);
         }
     }


### PR DESCRIPTION
...e original one,

but set the key as original not linked to the original.

Signed-off-by: Juhász Viktor viktor.juhasz@balabit.com
