### PR TITLE
system-source: Allow messages to flow through JSON

### DIFF
--- a/modules/system-source/system-source.c
+++ b/modules/system-source/system-source.c
@@ -302,9 +302,15 @@ system_generate_cim_parser(GlobalConfig *cfg, GString *sysblock)
     }
 
   g_string_append(sysblock,
+                  "channel {\n"
+                  "  channel {\n"
                   "    parser {\n"
-                  "        json-parser(prefix('.cim.') marker('@cim:'));\n"
-                  "    };\n");
+                  "      json-parser(prefix('.cim.') marker('@cim:'));\n"
+                  "    };\n"
+                  "    flags(final);\n"
+                  "  };\n"
+                  "  channel { };\n"
+                  "};\n");
 }
 
 static gboolean


### PR DESCRIPTION
In case a message does not match the JSON marker, allow them to flow
through unmodified. This makes system() work with non-CIM messages
again.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
