### PR TITLE
Change control socket message from notice to debug

### DIFF
--- a/lib/control/control-server.c
+++ b/lib/control/control-server.c
@@ -126,7 +126,7 @@ control_connection_io_input(void *s)
     }
   else if (rc == 0)
     {
-      msg_notice("EOF on control channel, closing connection",
+      msg_debug("EOF on control channel, closing connection",
                 NULL);
       goto destroy_connection;
     }


### PR DESCRIPTION
In 3.3 or 3.4, syslog-ng started emitting log lines whenever a control socket was closed.  This isn't very useful and can be pretty noisy if the control socket is used regularly to collect statistics.

This commit changes the level to debug so the lines do not show up under normal usage.

Signed-off-by: Brian De Wolf git@bldewolf.com
