### PR TITLE
logpipe: do not reset config when pipe is deinited

### DIFF
--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -278,11 +278,9 @@ log_pipe_deinit(LogPipe *s)
     {
       if (!s->deinit || s->deinit(s))
         {
-          log_pipe_reset_config(s);
           s->flags &= ~PIF_INITIALIZED;
           return TRUE;
         }
-      log_pipe_reset_config(s);
       return FALSE;
     }
   return TRUE;


### PR DESCRIPTION
There are two kind of initialization around log_pipes.

One is log_pipe_init_instance(), a kind of constructor, which is
called only once, when the object is constructed.

And there is log_pipe_init() (and its corresponding pair, log_pipe_deinit())
which could be called several times on a construced object (eg.:during reload).

Config is set by log_pipe_init_instance() but reset is called by
log_pipe_deinit().

During reload we already have a constructed object in deinited state
(config is set to NULL after deinit). When we call init() on such an object
it will cause seg.fault because config is NULL.

references:
#203

Signed-off-by: Budai Laszlo Laszlo.Budai@balabit.com
