### PR TITLE
scl/scl.conf: Use a wildcard to include SCL snippets

### DIFF
--- a/scl/scl.conf
+++ b/scl/scl.conf
@@ -28,8 +28,4 @@
 @define scl-root "`syslog-ng-data`/include/scl"
 @define include-path "`include-path`:`syslog-ng-data`/include"
 
-@include 'scl/system/plugin.conf'
-@include 'scl/pacct/plugin.conf'
-@include 'scl/syslogconf/plugin.conf'
-@include 'scl/nodejs/plugin.conf'
-@include 'scl/graphite/plugin.conf'
+@include 'scl/*/plugin.conf'


### PR DESCRIPTION
To be able to install SCL snippets to be included by default, without
modifying scl.conf itself, use a wildcard-include. This allows
distributions to ship some of the SCLs in different packages, without
breaking the default config, or having to enable them in other ways.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
