### PR TITLE
timeutils: fix bad pointer cast that leads to timestamp overwriting

### DIFF
--- a/lib/timeutils.c
+++ b/lib/timeutils.c
@@ -935,4 +935,3 @@ time_zone_info_free(TimeZoneInfo *self)
   zone_info_free(self->zone64);
   g_free(self);
 }
-

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -245,6 +245,7 @@ log_msg_parse_date(LogMessage *self, const guchar **data, gint *length, guint pa
     {
       /* RFC3339 timestamp, expected format: YYYY-MM-DDTHH:MM:SS[.frac]<+/->ZZ:ZZ */
       gint hours, mins;
+      time_t now_tv_sec = (time_t)now.tv_sec;
 
       self->timestamps[LM_TS_STAMP].tv_usec = 0;
 
@@ -253,7 +254,7 @@ log_msg_parse_date(LogMessage *self, const guchar **data, gint *length, guint pa
        * not exist on all platforms and 0 initializing it causes trouble on
        * time-zone barriers */
 
-      cached_localtime(&now.tv_sec, &tm);
+      cached_localtime(&now_tv_sec, &tm);
       if (!scan_iso_timestamp((const gchar **) &src, &left, &tm))
         {
           goto error;
@@ -315,8 +316,8 @@ log_msg_parse_date(LogMessage *self, const guchar **data, gint *length, guint pa
         {
           /* PIX timestamp, expected format: MMM DD YYYY HH:MM:SS: */
           /* ASA timestamp, expected format: MMM DD YYYY HH:MM:SS */
-
-          cached_localtime(&now.tv_sec, &tm);
+          time_t now_tv_sec = (time_t)now.tv_sec;
+          cached_localtime(&now_tv_sec, &tm);
           if (!scan_pix_timestamp((const gchar **) &src, &left, &tm))
             goto error;
 
@@ -338,7 +339,8 @@ log_msg_parse_date(LogMessage *self, const guchar **data, gint *length, guint pa
         {
           /* LinkSys timestamp, expected format: MMM DD HH:MM:SS YYYY */
 
-          cached_localtime(&now.tv_sec, &tm);
+          time_t now_tv_sec = (time_t)now.tv_sec;
+          cached_localtime(&now_tv_sec, &tm);
           if (!scan_linksys_timestamp((const gchar **) &src, &left, &tm))
             goto error;
           tm.tm_isdst = -1;
@@ -354,8 +356,8 @@ log_msg_parse_date(LogMessage *self, const guchar **data, gint *length, guint pa
           /* RFC 3164 timestamp, expected format: MMM DD HH:MM:SS ... */
           struct tm nowtm;
           glong usec = 0;
-
-          cached_localtime(&now.tv_sec, &nowtm);
+          time_t now_tv_sec = (time_t)now.tv_sec;
+          cached_localtime(&now_tv_sec, &nowtm);
           tm = nowtm;
           if (!scan_bsd_timestamp((const gchar **) &src, &left, &tm))
             goto error;
@@ -873,7 +875,7 @@ log_msg_parse_legacy(const MsgFormatOptions *parse_options,
   log_msg_parse_seq(self, &src, &left);
   log_msg_parse_skip_chars(self, &src, &left, " ", -1);
   cached_g_current_time(&now);
-  if (log_msg_parse_date(self, &src, &left, parse_options->flags & ~LP_SYSLOG_PROTOCOL, time_zone_info_get_offset(parse_options->recv_time_zone_info, now.tv_sec)))
+  if (log_msg_parse_date(self, &src, &left, parse_options->flags & ~LP_SYSLOG_PROTOCOL, time_zone_info_get_offset(parse_options->recv_time_zone_info, (time_t)now.tv_sec)))
     {
       /* Expected format: hostname program[pid]: */
       /* Possibly: Message forwarded from hostname: ... */


### PR DESCRIPTION
In `log_msg_parse_date()` the variable `now` is of type `GTimeVal`.
Its member `tv_sec` is of type `long`, and its address was cast to a `time_t`
pointer.
This led bad argument passing to the `cached_localtime()` function.

Fixes: #304

Signed-off-by: Budai Laszlo Laszlo.Budai@balabit.com
