### PR TITLE
Makefile: remove explicit libsyslog-ng-crypto references

### DIFF
--- a/modules/dbparser/Makefile.am
+++ b/modules/dbparser/Makefile.am
@@ -21,9 +21,9 @@ modules_dbparser_libsyslog_ng_patterndb_la_CFLAGS	=	\
 	$(AM_CFLAGS) -fPIC @CFLAGS_NOWARN_POINTER_SIGN@
 modules_dbparser_libsyslog_ng_patterndb_la_LIBADD	=	\
 	$(MODULE_DEPS_LIBS)					\
-	$(top_builddir)/lib/libsyslog-ng-crypto.la
+	$(CRYPTO_LIBS)
 modules_dbparser_libsyslog_ng_patterndb_la_DEPENDENCIES	=	\
-	$(MODULE_DEPS_LIBS) lib/libsyslog-ng-crypto.la
+	$(MODULE_DEPS_LIBS) $(CRYPTO_LIBS)
 
 module_LTLIBRARIES					+= modules/dbparser/libdbparser.la
 modules_dbparser_libdbparser_la_SOURCES			=	\

--- a/syslog-ng-ctl/Makefile.am
+++ b/syslog-ng-ctl/Makefile.am
@@ -10,5 +10,5 @@ syslog_ng_ctl_syslog_ng_ctl_SOURCES		= 	\
 EXTRA_DIST					+=	\
 	syslog-ng-ctl/control-client-unix.c
 
-syslog_ng_ctl_syslog_ng_ctl_LDADD		= lib/libsyslog-ng.la lib/libsyslog-ng-crypto.la @BASE_LIBS@ @GLIB_LIBS@ @RESOLV_LIBS@
+syslog_ng_ctl_syslog_ng_ctl_LDADD		= lib/libsyslog-ng.la $(CRYPTO_LIBS) @BASE_LIBS@ @GLIB_LIBS@ @RESOLV_LIBS@
 


### PR DESCRIPTION
Instead of open-coding the optional libsyslog-ng-crypto as a dependency
use $(CRYPTO_LIBS) which conditionally contains the same if
libsyslog-ng-crypto is built.

Signed-off-by: Balazs Scheidler balazs.scheidler@balabit.com
