### PR TITLE
system-source: Under systemd, ignore forwarded messages

### DIFF
--- a/lib/service-management.h
+++ b/lib/service-management.h
@@ -37,5 +37,6 @@ void service_management_clear_status(void);
 void service_management_indicate_readiness(void);
 ServiceManagementType service_management_get_type(void);
 void service_management_init(void);
+gboolean service_management_is_forwarding_active(void);
 
 #endif


### PR DESCRIPTION
When running under systemd, and syslog forwarding is enabled, drop them on the floor, to stop the Journal from spamming us with forwarding errors. We get the entries directly from the journal, so dropping forwarded messages is safe.

This is not 100% ready yet, I have yet to test it on a real system with forwarding disabled. The unit file may need changes too, to not depend on syslog.socket. (If syslog.socket is started, `/run/systemd/journal/syslog` will be present, whether forwarding is enabled or not, which defeats our purpose.)

This is a fix/workaround for #314, until the journal starts supporting `journald.conf.d/` directories.
