### PR TITLE
systemd: remove syslog.socket references from service file

### DIFF
--- a/contrib/systemd/syslog-ng.service
+++ b/contrib/systemd/syslog-ng.service
@@ -3,7 +3,7 @@ Description=System Logger Daemon
 Documentation=man:syslog-ng(8)
 
 [Service]
-#Type=notify
+Type=notify
 ExecStart=/usr/sbin/syslog-ng -F
 ExecReload=/bin/kill -HUP $MAINPID
 StandardOutput=journal


### PR DESCRIPTION
Syslog-ng reads the messages directly from journal on systems with systemd, so
we don't need these settings anymore.

These settings can cause journald to emit this kind of messages:

```
Oct 15 06:42:08 XXXX systemd-journal[31451]: Forwarding to syslog
missed 30 messages.
```

Some comments on the modifications:
- removing `Requires` and `Alias` lines: systemd won't create the compatibility socket
- adding `StandardOutput` and `StandardError`: if syslog-ng's `-e` (log messages to stderr) is not turned on, this shouldn't cause any problems. Our internal messages goes to `/var/log/messages` and our `stdout` and `stderr` is forwarded to journald and they are read by syslog-ng only once (unless `-e` is turned on). This modification helps sysadmins to solve syslog-ng related problems.
- commenting out `Type`: syslog-ng's servive-management implements the required functions to use this, however, some notifications are not used (e.g. `RELOADING=1`). It's up to you to discard this change :)
