### PR TITLE
Add support for the monolithic libsystemd library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,7 @@ LMC_MIN_VERSION="0.1.8"
 LRMQ_MIN_VERSION="0.0.1"
 LRC_MIN_VERSION="1.0.0"
 JOURNALD_MIN_VERSION="195"
+LIBSYSTEMD_MIN_VERSION="209"
 
 dnl ***************************************************************************
 dnl Initial setup
@@ -1128,9 +1129,17 @@ if test "x$enable_systemd" = "xauto"; then
 
 fi
 
+if test "x$enable_systemd" != "xyes"; then
+  if test "x$with_systemd_journal" = "xauto"; then
+    with_systemd_journal=no
+  fi
+fi
+
 if test "x$enable_systemd" = "xyes"; then
-	PKG_CHECK_MODULES(libsystemd_daemon, libsystemd-daemon >= 31,enable_systemd="yes",enable_systemd="no")
-	if test "x$with_systemdsystemunitdir" = "xyes"; then
+        PKG_CHECK_MODULES(libsystemd, libsystemd >= ${LIBSYSTEMD_MIN_VERSION},
+                          have_libsystemd="yes", have_libsystemd="no")
+
+        if test "x$with_systemdsystemunitdir" = "xyes"; then
 		# no arguments, just --with-systemdsystemunitdir
 		systemdsystemunitdir=`$PKG_CONFIG --variable=systemdsystemunitdir systemd`
 		if test "$systemdsystemunitdir" = ""; then
@@ -1142,22 +1151,25 @@ if test "x$enable_systemd" = "xyes"; then
 	else
 		systemdsystemunitdir="$with_systemdsystemunitdir"
 	fi
-fi
 
-dnl ***************************************************************************
-dnl libsystemd-journal headers/libraries
-dnl ***************************************************************************
-
-if test "x$enable_systemd" != "xyes"; then
-  if test "x$with_systemd_journal" = "xauto"; then
-    with_systemd_journal=no
-  fi
-fi
-
-if test "x$with_systemd_journal" = "xauto"; then
-  PKG_CHECK_MODULES(LIBSYSTEMD_JOURNAL, libsystemd-journal >= $JOURNALD_MIN_VERSION, with_systemd_journal=system, with_systemd_journal=optional)
-elif test "x$with_systemd_journal" = "xsystem"; then
-  PKG_CHECK_MODULES(LIBSYSTEMD_JOURNAL, libsystemd-journal >= $JOURNALD_MIN_VERSION,, AC_MSG_ERROR[Detecting system releted systemd-journal library failed])
+        if test "x$have_libsystemd" = "xno"; then
+	    PKG_CHECK_MODULES(libsystemd_daemon, libsystemd-daemon >= 31,enable_systemd="yes",enable_systemd="no")
+            if test "x$with_systemd_journal" = "xauto"; then
+                PKG_CHECK_MODULES(LIBSYSTEMD_JOURNAL, libsystemd-journal >= $JOURNALD_MIN_VERSION,
+                                  with_systemd_journal=system, with_systemd_journal=optional)
+            elif test "x$with_systemd_journal" = "xsystem"; then
+                PKG_CHECK_MODULES(LIBSYSTEMD_JOURNAL, libsystemd-journal >= $JOURNALD_MIN_VERSION,,
+                AC_MSG_ERROR[Detecting system releted systemd-journal library failed])
+            fi
+            libsystemd_CFLAGS="${LIBSYSTEMD_JOURNAL_CFLAGS} ${libsystemd_daemon_CFLAGS}"
+            libsystemd_LDFLAGS="${LIBSYSTEMD_JOURNAL_LIBS} ${libsystemd_daemon_LIBS}"
+            AC_SUBST(libsystemd_CFLAGS)
+            AC_SUBST(libsystemd_LIBS)
+        else
+            if test "x$with_systemd_journal" = "xauto"; then
+                with_systemd_journal="system"
+            fi
+        fi
 fi
 
 PKG_CHECK_MODULES(UUID, uuid, enable_libuuid="yes", enable_libuuid="no")

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -31,7 +31,7 @@ LSNG_REVISION		= 0
 LSNG_AGE		= 0
 
 lib_LTLIBRARIES				+= lib/libsyslog-ng.la
-lib_libsyslog_ng_la_LIBADD		= @CORE_DEPS_LIBS@ $(libsystemd_daemon_LIBS)
+lib_libsyslog_ng_la_LIBADD		= @CORE_DEPS_LIBS@ $(libsystemd_LIBS)
 lib_libsyslog_ng_la_LDFLAGS		= -no-undefined -release ${LSNG_RELEASE} \
 					  -version-info ${LSNG_CURRENT}:${LSNG_REVISION}:${LSNG_AGE}
 
@@ -239,12 +239,12 @@ lib_libsyslog_ng_la_SOURCES		= \
 	$(compat_sources)
 
 if WITH_EMBEDDED_CRYPTO
-lib_libsyslog_ng_la_CFLAGS		= @UUID_CFLAGS@ $(libsystemd_daemon_CFLAGS)
+lib_libsyslog_ng_la_CFLAGS		= @UUID_CFLAGS@ $(libsystemd_CFLAGS)
 lib_libsyslog_ng_la_LIBADD		+= @OPENSSL_LIBS@ @UUID_LIBS@
 lib_libsyslog_ng_la_SOURCES		+= ${lib_libsyslog_ng_crypto_la_sources}
 else
 module_LTLIBRARIES			+= lib/libsyslog-ng-crypto.la
-lib_libsyslog_ng_crypto_la_CFLAGS	= @UUID_CFLAGS@ $(libsystemd_daemon_CFLAGS)
+lib_libsyslog_ng_crypto_la_CFLAGS	= @UUID_CFLAGS@ $(libsystemd_CFLAGS)
 lib_libsyslog_ng_crypto_la_LIBADD	= @MODULE_DEPS_LIBS@ @OPENSSL_LIBS@ @UUID_LIBS@
 lib_libsyslog_ng_crypto_la_LDFLAGS	= -no-undefined -avoid-version
 lib_libsyslog_ng_crypto_la_DEPENDENCIES	= lib/libsyslog-ng.la

--- a/modules/afsocket/Makefile.am
+++ b/modules/afsocket/Makefile.am
@@ -40,12 +40,12 @@ modules_afsocket_libafsocket_notls_la_SOURCES	=	\
 	modules/afsocket/afsocket-systemd-override.h
 
 modules_afsocket_libafsocket_notls_la_CPPFLAGS	=	\
-	$(AM_CPPFLAGS) $(libsystemd_daemon_CFLAGS)	\
+	$(AM_CPPFLAGS) $(libsystemd_CFLAGS)	\
 	-I${top_srcdir}/modules/afsocket		\
 	-I${top_builddir}/modules/afsocket
 modules_afsocket_libafsocket_notls_la_LIBADD	=	\
 	$(MODULE_DEPS_LIBS) $(LIBNET_LIBS)		\
-	$(LIBWRAP_LIBS) $(libsystemd_daemon_LIBS)
+	$(LIBWRAP_LIBS) $(libsystemd_LIBS)
 modules_afsocket_libafsocket_notls_la_LDFLAGS	  =	\
 	$(MODULE_LDFLAGS)
 modules_afsocket_libafsocket_notls_la_DEPENDENCIES=	\
@@ -56,7 +56,7 @@ module_LTLIBRARIES				+= modules/afsocket/libafsocket-tls.la
 modules_afsocket_libafsocket_tls_la_SOURCES	=	\
 	$(modules_afsocket_libafsocket_notls_la_SOURCES)
 modules_afsocket_libafsocket_tls_la_CPPFLAGS	=	\
-	$(AM_CPPFLAGS) $(libsystemd_daemon_CFLAGS)	\
+	$(AM_CPPFLAGS) $(libsystemd_CFLAGS)	\
 	-I${top_srcdir}/modules/afsocket		\
 	-I${top_builddir}/modules/afsocket		\
 	-DBUILD_WITH_SSL=1
@@ -64,7 +64,7 @@ modules_afsocket_libafsocket_tls_la_CPPFLAGS	=	\
 modules_afsocket_libafsocket_tls_la_LIBADD	=	\
 	$(MODULE_DEPS_LIBS) $(CRYPTO_LIBS) 		\
 	$(OPENSSL_LIBS) $(ZLIB_LIBS) $(LIBNET_LIBS)	\
-	$(LIBWRAP_LIBS) $(libsystemd_daemon_LIBS)
+	$(LIBWRAP_LIBS) $(libsystemd_LIBS)
 modules_afsocket_libafsocket_tls_la_DEPENDENCIES= 	\
 	$(MODULE_DEPS_LIBS) $(CRYPTO_LIBS)
 modules_afsocket_libafsocket_tls_la_LDFLAGS	= 	\

--- a/modules/system-source/Makefile.am
+++ b/modules/system-source/Makefile.am
@@ -3,9 +3,9 @@ module_LTLIBRARIES					+= modules/system-source/libsystem-source.la
 modules_system_source_libsystem_source_la_SOURCES	=	\
 	modules/system-source/system-source.c
 modules_system_source_libsystem_source_la_CPPFLAGS	=	\
-	$(AM_CPPFLAGS) $(libsystemd_daemon_CFLAGS)
+	$(AM_CPPFLAGS) $(libsystemd_CFLAGS)
 modules_system_source_libsystem_source_la_LIBADD	=	\
-	$(MODULE_DEPS_LIBS) $(libsystemd_daemon_LIBS)
+	$(MODULE_DEPS_LIBS) $(libsystemd_LIBS)
 modules_system_source_libsystem_source_la_LDFLAGS	=	\
 	$(MODULE_LDFLAGS)
 modules_system_source_libsystem_source_la_DEPENDENCIES	=	\

--- a/modules/systemd-journal/Makefile.am
+++ b/modules/systemd-journal/Makefile.am
@@ -18,8 +18,8 @@ BUILT_SOURCES += modules/systemd-journal/systemd-journal-grammar.y \
 		 modules/systemd-journal/systemd-journal-grammar.c \
 		 modules/systemd-journal/systemd-journal-grammar.h
 
-modules_systemd_journal_libsdjournal_la_CPPFLAGS = $(AM_CPPFLAGS) $(LIBSYSTEMD_JOURNAL_CFLAGS) -I$(top_srcdir)/modules/systemd-journal -I$(top_builddir)/modules/systemd-journal
-modules_systemd_journal_libsdjournal_la_LIBADD = $(MODULE_DEPS_LIBS) $(LIBSYSTEMD_JOURNAL_LIBS)
+modules_systemd_journal_libsdjournal_la_CPPFLAGS = $(AM_CPPFLAGS) $(libsystemd_CFLAGS) -I$(top_srcdir)/modules/systemd-journal -I$(top_builddir)/modules/systemd-journal
+modules_systemd_journal_libsdjournal_la_LIBADD = $(MODULE_DEPS_LIBS) $(libsystemd_LIBS)
 modules_systemd_journal_libsdjournal_la_LDFLAGS = $(MODULE_LDFLAGS)
 modules_systemd_journal_libsdjournal_la_DEPENDENCIES = $(MODULE_DEPS_LIBS)
 


### PR DESCRIPTION
In systemd 209, the various small libsystemd-\* libraries were merged
into a single libsystemd. This patch adds support for the detecting and
using the merged library when present, while still supporting the split
ones too. If the merged library is found, that will be preferred.

The only downside is that when using the split libraries, things were
only linked against libsystemd-daemon will also be linked against
libsystemd-journal too. Thankfully, that's harmless, and can be worked
around by using a clever linker.

This fixes #299.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
