### PR TITLE
riemann: Do not crash without attributes() set

### DIFF
--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -229,6 +229,9 @@ _value_pairs_always_exclude_properties(RiemannDestDriver *self)
                                       "ttl", "metric", NULL};
   gint i;
 
+  if (!self->fields.attributes)
+    return;
+
   for (i = 0; properties[i]; i++)
     value_pairs_add_glob_pattern(self->fields.attributes, properties[i], FALSE);
 }


### PR DESCRIPTION
When using a riemann destination, do not crash when no attributes are set.
