### PR TITLE
configure.ac: Add an --enable-all-modules option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -230,6 +230,23 @@ AC_ARG_WITH(systemd-journal,
                                          Link against the system supplied or the wrapper library. (default: auto)]
               ,,with_systemd_journal="auto")
 
+AC_ARG_ENABLE(all-modules,
+              [  --enable-all-modules    Forcibly enable all modules. (default: auto)]
+              ,,enable_all_modules="auto")
+
+if test "x$enable_all_modules" != "xauto"; then
+   state="$enable_all_modules"
+
+   MODULES="spoof_source sun_streams sql pacct mongodb json amqp stomp \
+            redis systemd geoip riemann ssl ipv6 smtp"
+   for mod in ${MODULES}; do
+       modstate=$(eval echo \$enable_${mod})
+       if test "x$modstate" = "xauto"; then
+          eval enable_${mod}=${state}
+       fi
+   done
+fi
+
 if test "x$wcmp_date" != "xno"; then
   wcmp_date="1"
 else


### PR DESCRIPTION
This option will turn on or off all modules and most features when enabled, unless a feature was explicitly changed from being auto-detected. Currently, this means that pacct must be explicitly enabled, since it defaults to "no" (while all others default to "auto").

This also means that Sun Streams are turned on even on Linux, which leads to a compile error later. So on Linux, --enable-all-modules should be used together with --disable-sun-streams.

Fixes #149.

A better option would be to clean up configure, and have an m4 macro that handles the module enable/disable foo, and also registers it in a list, so when adding a new module, one wouldn't need to update the `MODULES` list introduced here too. But that's beyond my time limit at the moment.
