### PR TITLE
systemd-journal: Prefer SYSLOG_IDENTIFIER over _COMM

### DIFF
--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -173,11 +173,11 @@ __handle_data(gchar *key, gchar *value, gpointer user_data)
     {
       log_msg_set_value(msg, LM_V_PID, value, value_len);
     }
-  else if (strcmp(key, "_COMM") == 0)
+  else if (strcmp(key, "SYSLOG_IDENTIFIER") == 0)
     {
       log_msg_set_value(msg, LM_V_PROGRAM, value, value_len);
     }
-  else if (strcmp(key, "SYSLOG_IDENTIFIER") == 0)
+  else if (strcmp(key, "_COMM") == 0)
     {
       gssize program_length;
       (void)log_msg_get_value(msg, LM_V_PROGRAM, &program_length);


### PR DESCRIPTION
In order to not break assumptions, prefer `SYSLOG_IDENTIFIER` over `_COMM`. For example, postfix uses `postfix/qmgr` as `SYSLOG_IDENTIFIER`, but `_COMM` is only `qmgr`. The journal itself uses `SYSLOG_IDENTIFIER` when reconstructing the syslog message, so we should not deviate from that behaviour, either.

Similarly, rsyslog also prefers `SYSLOG_IDENTIFIER`, so for the sake of compatibility, doing the same is preferable.

Reported-by: Alexander Görtz
Signed-off-by: Gergely Nagy algernon@madhouse-project.org
