### PR TITLE
afprog: kill program destination before stopping syslog-ng

### DIFF
--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -276,11 +276,12 @@ afprogram_dd_kill_child(AFProgramDestDriver *self)
 {
   if (self->pid != -1)
     {
+      child_manager_unregister(self->pid);
       msg_verbose("Sending destination program a TERM signal",
                   evt_tag_str("cmdline", self->cmdline->str),
                   evt_tag_int("child_pid", self->pid),
                   NULL);
-      kill(-self->pid, SIGTERM);
+      killpg(getpgid(self->pid), SIGTERM);
       self->pid = -1;
     }
 }


### PR DESCRIPTION
Stop procedure of syslog-ng is not stopped program destination and it is
running after syslog-ng was stopped. This patch set program group ID to all
child processes of syslog-ng and kill them process that have the same
program gorup ID than syslog-ng before syslog-ng has been stoped.
