### PR TITLE
afinet: max packet length for spoof source is set to 1024

### DIFF
--- a/modules/afsocket/afinet-dest.h
+++ b/modules/afsocket/afinet-dest.h
@@ -44,6 +44,7 @@ typedef struct _AFInetDestDriver
   struct libnet_context *lnet_ctx;
   GStaticMutex lnet_lock;
   GString *lnet_buffer;
+  gint spoof_source_maxmsglen;
 #endif
   gchar *hostname;
 


### PR DESCRIPTION
If actual packet size is bigger than AFInetDestDriver.spoof_source_maxmsglen,
the packet is truncated.

AFInetDestDriver.spoof_source_maxmsglen is set to 1024
and cannot set via config file at this time.

Signed-off-by: Budai Laszlo Laszlo.Budai@balabit.com
