### PR TITLE
afsql: Fixed memleak in `afsql_dd_insert_db()`.

### DIFF
--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -987,7 +987,7 @@ afsql_dd_insert_db(AFSqlDestDriver *self)
           g_string_free(insert_command, TRUE);
           msg_set_context(NULL);
 
-          return FALSE;
+          success = FALSE;
         }
     }
 


### PR DESCRIPTION
When a transaction failed we just returned and leaked all
the allocated resources.

Signed-off-by: Budai Laszlo Laszlo.Budai@balabit.com
