### PR TITLE
templates: macros depend on templates ( via `log_macro_expand()` )

### DIFF
--- a/lib/template/macros.h
+++ b/lib/template/macros.h
@@ -26,8 +26,7 @@
 #define TEMPLATE_MACROS_H_INCLUDED
 
 #include "syslog-ng.h"
-
-typedef struct _LogTemplateOptions LogTemplateOptions;
+#include "templates.h"
 
 /* macro IDs */
 enum


### PR DESCRIPTION
fixes #317

Signed-off-by: Budai Laszlo Laszlo.Budai@balabit.com
