### PR TITLE
scl/scl.conf: Do not force "plugin.conf" when including

### DIFF
--- a/scl/scl.conf
+++ b/scl/scl.conf
@@ -28,4 +28,4 @@
 @define scl-root "`syslog-ng-data`/include/scl"
 @define include-path "`include-path`:`syslog-ng-data`/include"
 
-@include 'scl/*/plugin.conf'
+@include 'scl/*/*.conf'


### PR DESCRIPTION
Use a less strict wildcard when including other SCL snippets, otherwise some of the existing plugins will not be loaded by default. (This also brings 3.6's scl.conf in line with 3.7's.)
