### PR TITLE
redis: free reply object after a succesful ping

### DIFF
--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -132,9 +132,14 @@ redis_dd_format_persist_name(LogThrDestDriver *d)
 static gboolean
 redis_dd_connect(RedisDriver *self, gboolean reconnect)
 {
+  redisReply *reply;
+  
   if (reconnect && (self->c != NULL))
     {
-      redisCommand(self->c, "ping");
+      reply = redisCommand(self->c, "ping");
+
+      if (reply)
+        freeReplyObject(reply);
 
       if (!self->c->err)
         return TRUE;


### PR DESCRIPTION
This PR fixes a memleak issue with the redis driver.

According to [1], syslog-ng should free the reply object returned by `redisCommand`.

[[1] https://github.com/redis/hiredis#using-replies](https://github.com/redis/hiredis#using-replies)
