### PR TITLE
pytest_framework: MessageReader: Explain the local context around python asserts

### DIFF
--- a/tests/pytest_framework/src/message_reader/message_reader.py
+++ b/tests/pytest_framework/src/message_reader/message_reader.py
@@ -51,7 +51,11 @@ class MessageReader(object):
         return counter
 
     def pop_messages(self, counter, timeout=DEFAULT_TIMEOUT):
-        assert wait_until_true_custom(self.__buffer_and_parse, args=(counter,), timeout=timeout) is True
+        assert (
+            wait_until_true_custom(self.__buffer_and_parse, args=(counter,), timeout=timeout)
+        ), "\nExpected message counter: [{}]\nArrived message counter: [{}]\nArrived messages: [{}]".format(
+            counter, len(self.__parser.msg_list), self.__parser.msg_list
+        )
         counter = self.__map_counter(counter)
         required_number_of_messages = self.__parser.msg_list[0:counter]
         self.__parser.msg_list = self.__parser.msg_list[
@@ -60,7 +64,11 @@ class MessageReader(object):
         return required_number_of_messages
 
     def peek_messages(self, counter):
-        assert wait_until_true_custom(self.__buffer_and_parse, args=(counter,)) is True
+        assert (
+            wait_until_true_custom(self.__buffer_and_parse, args=(counter,))
+        ), "\nExpected message counter: [{}]\nArrived message counter: [{}]\nArrived messages: [{}]".format(
+            counter, len(self.__parser.msg_list), self.__parser.msg_list
+        )
         counter = self.__map_counter(counter)
         required_number_of_messages = self.__parser.msg_list[0:counter]
         return required_number_of_messages


### PR DESCRIPTION
 - With the help of this local context we could imagine
why the assert Failes

Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>

Before the patch the context of the assertion was look like:
```
    def pop_messages(self, counter, timeout=DEFAULT_TIMEOUT):
>       assert wait_until_true_custom(self.__buffer_and_parse, args=(counter,), timeout=timeout) is True
E       AssertionError

counter    = 4
self       = <src.message_reader.message_reader.MessageReader object at 0x7fdc84117048>
timeout    = 10
```

After the patch it will look like:
```
    def pop_messages(self, counter, timeout=DEFAULT_TIMEOUT):
>       assert wait_until_true_custom(self.__buffer_and_parse, args=(counter,), timeout=timeout) is True, "\nExpected message counter: [{}]\nArrived message counter: [{}]\nArrived messages: [{}]".format(counter, len(self.__parser.msg_list), self.__parser.msg_list)
E       AssertionError: 
E       Expected message counter: [4]
E       Arrived message counter: [3]
E       Arrived messages: [['Jan 23 05:08:52 tristram testprogram[9999]: test message\n', 'Jan 23 05:08:52 tristram testprogram[9999]: test message\n', 'Jan 23 05:08:52 tristram testprogram[9999]: test message\n']]

counter    = 4
self       = <src.message_reader.message_reader.MessageReader object at 0x7f61778b38d0>
timeout    = 10
```