### PR TITLE
Elasticsearch java dest optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,16 @@ dbld/rules.conf
 debian/build-tree/
 debian/*.log
 debian/autoreconf.*
+*.lo
+*grammar.c
+*grammar.h
+*grammar.y
+*.la
+*.o
+.dirstamp
+.libs
+modules/java-modules/*/gradle
+.gradle
+gradle*
+.idea
+**/out

--- a/Makefile.am
+++ b/Makefile.am
@@ -23,7 +23,8 @@
 
 SUBDIRS			=
 DIST_SUBDIRS		=
-AM_MAKEFLAGS		= --no-print-directory
+#AM_MAKEFLAGS		= --no-print-directory
+AM_MAKEFLAGS		= 
 AM_YFLAGS		= -Wno-yacc -Wno-other
 
 AM_TESTS_ENVIRONMENT	= top_srcdir="$(top_srcdir)"

--- a/modules/java-modules/build.gradle
+++ b/modules/java-modules/build.gradle
@@ -7,6 +7,7 @@ subprojects {
     apply plugin: 'idea'
 
     repositories {
+      mavenLocal()
         maven {
           url "/usr/lib/syslog-ng-java-compile-deps-mvn-repo"
         }
@@ -18,8 +19,8 @@ subprojects {
     }
 
     compileJava {
-        sourceCompatibility "1.7"
-        targetCompatibility "1.7"
+        sourceCompatibility "1.8"
+        targetCompatibility "1.8"
     }
 }
 

--- a/modules/java-modules/elastic-v2/src/main/java/io/searchbox/client/ESJestClientFactory.java
+++ b/modules/java-modules/elastic-v2/src/main/java/io/searchbox/client/ESJestClientFactory.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2016 Balabit
+ * Copyright (c) 2016 Laszlo Budai <laszlo.budai@balabit.com>
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package io.searchbox.client;
 
 import com.google.gson.Gson;

--- a/modules/java-modules/elastic-v2/src/main/java/io/searchbox/client/ESJestClientFactory.java
+++ b/modules/java-modules/elastic-v2/src/main/java/io/searchbox/client/ESJestClientFactory.java
@@ -7,6 +7,10 @@ import io.searchbox.client.config.idle.HttpReapableConnectionManager;
 import io.searchbox.client.config.idle.IdleConnectionReaper;
 import io.searchbox.client.http.ESJestHttpClient;
 import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClients;
 import org.apache.http.nio.conn.NHttpClientConnectionManager;
 
 public class ESJestClientFactory extends  JestClientFactory {
@@ -61,6 +65,28 @@ public class ESJestClientFactory extends  JestClientFactory {
     }
 
     return client;
+  }
+
+  protected CloseableHttpClient createHttpClient(HttpClientConnectionManager connectionManager) {
+    return configureHttpClient(
+            HttpClients.custom()
+                    .setConnectionManager(connectionManager)
+                    .setDefaultRequestConfig(getRequestConfig())
+                    .setProxyAuthenticationStrategy(httpClientConfig.getProxyAuthenticationStrategy())
+                    .setRoutePlanner(getRoutePlanner())
+                    .setDefaultCredentialsProvider(httpClientConfig.getCredentialsProvider())
+    ).build();
+  }
+
+  protected CloseableHttpAsyncClient createAsyncHttpClient(NHttpClientConnectionManager connectionManager) {
+    return configureHttpClient(
+            HttpAsyncClients.custom()
+                    .setConnectionManager(connectionManager)
+                    .setDefaultRequestConfig(getRequestConfig())
+                    .setProxyAuthenticationStrategy(httpClientConfig.getProxyAuthenticationStrategy())
+                    .setRoutePlanner(getRoutePlanner())
+                    .setDefaultCredentialsProvider(httpClientConfig.getCredentialsProvider())
+    ).build();
   }
 
   public void setHttpClientConfig(HttpClientConfig httpClientConfig) {

--- a/modules/java-modules/elastic-v2/src/main/java/io/searchbox/client/ESJestClientFactory.java
+++ b/modules/java-modules/elastic-v2/src/main/java/io/searchbox/client/ESJestClientFactory.java
@@ -1,0 +1,71 @@
+package io.searchbox.client;
+
+import com.google.gson.Gson;
+import io.searchbox.client.config.HttpClientConfig;
+import io.searchbox.client.config.discovery.NodeChecker;
+import io.searchbox.client.config.idle.HttpReapableConnectionManager;
+import io.searchbox.client.config.idle.IdleConnectionReaper;
+import io.searchbox.client.http.ESJestHttpClient;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.nio.conn.NHttpClientConnectionManager;
+
+public class ESJestClientFactory extends  JestClientFactory {
+
+  private HttpClientConfig httpClientConfig;
+
+  public JestClient getObject() {
+    ESJestHttpClient client = new ESJestHttpClient();
+
+    if (httpClientConfig == null) {
+      log.debug("There is no configuration to create http client. Going to create simple client with default values");
+      httpClientConfig = new HttpClientConfig.Builder("http://localhost:9200").build();
+    }
+
+    client.setRequestCompressionEnabled(httpClientConfig.isRequestCompressionEnabled());
+    client.setServers(httpClientConfig.getServerList());
+    final HttpClientConnectionManager connectionManager = getConnectionManager();
+    final NHttpClientConnectionManager asyncConnectionManager = getAsyncConnectionManager();
+    client.setHttpClient(createHttpClient(connectionManager));
+    client.setAsyncClient(createAsyncHttpClient(asyncConnectionManager));
+
+    // set custom gson instance
+    Gson gson = httpClientConfig.getGson();
+    if (gson == null) {
+      log.info("Using default GSON instance");
+    } else {
+      log.info("Using custom GSON instance");
+      client.setGson(gson);
+    }
+
+    // set discovery (should be set after setting the httpClient on jestClient)
+    if (httpClientConfig.isDiscoveryEnabled()) {
+      log.info("Node Discovery enabled...");
+      NodeChecker nodeChecker = new NodeChecker(client, httpClientConfig);
+      client.setNodeChecker(nodeChecker);
+      nodeChecker.startAsync();
+      nodeChecker.awaitRunning();
+    } else {
+      log.info("Node Discovery disabled...");
+    }
+
+    // schedule idle connection reaping if configured
+    if (httpClientConfig.getMaxConnectionIdleTime() > 0) {
+      log.info("Idle connection reaping enabled...");
+
+      IdleConnectionReaper reaper = new IdleConnectionReaper(httpClientConfig, new HttpReapableConnectionManager(connectionManager, asyncConnectionManager));
+      client.setIdleConnectionReaper(reaper);
+      reaper.startAsync();
+      reaper.awaitRunning();
+    } else {
+      log.info("Idle connection reaping disabled...");
+    }
+
+    return client;
+  }
+
+  public void setHttpClientConfig(HttpClientConfig httpClientConfig) {
+    this.httpClientConfig = httpClientConfig;
+    super.setHttpClientConfig(httpClientConfig);
+  }
+
+}

--- a/modules/java-modules/elastic-v2/src/main/java/io/searchbox/client/http/ESJestHttpClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/io/searchbox/client/http/ESJestHttpClient.java
@@ -1,0 +1,202 @@
+package io.searchbox.client.http;
+
+import io.searchbox.action.Action;
+import io.searchbox.client.JestResult;
+import io.searchbox.client.JestResultHandler;
+import io.searchbox.core.ESJestBulkActions;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.*;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.entity.ContentType;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.protocol.HTTP;
+import org.apache.http.util.CharArrayBuffer;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
+import java.util.Map;
+
+import static io.searchbox.core.ESJestBulkActions.BLANK;
+
+public class ESJestHttpClient extends JestHttpClient {
+  private final static Logger log = LoggerFactory.getLogger(ESJestHttpClient.class);
+
+  @Override
+  public <T extends JestResult> T execute(Action<T> clientRequest) throws IOException {
+    if (log.isDebugEnabled()) {
+      log.debug("SB: [{}] About to send {}", Thread.currentThread().getName(), clientRequest.getURI());
+    }
+    HttpUriRequest request = prepareRequest(clientRequest);
+    HttpResponse response = getHttpClient().execute(request);
+    if (log.isDebugEnabled()) {
+      log.debug("SB: [{}] Received response {}", Thread.currentThread().getName(), clientRequest.getURI());
+    }
+    String firstFewLines = null;
+    if (clientRequest instanceof ESJestBulkActions) {
+      try {
+        firstFewLines = getFirstFewLines(response);
+        if (StringUtils.isNotBlank(firstFewLines) &&
+                ((ESJestBulkActions)clientRequest)
+                        .isSuccessFull(firstFewLines, response.getStatusLine().getStatusCode())) {
+          //EntityUtils.consumeQuietly(response.getEntity());
+          try {
+            HttpEntity e = response.getEntity();
+            if (e != null) {
+              InputStream s = e.getContent();
+              if (s != null) {
+                s.close();
+              }
+            }
+          } catch (Exception e) {
+            //ignore
+            ;
+          }
+          if (log.isDebugEnabled()) {
+            log.debug("SB: [{}] Message successfully Processed {}", Thread.currentThread().getName(),
+                    clientRequest.getURI());
+          }
+          return null;
+        }
+      } catch (IOException e) {
+        log.warn("SB: Got exception response while executing request " + e.getMessage(), e);
+        throw e;
+      }
+    }
+
+    return deserializeResponse(response, request, clientRequest, firstFewLines);
+  }
+
+  @Override
+  protected <T extends JestResult> HttpUriRequest prepareRequest(final Action<T> clientRequest) {
+    String elasticSearchRestUrl = getRequestURL(getNextServer(), clientRequest.getURI());
+    HttpUriRequest request = constructHttpMethod(clientRequest.getRestMethodName(), elasticSearchRestUrl, clientRequest.getData(gson));
+
+    log.debug("Request method={} url={}", clientRequest.getRestMethodName(), elasticSearchRestUrl);
+
+    return request;
+  }
+
+  @Override
+  public <T extends JestResult> void executeAsync(final Action<T> clientRequest, final JestResultHandler<? super T> resultHandler) {
+    CloseableHttpAsyncClient asyncClient = getAsyncClient();
+
+    synchronized (this) {
+      if (!asyncClient.isRunning()) {
+        asyncClient.start();
+      }
+    }
+
+    HttpUriRequest request = prepareRequest(clientRequest);
+    asyncClient.execute(request, new ESHttpCallback<T>(clientRequest, request, resultHandler));
+  }
+
+  protected class ESHttpCallback<T extends JestResult> extends DefaultCallback<T>  {
+    private final Action<T> clientRequest;
+    private final HttpRequest request;
+    private final JestResultHandler<? super T> resultHandler;
+
+    ESHttpCallback(Action<T> clientRequest,
+                          final HttpRequest request,
+                          JestResultHandler<? super T> resultHandler) {
+      super(clientRequest, request, resultHandler);
+      this.clientRequest = clientRequest;
+      this.request = request;
+      this.resultHandler = resultHandler;
+    }
+
+    @Override
+    public void completed(final HttpResponse response) {
+      String firstFewLines = null;
+      if (clientRequest instanceof ESJestBulkActions) {
+        try {
+          firstFewLines = getFirstFewLines(response);
+          if (StringUtils.isNotBlank(firstFewLines) &&
+                  ((ESJestBulkActions)clientRequest)
+                          .isSuccessFull(firstFewLines, response.getStatusLine().getStatusCode())) {
+            EntityUtils.consumeQuietly(response.getEntity());
+            return;
+          }
+        } catch (IOException e) {
+          failed(e);
+        }
+      }
+
+      T jestResult = null;
+      try {
+        jestResult = deserializeResponse(response, request, clientRequest, firstFewLines);
+      } catch (IOException e) {
+        failed(e);
+      }
+      if (jestResult != null) resultHandler.completed(jestResult);
+    }
+  }
+
+  private String getFirstFewLines(HttpResponse response) throws IOException {
+    StatusLine statusLine = response.getStatusLine();
+    HttpEntity entity = response.getEntity();
+    if(statusLine.getStatusCode() != 200 || entity == null) {
+      return null;
+    }
+
+    final InputStream instream = entity.getContent();
+    if (instream == null) {
+      return null;
+    }
+
+    Charset charset = null;
+    try {
+      final ContentType contentType = ContentType.get(entity);
+      if (contentType != null) {
+        charset = contentType.getCharset();
+      }
+    } catch (final UnsupportedCharsetException ex) {
+      // will get caught at EntityUtils.toString.
+      return null;
+    }
+    if (charset == null) {
+      charset = HTTP.DEF_CONTENT_CHARSET;
+    }
+    final Reader reader = new InputStreamReader(instream, charset);
+    final CharArrayBuffer buffer = new CharArrayBuffer(1024);
+    final char[] tmp = new char[1024];
+    int l;
+    if ((l = reader.read(tmp)) != -1) {
+      buffer.append(tmp, 0, l);
+    }
+    return buffer.toString();
+  }
+
+  private <T extends JestResult> T deserializeResponse(HttpResponse response,
+                                                       final HttpRequest httpRequest,
+                                                       Action<T> clientRequest,
+                                                       final String firstFewLines) throws IOException {
+    StatusLine statusLine = response.getStatusLine();
+    try {
+      return clientRequest.createNewElasticSearchResult(
+                      (response.getEntity() == null ? null :
+                              firstFewLines != null ? firstFewLines + EntityUtils.toString(response.getEntity()) :
+                                      EntityUtils.toString(response.getEntity())),
+              statusLine.getStatusCode(),
+              statusLine.getReasonPhrase(),
+              gson
+      );
+    } catch (com.google.gson.JsonSyntaxException e) {
+      for (Header header : response.getHeaders("Content-Type")) {
+        final String mimeType = header.getValue();
+        if (!mimeType.startsWith("application/json")) {
+          // probably a proxy that responded in text/html
+          final String message = "Request " + httpRequest.toString() + " yielded " + mimeType
+                  + ", should be json: " + statusLine.toString();
+          throw new IOException(message, e);
+        }
+      }
+      throw e;
+    }
+  }
+
+}

--- a/modules/java-modules/elastic-v2/src/main/java/io/searchbox/client/http/ESJestHttpClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/io/searchbox/client/http/ESJestHttpClient.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2016 Balabit
+ * Copyright (c) 2016 Laszlo Budai <laszlo.budai@balabit.com>
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package io.searchbox.client.http;
 
 import io.searchbox.action.Action;

--- a/modules/java-modules/elastic-v2/src/main/java/io/searchbox/client/http/ESJestHttpClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/io/searchbox/client/http/ESJestHttpClient.java
@@ -28,12 +28,12 @@ public class ESJestHttpClient extends JestHttpClient {
   @Override
   public <T extends JestResult> T execute(Action<T> clientRequest) throws IOException {
     if (log.isDebugEnabled()) {
-      log.debug("SB: ["+ Thread.currentThread().getName() + "] About to send " + clientRequest.getURI());
+      log.debug("["+ Thread.currentThread().getName() + "] About to send " + clientRequest.getURI());
     }
     HttpUriRequest request = prepareRequest(clientRequest);
     HttpResponse response = getHttpClient().execute(request);
     if (log.isDebugEnabled()) {
-      log.debug("SB: ["+ Thread.currentThread().getName() + "] Received response " + clientRequest.getURI());
+      log.debug("["+ Thread.currentThread().getName() + "] Received response " + clientRequest.getURI());
     }
     String firstFewLines = null;
     if (clientRequest instanceof ESJestBulkActions) {
@@ -56,12 +56,12 @@ public class ESJestHttpClient extends JestHttpClient {
             ;
           }
           if (log.isDebugEnabled()) {
-            log.debug("SB: ["+ Thread.currentThread().getName() + "] Message successfully Processed " + clientRequest.getURI());
+            log.debug("["+ Thread.currentThread().getName() + "] Message successfully Processed " + clientRequest.getURI());
           }
           return null;
         }
       } catch (IOException e) {
-        log.warn("SB: Got exception response while executing request " + e.getMessage(), e);
+        log.warn("Got exception response while executing request " + e.getMessage(), e);
         throw e;
       }
     }

--- a/modules/java-modules/elastic-v2/src/main/java/io/searchbox/client/http/ESJestHttpClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/io/searchbox/client/http/ESJestHttpClient.java
@@ -73,18 +73,23 @@ public class ESJestHttpClient extends JestHttpClient {
 
   @Override
   protected <T extends JestResult> HttpUriRequest prepareRequest(final Action<T> clientRequest) {
-    String nextServerUrl = getNextServer();
-    if (!(clientRequest instanceof ESJestBulkActions)) {
-      final Matcher m = getURI.matcher(nextServerUrl);
-      if(m.matches() && m.groupCount() > 1) {
-        nextServerUrl = m.group(1);
+    HttpUriRequest request = null;
+    try {
+      String nextServerUrl = getNextServer();
+      if (!(clientRequest instanceof ESJestBulkActions)) {
+        final Matcher m = getURI.matcher(nextServerUrl);
+        if (m.matches() && m.groupCount() > 1) {
+          nextServerUrl = m.group(1);
+        }
       }
+      String elasticSearchRestUrl = getRequestURL(nextServerUrl, clientRequest.getURI());
+      request = constructHttpMethod(clientRequest.getRestMethodName(), elasticSearchRestUrl, clientRequest.getData(gson));
+
+      log.debug("Request method=" + clientRequest.getRestMethodName() + " url=" + elasticSearchRestUrl);
+    } catch(Exception e) {
+      log.error("Error preparing request " + e.getMessage(), e);
+      throw e;
     }
-    String elasticSearchRestUrl = getRequestURL(nextServerUrl, clientRequest.getURI());
-    HttpUriRequest request = constructHttpMethod(clientRequest.getRestMethodName(), elasticSearchRestUrl, clientRequest.getData(gson));
-
-    log.debug("Request method=" + clientRequest.getRestMethodName() + " url=" + elasticSearchRestUrl);
-
     return request;
   }
 

--- a/modules/java-modules/elastic-v2/src/main/java/io/searchbox/core/ESJestBulkActions.java
+++ b/modules/java-modules/elastic-v2/src/main/java/io/searchbox/core/ESJestBulkActions.java
@@ -4,10 +4,8 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import io.searchbox.action.Action;
-import io.searchbox.client.JestResult;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.log4j.Logger;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -17,7 +15,7 @@ import java.util.regex.Pattern;
 public class ESJestBulkActions implements Action<BulkResult> {
 
   public static String CHARSET = "utf-8";
-  final static Logger log = LoggerFactory.getLogger(ESJestBulkActions.class);
+  final static Logger log = Logger.getRootLogger();
 
   private StringBuilder data = new StringBuilder();
   private int rowCount = 0;
@@ -70,7 +68,11 @@ public class ESJestBulkActions implements Action<BulkResult> {
       log.error("Error occurred while adding index/type to uri", e);
     }
 
-    return sb.append("/_bulk").toString();
+    if (StringUtils.isNotBlank(this.pipeline)) {
+      return sb.append("/_bulk").append("?pipeline=").append(this.pipeline).toString();
+    } else {
+      return sb.append("/_bulk").toString();
+    }
   }
 
 
@@ -123,7 +125,7 @@ public class ESJestBulkActions implements Action<BulkResult> {
     String payload = data.toString();
     data = null;
     if (debugEnabled)
-        log.warn("SB: Http Bulk Payload : " + payload);
+        log.info("SB: Http Bulk Payload : " + payload);
     return payload;
   }
 

--- a/modules/java-modules/elastic-v2/src/main/java/io/searchbox/core/ESJestBulkActions.java
+++ b/modules/java-modules/elastic-v2/src/main/java/io/searchbox/core/ESJestBulkActions.java
@@ -125,7 +125,7 @@ public class ESJestBulkActions implements Action<BulkResult> {
     String payload = data.toString();
     data = null;
     if (debugEnabled)
-        log.info("SB: Http Bulk Payload : " + payload);
+        log.info("Http Bulk Payload : " + payload);
     return payload;
   }
 

--- a/modules/java-modules/elastic-v2/src/main/java/io/searchbox/core/ESJestBulkActions.java
+++ b/modules/java-modules/elastic-v2/src/main/java/io/searchbox/core/ESJestBulkActions.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2016 Balabit
+ * Copyright (c) 2016 Laszlo Budai <laszlo.budai@balabit.com>
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package io.searchbox.core;
 
 import com.google.gson.Gson;

--- a/modules/java-modules/elastic-v2/src/main/java/io/searchbox/core/ESJestBulkActions.java
+++ b/modules/java-modules/elastic-v2/src/main/java/io/searchbox/core/ESJestBulkActions.java
@@ -20,6 +20,7 @@ public class ESJestBulkActions implements Action<BulkResult> {
   final static Logger log = LoggerFactory.getLogger(ESJestBulkActions.class);
 
   private StringBuilder data = new StringBuilder();
+  private int rowCount = 0;
 
   private final String indexName;
   private final String typeName;
@@ -98,6 +99,7 @@ public class ESJestBulkActions implements Action<BulkResult> {
       data.append(END_INDEX);
     }
     data.append(msg).append(NEWLINE);
+    rowCount++;
   }
 
   //{"took":0,"ingest_took":0,"errors":false,"items":[{
@@ -138,6 +140,10 @@ public class ESJestBulkActions implements Action<BulkResult> {
   @Override
   public BulkResult createNewElasticSearchResult(String responseBody, int statusCode, String reasonPhrase, Gson gson) {
     return createNewElasticSearchResult(new BulkResult(gson), responseBody, statusCode, reasonPhrase, gson);
+  }
+
+  public int getRowCount() {
+    return rowCount;
   }
 
   protected boolean isHttpSuccessful(int httpCode) {

--- a/modules/java-modules/elastic-v2/src/main/java/io/searchbox/core/ESJestBulkActions.java
+++ b/modules/java-modules/elastic-v2/src/main/java/io/searchbox/core/ESJestBulkActions.java
@@ -1,0 +1,189 @@
+package io.searchbox.core;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.searchbox.action.Action;
+import io.searchbox.client.JestResult;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ESJestBulkActions implements Action<BulkResult> {
+
+  public static String CHARSET = "utf-8";
+  final static Logger log = LoggerFactory.getLogger(ESJestBulkActions.class);
+
+  private StringBuilder data = new StringBuilder();
+
+  private final String indexName;
+  private final String typeName;
+  private final String pipeline;
+
+  private final String uri;
+
+  private static final String NEWLINE = "\n";
+  private static final String idxMetaPlaceHolder = "{\"index\" : {} }" + NEWLINE;
+
+  private static final String BEGIN_INDEX = "{\"index\" : {";
+  private static final String END_INDEX = "} }" + NEWLINE;
+  private static final String QUOTE = "\"";
+  private static final String DELIMETER = "\" : \"";
+  private static final String COMMA = ",";
+  public static final String BLANK = "";
+
+  public ESJestBulkActions(String defaultIndex, String defaultType, String defaultPipeline) {
+//    super(new Bulk.Builder().defaultIndex(defaultIndex).defaultType(defaultType));
+    this.indexName = defaultIndex;
+    this.typeName = defaultType;
+    if (StringUtils.isNotBlank(defaultPipeline)) {
+      this.pipeline = defaultPipeline;
+    } else {
+      this.pipeline = BLANK;
+    }
+    uri = buildURI();
+  }
+
+  private String buildURI() {
+    StringBuilder sb = new StringBuilder();
+
+    try {
+      if (StringUtils.isNotBlank(indexName)) {
+        sb.append(URLEncoder.encode(indexName, CHARSET));
+
+        if (StringUtils.isNotBlank(typeName)) {
+          sb.append("/").append(URLEncoder.encode(typeName, CHARSET));
+        }
+      }
+    } catch (UnsupportedEncodingException e) {
+      // unless CHARSET is overridden with a wrong value in a subclass,
+      // this exception won't be thrown.
+      log.error("Error occurred while adding index/type to uri", e);
+    }
+
+    return sb.append("/_bulk").toString();
+  }
+
+
+  private void addIndexMetadata(final String tag, final String value, final boolean isFirst) {
+    if (StringUtils.isBlank(value)) {
+      return;
+    }
+    if(!isFirst) {
+      data.append(COMMA);
+    }
+    data.append(QUOTE).append(tag).append(DELIMETER).append(value).append(QUOTE);
+  }
+
+  public final void addMessage(String msg, String index, String type, String pipeline, String id) {
+    if(this.indexName.equalsIgnoreCase(index) &&
+            this.typeName.equalsIgnoreCase(type) &&
+            this.pipeline.equalsIgnoreCase(StringUtils.isBlank(pipeline) ? BLANK : pipeline)) {
+      data.append(idxMetaPlaceHolder);
+    } else {
+      // { "index" : { "_index" : "<>", "_type" : "<>", "_id" : "<>", "pipeline" : "<>" } }
+      data.append(BEGIN_INDEX);
+      addIndexMetadata("_index", index, true);
+      addIndexMetadata("_type", type, false);
+      addIndexMetadata("pipeline", pipeline,false);
+      addIndexMetadata("_id", id, false);
+      data.append(END_INDEX);
+    }
+    data.append(msg).append(NEWLINE);
+  }
+
+  //{"took":0,"ingest_took":0,"errors":false,"items":[{
+  //{"took":0,"errors":false,"items":[{
+  private static final Pattern successPattern =
+          Pattern.compile("\\{\"took\":[0-9]+,(\"ingest_took\":[0-9]+,)?\"errors\":false,");
+
+  @Override
+  public String getURI() {
+    return uri;
+  }
+
+  @Override
+  public String getRestMethodName() {
+    return "POST";
+  }
+
+  @Override
+  public String getData(Gson gson) {
+    data.append(NEWLINE);
+    String payload = data.toString();
+    data = null;
+    return payload;
+  }
+
+  @Override
+  public String getPathToResult() {
+    return null;
+  }
+
+  @Override
+  public Map<String, Object> getHeaders() {
+    return null;
+  }
+
+  @Override
+  public BulkResult createNewElasticSearchResult(String responseBody, int statusCode, String reasonPhrase, Gson gson) {
+    return createNewElasticSearchResult(new BulkResult(gson), responseBody, statusCode, reasonPhrase, gson);
+  }
+
+  protected boolean isHttpSuccessful(int httpCode) {
+    return (httpCode / 100) == 2;
+  }
+
+  protected JsonObject parseResponseBody(String responseBody) {
+    if (responseBody != null && !responseBody.trim().isEmpty()) {
+      return new JsonParser().parse(responseBody).getAsJsonObject();
+    }
+    return new JsonObject();
+  }
+
+  protected BulkResult createNewElasticSearchResult(BulkResult result, String responseBody, int statusCode, String reasonPhrase, Gson gson) {
+    JsonObject jsonMap = parseResponseBody(responseBody);
+    result.setResponseCode(statusCode);
+    result.setJsonString(responseBody);
+    result.setJsonObject(jsonMap);
+    result.setPathToResult(getPathToResult());
+
+    if (isHttpSuccessful(statusCode)) {
+      if(jsonMap.has("errors") && jsonMap.get("errors").getAsBoolean())
+      {
+        result.setSucceeded(false);
+        result.setErrorMessage("One or more of the items in the Bulk request failed, check BulkResult.getItems() for more information.");
+        log.debug("Bulk operation failed due to one or more failed actions within the Bulk request");
+      } else {
+        result.setSucceeded(true);
+        log.debug("Bulk operation was successfull");
+      }
+    } else {
+      result.setSucceeded(false);
+      // provide the generic HTTP status code error, if one hasn't already come in via the JSON response...
+      // eg.
+      //  IndicesExist will return 404 (with no content at all) for a missing index, but:
+      //  Update will return 404 (with an error message for DocumentMissingException)
+      if (result.getErrorMessage() == null) {
+        result.setErrorMessage(statusCode + " " + (reasonPhrase == null ? "null" : reasonPhrase));
+      }
+      log.debug("Bulk operation failed with an HTTP error");
+    }
+    return result;
+  }
+
+  public boolean isSuccessFull(String firstFewLines, int statusCode) {
+    if (!isHttpSuccessful(statusCode)) {
+      return false;
+    }
+
+    return successPattern.matcher(firstFewLines).find(0);
+  }
+}

--- a/modules/java-modules/elastic-v2/src/main/java/io/searchbox/core/JestIndex.java
+++ b/modules/java-modules/elastic-v2/src/main/java/io/searchbox/core/JestIndex.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2016 Balabit
+ * Copyright (c) 2016 Laszlo Budai <laszlo.budai@balabit.com>
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package io.searchbox.core;
 
 public final class JestIndex extends Index {

--- a/modules/java-modules/elastic-v2/src/main/java/io/searchbox/core/JestIndex.java
+++ b/modules/java-modules/elastic-v2/src/main/java/io/searchbox/core/JestIndex.java
@@ -1,0 +1,33 @@
+package io.searchbox.core;
+
+public final class JestIndex extends Index {
+
+  public JestIndex() { super(new Index.Builder(null)); }
+
+
+  public JestIndex setIndexName(final String index) {
+    super.indexName = index;
+    return this;
+  }
+
+  public JestIndex setId(final String id) {
+    super.id = id;
+    return this;
+  }
+
+  public JestIndex setType(final String type) {
+    super.typeName = type;
+    return this;
+  }
+
+  public JestIndex setPipeline(final String pipeline) {
+    super.pipeline = pipeline;
+    return this;
+  }
+
+  public JestIndex setFormattedMessage(final String message) {
+    super.payload = message;
+    return this;
+  }
+
+}

--- a/modules/java-modules/elastic-v2/src/main/java/io/searchbox/core/JestIndex.java
+++ b/modules/java-modules/elastic-v2/src/main/java/io/searchbox/core/JestIndex.java
@@ -20,11 +20,6 @@ public final class JestIndex extends Index {
     return this;
   }
 
-  public JestIndex setPipeline(final String pipeline) {
-    super.pipeline = pipeline;
-    return this;
-  }
-
   public JestIndex setFormattedMessage(final String message) {
     super.payload = message;
     return this;

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchDestination.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchDestination.java
@@ -114,16 +114,21 @@ public class ElasticSearchDestination extends StructuredLogDestination {
 
 	@Override
 	protected int send(LogMessage msg) {
-		if (!client.isOpened()) {
-			return NOT_CONNECTED;
-		}
+		try {
+      if (!client.isOpened()) {
+        return NOT_CONNECTED;
+      }
 
-    Function<IndexFieldHandler, Object> index = f -> createIndexRequest(this, msg, f);
-		if (options.getFlushLimit() > 1) {
-      return send_batch(index);
-    }
-		else {
-      return send_single(index);
+      Function<IndexFieldHandler, Object> index = f -> createIndexRequest(this, msg, f);
+      if (options.getFlushLimit() > 1) {
+        return send_batch(index);
+      }
+      else {
+        return send_single(index);
+      }
+    } catch(Exception e) {
+		  logger.error("Exception in ES destination during send: " + e.getMessage(), e);
+		  throw e;
     }
   }
 
@@ -149,9 +154,14 @@ public class ElasticSearchDestination extends StructuredLogDestination {
 
 	@Override
 	public int flush() {
-		if (client.flush())
-			return SUCCESS;
-		else
+    try {
+      if (client.flush())
+        return SUCCESS;
+      else
+        return ERROR;
+    } catch (Exception e) {
+      logger.error("Exception in ES destination during flush: " + e.getMessage(), e);
 			return ERROR;
+    }
 	}
 }

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchDestination.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchDestination.java
@@ -47,7 +47,7 @@ public class ElasticSearchDestination extends StructuredLogDestination {
 	public ElasticSearchDestination(long handle) {
 		super(handle);
 		logger = Logger.getRootLogger();
-		logger.error("SB: state of the logger: " + logger.isDebugEnabled());
+		logger.error("SB: ESD: state of the logger: " + logger.isDebugEnabled());
 		SyslogNgInternalLogger.register(logger);
 		options = new ElasticSearchOptions(this);
   }
@@ -144,6 +144,7 @@ public class ElasticSearchDestination extends StructuredLogDestination {
 
 	@Override
 	protected void deinit() {
+    logger.warn("SB: ESD: Deinit called ");
 		client.deinit();
 		options.deinit();
 	}

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchDestination.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchDestination.java
@@ -47,7 +47,6 @@ public class ElasticSearchDestination extends StructuredLogDestination {
 	public ElasticSearchDestination(long handle) {
 		super(handle);
 		logger = Logger.getRootLogger();
-		logger.error("SB: ESD: state of the logger: isDebugEnabled=" + logger.isDebugEnabled());
 		SyslogNgInternalLogger.register(logger);
 		options = new ElasticSearchOptions(this);
   }

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchDestination.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchDestination.java
@@ -47,7 +47,7 @@ public class ElasticSearchDestination extends StructuredLogDestination {
 	public ElasticSearchDestination(long handle) {
 		super(handle);
 		logger = Logger.getRootLogger();
-		logger.error("SB: ESD: state of the logger: " + logger.isDebugEnabled());
+		logger.error("SB: ESD: state of the logger: isDebugEnabled=" + logger.isDebugEnabled());
 		SyslogNgInternalLogger.register(logger);
 		options = new ElasticSearchOptions(this);
   }
@@ -63,7 +63,7 @@ public class ElasticSearchDestination extends StructuredLogDestination {
                         setBatchTimeout(options.getFlushTimeout());
 
 			client = ESClientFactory.getESClient(options);
-			client.init();
+			client.init(this::incDroppedMessages);
 			result = true;
 		}
 		catch (InvalidOptionException | UnknownESClientModeException e){
@@ -97,7 +97,6 @@ public class ElasticSearchDestination extends StructuredLogDestination {
 
 		return fieldsHandler.handle(index, type, customId, pipeline, formattedMessage);
 	}
-
 
 	private int send_batch(Function<IndexFieldHandler, Object> index) {
 		if (client.send(index))
@@ -144,7 +143,6 @@ public class ElasticSearchDestination extends StructuredLogDestination {
 
 	@Override
 	protected void deinit() {
-    logger.warn("SB: ESD: Deinit called ");
 		client.deinit();
 		options.deinit();
 	}

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchOptions.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/ElasticSearchOptions.java
@@ -35,6 +35,7 @@ import org.syslog_ng.options.*;
 
 public class ElasticSearchOptions {
 
+	public static String IDENTIFIER = "identifier";
 	public static String SERVER = "server";
 	public static String PORT = "port";
 	public static String CLUSTER = "cluster";
@@ -48,6 +49,7 @@ public class ElasticSearchOptions {
 	public static String CONFIG_FILE = "resource";
 	public static String CONCURRENT_REQUESTS = "concurrent_requests";
 	public static String CLUSTER_URL = "cluster_url";
+	public static String PIPELINE = "pipeline";
 
 	public static String SERVER_DEFAULT = "localhost";
 	private static final String PORT_DEFAULT = "0";
@@ -108,6 +110,8 @@ public class ElasticSearchOptions {
 		return options.get(optionName);
 	}
 
+	public TemplateOption getIdentifier() { return options.getTemplateOption(IDENTIFIER); }
+
 	public TemplateOption getMessageTemplate() {
 		return options.getTemplateOption(MESSAGE_TEMPLATE);
 	}
@@ -119,6 +123,8 @@ public class ElasticSearchOptions {
 	public TemplateOption getIndex() {
 		return options.getTemplateOption(INDEX);
 	}
+
+	public TemplateOption getPipeline() { return options.getTemplateOption(PIPELINE);	}
 
 	public TemplateOption getType() {
 		return options.getTemplateOption(TYPE);
@@ -223,8 +229,10 @@ public class ElasticSearchOptions {
 	private void fillTemplateOptions() {
 		options.put(new TemplateOption(owner.getConfigHandle(), new RequiredOptionDecorator(new StringOption(owner, INDEX))));
 		options.put(new TemplateOption(owner.getConfigHandle(), new RequiredOptionDecorator(new StringOption(owner, TYPE))));
+		options.put(new TemplateOption(owner.getConfigHandle(), new StringOption(owner, PIPELINE)));
 		options.put(new TemplateOption(owner.getConfigHandle(), new StringOption(owner, MESSAGE_TEMPLATE, MESSAGE_TEMPLATE_DEFAULT)));
 		options.put(new TemplateOption(owner.getConfigHandle(), new StringOption(owner, CUSTOM_ID)));
+		options.put(new TemplateOption(owner.getConfigHandle(), new StringOption(owner, IDENTIFIER)));
 	}
 
 	private void fillStringOptions() {

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClient.java
@@ -23,7 +23,10 @@
 
 package org.syslog_ng.elasticsearch_v2.client;
 
-import org.syslog_ng.elasticsearch_v2.messageprocessor.ESIndex;
+import org.syslog_ng.elasticsearch_v2.messageprocessor.http.IndexFieldHandler;
+
+import java.util.function.Function;
+
 
 public interface ESClient {
 	boolean open();
@@ -31,7 +34,7 @@ public interface ESClient {
 	boolean isOpened();
 	void init();
 	void deinit();
-	boolean send(ESIndex index);
+	boolean send(Function<IndexFieldHandler, Object> messageBuilder);
 	String getClusterName();
 	boolean flush();
 }

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/ESClient.java
@@ -25,14 +25,16 @@ package org.syslog_ng.elasticsearch_v2.client;
 
 import org.syslog_ng.elasticsearch_v2.messageprocessor.http.IndexFieldHandler;
 
+import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 
 public interface ESClient {
 	boolean open();
 	void close();
 	boolean isOpened();
-	void init();
+	void init(Consumer<Integer> incDroppedBatchCounter);
 	void deinit();
 	boolean send(Function<IndexFieldHandler, Object> messageBuilder);
 	String getClusterName();

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/esnative/ESNativeClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/esnative/ESNativeClient.java
@@ -26,6 +26,7 @@ package org.syslog_ng.elasticsearch_v2.client.esnative;
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Paths;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.apache.log4j.Logger;
@@ -115,7 +116,7 @@ public abstract class ESNativeClient implements ESClient {
 
 	public abstract void deinit();
 
-	public final void init() {
+	public final void init(Consumer<Integer> incDroppedBatchCounter) {
 		client = createClient();
 	}
 

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/esnative/ESNativeClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/esnative/ESNativeClient.java
@@ -26,6 +26,7 @@ package org.syslog_ng.elasticsearch_v2.client.esnative;
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Paths;
+import java.util.function.Function;
 
 import org.apache.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
@@ -40,6 +41,7 @@ import org.syslog_ng.elasticsearch_v2.client.ESClient;
 import org.syslog_ng.elasticsearch_v2.messageprocessor.ESIndex;
 import org.syslog_ng.elasticsearch_v2.messageprocessor.ESMessageProcessorFactory;
 import org.syslog_ng.elasticsearch_v2.messageprocessor.esnative.ESNativeMessageProcessor;
+import org.syslog_ng.elasticsearch_v2.messageprocessor.http.IndexFieldHandler;
 
 public abstract class ESNativeClient implements ESClient {
 	private Client client;
@@ -140,8 +142,8 @@ public abstract class ESNativeClient implements ESClient {
     }
 
 	@Override
-	public boolean send(ESIndex index) {
-		return messageProcessor.send(index);
+	public boolean send(Function<IndexFieldHandler, Object> messageBuilder) {
+		return messageProcessor.send(messageBuilder);
 	}
 
 	@Override

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/http/ESHttpClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/http/ESHttpClient.java
@@ -41,6 +41,7 @@ import org.syslog_ng.elasticsearch_v2.messageprocessor.http.IndexFieldHandler;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 public class ESHttpClient implements ESClient {
@@ -49,6 +50,7 @@ public class ESHttpClient implements ESClient {
 	private JestClient client;
 	private HttpMessageProcessor messageProcessor;
 	protected Logger logger;
+	private Consumer<Integer> incDroppedBatchCounter;
 
   static  {
 		final String log4jPath = System.getProperty("log4j.configuration");
@@ -117,9 +119,12 @@ public class ESHttpClient implements ESClient {
 		return client;
 	}
 
+	public synchronized void incDroppedBatchCounter(int batchSize) {
+    incDroppedBatchCounter(batchSize);
+  }
+
 	@Override
 	public boolean open() {
-		logger.warn("SB: EHC: opening HMP");
 		if (client == null) {
       try {
 			  client = createClient();
@@ -135,7 +140,6 @@ public class ESHttpClient implements ESClient {
 
 	@Override
 	public void close() {
-		logger.warn("SB: EHC: closing HMP");
 		messageProcessor.flush();
 		messageProcessor.deinit();
 	}
@@ -146,8 +150,9 @@ public class ESHttpClient implements ESClient {
 	}
 
 	@Override
-	public void init() {
+	public void init(Consumer<Integer> incDroppedBatchCounter) {
 		this.client = createClient();
+		this.incDroppedBatchCounter = incDroppedBatchCounter;
 	}
 
 	@Override

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/http/ESHttpClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/http/ESHttpClient.java
@@ -88,7 +88,6 @@ public class ESHttpClient implements ESClient {
   protected void setupHttpClientBuilder(HttpClientConfig.Builder httpClientConfigBuilder, ElasticSearchOptions options) {}
 
   private HttpClientConfig buildHttpClientConfig() {
-		// SB: honor concurrent_requests in client-mode(http).
 		int concurrentRequests = options.getConcurrentRequests();
 		int totalRoutes = options.getClusterUrls().size();
 		String connPoolTimes = System.getProperty("HttpConnectionPoolTimes", "3");
@@ -174,7 +173,6 @@ public class ESHttpClient implements ESClient {
 		try {
 			JestResult result = client.execute(nodesinfo);
 			if (result != null ) {
-				logger.error("SB: Node Info: " + result.getJsonString());
 				Object cname = result.getValue("cluster_name");
 				if(cname != null) {
 					clusterName = result.getValue("cluster_name").toString();

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/http/ESHttpClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/http/ESHttpClient.java
@@ -120,7 +120,8 @@ public class ESHttpClient implements ESClient {
 	}
 
 	public synchronized void incDroppedBatchCounter(int batchSize) {
-    incDroppedBatchCounter(batchSize);
+  	if(incDroppedBatchCounter != null)
+  		this.incDroppedBatchCounter.accept(batchSize);
   }
 
 	@Override

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/http/ESHttpClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/http/ESHttpClient.java
@@ -168,7 +168,13 @@ public class ESHttpClient implements ESClient {
 		try {
 			JestResult result = client.execute(nodesinfo);
 			if (result != null ) {
-				clusterName = result.getValue("cluster_name").toString();
+				logger.error("SB: Node Info: " + result.getJsonString());
+				Object cname = result.getValue("cluster_name");
+				if(cname != null) {
+					clusterName = result.getValue("cluster_name").toString();
+				} else {
+					logger.info("Failed to get cluster name from the client, use the name set in the config file: " + clusterName);
+				}
 			}
 		} catch (IOException e) {
       logger.info("Failed to get cluster name from the client, use the name set in the config file: " + clusterName);

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/http/ESHttpClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/http/ESHttpClient.java
@@ -24,37 +24,24 @@
 
 package org.syslog_ng.elasticsearch_v2.client.http;
 
+import io.searchbox.client.ESJestClientFactory;
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestClientFactory;
 import io.searchbox.client.JestResult;
 import io.searchbox.client.config.HttpClientConfig;
 import io.searchbox.cluster.NodesInfo;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
+import org.apache.log4j.PropertyConfigurator;
 import org.syslog_ng.elasticsearch_v2.ElasticSearchOptions;
 import org.syslog_ng.elasticsearch_v2.client.ESClient;
-import org.syslog_ng.elasticsearch_v2.messageprocessor.ESIndex;
 import org.syslog_ng.elasticsearch_v2.messageprocessor.ESMessageProcessorFactory;
 import org.syslog_ng.elasticsearch_v2.messageprocessor.http.HttpMessageProcessor;
-import java.util.Set;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.HostnameVerifier;
-import org.apache.http.conn.ssl.DefaultHostnameVerifier;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.conn.ssl.TrustStrategy;
-import org.apache.http.ssl.SSLContextBuilder;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.nio.conn.SchemeIOSessionStrategy;
-import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-import java.security.UnrecoverableKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.io.FileInputStream;
-import org.apache.log4j.PropertyConfigurator;
+import org.syslog_ng.elasticsearch_v2.messageprocessor.http.IndexFieldHandler;
 
+import java.io.File;
 import java.io.IOException;
+import java.util.function.Function;
 
 public class ESHttpClient implements ESClient {
 	private ElasticSearchOptions options;
@@ -64,7 +51,13 @@ public class ESHttpClient implements ESClient {
 	protected Logger logger;
 
   static  {
-      PropertyConfigurator.configure(System.getProperty("log4j.configuration"));
+		final String log4jPath = System.getProperty("log4j.configuration");
+		if (StringUtils.isNotBlank(log4jPath)) {
+			final File f = new File(log4jPath);
+			if (f.isFile()) {
+				PropertyConfigurator.configure(f.getAbsolutePath());
+			}
+		}
   }
 
 
@@ -93,22 +86,29 @@ public class ESHttpClient implements ESClient {
   protected void setupHttpClientBuilder(HttpClientConfig.Builder httpClientConfigBuilder, ElasticSearchOptions options) {}
 
   private HttpClientConfig buildHttpClientConfig() {
+		// SB: honor concurrent_requests in client-mode(http).
+		int concurrentRequests = options.getConcurrentRequests();
+		int totalRoutes = options.getClusterUrls().size();
+		String connPoolTimes = System.getProperty("HttpConnectionPoolTimes", "3");
  		HttpClientConfig.Builder httpClientConfigBuilder = new HttpClientConfig
 			.Builder(options.getClusterUrls())
 			.multiThreaded(true)
+						.defaultMaxTotalConnectionPerRoute(concurrentRequests)
+						.maxTotalConnection(concurrentRequests * Integer.valueOf(connPoolTimes))
 			.defaultSchemeForDiscoveredNodes(options.getClientMode());
 
 		/* HTTP Basic authentication requested */
 		if (options.getHttpAuthType().equals("basic")) {
 			httpClientConfigBuilder.defaultCredentials(options.getHttpAuthTypeBasicUsername(), options.getHttpAuthTypeBasicPassword());
     }
+    httpClientConfigBuilder.readTimeout(30000);
     setupHttpClientBuilder(httpClientConfigBuilder, this.options);
 
     return httpClientConfigBuilder.build();
   }
 
 	private JestClient createClient() {
-		JestClientFactory clientFactory = new JestClientFactory();
+    ESJestClientFactory clientFactory = new ESJestClientFactory();
 	  clientFactory.setHttpClientConfig(buildHttpClientConfig());
 		return clientFactory.getObject();
 	}
@@ -134,6 +134,8 @@ public class ESHttpClient implements ESClient {
 
 	@Override
 	public void close() {
+		messageProcessor.flush();
+		messageProcessor.deinit();
 	}
 
 	@Override
@@ -153,8 +155,8 @@ public class ESHttpClient implements ESClient {
 	}
 
 	@Override
-	public boolean send(ESIndex index) {
-		return messageProcessor.send(index);
+	public boolean send(Function<IndexFieldHandler, Object> messageBuilder) {
+		return messageProcessor.send(messageBuilder);
 	}
 
 	@Override

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/http/ESHttpClient.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/client/http/ESHttpClient.java
@@ -119,6 +119,7 @@ public class ESHttpClient implements ESClient {
 
 	@Override
 	public boolean open() {
+		logger.warn("SB: EHC: opening HMP");
 		if (client == null) {
       try {
 			  client = createClient();
@@ -134,6 +135,7 @@ public class ESHttpClient implements ESClient {
 
 	@Override
 	public void close() {
+		logger.warn("SB: EHC: closing HMP");
 		messageProcessor.flush();
 		messageProcessor.deinit();
 	}

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/ESIndex.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/ESIndex.java
@@ -23,17 +23,21 @@
 
 package org.syslog_ng.elasticsearch_v2.messageprocessor;
 
+import org.apache.commons.lang3.StringUtils;
+
 public class ESIndex {
 	private String formattedMessage;
 	private String index;
 	private String type;
 	private String id;
+	private String pipeline;
 
 	public static class Builder {
 		String formattedMessage;
 		String index;
 		String type;
 		String id;
+		String pipeline;
 
 		public Builder formattedMessage(String formattedMessage) {
 			Builder.this.formattedMessage = formattedMessage;
@@ -42,6 +46,11 @@ public class ESIndex {
 
 		public Builder index(String index) {
 			Builder.this.index = index;
+			return Builder.this;
+		}
+
+		public Builder pipeline(String pipeline) {
+			Builder.this.pipeline = pipeline;
 			return Builder.this;
 		}
 
@@ -65,6 +74,7 @@ public class ESIndex {
 		this.index = builder.index;
 		this.type = builder.type;
 		this.id = builder.id;
+  	this.pipeline = builder.pipeline;
 	}
 
 	public String getFormattedMessage() {
@@ -78,6 +88,8 @@ public class ESIndex {
 	public String getType() {
 		return type;
 	}
+
+	public String getPipeline() { return pipeline; }
 
 	public String getId() {
 		return id;

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/ESMessageProcessor.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/ESMessageProcessor.java
@@ -23,6 +23,10 @@
 
 package org.syslog_ng.elasticsearch_v2.messageprocessor;
 
+import org.syslog_ng.elasticsearch_v2.messageprocessor.http.IndexFieldHandler;
+
+import java.util.function.Function;
+
 public interface ESMessageProcessor {
-	boolean send(ESIndex index);
+	boolean send(Function<IndexFieldHandler, Object> messageBuilder);
 }

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/esnative/ESNativeMessageProcessor.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/esnative/ESNativeMessageProcessor.java
@@ -29,6 +29,9 @@ import org.syslog_ng.elasticsearch_v2.ElasticSearchOptions;
 import org.syslog_ng.elasticsearch_v2.client.esnative.ESNativeClient;
 import org.syslog_ng.elasticsearch_v2.messageprocessor.ESIndex;
 import org.syslog_ng.elasticsearch_v2.messageprocessor.ESMessageProcessor;
+import org.syslog_ng.elasticsearch_v2.messageprocessor.http.IndexFieldHandler;
+
+import java.util.function.Function;
 
 public abstract class ESNativeMessageProcessor implements ESMessageProcessor {
 	protected ElasticSearchOptions options;
@@ -57,8 +60,13 @@ public abstract class ESNativeMessageProcessor implements ESMessageProcessor {
 	protected abstract boolean send(IndexRequest req);
 
 	@Override
-	public final boolean send(ESIndex index) {
-		IndexRequest req = new IndexRequest(index.getIndex(), index.getType(), index.getId()).source(index.getFormattedMessage());
+	public boolean send(Function<IndexFieldHandler, Object> messageBuilder) {
+
+		IndexRequest req = (IndexRequest) messageBuilder.apply(((index, type, id, pipeline, formattedMessage) -> {
+			return new IndexRequest(index, type, id).source(formattedMessage);
+		}));
+
 		return send(req);
 	}
+
 }

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpBulkMessageProcessor.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpBulkMessageProcessor.java
@@ -93,7 +93,7 @@ public class HttpBulkMessageProcessor extends HttpMessageProcessor {
           while (!shutDown) {
               if ((bulkActions = messageQueue.poll(
                       100, TimeUnit.MILLISECONDS)) == null) {
-                if(logger.isDebugEnabled()) {
+                if(logger.isTraceEnabled()) {
                   logmsg(() -> "No events found in the message queue. " + messageQueue.size());
                 }
                 continue;
@@ -249,7 +249,7 @@ public class HttpBulkMessageProcessor extends HttpMessageProcessor {
                                  String formattedMessage) {
 
     if (processor.bulk == null) {
-      processor.bulk = new ESJestBulkActions(index, type, pipeline, processor.debugEnabled);
+      processor.bulk = new ESJestBulkActions(index, type, pipeline, processor.logger.isDebugEnabled());
     }
     processor.bulk.addMessage(formattedMessage, index, type, pipeline, id);
 

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpBulkMessageProcessor.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpBulkMessageProcessor.java
@@ -75,10 +75,6 @@ public class HttpBulkMessageProcessor extends HttpMessageProcessor {
   @Override
   public void init() {
 
-    if (isInitialized) {
-      logger.error("SB: INITIALIZED invoked again....");
-    }
-
     flushLimit = options.getFlushLimit();
     shutDown = false;
     assert client.getClient() != null : "Client must be initialized by this time.";
@@ -140,12 +136,12 @@ public class HttpBulkMessageProcessor extends HttpMessageProcessor {
               }
 
               if (httpRequestErrorCount > 0) {
-                logger.warn(name + " SB: " + httpRequestErrorCount + " ");
+                logger.warn(name + " http error " + httpRequestErrorCount + " occurred.");
                 httpRequestErrorCount = 0;
               }
 
               if (debugEnabled && jestResult != null) {
-                logmsg(() -> " SB: processed [" + jestResult.getJsonString() + "]");
+                logmsg(() -> " processed jest result [" + jestResult.getJsonString() + "]");
               }
           } // end of while
         } catch (InterruptedException e) {
@@ -170,7 +166,7 @@ public class HttpBulkMessageProcessor extends HttpMessageProcessor {
     }
 
     senders.forEach(t -> {
-      logger.info("SB: Starting " + t.getName());
+      logger.info("Starting sender " + t.getName());
       t.start();
     });
 
@@ -195,14 +191,14 @@ public class HttpBulkMessageProcessor extends HttpMessageProcessor {
 
   @Override
   public void deinit() {
-    logmsg(() -> "SB: HMP: deinit called... shutting down the threadpool");
+    logmsg(() -> "HttpBulkMessageProcessor deinit called... shutting down the threadpool");
     shutDown = true;
     senders.forEach(t -> {
-      logmsg(() -> "SB: Waiting for " + t.getName() + " to terminate");
+      logmsg(() -> "Waiting for " + t.getName() + " to terminate");
       try {
         t.join(10000);
       } catch (InterruptedException e) {
-        logger.error(name + "SB: " + Thread.currentThread() + " received " +
+        logger.error(name + " " + Thread.currentThread() + " " +
                 t.getName() + " interrupted while waiting for termination.", e);
       }
     });
@@ -214,7 +210,7 @@ public class HttpBulkMessageProcessor extends HttpMessageProcessor {
       if (!messageQueue.offer(bulkActions, enqueueTimeout, TimeUnit.MILLISECONDS)) {
         if(enqueueFailCount <= 0) {
           if(logger.isDebugEnabled()) {
-            logger.debug(Thread.currentThread().getId() + "SB: " + name + " " + enqueueTimeout + " millis elapsed to schedule bulk request. " +
+            logger.debug(Thread.currentThread().getId() + " " + name + " " + enqueueTimeout + " millis elapsed to schedule bulk request. " +
                     "Queue full with " + messageQueue.size() + " messages. " +
                     "Consider increasing concurrent_request or elastic cluster capacity.");
           }
@@ -225,7 +221,7 @@ public class HttpBulkMessageProcessor extends HttpMessageProcessor {
         client.incDroppedBatchCounter(bulkActions.getRowCount());
         return true;
       } else if (enqueueFailCount != 0) {
-        logmsg(() -> " SB: " + name + " " + enqueueFailCount +
+        logmsg(() -> " " + name + " " + enqueueFailCount +
                 " enqueue attempts failed and " + (System.currentTimeMillis() - enqueueStartTime) +
                 " millis elapsed since last success.");
         enqueueFailCount = 0;

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpBulkMessageProcessor.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpBulkMessageProcessor.java
@@ -180,6 +180,7 @@ public class HttpBulkMessageProcessor extends HttpMessageProcessor {
                 t.getName() + " interrupted while waiting for termination.", e);
       }
     });
+    senders.clear();
   }
 
   private void scheduleBulkAction(final ESJestBulkActions bulkActions) {

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpMessageProcessor.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpMessageProcessor.java
@@ -24,13 +24,12 @@
 
 package org.syslog_ng.elasticsearch_v2.messageprocessor.http;
 
-import io.searchbox.core.Index;
 import org.apache.log4j.Logger;
 import org.syslog_ng.elasticsearch_v2.ElasticSearchOptions;
 import org.syslog_ng.elasticsearch_v2.client.http.ESHttpClient;
-import org.syslog_ng.elasticsearch_v2.messageprocessor.ESIndex;
 import org.syslog_ng.elasticsearch_v2.messageprocessor.ESMessageProcessor;
-import java.io.IOException;
+
+import java.util.function.Function;
 
 public abstract class HttpMessageProcessor implements ESMessageProcessor {
 	protected ElasticSearchOptions options;
@@ -54,11 +53,22 @@ public abstract class HttpMessageProcessor implements ESMessageProcessor {
 
 	}
 
-	protected abstract boolean send(Index req);
+	protected abstract boolean sendImpl(Function<IndexFieldHandler, Object> msgBuilder);
 
 	@Override
-	public boolean send(ESIndex index) {
-		Index req = new Index.Builder(index.getFormattedMessage()).index(index.getIndex()).type(index.getType()).id(index.getId()).build();
-		return send(req);
+	public boolean send(Function<IndexFieldHandler, Object> messageBuilder) {
+		return sendImpl(messageBuilder);
 	}
+<<<<<<< HEAD
+||||||| parent of 2e070b73e... Base changes to the ES plugin
+
+    public void onMessageQueueEmpty() {
+
+    }
+=======
+
+	public void onMessageQueueEmpty() {
+
+    }
+>>>>>>> 2e070b73e... Base changes to the ES plugin
 }

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpMessageProcessor.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpMessageProcessor.java
@@ -59,16 +59,5 @@ public abstract class HttpMessageProcessor implements ESMessageProcessor {
 	public boolean send(Function<IndexFieldHandler, Object> messageBuilder) {
 		return sendImpl(messageBuilder);
 	}
-<<<<<<< HEAD
-||||||| parent of 2e070b73e... Base changes to the ES plugin
 
-    public void onMessageQueueEmpty() {
-
-    }
-=======
-
-	public void onMessageQueueEmpty() {
-
-    }
->>>>>>> 2e070b73e... Base changes to the ES plugin
 }

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpSingleMessageProcessor.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpSingleMessageProcessor.java
@@ -43,7 +43,7 @@ public class HttpSingleMessageProcessor extends  HttpMessageProcessor {
 	public boolean sendImpl(Function<IndexFieldHandler, Object> msgBuilder) {
 
 		JestIndex req = (JestIndex) msgBuilder.apply((index, type, id, pipeline, formattedMessage) ->
-						new JestIndex().setIndexName(index).setType(type).setId(id).setPipeline(pipeline)
+						new JestIndex().setIndexName(index).setType(type).setId(id)
 						.setFormattedMessage(formattedMessage));
 
 	  JestResult jestResult = null;

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpSingleMessageProcessor.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/HttpSingleMessageProcessor.java
@@ -26,10 +26,12 @@ package org.syslog_ng.elasticsearch_v2.messageprocessor.http;
 
 import io.searchbox.core.Index;
 import io.searchbox.client.JestResult;
+import io.searchbox.core.JestIndex;
 import org.syslog_ng.elasticsearch_v2.ElasticSearchOptions;
 import org.syslog_ng.elasticsearch_v2.client.http.ESHttpClient;
 
 import java.io.IOException;
+import java.util.function.Function;
 
 public class HttpSingleMessageProcessor extends  HttpMessageProcessor {
 
@@ -38,7 +40,12 @@ public class HttpSingleMessageProcessor extends  HttpMessageProcessor {
 	}
 
 	@Override
-	public boolean send(Index req) {
+	public boolean sendImpl(Function<IndexFieldHandler, Object> msgBuilder) {
+
+		JestIndex req = (JestIndex) msgBuilder.apply((index, type, id, pipeline, formattedMessage) ->
+						new JestIndex().setIndexName(index).setType(type).setId(id).setPipeline(pipeline)
+						.setFormattedMessage(formattedMessage));
+
 	  JestResult jestResult = null;
 		try {
 			jestResult = client.getClient().execute(req);
@@ -56,3 +63,4 @@ public class HttpSingleMessageProcessor extends  HttpMessageProcessor {
 	}
 
 }
+

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/IndexFieldHandler.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/IndexFieldHandler.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2016 Balabit
+ * Copyright (c) 2016 Laszlo Budai <laszlo.budai@balabit.com>
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 package org.syslog_ng.elasticsearch_v2.messageprocessor.http;
 
 @FunctionalInterface

--- a/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/IndexFieldHandler.java
+++ b/modules/java-modules/elastic-v2/src/main/java/org/syslog_ng/elasticsearch_v2/messageprocessor/http/IndexFieldHandler.java
@@ -1,0 +1,6 @@
+package org.syslog_ng.elasticsearch_v2.messageprocessor.http;
+
+@FunctionalInterface
+public interface IndexFieldHandler<T> {
+     T handle(String index, String type, String id, String pipeline, String formattedMessage);
+}

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -99,6 +99,13 @@ Java_org_syslog_1ng_LogPipe_getConfigHandle(JNIEnv *env, jobject obj, jlong hand
   return (jlong)log_pipe_get_config(&self->super.super.super.super);
 }
 
+JNIEXPORT void JNICALL
+Java_org_syslog_1ng_LogDestination_incDroppedMessages(JNIEnv *env, jobject obj, jlong handle, jint batch_size)
+{
+  JavaDestDriver *self = (JavaDestDriver *)handle;
+  stats_counter_add(self->super.dropped_messages, batch_size);
+}
+
 void java_dd_set_option(LogDriver *s, const gchar *key, const gchar *value)
 {
   JavaDestDriver *self = (JavaDestDriver *)s;

--- a/modules/java/src/main/java/org/syslog_ng/LogDestination.java
+++ b/modules/java/src/main/java/org/syslog_ng/LogDestination.java
@@ -49,6 +49,7 @@ public abstract class LogDestination extends LogPipe {
  		return getSeqNum(getHandle());
         }
 
+<<<<<<< HEAD
 	public int getBatchLines() {
  		return getBatchLines(getHandle());
         }
@@ -61,6 +62,13 @@ public abstract class LogDestination extends LogPipe {
  		setBatchTimeout(getHandle(), timeout);
         }
 
+||||||| parent of cbe091a70... Adding 'dropped' statistics
+=======
+  public void incDroppedMessages(int batch_size) {
+    incDroppedMessages(getHandle(), batch_size);
+  }
+
+>>>>>>> cbe091a70... Adding 'dropped' statistics
 	protected abstract boolean open();
 
 	protected abstract void close();
@@ -71,10 +79,11 @@ public abstract class LogDestination extends LogPipe {
 
 	private native String getOption(long ptr, String key);
 
-	private native long getTemplateOptionsHandle(long ptr);
+  private native long getTemplateOptionsHandle(long ptr);
 
 	private native int getSeqNum(long ptr);
 
+<<<<<<< HEAD
 	private native int getBatchLines(long ptr);
 
 	private native int setBatchLines(long ptr, long batch_size);
@@ -83,6 +92,15 @@ public abstract class LogDestination extends LogPipe {
 
 	protected int flush() {
 		return SUCCESS;
+||||||| parent of cbe091a70... Adding 'dropped' statistics
+	protected void onMessageQueueEmpty() {
+		return;
+=======
+  private native void incDroppedMessages(long ptr, int batch_size);
+
+	protected void onMessageQueueEmpty() {
+		return;
+>>>>>>> cbe091a70... Adding 'dropped' statistics
 	}
 
 	public boolean openProxy() {

--- a/modules/java/src/main/java/org/syslog_ng/LogDestination.java
+++ b/modules/java/src/main/java/org/syslog_ng/LogDestination.java
@@ -49,7 +49,6 @@ public abstract class LogDestination extends LogPipe {
  		return getSeqNum(getHandle());
         }
 
-<<<<<<< HEAD
 	public int getBatchLines() {
  		return getBatchLines(getHandle());
         }
@@ -62,13 +61,10 @@ public abstract class LogDestination extends LogPipe {
  		setBatchTimeout(getHandle(), timeout);
         }
 
-||||||| parent of cbe091a70... Adding 'dropped' statistics
-=======
   public void incDroppedMessages(int batch_size) {
     incDroppedMessages(getHandle(), batch_size);
   }
 
->>>>>>> cbe091a70... Adding 'dropped' statistics
 	protected abstract boolean open();
 
 	protected abstract void close();
@@ -83,7 +79,6 @@ public abstract class LogDestination extends LogPipe {
 
 	private native int getSeqNum(long ptr);
 
-<<<<<<< HEAD
 	private native int getBatchLines(long ptr);
 
 	private native int setBatchLines(long ptr, long batch_size);
@@ -92,16 +87,9 @@ public abstract class LogDestination extends LogPipe {
 
 	protected int flush() {
 		return SUCCESS;
-||||||| parent of cbe091a70... Adding 'dropped' statistics
-	protected void onMessageQueueEmpty() {
-		return;
-=======
-  private native void incDroppedMessages(long ptr, int batch_size);
-
-	protected void onMessageQueueEmpty() {
-		return;
->>>>>>> cbe091a70... Adding 'dropped' statistics
 	}
+
+  private native void incDroppedMessages(long ptr, int batch_size);
 
 	public boolean openProxy() {
 		try {

--- a/modules/java/src/main/java/org/syslog_ng/SyslogNgClassLoader.java
+++ b/modules/java/src/main/java/org/syslog_ng/SyslogNgClassLoader.java
@@ -58,7 +58,6 @@ public class SyslogNgClassLoader {
 
   public Class loadClass(String className, String pathList) {
     Class result = null;
-    System.err.println("SB: pathLIST : " + pathList);
     URL[] urls = createUrls(pathList);
 
     try {
@@ -142,7 +141,6 @@ public class SyslogNgClassLoader {
       Method method = URLClassLoader.class.getDeclaredMethod("addURL", new Class[]{URL.class});
       method.setAccessible(true);
       for (URL url:urls) {
-        System.err.println("SB: pathLIST : " + url);
           method.invoke(classLoader, new Object[]{url});
       }
   }

--- a/modules/java/src/main/java/org/syslog_ng/SyslogNgClassLoader.java
+++ b/modules/java/src/main/java/org/syslog_ng/SyslogNgClassLoader.java
@@ -58,6 +58,7 @@ public class SyslogNgClassLoader {
 
   public Class loadClass(String className, String pathList) {
     Class result = null;
+    System.err.println("SB: pathLIST : " + pathList);
     URL[] urls = createUrls(pathList);
 
     try {
@@ -141,6 +142,7 @@ public class SyslogNgClassLoader {
       Method method = URLClassLoader.class.getDeclaredMethod("addURL", new Class[]{URL.class});
       method.setAccessible(true);
       for (URL url:urls) {
+        System.err.println("SB: pathLIST : " + url);
           method.invoke(classLoader, new Object[]{url});
       }
   }

--- a/scl/elasticsearch/plugin.conf
+++ b/scl/elasticsearch/plugin.conf
@@ -23,8 +23,10 @@
 @requires json-plugin
 
 block destination elasticsearch2(
+  identifier("")
   index()
   type()
+  pipeline("")
   template("$(format-json --scope rfc5424 --exclude DATE --key ISODATE @timestamp=${ISODATE})")
   port("")
   server("localhost")
@@ -53,9 +55,11 @@ block destination elasticsearch2(
   java(
     class_path("`java-module-dir`/*.jar:`java-module-dir`/elastic-jest-client/*.jar:`client_lib_dir`/*.jar")
     class_name("org.syslog_ng.elasticsearch_v2.ElasticSearchDestination")
+    option("identifier", "`identifier`")
     option("index", `index`)
     option("type", `type`)
     option("server", `server`)
+    option("pipeline", "`pipeline`")
     option("port", "`port`")
     option("message-template", `template`)
     option("cluster", "`cluster`")


### PR DESCRIPTION
All observation started from syslogng 3.16 and found to be accurate upto 3.20.

While scaling for 1 million msgs/sec ingestion into elasticsearch using syslog-ng elastic-v2 java destination, we found few bottlenecks when we ran experiments for several hours (upto 72 hrs of constant traffic). Our goal was to get a sustained input without any jitters while listening on multiple udp ports in syslog-ng. 

Primary issue we found in the plugin is: 
a) Too much garbage generation and inefficient json formatting using Gson. 
b) Another glaring issue was no matter how many threads we employed, things weren't scaling due to threads either spending its time in formatting log messages or waiting for http reply but both never happening at the same time. In other words, a destination thread was either formatting message or sending bulk message & formatting was costlier than sending and waiting.

Throughput was viewed in kibana discovery graph and was extremely wavy. We found ES wasn't pushed hard enough in the beginning.

We tried async httpcomponent and connection pool causing http timeout. Main issue was too many ESReject of the bulk message occurring when constant traffic flowed in for longer duration. 

Also, with some http message profiling, we noted message was getting copied multiple times in its path, firstly during formatting and then Jest api level string concatenation and lastly httpcomponent trying to push the message. Message fragmentation at the httpcomponent level wasn't getting avoided due to lack of length prefix provided and these message copy was causing too much gc pressure.

Initially we tried introducing multiple threads in the elastic-v2 plugin that will accumulate individual messages and format them into a bulk message & do send/receive. Idea was if enough threads are introduced, at the cost of higher context switches, we should be able to send continuous stream of bulk messages using http connection pool timeout settings appropriately. This didn't turned out very effective as CMS garbage collector still paused heavily the entire operation and G1GC in java-8 was showed instability on continuous load. Quickly realised upgrading to java-11 isn't easy due to jni level incompatibilities.

Second approach which is in this PR was to introduce a dedicated threadpool of finite size according to the hardware configuration. Speaking of h/w configuration, though syslogng is designed for 1 instance per host, our client had high end boxes (in aws terms xLarge with 32 cores and 168GB ram) for syslogng. Another imposition was to use docker containers. This changed the dynamics quite a bit because now multiple syslogng instances were contesting for the same h/w resources. Decoupling log formatting and bulk request send/receive showed promising results and supported our analysis of the bottleneck. Early closure of the response by reading response code '200' worked out great as it means all messages were success and doesn't really need parsing of the whole response for message ids.
Traffic overload could gracefully be handled by dropping messages and inferences from statistics was more accurate. Our usecase was to give preference to latest data over earlier minute data i.e. unlike syslogng using FIFO queue, we intend to use LIFO queue at a later time to guarantee message delivery of stale data during the lull period instead of trying to catchup with the queued messages at the very next second. For network security analytics, current second data (whatever we could capture) is more important than retrying message of last few seconds. However, eventually we need all of the data to be in the system for later analysis.

The connection pool at the plugin level increments dropped message count of the same destination statistics for now. In future, with the use of LIFO queue, guaranteed delivery can be achieved. The entire pool implementation can be disabled with concurrent-request(1) in the configuration.
 
We could achieve better stable input to ES when compared to native http performance introduced in syslogng. One primary disadvantage with native http plugin as of now is higher network payload mainly due to complete parsing of the http bulk message response from ES which is significant. That effectively slows down on the next request, consumes higher cpu and eats up network bandwidth as well as blocks ES side writer thread pool longer.

In ES, the bulk message hops around multiple servers in the current design. In the java plugin, we introduced facility to avoid such hoping without need for 'key' based shard allocation. Using key based shard routing mandates that key to be known during query time which becomes counter productive while asking adhoc queries. So, to achieve single hop bulk message processing in ES, a more viable design is to define one index per ES host and freeze the REST url's host ip and index name association. In java plugin, index name can't be embedded into url, we enabled it optionaly in this PR. This resulted in great overall stability in traffic ingestion as cross distribution of messages in ES side was all local among multiple ES instances hosted on a single machine. OTOH, syslogng could roundrobin bulk messages and keep the load shifting among ES instances and remained uneffected during index merges happening on the other end. So, ESReject bulk message from one ES server helped failing over to another without any involved changes.

This is just a brief description and if the community thinks this is good to pursue, I can provide with more details on the experiments (basically the numbers around tps/mem/cpu/network) and configuration details.

Few comments in another ticket with additional experiment details.
https://github.com/balabit/syslog-ng/issues/2466#issuecomment-456366108
https://github.com/balabit/syslog-ng/issues/2466#issuecomment-456872007
