### PR TITLE
Fix TLS connection closure (source side)

### DIFF
--- a/lib/transport/transport-socket.c
+++ b/lib/transport/transport-socket.c
@@ -198,7 +198,7 @@ log_transport_stream_socket_write_method(LogTransport *s, const gpointer buf, gs
   return rc;
 }
 
-static void
+void
 log_transport_stream_socket_free_method(LogTransport *s)
 {
   if (s->fd != -1)

--- a/lib/transport/transport-socket.h
+++ b/lib/transport/transport-socket.h
@@ -39,6 +39,7 @@ void log_transport_dgram_socket_init_instance(LogTransportSocket *self, gint fd)
 LogTransport *log_transport_dgram_socket_new(gint fd);
 
 void log_transport_stream_socket_init_instance(LogTransportSocket *self, gint fd);
+void log_transport_stream_socket_free_method(LogTransport *s);
 LogTransport *log_transport_stream_socket_new(gint fd);
 
 #endif

--- a/lib/transport/transport-tls.c
+++ b/lib/transport/transport-tls.c
@@ -82,10 +82,9 @@ log_transport_tls_read_method(LogTransport *s, gpointer buf, gsize buflen, LogTr
         }
     }
   while (rc == -1 && errno == EINTR);
-  if (rc != -1)
-    {
-      self->super.super.cond = 0;
-    }
+
+  if (rc > 0)
+    self->super.super.cond = 0;
 
   return rc;
 tls_error:

--- a/news/bugfix-2811.md
+++ b/news/bugfix-2811.md
@@ -1,0 +1,6 @@
+network sources: fix TLS connection closure
+
+RFC 5425 specifies that once the transport receiver gets `close_notify` from the
+transport sender, it MUST reply with a `close_notify`.
+
+The `close_notify` alert is now sent back correctly in case of TLS network sources.


### PR DESCRIPTION
This pull request fixes the TLS connection closure on the source (receiver) side by sending back close_notify alerts.

RFC5425:
>  Once the transport receiver gets close_notify from the transport sender, it MUST reply with a close_notify unless it becomes aware that the connection has already been closed by the transport sender (e.g., the closure was indicated by TCP).

TODO:
- The destination (sender) side has to be fixed as well (in a separate PR):

> A transport sender MUST close the associated TLS connection if the connection is not expected to deliver any syslog messages later.  It MUST send a TLS close_notify alert before closing the connection.  A transport sender (TLS client) MAY choose to not wait for the transport receiver's close_notify alert and simply close the connection, thus generating an incomplete close on the transport receiver (TLS server) side.

Implementing this on the destination side is more complicated, we might need to introduce `log_proto_client_shutdown() -> log_transport_shutdown()` because `SSL_shutdown()` requires non-blocking write operations, so fd watches should be registered during shutdown. Currently, we destroy/shutdown transports after stopping watches and deiniting `LogWriter`. Another tricky part is `log_writer_reopen_deferred()`.

Fixes #2703