### PR TITLE
Dbld readd centos6 support

### DIFF
--- a/dbld/Makefile.am
+++ b/dbld/Makefile.am
@@ -18,6 +18,7 @@ EXTRA_DIST += \
 	dbld/images/helpers/packages.manifest \
 	dbld/images/helpers/pip_packages.manifest \
 	dbld/images/README.md \
+	dbld/images/centos-6.dockerfile \
 	dbld/images/centos-7.dockerfile \
 	dbld/images/fedora-30.dockerfile \
 	dbld/images/debian-jessie.dockerfile \

--- a/dbld/functions.sh
+++ b/dbld/functions.sh
@@ -2,6 +2,7 @@ set -e
 
 function get_version() {
 	cd /source
+	[ -n "$VERSION" ] && echo $VERSION && return
 	scripts/version.sh
 }
 

--- a/dbld/images/centos-6.dockerfile
+++ b/dbld/images/centos-6.dockerfile
@@ -1,0 +1,23 @@
+FROM centos:6
+LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
+
+ARG OS_PLATFORM
+ARG COMMIT
+ENV OS_PLATFORM ${OS_PLATFORM}
+LABEL COMMIT=${COMMIT}
+
+COPY helpers/* /helpers/
+
+RUN /helpers/dependencies.sh add_epel_repo
+RUN /helpers/dependencies.sh install_yum_packages
+RUN /helpers/dependencies.sh install_pip_packages
+
+RUN /helpers/dependencies.sh install_criterion
+RUN /helpers/dependencies.sh install_gradle
+RUN /helpers/dependencies.sh install_gosu amd64
+RUN mv /helpers/fake-sudo.sh /usr/bin/sudo
+
+VOLUME /source
+VOLUME /build
+
+ENTRYPOINT ["/helpers/entrypoint.sh"]

--- a/dbld/images/helpers/dependencies.sh
+++ b/dbld/images/helpers/dependencies.sh
@@ -107,6 +107,9 @@ function install_yum_packages {
 
 function install_pip_packages {
     case "${OS_PLATFORM}" in
+        centos-6)
+            pip install --upgrade pip==9.0.3
+            ;;
         centos-7)
             python -m pip install --upgrade pip==9.0.3
             ;;
@@ -114,7 +117,7 @@ function install_pip_packages {
             python -m pip install --upgrade pip
             ;;
     esac
-    filter_packages_by_platform /helpers/pip_packages.manifest | xargs python -m pip install -U
+    filter_packages_by_platform /helpers/pip_packages.manifest | xargs pip install -U
 }
 
 function enable_dbgsyms {

--- a/dbld/images/helpers/packages.manifest
+++ b/dbld/images/helpers/packages.manifest
@@ -38,11 +38,11 @@ pcre-devel                      [centos, fedora]
 # packages to run successful configure with module support
     # libbson-dev
     libbson-dev                 [debian-stretch, debian-buster, ubuntu-xenial, ubuntu-bionic, ubuntu-cosmic]
-    libbson-devel               [centos, fedora]
+    libbson-devel               [centos-7, fedora]
 
     # librabbitmq-dev
     librabbitmq-dev             [debian-jessie, debian-stretch, debian-buster, ubuntu-xenial, ubuntu-bionic, ubuntu-cosmic]
-    librabbitmq-devel           [centos, fedora]
+    librabbitmq-devel           [centos-7, fedora]
 
     # libmongoc-dev (not available on debian-jessie)
     libmongoc-dev               [debian-stretch, debian-buster, ubuntu-xenial, ubuntu-bionic, ubuntu-cosmic]
@@ -58,7 +58,7 @@ pcre-devel                      [centos, fedora]
 
     # libmaxmindb-dev
     libmaxminddb-dev            [debian-stretch, debian-buster, ubuntu-xenial, ubuntu-bionic, ubuntu-cosmic]
-    libmaxminddb-devel          [centos, fedora]
+    libmaxminddb-devel          [centos-7, fedora]
 
     # libcurl-dev
     libcurl4-openssl-dev        [debian, ubuntu]
@@ -82,14 +82,15 @@ pcre-devel                      [centos, fedora]
 
     # libriemann-dev
     libriemann-client-dev       [debian-stretch, debian-buster, ubuntu-xenial, ubuntu-bionic, ubuntu-cosmic]
-    riemann-c-client-devel      [centos, fedora]
+    riemann-c-client-devel      [centos-7, fedora]
 
     # java-7
     openjdk-7-jdk               [debian-jessie, ubuntu-trusty]
+    java-1.7.0-openjdk-devel    [centos-6]
 
     # java-8
     openjdk-8-jdk               [debian-stretch, ubuntu-xenial, ubuntu-bionic, ubuntu-cosmic]
-    java-1.8.0-openjdk-devel    [centos, fedora]
+    java-1.8.0-openjdk-devel    [centos-7, fedora]
 
     # no java 8 for buster, java-11 does not yet work
     #openjdk-11-jdk               [debian-buster]
@@ -169,7 +170,7 @@ dpkg-dev                        [debian, ubuntu]
 fakeroot                        [centos, fedora, debian, ubuntu]
 doxygen                         [centos, fedora, debian, ubuntu]
 rpm-build                       [centos, fedora]
-cyrus-sasl-devel                [centos, fedora]
+cyrus-sasl-devel                [centos-7, fedora]
 
     #libivykis-dev
     libivykis-dev               [debian, ubuntu]

--- a/dbld/images/helpers/pip_packages.manifest
+++ b/dbld/images/helpers/pip_packages.manifest
@@ -1,7 +1,9 @@
 # pip packages for successful run unit tests
-hy                      [centos, fedora, debian, ubuntu]
 nose                    [centos, fedora, debian, ubuntu]
 ply                     [centos, fedora, debian, ubuntu]
+
+# pip packages for kira tests
+hy			[devshell, ubuntu-xenial]
 
 # pip packages for python functional tests
 pathlib2                [centos, fedora, debian, ubuntu]

--- a/dbld/rules
+++ b/dbld/rules
@@ -18,6 +18,7 @@ TARBALL_IMAGE ?= ubuntu-bionic
 DEFAULT_DEB_IMAGE=$(DEFAULT_IMAGE)
 DEFAULT_RPM_IMAGE=centos-7
 DOCKER=docker
+VERSION=$(shell scripts/version.sh)
 DOCKER_RUN_ARGS=-e USER_NAME_ON_HOST=$(shell whoami)	\
         --network=host --privileged \
 	--ulimit nofile=1024:1024 \
@@ -26,6 +27,7 @@ DOCKER_RUN_ARGS=-e USER_NAME_ON_HOST=$(shell whoami)	\
 	-v $(DBLD_DIR)/install:/install \
 	-e CONFIGURE_OPTS="$${CONFIGURE_OPTS:-$(CONFIGURE_OPTS)}" \
 	-e CCACHE_DIR=/build/ccache \
+	-e VERSION=$(VERSION) \
 	-e PATH=/usr/lib/ccache:/usr/lib64/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
 	-e GRADLE_USER_HOME=/build/gradle-home \
 	-e GRADLE_PROJECT_CACHE_DIR=/build/gradle-cache \
@@ -35,7 +37,6 @@ ROOT_DIR=$(shell pwd)
 DBLD_DIR=$(ROOT_DIR)/dbld
 BUILD_DIR=$(DBLD_DIR)/build
 RELEASE_DIR=$(DBLD_DIR)/release
-VERSION=$(shell scripts/version.sh)
 TARBALL=$(BUILD_DIR)/syslog-ng-$(VERSION).tar.gz
 MODE=snapshot
 CONFIGURE_OPTS=--enable-debug --enable-manpages --with-python=2 --prefix=/install $(CONFIGURE_ADD)

--- a/dbld/rules
+++ b/dbld/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 
 BUILDER_IMAGES=		\
+	centos-6 	\
 	centos-7 	\
 	fedora-30	\
 	debian-jessie 	\

--- a/packaging/rhel/syslog-ng.spec
+++ b/packaging/rhel/syslog-ng.spec
@@ -45,9 +45,25 @@ Intentional syntax error to cause rpmbuild to abort.
 %endif
 
 %else
+
+%if 0%{rhel} == 6
+%bcond_with sql
+%bcond_with mongodb
+%bcond_with systemd
+%bcond_with redis
+%bcond_with riemann
+%bcond_with maxminddb
+%bcond_with amqp
+%bcond_without java
+%bcond_with kafka
+%bcond_without snmpdest
+%global        python_devel python-devel
+%global        py_ver  2.6
+%else
 %{error:Unsupported distro, we currently only try to build on RHEL >= 7 or Fedora >= 30}
 %endif
 
+%endif
 %global ivykis_ver 0.36.1
 
 Name: syslog-ng
@@ -316,15 +332,15 @@ export GEOIP_LIBS=-lGeoIP
     --enable-dynamic-linking \
     --enable-python \
     --with-python=%{py_ver} \
-    %{?with kafka:--enable-kafka} \
-    %{?with snmpdest:--enable-snmp-dest} \
-    %{?with java:--enable-java} \
-    %{?with sql:--enable-sql} \
-    %{?with systemd:--enable-systemd} \
-    %{?with mongodb:--enable-mongodb} \
-    %{?with amqp:--enable-amqp} \
-    %{?with redis:--enable-redis} \
-    %{?with riemann:--enable-riemann}
+    %{?with_kafka:--enable-kafka} \
+    %{?with_snmpdest:--enable-snmp-dest} %{!?with_snmpdest:--disable-snmp-dest} \
+    %{?with_java:--enable-java} %{!?with_java:--disable-java} \
+    %{?with_sql:--enable-sql} \
+    %{?with_systemd:--enable-systemd} \
+    %{?with_mongodb:--enable-mongodb} \
+    %{?with_amqp:--enable-amqp} \
+    %{?with_redis:--enable-redis} \
+    %{?with_riemann:--enable-riemann}
 
 # disable broken test by setting a different target
 sed -i 's/libs build/libs assemble/' Makefile


### PR DESCRIPTION
Just recently someone was trying to compile/run syslog-ng on RHEL6, so albeit I've dropped support
for it in dbld, it is still in use. So I've decided to go back and understand why I've felt that it was so difficult to support. With our glib compat code, it turned out not that difficult, even though we had a lot of warnings.

~~With warnings fixed, this actually improves the code, so here it comes as a PR.~~ I've added the bits independent of centos6 into a separate PR #2971.

~~This depends on #2859 so putting it into WIP until that one is merged.~~

Now all dependencies are in, so this is also ready to go in.
