### PR TITLE
avoid `@requires` loading the plugins themselves

### DIFF
--- a/contrib/valgrind/syslog-ng.supp
+++ b/contrib/valgrind/syslog-ng.supp
@@ -84,11 +84,11 @@
 }
 
 {
-     suppress_syslog_ng_plugin_load_candidate_modules
+     suppress_syslog_ng_plugin_discover_candidate_modules
      Memcheck:Leak
      fun:*alloc
      ...
-     fun:plugin_load_candidate_modules
+     fun:plugin_discover_candidate_modules
 }
 
 {

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -1025,7 +1025,7 @@ cfg_lexer_preprocess(CfgLexer *self, gint tok, YYSTYPE *yylval, YYLTYPE *yylloc)
           return CLPR_ERROR;
         }
 
-      cfg_load_candidate_modules(self->cfg);
+      cfg_discover_candidate_modules(self->cfg);
 
       cfg_load_forced_modules(self->cfg);
 

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -1014,16 +1014,11 @@ cfg_lexer_preprocess(CfgLexer *self, gint tok, YYSTYPE *yylval, YYLTYPE *yylloc)
 
       return CLPR_LEX_AGAIN;
     }
-  else if (self->cfg->user_version == 0 && self->cfg->parsed_version != 0)
-    {
-      if (!cfg_set_version(self->cfg, configuration->parsed_version))
-        return CLPR_ERROR;
-    }
   else if (cfg_lexer_get_context_type(self) != LL_CONTEXT_PRAGMA && !self->non_pragma_seen)
     {
       /* first non-pragma token */
 
-      if (self->cfg->user_version == 0 && self->cfg->parsed_version == 0)
+      if (self->cfg->user_version == 0)
         {
           msg_error("ERROR: configuration files without a version number has become unsupported in " VERSION_3_13
                     ", please specify a version number using @version and update your configuration accordingly");

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -368,7 +368,8 @@ cfg_set_version(GlobalConfig *self, gint version)
   if (cfg_is_config_version_older(self, 0x0300))
     {
       msg_error("ERROR: compatibility with configurations below 3.0 was dropped in " VERSION_3_13
-                ", please update your configuration accordingly");
+                ", please update your configuration accordingly",
+                cfg_format_config_version_tag(self));
       return FALSE;
     }
 
@@ -378,20 +379,23 @@ cfg_set_version(GlobalConfig *self, gint version)
                   "Please update it to use the " VERSION_CURRENT " format at your time of convenience. "
                   "To upgrade the configuration, please review the warnings about incompatible changes printed "
                   "by syslog-ng, and once completed change the @version header at the top of the configuration "
-                  "file.");
+                  "file",
+                  cfg_format_config_version_tag(self));
     }
   else if (version_convert_from_user(self->user_version) > VERSION_VALUE)
     {
       msg_warning("WARNING: Configuration file format is newer than the current version, please specify the "
                   "current version number ("  VERSION_CURRENT_VER_ONLY ") in the @version directive. "
-                  "syslog-ng will operate at its highest supported version in this mode");
+                  "syslog-ng will operate at its highest supported version in this mode",
+                  cfg_format_config_version_tag(self));
       self->user_version = VERSION_VALUE;
     }
 
   if (cfg_is_config_version_older(self, 0x0303))
     {
       msg_warning("WARNING: global: the default value of log_fifo_size() has changed to 10000 in " VERSION_3_3
-                  " to reflect log_iw_size() changes for tcp()/udp() window size changes");
+                  " to reflect log_iw_size() changes for tcp()/udp() window size changes",
+                  cfg_format_config_version_tag(self));
     }
   return TRUE;
 }

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -355,10 +355,16 @@ cfg_deinit(GlobalConfig *cfg)
   return cfg_tree_stop(&cfg->tree);
 }
 
+void
+cfg_set_version_without_validation(GlobalConfig *self, gint version)
+{
+  self->user_version = version;
+}
+
 gboolean
 cfg_set_version(GlobalConfig *self, gint version)
 {
-  self->user_version = version;
+  cfg_set_version_without_validation(self, version);
   if (cfg_is_config_version_older(self, 0x0300))
     {
       msg_error("ERROR: compatibility with configurations below 3.0 was dropped in " VERSION_3_13

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -364,6 +364,13 @@ cfg_set_version_without_validation(GlobalConfig *self, gint version)
 gboolean
 cfg_set_version(GlobalConfig *self, gint version)
 {
+  if (self->user_version != 0)
+    {
+      msg_warning("WARNING: you have multiple @version directives in your configuration, only the first one is considered",
+                  cfg_format_config_version_tag(self),
+                  cfg_format_version_tag("new-version", version));
+      return TRUE;
+    }
   cfg_set_version_without_validation(self, version);
   if (cfg_is_config_version_older(self, 0x0300))
     {

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -237,6 +237,16 @@ cfg_discover_candidate_modules(GlobalConfig *self)
     }
 }
 
+gboolean
+cfg_is_module_available(GlobalConfig *self, const gchar *module_name)
+{
+  cfg_discover_candidate_modules(self);
+  if (!_is_module_autoload_enabled(self))
+    return cfg_load_module(self, module_name);
+
+  return plugin_is_module_available(&self->plugin_context, module_name);
+}
+
 Plugin *
 cfg_find_plugin(GlobalConfig *cfg, gint plugin_type, const gchar *plugin_name)
 {

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -757,12 +757,6 @@ cfg_get_user_version(const GlobalConfig *cfg)
   return cfg->user_version;
 }
 
-guint
-cfg_get_parsed_version(const GlobalConfig *cfg)
-{
-  return cfg->parsed_version;
-}
-
 void register_source_mangle_callback(GlobalConfig *src,mangle_callback cb)
 {
   src->source_mangle_callback_list = g_list_append(src->source_mangle_callback_list,cb);

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -183,10 +183,16 @@ _sync_plugin_module_path_with_global_define(GlobalConfig *self)
 }
 
 gboolean
-cfg_load_module(GlobalConfig *cfg, const gchar *module_name)
+cfg_load_module_with_args(GlobalConfig *cfg, const gchar *module_name, CfgArgs *args)
 {
   _sync_plugin_module_path_with_global_define(cfg);
-  return plugin_load_module(&cfg->plugin_context, module_name, NULL);
+  return plugin_load_module(&cfg->plugin_context, module_name, args);
+}
+
+gboolean
+cfg_load_module(GlobalConfig *cfg, const gchar *module_name)
+{
+  return cfg_load_module_with_args(cfg, module_name, NULL);
 }
 
 void

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -188,7 +188,7 @@ cfg_load_module(GlobalConfig *cfg, const gchar *module_name)
 }
 
 void
-cfg_load_candidate_modules(GlobalConfig *self)
+cfg_discover_candidate_modules(GlobalConfig *self)
 {
   gboolean autoload_enabled = atoi(cfg_args_get(self->globals, "autoload-compiled-modules") ? : "1");
 
@@ -196,7 +196,7 @@ cfg_load_candidate_modules(GlobalConfig *self)
       autoload_enabled)
     {
       _sync_plugin_module_path_with_global_define(self);
-      plugin_load_candidate_modules(&self->plugin_context);
+      plugin_discover_candidate_modules(&self->plugin_context);
     }
 }
 

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -123,6 +123,7 @@ struct _GlobalConfig
   GList *file_list;
 };
 
+gboolean cfg_load_module_with_args(GlobalConfig *cfg, const gchar *module_name, CfgArgs *args);
 gboolean cfg_load_module(GlobalConfig *cfg, const gchar *module_name);
 void cfg_discover_candidate_modules(GlobalConfig *self);
 

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -62,9 +62,6 @@ struct _GlobalConfig
   /* hex-encoded syslog-ng major/minor, e.g. 0x0201 is syslog-ng 2.1 format */
   gint user_version;
 
-  /* version number as parsed from the configuration file, it can be set
-   * multiple times if the user uses @version multiple times */
-  guint parsed_version;
   const gchar *filename;
   PluginContext plugin_context;
   gboolean use_plugin_discovery;

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -192,4 +192,17 @@ gint cfg_get_user_version(const GlobalConfig *cfg);
 guint cfg_get_parsed_version(const GlobalConfig *cfg);
 const gchar *cfg_get_filename(const GlobalConfig *cfg);
 
+static inline EVTTAG *
+cfg_format_version_tag(const gchar *tag_name, gint version)
+{
+  return evt_tag_printf(tag_name, "%d.%d", (version & 0xFF00) >> 8, version & 0xFF);
+}
+
+static inline EVTTAG *
+cfg_format_config_version_tag(GlobalConfig *self)
+{
+  return cfg_format_version_tag("config-version", self->user_version);
+}
+
+
 #endif

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -124,6 +124,7 @@ struct _GlobalConfig
 };
 
 gboolean cfg_load_module(GlobalConfig *cfg, const gchar *module_name);
+void cfg_discover_candidate_modules(GlobalConfig *self);
 
 Plugin *cfg_find_plugin(GlobalConfig *cfg, gint plugin_type, const gchar *plugin_name);
 gpointer cfg_parse_plugin(GlobalConfig *cfg, Plugin *plugin, YYLTYPE *yylloc, gpointer arg);
@@ -139,7 +140,6 @@ gint cfg_ts_format_value(gchar *format);
 
 void cfg_set_version_without_validation(GlobalConfig *self, gint version);
 gboolean cfg_set_version(GlobalConfig *self, gint version);
-void cfg_load_candidate_modules(GlobalConfig *self);
 
 void cfg_set_global_paths(GlobalConfig *self);
 

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -125,6 +125,7 @@ struct _GlobalConfig
 
 gboolean cfg_load_module_with_args(GlobalConfig *cfg, const gchar *module_name, CfgArgs *args);
 gboolean cfg_load_module(GlobalConfig *cfg, const gchar *module_name);
+gboolean cfg_is_module_available(GlobalConfig *self, const gchar *module_name);
 void cfg_discover_candidate_modules(GlobalConfig *self);
 
 Plugin *cfg_find_plugin(GlobalConfig *cfg, gint plugin_type, const gchar *plugin_name);

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -140,6 +140,7 @@ void cfg_set_mark_mode(GlobalConfig *self, const gchar *mark_mode);
 gint cfg_tz_convert_value(gchar *convert);
 gint cfg_ts_format_value(gchar *format);
 
+void cfg_set_version_without_validation(GlobalConfig *self, gint version);
 gboolean cfg_set_version(GlobalConfig *self, gint version);
 void cfg_load_candidate_modules(GlobalConfig *self);
 

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -417,6 +417,12 @@ _free_candidate_plugins(PluginContext *context)
   context->candidate_plugins = NULL;
 }
 
+gboolean
+plugin_has_discovery_run(PluginContext *context)
+{
+  return context->candidate_plugins != NULL;
+}
+
 void
 plugin_discover_candidate_modules(PluginContext *context)
 {

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -410,7 +410,7 @@ call_init:
  ************************************************************/
 
 void
-plugin_load_candidate_modules(PluginContext *context)
+plugin_discover_candidate_modules(PluginContext *context)
 {
   GModule *mod;
   gchar **mod_paths;

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -405,6 +405,19 @@ call_init:
   return result;
 }
 
+gboolean
+plugin_is_module_available(PluginContext *context, const gchar *module_name)
+{
+  for (GList *l = context->candidate_plugins; l; l = l->next)
+    {
+      PluginCandidate *pc = (PluginCandidate *) l->data;
+
+      if (strcmp(pc->module_name, module_name) == 0)
+        return TRUE;
+    }
+  return FALSE;
+}
+
 /************************************************************
  * Candidate modules
  ************************************************************/

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -409,6 +409,14 @@ call_init:
  * Candidate modules
  ************************************************************/
 
+static void
+_free_candidate_plugins(PluginContext *context)
+{
+  g_list_foreach(context->candidate_plugins, (GFunc) plugin_candidate_free, NULL);
+  g_list_free(context->candidate_plugins);
+  context->candidate_plugins = NULL;
+}
+
 void
 plugin_discover_candidate_modules(PluginContext *context)
 {
@@ -416,8 +424,7 @@ plugin_discover_candidate_modules(PluginContext *context)
   gchar **mod_paths;
   gint i, j;
 
-  if (context->candidate_plugins)
-    return;
+  _free_candidate_plugins(context);
 
   mod_paths = g_strsplit(context->module_path ? : "", G_SEARCHPATH_SEPARATOR_S, 0);
   for (i = 0; mod_paths[i]; i++)
@@ -504,14 +511,6 @@ _free_plugins(PluginContext *context)
   g_list_foreach(context->plugins, (GFunc) _free_plugin, NULL);
   g_list_free(context->plugins);
   context->plugins = NULL;
-}
-
-static void
-_free_candidate_plugins(PluginContext *context)
-{
-  g_list_foreach(context->candidate_plugins, (GFunc) plugin_candidate_free, NULL);
-  g_list_free(context->candidate_plugins);
-  context->candidate_plugins = NULL;
 }
 
 void

--- a/lib/plugin.h
+++ b/lib/plugin.h
@@ -109,7 +109,7 @@ gboolean plugin_load_module(PluginContext *context, const gchar *module_name, Cf
 
 void plugin_list_modules(FILE *out, gboolean verbose);
 
-void plugin_load_candidate_modules(PluginContext *context);
+void plugin_discover_candidate_modules(PluginContext *context);
 
 void plugin_context_copy_candidates(PluginContext *context, PluginContext *src_context);
 void plugin_context_set_module_path(PluginContext *context, const gchar *module_path);

--- a/lib/plugin.h
+++ b/lib/plugin.h
@@ -106,6 +106,7 @@ void plugin_candidate_free(PluginCandidate *self);
 
 void plugin_register(PluginContext *context, Plugin *p, gint number);
 gboolean plugin_load_module(PluginContext *context, const gchar *module_name, CfgArgs *args);
+gboolean plugin_is_module_available(PluginContext *context, const gchar *module_name);
 
 void plugin_list_modules(FILE *out, gboolean verbose);
 

--- a/lib/plugin.h
+++ b/lib/plugin.h
@@ -109,6 +109,7 @@ gboolean plugin_load_module(PluginContext *context, const gchar *module_name, Cf
 
 void plugin_list_modules(FILE *out, gboolean verbose);
 
+gboolean plugin_has_discovery_run(PluginContext *context);
 void plugin_discover_candidate_modules(PluginContext *context);
 
 void plugin_context_copy_candidates(PluginContext *context, PluginContext *src_context);

--- a/lib/pragma-grammar.ym
+++ b/lib/pragma-grammar.ym
@@ -81,9 +81,11 @@ pragma_stmt
 version_stmt
         : KW_VERSION ':' string_or_number
           {
-            configuration->parsed_version = process_version_string($3);
+            guint parsed_version = process_version_string($3);
             free($3);
-            if (configuration->parsed_version == 0)
+            if (parsed_version == 0)
+                PRAGMA_ERROR();
+            if (!cfg_set_version(configuration, parsed_version))
                 PRAGMA_ERROR();
           }
 

--- a/lib/pragma-grammar.ym
+++ b/lib/pragma-grammar.ym
@@ -106,7 +106,7 @@ define_stmt
 module_stmt
 	: KW_MODULE string { last_module_args = cfg_args_new(); } module_param module_params
           {
-            gboolean success = plugin_load_module(&configuration->plugin_context, $2, last_module_args);
+            gboolean success = cfg_load_module_with_args(configuration, $2, last_module_args);
             free($2);
 
             cfg_args_unref(last_module_args);
@@ -117,7 +117,7 @@ module_stmt
           }
 	| KW_MODULE string
           {
-            plugin_load_module(&configuration->plugin_context, $2, NULL);
+            cfg_load_module(configuration, $2);
             free($2);
           }
 	;
@@ -125,11 +125,11 @@ module_stmt
 requires_stmt
 	: KW_REQUIRES string
           {
-            if (!plugin_load_module(&configuration->plugin_context, $2, NULL))
+            if (!cfg_is_module_available(configuration, $2))
               {
                 if (0 == lexer->include_depth)
                   {
-                    msg_error("Cannot load required module ",
+                    msg_error("Cannot load required module",
                                 evt_tag_str("module", $2),
                                 cfg_lexer_format_location_tag(lexer,&@1));
                     free($2);

--- a/lib/template/tests/test_template_compile.c
+++ b/lib/template/tests/test_template_compile.c
@@ -211,11 +211,11 @@ Test(template_compile, test_macro_with_invalid_msgref_are_recognized_as_the_top_
 
 Test(template_compile, test_dollar_prefixed_with_backslash_is_a_literal_dollar)
 {
-  cfg_set_version(configuration, 0x304);
+  cfg_set_version_without_validation(configuration, 0x304);
   assert_template_compile("Test \\$STRING");
   assert_compiled_template(text = "Test $STRING", default_value = NULL, macro = M_NONE, type = LTE_MACRO, msg_ref = 0);
 
-  cfg_set_version(configuration, 0x305);
+  cfg_set_version_without_validation(configuration, 0x305);
   assert_template_compile("Test \\$STRING");
   assert_compiled_template(text = "Test \\", default_value = NULL, value_handle = log_msg_get_value_handle("STRING"),
                            type = LTE_VALUE, msg_ref = 0);
@@ -251,11 +251,11 @@ Test(template_compile, test_dollar_with_an_invalid_macro_name_without_braces_is_
 
 Test(template_compile, test_backslash_without_finishing_the_escape_sequence_is_ignored)
 {
-  cfg_set_version(configuration, 0x304);
+  cfg_set_version_without_validation(configuration, 0x304);
   assert_template_compile("foo\\");
   assert_compiled_template(text = "foo", default_value = NULL, macro = M_NONE, type = LTE_MACRO, msg_ref = 0);
 
-  cfg_set_version(configuration, 0x305);
+  cfg_set_version_without_validation(configuration, 0x305);
   assert_template_compile("foo\\");
   assert_compiled_template(text = "foo\\", default_value = NULL, macro = M_NONE, type = LTE_MACRO, msg_ref = 0);
 }

--- a/lib/tests/test_lexer.c
+++ b/lib/tests/test_lexer.c
@@ -298,23 +298,26 @@ Test(lexer, at_version_stores_config_version_in_parsed_version_in_hex_form)
 {
   parser->lexer->ignore_pragma = FALSE;
 
+  cfg_set_version_without_validation(configuration, 0);
   _input("@version: 3.24\n\
 foo\n");
   assert_parser_identifier("foo");
-  cr_assert_eq(configuration->parsed_version, 0x0318,
-               "@version parsing mismatch, value %04x expected %04x", configuration->parsed_version, 0x0314);
+  cr_assert_eq(configuration->user_version, 0x0318,
+               "@version parsing mismatch, value %04x expected %04x", configuration->user_version, 0x0314);
 
+  cfg_set_version_without_validation(configuration, 0);
   _input("@version: 3.1\n\
 bar\n");
   assert_parser_identifier("bar");
-  cr_assert_eq(configuration->parsed_version, 0x0301,
-               "@version parsing mismatch, value %04x expected %04x", configuration->parsed_version, 0x0301);
+  cr_assert_eq(configuration->user_version, 0x0301,
+               "@version parsing mismatch, value %04x expected %04x", configuration->user_version, 0x0301);
 
+  cfg_set_version_without_validation(configuration, 0);
   _input("@version: 3.5\n\
 baz\n");
   assert_parser_identifier("baz");
-  cr_assert_eq(configuration->parsed_version, 0x0305,
-               "@version parsing mismatch, value %04x expected %04x", configuration->parsed_version, 0x0305);
+  cr_assert_eq(configuration->user_version, 0x0305,
+               "@version parsing mismatch, value %04x expected %04x", configuration->user_version, 0x0305);
 }
 
 Test(lexer, test_lexer_others)

--- a/persist-tool/persist-tool.c
+++ b/persist-tool/persist-tool.c
@@ -41,7 +41,7 @@ load_state_handler_modules(GlobalConfig *cfg)
 {
   plugin_context_init_instance(&cfg->plugin_context);
   plugin_context_set_module_path(&cfg->plugin_context, (const gchar *)get_installation_path_for(SYSLOG_NG_MODULE_PATH));
-  plugin_load_candidate_modules(&cfg->plugin_context);
+  plugin_discover_candidate_modules(&cfg->plugin_context);
 }
 
 static gboolean


### PR DESCRIPTION
The `@requires` statement should only be a declaration that the specific include file relies on
the availability of a specific plugin. We shouldn't necessarily load it as it might actually be unused.

Also, by loading it we are triggering ugly messages during startup (the kind that some plugins are registered multiple times).

This branch now properly handles the ordering between plugin discovery and the `@requires` keyword. It removes some old cruft.
