### PR TITLE
tls: add SNI support

### DIFF
--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -123,6 +123,7 @@ void tls_context_set_crl_dir(TLSContext *self, const gchar *crl_dir);
 void tls_context_set_cipher_suite(TLSContext *self, const gchar *cipher_suite);
 void tls_context_set_ecdh_curve_list(TLSContext *self, const gchar *ecdh_curve_list);
 void tls_context_set_dhparam_file(TLSContext *self, const gchar *dhparam_file);
+void tls_context_set_sni(TLSContext *self, const gchar *sni);
 const gchar *tls_context_get_key_file(TLSContext *self);
 EVTTAG *tls_context_format_tls_error_tag(TLSContext *self);
 EVTTAG *tls_context_format_location_tag(TLSContext *self);

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -656,7 +656,7 @@ dest_afinet_tcp_option
             gchar buf[256];
 	    last_tls_context = tls_context_new(TM_CLIENT, cfg_lexer_format_location(lexer, &@1, buf, sizeof(buf)));
 	  }
-	  '(' tls_options ')'
+	  '(' dest_tls_options ')'
 	  {
 	    afinet_dd_set_tls_context(last_driver, last_tls_context);
           }
@@ -747,7 +747,7 @@ dest_afsocket_transport
 
             last_tls_context = tls_context_new(TM_CLIENT, cfg_lexer_format_location(lexer, &@1, buf, sizeof(buf)));
           }
-          '(' tls_options ')'
+          '(' dest_tls_options ')'
           {
             afinet_dd_set_tls_context(last_driver, last_tls_context);
           }
@@ -760,6 +760,19 @@ afsocket_transport
         | KW_IP_PROTOCOL '(' inet_ip_protocol_option ')' { transport_mapper_set_address_family(last_transport_mapper, $3); }
         ;
 
+dest_tls_options
+        : dest_tls_option dest_tls_options
+        |
+        ;
+
+dest_tls_option
+        : tls_option
+        | KW_SNI '(' yesno ')'
+          {
+            if ($3)
+              tls_context_set_sni(last_tls_context, ((AFInetDestDriver *)last_driver)->primary);
+          }
+        ;
 
 tls_options
 	: tls_option tls_options
@@ -838,11 +851,6 @@ tls_option
           {
              transport_mapper_inet_set_allow_compress(last_transport_mapper, $3);
           }
-    | KW_SNI '(' string ')'
-      {
-        tls_context_set_sni(last_tls_context, $3);
-        free($3);
-      }
         | KW_ENDIF {
 }
         ;

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -187,6 +187,7 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 %token KW_CIPHER_SUITE
 %token KW_ECDH_CURVE_LIST
 %token KW_SSL_OPTIONS
+%token KW_SNI
 %token KW_ALLOW_COMPRESS
 
 /* INCLUDE_DECLS */
@@ -837,6 +838,11 @@ tls_option
           {
              transport_mapper_inet_set_allow_compress(last_transport_mapper, $3);
           }
+    | KW_SNI '(' string ')'
+      {
+        tls_context_set_sni(last_tls_context, $3);
+        free($3);
+      }
         | KW_ENDIF {
 }
         ;

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -57,6 +57,7 @@ static CfgLexerKeyword afsocket_keywords[] =
   { "ecdh_curve_list",    KW_ECDH_CURVE_LIST },
   { "curve_list",         KW_ECDH_CURVE_LIST, KWS_OBSOLETE, "ecdh_curve_list"},
   { "ssl_options",        KW_SSL_OPTIONS },
+  { "sni",                KW_SNI },
   { "allow_compress",     KW_ALLOW_COMPRESS },
 
   { "localip",            KW_LOCALIP },


### PR DESCRIPTION
Inspired by a syslog-ng maillist request:

> Hi,
> I am using TLS over TCP connection to forward my syslog events to a remote server.
> My remote server uses SNI (Server Name Identification) to route connections/events to one of the available backend servers.
> I observe that syslog-ng doesn't send SNI during TLS handshake.
> How can I enable it?
> My configuration is as follows:

```
source s_net { syslog(transport(udp) port(1514)); };
destination d_tcp {
        tcp(
                "XX.example.net"
                port(96)
                tls(
                        peer-verify(required-untrusted)
                        ca_dir("/etc/syslog-ng/ssl")
                        key-file("/etc/syslog-ng/ssl/globaltest/XX.example.net.key.pem")
                        cert-file("/etc/syslog-ng/ssl/globaltest/XX.example.net.cert.pem")
                  )
        );
};
log {
        source(s_net);
        destination(d_tcp);
};
```

> I want syslog-ng to send XX.example.net as SNI to my remote server
> Please advise
> Thanks
> Raghu

Example usage:
```
destination d_tls {
    tcp(
        "XX.example.net"
        port(96)
        tls(
            sni(yes)
            ca_dir("/etc/syslog-ng/ssl")
            key-file("/etc/syslog-ng/ssl/globaltest/XX.example.net.key.pem")
            cert-file("/etc/syslog-ng/ssl/globaltest/XX.example.net.cert.pem")
        )
    );
};
```
Wireshark:
![client_hello](https://user-images.githubusercontent.com/45236571/65036098-f6a00400-d94a-11e9-8869-ac4810b5d1fd.png)

Signed-off-by: Attila Szakacs <attila.szakacs@balabit.com>