### PR TITLE
WIP: Accept BSD timestamps with the day value not space padded (produced by Cisco ISE)

### DIFF
--- a/lib/timeutils/tests/test_scan-timestamp.c
+++ b/lib/timeutils/tests/test_scan-timestamp.c
@@ -133,6 +133,11 @@ Test(parse_timestamp, bsd_extensions)
   _expect_rfc3164_timestamp_eq("Dec  3 2019 09:10:12 ", "2019-12-03T09:10:12.000+01:00");
 }
 
+Test(parse_timestamp, bsd_timestamp_with_missing_padding_in_front_of_day)
+{
+  _expect_rfc3164_timestamp_eq("Dec 3 09:10:12", "2017-12-03T09:10:12.000+01:00");
+}
+
 Test(parse_timestamp, standard_bsd_format_year_in_the_future)
 {
   /* compared to 2017-12-13, this timestamp is from the future, so in the year 2018 */


### PR DESCRIPTION
Cisco ISE devices sometimes don't pad the "day" value in its BSD timestamps using spaces, contrary to the documentation.

https://www.cisco.com/c/en/us/td/docs/security/ise/2-6/Cisco_ISE_Syslogs/Cisco_ISE_Syslogs/Cisco_ISE_Syslogs_chapter_00.html

this causes the timestamp parsing to fail. I am still getting an actual log sample from  @rfaircloth-splunk (lost due to slack dropping history :( but in the meantime I've implemented it.

This branch originally contained a number of improvements that can go in separately, but I've split that off to #2935, which should go in first, so setting this to WIP. 