### PR TITLE
Timeutils refactor and performance improvements

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,7 @@ DIST_SUBDIRS		=
 AM_MAKEFLAGS		= --no-print-directory
 AM_YFLAGS		= -Wno-yacc -Wno-other -Werror=conflicts-sr -Werror=conflicts-rr
 
-AM_TESTS_ENVIRONMENT	= top_srcdir="$(top_srcdir)"
+AM_TESTS_ENVIRONMENT	= top_srcdir="$(top_srcdir)" CRITERION_TEST_PATTERN='!(*/*performance*)'
 
 ACLOCAL_AMFLAGS		= -I m4 --install
 

--- a/cmake/add_tests.cmake
+++ b/cmake/add_tests.cmake
@@ -65,7 +65,7 @@ function (add_unit_test)
   endif()
 
   add_test (${ADD_UNIT_TEST_TARGET} ${ADD_UNIT_TEST_TARGET})
-  set_tests_properties(${ADD_UNIT_TEST_TARGET} PROPERTIES ENVIRONMENT "ASAN_OPTIONS=detect_odr_violation=0")
+  set_tests_properties(${ADD_UNIT_TEST_TARGET} PROPERTIES ENVIRONMENT "ASAN_OPTIONS=detect_odr_violation=0;CRITERION_TEST_PATTERN='!(*/*performance*)'")
   set_tests_properties(${ADD_UNIT_TEST_TARGET} PROPERTIES FAIL_REGULAR_EXPRESSION "ERROR: (LeakSanitizer|AddressSanitizer)")
 endfunction ()
 

--- a/lib/str-format.c
+++ b/lib/str-format.c
@@ -295,24 +295,36 @@ format_hex_string(gpointer data, gsize data_len, gchar *result, gsize result_len
 gboolean
 scan_positive_int(const gchar **buf, gint *left, gint field_width, gint *num)
 {
+  const gchar *original_buf = *buf;
+  gint original_left = *left;
   guint32 result;
 
   result = 0;
 
-  while (*left > 0 && field_width > 0)
+  while (*left > 0 && field_width > 0 && **buf == ' ')
     {
-      if ((**buf) >= '0' && (**buf) <= '9')
-        result = result * 10 + ((**buf) - '0');
-      else if (!isspace((int) **buf))
-        return FALSE;
+      (*buf)++;
+      (*left)--;
+      field_width--;
+    }
+
+  while (*left > 0 && field_width > 0 &&
+         (**buf) >= '0' && (**buf) <= '9')
+    {
+      result = result * 10 + ((**buf) - '0');
       (*buf)++;
       (*left)--;
       field_width--;
     }
   if (field_width != 0)
-    return FALSE;
+    goto fail;
   *num = result;
   return TRUE;
+
+fail:
+  *buf = original_buf;
+  *left = original_left;
+  return FALSE;
 }
 
 gboolean

--- a/lib/str-format.c
+++ b/lib/str-format.c
@@ -293,7 +293,7 @@ format_hex_string(gpointer data, gsize data_len, gchar *result, gsize result_len
 /* parse 32 bit ints */
 
 gboolean
-scan_uint32(const gchar **buf, gint *left, gint field_width, guint32 *num)
+scan_positive_int(const gchar **buf, gint *left, gint field_width, gint *num)
 {
   guint32 result;
 
@@ -312,17 +312,6 @@ scan_uint32(const gchar **buf, gint *left, gint field_width, guint32 *num)
   if (field_width != 0)
     return FALSE;
   *num = result;
-  return TRUE;
-}
-
-gboolean
-scan_int(const gchar **buf, gint *left, gint field_width, gint *num)
-{
-  guint32 value;
-
-  if (!scan_uint32(buf, left, field_width, &value))
-    return FALSE;
-  *num = (gint) value;
   return TRUE;
 }
 

--- a/lib/str-format.h
+++ b/lib/str-format.h
@@ -36,8 +36,7 @@ gint format_int64_padded(GString *result, gint field_len, gchar pad_char, gint b
 gchar *format_hex_string(gpointer str, gsize str_len, gchar *result, gsize result_len);
 gchar *format_hex_string_with_delimiter(gpointer str, gsize str_len, gchar *result, gsize result_len, gchar delimiter);
 
-
-gboolean scan_int(const gchar **buf, gint *left, gint field_width, gint *num);
+gboolean scan_positive_int(const gchar **buf, gint *left, gint field_width, gint *num);
 gboolean scan_expect_char(const gchar **buf, gint *left, gchar value);
 gboolean scan_expect_str(const gchar **buf, gint *left, const gchar *value);
 

--- a/lib/template/macros.c
+++ b/lib/template/macros.c
@@ -305,7 +305,7 @@ log_macro_expand_date_time(GString *result, gint id, gboolean escape, const LogT
   switch (id)
     {
     case M_WEEK_DAY_ABBREV:
-      g_string_append_len(result, weekday_names_abbrev[wct.wct_wday], 3);
+      g_string_append_len(result, weekday_names_abbrev[wct.wct_wday], WEEKDAY_NAME_ABBREV_LEN);
       break;
     case M_WEEK_DAY_NAME:
       g_string_append(result, weekday_names[wct.wct_wday]);
@@ -334,7 +334,7 @@ log_macro_expand_date_time(GString *result, gint id, gboolean escape, const LogT
                                                ((wct.wct_mday % 7) >= wct.wct_wday))));
       break;
     case M_MONTH_ABBREV:
-      g_string_append_len(result, month_names_abbrev[wct.wct_mon], 3);
+      g_string_append_len(result, month_names_abbrev[wct.wct_mon], MONTH_NAME_ABBREV_LEN);
       break;
     case M_MONTH_NAME:
       g_string_append(result, month_names[wct.wct_mon]);

--- a/lib/template/macros.c
+++ b/lib/template/macros.c
@@ -252,8 +252,6 @@ log_macro_expand_date_time(GString *result, gint id, gboolean escape, const LogT
                            const gchar *context_id, const LogMessage *msg)
 {
   /* year, month, day */
-  gchar buf[64];
-  gint length;
   const UnixTime *stamp;
   UnixTime sstamp;
   guint tmp_hour;
@@ -392,8 +390,7 @@ log_macro_expand_date_time(GString *result, gint id, gboolean escape, const LogT
       break;
     case M_TZ:
     case M_TZOFFSET:
-      length = format_zone_info(buf, sizeof(buf), wct.wct_gmtoff);
-      g_string_append_len(result, buf, length);
+      append_format_zone_info(result, wct.wct_gmtoff);
       break;
     default:
       g_assert_not_reached();

--- a/lib/tests/test_str_format.c
+++ b/lib/tests/test_str_format.c
@@ -112,6 +112,13 @@ assert_scan_positive_int_in_field_fails(const gchar *input, gint field)
   cr_assert_not(success);
 }
 
+static void
+assert_scan_positive_int_fails(const gchar *input)
+{
+  return assert_scan_positive_int_in_field_fails(input, -1);
+}
+
+
 Test(test_str_format, scan_positive_int)
 {
   assert_scan_positive_int_value_equals("1", 1);
@@ -125,6 +132,11 @@ Test(test_str_format, scan_positive_int)
   assert_scan_positive_int_in_field_value_equals("  3", 2, 0);
   assert_scan_positive_int_in_field_value_equals("  3", 3, 3);
   assert_scan_positive_int_in_field_value_equals("  31", 3, 3);
+
+  assert_scan_positive_int_fails(" 3 ");
+  assert_scan_positive_int_fails(" 0 ");
+  assert_scan_positive_int_fails("a3");
+  assert_scan_positive_int_fails("3a");
 
   /* string too short for field_length */
   assert_scan_positive_int_in_field_fails("31", 3);

--- a/lib/tests/test_str_format.c
+++ b/lib/tests/test_str_format.c
@@ -70,3 +70,68 @@ Test(test_str_format, hex_string_with_delimiter__two_bytes__perfect)
   cr_expect_str_eq(output, expected_output,
                    "format_hex_string_with_delimiter output does not match in case of two bytes!");
 }
+
+static void
+assert_scan_positive_int_in_field_value_equals(const gchar *input, gint field, gint expected_result)
+{
+  const gchar *buf = input;
+  gint left = strlen(buf);
+  gint result = expected_result + 1;
+
+  gboolean success = scan_positive_int(&buf, &left, field >= 0 ? field : left, &result);
+
+  cr_assert(success);
+  if (field == -1 || field == strlen(input))
+    {
+      cr_assert(*buf == 0);
+      cr_assert(left == 0);
+    }
+  else
+    {
+      cr_assert(buf[0] == input[field]);
+      cr_assert(left == strlen(input) - field);
+    }
+  cr_assert_eq(result, expected_result);
+}
+
+static void
+assert_scan_positive_int_value_equals(const gchar *input, gint expected_result)
+{
+  return assert_scan_positive_int_in_field_value_equals(input, -1, expected_result);
+}
+
+static void
+assert_scan_positive_int_in_field_fails(const gchar *input, gint field)
+{
+  const gchar *buf = input;
+  gint left = strlen(buf);
+  gint result = 99;
+
+  gboolean success = scan_positive_int(&buf, &left, field >= 0 ? field : left, &result);
+
+  cr_assert_not(success);
+}
+
+Test(test_str_format, scan_positive_int)
+{
+  assert_scan_positive_int_value_equals("1", 1);
+  assert_scan_positive_int_value_equals("3", 3);
+  assert_scan_positive_int_value_equals("11", 11);
+  assert_scan_positive_int_value_equals("222", 222);
+
+  assert_scan_positive_int_value_equals(" 3", 3);
+  assert_scan_positive_int_value_equals("  3", 3);
+  assert_scan_positive_int_value_equals("   3", 3);
+  assert_scan_positive_int_in_field_value_equals("  3", 2, 0);
+  assert_scan_positive_int_in_field_value_equals("  3", 3, 3);
+  assert_scan_positive_int_in_field_value_equals("  31", 3, 3);
+
+  /* string too short for field_length */
+  assert_scan_positive_int_in_field_fails("31", 3);
+
+  /* non-number in front */
+  assert_scan_positive_int_in_field_fails("a31", 3);
+  assert_scan_positive_int_in_field_fails("aaaaaaaa31", 3);
+  assert_scan_positive_int_in_field_fails("31a", 3);
+  assert_scan_positive_int_in_field_fails("31aaaaaaaa", 3);
+}

--- a/lib/timeutils/format.c
+++ b/lib/timeutils/format.c
@@ -97,7 +97,7 @@ append_format_wall_clock_time(const WallClockTime *wct, GString *target, gint ts
   switch (ts_format)
     {
     case TS_FMT_BSD:
-      g_string_append(target, month_names_abbrev[wct->wct_mon]);
+      g_string_append_len(target, month_names_abbrev[wct->wct_mon], MONTH_NAME_ABBREV_LEN);
       g_string_append_c(target, ' ');
       format_uint32_padded(target, 2, ' ', 10, wct->wct_mday);
       g_string_append_c(target, ' ');
@@ -127,7 +127,7 @@ append_format_wall_clock_time(const WallClockTime *wct, GString *target, gint ts
     case TS_FMT_FULL:
       format_uint32_padded(target, 0, 0, 10, wct->wct_year + 1900);
       g_string_append_c(target, ' ');
-      g_string_append(target, month_names_abbrev[wct->wct_mon]);
+      g_string_append_len(target, month_names_abbrev[wct->wct_mon], MONTH_NAME_ABBREV_LEN);
       g_string_append_c(target, ' ');
       format_uint32_padded(target, 2, ' ', 10, wct->wct_mday);
       g_string_append_c(target, ' ');

--- a/lib/timeutils/format.c
+++ b/lib/timeutils/format.c
@@ -46,13 +46,13 @@ _append_frac_digits(glong usecs, GString *target, gint frac_digits)
     }
 }
 
-static gint
-_format_zone_info(gchar *buf, size_t buflen, glong gmtoff)
+void
+append_format_zone_info(GString *target, glong gmtoff)
 {
-  return g_snprintf(buf, buflen, "%c%02ld:%02ld",
-                    gmtoff < 0 ? '-' : '+',
-                    (gmtoff < 0 ? -gmtoff : gmtoff) / 3600,
-                    ((gmtoff < 0 ? -gmtoff : gmtoff) % 3600) / 60);
+  g_string_append_c(target, gmtoff < 0 ? '-' : '+');
+  format_uint32_padded(target, 2, '0', 10, (gmtoff < 0 ? -gmtoff : gmtoff) / 3600);
+  g_string_append_c(target, ':');
+  format_uint32_padded(target, 2, '0', 10, ((gmtoff < 0 ? -gmtoff : gmtoff) % 3600) / 60);
 }
 
 void
@@ -93,7 +93,6 @@ void
 append_format_wall_clock_time(const WallClockTime *wct, GString *target, gint ts_format, gint frac_digits)
 {
   UnixTime ut = UNIX_TIME_INIT;
-  char buf[8];
 
   switch (ts_format)
     {
@@ -123,8 +122,7 @@ append_format_wall_clock_time(const WallClockTime *wct, GString *target, gint ts
       format_uint32_padded(target, 2, '0', 10, wct->wct_sec);
 
       _append_frac_digits(wct->wct_usec, target, frac_digits);
-      _format_zone_info(buf, sizeof(buf), wct->wct_gmtoff);
-      g_string_append(target, buf);
+      append_format_zone_info(target, wct->wct_gmtoff);
       break;
     case TS_FMT_FULL:
       format_uint32_padded(target, 0, 0, 10, wct->wct_year + 1900);
@@ -149,14 +147,4 @@ append_format_wall_clock_time(const WallClockTime *wct, GString *target, gint ts
       g_assert_not_reached();
       break;
     }
-}
-
-
-gint
-format_zone_info(gchar *buf, size_t buflen, glong gmtoff)
-{
-  return g_snprintf(buf, buflen, "%c%02ld:%02ld",
-                    gmtoff < 0 ? '-' : '+',
-                    (gmtoff < 0 ? -gmtoff : gmtoff) / 3600,
-                    ((gmtoff < 0 ? -gmtoff : gmtoff) % 3600) / 60);
 }

--- a/lib/timeutils/format.h
+++ b/lib/timeutils/format.h
@@ -41,6 +41,6 @@ void format_wall_clock_time(const WallClockTime *stamp, GString *target,
                             gint ts_format, glong zone_offset, gint frac_digits);
 void append_format_wall_clock_time(const WallClockTime *stamp, GString *target,
                                    gint ts_format, gint frac_digits);
-gint format_zone_info(gchar *buf, size_t buflen, glong gmtoff);
+void append_format_zone_info(GString *target, glong gmtoff);
 
 #endif

--- a/lib/timeutils/names.h
+++ b/lib/timeutils/names.h
@@ -25,6 +25,9 @@
 #ifndef TIMEUTILS_NAMES_H_INCLUDED
 #define TIMEUTILS_NAMES_H_INCLUDED
 
+#define MONTH_NAME_ABBREV_LEN 3
+#define WEEKDAY_NAME_ABBREV_LEN 3
+
 extern const char *month_names_abbrev[];
 extern const char *month_names[];
 extern const char *weekday_names_abbrev[];

--- a/lib/timeutils/scan-timestamp.c
+++ b/lib/timeutils/scan-timestamp.c
@@ -137,17 +137,17 @@ gboolean
 scan_iso_timestamp(const gchar **buf, gint *left, WallClockTime *wct)
 {
   /* YYYY-MM-DDTHH:MM:SS */
-  if (!scan_int(buf, left, 4, &wct->wct_year) ||
+  if (!scan_positive_int(buf, left, 4, &wct->wct_year) ||
       !scan_expect_char(buf, left, '-') ||
-      !scan_int(buf, left, 2, &wct->wct_mon) ||
+      !scan_positive_int(buf, left, 2, &wct->wct_mon) ||
       !scan_expect_char(buf, left, '-') ||
-      !scan_int(buf, left, 2, &wct->wct_mday) ||
+      !scan_positive_int(buf, left, 2, &wct->wct_mday) ||
       !scan_expect_char(buf, left, 'T') ||
-      !scan_int(buf, left, 2, &wct->wct_hour) ||
+      !scan_positive_int(buf, left, 2, &wct->wct_hour) ||
       !scan_expect_char(buf, left, ':') ||
-      !scan_int(buf, left, 2, &wct->wct_min) ||
+      !scan_positive_int(buf, left, 2, &wct->wct_min) ||
       !scan_expect_char(buf, left, ':') ||
-      !scan_int(buf, left, 2, &wct->wct_sec))
+      !scan_positive_int(buf, left, 2, &wct->wct_sec))
     return FALSE;
   wct->wct_year -= 1900;
   wct->wct_mon -= 1;
@@ -160,15 +160,15 @@ scan_pix_timestamp(const gchar **buf, gint *left, WallClockTime *wct)
   /* PIX/ASA timestamp, expected format: MMM DD YYYY HH:MM:SS */
   if (!scan_month_abbrev(buf, left, &wct->wct_mon) ||
       !scan_expect_char(buf, left, ' ') ||
-      !scan_int(buf, left, 2, &wct->wct_mday) ||
+      !scan_positive_int(buf, left, 2, &wct->wct_mday) ||
       !scan_expect_char(buf, left, ' ') ||
-      !scan_int(buf, left, 4, &wct->wct_year) ||
+      !scan_positive_int(buf, left, 4, &wct->wct_year) ||
       !scan_expect_char(buf, left, ' ') ||
-      !scan_int(buf, left, 2, &wct->wct_hour) ||
+      !scan_positive_int(buf, left, 2, &wct->wct_hour) ||
       !scan_expect_char(buf, left, ':') ||
-      !scan_int(buf, left, 2, &wct->wct_min) ||
+      !scan_positive_int(buf, left, 2, &wct->wct_min) ||
       !scan_expect_char(buf, left, ':') ||
-      !scan_int(buf, left, 2, &wct->wct_sec))
+      !scan_positive_int(buf, left, 2, &wct->wct_sec))
     return FALSE;
   wct->wct_year -= 1900;
   return TRUE;
@@ -181,15 +181,15 @@ scan_linksys_timestamp(const gchar **buf, gint *left, WallClockTime *wct)
 
   if (!scan_month_abbrev(buf, left, &wct->wct_mon) ||
       !scan_expect_char(buf, left, ' ') ||
-      !scan_int(buf, left, 2, &wct->wct_mday) ||
+      !scan_positive_int(buf, left, 2, &wct->wct_mday) ||
       !scan_expect_char(buf, left, ' ') ||
-      !scan_int(buf, left, 2, &wct->wct_hour) ||
+      !scan_positive_int(buf, left, 2, &wct->wct_hour) ||
       !scan_expect_char(buf, left, ':') ||
-      !scan_int(buf, left, 2, &wct->wct_min) ||
+      !scan_positive_int(buf, left, 2, &wct->wct_min) ||
       !scan_expect_char(buf, left, ':') ||
-      !scan_int(buf, left, 2, &wct->wct_sec) ||
+      !scan_positive_int(buf, left, 2, &wct->wct_sec) ||
       !scan_expect_char(buf, left, ' ') ||
-      !scan_int(buf, left, 4, &wct->wct_year))
+      !scan_positive_int(buf, left, 4, &wct->wct_year))
     return FALSE;
   wct->wct_year -= 1900;
   return TRUE;
@@ -201,13 +201,13 @@ scan_bsd_timestamp(const gchar **buf, gint *left, WallClockTime *wct)
   /* RFC 3164 timestamp, expected format: MMM DD HH:MM:SS ... */
   if (!scan_month_abbrev(buf, left, &wct->wct_mon) ||
       !scan_expect_char(buf, left, ' ') ||
-      !scan_int(buf, left, 2, &wct->wct_mday) ||
+      !scan_positive_int(buf, left, 2, &wct->wct_mday) ||
       !scan_expect_char(buf, left, ' ') ||
-      !scan_int(buf, left, 2, &wct->wct_hour) ||
+      !scan_positive_int(buf, left, 2, &wct->wct_hour) ||
       !scan_expect_char(buf, left, ':') ||
-      !scan_int(buf, left, 2, &wct->wct_min) ||
+      !scan_positive_int(buf, left, 2, &wct->wct_min) ||
       !scan_expect_char(buf, left, ':') ||
-      !scan_int(buf, left, 2, &wct->wct_sec))
+      !scan_positive_int(buf, left, 2, &wct->wct_sec))
     return FALSE;
   return TRUE;
 }

--- a/lib/timeutils/scan-timestamp.c
+++ b/lib/timeutils/scan-timestamp.c
@@ -244,7 +244,10 @@ __is_bsd_linksys(const guchar *src, guint32 left)
 {
   /* "MMM DD HH:MM:SS YYYY " */
   return (left >= 21
-          && __is_bsd_rfc_3164(src, left)
+          && src[3] == ' '
+          && src[6] == ' '
+          && src[9] == ':'
+          && src[12] == ':'
           && src[15] == ' '
           && isdigit(src[16])
           && isdigit(src[17])

--- a/lib/timeutils/scan-timestamp.c
+++ b/lib/timeutils/scan-timestamp.c
@@ -131,12 +131,51 @@ scan_month_abbrev(const gchar **buf, gint *left, gint *mon)
   return TRUE;
 }
 
+/*******************************************************************************
+ * RFC 3164 timestamp, expected format: "MMM DD HH:MM:SS" ...
+ *******************************************************************************/
 
-/* this function parses the date/time portion of an ISODATE */
+static gboolean
+__is_bsd_rfc_3164(const guchar *src, guint32 left)
+{
+  return left >= 15 && src[3] == ' ' && src[6] == ' ' && src[9] == ':' && src[12] == ':';
+}
+
+gboolean
+scan_bsd_timestamp(const gchar **buf, gint *left, WallClockTime *wct)
+{
+  if (!scan_month_abbrev(buf, left, &wct->wct_mon) ||
+      !scan_expect_char(buf, left, ' ') ||
+      !scan_positive_int(buf, left, 2, &wct->wct_mday) ||
+      !scan_expect_char(buf, left, ' ') ||
+      !scan_positive_int(buf, left, 2, &wct->wct_hour) ||
+      !scan_expect_char(buf, left, ':') ||
+      !scan_positive_int(buf, left, 2, &wct->wct_min) ||
+      !scan_expect_char(buf, left, ':') ||
+      !scan_positive_int(buf, left, 2, &wct->wct_sec))
+    return FALSE;
+  return TRUE;
+}
+
+/*******************************************************************************
+ * ISO timestamp as specified in RFC5424, expected format "YYYY-MM-DDTHH:MM:SS"
+ *******************************************************************************/
+
+static gboolean
+__is_iso_stamp(const gchar *stamp, gint length)
+{
+  return (length >= 19
+          && stamp[4] == '-'
+          && stamp[7] == '-'
+          && stamp[10] == 'T'
+          && stamp[13] == ':'
+          && stamp[16] == ':'
+         );
+}
+
 gboolean
 scan_iso_timestamp(const gchar **buf, gint *left, WallClockTime *wct)
 {
-  /* YYYY-MM-DDTHH:MM:SS */
   if (!scan_positive_int(buf, left, 4, &wct->wct_year) ||
       !scan_expect_char(buf, left, '-') ||
       !scan_positive_int(buf, left, 2, &wct->wct_mon) ||
@@ -154,10 +193,32 @@ scan_iso_timestamp(const gchar **buf, gint *left, WallClockTime *wct)
   return TRUE;
 }
 
+/*******************************************************************************
+ * Cisco modified RFC3164 timestamp, expected format:
+ *    "MMM DD YYYY HH:MM:SS:"
+ *    "MMM DD YYYY HH:MM:SS "
+ *******************************************************************************/
+
+static gboolean
+__is_bsd_pix_or_asa(const guchar *src, guint32 left)
+{
+  return (left >= 21
+          && src[3] == ' '
+          && src[6] == ' '
+          && src[11] == ' '
+          && src[14] == ':'
+          && src[17] == ':'
+          && (src[20] == ':' || src[20] == ' ')
+          && isdigit(src[7])
+          && isdigit(src[8])
+          && isdigit(src[9])
+          && isdigit(src[10])
+         );
+}
+
 gboolean
 scan_pix_timestamp(const gchar **buf, gint *left, WallClockTime *wct)
 {
-  /* PIX/ASA timestamp, expected format: MMM DD YYYY HH:MM:SS */
   if (!scan_month_abbrev(buf, left, &wct->wct_mon) ||
       !scan_expect_char(buf, left, ' ') ||
       !scan_positive_int(buf, left, 2, &wct->wct_mday) ||
@@ -172,6 +233,25 @@ scan_pix_timestamp(const gchar **buf, gint *left, WallClockTime *wct)
     return FALSE;
   wct->wct_year -= 1900;
   return TRUE;
+}
+
+/*******************************************************************************
+ * LinkSys modified RFC3164 timestamp, expected format:
+ *    "MMM DD HH:MM:SS YYYY "
+ *******************************************************************************/
+static gboolean
+__is_bsd_linksys(const guchar *src, guint32 left)
+{
+  /* "MMM DD HH:MM:SS YYYY " */
+  return (left >= 21
+          && __is_bsd_rfc_3164(src, left)
+          && src[15] == ' '
+          && isdigit(src[16])
+          && isdigit(src[17])
+          && isdigit(src[18])
+          && isdigit(src[19])
+          && isspace(src[20])
+         );
 }
 
 gboolean
@@ -192,23 +272,6 @@ scan_linksys_timestamp(const gchar **buf, gint *left, WallClockTime *wct)
       !scan_positive_int(buf, left, 4, &wct->wct_year))
     return FALSE;
   wct->wct_year -= 1900;
-  return TRUE;
-}
-
-gboolean
-scan_bsd_timestamp(const gchar **buf, gint *left, WallClockTime *wct)
-{
-  /* RFC 3164 timestamp, expected format: MMM DD HH:MM:SS ... */
-  if (!scan_month_abbrev(buf, left, &wct->wct_mon) ||
-      !scan_expect_char(buf, left, ' ') ||
-      !scan_positive_int(buf, left, 2, &wct->wct_mday) ||
-      !scan_expect_char(buf, left, ' ') ||
-      !scan_positive_int(buf, left, 2, &wct->wct_hour) ||
-      !scan_expect_char(buf, left, ':') ||
-      !scan_positive_int(buf, left, 2, &wct->wct_min) ||
-      !scan_expect_char(buf, left, ':') ||
-      !scan_positive_int(buf, left, 2, &wct->wct_sec))
-    return FALSE;
   return TRUE;
 }
 
@@ -278,17 +341,6 @@ __parse_iso_timezone(const guchar **data, gint *length)
   return tz;
 }
 
-static gboolean
-__is_iso_stamp(const gchar *stamp, gint length)
-{
-  return (length >= 19
-          && stamp[4] == '-'
-          && stamp[7] == '-'
-          && stamp[10] == 'T'
-          && stamp[13] == ':'
-          && stamp[16] == ':'
-         );
-}
 
 static gboolean
 __parse_iso_stamp(WallClockTime *wct, const guchar **data, gint *length)
@@ -326,43 +378,6 @@ __parse_iso_stamp(WallClockTime *wct, const guchar **data, gint *length)
 /*******************************************************************************
  * Parse BSD timestamp
  *******************************************************************************/
-
-static gboolean
-__is_bsd_rfc_3164(const guchar *src, guint32 left)
-{
-  return left >= 15 && src[3] == ' ' && src[6] == ' ' && src[9] == ':' && src[12] == ':';
-}
-
-static gboolean
-__is_bsd_linksys(const guchar *src, guint32 left)
-{
-  return (left >= 21
-          && __is_bsd_rfc_3164(src, left)
-          && src[15] == ' '
-          && isdigit(src[16])
-          && isdigit(src[17])
-          && isdigit(src[18])
-          && isdigit(src[19])
-          && isspace(src[20])
-         );
-}
-
-static gboolean
-__is_bsd_pix_or_asa(const guchar *src, guint32 left)
-{
-  return (left >= 21
-          && src[3] == ' '
-          && src[6] == ' '
-          && src[11] == ' '
-          && src[14] == ':'
-          && src[17] == ':'
-          && (src[20] == ':' || src[20] == ' ')
-          && isdigit(src[7])
-          && isdigit(src[8])
-          && isdigit(src[9])
-          && isdigit(src[10])
-         );
-}
 
 static gboolean
 __parse_bsd_timestamp(const guchar **data, gint *length, WallClockTime *wct)

--- a/lib/timeutils/tests/test_scan-timestamp.c
+++ b/lib/timeutils/tests/test_scan-timestamp.c
@@ -120,9 +120,17 @@ Test(parse_timestamp, standard_bsd_format)
   _expect_rfc3164_timestamp_eq("Oct  1 17:46:12", "2017-10-01T17:46:12.000+02:00");
 }
 
-Test(parse_timestamp, bsd_with_fractions_of_a_second)
+Test(parse_timestamp, bsd_extensions)
 {
-  _expect_rfc3164_timestamp_eq("Dec 13 09:10:12.987", "2017-12-13T09:10:12.987+01:00");
+  /* fractions of a second */
+  _expect_rfc3164_timestamp_eq("Dec  3 09:10:12.987", "2017-12-03T09:10:12.987+01:00");
+
+  /* year added at the end (linksys) */
+  _expect_rfc3164_timestamp_eq("Dec  3 09:10:12 2019 ", "2019-12-03T09:10:12.000+01:00");
+
+  /* year after the mon/day (cisco) */
+  _expect_rfc3164_timestamp_eq("Dec  3 2019 09:10:12:", "2019-12-03T09:10:12.000+01:00");
+  _expect_rfc3164_timestamp_eq("Dec  3 2019 09:10:12 ", "2019-12-03T09:10:12.000+01:00");
 }
 
 Test(parse_timestamp, standard_bsd_format_year_in_the_future)

--- a/lib/timeutils/tests/test_scan-timestamp.c
+++ b/lib/timeutils/tests/test_scan-timestamp.c
@@ -21,12 +21,14 @@
  * COPYING for details.
  *
  */
-#include <criterion/criterion.h>
 #include "apphook.h"
 #include "timeutils/scan-timestamp.h"
 #include "timeutils/cache.h"
 #include "timeutils/format.h"
 #include "timeutils/conv.h"
+
+#include <criterion/criterion.h>
+#include "stopwatch.h"
 
 static void
 fake_time(time_t now)
@@ -291,6 +293,38 @@ Test(parse_timestamp, rfc5424_timestamps)
 {
   _expect_rfc5424_timestamp_eq("2017-06-14T23:57:27+02:00", "2017-06-14T23:57:27.000+02:00");
   _expect_rfc5424_timestamp_eq("2017-06-14T23:57:27Z", "2017-06-14T23:57:27.000+00:00");
+}
+
+Test(parse_timestamp, rfc3164_performance)
+{
+  const gchar *ts = "Dec 14 05:27:22";
+  const guchar *data = (const guchar *) ts;
+  gint length = strlen(ts);
+  WallClockTime wct = WALL_CLOCK_TIME_INIT;
+  gint it = 1000000;
+
+  start_stopwatch();
+  for (gint i = 0; i < it; i++)
+    {
+      scan_rfc3164_timestamp(&data, &length, &wct);
+    }
+  stop_stopwatch_and_display_result(it, "RFC3164 timestamp parsing speed");
+}
+
+Test(parse_timestamp, rfc5424_performance)
+{
+  const gchar *ts = "2019-12-14T05:27:22";
+  const guchar *data = (const guchar *) ts;
+  gint length = strlen(ts);
+  WallClockTime wct = WALL_CLOCK_TIME_INIT;
+  gint it = 1000000;
+
+  start_stopwatch();
+  for (gint i = 0; i < it; i++)
+    {
+      scan_rfc5424_timestamp(&data, &length, &wct);
+    }
+  stop_stopwatch_and_display_result(it, "RFC5424 timestamp parsing speed");
 }
 
 

--- a/modules/csvparser/tests/test_csvparser_perf.c
+++ b/modules/csvparser/tests/test_csvparser_perf.c
@@ -131,7 +131,7 @@ perftest_parser(LogParser *p, const gchar *input)
   log_pipe_unref(&p->super);
 }
 
-Test(csvparser_perf, test_escaped_parsers)
+Test(csvparser_perf, test_escaped_parsers_performance)
 {
   perftest_parser(_construct_parser(3, CSV_SCANNER_ESCAPE_NONE, " ", NULL, "", NULL),
                   "foo bar baz");

--- a/modules/snmptrapd-parser/snmptrapd-header-parser.c
+++ b/modules/snmptrapd-parser/snmptrapd-header-parser.c
@@ -247,17 +247,17 @@ static gboolean
 scan_snmptrapd_timestamp(const gchar **buf, gint *left, WallClockTime *wct)
 {
   /* YYYY-MM-DD HH:MM:SS */
-  if (!scan_int(buf, left, 4, &wct->wct_year) ||
+  if (!scan_positive_int(buf, left, 4, &wct->wct_year) ||
       !scan_expect_char(buf, left, '-') ||
-      !scan_int(buf, left, 2, &wct->wct_mon) ||
+      !scan_positive_int(buf, left, 2, &wct->wct_mon) ||
       !scan_expect_char(buf, left, '-') ||
-      !scan_int(buf, left, 2, &wct->wct_mday) ||
+      !scan_positive_int(buf, left, 2, &wct->wct_mday) ||
       !scan_expect_char(buf, left, ' ') ||
-      !scan_int(buf, left, 2, &wct->wct_hour) ||
+      !scan_positive_int(buf, left, 2, &wct->wct_hour) ||
       !scan_expect_char(buf, left, ':') ||
-      !scan_int(buf, left, 2, &wct->wct_min) ||
+      !scan_positive_int(buf, left, 2, &wct->wct_min) ||
       !scan_expect_char(buf, left, ':') ||
-      !scan_int(buf, left, 2, &wct->wct_sec))
+      !scan_positive_int(buf, left, 2, &wct->wct_sec))
     return FALSE;
   wct->wct_year -= 1900;
   wct->wct_mon -= 1;


### PR DESCRIPTION
This PR contains the refactoring/performance improvements pieces of #2931 which we can merge independently of the other, where we are waiting for a 3rd party confirmation of the log format.

This branch also contains the exclusion of performance tests in "make check", reducing the time needed to run make check by 25% on my laptop. ~~This is only done for automake, cmake help would be appreciated.~~
