### PR TITLE
Accept legacy wildcard file configurations

### DIFF
--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -133,11 +133,22 @@ source_stdin_params
 source_affile_params
 	: string
 	  {
-            last_driver = *instance = affile_sd_new($1, configuration);
-	    last_file_reader_options = &((AFFileSourceDriver *) last_driver)->file_reader_options;
-	    last_reader_options = &last_file_reader_options->reader_options;
-	    last_file_perm_options = &((AFFileSourceDriver *) last_driver)->file_opener_options.file_perm_options;
-            last_log_proto_options = file_reader_options_get_log_proto_options(last_file_reader_options);
+	    if (!affile_is_legacy_wildcard_source($1))
+	      {
+	        last_driver = *instance = affile_sd_new($1, configuration);
+	        last_file_reader_options = &((AFFileSourceDriver *) last_driver)->file_reader_options;
+	        last_reader_options = &last_file_reader_options->reader_options;
+	        last_file_perm_options = &((AFFileSourceDriver *) last_driver)->file_opener_options.file_perm_options;
+	        last_log_proto_options = file_reader_options_get_log_proto_options(last_file_reader_options);
+	      }
+	    else
+	      {
+	        last_driver = *instance = wildcard_sd_legacy_new($1, configuration);
+	        last_file_reader_options = &((WildcardSourceDriver *) last_driver)->file_reader_options;
+	        last_reader_options = &last_file_reader_options->reader_options;
+	        last_file_perm_options = &((WildcardSourceDriver *) last_driver)->file_opener_options.file_perm_options;
+	        last_log_proto_options = file_reader_options_get_log_proto_options(last_file_reader_options);
+	      }
 	  }
           source_affile_options                 { $$ = last_driver; free($1); }
         ;

--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -46,6 +46,27 @@
 
 FileReaderOptions *last_file_reader_options;
 LogProtoFileReaderOptions *last_log_proto_options;
+
+static void
+affile_grammar_set_file_source_driver(AFFileSourceDriver *sd)
+{
+  last_driver = &sd->super.super;
+  last_file_reader_options = &sd->file_reader_options;
+  last_reader_options = &last_file_reader_options->reader_options;
+  last_file_perm_options = &sd->file_opener_options.file_perm_options;
+  last_log_proto_options = file_reader_options_get_log_proto_options(last_file_reader_options);
+}
+
+static void
+affile_grammar_set_wildcard_file_source_driver(WildcardSourceDriver *sd)
+{
+  last_driver = &sd->super.super;
+  last_file_reader_options = &sd->file_reader_options;
+  last_reader_options = &last_file_reader_options->reader_options;
+  last_file_perm_options = &sd->file_opener_options.file_perm_options;
+  last_log_proto_options = file_reader_options_get_log_proto_options(last_file_reader_options);
+}
+
 }
 
 %name-prefix "affile_"
@@ -101,11 +122,9 @@ source_affile
 	| KW_STDIN '(' source_stdin_params ')'	{ $$ = $3; }
 	| KW_WILDCARD_FILE
 	{
-		last_driver = *instance = wildcard_sd_new(configuration);
-		last_file_reader_options = &((WildcardSourceDriver *) last_driver)->file_reader_options;
-		last_reader_options = &last_file_reader_options->reader_options;
-	        last_file_perm_options = &((WildcardSourceDriver *) last_driver)->file_opener_options.file_perm_options;
-	        last_log_proto_options = file_reader_options_get_log_proto_options(last_file_reader_options);
+	  WildcardSourceDriver *sd = (WildcardSourceDriver *) wildcard_sd_new(configuration);;
+	  *instance = &sd->super.super;
+	  affile_grammar_set_wildcard_file_source_driver(sd);
 	} '(' source_wildcard_params ')' { $$ = last_driver; }
 	;
 
@@ -121,33 +140,27 @@ source_wildcard_options
 source_stdin_params
 	:
 	  {
-            last_driver = *instance = stdin_sd_new(configuration);
-	    last_file_reader_options = &((AFFileSourceDriver *) last_driver)->file_reader_options;
-	    last_reader_options = &last_file_reader_options->reader_options;
-	    last_file_perm_options = &((AFFileSourceDriver *) last_driver)->file_opener_options.file_perm_options;
-            last_log_proto_options = file_reader_options_get_log_proto_options(last_file_reader_options);
+	    AFFileSourceDriver *sd = (AFFileSourceDriver *) stdin_sd_new(configuration);
+	    *instance = &sd->super.super;
+	    affile_grammar_set_file_source_driver(sd);
 	  }
           source_affile_options                 { $$ = last_driver; }
-        ;
+	;
 
 source_affile_params
 	: string
 	  {
 	    if (!affile_is_legacy_wildcard_source($1))
 	      {
-	        last_driver = *instance = affile_sd_new($1, configuration);
-	        last_file_reader_options = &((AFFileSourceDriver *) last_driver)->file_reader_options;
-	        last_reader_options = &last_file_reader_options->reader_options;
-	        last_file_perm_options = &((AFFileSourceDriver *) last_driver)->file_opener_options.file_perm_options;
-	        last_log_proto_options = file_reader_options_get_log_proto_options(last_file_reader_options);
+	        AFFileSourceDriver *sd = (AFFileSourceDriver *) affile_sd_new($1, configuration);
+	        *instance = &sd->super.super;
+	        affile_grammar_set_file_source_driver(sd);
 	      }
 	    else
 	      {
-	        last_driver = *instance = wildcard_sd_legacy_new($1, configuration);
-	        last_file_reader_options = &((WildcardSourceDriver *) last_driver)->file_reader_options;
-	        last_reader_options = &last_file_reader_options->reader_options;
-	        last_file_perm_options = &((WildcardSourceDriver *) last_driver)->file_opener_options.file_perm_options;
-	        last_log_proto_options = file_reader_options_get_log_proto_options(last_file_reader_options);
+	        WildcardSourceDriver *sd = (WildcardSourceDriver *) wildcard_sd_legacy_new($1, configuration);
+	        *instance = &sd->super.super;
+	        affile_grammar_set_wildcard_file_source_driver(sd);
 	      }
 	  }
           source_affile_options                 { $$ = last_driver; free($1); }
@@ -184,11 +197,9 @@ source_wildcard_option
 source_afpipe_params
 	: string
 	  {
-	    last_driver = *instance = pipe_sd_new($1, configuration);
-	    last_file_reader_options = &((AFFileSourceDriver *) last_driver)->file_reader_options;
-	    last_reader_options = &last_file_reader_options->reader_options;
-	    last_file_perm_options = &((AFFileSourceDriver *) last_driver)->file_opener_options.file_perm_options;
-            last_log_proto_options = file_reader_options_get_log_proto_options(last_file_reader_options);
+	    AFFileSourceDriver *sd = (AFFileSourceDriver *) pipe_sd_new($1, configuration);
+	    *instance = &sd->super.super;
+	    affile_grammar_set_file_source_driver(sd);
 	  }
 	  source_afpipe_options				{ $$ = last_driver; free($1); }
 	;

--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -46,6 +46,7 @@
 
 FileReaderOptions *last_file_reader_options;
 LogProtoFileReaderOptions *last_log_proto_options;
+WildcardSourceDriver *last_legacy_wildcard_src_driver;
 
 static void
 affile_grammar_set_file_source_driver(AFFileSourceDriver *sd)
@@ -98,6 +99,7 @@ affile_grammar_set_wildcard_file_source_driver(WildcardSourceDriver *sd)
 %token KW_RECURSIVE
 %token KW_MAX_FILES
 %token KW_MONITOR_METHOD
+%token KW_FORCE_DIRECTORY_POLLING
 
 %token KW_STDIN
 
@@ -159,15 +161,17 @@ source_affile_params
 	    else
 	      {
 	        WildcardSourceDriver *sd = (WildcardSourceDriver *) wildcard_sd_legacy_new($1, configuration);
+	        last_legacy_wildcard_src_driver = sd;
 	        *instance = &sd->super.super;
 	        affile_grammar_set_wildcard_file_source_driver(sd);
 	      }
 	  }
-          source_affile_options                 { $$ = last_driver; free($1); }
+          source_affile_options                 { $$ = last_driver; last_legacy_wildcard_src_driver = NULL; free($1); }
         ;
 
 source_affile_options
         : source_affile_option source_affile_options
+        | source_legacy_wildcard_option source_affile_options
         |
         ;
 
@@ -192,6 +196,19 @@ source_wildcard_option
 	| KW_MAX_FILES '(' LL_NUMBER ')' { wildcard_sd_set_max_files(last_driver, $3); }
 	| KW_MONITOR_METHOD '(' string ')' { CHECK_ERROR(wildcard_sd_set_monitor_method(last_driver, $3), @3, "Invalid monitor-method"); free($3); }
 	| source_affile_option
+	;
+
+source_legacy_wildcard_option
+	: KW_FORCE_DIRECTORY_POLLING '(' yesno ')'
+	  {
+	    CHECK_ERROR(last_legacy_wildcard_src_driver, @1, "Invalid option, force-directory-polling() can only be used in legacy wildcard file sources");
+	    wildcard_sd_set_monitor_method(&last_legacy_wildcard_src_driver->super.super, $3 ? "poll" : "auto");
+	  }
+	| KW_RECURSIVE '(' yesno ')'
+	  {
+	    CHECK_ERROR(last_legacy_wildcard_src_driver, @1, "Invalid option, recursive() can only be used in legacy wildcard file sources");
+	    wildcard_sd_set_recursive(&last_legacy_wildcard_src_driver->super.super, $3);
+	  }
 	;
 
 source_afpipe_params

--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -99,7 +99,7 @@ source_affile
 	: KW_FILE '(' source_affile_params ')'	{ $$ = $3; }
 	| KW_PIPE '(' source_afpipe_params ')'	{ $$ = $3; }
 	| KW_STDIN '(' source_stdin_params ')'	{ $$ = $3; }
-	| KW_WILDCARD_FILE 
+	| KW_WILDCARD_FILE
 	{
 		last_driver = *instance = wildcard_sd_new(configuration);
 		last_file_reader_options = &((WildcardSourceDriver *) last_driver)->file_reader_options;
@@ -108,15 +108,15 @@ source_affile
 	        last_log_proto_options = file_reader_options_get_log_proto_options(last_file_reader_options);
 	} '(' source_wildcard_params ')' { $$ = last_driver; }
 	;
-	
+
 source_wildcard_params
     : source_wildcard_options
     ;
- 
+
 source_wildcard_options
     : source_wildcard_option source_wildcard_options
     |
-    ;    
+    ;
 
 source_stdin_params
 	:

--- a/modules/affile/affile-parser.c
+++ b/modules/affile/affile-parser.c
@@ -42,6 +42,7 @@ static CfgLexerKeyword affile_keywords[] =
   { "recursive",          KW_RECURSIVE },
   { "max_files",          KW_MAX_FILES },
   { "monitor_method",     KW_MONITOR_METHOD },
+  { "force_directory_polling", KW_FORCE_DIRECTORY_POLLING, KWS_OBSOLETE, "Use wildcard-file(monitor-method())" },
 
   { "fsync",              KW_FSYNC },
   { "remove_if_older",    KW_OVERWRITE_IF_OLDER, KWS_OBSOLETE, "overwrite_if_older" },

--- a/modules/affile/wildcard-source.h
+++ b/modules/affile/wildcard-source.h
@@ -61,4 +61,7 @@ void wildcard_sd_set_recursive(LogDriver *s, gboolean recursive);
 gboolean wildcard_sd_set_monitor_method(LogDriver *s, const gchar *method);
 void wildcard_sd_set_max_files(LogDriver *s, guint32 max_files);
 
+gboolean affile_is_legacy_wildcard_source(const gchar *filename);
+LogDriver *wildcard_sd_legacy_new(const gchar *filename, GlobalConfig *cfg);
+
 #endif /* MODULES_AFFILE_WILDCARD_SOURCE_H_ */


### PR DESCRIPTION
This PR allows legacy (syslog-ng PE 6-style) configurations for the wildcard file source.

The PR contains unit tests and refactor steps, the actual support for the legacy format is **not more than ~40 lines of well-separated code**.

When using the legacy format, the following warning is shown:
> WARNING: Using wildcard characters in the file() source is deprecated, use wildcard-file() instead. The legacy wildcard file() source can only monitor up to 100 files, use wildcard-file(max-files()) to change this limit.

Examples:
```
file("/var/log/messages*");
file("/mnt/messages?.log" force-directory-polling(yes));
file("/var/log/*" recursive(yes));
```

The persist name and entry format are also compatible with PE 6.

Please do NOT document these options/this syntax.