### PR TITLE
dbld: warn about /usr/bin/man AppArmor bug if it is biting us

### DIFF
--- a/dbld/deb
+++ b/dbld/deb
@@ -22,6 +22,7 @@ function capture_debs() {
 
 cd /build
 
+validate_container
 setup_dirs
 prepare_source
 


### PR DESCRIPTION
This branch adds an explicit check to deb builds that /usr/bin/man is operational. On ubuntu a bug in apparmor may cause the man binary not to work (complaining about a missing .so file), in which case deb builds fail.

The check will display an actionable error message to the user how to fix the issue.