### PR TITLE
kafka: fix a per-message memory leak in kafka destination

### DIFF
--- a/modules/kafka/kafka-dest-worker.c
+++ b/modules/kafka/kafka-dest-worker.c
@@ -86,7 +86,7 @@ _publish_message(KafkaDestWorker *self, LogMessage *msg)
 
   /* we passed the allocated buffers to rdkafka, which will eventually free them */
   g_string_steal(message);
-  if (key)
+  if (key->str)
     g_string_steal(key);
   return TRUE;
 }


### PR DESCRIPTION
In case the key() option is not used, we are allocating a g_malloc(1) memory
for every message that never gets freed. Although in small bites, but we
can eventually leak a large amount of memory.

Thanks to the efforts of @jbfuzier we got enough information to
troubleshoot the issue.

This should fix #2929 