### PR TITLE
balabit/syslog-ng -> syslog-ng/syslog-ng transition

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ is to participate in the discussions about features, bugs and design.
 Some of these discussions started on the
 [mailing list][ar:mailing-list], some in the
 [issue tracker][ar:issue-tracker]. Bugs tagged
-[`help`][ar:issues:help] are generally good targets to contribute your
+[`good first issue`][ar:issues:good-first-issue] are generally good targets to contribute your
 feedback - but pretty much any open issue can be a good start!
 
 ### Reporting bugs
@@ -127,5 +127,5 @@ testing.
  [ar:gitter]: https://gitter.im/syslog-ng/syslog-ng
  [ar:mailing-list]: http://lists.balabit.com/mailman/listinfo/syslog-ng
  [ar:issue-tracker]: https://github.com/syslog-ng/syslog-ng/issues
- [ar:issues:help]: https://github.com/syslog-ng/syslog-ng/labels/help
+ [ar:issues:good-first-issue]: https://github.com/syslog-ng/syslog-ng/labels/good%20first%20issue
  [ar:travis]: https://travis-ci.org/syslog-ng/syslog-ng/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ around them.
 
 We use the same [issue tracker][ar:issue-tracker] to handle features
 requests (they're all tagged with the
-[`enhancement`](https://github.com/balabit/syslog-ng/labels/enhancement)
+[`enhancement`](https://github.com/syslog-ng/syslog-ng/labels/enhancement)
 label. You are welcome to share your ideas on existing requests, or to
 submit your own.
 
@@ -86,7 +86,7 @@ guidelines are very, very simple:
  8. A well-documented pull request is much easier to review and merge.
 
 Before submitting a separate module, please consider submitting it to
-the [Incubator](https://github.com/balabit/syslog-ng-incubator) first,
+the [Incubator](https://github.com/syslog-ng/syslog-ng-incubator) first,
 because it is easier to have your code accepted there. The Incubator
 is the repository of new and experimental modules.
 
@@ -129,8 +129,8 @@ We use [GitHub issues][ar:issue-tracker] to track issues, feature requests
 and patches. We are also using [Travis CI][ar:travis] for automatic
 testing.
 
- [ar:gitter]: https://gitter.im/balabit/syslog-ng
+ [ar:gitter]: https://gitter.im/syslog-ng/syslog-ng
  [ar:mailing-list]: http://lists.balabit.com/mailman/listinfo/syslog-ng
- [ar:issue-tracker]: https://github.com/balabit/syslog-ng/issues
- [ar:issues:help]: https://github.com/balabit/syslog-ng/labels/help
- [ar:travis]: https://travis-ci.org/balabit/syslog-ng/
+ [ar:issue-tracker]: https://github.com/syslog-ng/syslog-ng/issues
+ [ar:issues:help]: https://github.com/syslog-ng/syslog-ng/labels/help
+ [ar:travis]: https://travis-ci.org/syslog-ng/syslog-ng/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,11 +85,6 @@ guidelines are very, very simple:
  7. If possible, write tests! We love tests.
  8. A well-documented pull request is much easier to review and merge.
 
-Before submitting a separate module, please consider submitting it to
-the [Incubator](https://github.com/syslog-ng/syslog-ng-incubator) first,
-because it is easier to have your code accepted there. The Incubator
-is the repository of new and experimental modules.
-
 ## Licensing
 
 Please ensure that your contribution is clean in respect to licensing and

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/balabit/syslog-ng?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=body_badge)
-[![Build Status](https://travis-ci.org/balabit/syslog-ng.svg?branch=master)](https://travis-ci.org/balabit/syslog-ng)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/syslog-ng/syslog-ng?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=body_badge)
+[![Build Status](https://travis-ci.org/syslog-ng/syslog-ng.svg?branch=master)](https://travis-ci.org/syslog-ng/syslog-ng)
 
 syslog-ng
 =========
@@ -94,8 +94,8 @@ For a brief introduction to configuring the syslog-ng application, see the [quic
 ### Community
 
   * syslog-ng is developed by a community of volunteers, the best way to
-    contact us is via our [github project page](http://github.com/balabit/syslog-ng)
-    project, our [gitter channel](https://gitter.im/balabit/syslog-ng) or
+    contact us is via our [github project page](http://github.com/syslog-ng/syslog-ng)
+    project, our [gitter channel](https://gitter.im/syslog-ng/syslog-ng) or
     our [mailing list](https://lists.balabit.hu/mailman/listinfo/syslog-ng).
   * syslog-ng is integrated into almost all Linux distributions and BSDs, it
     is also incorporated into a number of products, see our [powered by
@@ -122,7 +122,7 @@ Just send an email to feedback (at) syslog-ng.org.
 
 Releases and precompiled tarballs are available on [GitHub][github-repo].
 
- [github-repo]: https://github.com/balabit/syslog-ng/releases
+ [github-repo]: https://github.com/syslog-ng/syslog-ng/releases
 
 To compile from source, the usual drill applies (assuming you have
 the required dependencies):

--- a/lib/str-utils.c
+++ b/lib/str-utils.c
@@ -60,7 +60,7 @@ str_replace_char(const gchar *str, const gchar from, const gchar to)
   investigate if the two can be aligned. Hint: as flag normalization has
   strong position in the code, aligning block normalization to flag
   normalization might prove easier. Some more info:
-  https://github.com/balabit/syslog-ng/pull/2162#discussion_r202247468
+  https://github.com/syslog-ng/syslog-ng/pull/2162#discussion_r202247468
 */
 gchar *
 __normalize_key(const gchar *buffer)

--- a/modules/java/Makefile.am
+++ b/modules/java/Makefile.am
@@ -69,7 +69,6 @@ module_LTLIBRARIES += modules/java/libmod-java.la
 modules_java_libmod_java_la_CFLAGS = \
     $(AM_CFLAGS) \
     $(JNI_CFLAGS)  \
-    $(INCUBATOR_CFLAGS) \
     -I$(top_srcdir)/modules/java    \
     -I$(top_builddir)/modules/java	\
     -I$(top_srcdir)/modules/java/native \

--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -1,7 +1,7 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: syslog-ng
 Upstream-Contact: Syslog-ng users' and developers' mailing list <syslog-ng@lists.balabit.hu>
-Source: git://github.com/balabit/syslog-ng.git
+Source: git://github.com/syslog-ng/syslog-ng.git
 Copyright: Copyright (C) Balázs Scheidler
            Copyright (C) BalaBit IT Security Ltd.
 

--- a/packaging/debian/watch
+++ b/packaging/debian/watch
@@ -1,3 +1,3 @@
 version=3
 
-https://github.com/balabit/syslog-ng/tags .*/syslog-ng-([\d\.]+)\.tar\.gz
+https://github.com/syslog-ng/syslog-ng/tags .*/syslog-ng-([\d\.]+)\.tar\.gz

--- a/packaging/rhel/syslog-ng.spec
+++ b/packaging/rhel/syslog-ng.spec
@@ -58,7 +58,7 @@ Summary: Next-generation syslog server
 Group: System Environment/Daemons
 License: GPLv2+
 URL: http://www.balabit.com/network-security/syslog-ng
-Source0: https://github.com/balabit/syslog-ng/releases/download/syslog-ng-%{version}/%{name}-%{version}.tar.gz
+Source0: https://github.com/syslog-ng/syslog-ng/releases/download/syslog-ng-%{version}/%{name}-%{version}.tar.gz
 Source1: syslog-ng.conf
 Source2: syslog-ng.logrotate
 Source3: syslog-ng.service

--- a/scl/system/plugin.conf
+++ b/scl/system/plugin.conf
@@ -34,5 +34,5 @@
 # This is the mailing list address where developers are lurking:
 #     syslog-ng@lists.balabit.hu.
 #
-# Alternatively, you can open an issue on github.com/balabit/syslog-ng
+# Alternatively, you can open an issue on github.com/syslog-ng/syslog-ng
 #

--- a/tests/valgrind/unit-test-leak.supp
+++ b/tests/valgrind/unit-test-leak.supp
@@ -1,5 +1,5 @@
 {
-   nvtable-uninitialized: https://github.com/balabit/syslog-ng/issues/946
+   nvtable-uninitialized: https://github.com/syslog-ng/syslog-ng/issues/946
    Memcheck:Param
    pwrite64(buf)
    ...


### PR DESCRIPTION
- [x] Travis
- [x] Kira
- [x] Gitter
- [x] LGTM

Less important:
- [ ] Docker Hub
- [ ] Move ose-guides, syslog-ng-docker, syslog-ng-gitbook, syslog-ng-patterndb, other repos as well
