### PR TITLE
persist-state: add g_assert to persist_state_map_entry

### DIFF
--- a/lib/persist-state.c
+++ b/lib/persist-state.c
@@ -685,6 +685,7 @@ persist_state_map_entry(PersistState *self, PersistEntryHandle handle)
 {
   /* we count the number of mapped entries in order to know if we're
    * safe to remap the file region */
+  g_assert(handle);
   g_mutex_lock(self->mapped_lock);
   self->mapped_counter++;
   g_mutex_unlock(self->mapped_lock);


### PR DESCRIPTION
We encountered an error during development, where one of the drivers
did not save the allocated persist handle, which resulted calling the
persist_state_map_entry with a 0 value.

Calling map_entry with 0 value, will result overwriting the persist file
header.