### PR TITLE
.mailmap: add mailmap file to map commiters to their canonical email …

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,65 @@
+Balazs Scheidler <bazsi77@gmail.com> <balazs.scheidler@balabit.com>
+<bazsi77@gmail.com> <bazsi@balabit.hu>
+<bazsi77@gmail.com> <bazsi@bzorp.balabit>
+<bazsi77@gmail.com> <balazs.scheidler@oneidentity.com>
+Laszlo Budai <laszlo.budai@balabit.com> <laszlo.budai@outlook.com>
+Laszlo Budai <laszlo.budai@balabit.com> <Laszlo.Budai@balabit.com>
+Laszlo Budai <laszlo.budai@balabit.com> <laszlo.budai@balabit.com>
+Laszlo Budai <laszlo.budai@balabit.com> <lbudai@balabit.hu>
+Laszlo Budai <laszlo.budai@balabit.com> <stentor.bgyk@gmail.com>
+Andras Mitzki <andras.mitzki@balabit.com> <andras.mitzki@balabit.com>
+Andras Mitzki <andras.mitzki@balabit.com> <mitzkia@gmail.com>
+Andras Mitzki <andras.mitzki@balabit.com> <micek@balabit.hu>
+Attila Szakacs <attila.szakacs@balabit.com> <attila.szakacs@quest.com>
+Attila Szakacs <attila.szakacs@balabit.com> <attila.szakacs@balabit.com>
+Attila Szakacs <attila.szakacs@balabit.com> <45236571+alltilla@users.noreply.github.com>
+Balint Kovacs <balint.kovacs@balasys.hu> <blint@balabit.hu>
+Balint Kovacs <balint.kovacs@balasys.hu> <blint@blint.hu>
+Fabien Wernli <wernli@in2p3.fr> <wernli@in2p3.fr>
+Fabien Wernli <wernli@in2p3.fr> <cpan@faxm0dem.org>
+Fabien Wernli <wernli@in2p3.fr> <git@faxmodem.org>
+Gergely Nagy <algernon@balabit.com> <algernon@balabit.com>
+Gergely Nagy <algernon@balabit.com> <algernon@balabit.hu>
+Gergely Nagy <algernon@balabit.com> <algernon@madhouse-project.org>
+Gergely Nagy <algernon@balabit.com> <algernon@users.noreply.github.com>
+Gabor Nagy <gabor.nagy@balabit.com> <gabor.nagy@balabit.com>
+Viktor Juhasz <juhasz.viktor81@gmail.com> <juhasz.viktor81@gmail.com>
+Viktor Juhasz <juhasz.viktor81@gmail.com> <jviktor@balabit.hu>
+Viktor Juhasz <juhasz.viktor81@gmail.com> <viktor.juhasz@balabit.com>
+Peter Kokai <peter.kokai@balabit.com> <kokaipeter@gmail.com>
+Peter Kokai <peter.kokai@balabit.com> <peter.kokai@balabit.com>
+Laszlo Meszaros <laszlo.meszaros@balabit.com> <lacienator@gmail.com>
+Laszlo Meszaros <laszlo.meszaros@balabit.com> <lmesz@balabit.hu>
+Laszlo Szemere <laszlo.szemere@balabit.com> <laszlo.szemere@balabit.com>
+Laszlo Szemere <laszlo.szemere@balabit.com> <laszlo.szemere@oneidentity.com>
+Lorand Muzamel <lorand.muzamel@balabit.com> <lorand.muzamel@balabit.com>
+Lorand Muzamel <lorand.muzamel@balabit.com> <lorand.muzamel@oneidentity.com>
+László Várady <laszlo.varady@balabit.com> <3130044+MrAnno@users.noreply.github.com>
+László Várady <laszlo.varady@balabit.com> <MrAnno@users.noreply.github.com>
+László Várady <laszlo.varady@balabit.com> <laszlo.varady93@gmail.com>
+László Várady <laszlo.varady@balabit.com> <laszlo.varady@balabit.com>
+Marton ILLES <marton.illes@balabit.com> <marton.illes@balabit.com>
+Marton ILLES <marton.illes@balabit.com> <marci@balabit.com>
+Adam Istvan MOZES <adam.mozes@balabit.com> <adam.mozes@balabit.com>
+Adam Istvan MOZES <adam.mozes@balabit.com> <mozes.adam.istvan@gmail.com>
+Adam Istvan MOZES <adam.mozes@balabit.com> <dnsjts@users.noreply.github.com>
+Mate Farkas <mate.farkas@balabit.com> <mate.farkas@balabit.com>
+Mate Farkas <mate.farkas@balabit.com> <presidento@farkas-mate.hu>
+Noemi Vanyi <noemi.vanyi@balabit.com> <sitbackandwait@gmail.com>
+Noemi Vanyi <noemi.vanyi@balabit.com> <kvch@users.noreply.github.com>
+Peter Czanik (CzP) <peter.czanik@balabit.com> <peter.czanik@balabit.com>
+Peter Czanik (CzP) <peter.czanik@balabit.com> <czanik@balabit.hu>
+Peter Czanik (CzP) <peter.czanik@balabit.com> <peter@czanik.hu>
+Peter Gyorko <peter.gyorko@balabit.com>
+Peter Gyorko <peter.gyorko@balabit.com> <gyorkop@balabit.hu>
+Zoltan Pallagi <zoltan.pallagi@balabit.com> <zoltan.pallagi@balabit.com>
+Zoltan Pallagi <zoltan.pallagi@balabit.com> <pzolee@balabit.com>
+Zoltan Pallagi <zoltan.pallagi@balabit.com> <pzoleex@gmail.com>
+Zoltan Pallagi <zoltan.pallagi@balabit.com> <pzoleex@users.noreply.github.com>
+Zoltan Pallagi <zoltan.pallagi@balabit.com> <pzolee@balabit.hu>
+Antal Nemes <antal.nemes@balabit.com>
+Antal Nemes <antal.nemes@balabit.com> <furiel@users.noreply.github.com>
+Norbert Takacs <norbert.takacs@balabit.com>
+Viktor Tusa <viktor.tusa@balabit.com> <tusavik@gmail.com>
+Viktor Tusa <viktor.tusa@balabit.com> <tusa.balabit.hu>
+Viktor Tusa <viktor.tusa@balabit.com> <tusa@balabit.hu>

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -1,5 +1,6 @@
  ignore
-.ctags
+\.ctags
+\.mailmap
 scl/syslogconf/convert-syslogconf.awk$
 .*/.*\.am$
 .*\.(ql|yml|md|y|l|txt|xml|xsd|log|key|crt|files|in|conf\.example|gradle|mk|supp|sub|guess|list|pc\.cmake)$


### PR DESCRIPTION
…address

To make git statistics reasonably correct.

Signed-off-by: Balazs Scheidler <bazsi77@gmail.com>