### PR TITLE
basicfuncs: add list-search function

### DIFF
--- a/lib/scanner/list-scanner/list-scanner.c
+++ b/lib/scanner/list-scanner/list-scanner.c
@@ -170,6 +170,14 @@ list_scanner_scan_next(ListScanner *self)
   return FALSE;
 }
 
+void
+list_scanner_skip_n(ListScanner *self, gint n)
+{
+  gint count = 0;
+  while (++count <= n && list_scanner_scan_next(self))
+    ;
+}
+
 const gchar *
 list_scanner_get_current_value(ListScanner *self)
 {

--- a/lib/scanner/list-scanner/list-scanner.c
+++ b/lib/scanner/list-scanner/list-scanner.c
@@ -69,7 +69,7 @@ list_scanner_input_va(ListScanner *self, const gchar *arg1, ...)
 }
 
 void
-list_scanner_input_gstring_array(ListScanner *self, gint argc, GString *argv[])
+list_scanner_input_gstring_array(ListScanner *self, gint argc, GString *const *argv)
 {
   gint i;
 

--- a/lib/scanner/list-scanner/list-scanner.h
+++ b/lib/scanner/list-scanner/list-scanner.h
@@ -39,7 +39,7 @@ struct _ListScanner
 };
 
 void list_scanner_input_va(ListScanner *self, const gchar *arg1, ...);
-void list_scanner_input_gstring_array(ListScanner *self, gint argc, GString *argv[]);
+void list_scanner_input_gstring_array(ListScanner *self, gint argc, GString *const *argv);
 void list_scanner_input_string(ListScanner *self, const gchar *value, gssize value_len);
 gboolean list_scanner_scan_next(ListScanner *self);
 void list_scanner_skip_n(ListScanner *self, gint n);

--- a/lib/scanner/list-scanner/list-scanner.h
+++ b/lib/scanner/list-scanner/list-scanner.h
@@ -42,6 +42,7 @@ void list_scanner_input_va(ListScanner *self, const gchar *arg1, ...);
 void list_scanner_input_gstring_array(ListScanner *self, gint argc, GString *argv[]);
 void list_scanner_input_string(ListScanner *self, const gchar *value, gssize value_len);
 gboolean list_scanner_scan_next(ListScanner *self);
+void list_scanner_skip_n(ListScanner *self, gint n);
 const gchar *list_scanner_get_current_value(ListScanner *self);
 gsize list_scanner_get_current_value_len(ListScanner *self);
 void list_scanner_free_method(ListScanner *self);

--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -103,6 +103,7 @@ static Plugin basicfuncs_plugins[] =
   TEMPLATE_FUNCTION_PLUGIN(tf_list_slice, "list-slice"),
   TEMPLATE_FUNCTION_PLUGIN(tf_list_count, "list-count"),
   TEMPLATE_FUNCTION_PLUGIN(tf_list_append, "list-append"),
+  TEMPLATE_FUNCTION_PLUGIN(tf_list_search, "list-search"),
 
   /* numeric-funcs */
   TEMPLATE_FUNCTION_PLUGIN(tf_num_plus, "+"),

--- a/modules/basicfuncs/list-funcs.c
+++ b/modules/basicfuncs/list-funcs.c
@@ -332,7 +332,8 @@ TEMPLATE_FUNCTION_SIMPLE(tf_implode);
 typedef enum _StringMatchMode
 {
   SMM_LITERAL = 0,
-  SMM_PREFIX
+  SMM_PREFIX,
+  SMM_SUBSTRING
 } StringMatchMode;
 
 typedef struct _StringMatcher
@@ -360,6 +361,8 @@ string_matcher_match(StringMatcher *self, const char *string, gsize string_len)
       return (strcmp(string, self->pattern) == 0);
     case SMM_PREFIX:
       return (strncmp(string, self->pattern, strlen(self->pattern)) == 0);
+    case SMM_SUBSTRING:
+      return (strstr(string, self->pattern) != NULL);
     default:
       g_assert_not_reached();
     }
@@ -410,6 +413,8 @@ _list_search_mode_str_to_string_match_mode(const gchar *mode_str, StringMatchMod
     *string_match_mode = SMM_LITERAL;
   else if (strcmp(mode_str, "prefix") == 0)
     *string_match_mode = SMM_PREFIX;
+  else if (strcmp(mode_str, "substring") == 0)
+    *string_match_mode = SMM_SUBSTRING;
   else
     result = FALSE;
 
@@ -441,7 +446,7 @@ _list_search_parse_options(StringMatchMode *mode, gint *start_index, gint *argc,
     {
       g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
                   "$(list-search) Invalid list-search mode: %s. "
-                  "Valid modes are: literal, prefix", mode_str);
+                  "Valid modes are: literal, prefix, substring", mode_str);
       goto exit;
     }
 

--- a/modules/basicfuncs/list-funcs.c
+++ b/modules/basicfuncs/list-funcs.c
@@ -328,3 +328,27 @@ tf_implode(LogMessage *msg, gint argc, GString *argv[], GString *result)
 }
 
 TEMPLATE_FUNCTION_SIMPLE(tf_implode);
+
+typedef struct _ListSearchState
+{
+} ListSearchState;
+
+static void
+list_search_state_free(gpointer s)
+{
+}
+
+static gboolean
+tf_list_search_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, gint argc, gchar *argv[],
+                       GError **error)
+{
+  return TRUE;
+}
+
+static void
+tf_list_search_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArgs *args, GString *result)
+{
+}
+
+TEMPLATE_FUNCTION(ListSearchState, tf_list_search, tf_list_search_prepare, NULL,
+                  tf_list_search_call, list_search_state_free, NULL);

--- a/modules/basicfuncs/list-funcs.c
+++ b/modules/basicfuncs/list-funcs.c
@@ -329,26 +329,198 @@ tf_implode(LogMessage *msg, gint argc, GString *argv[], GString *result)
 
 TEMPLATE_FUNCTION_SIMPLE(tf_implode);
 
+typedef enum _StringMatchMode
+{
+  SMM_LITERAL = 0
+} StringMatchMode;
+
+typedef struct _StringMatcher
+{
+  StringMatchMode mode;
+  gchar *pattern;
+} StringMatcher;
+
+static gboolean
+string_matcher_prepare(StringMatcher *self)
+{
+  switch (self->mode)
+    {
+    default:
+      return TRUE;
+    }
+}
+
+static gboolean
+string_matcher_match(StringMatcher *self, const char *string, gsize string_len)
+{
+  switch (self->mode)
+    {
+    case SMM_LITERAL:
+      return (strcmp(string, self->pattern) == 0);
+    default:
+      g_assert_not_reached();
+    }
+}
+
+static StringMatcher *
+string_matcher_new(StringMatchMode mode, const gchar *pattern)
+{
+  StringMatcher *self = g_new0(StringMatcher, 1);
+
+  self->mode = mode;
+  self->pattern = g_strdup(pattern);
+
+  return self;
+}
+
+static void
+string_matcher_free(StringMatcher *self)
+{
+  if (self->pattern)
+    g_free(self->pattern);
+  g_free(self);
+}
+
 typedef struct _ListSearchState
 {
+  TFSimpleFuncState super;
+  StringMatcher *matcher;
+  gint start_index;
 } ListSearchState;
 
 static void
 list_search_state_free(gpointer s)
 {
+  ListSearchState *self = (ListSearchState *)s;
+
+  if (self->matcher)
+    string_matcher_free(self->matcher);
+  tf_simple_func_free_state(&self->super);
+}
+
+static gboolean
+_list_search_mode_str_to_string_match_mode(const gchar *mode_str, StringMatchMode *string_match_mode)
+{
+  gboolean result = TRUE;
+
+  if (mode_str == NULL || strcmp(mode_str, "literal") == 0)
+    *string_match_mode = SMM_LITERAL;
+  else
+    result = FALSE;
+
+  return result;
+}
+
+static gboolean
+_list_search_parse_options(StringMatchMode *mode, gint *start_index, gint *argc, gchar **argv[], GError **error)
+{
+  gboolean result = FALSE;
+  GOptionContext *ctx;
+  gchar *mode_str = NULL;
+  GOptionEntry list_search_options[] =
+  {
+    { "mode", 0, 0, G_OPTION_ARG_STRING, &mode_str, NULL, NULL },
+    { "start-index", 0, 0, G_OPTION_ARG_INT, start_index, NULL, NULL },
+    { NULL }
+  };
+
+  ctx = g_option_context_new((*argv)[0]);
+  g_option_context_add_main_entries(ctx, list_search_options, NULL);
+
+  if (!g_option_context_parse(ctx, argc, argv, error))
+    {
+      goto exit;
+    }
+
+  if (!_list_search_mode_str_to_string_match_mode(mode_str, mode))
+    {
+      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
+                  "$(list-search) Invalid list-search mode: %s. "
+                  "Valid modes are: literal", mode_str);
+      goto exit;
+    }
+
+  result = TRUE;
+
+exit:
+  g_free(mode_str);
+  g_option_context_free(ctx);
+
+  return result;
+}
+
+static gboolean
+_list_search_init_matcher(ListSearchState *state, StringMatchMode mode, gint argc, gchar *argv[], GError **error)
+{
+  if (argc < 2)
+    {
+      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
+                  "$(list-search) Pattern is missing. Usage: $(list-search [options] <pattern> ${list})");
+      return FALSE;
+    }
+  else if (argc < 3)
+    {
+      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
+                  "$(list-search) List is missing. Usage: $(list-search [options] <pattern> ${list}");
+      return FALSE;
+    }
+
+  gchar *pattern = argv[1];
+  state->matcher = string_matcher_new(mode, pattern);
+
+  if (!string_matcher_prepare(state->matcher))
+    {
+      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
+                  "$(list-search) Failed to prepare pattern: %s", pattern);
+      return FALSE;
+    }
+
+  return TRUE;
 }
 
 static gboolean
 tf_list_search_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, gint argc, gchar *argv[],
                        GError **error)
 {
+  ListSearchState *state = (ListSearchState *)s;
+  StringMatchMode mode;
+
+  if (!_list_search_parse_options(&mode, &state->start_index, &argc, &argv, error))
+    return FALSE;
+
+  if (!_list_search_init_matcher(state, mode, argc, argv, error))
+    return FALSE;
+
+  if (!tf_simple_func_prepare(self, state, parent, argc, argv, error))
+    return FALSE;
+
   return TRUE;
 }
 
 static void
 tf_list_search_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArgs *args, GString *result)
 {
+  ListSearchState *state = (ListSearchState *)s;
+  ListScanner scanner;
+  gint index = state->start_index;
+
+  list_scanner_init(&scanner);
+  list_scanner_input_gstring_array(&scanner, state->super.argc - 1, &args->argv[1]);
+  list_scanner_skip_n(&scanner, index);
+
+  while (list_scanner_scan_next(&scanner))
+    {
+      if (string_matcher_match(state->matcher,
+                               list_scanner_get_current_value(&scanner),
+                               list_scanner_get_current_value_len(&scanner)))
+        {
+          format_int32_padded(result, -1, ' ', 10, index);
+          break;
+        }
+      index++;
+    }
+  list_scanner_deinit(&scanner);
 }
 
-TEMPLATE_FUNCTION(ListSearchState, tf_list_search, tf_list_search_prepare, NULL,
+TEMPLATE_FUNCTION(ListSearchState, tf_list_search, tf_list_search_prepare, tf_simple_func_eval,
                   tf_list_search_call, list_search_state_free, NULL);

--- a/modules/basicfuncs/list-funcs.c
+++ b/modules/basicfuncs/list-funcs.c
@@ -331,7 +331,8 @@ TEMPLATE_FUNCTION_SIMPLE(tf_implode);
 
 typedef enum _StringMatchMode
 {
-  SMM_LITERAL = 0
+  SMM_LITERAL = 0,
+  SMM_PREFIX
 } StringMatchMode;
 
 typedef struct _StringMatcher
@@ -357,6 +358,8 @@ string_matcher_match(StringMatcher *self, const char *string, gsize string_len)
     {
     case SMM_LITERAL:
       return (strcmp(string, self->pattern) == 0);
+    case SMM_PREFIX:
+      return (strncmp(string, self->pattern, strlen(self->pattern)) == 0);
     default:
       g_assert_not_reached();
     }
@@ -405,6 +408,8 @@ _list_search_mode_str_to_string_match_mode(const gchar *mode_str, StringMatchMod
 
   if (mode_str == NULL || strcmp(mode_str, "literal") == 0)
     *string_match_mode = SMM_LITERAL;
+  else if (strcmp(mode_str, "prefix") == 0)
+    *string_match_mode = SMM_PREFIX;
   else
     result = FALSE;
 
@@ -436,7 +441,7 @@ _list_search_parse_options(StringMatchMode *mode, gint *start_index, gint *argc,
     {
       g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
                   "$(list-search) Invalid list-search mode: %s. "
-                  "Valid modes are: literal", mode_str);
+                  "Valid modes are: literal, prefix", mode_str);
       goto exit;
     }
 

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -469,6 +469,13 @@ Test(basicfuncs, test_list_funcs)
   assert_template_format("$(list-search --mode glob ar '\"foo,\",\"bar\",\"baz\"')", "");
   assert_template_format("$(list-search --mode glob ba* '\"foo,\",\"bar\",\"baz\"')", "1");
   assert_template_format("$(list-search --mode glob al*fa '\"foo,\",\"bar\",\"baz\"')", "");
+
+  assert_template_format("$(list-search --mode pcre al.*fa '')", "");
+  assert_template_format("$(list-search --mode pcre --start-index 0 f.*, '\"foo,\",\"bar\",\"baz\"')", "0");
+  assert_template_format("$(list-search --start-index 1 --mode pcre .az '\"foo,\",\"bar\",\"baz\"')", "2");
+  assert_template_format("$(list-search --mode pcre ^bar$ '\"foo,\",\"bar\",\"baz\"')", "1");
+  assert_template_format("$(list-search --mode pcre ba. '\"foo,\",\"bar\",\"baz\"')", "1");
+  assert_template_format("$(list-search --mode pcre a...fa '\"foo,\",\"bar\",\"baz\"')", "");
 }
 
 Test(basicfuncs, test_context_funcs)

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -455,6 +455,13 @@ Test(basicfuncs, test_list_funcs)
   assert_template_format("$(list-search --mode prefix --start-index 1 ba '\"foo,\",\"bar\",\"baz\"')", "1");
   assert_template_format("$(list-search --start-index 2 --mode prefix ba '\"foo,\",\"bar\",\"baz\"')", "2");
   assert_template_format("$(list-search --mode prefix --start-index 0 almafa '\"foo,\",\"bar\",\"baz\"')", "");
+
+  assert_template_format("$(list-search --mode substring almafa '')", "");
+  assert_template_format("$(list-search --start-index 0 --mode substring oo '\"foo,\",\"bar\",\"baz\"')", "0");
+  assert_template_format("$(list-search --mode substring --start-index 2 a '\"foo,\",\"bar\",\"baz\"')", "2");
+  assert_template_format("$(list-search --mode substring ar '\"foo,\",\"bar\",\"baz\"')", "1");
+  assert_template_format("$(list-search --start-index 1 --mode substring ar '\"foo,\",\"bar\",\"baz\"')", "1");
+  assert_template_format("$(list-search --mode substring almafa '\"foo,\",\"bar\",\"baz\"')", "");
 }
 
 Test(basicfuncs, test_context_funcs)

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -462,6 +462,13 @@ Test(basicfuncs, test_list_funcs)
   assert_template_format("$(list-search --mode substring ar '\"foo,\",\"bar\",\"baz\"')", "1");
   assert_template_format("$(list-search --start-index 1 --mode substring ar '\"foo,\",\"bar\",\"baz\"')", "1");
   assert_template_format("$(list-search --mode substring almafa '\"foo,\",\"bar\",\"baz\"')", "");
+
+  assert_template_format("$(list-search --mode glob al*fa '')", "");
+  assert_template_format("$(list-search --start-index 0 --mode glob f*, '\"foo,\",\"bar\",\"baz\"')", "0");
+  assert_template_format("$(list-search --mode glob --start-index 1 *az '\"foo,\",\"bar\",\"baz\"')", "2");
+  assert_template_format("$(list-search --mode glob ar '\"foo,\",\"bar\",\"baz\"')", "");
+  assert_template_format("$(list-search --mode glob ba* '\"foo,\",\"bar\",\"baz\"')", "1");
+  assert_template_format("$(list-search --mode glob al*fa '\"foo,\",\"bar\",\"baz\"')", "");
 }
 
 Test(basicfuncs, test_context_funcs)

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -439,6 +439,8 @@ Test(basicfuncs, test_list_funcs)
 
   assert_template_format("$(implode ' ' foo,bar,xxx,baz,bad)", "foo bar xxx baz bad");
   assert_template_format("$(implode ' ' $(list-slice :3 foo,bar,xxx,baz,bad))", "foo bar xxx");
+
+  assert_template_format("$(list-search)", "");
 }
 
 Test(basicfuncs, test_context_funcs)

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -448,6 +448,13 @@ Test(basicfuncs, test_list_funcs)
   assert_template_format("$(list-search --start-index 5 baz '\"foo,\",\"bar\",\"baz\",\"bar\"' '\"foo,\",\"bar\",\"baz\",\"bar\"')",
                          "6");
   assert_template_format("$(list-search almafa --mode literal '\"foo,\",\"bar\",\"baz\",\"bar\"')", "");
+
+  assert_template_format("$(list-search --mode prefix --start-index 0 almafa '')", "");
+  assert_template_format("$(list-search --start-index 0 --mode prefix fo '\"foo,\",\"bar\",\"baz\"')", "0");
+  assert_template_format("$(list-search --mode prefix ba '\"foo,\",\"bar\",\"baz\"')", "1");
+  assert_template_format("$(list-search --mode prefix --start-index 1 ba '\"foo,\",\"bar\",\"baz\"')", "1");
+  assert_template_format("$(list-search --start-index 2 --mode prefix ba '\"foo,\",\"bar\",\"baz\"')", "2");
+  assert_template_format("$(list-search --mode prefix --start-index 0 almafa '\"foo,\",\"bar\",\"baz\"')", "");
 }
 
 Test(basicfuncs, test_context_funcs)

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -440,7 +440,14 @@ Test(basicfuncs, test_list_funcs)
   assert_template_format("$(implode ' ' foo,bar,xxx,baz,bad)", "foo bar xxx baz bad");
   assert_template_format("$(implode ' ' $(list-slice :3 foo,bar,xxx,baz,bad))", "foo bar xxx");
 
-  assert_template_format("$(list-search)", "");
+  assert_template_format("$(list-search almafa '')", "");
+  assert_template_format("$(list-search 'foo,' '\"foo,\",\"bar\",\"baz\",\"bar\"')", "0");
+  assert_template_format("$(list-search --start-index 0 --mode literal bar '\"foo,\",\"bar\",\"baz\",\"bar\"')", "1");
+  assert_template_format("$(list-search --start-index 2 bar '\"foo,\",\"bar\",\"baz\",\"bar\"')", "3");
+  assert_template_format("$(list-search --mode literal --start-index 1 baz '\"foo,\",\"bar\",\"baz\",\"bar\"')", "2");
+  assert_template_format("$(list-search --start-index 5 baz '\"foo,\",\"bar\",\"baz\",\"bar\"' '\"foo,\",\"bar\",\"baz\",\"bar\"')",
+                         "6");
+  assert_template_format("$(list-search almafa --mode literal '\"foo,\",\"bar\",\"baz\",\"bar\"')", "");
 }
 
 Test(basicfuncs, test_context_funcs)


### PR DESCRIPTION
Returns with the index of the first match of `keyword` in the `list`.
Starts the search at `start_index`. 0 based. If not found, returns empty string.

New usage:
 * Literal match:
     `$(list-search <pattern> ${list})`
     or
     `$(list-search --mode literal <pattern> ${list})`
 * Prefix match: `$(list-search --mode prefix <pattern> ${list})`
 * Substring match: `$(list-search --mode substring <pattern> ${list})`
 * Glob match: `$(list-search --mode glob <pattern> ${list})`
 * Regex match: `$(list-search --mode pcre <pattern> ${list})`

Add `--start-index <index>` to change the start index.

Implements #2924

TODO:
- [x] Add starting position
- [x] ~Add backwards search~
- [x] Support regex, glob, etc...
- [x] Support prefix, substring
- [x] Cleanup commits

Signed-off-by: Attila Szakacs <attila.szakacs@balabit.com>