### PR TITLE
scl/default-network-drivers: add max-connections

### DIFF
--- a/scl/default-network-drivers/plugin.conf
+++ b/scl/default-network-drivers/plugin.conf
@@ -24,6 +24,7 @@
 block source default-network-drivers(
 	udp-port(514)
 	tcp-port(514)
+	max-connections(10)
 	rfc5424-tls-port(6514)
 	rfc5424-tcp-port(601)
 	log-msg-size(65536)
@@ -36,6 +37,7 @@ block source default-network-drivers(
 		source {
 			network(transport(tcp)
 				port(`tcp-port`)
+				max-connections(`max-connections`)
 				log-msg-size(`log-msg-size`)
 				flags(no-parse, `flags`)
 				hook-commands(`hook-commands`));
@@ -63,10 +65,12 @@ block source default-network-drivers(
 		source {
 			syslog(transport(tls) tls(`tls`)
 			       port(`rfc5424-tls-port`)
+			       max-connections(`max-connections`)
 			       flags(`flags`)
 	                       log-msg-size(`log-msg-size`));
 			syslog(transport(tcp)
 			       port(`rfc5424-tcp-port`)
+			       max-connections(`max-connections`)
 			       flags(`flags`)
 	                       log-msg-size(`log-msg-size`));
 		};


### PR DESCRIPTION
Allows to passthrough max-connections parameter to the network tcp source.
The default value of 10 connections is very limiting.