### PR TITLE
extend travis build with arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -207,6 +207,7 @@ matrix:
             - libjson-c-dev
             - python-dev
             - python-pip
+            - python-setuptools
             - libnet1-dev
             - libriemann-client-dev
             - librdkafka-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -220,6 +220,13 @@ matrix:
       before_script:
       script:
         - set -e
+        - git clone https://github.com/Snaipe/Criterion.git
+        - cd Criterion
+        - git submodule update --init
+        - cmake .
+        - make all
+        - sudo make install
+        - cd ..
         - mkdir build
         - cd build
         - cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -194,6 +194,7 @@ matrix:
             - flex
             - gradle
             - libcap-dev
+            - libcurl4-openssl-dev
             - libdbd-sqlite3
             - libdbi0-dev
             - libesmtp-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
       - bison
       - docbook-xsl
       - flex
-      - gradle-2.2.1
+      - gradle
       - libcap-dev
       - libdbd-sqlite3
       - libdbi0-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -215,6 +215,8 @@ matrix:
             - libxml2-utils
             - doxygen
             - libsnmp-dev
+      git:
+        submodules: false
       before_script:
       script:
         - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -205,6 +205,7 @@ matrix:
             - librabbitmq-dev
             - libmongoc-dev
             - libjson-c-dev
+            - python-dev
             - libnet1-dev
             - libriemann-client-dev
             - librdkafka-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -185,6 +185,36 @@ matrix:
       compiler: gcc
       sudo: required
       arch: arm64
+      addons:
+        apt:
+          packages:
+            - autoconf-archive
+            - bison
+            - docbook-xsl
+            - flex
+            - gradle
+            - libcap-dev
+            - libdbd-sqlite3
+            - libdbi0-dev
+            - libesmtp-dev
+            - libgeoip-dev
+            - libglib2.0-dev
+            - libhiredis-dev
+            - libivykis-dev
+            - librabbitmq-dev
+            - libmongoc-dev
+            - libjson-c-dev
+            - libnet1-dev
+            - libriemann-client-dev
+            - librdkafka-dev
+            - libwrap0-dev
+            - pkg-config
+            - sqlite3
+            - xsltproc
+            - libmaxminddb-dev
+            - libxml2-utils
+            - doxygen
+            - libsnmp-dev
       before_script:
       script:
         - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -206,6 +206,7 @@ matrix:
             - libmongoc-dev
             - libjson-c-dev
             - python-dev
+            - python-pip
             - libnet1-dev
             - libriemann-client-dev
             - librdkafka-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -181,6 +181,23 @@ matrix:
         - make --keep-going -j $(nproc) all install
         - ctest -j $(nproc) --output-on-failure
 
+    - env: B=cmake-arm
+      compiler: gcc
+      sudo: required
+      arch: arm64
+      before_script:
+      script:
+        - set -e
+        - mkdir build
+        - cd build
+        - cmake
+            -DCMAKE_C_FLAGS=-Werror
+            -DPYTHON_VERSION=2
+            -DCMAKE_INSTALL_PREFIX=$HOME/install/syslog-ng
+            ..
+        - make --keep-going -j $(nproc) all install
+        - ctest -j $(nproc) --output-on-failure
+
     - env: B=check
       os: osx
       osx_image: xcode9.3


### PR DESCRIPTION
Not Arm related change: replaces *gradle* fixed version with the latest.

Add basic build and Ut execution for amr64 platform.

Note: due to lack of Criterion arm64 package, this job builds Criterion locally. As it was relativly quick (~70 second) to build from zero and the overall job was not the slowest. I avoided adding Criterion build cache.