### PR TITLE
Updated Quickstart link

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ run `./autogen.sh` to generate it.
 Some of the functionality of syslog-ng is compiled only if the required
 development libraries are present. The configure script displays a
 summary of enabled features at the end of its run.
-For details, see the [syslog-ng compiling instructions](https://www.balabit.com/sites/default/files/documents/syslog-ng-ose-latest-guides/en/syslog-ng-ose-guide-admin/html/compiling-syslog-ng.html).
+For details, see the [syslog-ng compiling instructions](https://support.oneidentity.com/technical-documents/syslog-ng-open-source-edition/administration-guide/installing-syslog-ng).
 
 
 ## Installation from binaries

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ In which case the resulting message will be:
 ```
 name1=value1 name2=value2
 ```
-For a brief introduction to configuring the syslog-ng application, see the [quickstart guide](https://syslog-ng.com/documents/html/syslog-ng-ose-latest-guides/en/syslog-ng-ose-guide-admin/html/chapter-quickstart.html).
+For a brief introduction to configuring the syslog-ng application, see the [quickstart guide](https://support.oneidentity.com/technical-documents/syslog-ng-open-source-edition/administration-guide/the-syslog-ng-ose-quick-start-guide).
 
 
 ## Features


### PR DESCRIPTION
#2962 There is actually two ways to correct the README.md:

- change the quickstart quide link to https://www.syslog-ng.com/technical-documents/list/syslog-ng-open-source-edition/ so that this link is correct for all future versions (by the way, it would be good to rename quickguide to technical documentation),
- change the quickstart guide link to https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.23/administration-guide/11#TOPIC-1268425 so that it is directly linked to what is expected, however, this must be changed for every new version.

Resolves #2962