### PR TITLE
dbld: fix OS_PLATFORM value in devshell images

### DIFF
--- a/dbld/images/devshell.dockerfile
+++ b/dbld/images/devshell.dockerfile
@@ -1,14 +1,5 @@
 FROM balabit/syslog-ng-ubuntu-bionic:latest
-LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
-
-ARG OS_PLATFORM
-ARG COMMIT
-ENV OS_PLATFORM ${OS_PLATFORM}
-LABEL COMMIT=${COMMIT}
-
-ENV DEBIAN_FRONTEND=noninteractive
-ENV DEBCONF_NONINTERACTIVE_SEEN=true
-ENV LANG C.UTF-8
+ENV OS_PLATFORM devshell
 
 RUN /helpers/dependencies.sh enable_dbgsyms
 RUN /helpers/dependencies.sh install_perf


### PR DESCRIPTION
docker seems to prefer the ENV value inherited from the base image (specified
using FROM) over the value in the command line, thus even though
dbld/rules specifies "--build-arg OS_PLATFORM", its value does not
make it to the Dockerfile.

Since the devshell is special in any case (using the bionic image as its
base), override OS_PLATFORM via a hard-wired value, fixing the package
installation.

This patch also removes redundant ENV/LABEL commands from the Dockerfile, as
all of those are already inherited from the parent image.

Signed-off-by: Balazs Scheidler <bazsi77@gmail.com>