### PR TITLE
Improve Redis driver connection handling

### DIFF
--- a/modules/redis/redis-grammar.ym
+++ b/modules/redis/redis-grammar.ym
@@ -44,6 +44,7 @@
 %token KW_REDIS
 %token KW_COMMAND
 %token KW_AUTH
+%token KW_TIMEOUT
 
 %%
 
@@ -79,6 +80,10 @@ redis_option
           {
             redis_dd_set_command_ref(last_driver, $3, $4);
             free($3);
+          }
+        | KW_TIMEOUT '(' nonnegative_integer ')'
+          {
+            redis_dd_set_timeout(last_driver, $3);
           }
         | threaded_dest_driver_option
         | { last_template_options = redis_dd_get_template_options(last_driver); } template_option

--- a/modules/redis/redis-parser.c
+++ b/modules/redis/redis-parser.c
@@ -35,6 +35,7 @@ static CfgLexerKeyword redis_keywords[] =
   { "host",     KW_HOST },
   { "port",     KW_PORT },
   { "auth",     KW_AUTH },
+  { "timeout",  KW_TIMEOUT },
   { NULL }
 };
 

--- a/modules/redis/redis.h
+++ b/modules/redis/redis.h
@@ -28,6 +28,7 @@
 
 LogDriver *redis_dd_new(GlobalConfig *cfg);
 
+void redis_dd_set_timeout(LogDriver *d, const glong timeout);
 void redis_dd_set_host(LogDriver *d, const gchar *host);
 void redis_dd_set_port(LogDriver *d, gint port);
 void redis_dd_set_auth(LogDriver *d, const gchar *auth);


### PR DESCRIPTION
UPDATE:
Dropped the batching part due to problems with message tracking in case of connection errors, but I thought it would be nice to include the rest of the refactors in the next release.
The reduced number of  `redis_dd_connect` calls still gives us a decent speed improvement. (~20k according my measurements)
- added timeout() option for amqp. This adds a timeout for the blocking socket operations.

----------


Add **batch-lines** support for the Redis driver. Redis API calls it pipelining: https://redis.io/topics/pipelining

Also:
 - Thanks for @Kokan, some performance improvement with template handling.
 - Put `_argv_to_string` behind `debug_flag`, because it has a high performance impact.
 - Removed an extra `check_connection_to_redis` call from the insert call chain. (Since it requires a network round trip, it has a high performance impact!)
- by default amqp does not use batching, to enable it, use the `batch-lines()` option.
- added `timeout()` option for amqp. This adds a timeout for the blocking socket operations.


My measurements on my laptop:
 - original driver: ~160 msg/s
 - new driver without batch mode: ~400msg/s
 - batching mode, batch_lines(2): ~2000 msg/s
 - batching mode, batch_lines(5): ~ 50 000 msg/s

note: With some tweaks with batch_lines and batch_timeout I managed to squeez out around: ~80-100k msg/s from the driver, but I think it highly depends on the infrastructure.