### PR TITLE
LightPytestRuntestSetupHook: Refactor pytest_runtest_setup() hook

### DIFF
--- a/tests/python_functional/conftest.py
+++ b/tests/python_functional/conftest.py
@@ -55,18 +55,6 @@ def pytest_addoption(parser):
     )
 
 
-def reports(request):
-    return request.config.getoption("--reports")
-
-
-def installdir(request):
-    return request.config.getoption("--installdir")
-
-
-def runundertool(request):
-    return request.config.getoption("--run-under")
-
-
 def get_relative_report_dir():
     return str(Path("reports/", get_current_date()))
 

--- a/tests/python_functional/src/common/pytest_operations.py
+++ b/tests/python_functional/src/common/pytest_operations.py
@@ -22,7 +22,7 @@
 #############################################################################
 
 
-def calculate_testcase_name(pytest_request):
+def calculate_testcase_name(item_name):
     # In case of parametrized tests we need to replace "[" and "]" because
     # testcase name will appear in directory name
-    return pytest_request.node.name.replace("[", "_").replace("]", "_")
+    return item_name.replace("[", "_").replace("]", "_")

--- a/tests/python_functional/src/conftest.py
+++ b/tests/python_functional/src/conftest.py
@@ -22,6 +22,7 @@
 #
 #############################################################################
 import pytest
+from pathlib2 import Path
 
 import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.testcase_parameters.testcase_parameters import TestcaseParameters
@@ -36,10 +37,13 @@ def test_message():
 def fake_testcase_parameters(request, tmpdir):
     orig_installdir = request.config.option.installdir
     orig_reportdir = request.config.option.reports
-    tc_parameters.WORKING_DIR = tmpdir.join("workingdir")
+    tc_parameters.WORKING_DIR = working_dir = Path(tmpdir.join("working_dir"))
     request.config.option.installdir = tmpdir.join("installdir")
     request.config.option.reports = tmpdir.join("reports")
     request.config.option.runundertool = ""
+    request.node.user_properties.append(("working_dir", working_dir))
+    request.node.user_properties.append(("relative_working_dir", working_dir.relative_to(tmpdir.join("working_dir"))))
+
     yield TestcaseParameters(request)
     request.config.option.installdir = orig_installdir
     request.config.option.reports = orig_reportdir

--- a/tests/python_functional/src/testcase_parameters/testcase_parameters.py
+++ b/tests/python_functional/src/testcase_parameters/testcase_parameters.py
@@ -24,18 +24,23 @@ from pathlib2 import Path
 
 from src.common.pytest_operations import calculate_testcase_name
 
+
 WORKING_DIR = None
 
 
 class TestcaseParameters(object):
     def __init__(self, pytest_request):
-        testcase_name = calculate_testcase_name(pytest_request)
-        relative_report_dir = pytest_request.config.getoption("--reports")
+        testcase_name = calculate_testcase_name(pytest_request.node.name)
+        for item in pytest_request.node.user_properties:
+            if item[0] == "working_dir":
+                self.working_dir = None
+                self.set_working_dir(item[1])
+            elif item[0] == "relative_working_dir":
+                self.relative_working_dir = None
+                self.set_relative_working_dir(item[1])
         absolute_framework_dir = Path.cwd()
         self.testcase_parameters = {
             "dirs": {
-                "working_dir": Path(absolute_framework_dir, relative_report_dir, testcase_name),
-                "relative_working_dir": Path(relative_report_dir, testcase_name),
                 "install_dir": Path(pytest_request.config.getoption("--installdir")),
                 "shared_dir": Path(absolute_framework_dir, "shared_files"),
             },
@@ -46,11 +51,17 @@ class TestcaseParameters(object):
             "external_tool": pytest_request.config.getoption("--run-under"),
         }
 
+    def set_working_dir(self, working_dir):
+        self.working_dir = working_dir
+
+    def set_relative_working_dir(self, relative_working_dir):
+        self.relative_working_dir = relative_working_dir
+
     def get_working_dir(self):
-        return self.testcase_parameters["dirs"]["working_dir"]
+        return self.working_dir
 
     def get_relative_working_dir(self):
-        return self.testcase_parameters["dirs"]["relative_working_dir"]
+        return self.relative_working_dir
 
     def get_install_dir(self):
         return self.testcase_parameters["dirs"]["install_dir"]


### PR DESCRIPTION
Motivation:
There was an incorrectly used pytest object in pytest_runtest_setup() hook: `item._request`
This is not a public object and it can cause a pytest error in some circumstances.
