### PR TITLE
logmsg: add default PRI value to log_msg_init

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -48,6 +48,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <syslog.h>
 
 /*
  * Reference/ACK counting for LogMessage structures
@@ -1102,6 +1103,7 @@ log_msg_init(LogMessage *self, GSockAddr *saddr)
 
   self->original = NULL;
   self->flags |= LF_STATE_OWN_MASK;
+  self->pri = LOG_USER | LOG_NOTICE;
 
   self->rcptid = rcptid_generate_id();
   log_msg_set_host_id(self);


### PR DESCRIPTION
In case it's left uninitialized, the message could seem as having a pri LOG_KERN | LOG_EMERG.

This is only interesting, if a user would like to create a log message, but without initial parsing,
thus log_msg_new() is not suitable, as that needs a format_handler, e.g. syslog.

Currently this is done by log_msg_new_empty(), which is used by some drivers, but they are not setting
PRI fields.