### PR TITLE
Fix syntax error in telegram()

### DIFF
--- a/scl/telegram/telegram.conf
+++ b/scl/telegram/telegram.conf
@@ -30,7 +30,7 @@ block destination telegram(
       parse-mode("none")
       throttle(1)
       disable-web-page-preview("true")
-      use_system_cert_store("yes")
+      use_system_cert_store(yes)
       ...)
 {
     http(

--- a/scl/telegram/telegram.conf
+++ b/scl/telegram/telegram.conf
@@ -30,7 +30,7 @@ block destination telegram(
       parse-mode("none")
       throttle(1)
       disable-web-page-preview("true")
-      use_system_cert_store(yes)
+      use-system-cert-store(yes)
       ...)
 {
     http(
@@ -38,7 +38,7 @@ block destination telegram(
         method("POST")
         body("disable_web_page_preview=`disable-web-page-preview`&parse_mode=`parse-mode`&chat_id=`chat-id`&text=$(url-encode \"`template`\")\n")
         throttle(`throttle`)
-        use_system_cert_store(`use_system_cert_store`)
+        use-system-cert-store(`use-system-cert-store`)
         `__VARARGS__`
     );
 };


### PR DESCRIPTION
After fixing the SCL parameter substitution in #2901, the Telegram destination has stopped working.

The type of the `use-system-cert-store()` option should be `yes/no`, strings are not accepted.