### PR TITLE
Improve LogSource's test coverage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -560,6 +560,7 @@ case "$ostype" in
 		;;
 	Darwin)
 		MODULE_LDFLAGS="-avoid-version -dylib"
+		LDFLAGS="$LDFLAGS -Wl,-flat_namespace"
     ;;
 	OSF1)
 		CFLAGS="${CFLAGS} -D_XOPEN_SOURCE=500 -D_XOPEN_SOURCE_EXTENDED -D_OSF_SOURCE -D_POSIX_C_SOURCE"
@@ -1053,7 +1054,7 @@ if test -n "$LIBNET_CONFIG" -a -x "$LIBNET_CONFIG"; then
         LIBNET_LIBS="`$LIBNET_CONFIG --libs`"
         AC_MSG_RESULT(yes)
 dnl libnet-config does not provide the _DEFAULT_SOURCE define, that can cause warning during build
-dnl as upstream libnet-config does uses _DEFAULT_SOURCE this is just a fix till 
+dnl as upstream libnet-config does uses _DEFAULT_SOURCE this is just a fix till
         LIBNET_CFLAGS="$LIBNET_CFLAGS -D_DEFAULT_SOURCE"
 
 else

--- a/lib/ack-tracker/bookmark.h
+++ b/lib/ack-tracker/bookmark.h
@@ -45,14 +45,6 @@ struct _Bookmark
 };
 
 static inline void
-bookmark_init(Bookmark *self)
-{
-  self->persist_state = NULL;
-  self->save = NULL;
-  self->destroy = NULL;
-}
-
-static inline void
 bookmark_save(Bookmark *self)
 {
   if (self->save)

--- a/lib/ack-tracker/late_ack_tracker.c
+++ b/lib/ack-tracker/late_ack_tracker.c
@@ -117,7 +117,7 @@ _ack_record_save_bookmark(LateAckRecord *ack_record)
 {
   Bookmark *bookmark = &(ack_record->bookmark);
 
-  bookmark->save(bookmark);
+  bookmark_save(bookmark);
 }
 
 static guint32

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -396,14 +396,7 @@ log_source_mangle_hostname(LogSource *self, LogMessage *msg)
           else
             {
               /* everything else, append source hostname */
-              if (orig_host && orig_host[0])
-                host_len = g_snprintf(host, sizeof(host), "%s/%s", orig_host, resolved_name);
-              else
-                {
-                  strncpy(host, resolved_name, sizeof(host));
-                  /* just in case it is not zero terminated */
-                  host[255] = 0;
-                }
+              host_len = g_snprintf(host, sizeof(host), "%s/%s", orig_host, resolved_name);
             }
           if (host_len >= sizeof(host))
             host_len = sizeof(host) - 1;

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -37,7 +37,7 @@
 
 gboolean accurate_nanosleep = FALSE;
 
-void
+static void
 log_source_wakeup(LogSource *self)
 {
   if (self->wakeup)

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -354,6 +354,9 @@ _dynamic_window_rebalance(LogSource *self)
 void
 log_source_dynamic_window_realloc(LogSource *self)
 {
+  /* it is safe to assume that the window size is not decremented while this function runs,
+   * only incrementation is possible by destination threads */
+
   if (!_reclaim_window_instead_of_rebalance(self))
     _dynamic_window_rebalance(self);
 

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -128,7 +128,6 @@ void log_source_options_init(LogSourceOptions *options, GlobalConfig *cfg, const
 void log_source_options_destroy(LogSourceOptions *options);
 void log_source_options_set_tags(LogSourceOptions *options, GList *tags);
 void log_source_free(LogPipe *s);
-void log_source_wakeup(LogSource *self);
 void log_source_flow_control_adjust(LogSource *self, guint32 window_size_increment);
 void log_source_flow_control_adjust_when_suspended(LogSource *self, guint32 window_size_increment);
 void log_source_flow_control_suspend(LogSource *self);

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_unit_test(CRITERION TARGET test_atomic_gssize)
 add_unit_test(CRITERION TARGET test_window_size_counter)
 add_unit_test(CRITERION TARGET test_apphook)
 add_unit_test(CRITERION TARGET test_dynamic_window)
+add_unit_test(CRITERION TARGET test_logsource)
 
 SET_DIRECTORY_PROPERTIES(PROPERTIES
   ADDITIONAL_MAKE_CLEAN_FILES

--- a/lib/tests/Makefile.am
+++ b/lib/tests/Makefile.am
@@ -20,7 +20,8 @@ lib_tests_TESTS		= \
 	lib/tests/test_window_size_counter \
 	lib/tests/test_apphook \
 	lib/tests/test_dynamic_window \
-	lib/tests/test_logqueue
+	lib/tests/test_logqueue \
+	lib/tests/test_logsource
 
 EXTRA_DIST += lib/tests/CMakeLists.txt
 
@@ -138,6 +139,9 @@ lib_tests_test_dynamic_window_LDADD	=	\
 
 lib_tests_test_logqueue_CFLAGS = $(TEST_CFLAGS)
 lib_tests_test_logqueue_LDADD = $(TEST_LDADD)
+
+lib_tests_test_logsource_CFLAGS = $(TEST_CFLAGS)
+lib_tests_test_logsource_LDADD = $(TEST_LDADD)
 
 CLEANFILES				+= \
 	test_values.persist		   \

--- a/lib/tests/test_logsource.c
+++ b/lib/tests/test_logsource.c
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2019 One Identity
+ * Copyright (c) 2019 László Várady
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "syslog-ng.h"
+#include "logsource.h"
+#include "logmsg/logmsg.h"
+#include "logpipe.h"
+#include "cfg.h"
+#include "apphook.h"
+
+#include <criterion/criterion.h>
+#include <criterion/parameterized.h>
+
+#include <string.h>
+
+#define TEST_SOURCE_GROUP "test_source_group"
+#define TEST_STATS_ID "test_stats_id"
+#define TEST_STATS_INSTANCE "test_stats_instance"
+
+GlobalConfig *cfg;
+LogSourceOptions source_options;
+
+void
+setup(void)
+{
+  cfg = cfg_new_snippet();
+  log_source_options_defaults(&source_options);
+  app_startup();
+}
+
+void
+teardown(void)
+{
+  app_shutdown();
+  log_source_options_destroy(&source_options);
+  cfg_free(cfg);
+}
+
+typedef struct TestSource
+{
+  LogSource super;
+  gsize wakeup_count;
+} TestSource;
+
+void
+test_source_wakeup(LogSource *s)
+{
+  TestSource *source = (TestSource *) s;
+  source->wakeup_count++;
+}
+
+LogSource *
+test_source_init(LogSourceOptions *options)
+{
+  TestSource *source = g_new0(TestSource, 1);
+  log_source_init_instance(&source->super, cfg);
+  source->super.wakeup = test_source_wakeup;
+
+  log_source_options_init(options, cfg, TEST_SOURCE_GROUP);
+  log_source_set_options(&source->super, options, TEST_STATS_ID, TEST_STATS_INSTANCE, TRUE, FALSE, NULL);
+  cr_assert(log_pipe_init(&source->super.super));
+  return &source->super;
+}
+
+void
+test_source_destroy(LogSource *source)
+{
+  log_pipe_deinit(&source->super);
+  log_pipe_unref(&source->super);
+}
+
+
+const gchar *
+resolve_sockaddr_to_hostname(gsize *result_len, GSockAddr *saddr, const HostResolveOptions *host_resolve_options)
+{
+  static const gchar *test_hostname = "resolved-test-host";
+  *result_len = strlen(test_hostname);
+  return test_hostname;
+}
+
+typedef struct _MangleHostnameParams
+{
+  gboolean keep_hostname;
+  gboolean chain_hostnames;
+  const gchar *input_host;
+  const gchar *expected_hostname;
+
+  guint32 msg_flags;
+} MangleHostnameParams;
+
+ParameterizedTestParameters(log_source, test_mangle_hostname)
+{
+  static MangleHostnameParams test_params[] =
+  {
+    { .keep_hostname = TRUE, .chain_hostnames = FALSE, "msg-test-host", "msg-test-host" },
+    { .keep_hostname = TRUE, .chain_hostnames = FALSE, NULL, "resolved-test-host" },
+    { .keep_hostname = TRUE, .chain_hostnames = FALSE, "", "resolved-test-host" },
+    { .keep_hostname = TRUE, .chain_hostnames = TRUE, "msg-test-host", "msg-test-host" },
+    { .keep_hostname = FALSE, .chain_hostnames = TRUE, NULL, "resolved-test-host/resolved-test-host" },
+    { .keep_hostname = FALSE, .chain_hostnames = TRUE, "", "resolved-test-host/resolved-test-host" },
+    { .keep_hostname = FALSE, .chain_hostnames = FALSE, "msg-test-host", "resolved-test-host" },
+    { .keep_hostname = FALSE, .chain_hostnames = TRUE, "msg-test-host", "msg-test-host/resolved-test-host" },
+    {
+      .keep_hostname = FALSE, .chain_hostnames = TRUE, "msg-test-host", TEST_SOURCE_GROUP "@resolved-test-host",
+      .msg_flags = LF_LOCAL
+    },
+    {
+      .keep_hostname = FALSE, .chain_hostnames = TRUE, "msg-test-host", "resolved-test-host",
+      .msg_flags = LF_LOCAL | LF_SIMPLE_HOSTNAME
+    },
+  };
+
+  return cr_make_param_array(MangleHostnameParams, test_params, G_N_ELEMENTS(test_params));
+}
+
+ParameterizedTest(MangleHostnameParams *test_params, log_source, test_mangle_hostname)
+{
+  source_options.keep_hostname = test_params->keep_hostname;
+  source_options.chain_hostnames = test_params->chain_hostnames;
+  LogSource *source = test_source_init(&source_options);
+
+  LogMessage *msg = log_msg_new_empty();
+
+  if (test_params->input_host)
+    log_msg_set_value(msg, LM_V_HOST, test_params->input_host, -1);
+
+  msg->flags |= test_params->msg_flags;
+
+  log_source_mangle_hostname(source, msg);
+
+  const gchar *actual_hostname = log_msg_get_value(msg, LM_V_HOST, NULL);
+  cr_assert_str_eq(actual_hostname, test_params->expected_hostname);
+
+  log_msg_unref(msg);
+  test_source_destroy(source);
+}
+
+Test(log_source, test_chain_hostname_truncates_long_chained_hostnames)
+{
+  source_options.chain_hostnames = TRUE;
+  LogSource *source = test_source_init(&source_options);
+  LogMessage *msg = log_msg_new_empty();
+
+  const gsize long_hostname_size = 512;
+  gchar long_hostname[long_hostname_size];
+  memset(long_hostname, 'Z', long_hostname_size);
+  log_msg_set_value(msg, LM_V_HOST, long_hostname, long_hostname_size);
+
+  log_source_mangle_hostname(source, msg);
+
+  const gchar *actual_hostname = log_msg_get_value(msg, LM_V_HOST, NULL);
+  gsize expected_hostname_len = 255;
+
+  cr_assert_eq(strlen(actual_hostname), expected_hostname_len);
+  cr_assert_arr_eq(actual_hostname, long_hostname, expected_hostname_len);
+
+  log_msg_unref(msg);
+  test_source_destroy(source);
+}
+
+TestSuite(log_source, .init = setup, .fini = teardown);

--- a/lib/tests/test_logsource.c
+++ b/lib/tests/test_logsource.c
@@ -179,4 +179,26 @@ Test(log_source, test_chain_hostname_truncates_long_chained_hostnames)
   test_source_destroy(source);
 }
 
+Test(log_source, test_host_and_program_override)
+{
+  source_options.host_override = g_strdup("test-host-override");
+  source_options.program_override = g_strdup("test-program-override");
+  LogSource *source = test_source_init(&source_options);
+
+  LogMessage *msg = log_msg_new_empty();
+  log_msg_set_value(msg, LM_V_HOST, "hostname-to-override", -1);
+  log_msg_set_value(msg, LM_V_PROGRAM, "program-to-override", -1);
+
+  log_msg_ref(msg);
+  log_source_post(source, msg);
+
+  const gchar *actual_hostname = log_msg_get_value(msg, LM_V_HOST, NULL);
+  cr_expect_str_eq(actual_hostname, source_options.host_override);
+  const gchar *actual_program = log_msg_get_value(msg, LM_V_PROGRAM, NULL);
+  cr_expect_str_eq(actual_program, source_options.program_override);
+
+  log_msg_unref(msg);
+  test_source_destroy(source);
+}
+
 TestSuite(log_source, .init = setup, .fini = teardown);

--- a/lib/tests/test_logsource.c
+++ b/lib/tests/test_logsource.c
@@ -201,4 +201,25 @@ Test(log_source, test_host_and_program_override)
   test_source_destroy(source);
 }
 
+Test(log_source, test_source_tags)
+{
+  GList *tags = NULL;
+  tags = g_list_prepend(tags, g_strdup("tag1"));
+  tags = g_list_prepend(tags, g_strdup("tag2"));
+  log_source_options_set_tags(&source_options, tags);
+
+  LogSource *source = test_source_init(&source_options);
+
+  LogMessage *msg = log_msg_new_empty();
+  log_msg_ref(msg);
+  log_source_post(source, msg);
+
+  cr_expect(log_msg_is_tag_by_name(msg, "tag1"));
+  cr_expect(log_msg_is_tag_by_name(msg, "tag2"));
+  cr_expect(log_msg_is_tag_by_name(msg, ".source." TEST_SOURCE_GROUP));
+
+  log_msg_unref(msg);
+  test_source_destroy(source);
+}
+
 TestSuite(log_source, .init = setup, .fini = teardown);


### PR DESCRIPTION
This PR improves the test coverage of `LogSource`. Now only `_flow_control_rate_adjust()` is untested.

Unfortunately, these are not clean unit tests, there is a `TestPipe` object, for example, that emulates the destination queue/message acks. This would be eliminated if we could mock out a few things.

Because I measured the test coverage, I also removed unreachable and unused code, etc.