### PR TITLE
[WIP] dbld: remove the automatic rm function from the shell command

### DIFF
--- a/dbld/rules
+++ b/dbld/rules
@@ -131,8 +131,12 @@ run-%: setup
 
 shell: shell-$(DEFAULT_IMAGE)
 shell-%: setup
-	$(DOCKER) run $(DOCKER_RUN_ARGS) --rm -ti balabit/syslog-ng-$* /source/dbld/shell
-
+	$(DOCKER) inspect $* > /dev/null 2>&1; \
+	if [ $$? -eq 0 ]; then \
+		$(DOCKER) start -ia $*; \
+	else \
+		$(DOCKER) run $(DOCKER_RUN_ARGS) -ti --name $* balabit/syslog-ng-$* /source/dbld/shell; \
+	fi
 
 images: $(foreach image,$(IMAGES), image-$(image))
 image: image-$(DEFAULT_IMAGE)


### PR DESCRIPTION
WIP: Because I just wanted to start a discussion about the topic.

pro: I use devshell for development and it is a little inconvenient that I lose my installed packages, and other changes in case my terminal frozen, or I have to reboot my computer in case of updates.

con: With this change a user has to manually delete old containers, and it might happen that he is not working in a clean environment. (CI systems do not use interactive shells, so they are not affected by this change.)
