### PR TITLE
Affile delay acks until messages written to disk

### DIFF
--- a/lib/transport/logtransport.h
+++ b/lib/transport/logtransport.h
@@ -37,6 +37,7 @@ struct _LogTransport
   const gchar *name;
   gssize (*read)(LogTransport *self, gpointer buf, gsize count, LogTransportAuxData *aux);
   gssize (*write)(LogTransport *self, const gpointer buf, gsize count);
+  gssize (*writev)(LogTransport *self, struct iovec *iov, gint iov_count);
   void (*free_fn)(LogTransport *self);
 };
 
@@ -44,6 +45,12 @@ static inline gssize
 log_transport_write(LogTransport *self, const gpointer buf, gsize count)
 {
   return self->write(self, buf, count);
+}
+
+static inline gssize
+log_transport_writev(LogTransport *self, struct iovec *iov, gint iov_count)
+{
+  return self->writev(self, iov, iov_count);
 }
 
 static inline gssize

--- a/lib/transport/transport-file.c
+++ b/lib/transport/transport-file.c
@@ -25,6 +25,7 @@
 
 #include <errno.h>
 #include <unistd.h>
+#include <sys/uio.h>
 
 gssize
 log_transport_file_read_method(LogTransport *self, gpointer buf, gsize buflen, LogTransportAuxData *aux)
@@ -66,12 +67,26 @@ log_transport_file_write_method(LogTransport *self, const gpointer buf, gsize bu
   return rc;
 }
 
+gssize
+log_transport_file_writev_method(LogTransport *self, struct iovec *iov, gint iov_count)
+{
+  gint rc;
+
+  do
+    {
+      rc = writev(self->fd, iov, iov_count);
+    }
+  while (rc == -1 && errno == EINTR);
+  return rc;
+}
+
 void
 log_transport_file_init_instance(LogTransportFile *self, gint fd)
 {
   log_transport_init_instance(&self->super, fd);
   self->super.read = log_transport_file_read_method;
   self->super.write = log_transport_file_write_method;
+  self->super.writev = log_transport_file_writev_method;
   self->super.free_fn = log_transport_free_method;
 }
 

--- a/libtest/mock-transport.c
+++ b/libtest/mock-transport.c
@@ -190,6 +190,14 @@ log_transport_mock_set_write_chunk_limit(LogTransportMock *self, gsize chunk_lim
   self->write_chunk_limit = chunk_limit;
 }
 
+void
+log_transport_mock_empty_write_buffer(LogTransportMock *self)
+{
+  g_array_set_size(self->write_buffer, 0);
+  self->write_buffer_index = 0;
+  self->current_value_ndx = 0;
+}
+
 gssize
 log_transport_mock_read_method(LogTransport *s, gpointer buf, gsize count, LogTransportAuxData *aux)
 {

--- a/libtest/mock-transport.h
+++ b/libtest/mock-transport.h
@@ -67,6 +67,9 @@ log_transport_mock_read_chunk_from_write_buffer(LogTransportMock *self, gchar *b
 void
 log_transport_mock_set_write_chunk_limit(LogTransportMock *self, gsize chunk_limit);
 
+void
+log_transport_mock_empty_write_buffer(LogTransportMock *self);
+
 LogTransportMock *
 log_transport_mock_clone(LogTransportMock *self);
 

--- a/libtest/mock-transport.h
+++ b/libtest/mock-transport.h
@@ -64,6 +64,9 @@ log_transport_mock_read_from_write_buffer(LogTransportMock *self, gchar *buffer,
 gssize
 log_transport_mock_read_chunk_from_write_buffer(LogTransportMock *self, gchar *buffer);
 
+void
+log_transport_mock_set_write_chunk_limit(LogTransportMock *self, gsize chunk_limit);
+
 LogTransportMock *
 log_transport_mock_clone(LogTransportMock *self);
 

--- a/libtest/tests/test_mock_transport.c
+++ b/libtest/tests/test_mock_transport.c
@@ -67,16 +67,63 @@ Test(mock_transport, test_mock_transport_simple_write)
   log_transport_free((LogTransport *)transport);
 }
 
+Test(mock_transport, test_mock_transport_write_with_chunk_limit)
+{
+  LogTransportMock *transport = (LogTransportMock *)log_transport_mock_records_new(LTM_EOF);
+  cr_assert(transport);
+
+  gchar buffer[100];
+
+  log_transport_mock_set_write_chunk_limit(transport, 2);
+  gssize count = log_transport_write((LogTransport *)transport, "chunk", 6);
+  cr_assert(count == 2);
+  count = log_transport_write((LogTransport *)transport, "unk", 4);
+  cr_assert(count == 2);
+  count = log_transport_write((LogTransport *)transport, "k", 2);
+  cr_assert(count == 2);
+
+  log_transport_mock_read_from_write_buffer(transport, buffer, sizeof(buffer));
+  cr_assert_str_eq(buffer, "chunk");
+
+  log_transport_free((LogTransport *)transport);
+}
+
 Test(mock_transport, test_mock_transport_writev)
 {
   LogTransportMock *transport = (LogTransportMock *)log_transport_mock_records_new(LTM_EOF);
   cr_assert(transport);
 
   gchar buffer[100] = "chunkofdata";
-  
+
   struct iovec iov = { .iov_base = buffer, .iov_len = strlen(buffer) + 1 };
 
   log_transport_writev((LogTransport *)transport, &iov, 1);
+  memset(buffer, 0, sizeof(buffer));
+  log_transport_mock_read_from_write_buffer(transport, buffer, sizeof(buffer));
+  cr_assert_str_eq(buffer, "chunkofdata");
+
+  log_transport_free((LogTransport *)transport);
+}
+
+Test(mock_transport, test_mock_transport_writev_with_chunk_limit)
+{
+  LogTransportMock *transport = (LogTransportMock *)log_transport_mock_records_new(LTM_EOF);
+  cr_assert(transport);
+
+  gchar buffer[100] = "chunkofdata";
+
+  struct iovec iov = { .iov_base = buffer, .iov_len = strlen(buffer) + 1 };
+
+  log_transport_mock_set_write_chunk_limit(transport, 2);
+  gssize count = log_transport_writev((LogTransport *)transport, &iov, 1);
+  cr_assert(count == 2);
+
+  log_transport_mock_set_write_chunk_limit(transport, 0);
+  iov.iov_base = &buffer[2];
+  iov.iov_len -= 2;
+  count = log_transport_writev((LogTransport *)transport, &iov, 1);
+  cr_assert(count == 10);
+
   memset(buffer, 0, sizeof(buffer));
   log_transport_mock_read_from_write_buffer(transport, buffer, sizeof(buffer));
   cr_assert_str_eq(buffer, "chunkofdata");

--- a/libtest/tests/test_mock_transport.c
+++ b/libtest/tests/test_mock_transport.c
@@ -67,6 +67,23 @@ Test(mock_transport, test_mock_transport_simple_write)
   log_transport_free((LogTransport *)transport);
 }
 
+Test(mock_transport, test_mock_transport_writev)
+{
+  LogTransportMock *transport = (LogTransportMock *)log_transport_mock_records_new(LTM_EOF);
+  cr_assert(transport);
+
+  gchar buffer[100] = "chunkofdata";
+  
+  struct iovec iov = { .iov_base = buffer, .iov_len = strlen(buffer) + 1 };
+
+  log_transport_writev((LogTransport *)transport, &iov, 1);
+  memset(buffer, 0, sizeof(buffer));
+  log_transport_mock_read_from_write_buffer(transport, buffer, sizeof(buffer));
+  cr_assert_str_eq(buffer, "chunkofdata");
+
+  log_transport_free((LogTransport *)transport);
+}
+
 Test(mock_transport, test_mock_transport_read_from_write_buffer)
 {
   LogTransportMock *transport = (LogTransportMock *)log_transport_mock_records_new(LTM_EOF);

--- a/modules/affile/logproto-file-writer.c
+++ b/modules/affile/logproto-file-writer.c
@@ -71,7 +71,7 @@ log_proto_file_writer_flush(LogProtoClient *s)
       else if (rc != len)
         {
           self->partial_pos += rc;
-          return LPS_SUCCESS;
+          return LPS_PARTIAL;
         }
       else
         {

--- a/modules/affile/logproto-file-writer.c
+++ b/modules/affile/logproto-file-writer.c
@@ -61,7 +61,7 @@ log_proto_file_writer_flush(LogProtoClient *s)
       /* there is still some data from the previous file writing process */
       gint len = self->partial_len - self->partial_pos;
 
-      rc = write(self->fd, self->partial + self->partial_pos, len);
+      rc = log_transport_write(self->super.transport, self->partial + self->partial_pos, len);
       if (rc > 0 && self->fsync)
         fsync(self->fd);
       if (rc < 0)
@@ -84,7 +84,7 @@ log_proto_file_writer_flush(LogProtoClient *s)
   if (self->buf_count == 0)
     return LPS_SUCCESS;
 
-  rc = writev(self->fd, self->buffer, self->buf_count);
+  rc = log_transport_writev(self->super.transport, self->buffer, self->buf_count);
   if (rc > 0 && self->fsync)
     fsync(self->fd);
 

--- a/modules/affile/tests/CMakeLists.txt
+++ b/modules/affile/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_unit_test(CRITERION LIBTEST TARGET test_wildcard_source DEPENDS affile)
 add_unit_test(CRITERION TARGET test_directory_monitor DEPENDS affile)
 add_unit_test(CRITERION TARGET test_collection_comparator DEPENDS affile)
+add_unit_test(CRITERION LIBTEST TARGET test_file_writer DEPENDS affile)
 add_unit_test(CRITERION TARGET test_file_opener DEPENDS affile)
 add_unit_test(CRITERION TARGET test_wildcard_file_reader DEPENDS affile)
 add_unit_test(CRITERION TARGET test_file_list DEPENDS affile)

--- a/modules/affile/tests/CMakeLists.txt
+++ b/modules/affile/tests/CMakeLists.txt
@@ -1,14 +1,6 @@
 add_unit_test(CRITERION LIBTEST TARGET test_wildcard_source DEPENDS affile)
 add_unit_test(CRITERION TARGET test_directory_monitor DEPENDS affile)
 add_unit_test(CRITERION TARGET test_collection_comparator DEPENDS affile)
-add_unit_test(CRITERION TARGET test_file_opener
-  INCLUDES "${CMAKE_SOURCE_DIR}/modules"
-  DEPENDS affile)
-
-add_unit_test(CRITERION TARGET test_wildcard_file_reader
-  INCLUDES "${CMAKE_SOURCE_DIR}/modules"
-  DEPENDS affile)
-
-add_unit_test(CRITERION TARGET test_file_list
-  INCLUDES "${CMAKE_SOURCE_DIR}/modules"
-  DEPENDS affile)
+add_unit_test(CRITERION TARGET test_file_opener DEPENDS affile)
+add_unit_test(CRITERION TARGET test_wildcard_file_reader DEPENDS affile)
+add_unit_test(CRITERION TARGET test_file_list DEPENDS affile)

--- a/modules/affile/tests/Makefile.am
+++ b/modules/affile/tests/Makefile.am
@@ -9,7 +9,8 @@ modules_affile_tests_TESTS 				= \
 	modules/affile/tests/test_collection_comparator \
 	modules/affile/tests/test_file_opener \
 	modules/affile/tests/test_wildcard_file_reader \
-	modules/affile/tests/test_file_list
+	modules/affile/tests/test_file_list		\
+	modules/affile/tests/test_file_writer
 
 modules_affile_tests_test_wildcard_source_CFLAGS  = $(TEST_CFLAGS) -I$(top_srcdir)/modules/affile
 modules_affile_tests_test_wildcard_source_LDADD   = $(TEST_LDADD) \
@@ -33,4 +34,8 @@ modules_affile_tests_test_wildcard_file_reader_SOURCES = modules/affile/tests/te
 
 modules_affile_tests_test_file_list_CFLAGS = $(TEST_CFLAGS) -I$(top_srcdir)/modules/affile
 modules_affile_tests_test_file_list_LDADD	= $(TEST_LDADD) \
+	-dlpreopen $(top_builddir)/modules/affile/libaffile.la
+
+modules_affile_tests_test_file_writer_CFLAGS = $(TEST_CFLAGS) -I$(top_srcdir)/modules/affile
+modules_affile_tests_test_file_writer_LDADD	= $(TEST_LDADD) \
 	-dlpreopen $(top_builddir)/modules/affile/libaffile.la

--- a/modules/affile/tests/test_file_writer.c
+++ b/modules/affile/tests/test_file_writer.c
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2019 Balazs Scheidler <bazsi77@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "logproto-file-writer.h"
+#include "logmsg/logmsg.h"
+#include "apphook.h"
+
+#include <criterion/criterion.h>
+#include "cr_template.h"
+#include "mock-transport.h"
+
+static void _ack_callback(gint num_acked, gpointer user_data);
+
+/* helper variables used by all testcases below */
+
+static LogProtoClientOptions options = {0};
+static LogMessage *msg;
+static LogTransport *transport;
+static LogProtoClientFlowControlFuncs flow_control_funcs =
+{
+  .ack_callback = _ack_callback,
+};
+static gchar output_buffer[8192];
+static LogProtoStatus status;
+static gint messages_acked = 0;
+static gboolean consumed;
+static const gchar *payload = "PAYLOAD";
+static gssize count;
+
+static void
+_ack_callback(gint num_acked, gpointer user_data)
+{
+  messages_acked += num_acked;
+}
+
+Test(file_writer, write_single_message_and_flush_is_expected_to_dump_the_payload_to_the_output)
+{
+  LogProtoClient *fw = log_proto_file_writer_new(transport, &options, 100, FALSE);
+
+  log_proto_client_set_client_flow_control(fw, &flow_control_funcs);
+
+  status = log_proto_client_post(fw, msg, (guchar *) g_strdup(payload), strlen(payload) + 1, &consumed);
+  cr_assert(status == LPS_SUCCESS);
+  cr_assert(consumed == TRUE);
+
+  status = log_proto_client_flush(fw);
+  cr_assert(status == LPS_SUCCESS);
+
+  log_transport_mock_read_from_write_buffer((LogTransportMock *) transport, output_buffer, sizeof(output_buffer));
+  cr_assert_str_eq(output_buffer, "PAYLOAD");
+  cr_assert(messages_acked == 1);
+
+  log_proto_client_free(fw);
+}
+
+Test(file_writer, batches_of_messages_should_be_flushed_to_the_output)
+{
+  const gint BATCH_SIZE = 10;
+  const gint MESSAGE_COUNT = BATCH_SIZE * 3;
+  LogProtoClient *fw = log_proto_file_writer_new(transport, &options, BATCH_SIZE, FALSE);
+
+  log_proto_client_set_client_flow_control(fw, &flow_control_funcs);
+  for (gint i = 0; i < MESSAGE_COUNT; i++)
+    {
+      status = log_proto_client_post(fw, msg, (guchar *) g_strdup(payload), strlen(payload) + 1, &consumed);
+      cr_assert(status == LPS_SUCCESS);
+      cr_assert(consumed == TRUE);
+    }
+
+  status = log_proto_client_flush(fw);
+  cr_assert(status == LPS_SUCCESS);
+
+  count = log_transport_mock_read_from_write_buffer((LogTransportMock *) transport, output_buffer, sizeof(output_buffer));
+  cr_assert_eq(count, MESSAGE_COUNT * (strlen(payload) + 1));
+
+  for (gint i = 0; i < MESSAGE_COUNT; i++)
+    {
+      const gchar *output_element = output_buffer + i * (strlen(payload) + 1);
+      cr_assert_str_eq(output_element, "PAYLOAD");
+    }
+  cr_assert_eq(messages_acked, MESSAGE_COUNT);
+
+  log_proto_client_free(fw);
+}
+
+Test(file_writer, messages_should_be_flushed_automatically_once_we_reach_batch_size)
+{
+  const gint BATCH_SIZE = 10;
+  LogProtoClient *fw = log_proto_file_writer_new(transport, &options, BATCH_SIZE, FALSE);
+
+  log_proto_client_set_client_flow_control(fw, &flow_control_funcs);
+  for (gint i = 0; i < BATCH_SIZE - 1; i++)
+    {
+      status = log_proto_client_post(fw, msg, (guchar *) g_strdup(payload), strlen(payload) + 1, &consumed);
+      cr_assert(status == LPS_SUCCESS);
+      cr_assert(consumed == TRUE);
+    }
+
+  count = log_transport_mock_read_from_write_buffer((LogTransportMock *) transport, output_buffer, sizeof(output_buffer));
+  cr_assert_eq(count, 0);
+
+  /* Push an extra item, which causes the BATCH_SIZE limit to be reached. There's an automatic flush in this case. */
+  status = log_proto_client_post(fw, msg, (guchar *) g_strdup(payload), strlen(payload) + 1, &consumed);
+  cr_assert(status == LPS_SUCCESS);
+  cr_assert(consumed == TRUE);
+
+  count = log_transport_mock_read_from_write_buffer((LogTransportMock *) transport, output_buffer, sizeof(output_buffer));
+  cr_assert_eq(count, BATCH_SIZE * (strlen(payload) + 1));
+  cr_assert_eq(messages_acked, BATCH_SIZE);
+
+  log_proto_client_free(fw);
+}
+
+Test(file_writer, batches_of_messages_are_flushed_even_if_the_underlying_transport_is_accepting_a_few_bytes_per_write)
+{
+  const gint BATCH_SIZE = 10;
+  LogProtoClient *fw = log_proto_file_writer_new(transport, &options, BATCH_SIZE, FALSE);
+
+  log_transport_mock_set_write_chunk_limit((LogTransportMock *) transport, 2);
+  log_proto_client_set_client_flow_control(fw, &flow_control_funcs);
+  for (gint i = 0; i < BATCH_SIZE; i++)
+    {
+      status = log_proto_client_post(fw, msg, (guchar *) g_strdup(payload), strlen(payload) + 1, &consumed);
+      cr_assert(status == LPS_SUCCESS, "status=%d", status);
+      cr_assert(consumed == TRUE);
+    }
+
+  while ((status = log_proto_client_flush(fw)) == LPS_PARTIAL)
+    ;
+
+  cr_assert(status == LPS_SUCCESS);
+
+  count = log_transport_mock_read_from_write_buffer((LogTransportMock *) transport, output_buffer, sizeof(output_buffer));
+  cr_assert_eq(count, BATCH_SIZE * (strlen(payload) + 1));
+
+  for (gint i = 0; i < BATCH_SIZE; i++)
+    {
+      const gchar *output_element = output_buffer + i * (strlen(payload) + 1);
+      cr_assert_str_eq(output_element, "PAYLOAD");
+    }
+  cr_assert_eq(messages_acked, BATCH_SIZE);
+
+  log_proto_client_free(fw);
+}
+
+static void
+startup(void)
+{
+  app_startup();
+  msg = create_empty_message();
+  transport = log_transport_mock_stream_new(NULL, 0);
+}
+
+static void
+teardown(void)
+{
+  log_msg_unref(msg);
+  app_shutdown();
+}
+
+TestSuite(file_writer, .init = startup, .fini = teardown);

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -71,6 +71,7 @@ modules/http/http-grammar.ym
 modules/timestamp/rewrite-.*$
 modules/add-contextual-data/add-contextual-data-glob-selector\.[ch]$
 modules/add-contextual-data/tests/test_glob_selector\.c$
+modules/affile/tests/test_file_writer\.c$
  GPLv2+_SSL
 dev-utils/plugin_skeleton_creator/create_plugin.sh
 tests/functional


### PR DESCRIPTION
As discussed in #2887 due to a failing testcase the file destination was pretty optimistic on when to acknowledge a message back, even though the entire infrastructure is now in place to do it somewhat later.

This branch does exactly that, instead of acking the message in log_proto_client_post(), we do it once write() acknowledged that it wrote the message. This combined with fsync() we can really be sure that the buffer embedded in LogProtoFileWriter will not hold messages that are not yet written but are acknowledged to the source.

I think some refactorings are heavily needed here, I am just wondering what @kira-syslogng thinks about the patch.

The branch also improves testing in this corner of the codebase.