### PR TITLE
Light property based test fixes

### DIFF
--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -193,7 +193,7 @@ source_wildcard_option
 	    free($3);
           }
 	| KW_RECURSIVE '(' yesno ')' { wildcard_sd_set_recursive(last_driver, $3); }
-	| KW_MAX_FILES '(' LL_NUMBER ')' { wildcard_sd_set_max_files(last_driver, $3); }
+	| KW_MAX_FILES '(' positive_integer ')' { wildcard_sd_set_max_files(last_driver, $3); }
 	| KW_MONITOR_METHOD '(' string ')' { CHECK_ERROR(wildcard_sd_set_monitor_method(last_driver, $3), @3, "Invalid monitor-method"); free($3); }
 	| source_affile_option
 	;

--- a/modules/afstomp/afstomp.c
+++ b/modules/afstomp/afstomp.c
@@ -224,8 +224,8 @@ afstomp_dd_connect(STOMPDestDriver *self, gboolean reconnect)
       return FALSE;
     }
 
-  stomp_receive_frame(self->conn, &frame);
-  if (strcmp(frame.command, "CONNECTED"))
+  gboolean frame_read = stomp_receive_frame(self->conn, &frame);
+  if (!frame_read || strcmp(frame.command, "CONNECTED") != 0)
     {
       msg_debug("Error connecting to STOMP server, stomp server did not accept CONNECT request");
       stomp_frame_deinit(&frame);

--- a/modules/afstomp/tests/test_stomp_proto.c
+++ b/modules/afstomp/tests/test_stomp_proto.c
@@ -97,3 +97,10 @@ Test(stomp_proto, test_generate_gstring_from_frame)
   stomp_frame_deinit(&frame);
 };
 
+Test(stomp_proto, test_invalid_command)
+{
+  stomp_frame frame;
+
+  cr_assert_not(stomp_parse_frame(g_string_new("CONNECTED\n no-colon\n"), &frame));
+  stomp_frame_deinit(&frame);
+};

--- a/modules/examples/sources/threaded-random-generator/threaded-random-generator.c
+++ b/modules/examples/sources/threaded-random-generator/threaded-random-generator.c
@@ -112,7 +112,13 @@ _init(LogPipe *s)
       return FALSE;
     }
 
-  return log_threaded_source_driver_init_method(s);
+  if (!log_threaded_source_driver_init_method(s))
+    return FALSE;
+
+  log_threaded_source_driver_set_worker_run_func(&self->super, _run);
+  log_threaded_source_driver_set_worker_request_exit_func(&self->super, _request_exit);
+
+  return TRUE;
 }
 
 static const gchar *
@@ -167,9 +173,6 @@ threaded_random_generator_sd_new(GlobalConfig *cfg)
   self->freq = 1000;
   self->flags = GRND_RANDOM;
   g_atomic_counter_set(&self->exit_requested, FALSE);
-
-  log_threaded_source_driver_set_worker_run_func(&self->super, _run);
-  log_threaded_source_driver_set_worker_request_exit_func(&self->super, _request_exit);
 
   self->super.super.super.super.init = _init;
   self->super.format_stats_instance = _format_stats_instance;

--- a/modules/pseudofile/pseudofile.c
+++ b/modules/pseudofile/pseudofile.c
@@ -186,6 +186,13 @@ pseudofile_dd_init(LogPipe *s)
   GlobalConfig *cfg = log_pipe_get_config(s);
 
   log_template_options_init(&self->template_options, cfg);
+
+  if (!self->template)
+    {
+      msg_error("The template() option for pseudofile() is mandatory", log_pipe_location_tag(s));
+      return FALSE;
+    }
+
   return log_dest_driver_init_method(s);
 }
 


### PR DESCRIPTION
This PR contains 4 fixes for bugs we've found with property-based testing method (using Light).
3 of them are trivial; the 4th (stomp() patch) fixes some buffer overrun issues that can be triggered remotely with suitably crafted input.

There are 3 more, but they deserve a separate PR as they are not that trivial.