### PR TITLE
cfg-tree: inline network destinations disjoint the rest of the config

### DIFF
--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -1049,6 +1049,31 @@ cfg_tree_compile_sequence(CfgTree *self, LogExprNode *node,
       node_properties_propagated = TRUE;
     }
 
+  if (node->content == ENC_DESTINATION)
+    {
+      /* We want to leave pipe-next available to use for
+         destinations. Config graph uses pipe-next to pass messages forward
+         in a sequence layout. But pipe-next might be overridden (for
+         example network destination with LogWriter) hence disjointing
+         the config graph.
+
+         This patch links destinations in T form, instead of single link.
+
+         * (endpoint of sequence)
+         |
+         V
+         * (multiplexer) -(next-hop)-> destination -(pipe-next*)-> logwriter
+         |
+         (pipe-next)
+         |
+         V
+         * (rest of the sequence)
+         That way destinations are free to use the pipe-next*
+      */
+
+      last_pipe = first_pipe;
+    }
+
   *outer_pipe_tail = last_pipe;
   *outer_pipe_head = first_pipe;
   return TRUE;


### PR DESCRIPTION
Fixes: https://github.com/syslog-ng/syslog-ng/issues/2820

Any destination after an inline network destination driver does not handle messages.

The root cause of the issue was that afsocket overwrites its `pipe_next` field with its own writer. Previously, `pipe_next` was pointing to the rest of the config graph. Essentially distjointing the config after the inline network driver. The problem only happens with network driver, and only when the network was inline. Some additional info can be found in #2820.

For example:
```
@version: 3.24

options {
  time-reopen(5);
};

destination d_network {
    network("127.0.0.1" port(4448) );
};

log {
	source { example-msg-generator(); };
	destination { network("127.0.0.1" port(4447) ); };
        destination(d_network);
	flags(flow-control);
};
```

Explanation of the patch is here: https://github.com/syslog-ng/syslog-ng/pull/2989#issuecomment-554925749

After this change, the config graph of the previous example becomes this.

![tmp](https://user-images.githubusercontent.com/11007226/69038319-dd1e4580-09e9-11ea-9026-0d2f6fb9a581.png)

Pros:
- From now any destinations can attach their own pipes to themselves without corrupting the config graph.