### PR TITLE
visualize config graph

### DIFF
--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -84,6 +84,8 @@ EXTRA_DIST += \
 	contrib/systemd/syslog-ng@.service \
 	contrib/systemd/syslog-ng@default \
 	\
+	contrib/scripts/config-graph-json-to-dot.py \
+	\
 	contrib/valgrind/syslog-ng.supp
 
 if ENABLE_SYSTEMD_UNIT_INSTALL

--- a/contrib/scripts/config-graph-json-to-dot.py
+++ b/contrib/scripts/config-graph-json-to-dot.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+import json, sys
+
+j = None
+
+if len(sys.argv) == 1:
+    j = json.loads(sys.stdin.read())
+else:
+    file_name = sys.argv[1]
+    with open(file_name) as f:
+        j = json.loads(f.read())
+
+nodes = j["nodes"]
+arcs = j["arcs"]
+
+print("digraph D {")
+for node in nodes:
+    print("  Node{} [label=\"{} {}\"]".format(node["node"], node["node"], ", ".join(node["info"])))
+for arc in arcs:
+    print("  Node{} -> Node{} [label=\"{}\"]".format(arc["from"], arc["to"], arc["type"]))
+print("}")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -76,6 +76,7 @@ set (LIB_HEADERS
     cfg-parser.h
     cfg-path.h
     cfg-tree.h
+    cfg-walker.h
     children.h
     crypto.h
     dnscache.h
@@ -165,6 +166,7 @@ set(LIB_SOURCES
     cfg-parser.c
     cfg-path.c
     cfg-tree.c
+    cfg-walker.c
     children.c
     dnscache.c
     driver.c

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -111,6 +111,7 @@ pkginclude_HEADERS			+= \
 	lib/cfg-parser.h		\
 	lib/cfg-path.h			\
 	lib/cfg-tree.h			\
+	lib/cfg-walker.h		\
 	lib/children.h			\
 	lib/crypto.h			\
 	lib/dnscache.h			\
@@ -198,6 +199,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	lib/cfg-parser.c		\
 	lib/cfg-path.c			\
 	lib/cfg-tree.c			\
+	lib/cfg-walker.c		\
 	lib/children.c			\
 	lib/dnscache.c			\
 	lib/driver.c			\

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -621,6 +621,7 @@ cfg_tree_new_pipe(CfgTree *self, LogExprNode *related_expr)
   LogPipe *pipe = log_pipe_new(self->cfg);
   pipe->expr_node = related_expr;
   g_ptr_array_add(self->initialized_pipes, pipe);
+  log_pipe_add_info(pipe, "cfg_tree_pipe");
   return pipe;
 }
 
@@ -809,6 +810,7 @@ cfg_tree_compile_reference(CfgTree *self, LogExprNode *node,
           if (!sub_pipe_tail->pipe_next)
             {
               mpx = cfg_tree_new_mpx(self, referenced_node);
+              log_pipe_add_info(&mpx->super, "mpx(source)");
               log_pipe_append(sub_pipe_tail, &mpx->super);
             }
           else
@@ -849,6 +851,7 @@ cfg_tree_compile_reference(CfgTree *self, LogExprNode *node,
       */
 
       mpx = cfg_tree_new_mpx(self, node);
+      log_pipe_add_info(&mpx->super, "mpx(destination-reference)");
 
       if (sub_pipe_head)
         {
@@ -1108,6 +1111,7 @@ cfg_tree_compile_junction(CfgTree *self,
           if (!fork_mpx)
             {
               fork_mpx = cfg_tree_new_mpx(self, node);
+              log_pipe_add_info(&fork_mpx->super, "mpx(junction)");
               *outer_pipe_head = &fork_mpx->super;
             }
           log_multiplexer_add_next_hop(fork_mpx, sub_pipe_head);

--- a/lib/cfg-walker.c
+++ b/lib/cfg-walker.c
@@ -23,10 +23,39 @@
 
 #include "cfg-walker.h"
 
+Arc *
+arc_new(LogPipe *from, LogPipe *to, ArcType arc_type)
+{
+  Arc *self = g_new0(Arc, 1);
+  self->from = from;
+  self->to = to;
+  self->arc_type = arc_type;
+
+  return self;
+};
+
+void
+arc_free(Arc *self)
+{
+  g_free(self);
+}
+
+static guint
+arc_hash(Arc *arc)
+{
+  return g_direct_hash(arc->from);
+}
+
+static gboolean
+arc_equal(Arc *arc1, Arc *arc2)
+{
+  return arc1->to == arc2->to;
+}
+
 void
 cfg_walker_get_graph(GPtrArray *start_nodes, GHashTable **nodes, GHashTable **arcs)
 {
   *nodes = g_hash_table_new(g_direct_hash, g_direct_equal);
-  *arcs = g_hash_table_new(g_direct_hash, g_direct_equal);
+  *arcs = g_hash_table_new_full((GHashFunc)arc_hash, (GEqualFunc)arc_equal, (GDestroyNotify)arc_free, NULL);
   return;
 }

--- a/lib/cfg-walker.c
+++ b/lib/cfg-walker.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "cfg-walker.h"
+
+void
+cfg_walker_get_graph(GPtrArray *start_nodes, GHashTable **nodes, GHashTable **arcs)
+{
+  *nodes = g_hash_table_new(g_direct_hash, g_direct_equal);
+  *arcs = g_hash_table_new(g_direct_hash, g_direct_equal);
+  return;
+}

--- a/lib/cfg-walker.h
+++ b/lib/cfg-walker.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef CFG_WALKER_H_INCLUDED
+#define CFG_WALKER_H_INCLUDED
+
+#include "syslog-ng.h"
+
+void cfg_walker_get_graph(GPtrArray *start_nodes, GHashTable **nodes, GHashTable **arcs);
+
+#endif

--- a/lib/cfg-walker.h
+++ b/lib/cfg-walker.h
@@ -26,6 +26,21 @@
 
 #include "syslog-ng.h"
 
+typedef enum
+{
+  ARC_TYPE_PIPE_NEXT,
+  ARC_TYPE_NEXT_HOP
+} ArcType;
+
+typedef struct
+{
+  LogPipe *from;
+  LogPipe *to;
+  ArcType arc_type;
+} Arc;
+
 void cfg_walker_get_graph(GPtrArray *start_nodes, GHashTable **nodes, GHashTable **arcs);
+Arc *arc_new(LogPipe *from, LogPipe *to, ArcType arc_type);
+void arc_free(Arc *self);
 
 #endif

--- a/lib/logmpx.c
+++ b/lib/logmpx.c
@@ -175,5 +175,6 @@ log_multiplexer_new(GlobalConfig *cfg)
   self->super.free_fn = log_multiplexer_free;
   self->next_hops = g_ptr_array_new();
   self->super.arcs = _arcs;
+  log_pipe_add_info(&self->super, "multiplexer");
   return self;
 }

--- a/lib/logmpx.c
+++ b/lib/logmpx.c
@@ -23,6 +23,7 @@
  */
 
 #include "logmpx.h"
+#include "cfg-walker.h"
 
 
 void
@@ -138,6 +139,30 @@ log_multiplexer_free(LogPipe *s)
   log_pipe_free_method(s);
 }
 
+static void
+_append(LogPipe *to, gpointer *user_data)
+{
+  LogPipe *from = user_data[0];
+  GList **list = user_data[1];
+
+  Arc *arc = arc_new(from, to, ARC_TYPE_NEXT_HOP);
+  *list = g_list_append(*list, arc);
+}
+
+static GList *
+_arcs(LogPipe *s)
+{
+  LogMultiplexer *self = (LogMultiplexer *)s;
+  GList *list = NULL;
+  g_ptr_array_foreach(self->next_hops, (GFunc)_append, (gpointer[2])
+  {
+    self, &list
+  });
+  if (s->pipe_next)
+    list = g_list_append(list, arc_new((LogPipe *)self, s->pipe_next, ARC_TYPE_PIPE_NEXT));
+  return list;
+};
+
 LogMultiplexer *
 log_multiplexer_new(GlobalConfig *cfg)
 {
@@ -149,5 +174,6 @@ log_multiplexer_new(GlobalConfig *cfg)
   self->super.queue = log_multiplexer_queue;
   self->super.free_fn = log_multiplexer_free;
   self->next_hops = g_ptr_array_new();
+  self->super.arcs = _arcs;
   return self;
 }

--- a/lib/logpipe.c
+++ b/lib/logpipe.c
@@ -24,6 +24,7 @@
 
 #include "logpipe.h"
 #include "cfg-tree.h"
+#include "cfg-walker.h"
 
 gboolean (*pipe_single_step_hook)(LogPipe *pipe, LogMessage *msg, const LogPathOptions *path_options);
 
@@ -47,6 +48,15 @@ void log_pipe_detach_expr_node(LogPipe *self)
   self->expr_node = NULL;
 }
 
+static GList *
+_arcs(LogPipe *self)
+{
+  if (self->pipe_next)
+    return g_list_append(NULL, arc_new(self, self->pipe_next, ARC_TYPE_PIPE_NEXT));
+  else
+    return NULL;
+}
+
 void
 log_pipe_init_instance(LogPipe *self, GlobalConfig *cfg)
 {
@@ -63,6 +73,7 @@ log_pipe_init_instance(LogPipe *self, GlobalConfig *cfg)
 
   self->queue = NULL;
   self->free_fn = log_pipe_free_method;
+  self->arcs = _arcs;
 }
 
 LogPipe *

--- a/lib/logpipe.c
+++ b/lib/logpipe.c
@@ -110,6 +110,7 @@ _free(LogPipe *self)
     self->free_fn(self);
   g_free((gpointer)self->persist_name);
   g_free(self->plugin_name);
+  g_list_free_full(self->info, g_free);
   g_free(self);
 }
 
@@ -142,6 +143,12 @@ log_pipe_get_persist_name(const LogPipe *self)
 {
   return (self->generate_persist_name != NULL) ? self->generate_persist_name(self)
          : self->persist_name;
+}
+
+void
+log_pipe_add_info(LogPipe *self, const gchar *info)
+{
+  self->info = g_list_append(self->info, g_strdup(info));
 }
 
 #ifdef __linux__

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -241,6 +241,7 @@ struct _LogPipe
 
   void (*free_fn)(LogPipe *self);
   void (*notify)(LogPipe *self, gint notify_code, gpointer user_data);
+  GList *info;
 };
 
 /*
@@ -406,4 +407,6 @@ log_pipe_get_arcs(LogPipe *s)
 {
   return s->arcs(s);
 }
+
+void log_pipe_add_info(LogPipe *self, const gchar *info);
 #endif

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -231,6 +231,7 @@ struct _LogPipe
   void (*post_deinit)(LogPipe *self);
 
   const gchar *(*generate_persist_name)(const LogPipe *self);
+  GList *(*arcs)(LogPipe *self);
 
   /* clone this pipe when used in multiple locations in the processing
    * pipe-line. If it contains state, it should behave as if it was
@@ -400,4 +401,9 @@ log_pipe_get_persist_name(const LogPipe *self);
 
 void log_pipe_free_method(LogPipe *s);
 
+static inline GList *
+log_pipe_get_arcs(LogPipe *s)
+{
+  return s->arcs(s);
+}
 #endif

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1416,6 +1416,8 @@ log_writer_init(LogPipe *s)
       log_writer_postpone_mark_timer(self);
     }
 
+  log_pipe_add_info(s, "writer");
+
   return TRUE;
 }
 

--- a/lib/mainloop-control.c
+++ b/lib/mainloop-control.c
@@ -277,6 +277,13 @@ control_connection_list_files(ControlConnection *cc, GString *command, gpointer 
   control_connection_send_reply(cc, result);
 }
 
+static void
+export_config_graph(ControlConnection *cc, GString *command, gpointer user_data)
+{
+  GString *result = g_string_new("{}");
+  control_connection_send_reply(cc, result);
+}
+
 ControlCommand default_commands[] =
 {
   { "LOG", control_connection_message_log },
@@ -287,6 +294,7 @@ ControlCommand default_commands[] =
   { "LICENSE", show_ose_license_info },
   { "PWD", process_credentials },
   { "LISTFILES", control_connection_list_files },
+  { "EXPORT_CONFIG_GRAPH", export_config_graph },
   { NULL, NULL },
 };
 

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -101,6 +101,12 @@ static GOptionEntry slng_options[] =
   { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL }
 };
 
+gint
+slng_export_config_graph(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
+{
+  return dispatch_command("EXPORT_CONFIG_GRAPH");
+}
+
 static CommandDescriptor modes[] =
 {
   { "stats", stats_options, "Get syslog-ng statistics in CSV format", slng_stats, NULL },
@@ -115,6 +121,7 @@ static CommandDescriptor modes[] =
   { "credentials", no_options, "Credentials manager", NULL, credentials_commands },
   { "config", config_options, "Print current config", slng_config, NULL },
   { "list-files", no_options, "Print files present in config", slng_listfiles, NULL },
+  { "export-config-graph", no_options, "export configuration graph", slng_export_config_graph, NULL },
   { NULL, NULL },
 };
 


### PR DESCRIPTION
This patchset intends add supporting code so that users could visualize configuration graph. The results could be used for debugging.

Usage:
- Generate config graph from a running syslog-ng instance using syslog-ng-ctl
```
./syslog-ng-ctl export-config-graph
```

Optional:
- Use a newly added script in contrib to convert json to dot format. Then you can create a png, pdf or your preference (paths may differ for you):
```
rm tmp.png; ./syslog-ng-ctl export-config-graph | ../../syslog-ng/contrib/scripts/config-graph-json-to-dot.py | dot -Tpng -o tmp.png && xdg-open tmp.png
```
---

The idea is simple: logpipes will be nodes, arcs will be connections either through multiplexer (`next_hop`) or `pipe_next`. The walk starts from `cfg->initialized_pipes`. Anything that does something with message processing should be accessible from those.

During graph walk, I needed to use `sets` when collecting nodes, because some pipes can occur multiple times during walk. For example multiplexers are added to initialized pipes, but also linked inside the graph.

Some metadata data needed to be added that made easier to identify the logpipes. The metadata of choice were based on my needs in #2989, so it is surely incomplete. I do not plan to make this complete in the scope of this PR (I do not have any usecase that I could follow).

Here is an example for config:
```
@version: 3.24

options {
  time-reopen(5);
};

destination d_network {
    network("127.0.0.1" port(4447));
    network("127.0.0.1" port(4448));
};

log {
	source { example-msg-generator(); };
	source { example-msg-generator(); };
        destination(d_network);
        destination { file(/tmp/a.txt); };
        destination { file(/tmp/b.txt); };
        destination { file(/tmp/c.txt); };
	flags(flow-control);
};
```
And here is the output:

![tmp](https://user-images.githubusercontent.com/11007226/69005155-ff4a9180-091d-11ea-8636-5a9ca8d6361a.png)

PS:
Me neither know what is that logpipe on the top right :)