### PR TITLE
Add disable jit flag to logmatcher

### DIFF
--- a/lib/logmatcher.h
+++ b/lib/logmatcher.h
@@ -35,7 +35,6 @@ GQuark log_matcher_error_quark(void);
 enum
 {
   /* use global search/replace */
-  /* use global search/replace */
   LMF_GLOBAL = 0x0001,
   LMF_ICASE  = 0x0002,
   LMF_MATCH_ONLY = 0x0004,
@@ -44,12 +43,11 @@ enum
   LMF_NEWLINE= 0x0008,
   LMF_UTF8   = 0x0010,
   LMF_STORE_MATCHES = 0x0020,
-  LMF_VALID_REGEXP_FLAGS = 0x0037,
+  LMF_DISABLE_JIT = 0x0040,
 
   /* string flags */
-  LMF_SUBSTRING = 0x0040,
-  LMF_PREFIX = 0x0080,
-  LMF_VALID_STRING_FLAGS = 0x00C7,
+  LMF_SUBSTRING = 0x0080,
+  LMF_PREFIX = 0x0100,
 };
 
 typedef struct _LogMatcherOptions

--- a/tests/unit/test_matcher.c
+++ b/tests/unit/test_matcher.c
@@ -154,12 +154,10 @@ Test(matcher, pcre_regexp, .description = "PCRE regexp")
                    _construct_matcher(LMF_GLOBAL, log_matcher_pcre_re_new));
 }
 
-Test(matcher, back_ref, .description = "back references are not portable, they work only on Linux")
+Test(matcher, back_ref)
 {
-#if __linux__
   testcase_replace("<155>2006-02-11T10:34:56+01:00 bzorp syslog-ng[23323]: wikiwiki", "(wiki)\\1", "", "",
                    _construct_matcher(LMF_STORE_MATCHES, log_matcher_pcre_re_new));
-#endif
 }
 
 Test(matcher, empty_global, .description = "empty match with global flag")

--- a/tests/unit/test_matcher.c
+++ b/tests/unit/test_matcher.c
@@ -188,6 +188,12 @@ Test(matcher, empty_global, .description = "empty match with global flag")
                    _construct_matcher(LMF_GLOBAL, log_matcher_pcre_re_new));
 }
 
+Test(matcher, disable_jit)
+{
+  testcase_replace("<155>2006-02-11T10:34:56+01:00 bzorp syslog-ng[23323]: árvíztűrőtükörfúrógép", "árvíz",
+                   "favíz", "favíztűrőtükörfúrógép", _construct_matcher(LMF_DISABLE_JIT, log_matcher_pcre_re_new));
+}
+
 Test(matcher, string_match)
 {
   testcase_replace("<155>2006-02-11T10:34:56+01:00 bzorp syslog-ng[23323]: árvíztűrőtükörfúrógép", "árvíz",


### PR DESCRIPTION
logmatcher: allow the user to disable PCRE JIT using the disable-jit flag

this should resolve #2986 at least the normal filter() case. the same in multi-line(regexp) support is not this trivial.

**EDIT**:
config examples
```
rewrite r_demo {
  subst("a+" "b" value(".extra.info") flags("disable-jit"));
};

filter f_demo {
  host("internal-.*" flags("disable-jit"));
};

```
