### PR TITLE
packaging: add ordering dependencies to the service files

### DIFF
--- a/contrib/systemd/syslog-ng@.service
+++ b/contrib/systemd/syslog-ng@.service
@@ -2,6 +2,8 @@
 Description=System Logger Daemon "%i" instance
 Documentation=man:syslog-ng(8)
 Conflicts=emergency.service emergency.target
+Wants=network.target network-online.target
+After=network.target network-online.target
 
 [Service]
 Type=notify

--- a/packaging/debian/syslog-ng.systemd
+++ b/packaging/debian/syslog-ng.systemd
@@ -1,6 +1,8 @@
 [Unit]
 Description=System Logger Daemon
 Documentation=man:syslog-ng(8)
+Wants=network.target network-online.target
+After=network.target network-online.target
 
 [Service]
 Type=notify

--- a/packaging/rhel/syslog-ng.service
+++ b/packaging/rhel/syslog-ng.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=System Logger Daemon
 Documentation=man:syslog-ng(8)
+Wants=network.target network-online.target
+After=network.target network-online.target
 
 [Service]
 Type=notify


### PR DESCRIPTION
fix #2667
See the discussion in the issue.

Both option allows Syslog-ng to start even if the network service is not configured or failed to start.
Before: https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Before=
Wants: https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Wants=