### PR TITLE
fix python exception reporting when no exception happened

### DIFF
--- a/modules/python/python-helpers.c
+++ b/modules/python/python-helpers.c
@@ -53,6 +53,8 @@ _py_log_python_traceback_to_stderr_in_debug_mode(void)
   PyObject *exc, *value, *tb;
 
   PyErr_Fetch(&exc, &value, &tb);
+  if (!exc)
+    return;
 
   traceback_module = _py_do_import("traceback");
   if (!traceback_module)

--- a/modules/python/python-helpers.c
+++ b/modules/python/python-helpers.c
@@ -45,7 +45,7 @@ _py_get_callable_name(PyObject *callable, gchar *buf, gsize buf_len)
 }
 
 void
-_py_log_python_traceback_to_stderr_in_debug_mode(void)
+_py_log_python_traceback_to_stderr(void)
 {
   PyObject *traceback_module = NULL;
   PyObject *print_exception = NULL;
@@ -114,7 +114,7 @@ _py_format_exception_text(gchar *buf, gsize buf_len)
 void
 _py_finish_exception_handling(void)
 {
-  _py_log_python_traceback_to_stderr_in_debug_mode();
+  _py_log_python_traceback_to_stderr();
   PyErr_Clear();
 }
 


### PR DESCRIPTION
Sometimes exception reporting is called even when no exception has
happened.

For example when the python class is not found: 
While searching for python class, the code simply calls
getattr, which does not generate exception, just returns null.

In those cases python destination emitted this unnecessarily.
```
[2019-11-04T09:18:44.079993] Error printing proper Python traceback for the exception, printing the error caused by print_exception() itself;
SystemError: NULL object passed to Py_BuildValue
```

This patch makes this function no-op if no exception happened.