### PR TITLE
python-dest: actually use return value of open method

### DIFF
--- a/lib/versioning.h
+++ b/lib/versioning.h
@@ -119,6 +119,7 @@
 #define VERSION_3_22 "syslog-ng 3.22"
 #define VERSION_3_23 "syslog-ng 3.23"
 #define VERSION_3_24 "syslog-ng 3.24"
+#define VERSION_3_25 "syslog-ng 3.25"
 
 #define VERSION_VALUE_3_0  0x0300
 #define VERSION_VALUE_3_1  0x0301
@@ -145,6 +146,7 @@
 #define VERSION_VALUE_3_22 0x0316
 #define VERSION_VALUE_3_23 0x0317
 #define VERSION_VALUE_3_24 0x0318
+#define VERSION_VALUE_3_25 0x0319
 
 
 /* config version code, in the same format as GlobalConfig->version */

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -182,7 +182,15 @@ _py_invoke_open(PythonDestDriver *self)
   if (!self->py.open)
     return TRUE;
 
-  return _dd_py_invoke_bool_function(self, self->py.open, NULL);
+  PyObject *ret;
+  gboolean result = FALSE;
+
+  ret = _py_invoke_function(self->py.open, NULL, self->class, self->super.super.super.id);
+  if (ret)
+    result = PyObject_IsTrue(ret);
+  Py_XDECREF(ret);
+
+  return result;
 }
 
 static void

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -200,6 +200,14 @@ _py_invoke_open(PythonDestDriver *self)
     }
   Py_XDECREF(ret);
 
+  if (self->py.is_opened)
+    {
+      if (!result)
+        return FALSE;
+
+      return _py_invoke_is_opened(self);
+    }
+
   return result;
 }
 
@@ -440,8 +448,7 @@ python_dd_insert(LogThreadedDestDriver *d, LogMessage *msg)
   gstate = PyGILState_Ensure();
   if (!_py_invoke_is_opened(self))
     {
-      _py_invoke_open(self);
-      if (!_py_invoke_is_opened(self))
+      if (!_py_invoke_open(self))
         {
           result = LTR_NOT_CONNECTED;
           goto exit;
@@ -465,10 +472,10 @@ python_dd_open(PythonDestDriver *self)
   PyGILState_STATE gstate;
 
   gstate = PyGILState_Ensure();
-  _py_invoke_open(self);
+  gboolean retval = _py_invoke_open(self);
 
   PyGILState_Release(gstate);
-  return TRUE; // Will be changed to the retval of open later
+  return retval;
 }
 
 static LogThreadedResult

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -187,7 +187,17 @@ _py_invoke_open(PythonDestDriver *self)
 
   ret = _py_invoke_function(self->py.open, NULL, self->class, self->super.super.super.id);
   if (ret)
-    result = PyObject_IsTrue(ret);
+    {
+      if (ret == Py_None)
+        {
+          msg_warning_once("Since " VERSION_3_25 ", the return value of open method in python destination "
+                           "is used as success/failure indicator. Please use return True or return False explicitely",
+                           evt_tag_str("class", self->class));
+          result = TRUE;
+        }
+      else
+        result = PyObject_IsTrue(ret);
+    }
   Py_XDECREF(ret);
 
   return result;

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -435,7 +435,7 @@ exit:
   return result;
 }
 
-static void
+static gboolean
 python_dd_open(PythonDestDriver *self)
 {
   PyGILState_STATE gstate;
@@ -445,6 +445,7 @@ python_dd_open(PythonDestDriver *self)
     _py_invoke_open(self);
 
   PyGILState_Release(gstate);
+  return TRUE; // Will be changed to the retval of open later
 }
 
 static LogThreadedResult
@@ -470,12 +471,12 @@ python_dd_close(PythonDestDriver *self)
   PyGILState_Release(gstate);
 }
 
-static void
-python_dd_worker_init(LogThreadedDestDriver *d)
+static gboolean
+python_dd_connect(LogThreadedDestDriver *d)
 {
-  PythonDestDriver *self = (PythonDestDriver *)d;
+  PythonDestDriver *self = (PythonDestDriver *) d;
 
-  python_dd_open(self);
+  return python_dd_open(self);
 }
 
 static void
@@ -576,7 +577,7 @@ python_dd_new(GlobalConfig *cfg)
   self->super.super.super.super.free_fn = python_dd_free;
   self->super.super.super.super.generate_persist_name = python_dd_format_persist_name;
 
-  self->super.worker.thread_init = python_dd_worker_init;
+  self->super.worker.connect = python_dd_connect;
   self->super.worker.disconnect = python_dd_disconnect;
   self->super.worker.insert = python_dd_insert;
   self->super.worker.flush = python_dd_flush;

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -446,7 +446,7 @@ python_dd_insert(LogThreadedDestDriver *d, LogMessage *msg)
   PyGILState_STATE gstate;
 
   gstate = PyGILState_Ensure();
-  if (!_py_invoke_is_opened(self))
+  if (self->py.is_opened && !_py_invoke_is_opened(self))
     {
       if (!_py_invoke_open(self))
         {
@@ -496,8 +496,15 @@ python_dd_close(PythonDestDriver *self)
   PyGILState_STATE gstate;
 
   gstate = PyGILState_Ensure();
-  if (_py_invoke_is_opened(self))
-    _py_invoke_close(self);
+  if (self->py.is_opened)
+    {
+      if (_py_invoke_is_opened(self))
+        _py_invoke_close(self);
+    }
+  else
+    {
+      _py_invoke_close(self);
+    }
   PyGILState_Release(gstate);
 }
 

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -441,8 +441,7 @@ python_dd_open(PythonDestDriver *self)
   PyGILState_STATE gstate;
 
   gstate = PyGILState_Ensure();
-  if (!_py_invoke_is_opened(self))
-    _py_invoke_open(self);
+  _py_invoke_open(self);
 
   PyGILState_Release(gstate);
   return TRUE; // Will be changed to the retval of open later

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -51,6 +51,7 @@ typedef struct
     PyObject *class;
     PyObject *instance;
     PyObject *is_opened;
+    PyObject *open;
     PyObject *send;
     PyObject *flush;
     PyObject *log_template_options;
@@ -159,7 +160,7 @@ _dd_py_invoke_bool_method_by_name_with_args(PythonDestDriver *self, const gchar 
                                                   self->super.super.super.id);
 }
 
-static gboolean
+static gboolean G_GNUC_UNUSED
 _dd_py_invoke_bool_method_by_name(PythonDestDriver *self, const gchar *method_name)
 {
   return _py_invoke_bool_method_by_name_with_args(self->py.instance, method_name, NULL, self->class,
@@ -178,7 +179,10 @@ _py_invoke_is_opened(PythonDestDriver *self)
 static gboolean
 _py_invoke_open(PythonDestDriver *self)
 {
-  return _dd_py_invoke_bool_method_by_name(self, "open");
+  if (!self->py.open)
+    return TRUE;
+
+  return _dd_py_invoke_bool_function(self, self->py.open, NULL);
 }
 
 static void
@@ -336,6 +340,7 @@ _py_init_bindings(PythonDestDriver *self)
 
   /* these are fast paths, store references to be faster */
   self->py.is_opened = _py_get_attr_or_null(self->py.instance, "is_opened");
+  self->py.open = _py_get_attr_or_null(self->py.instance, "open");
   self->py.flush = _py_get_attr_or_null(self->py.instance, "flush");
   self->py.send = _py_get_attr_or_null(self->py.instance, "send");
   if (!self->py.send)
@@ -349,6 +354,7 @@ _py_init_bindings(PythonDestDriver *self)
   g_ptr_array_add(self->py._refs_to_clean, self->py.class);
   g_ptr_array_add(self->py._refs_to_clean, self->py.instance);
   g_ptr_array_add(self->py._refs_to_clean, self->py.is_opened);
+  g_ptr_array_add(self->py._refs_to_clean, self->py.open);
   g_ptr_array_add(self->py._refs_to_clean, self->py.flush);
   g_ptr_array_add(self->py._refs_to_clean, self->py.send);
   g_ptr_array_add(self->py._refs_to_clean, self->py.log_template_options);


### PR DESCRIPTION
Fixes: https://github.com/syslog-ng/syslog-ng/issues/2513.

Although the admin guide tells users to set the return value of open properly, the code does not check that. Instead, there is an is_opened method that was used to answer:
- if the driver is open
- In some cases, if the last open was successful or not.

This architecture makes users write unnecessary complex code, since the open-ness must be stored and updated as side-effects.

For example this does not do what one would expect, because it sends message even though open returns with false.

<details>

```
@version: 3.24

log {
  source { example-msg-generator(num(1)); };
  destination { python(class(PythonDest)); };
};

python {
class PythonDest(object):
    def open(self):
        return False

    def send(self, message):
        print("sending message")
        return True
};

$ ./syslog-ng -Fe -f ../etc/python.conf 
[2019-11-05T09:35:54.243644] syslog-ng starting up; version='3.24.1.70.ge11a8e4'
sending message
[2019-11-05T09:35:56.766802] syslog-ng shutting down; version='3.24.1.70.ge11a8e4'
```

</details>

This patchset make use of the return value of open method, and act accordingly. This allows user to use open without is_opened.

Conceptually, one can think of `is_opened` as a ping or heartbeat or any similar functionality that detects if the underlying resource is open or not.

For compatibility reasons, if open is void, I consider it as a success return value. At a later time, we can remove the related code.

One known functional change:
- is_opened will not be called during thread_init, before the first open call.
Logically, this should be ok, because a driver should not be open before the first open. Still, this can break code that can be open before the first open.

Updated the e2e tests because of the functional change, and added a new test dedicated to is_opened.