### PR TITLE
Handling single dots in lexer

### DIFF
--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -148,7 +148,6 @@ yy_filter_input(CfgLexer *self, gchar *buf, gsize buf_size)
           if (rc < 0)                                                   \
             {                                                           \
               YY_FATAL_ERROR("configuration input filtering failure");  \
-              result = YY_NULL;                                         \
             }                                                           \
           else                                                          \
             {                                                           \
@@ -399,7 +398,7 @@ word	[^ \#'"\(\)\{\}\[\]\\;\r\n\t,|\.@:]
 
     /* rules to parse a block as a LL_BLOCK token */
 <block>{white}+            ;
-<block>[^{( \t\r\n]+       { YY_FATAL_ERROR("Expected opening bracket as block boundary, e.g. opening brace or parenthesis"); return LL_ERROR; }
+<block>[^{( \t\r\n]+       { YY_FATAL_ERROR("Expected opening bracket as block boundary, e.g. opening brace or parenthesis"); }
 <block>\r?\n		   { _cfg_lex_move_token_location_to_new_line(yyextra); };
 <block>\({white}*\)        { yy_pop_state(yyscanner); yylval->cptr = NULL; return LL_BLOCK; }
 <block>\({white}*\"\"{white}*\) { yy_pop_state(yyscanner); yylval->cptr = g_strdup(""); return LL_BLOCK; }

--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -318,15 +318,6 @@ word	[^ \#'"\(\)\{\}\[\]\\;\r\n\t,|\.@:]
                              return LL_NUMBER;
                            }
 ({word}+(\.)?)*{word}+ 	   { return cfg_lexer_lookup_keyword(yyextra, yylval, yylloc, yytext); }
-\(	      		   |
-\)			   |
-\;			   |
-\{			   |
-\}			   |
-\[			   |
-\]			   |
-\:			   |
-\|			   { return yytext[0]; }
 \,			   ;
 
 \"                         {
@@ -337,7 +328,7 @@ word	[^ \#'"\(\)\{\}\[\]\\;\r\n\t,|\.@:]
 			     g_string_truncate(yyextra->string_buffer, 0);
 			     yy_push_state(qstring, yyscanner);
 			   }
-
+.                          { return (unsigned char) yytext[0]; }
 
     /* continuation line within a string: just move the location and skip the newline character as if it was never there */
 <string,qstring>\\\r?\n    { _cfg_lex_extend_token_location_to_next_line(yyextra); }

--- a/lib/tests/test_lexer.c
+++ b/lib/tests/test_lexer.c
@@ -160,6 +160,19 @@ Test(lexer, test_string)
   assert_parser_string("test\n\r\a\t\vc");
 }
 
+Test(lexer, test_unquoted_string)
+{
+  _input("test");
+  assert_parser_identifier("test");
+
+  _input("..test");
+  assert_parser_token(LL_DOTDOT);
+
+  _input(".test");
+  assert_parser_token('.');
+  assert_parser_identifier("test");
+}
+
 Test(lexer, test_qstring)
 {
   _input("'test'");

--- a/modules/affile/tests/test_wildcard_source.c
+++ b/modules/affile/tests/test_wildcard_source.c
@@ -91,7 +91,7 @@ Test(wildcard_source, test_option_inheritance_multiline)
                                                              "follow-freq(10)"
                                                              "follow-freq(10.0)"
                                                              "multi-line-mode(regexp)"
-                                                             "multi-line-prefix(\\d+)"
+                                                             "multi-line-prefix('\\d+')"
                                                              "multi-line-garbage(garbage)");
   cr_assert_eq(driver->file_reader_options.follow_freq, 10000);
   cr_assert_eq(file_reader_options_get_log_proto_options(&driver->file_reader_options)->super.mode, MLM_PREFIX_GARBAGE);


### PR DESCRIPTION
Syslog-ng has a (not well documented) feature to accept strings
without quotation marks. One of the key benefit of this feature
is that we do not need to put identifiers (i.e.: block names)
into quotation marks. Which makes the config much more readable.

We achieve this by an internal lookup. After Flex successfully
identified a "word" (for details, please investigate the rule
inside the lexer file), we will search for it in the list of
known keywords. If there is no match, we will handle that token
as a string.


Flex - by design - ignores inputs without matching patterns.
(Writes them on standard error, and continues parsing.)

Right now, if a single dot "." character do not breaks an another
pattern (i.e. order of keywords or parentheses) inside the lexer,
it will be silently ignored. Yes, you can put arbitary number of
dots in some places inside the config.

The sum of this two mechanism leads to a mostly hidden error
inside Syslog-ng: strings will lose leading or trailing dots if
they were given without quotation marks.

As an example, the triggering issue was a problem with the prefix
option of the XML parser: "xml(prefix(.SDATA.))"
In this case the XML parser was initialized successfully, there
were no error messages from Syslog-ng. However the final value of
the prefix string inside XML parser was: "SDATA".


KUDOS for @Kokan with debugging Flex. (For further notes: Syslog-ng has a built in command line option for debugging the lexer: `-y` which will enable YYDEBUG.)