### PR TITLE
Revert "logsource: make log_source_wakeup() private"

### DIFF
--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -37,7 +37,7 @@
 
 gboolean accurate_nanosleep = FALSE;
 
-static void
+void
 log_source_wakeup(LogSource *self)
 {
   if (self->wakeup)

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -128,6 +128,7 @@ void log_source_options_init(LogSourceOptions *options, GlobalConfig *cfg, const
 void log_source_options_destroy(LogSourceOptions *options);
 void log_source_options_set_tags(LogSourceOptions *options, GList *tags);
 void log_source_free(LogPipe *s);
+void log_source_wakeup(LogSource *self);
 void log_source_flow_control_adjust(LogSource *self, guint32 window_size_increment);
 void log_source_flow_control_adjust_when_suspended(LogSource *self, guint32 window_size_increment);
 void log_source_flow_control_suspend(LogSource *self);


### PR DESCRIPTION
This reverts commit 289408b3caa83613ab1b6f2fceaca7a36ec17e0f.

The wakeup function is not completely private, it is used internally by `LogProtos`, so I should not have made it static.

Sorry about that, I was concentrating on the unit test (#2980).