### PR TITLE
confgen: fix crash when parameter is empty

### DIFF
--- a/modules/confgen/confgen-plugin.c
+++ b/modules/confgen/confgen-plugin.c
@@ -35,14 +35,21 @@
 static void
 confgen_set_args_as_env(gpointer k, gpointer v, gpointer user_data)
 {
-  gchar buf[1024];
+  if (!v)
+    {
+      msg_debug("confgen: Skipping empty argument",
+                evt_tag_str("name", (gchar *) k));
+      return;
+    }
 
+  gchar buf[1024];
   g_snprintf(buf, sizeof(buf), "confgen_%s", (gchar *)k);
 
   msg_debug("confgen: Passing argument to confgen script",
             evt_tag_str("name", (gchar *) k),
             evt_tag_str("value", (gchar *) v),
             evt_tag_str("env_name", buf));
+
   setenv(buf, (gchar *)v, 1);
 }
 


### PR DESCRIPTION
Previously, when a confgen parameter was empty, syslog-ng crashed in a null-pointer dereference.

Adding an empty parameter (e.g. `parameters()`) does not make sense, but passing `__VARARGS__` to the confgen script is a real use-case, and `__VARARGS__` can be empty.

This PR fixes SCLs, such as the `network-load-balancer()`, where `__VARARGS__` is passed to the confgen script as a parameter:

https://github.com/syslog-ng/syslog-ng/blob/a72580ee65641e8f096958605a2834a346d38128/scl/loadbalancer/plugin.conf#L23-L31

Reproduction:
```
destination d_test {
    network-load-balancer(targets(2));
};
```