### PR TITLE
syslog-ng-ctl: refactor - split into many files

### DIFF
--- a/syslog-ng-ctl/CMakeLists.txt
+++ b/syslog-ng-ctl/CMakeLists.txt
@@ -1,6 +1,20 @@
 set(SYSLOG_NG_CTL_SOURCES
     syslog-ng-ctl.c
     control-client.h
+    commands/commands.h
+    commands/commands.c
+    commands/credentials.h
+    commands/credentials.c
+    commands/verbose.h
+    commands/verbose.c
+    commands/ctl-stats.h
+    commands/ctl-stats.c
+    commands/query.h
+    commands/query.c
+    commands/license.h
+    commands/license.c
+    commands/config.h
+    commands/config.c
     control-client.c
 )
 

--- a/syslog-ng-ctl/Makefile.am
+++ b/syslog-ng-ctl/Makefile.am
@@ -4,6 +4,20 @@ sbin_PROGRAMS			+= syslog-ng-ctl/syslog-ng-ctl
 
 syslog_ng_ctl_syslog_ng_ctl_SOURCES		= 	\
 	syslog-ng-ctl/syslog-ng-ctl.c			\
+	syslog-ng-ctl/commands/commands.h		\
+	syslog-ng-ctl/commands/commands.c		\
+	syslog-ng-ctl/commands/config.h			\
+	syslog-ng-ctl/commands/config.c			\
+	syslog-ng-ctl/commands/credentials.h		\
+	syslog-ng-ctl/commands/credentials.c		\
+	syslog-ng-ctl/commands/verbose.h		\
+	syslog-ng-ctl/commands/verbose.c		\
+	syslog-ng-ctl/commands/ctl-stats.h		\
+	syslog-ng-ctl/commands/ctl-stats.c		\
+	syslog-ng-ctl/commands/query.h			\
+	syslog-ng-ctl/commands/query.c			\
+	syslog-ng-ctl/commands/license.h		\
+	syslog-ng-ctl/commands/license.c		\
 	syslog-ng-ctl/control-client.h			\
 	syslog-ng-ctl/control-client.c
 
@@ -14,5 +28,9 @@ syslog_ng_ctl_syslog_ng_ctl_LDADD		= \
 	$(MODULE_DEPS_LIBS) \
 	$(TOOL_DEPS_LIBS) \
 	$(top_builddir)/lib/secret-storage/libsecret-storage.la
+
+syslog_ng_ctl_syslog_ng_ctl_CPPFLAGS  =     \
+  $(AM_CPPFLAGS)            \
+  -I$(top_srcdir)/syslog-ng-ctl
 
 syslog_ng_ctl_syslog_ng_ctl_DEPENDENCIES	= lib/libsyslog-ng.la lib/secret-storage/libsecret-storage.la

--- a/syslog-ng-ctl/commands/commands.c
+++ b/syslog-ng-ctl/commands/commands.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "commands.h"
+#include "control-client.h"
+
+#include <string.h>
+#include <stdio.h>
+
+static ControlClient *control_client;
+
+GOptionEntry no_options[] =
+{
+  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL }
+};
+
+gboolean
+is_syslog_ng_running(void)
+{
+  return control_client_connect(control_client);
+}
+
+gint
+process_response_status(GString *response)
+{
+  if (strncmp(response->str, "FAIL ", 5) == 0)
+    {
+      g_string_erase(response, 0, 5);
+      return 1;
+    }
+  else if (strncmp(response->str, "OK ", 3) == 0)
+    {
+      g_string_erase(response, 0, 3);
+      return 0;
+    }
+  return 0;
+}
+
+static gboolean
+slng_send_cmd(const gchar *cmd)
+{
+  if (!control_client_connect(control_client))
+    {
+      return FALSE;
+    }
+
+  if (control_client_send_command(control_client,cmd) < 0)
+    {
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+GString *
+slng_run_command(const gchar *command)
+{
+  if (!slng_send_cmd(command))
+    return NULL;
+
+  return control_client_read_reply(control_client);
+}
+
+static gboolean
+_is_response_empty(GString *response)
+{
+  return (response == NULL || g_str_equal(response->str, ""));
+}
+
+static void
+clear_and_free(GString *str)
+{
+  if (str)
+    {
+      memset(str->str, 0, str->len);
+      g_string_free(str, TRUE);
+    }
+}
+
+gint
+dispatch_command(const gchar *cmd)
+{
+  gint retval = 0;
+  gchar *dispatchable_command = g_strdup_printf("%s\n", cmd);
+  GString *rsp = slng_run_command(dispatchable_command);
+
+  if (_is_response_empty(rsp))
+    {
+      retval = 1;
+    }
+  else
+    {
+      retval = process_response_status(rsp);
+      printf("%s\n", rsp->str);
+    }
+
+  clear_and_free(rsp);
+
+  secret_storage_wipe(dispatchable_command, strlen(dispatchable_command));
+  g_free(dispatchable_command);
+
+  return retval;
+}
+
+gint
+run(const gchar *control_name, gint argc, gchar **argv, CommandDescriptor *mode, GOptionContext *ctx)
+{
+  control_client = control_client_new(control_name);
+  gint result = mode->main(argc, argv, mode->mode, ctx);
+  control_client_free(control_client);
+  return result;
+}

--- a/syslog-ng-ctl/commands/commands.h
+++ b/syslog-ng-ctl/commands/commands.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SYSLOG_NG_CTL_COMMANDS_H_INCLUDED
+#define SYSLOG_NG_CTL_COMMANDS_H_INCLUDED 1
+
+#include "syslog-ng.h"
+#include "secret-storage/secret-storage.h"
+
+#include <stdio.h>
+
+extern GOptionEntry no_options[];
+
+typedef struct _CommandDescriptor
+{
+  const gchar *mode;
+  const GOptionEntry *options;
+  const gchar *description;
+  gint (*main)(gint argc, gchar *argv[], const gchar *mode, GOptionContext *ctx);
+  struct _CommandDescriptor *subcommands;
+} CommandDescriptor;
+
+gint dispatch_command(const gchar *cmd);
+GString *slng_run_command(const gchar *command);
+gint process_response_status(GString *response);
+gboolean is_syslog_ng_running(void);
+
+gint run(const gchar *control_name, gint argc, gchar **argv, CommandDescriptor *mode, GOptionContext *ctx);
+#endif

--- a/syslog-ng-ctl/commands/config.c
+++ b/syslog-ng-ctl/commands/config.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "config.h"
+#include "commands.h"
+
+static gboolean config_options_preprocessed = FALSE;
+static gboolean config_options_verify = FALSE;
+
+GOptionEntry config_options[] =
+{
+  { "preprocessed", 'p', 0, G_OPTION_ARG_NONE, &config_options_preprocessed, "preprocessed", NULL },
+  { "verify", 'v', 0, G_OPTION_ARG_NONE, &config_options_verify, "verify", NULL },
+  { NULL,           0,   0, G_OPTION_ARG_NONE, NULL,                         NULL,           NULL }
+};
+
+gint
+slng_config(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
+{
+  GString *cmd = g_string_new("CONFIG ");
+
+  if (config_options_verify)
+    g_string_append(cmd, "VERIFY ");
+  else
+    {
+      g_string_append(cmd, "GET ");
+
+      if(config_options_preprocessed)
+        g_string_append(cmd, "PREPROCESSED");
+      else
+        g_string_append(cmd, "ORIGINAL");
+    }
+
+  gint res = dispatch_command(cmd->str);
+  g_string_free(cmd, TRUE);
+
+  return res;
+}

--- a/syslog-ng-ctl/commands/config.h
+++ b/syslog-ng-ctl/commands/config.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SYSLOG_NG_CTL_CONFIG_H_INCLUDED
+#define SYSLOG_NG_CTL_CONFIG_H_INCLUDED 1
+
+#include "syslog-ng.h"
+
+extern GOptionEntry config_options[];
+gint slng_config(int argc, char *argv[], const gchar *mode, GOptionContext *ctx);
+
+#endif

--- a/syslog-ng-ctl/commands/credentials.c
+++ b/syslog-ng-ctl/commands/credentials.c
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "credentials.h"
+
+#include <termios.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
+static gchar *credentials_key;
+static gchar *credentials_secret;
+static gchar **credentials_remaining;
+
+static gchar *
+consume_next_from_remaining(gchar **remaining, gint *available_index)
+{
+  if (!remaining)
+    return NULL;
+
+  return remaining[(*available_index)++];
+}
+
+static void
+set_console_echo(gboolean new_state)
+{
+  if (!isatty(STDIN_FILENO))
+    return;
+
+  struct termios t;
+
+  if (tcgetattr(STDIN_FILENO, &t))
+    {
+      fprintf(stderr, "syslog-ng-ctl: error while tcgetattr: %s\n", strerror(errno));
+      return;
+    }
+
+  if (new_state)
+    t.c_lflag |= ECHO;
+  else
+    t.c_lflag &= ~((tcflag_t) ECHO);
+
+  if (tcsetattr(STDIN_FILENO, TCSANOW, &t))
+    fprintf(stderr, "syslog-ng-ctl: error while tcsetattr: %s\n", strerror(errno));
+}
+
+static void
+read_password_from_stdin(gchar *buffer, gsize *length)
+{
+  printf("enter password:");
+  set_console_echo(FALSE);
+  if (-1 == getline(&buffer, length, stdin))
+    {
+      set_console_echo(TRUE);
+      fprintf(stderr, "error while reading password from terminal: %s", strerror(errno));
+      g_assert_not_reached();
+    }
+  set_console_echo(TRUE);
+  printf("\n");
+}
+
+static gint
+slng_passwd_add(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
+{
+  gchar *answer;
+  gint remaining_unused_index = 0;
+
+
+  if (!credentials_key)
+    credentials_key = consume_next_from_remaining(credentials_remaining, &remaining_unused_index);
+
+  if (!credentials_key)
+    {
+      gchar *usage = g_option_context_get_help(ctx, TRUE, NULL);
+      fprintf(stderr, "Error: missing arguments!\n%s\n", usage);
+      g_free(usage);
+      return 1;
+    }
+
+  if (!is_syslog_ng_running())
+    return 1;
+
+  if (!credentials_secret)
+    credentials_secret = consume_next_from_remaining(credentials_remaining, &remaining_unused_index);
+
+  gchar *secret_to_store;
+  if (credentials_secret)
+    {
+      secret_to_store = g_strdup(credentials_secret);
+      if (!secret_to_store)
+        g_assert_not_reached();
+    }
+  else
+    {
+      gsize buff_size = 256;
+      secret_to_store = g_malloc0(buff_size);
+      if (!secret_to_store)
+        g_assert_not_reached();
+
+      read_password_from_stdin(secret_to_store, &buff_size);
+    }
+
+  gint retval = asprintf(&answer, "PWD %s %s %s", "add", credentials_key, secret_to_store);
+  if (retval == -1)
+    g_assert_not_reached();
+
+  secret_storage_wipe(secret_to_store, strlen(secret_to_store));
+  g_free(secret_to_store);
+
+  if (credentials_secret)
+    secret_storage_wipe(credentials_secret, strlen(credentials_secret));
+
+  gint result = dispatch_command(answer);
+
+  secret_storage_wipe(answer, strlen(answer));
+  g_free(answer);
+
+  return result;
+}
+
+static gint
+slng_passwd_status(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
+{
+  gchar *answer;
+
+  gint retval = asprintf(&answer, "PWD %s", "status");
+  if (retval == -1)
+    g_assert_not_reached();
+
+  return dispatch_command(answer);
+}
+
+static GOptionEntry credentials_options_add[] =
+{
+  { "id", 'i', 0, G_OPTION_ARG_STRING, &credentials_key, "ID of the credential", "<id>" },
+  { "secret", 's', 0, G_OPTION_ARG_STRING, &credentials_secret, "Secret part of the credential", "<secret>" },
+  { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, &credentials_remaining, NULL, NULL },
+  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL }
+};
+
+CommandDescriptor credentials_commands[] =
+{
+  { "add", credentials_options_add, "Add credentials to credential store", slng_passwd_add },
+  { "status", no_options, "Query stored credential status", slng_passwd_status },
+  { NULL }
+};

--- a/syslog-ng-ctl/commands/credentials.h
+++ b/syslog-ng-ctl/commands/credentials.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SYSLOG_NG_CTL_CREDENTIALS_H_INCLUDED
+#define SYSLOG_NG_CTL_CREDENTIALS_H_INCLUDED 1
+
+#include "commands.h"
+
+extern CommandDescriptor credentials_commands[];
+
+#endif

--- a/syslog-ng-ctl/commands/ctl-stats.c
+++ b/syslog-ng-ctl/commands/ctl-stats.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "ctl-stats.h"
+
+static gboolean stats_options_reset_is_set = FALSE;
+
+GOptionEntry stats_options[] =
+{
+  { "reset", 'r', 0, G_OPTION_ARG_NONE, &stats_options_reset_is_set, "reset counters", NULL },
+  { NULL,    0,   0, G_OPTION_ARG_NONE, NULL,                        NULL,             NULL }
+};
+
+static const gchar *
+_stats_command_builder(void)
+{
+  return stats_options_reset_is_set ? "RESET_STATS" : "STATS";
+}
+
+gint
+slng_stats(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
+{
+  return dispatch_command(_stats_command_builder());
+}

--- a/syslog-ng-ctl/commands/ctl-stats.h
+++ b/syslog-ng-ctl/commands/ctl-stats.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SYSLOG_NG_CTL_STATS_H_INCLUDED
+#define SYSLOG_NG_CTL_STATS_H_INCLUDED 1
+
+#include "commands.h"
+
+extern GOptionEntry stats_options[];
+gint slng_stats(int argc, char *argv[], const gchar *mode, GOptionContext *ctx);
+
+#endif

--- a/syslog-ng-ctl/commands/license.c
+++ b/syslog-ng-ctl/commands/license.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "license.h"
+
+static gboolean license_json = FALSE;
+
+GOptionEntry license_options[] =
+{
+  { "json", 'J', 0, G_OPTION_ARG_NONE, &license_json, "enable json output", NULL },
+  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL }
+};
+
+gint
+slng_license(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
+{
+  gchar buff[256];
+
+  if (license_json)
+    g_snprintf(buff, 255, "LICENSE JSON\n");
+  else
+    g_snprintf(buff, 255, "LICENSE\n");
+
+  return dispatch_command(buff);
+}

--- a/syslog-ng-ctl/commands/license.h
+++ b/syslog-ng-ctl/commands/license.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SYSLOG_NG_LICENSE_H_INCLUDED
+#define SYSLOG_NG_LICENSE_H_INCLUDED 1
+
+#include "commands.h"
+
+extern GOptionEntry license_options[];
+gint slng_license(int argc, char *argv[], const gchar *mode, GOptionContext *ctx);
+
+#endif

--- a/syslog-ng-ctl/commands/query.c
+++ b/syslog-ng-ctl/commands/query.c
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "query.h"
+
+static const gint QUERY_COMMAND = 0;
+static gboolean query_is_get_sum = FALSE;
+static gboolean query_reset = FALSE;
+static gchar **raw_query_params = NULL;
+
+GOptionEntry query_options[] =
+{
+  { "sum", 0, 0, G_OPTION_ARG_NONE, &query_is_get_sum, "aggregate sum", NULL },
+  { "reset", 0, 0, G_OPTION_ARG_NONE, &query_reset, "reset counters after query", NULL },
+  { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, &raw_query_params, NULL, NULL },
+  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
+};
+
+enum
+{
+  QUERY_CMD_LIST,
+  QUERY_CMD_LIST_RESET,
+  QUERY_CMD_GET,
+  QUERY_CMD_GET_RESET,
+  QUERY_CMD_GET_SUM,
+  QUERY_CMD_GET_SUM_RESET
+};
+
+static const gchar *QUERY_COMMANDS[] = {"LIST", "LIST_RESET", "GET", "GET_RESET", "GET_SUM", "GET_SUM_RESET"};
+
+static gint
+_get_query_list_cmd(void)
+{
+  if (query_is_get_sum)
+    return -1;
+
+  if (query_reset)
+    return QUERY_CMD_LIST_RESET;
+
+  return QUERY_CMD_LIST;
+}
+
+static gint
+_get_query_get_cmd(void)
+{
+  if (query_is_get_sum)
+    {
+      if (query_reset)
+        return QUERY_CMD_GET_SUM_RESET;
+
+      return QUERY_CMD_GET_SUM;
+    }
+
+  if (query_reset)
+    return QUERY_CMD_GET_RESET;
+
+  return QUERY_CMD_GET;
+
+}
+
+static gint
+_get_query_cmd(gchar *cmd)
+{
+  if (g_str_equal(cmd, "list"))
+    return _get_query_list_cmd();
+
+  if (g_str_equal(cmd, "get"))
+    return _get_query_get_cmd();
+
+  return -1;
+}
+
+static gboolean
+_is_query_params_empty(void)
+{
+  return raw_query_params == NULL;
+}
+
+static void
+_shift_query_command_out_of_params(void)
+{
+  if (raw_query_params[QUERY_COMMAND] != NULL)
+    ++raw_query_params;
+}
+
+static gboolean
+_validate_get_params(gint query_cmd)
+{
+  if(query_cmd == QUERY_CMD_GET || query_cmd == QUERY_CMD_GET_SUM)
+    if (*raw_query_params == NULL)
+      {
+        fprintf(stderr, "error: need a path argument\n");
+        return TRUE;
+      }
+  return FALSE;
+}
+
+static gchar *
+_get_query_command_string(gint query_cmd)
+{
+  gchar *query_params_to_pass, *command_to_dispatch;
+  query_params_to_pass = g_strjoinv(" ", raw_query_params);
+  if (query_params_to_pass)
+    {
+      command_to_dispatch = g_strdup_printf("QUERY %s %s", QUERY_COMMANDS[query_cmd], query_params_to_pass);
+    }
+  else
+    {
+      command_to_dispatch = g_strdup_printf("QUERY %s", QUERY_COMMANDS[query_cmd]);
+    }
+  g_free(query_params_to_pass);
+
+  return command_to_dispatch;
+}
+
+static gchar *
+_get_dispatchable_query_command(void)
+{
+  gint query_cmd;
+
+  if (_is_query_params_empty())
+    return NULL;
+
+  query_cmd = _get_query_cmd(raw_query_params[QUERY_COMMAND]);
+  if (query_cmd < 0)
+    return NULL;
+
+  _shift_query_command_out_of_params();
+  if(_validate_get_params(query_cmd))
+    return NULL;
+
+  return _get_query_command_string(query_cmd);
+}
+
+gint
+slng_query(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
+{
+  gint result;
+
+  gchar *cmd = _get_dispatchable_query_command();
+  if (cmd == NULL)
+    return 1;
+
+  result = dispatch_command(cmd);
+
+  g_free(cmd);
+
+  return result;
+}

--- a/syslog-ng-ctl/commands/query.h
+++ b/syslog-ng-ctl/commands/query.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SYSLOG_NG_CTL_QUERY_H_INCLUDED
+#define SYSLOG_NG_CTL_QUERY_H_INCLUDED 1
+
+#include "commands.h"
+
+extern GOptionEntry query_options[];
+gint slng_query(int argc, char *argv[], const gchar *mode, GOptionContext *ctx);
+
+#endif

--- a/syslog-ng-ctl/commands/verbose.c
+++ b/syslog-ng-ctl/commands/verbose.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "verbose.h"
+#include <strings.h>
+
+static gchar *verbose_set = NULL;
+
+GOptionEntry verbose_options[] =
+{
+  {
+    "set", 's', 0, G_OPTION_ARG_STRING, &verbose_set,
+    "enable/disable messages", "<on|off|0|1>"
+  },
+  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL }
+};
+
+gint
+slng_verbose(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
+{
+  gint ret = 0;
+  GString *rsp = NULL;
+  gchar buff[256];
+
+  if (!verbose_set)
+    g_snprintf(buff, 255, "LOG %s\n", mode);
+  else
+    g_snprintf(buff, 255, "LOG %s %s\n", mode,
+               strncasecmp(verbose_set, "on", 2) == 0 || verbose_set[0] == '1' ? "ON" : "OFF");
+
+  g_strup(buff);
+
+  rsp = slng_run_command(buff);
+  if (rsp == NULL)
+    return 1;
+
+  ret = process_response_status(rsp);
+  printf("%s\n", rsp->str);
+
+  g_string_free(rsp, TRUE);
+
+  return ret;
+}

--- a/syslog-ng-ctl/commands/verbose.h
+++ b/syslog-ng-ctl/commands/verbose.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SYSLOG_NG_CTL_VERBOSE_H_INCLUDED
+#define SYSLOG_NG_CTL_VERBOSE_H_INCLUDED 1
+
+#include "commands.h"
+
+extern GOptionEntry verbose_options[];
+gint slng_verbose(int argc, char *argv[], const gchar *mode, GOptionContext *ctx);
+
+#endif


### PR DESCRIPTION
This patch splits syslog-ng-ctl.c into smaller compilation units. That makes easier to add new commands.

From functional point of view, nothing should change.