### PR TITLE
python-source: fix memory corruption during reload

### DIFF
--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -551,7 +551,7 @@ static PyTypeObject py_log_fetcher_type =
   PyVarObject_HEAD_INIT(&PyType_Type, 0)
   .tp_name = "LogFetcher",
   .tp_basicsize = sizeof(PyLogFetcher),
-  .tp_dealloc = (destructor) PyObject_Del,
+  .tp_dealloc = py_slng_generic_dealloc,
   .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
   .tp_doc = "The LogFetcher class is a base class for custom Python fetchers.",
   .tp_new = PyType_GenericNew,

--- a/modules/python/python-global-code-loader.c
+++ b/modules/python/python-global-code-loader.c
@@ -67,7 +67,7 @@ static void
 _free(PyGlobalCodeLoader *self)
 {
   g_free(self->source);
-  PyObject_Del(self);
+  py_slng_generic_dealloc((PyObject *)self);
 }
 
 static PyMethodDef _methods[] =

--- a/modules/python/python-helpers.c
+++ b/modules/python/python-helpers.c
@@ -427,3 +427,9 @@ _py_string_from_string(const gchar *str, gssize len)
     return PyBytes_FromString(str);
 #endif
 }
+
+void
+py_slng_generic_dealloc(PyObject *self)
+{
+  Py_TYPE(self)->tp_free(self);
+}

--- a/modules/python/python-helpers.h
+++ b/modules/python/python-helpers.h
@@ -50,4 +50,5 @@ gboolean _py_is_string(PyObject *object);
 const gchar *_py_get_string_as_string(PyObject *object);
 PyObject *_py_string_from_string(const gchar *str, gssize len);
 
+void py_slng_generic_dealloc(PyObject *self);
 #endif

--- a/modules/python/python-logger.c
+++ b/modules/python/python-logger.c
@@ -108,7 +108,7 @@ PyTypeObject py_logger_type =
 {
   PyVarObject_HEAD_INIT(&PyType_Type, 0)
   .tp_basicsize = sizeof(PyObject),
-  .tp_dealloc = (destructor) PyObject_Del,
+  .tp_dealloc = py_slng_generic_dealloc,
   .tp_doc = "Those messages can be captured by internal() source.",
   .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
   .tp_methods = py_logger_methods,

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -588,7 +588,7 @@ static PyTypeObject py_log_source_type =
   PyVarObject_HEAD_INIT(&PyType_Type, 0)
   .tp_name = "LogSource",
   .tp_basicsize = sizeof(PyLogSource),
-  .tp_dealloc = (destructor) PyObject_Del,
+  .tp_dealloc = py_slng_generic_dealloc,
   .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
   .tp_doc = "The LogSource class is a base class for custom Python sources.",
   .tp_new = PyType_GenericNew,


### PR DESCRIPTION
According to documentation:
https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_dealloc
If the type is subtypeable, then tp_free must be called. 

The invalid deallocator causes memory corruption, which eventually
leads to crash.

Reproduce: busy reload loop on this configuration:
```
@version: 3.24

log {
  source { python-fetcher(class(PythonFetcher)); };
};

python {
from syslogng import LogFetcher
class PythonFetcher(LogFetcher):
    def fetch(self):
        return LogFetcher.FETCH_NO_DATA, None
};
```