### PR TITLE
Requires with error message

### DIFF
--- a/lib/pragma-grammar.ym
+++ b/lib/pragma-grammar.ym
@@ -104,7 +104,7 @@ define_stmt
 								  cfg_args_set(configuration->globals, $2, $3); free($2); free($3); }
 
 module_stmt
-	: KW_MODULE string { last_module_args = cfg_args_new(); } module_param module_params
+	: KW_MODULE string { last_module_args = cfg_args_new(); } module_params
           {
             gboolean success = cfg_load_module_with_args(configuration, $2, last_module_args);
             free($2);
@@ -115,11 +115,15 @@ module_stmt
             if (!success)
               PRAGMA_ERROR();
           }
-	| KW_MODULE string
-          {
-            cfg_load_module(configuration, $2);
-            free($2);
-          }
+	;
+
+module_params
+	: module_param module_params
+	|
+	;
+
+module_param
+	: LL_IDENTIFIER '(' string_or_number ')'		{ cfg_args_set(last_module_args, $1, $3); free($1); free($3); }
 	;
 
 requires_stmt
@@ -147,14 +151,6 @@ requires_stmt
           }
 	;
 
-module_params
-	: module_param module_params
-	|
-	;
-
-module_param
-	: LL_IDENTIFIER '(' string_or_number ')'		{ cfg_args_set(last_module_args, $1, $3); free($1); free($3); }
-	;
 
 /* INCLUDE_RULES */
 

--- a/lib/pragma-grammar.ym
+++ b/lib/pragma-grammar.ym
@@ -95,19 +95,16 @@ version_stmt
                 PRAGMA_ERROR();
           }
 
-include_stmt
-        : KW_INCLUDE string LL_EOL
-          {
-            CHECK_ERROR(cfg_lexer_include_file(lexer, $2), @2, "Error including %s", $2);
-            free($2);
-          }
-        ;
-
 define_stmt
-	: KW_DEFINE LL_IDENTIFIER string_or_number		{ msg_debug("Global value changed",
-                                                                            evt_tag_str("define", $2),
-                                                                            evt_tag_str("value", $3));
-								  cfg_args_set(configuration->globals, $2, $3); free($2); free($3); }
+	: KW_DEFINE LL_IDENTIFIER string_or_number
+          {
+            msg_debug("Global value changed",
+                      evt_tag_str("define", $2),
+                      evt_tag_str("value", $3));
+	    cfg_args_set(configuration->globals, $2, $3);
+            free($2);
+            free($3);
+          }
 
 module_stmt
 	: KW_MODULE string { last_module_args = cfg_args_new(); } module_params
@@ -131,6 +128,14 @@ module_params
 module_param
 	: LL_IDENTIFIER '(' string_or_number ')'		{ cfg_args_set(last_module_args, $1, $3); free($1); free($3); }
 	;
+
+include_stmt
+        : KW_INCLUDE string LL_EOL
+          {
+            CHECK_ERROR(cfg_lexer_include_file(lexer, $2), @2, "Error including %s", $2);
+            free($2);
+          }
+        ;
 
 requires_stmt
 	: KW_REQUIRES string LL_EOL

--- a/lib/pragma-grammar.ym
+++ b/lib/pragma-grammar.ym
@@ -64,18 +64,24 @@ CfgArgs *last_module_args = NULL;
 
 start
         : { PRAGMA_BEGIN(); }
-          stmt_and_eol                                  { if (yychar != YYEMPTY) { cfg_lexer_unput_token(lexer, &yylval); } PRAGMA_END(); YYACCEPT; }
+          stmt                                  { if (yychar != YYEMPTY) { cfg_lexer_unput_token(lexer, &yylval); } PRAGMA_END(); YYACCEPT; }
 
-stmt_and_eol
-        : pragma_stmt LL_EOL
-        | include_stmt
-        ;
+stmt
+	: stmt_without_eol LL_EOL
+	| stmt_with_eol
+	;
 
-pragma_stmt
+stmt_without_eol
         : version_stmt
         | define_stmt
         | module_stmt
         | requires_stmt
+        ;
+
+	/* LL_EOL as a token needs to be consumed by the rules below, as they can
+	 * change the lexer buffer by the time they return to the grammar. */
+stmt_with_eol
+        : include_stmt
         ;
 
 version_stmt

--- a/lib/pragma-grammar.ym
+++ b/lib/pragma-grammar.ym
@@ -75,13 +75,13 @@ stmt_without_eol
         : version_stmt
         | define_stmt
         | module_stmt
-        | requires_stmt
         ;
 
 	/* LL_EOL as a token needs to be consumed by the rules below, as they can
 	 * change the lexer buffer by the time they return to the grammar. */
 stmt_with_eol
         : include_stmt
+        | requires_stmt
         ;
 
 version_stmt
@@ -133,7 +133,7 @@ module_param
 	;
 
 requires_stmt
-	: KW_REQUIRES string
+	: KW_REQUIRES string LL_EOL
           {
             if (!cfg_is_module_available(configuration, $2))
               {

--- a/lib/pragma-grammar.ym
+++ b/lib/pragma-grammar.ym
@@ -60,7 +60,10 @@ CfgArgs *last_module_args = NULL;
 
 }
 
+%type   <cptr> requires_message
+
 %%
+
 
 start
         : { PRAGMA_BEGIN(); }
@@ -138,15 +141,16 @@ include_stmt
         ;
 
 requires_stmt
-	: KW_REQUIRES string LL_EOL
+	: KW_REQUIRES string requires_message LL_EOL
           {
             if (!cfg_is_module_available(configuration, $2))
               {
-                if (0 == lexer->include_depth)
+                if (0 == lexer->include_depth || $3)
                   {
                     msg_error("Cannot load required module",
-                                evt_tag_str("module", $2),
-                                cfg_lexer_format_location_tag(lexer,&@1));
+                              evt_tag_str("module", $2),
+                              evt_tag_str("details", $3 ? : "none"),
+                              cfg_lexer_format_location_tag(lexer,&@1));
                     free($2);
                     PRAGMA_ERROR();
                   }
@@ -162,6 +166,10 @@ requires_stmt
           }
 	;
 
+requires_message
+	: string		{ $$ = $1; }
+	| 			{ $$ = NULL; }
+	;
 
 /* INCLUDE_RULES */
 

--- a/scl/elasticsearch/elastic-http.conf
+++ b/scl/elasticsearch/elastic-http.conf
@@ -20,7 +20,6 @@
 #
 #############################################################################
 
-@requires http
 @requires json-plugin
 
 block destination elasticsearch-http(
@@ -36,14 +35,17 @@ block destination elasticsearch-http(
   body_suffix("\n")
   ...)
 {
-  http(
-  url(`url`)
-  headers(`headers`)
-  workers(`workers`)
-  batch_lines(`batch_lines`)
-  timeout(`timeout`)
-  body_suffix(`body_suffix`)
-  body("$(format-json --scope none --omit-empty-values index._index=`index` index._type=`type` index._id=`custom_id`)\n`template`")
-  `__VARARGS__`
-  );
+
+@requires http "The elasticsearch-http() driver depends on the syslog-ng http module, please install the syslog-ng-mod-http (Debian & derivatives) or the syslog-ng-http (RHEL & co) package"
+
+    http(
+        url(`url`)
+        headers(`headers`)
+        workers(`workers`)
+        batch_lines(`batch_lines`)
+        timeout(`timeout`)
+        body_suffix(`body_suffix`)
+        body("$(format-json --scope none --omit-empty-values index._index=`index` index._type=`type` index._id=`custom_id`)\n`template`")
+        `__VARARGS__`
+    );
 };

--- a/scl/elasticsearch/elastic-java.conf
+++ b/scl/elasticsearch/elastic-java.conf
@@ -51,6 +51,10 @@ block destination elasticsearch2(
   ...
 )
 {
+
+@requires java "The elasticsearch2() driver depends on the syslog-ng java module, please install the syslog-ng-mod-java (Debian & derivatives) or the syslog-ng-java (RHEL & co) package"
+
+
   java(
     class_path("`java-module-dir`/*.jar:`java-module-dir`/elastic-jest-client/*.jar:`client_lib_dir`/*.jar")
     class_name("org.syslog_ng.elasticsearch_v2.ElasticSearchDestination")

--- a/scl/slack/slack.conf
+++ b/scl/slack/slack.conf
@@ -20,7 +20,6 @@
 #
 #############################################################################
 
-@requires http
 @requires json-plugin
 @requires basicfuncs
 
@@ -45,6 +44,9 @@ block destination slack(
   use-system-cert-store(yes)
   ...)
 {
+
+@requires http "The slack() driver depends on the syslog-ng http module, please install the syslog-ng-mod-http (Debian & derivatives) or the syslog-ng-http (RHEL & co) package"
+
   http(
     url('`hook-url`')
     method('POST')

--- a/scl/telegram/telegram.conf
+++ b/scl/telegram/telegram.conf
@@ -21,7 +21,6 @@
 #############################################################################
 
 @requires http
-@requires basicfuncs
 
 # Throttle: https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this
 block destination telegram(
@@ -34,6 +33,9 @@ block destination telegram(
       use-system-cert-store(yes)
       ...)
 {
+
+@requires http "The telegram() driver depends on the syslog-ng http module, please install the syslog-ng-mod-http (Debian & derivatives) or the syslog-ng-http (RHEL & co) package"
+
     http(
         url("https://api.telegram.org/bot`bot-id`/sendMessage")
         method("POST")


### PR DESCRIPTION
This is a continuation of #2979 to improve error messages if an installed SCL is missing a dependency.

With these changes we are going to have this as an error message if we are using elasticsearch-http() without the http() module present:

```
[2019-11-14T21:18:09.766325] Cannot load required module; module='http', details='The http() driver is required for elasticsearch-http(), please install syslog-ng-mod-http (Debian) or syslog-ng-http (RHEL) package', location='etc/syslog-ng-elastic.conf:7:16'
Error parsing log statement, syntax error, unexpected LL_ERROR, expecting '}' in block destination elasticsearch-http() at /install/share/syslog-ng/include/scl/elasticsearch/elastic-http.conf:24:4:1-5:1:
1       
2       #Start Block block destination elasticsearch-http() at /install/share/syslog-ng/include/scl/elasticsearch/elastic-http.conf:24
3       
4-----> @requires http "The http() driver is required for elasticsearch-http(), please install syslog-ng-mod-http (Debian) or syslog-ng-http (RHEL) package"
4-----> ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
5----->   http(
6         url("http://localhost:1234/")
7         headers("Content-Type: application/x-ndjson")
8         workers(4)
9         batch_lines(100)

Included from etc/syslog-ng-elastic.conf:7:16-7:97:
2       
3       @include "scl/elasticsearch/elastic-http.conf"
4       
5       log {
6       	source { tcp(port(2000)); };
7-----> 	destination { elasticsearch-http(index("syslog") type("syslog") url("http://localhost:1234/")); };
7-----> 	              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
8       };


```

