### PR TITLE
python: specify stats/persist name from python

### DIFF
--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -11,6 +11,8 @@ set(PYTHON_SOURCES
     python-module.h
     python-config.h
     python-config.c
+    python-persist.h
+    python-persist.c
     python-helpers.h
     python-helpers.c
     python-main.h

--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -26,6 +26,8 @@ modules_python_libmod_python_la_SOURCES		= \
 	modules/python/python-module.h		  \
 	modules/python/python-config.h		  \
 	modules/python/python-config.c		  \
+	modules/python/python-persist.h		  \
+	modules/python/python-persist.c		  \
 	modules/python/python-helpers.h		  \
 	modules/python/python-helpers.c		  \
 	modules/python/python-main.h		  \

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -119,14 +119,32 @@ static const gchar *
 python_dd_format_stats_instance(LogThreadedDestDriver *d)
 {
   PythonDestDriver *self = (PythonDestDriver *)d;
-  return python_format_stats_instance((LogPipe *)d, self->py.generate_persist_name, self->options, "python", self->class);
+
+  PythonPersistMembers options =
+  {
+    .generate_persist_name_method = self->py.generate_persist_name,
+    .options = self->options,
+    .class = self->class,
+    .id = self->super.super.super.id
+  };
+
+  return python_format_stats_instance((LogPipe *)d, "python", &options);
 }
 
 static const gchar *
 python_dd_format_persist_name(const LogPipe *s)
 {
   const PythonDestDriver *self = (const PythonDestDriver *)s;
-  return python_format_persist_name(s, self->py.generate_persist_name, self->options, "python", self->class);
+
+  PythonPersistMembers options =
+  {
+    .generate_persist_name_method = self->py.generate_persist_name,
+    .options = self->options,
+    .class = self->class,
+    .id = self->super.super.super.id
+  };
+
+  return python_format_persist_name(s, "python", &options);
 }
 
 static gboolean
@@ -316,8 +334,15 @@ _inject_worker_insert_result_consts(PythonDestDriver *self)
 static PyObject *
 py_get_persist_name(PythonDestDriver *self)
 {
-  const gchar *persist_name = python_format_persist_name((LogPipe *)self, self->py.generate_persist_name,
-                                                         self->options, "python", self->class);
+  PythonPersistMembers options =
+  {
+    .generate_persist_name_method = self->py.generate_persist_name,
+    .options = self->options,
+    .class = self->class,
+    .id = self->super.super.super.id
+  };
+
+  const gchar *persist_name = python_format_persist_name((LogPipe *)self, "python", &options);
   return _py_string_from_string(persist_name, -1);
 }
 

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -34,6 +34,7 @@
 #include "string-list.h"
 #include "str-utils.h"
 #include "messages.h"
+#include "python-persist.h"
 
 typedef struct
 {
@@ -117,14 +118,7 @@ static const gchar *
 python_dd_format_stats_instance(LogThreadedDestDriver *d)
 {
   PythonDestDriver *self = (PythonDestDriver *)d;
-  static gchar persist_name[1024];
-
-  if (d->super.super.super.persist_name)
-    g_snprintf(persist_name, sizeof(persist_name), "python,%s", d->super.super.super.persist_name);
-  else
-    g_snprintf(persist_name, sizeof(persist_name), "python,%s", self->class);
-
-  return persist_name;
+  return python_format_stats_instance((LogPipe *)d, "python", self->class);
 }
 
 static const gchar *

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -119,14 +119,14 @@ static const gchar *
 python_dd_format_stats_instance(LogThreadedDestDriver *d)
 {
   PythonDestDriver *self = (PythonDestDriver *)d;
-  return python_format_stats_instance((LogPipe *)d, self->py.generate_persist_name, "python", self->class);
+  return python_format_stats_instance((LogPipe *)d, self->py.generate_persist_name, self->options, "python", self->class);
 }
 
 static const gchar *
 python_dd_format_persist_name(const LogPipe *s)
 {
   const PythonDestDriver *self = (const PythonDestDriver *)s;
-  return python_format_persist_name(s, self->py.generate_persist_name, "python", self->class);
+  return python_format_persist_name(s, self->py.generate_persist_name, self->options, "python", self->class);
 }
 
 static gboolean

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -57,6 +57,7 @@ typedef struct
     PyObject *flush;
     PyObject *log_template_options;
     PyObject *seqnum;
+    PyObject *generate_persist_name;
     GPtrArray *_refs_to_clean;
   } py;
 } PythonDestDriver;
@@ -356,6 +357,7 @@ _py_init_bindings(PythonDestDriver *self)
   self->py.open = _py_get_attr_or_null(self->py.instance, "open");
   self->py.flush = _py_get_attr_or_null(self->py.instance, "flush");
   self->py.send = _py_get_attr_or_null(self->py.instance, "send");
+  self->py.generate_persist_name = _py_get_attr_or_null(self->py.instance, "generate_persist_name");
   if (!self->py.send)
     {
       msg_error("Error initializing Python destination, class does not have a send() method",
@@ -372,6 +374,7 @@ _py_init_bindings(PythonDestDriver *self)
   g_ptr_array_add(self->py._refs_to_clean, self->py.send);
   g_ptr_array_add(self->py._refs_to_clean, self->py.log_template_options);
   g_ptr_array_add(self->py._refs_to_clean, self->py.seqnum);
+  g_ptr_array_add(self->py._refs_to_clean, self->py.generate_persist_name);
 
   return TRUE;
 }

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -126,7 +126,7 @@ static const gchar *
 python_dd_format_persist_name(const LogPipe *s)
 {
   const PythonDestDriver *self = (const PythonDestDriver *)s;
-  return python_format_persist_name(s, "python", self->class);
+  return python_format_persist_name(s, self->py.generate_persist_name, "python", self->class);
 }
 
 static gboolean

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -343,9 +343,10 @@ _py_init_bindings(PythonDestDriver *self)
 
   self->py.log_template_options = py_log_template_options_new(&self->template_options);
   PyObject_SetAttrString(self->py.class, "template_options", self->py.log_template_options);
+  Py_DECREF(self->py.log_template_options);
   self->py.seqnum = py_integer_pointer_new(&self->super.worker.instance.seq_num);
   PyObject_SetAttrString(self->py.class, "seqnum", self->py.seqnum);
-  Py_DECREF(self->py.log_template_options);
+  Py_DECREF(self->py.seqnum);
 
   self->py.instance = _py_invoke_function(self->py.class, NULL, self->class, self->super.super.super.id);
   if (!self->py.instance)

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -313,6 +313,14 @@ _inject_worker_insert_result_consts(PythonDestDriver *self)
   _inject_worker_insert_result(self, MAX);
 };
 
+static PyObject *
+py_get_persist_name(PythonDestDriver *self)
+{
+  const gchar *persist_name = python_format_persist_name((LogPipe *)self, self->py.generate_persist_name,
+                                                         self->options, "python", self->class);
+  return _py_string_from_string(persist_name, -1);
+}
+
 static gboolean
 _py_init_bindings(PythonDestDriver *self)
 {
@@ -365,6 +373,10 @@ _py_init_bindings(PythonDestDriver *self)
                 evt_tag_str("class", self->class));
       return FALSE;
     }
+
+  PyObject *py_persist_name = py_get_persist_name(self);
+  PyObject_SetAttrString(self->py.class, "persist_name", py_persist_name);
+  Py_DECREF(py_persist_name);
 
   g_ptr_array_add(self->py._refs_to_clean, self->py.class);
   g_ptr_array_add(self->py._refs_to_clean, self->py.instance);

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -65,12 +65,12 @@ typedef struct
 /** Setters & config glue **/
 
 void
-python_dd_set_class(LogDriver *d, gchar *filename)
+python_dd_set_class(LogDriver *d, gchar *class_name)
 {
   PythonDestDriver *self = (PythonDestDriver *)d;
 
   g_free(self->class);
-  self->class = g_strdup(filename);
+  self->class = g_strdup(class_name);
 }
 
 void

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -119,7 +119,7 @@ static const gchar *
 python_dd_format_stats_instance(LogThreadedDestDriver *d)
 {
   PythonDestDriver *self = (PythonDestDriver *)d;
-  return python_format_stats_instance((LogPipe *)d, "python", self->class);
+  return python_format_stats_instance((LogPipe *)d, self->py.generate_persist_name, "python", self->class);
 }
 
 static const gchar *

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -125,14 +125,7 @@ static const gchar *
 python_dd_format_persist_name(const LogPipe *s)
 {
   const PythonDestDriver *self = (const PythonDestDriver *)s;
-  static gchar persist_name[1024];
-
-  if (s->persist_name)
-    g_snprintf(persist_name, sizeof(persist_name), "python.%s", s->persist_name);
-  else
-    g_snprintf(persist_name, sizeof(persist_name), "python(%s)", self->class);
-
-  return persist_name;
+  return python_format_persist_name(s, "python", self->class);
 }
 
 static gboolean

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -334,16 +334,7 @@ _inject_worker_insert_result_consts(PythonDestDriver *self)
 static PyObject *
 py_get_persist_name(PythonDestDriver *self)
 {
-  PythonPersistMembers options =
-  {
-    .generate_persist_name_method = self->py.generate_persist_name,
-    .options = self->options,
-    .class = self->class,
-    .id = self->super.super.super.id
-  };
-
-  const gchar *persist_name = python_format_persist_name((LogPipe *)self, "python", &options);
-  return _py_string_from_string(persist_name, -1);
+  return _py_string_from_string(python_dd_format_persist_name(&self->super.super.super.super), -1);
 }
 
 static gboolean

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -88,7 +88,8 @@ static const gchar *
 python_fetcher_format_stats_instance(LogThreadedSourceDriver *s)
 {
   PythonFetcherDriver *self = (PythonFetcherDriver *) s;
-  return python_format_stats_instance((LogPipe *)s, self->py.generate_persist_name, "python-fetcher", self->class);
+  return python_format_stats_instance((LogPipe *)s, self->py.generate_persist_name, self->options,
+                                      "python-fetcher", self->class);
 }
 
 static void
@@ -473,7 +474,7 @@ static const gchar *
 python_fetcher_format_persist_name(const LogPipe *s)
 {
   const PythonFetcherDriver *self = (const PythonFetcherDriver *)s;
-  return python_format_persist_name(s, self->py.generate_persist_name, "python-fetcher", self->class);
+  return python_format_persist_name(s, self->py.generate_persist_name, self->options, "python-fetcher", self->class);
 }
 
 static gboolean

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -29,6 +29,8 @@
 #include "string-list.h"
 #include "python-persist.h"
 
+#include <structmember.h>
+
 typedef struct _PythonFetcherDriver
 {
   LogThreadedFetcherDriver super;
@@ -53,6 +55,7 @@ typedef struct _PyLogFetcher
 {
   PyObject_HEAD
   PythonFetcherDriver *driver;
+  gchar *persist_name;
 } PyLogFetcher;
 
 static PyTypeObject py_log_fetcher_type;
@@ -215,6 +218,10 @@ _py_is_log_fetcher(PyObject *obj)
 static void
 _py_free_bindings(PythonFetcherDriver *self)
 {
+  PyLogFetcher *py_instance = (PyLogFetcher *) self->py.instance;
+  if (py_instance)
+    g_free(py_instance->persist_name);
+
   Py_CLEAR(self->py.class);
   Py_CLEAR(self->py.instance);
   Py_CLEAR(self->py.fetch_method);
@@ -290,6 +297,15 @@ _py_lookup_fetch_method(PythonFetcherDriver *self)
   return TRUE;
 }
 
+static const gchar *python_fetcher_format_persist_name(const LogPipe *s);
+static void
+_py_set_persist_name(PythonFetcherDriver *self)
+{
+  const gchar *persist_name = python_fetcher_format_persist_name((LogPipe *)self);
+  PyLogFetcher *py_instance = (PyLogFetcher *) self->py.instance;
+  py_instance->persist_name = g_strdup(persist_name);
+}
+
 static gboolean
 _py_init_methods(PythonFetcherDriver *self)
 {
@@ -300,6 +316,8 @@ _py_init_methods(PythonFetcherDriver *self)
   self->py.open_method = _py_get_attr_or_null(self->py.instance, "open");
   self->py.close_method = _py_get_attr_or_null(self->py.instance, "close");
   self->py.generate_persist_name = _py_get_attr_or_null(self->py.instance, "generate_persist_name");
+
+  _py_set_persist_name(self);
 
   return TRUE;
 }
@@ -551,6 +569,11 @@ python_fetcher_new(GlobalConfig *cfg)
   return &self->super.super.super.super;
 }
 
+static PyMemberDef py_log_fetcher_members[] =
+{
+  { "persist_name", T_STRING, offsetof(PyLogFetcher, persist_name), READONLY },
+  {NULL}
+};
 
 static PyTypeObject py_log_fetcher_type =
 {
@@ -561,6 +584,7 @@ static PyTypeObject py_log_fetcher_type =
   .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
   .tp_doc = "The LogFetcher class is a base class for custom Python fetchers.",
   .tp_new = PyType_GenericNew,
+  .tp_members = py_log_fetcher_members,
   0,
 };
 

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -91,8 +91,16 @@ static const gchar *
 python_fetcher_format_stats_instance(LogThreadedSourceDriver *s)
 {
   PythonFetcherDriver *self = (PythonFetcherDriver *) s;
-  return python_format_stats_instance((LogPipe *)s, self->py.generate_persist_name, self->options,
-                                      "python-fetcher", self->class);
+
+  PythonPersistMembers options =
+  {
+    .generate_persist_name_method = self->py.generate_persist_name,
+    .options = self->options,
+    .class = self->class,
+    .id = self->super.super.super.super.id
+  };
+
+  return python_format_stats_instance((LogPipe *)s, "python-fetcher", &options);
 }
 
 static void
@@ -492,7 +500,16 @@ static const gchar *
 python_fetcher_format_persist_name(const LogPipe *s)
 {
   const PythonFetcherDriver *self = (const PythonFetcherDriver *)s;
-  return python_format_persist_name(s, self->py.generate_persist_name, self->options, "python-fetcher", self->class);
+
+  PythonPersistMembers options =
+  {
+    .generate_persist_name_method = self->py.generate_persist_name,
+    .options = self->options,
+    .class = self->class,
+    .id = self->super.super.super.super.id
+  };
+
+  return python_format_persist_name(s, "python-fetcher", &options);
 }
 
 static gboolean

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -45,6 +45,7 @@ typedef struct _PythonFetcherDriver
     PyObject *open_method;
     PyObject *close_method;
     PyObject *request_exit_method;
+    PyObject *generate_persist_name;
   } py;
 } PythonFetcherDriver;
 
@@ -219,6 +220,7 @@ _py_free_bindings(PythonFetcherDriver *self)
   Py_CLEAR(self->py.open_method);
   Py_CLEAR(self->py.close_method);
   Py_CLEAR(self->py.request_exit_method);
+  Py_CLEAR(self->py.generate_persist_name);
 }
 
 static gboolean
@@ -296,6 +298,7 @@ _py_init_methods(PythonFetcherDriver *self)
   self->py.request_exit_method = _py_get_attr_or_null(self->py.instance, "request_exit");
   self->py.open_method = _py_get_attr_or_null(self->py.instance, "open");
   self->py.close_method = _py_get_attr_or_null(self->py.instance, "close");
+  self->py.generate_persist_name = _py_get_attr_or_null(self->py.instance, "generate_persist_name");
 
   return TRUE;
 }

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -88,7 +88,7 @@ static const gchar *
 python_fetcher_format_stats_instance(LogThreadedSourceDriver *s)
 {
   PythonFetcherDriver *self = (PythonFetcherDriver *) s;
-  return python_format_stats_instance((LogPipe *)s, "python-fetcher", self->class);
+  return python_format_stats_instance((LogPipe *)s, self->py.generate_persist_name, "python-fetcher", self->class);
 }
 
 static void

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -469,6 +469,13 @@ python_fetcher_fetch(LogThreadedFetcherDriver *s)
   return fetch_result;
 }
 
+static const gchar *
+python_fetcher_format_persist_name(const LogPipe *s)
+{
+  const PythonFetcherDriver *self = (const PythonFetcherDriver *)s;
+  return python_format_persist_name(s, self->py.generate_persist_name, "python-fetcher", self->class);
+}
+
 static gboolean
 python_fetcher_init(LogPipe *s)
 {
@@ -530,6 +537,7 @@ python_fetcher_new(GlobalConfig *cfg)
   self->super.super.super.super.super.init = python_fetcher_init;
   self->super.super.super.super.super.deinit = python_fetcher_deinit;
   self->super.super.super.super.super.free_fn = python_fetcher_free;
+  self->super.super.super.super.super.generate_persist_name = python_fetcher_format_persist_name;
 
   self->super.super.format_stats_instance = python_fetcher_format_stats_instance;
   self->super.super.worker_options.super.stats_level = STATS_LEVEL0;

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -27,6 +27,7 @@
 #include "logthrsource/logthrfetcherdrv.h"
 #include "str-utils.h"
 #include "string-list.h"
+#include "python-persist.h"
 
 typedef struct _PythonFetcherDriver
 {
@@ -86,14 +87,7 @@ static const gchar *
 python_fetcher_format_stats_instance(LogThreadedSourceDriver *s)
 {
   PythonFetcherDriver *self = (PythonFetcherDriver *) s;
-  static gchar persist_name[1024];
-
-  if (s->super.super.super.persist_name)
-    g_snprintf(persist_name, sizeof(persist_name), "python-fetcher,%s", s->super.super.super.persist_name);
-  else
-    g_snprintf(persist_name, sizeof(persist_name), "python-fetcher,%s", self->class);
-
-  return persist_name;
+  return python_format_stats_instance((LogPipe *)s, "python-fetcher", self->class);
 }
 
 static void

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -21,6 +21,8 @@
  */
 
 #include "python-persist.h"
+#include "python-helpers.h"
+#include "driver.h"
 
 static void
 format_default_stats_instance(gchar *buffer, gsize size, const gchar *module, const gchar *name)
@@ -28,13 +30,40 @@ format_default_stats_instance(gchar *buffer, gsize size, const gchar *module, co
   g_snprintf(buffer, size, "%s,%s", module, name);
 }
 
+static void
+copy_stats_instance(const LogPipe *self, PyObject *generate_persist_name_method, const gchar *module,
+                    const gchar *class, gchar *buffer, gsize size)
+{
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+
+  PyObject *ret;
+  ret = _py_invoke_function(generate_persist_name_method, NULL, class, ((LogDriver *)self)->id);
+  if (ret)
+    g_snprintf(buffer, size, "%s,%s", module, _py_get_string_as_string(ret));
+  else
+    {
+      format_default_stats_instance(buffer, size, module, class);
+      msg_error("Failed while generating persist name, using default",
+                evt_tag_str("default_persist_name", buffer),
+                evt_tag_str("driver", ((LogDriver *)self)->id),
+                evt_tag_str("class", class));
+    }
+  Py_XDECREF(ret);
+
+  PyGILState_Release(gstate);
+}
+
 const gchar *
-python_format_stats_instance(LogPipe *p, const gchar *module, const gchar *class)
+python_format_stats_instance(LogPipe *p, PyObject *generate_persist_name_method, const gchar *module,
+                             const gchar *class)
 {
   static gchar persist_name[1024];
 
   if (p->persist_name)
     format_default_stats_instance(persist_name, sizeof(persist_name), module, p->persist_name);
+  else if (generate_persist_name_method)
+    copy_stats_instance(p, generate_persist_name_method, module, class, persist_name, sizeof(persist_name));
   else
     format_default_stats_instance(persist_name, sizeof(persist_name), module, class);
 

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "python-persist.h"

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -21,3 +21,22 @@
  */
 
 #include "python-persist.h"
+
+static void
+format_default_stats_instance(gchar *buffer, gsize size, const gchar *module, const gchar *name)
+{
+  g_snprintf(buffer, size, "%s,%s", module, name);
+}
+
+const gchar *
+python_format_stats_instance(LogPipe *p, const gchar *module, const gchar *class)
+{
+  static gchar persist_name[1024];
+
+  if (p->persist_name)
+    format_default_stats_instance(persist_name, sizeof(persist_name), module, p->persist_name);
+  else
+    format_default_stats_instance(persist_name, sizeof(persist_name), module, class);
+
+  return persist_name;
+}

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -24,6 +24,16 @@
 #include "python-helpers.h"
 #include "driver.h"
 
+static PyObject *
+_call_generate_persist_name_method(PyObject *generate_persist_name_method, GHashTable *options,
+                                   const gchar *class, const gchar *id)
+{
+  PyObject *py_options = options ? _py_create_arg_dict(options) : NULL;
+  PyObject *ret = _py_invoke_function(generate_persist_name_method, py_options, class, id);
+  Py_XDECREF(py_options);
+  return ret;
+}
+
 static void
 format_default_stats_instance(gchar *buffer, gsize size, const gchar *module, const gchar *name)
 {
@@ -31,14 +41,14 @@ format_default_stats_instance(gchar *buffer, gsize size, const gchar *module, co
 }
 
 static void
-copy_stats_instance(const LogPipe *self, PyObject *generate_persist_name_method, const gchar *module,
-                    const gchar *class, gchar *buffer, gsize size)
+copy_stats_instance(const LogPipe *self, PyObject *generate_persist_name_method, GHashTable *options,
+                    const gchar *module, const gchar *class, gchar *buffer, gsize size)
 {
   PyGILState_STATE gstate;
   gstate = PyGILState_Ensure();
 
-  PyObject *ret;
-  ret = _py_invoke_function(generate_persist_name_method, NULL, class, ((LogDriver *)self)->id);
+  PyObject *ret =_call_generate_persist_name_method(generate_persist_name_method,
+                                                    options, class, ((LogDriver *)self)->id);
   if (ret)
     g_snprintf(buffer, size, "%s,%s", module, _py_get_string_as_string(ret));
   else
@@ -55,15 +65,15 @@ copy_stats_instance(const LogPipe *self, PyObject *generate_persist_name_method,
 }
 
 const gchar *
-python_format_stats_instance(LogPipe *p, PyObject *generate_persist_name_method, const gchar *module,
-                             const gchar *class)
+python_format_stats_instance(LogPipe *p, PyObject *generate_persist_name_method, GHashTable *options,
+                             const gchar *module, const gchar *class)
 {
   static gchar persist_name[1024];
 
   if (p->persist_name)
     format_default_stats_instance(persist_name, sizeof(persist_name), module, p->persist_name);
   else if (generate_persist_name_method)
-    copy_stats_instance(p, generate_persist_name_method, module, class, persist_name, sizeof(persist_name));
+    copy_stats_instance(p, generate_persist_name_method, options, module, class, persist_name, sizeof(persist_name));
   else
     format_default_stats_instance(persist_name, sizeof(persist_name), module, class);
 
@@ -83,14 +93,14 @@ format_default_persist_name_with_class(gchar *buffer, gsize size, const gchar *m
 }
 
 static void
-copy_persist_name(const LogPipe *self, PyObject *generate_persist_name_method, const gchar *module,
-                  const gchar *class, gchar *buffer, gsize size)
+copy_persist_name(const LogPipe *self, PyObject *generate_persist_name_method, GHashTable *options,
+                  const gchar *module, const gchar *class, gchar *buffer, gsize size)
 {
   PyGILState_STATE gstate;
   gstate = PyGILState_Ensure();
 
-  PyObject *ret;
-  ret = _py_invoke_function(generate_persist_name_method, NULL, class, ((LogDriver *)self)->id);
+  PyObject *ret =_call_generate_persist_name_method(generate_persist_name_method,
+                                                    options, class, ((LogDriver *)self)->id);
   if (ret)
     g_snprintf(buffer, size, "%s.%s", module, _py_get_string_as_string(ret));
   else
@@ -107,15 +117,15 @@ copy_persist_name(const LogPipe *self, PyObject *generate_persist_name_method, c
 }
 
 const gchar *
-python_format_persist_name(const LogPipe *p, PyObject *generate_persist_name_method, const gchar *module,
-                           const gchar *class)
+python_format_persist_name(const LogPipe *p, PyObject *generate_persist_name_method, GHashTable *options,
+                           const gchar *module, const gchar *class)
 {
   static gchar persist_name[1024];
 
   if (p->persist_name)
     format_default_persist_name_with_persist_name(persist_name, sizeof(persist_name), module, p->persist_name);
   else if (generate_persist_name_method)
-    copy_persist_name(p, generate_persist_name_method, module, class, persist_name, sizeof(persist_name));
+    copy_persist_name(p, generate_persist_name_method, options, module, class, persist_name, sizeof(persist_name));
   else
     format_default_persist_name_with_class(persist_name, sizeof(persist_name), module, class);
 

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -40,3 +40,28 @@ python_format_stats_instance(LogPipe *p, const gchar *module, const gchar *class
 
   return persist_name;
 }
+
+static void
+format_default_persist_name_with_persist_name(gchar *buffer, gsize size, const gchar *module, const gchar *persist_name)
+{
+  g_snprintf(buffer, size, "%s.%s", module, persist_name);
+}
+
+static void
+format_default_persist_name_with_class(gchar *buffer, gsize size, const gchar *module, const gchar *class)
+{
+  g_snprintf(buffer, size, "%s(%s)", module, class);
+}
+
+const gchar *
+python_format_persist_name(const LogPipe *p, const gchar *module, const gchar *class)
+{
+  static gchar persist_name[1024];
+
+  if (p->persist_name)
+    format_default_persist_name_with_persist_name(persist_name, sizeof(persist_name), module, p->persist_name);
+  else
+    format_default_persist_name_with_class(persist_name, sizeof(persist_name), module, class);
+
+  return persist_name;
+}

--- a/modules/python/python-persist.h
+++ b/modules/python/python-persist.h
@@ -24,5 +24,8 @@
 #define SNG_PYTHON_PERSIST_H_INCLUDED
 
 #include "python-module.h"
+#include "logpipe.h"
+
+const gchar *python_format_stats_instance(LogPipe *p, const gchar *module, const gchar *class);
 
 #endif

--- a/modules/python/python-persist.h
+++ b/modules/python/python-persist.h
@@ -27,5 +27,6 @@
 #include "logpipe.h"
 
 const gchar *python_format_stats_instance(LogPipe *p, const gchar *module, const gchar *class);
+const gchar *python_format_persist_name(const LogPipe *p, const gchar *module, const gchar *class);
 
 #endif

--- a/modules/python/python-persist.h
+++ b/modules/python/python-persist.h
@@ -26,10 +26,15 @@
 #include "python-module.h"
 #include "logpipe.h"
 
-const gchar *python_format_stats_instance(LogPipe *p, PyObject *generate_persist_name_method,
-                                          GHashTable *options, const gchar *module, const gchar *class);
-const gchar *python_format_persist_name(const LogPipe *p, PyObject *generate_persist_name_method,
-                                        GHashTable *options, const gchar *module, const gchar *class);
+typedef struct
+{
+  PyObject *generate_persist_name_method;
+  GHashTable *options;
+  const gchar *class;
+  const gchar *id;
+} PythonPersistMembers;
 
+const gchar *python_format_stats_instance(LogPipe *p, const gchar *module, PythonPersistMembers *options);
+const gchar *python_format_persist_name(const LogPipe *p, const gchar *module, PythonPersistMembers *options);
 
 #endif

--- a/modules/python/python-persist.h
+++ b/modules/python/python-persist.h
@@ -28,6 +28,8 @@
 
 const gchar *python_format_stats_instance(LogPipe *p, PyObject *generate_persist_name_method,
                                           const gchar *module, const gchar *class);
-const gchar *python_format_persist_name(const LogPipe *p, const gchar *module, const gchar *class);
+const gchar *python_format_persist_name(const LogPipe *p, PyObject *generate_persist_name_method,
+                                        const gchar *module, const gchar *class);
+
 
 #endif

--- a/modules/python/python-persist.h
+++ b/modules/python/python-persist.h
@@ -26,7 +26,8 @@
 #include "python-module.h"
 #include "logpipe.h"
 
-const gchar *python_format_stats_instance(LogPipe *p, const gchar *module, const gchar *class);
+const gchar *python_format_stats_instance(LogPipe *p, PyObject *generate_persist_name_method,
+                                          const gchar *module, const gchar *class);
 const gchar *python_format_persist_name(const LogPipe *p, const gchar *module, const gchar *class);
 
 #endif

--- a/modules/python/python-persist.h
+++ b/modules/python/python-persist.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SNG_PYTHON_PERSIST_H_INCLUDED
+#define SNG_PYTHON_PERSIST_H_INCLUDED
+
+#include "python-module.h"
+
+#endif

--- a/modules/python/python-persist.h
+++ b/modules/python/python-persist.h
@@ -27,9 +27,9 @@
 #include "logpipe.h"
 
 const gchar *python_format_stats_instance(LogPipe *p, PyObject *generate_persist_name_method,
-                                          const gchar *module, const gchar *class);
+                                          GHashTable *options, const gchar *module, const gchar *class);
 const gchar *python_format_persist_name(const LogPipe *p, PyObject *generate_persist_name_method,
-                                        const gchar *module, const gchar *class);
+                                        GHashTable *options, const gchar *module, const gchar *class);
 
 
 #endif

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -28,6 +28,7 @@
 #include "thread-utils.h"
 #include "str-utils.h"
 #include "string-list.h"
+#include "python-persist.h"
 
 typedef struct _PythonSourceDriver PythonSourceDriver;
 
@@ -92,14 +93,8 @@ static const gchar *
 python_sd_format_stats_instance(LogThreadedSourceDriver *s)
 {
   PythonSourceDriver *self = (PythonSourceDriver *) s;
-  static gchar persist_name[1024];
+  return python_format_stats_instance((LogPipe *)s, "python", self->class);
 
-  if (s->super.super.super.persist_name)
-    g_snprintf(persist_name, sizeof(persist_name), "python,%s", s->super.super.super.persist_name);
-  else
-    g_snprintf(persist_name, sizeof(persist_name), "python,%s", self->class);
-
-  return persist_name;
 }
 
 static void

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -94,7 +94,7 @@ static const gchar *
 python_sd_format_stats_instance(LogThreadedSourceDriver *s)
 {
   PythonSourceDriver *self = (PythonSourceDriver *) s;
-  return python_format_stats_instance((LogPipe *)s, self->py.generate_persist_name, "python", self->class);
+  return python_format_stats_instance((LogPipe *)s, self->py.generate_persist_name, self->options, "python", self->class);
 }
 
 static void
@@ -501,7 +501,7 @@ static const gchar *
 python_source_format_persist_name(const LogPipe *s)
 {
   const PythonSourceDriver *self = (const PythonSourceDriver *)s;
-  return python_format_persist_name(s, self->py.generate_persist_name, "python-source", self->class);
+  return python_format_persist_name(s, self->py.generate_persist_name, self->options, "python-source", self->class);
 }
 
 static gboolean

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -30,6 +30,8 @@
 #include "string-list.h"
 #include "python-persist.h"
 
+#include <structmember.h>
+
 typedef struct _PythonSourceDriver PythonSourceDriver;
 
 struct _PythonSourceDriver
@@ -59,6 +61,7 @@ typedef struct _PyLogSource
 {
   PyObject_HEAD
   PythonSourceDriver *driver;
+  gchar *persist_name;
 } PyLogSource;
 
 static PyTypeObject py_log_source_type;
@@ -161,6 +164,10 @@ _py_is_log_source(PyObject *obj)
 static void
 _py_free_bindings(PythonSourceDriver *self)
 {
+  PyLogSource *py_instance = (PyLogSource *) self->py.instance;
+  if (py_instance)
+    g_free(py_instance->persist_name);
+
   Py_CLEAR(self->py.class);
   Py_CLEAR(self->py.instance);
   Py_CLEAR(self->py.run_method);
@@ -280,12 +287,24 @@ _py_lookup_generate_persist_name_method(PythonSourceDriver *self)
 }
 
 static gboolean
+_py_set_persist_name(PythonSourceDriver *self)
+{
+  const gchar *persist_name = python_format_persist_name((LogPipe *)self, self->py.generate_persist_name,
+                                                         self->options, "python-source", self->class);
+  PyLogSource *py_instance = (PyLogSource *) self->py.instance;
+  py_instance->persist_name = g_strdup(persist_name);
+
+  return TRUE;
+}
+
+static gboolean
 _py_init_methods(PythonSourceDriver *self)
 {
   return _py_lookup_run_method(self)
          && _py_lookup_request_exit_method(self)
          && _py_lookup_suspend_and_wakeup_methods(self)
-         && _py_lookup_generate_persist_name_method(self);
+         && _py_lookup_generate_persist_name_method(self)
+         && _py_set_persist_name(self);
 }
 
 static gboolean
@@ -595,6 +614,12 @@ static PyMethodDef py_log_source_methods[] =
   {NULL}
 };
 
+static PyMemberDef py_log_source_members[] =
+{
+  { "persist_name", T_STRING, offsetof(PyLogSource, persist_name), READONLY },
+  {NULL}
+};
+
 static PyTypeObject py_log_source_type =
 {
   PyVarObject_HEAD_INIT(&PyType_Type, 0)
@@ -605,6 +630,7 @@ static PyTypeObject py_log_source_type =
   .tp_doc = "The LogSource class is a base class for custom Python sources.",
   .tp_new = PyType_GenericNew,
   .tp_methods = py_log_source_methods,
+  .tp_members = py_log_source_members,
   0,
 };
 

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -97,7 +97,16 @@ static const gchar *
 python_sd_format_stats_instance(LogThreadedSourceDriver *s)
 {
   PythonSourceDriver *self = (PythonSourceDriver *) s;
-  return python_format_stats_instance((LogPipe *)s, self->py.generate_persist_name, self->options, "python", self->class);
+
+  PythonPersistMembers options =
+  {
+    .generate_persist_name_method = self->py.generate_persist_name,
+    .options = self->options,
+    .class = self->class,
+    .id = self->super.super.super.id
+  };
+
+  return python_format_stats_instance((LogPipe *)s, "python", &options);
 }
 
 static void
@@ -289,8 +298,15 @@ _py_lookup_generate_persist_name_method(PythonSourceDriver *self)
 static gboolean
 _py_set_persist_name(PythonSourceDriver *self)
 {
-  const gchar *persist_name = python_format_persist_name((LogPipe *)self, self->py.generate_persist_name,
-                                                         self->options, "python-source", self->class);
+  PythonPersistMembers options =
+  {
+    .generate_persist_name_method = self->py.generate_persist_name,
+    .options = self->options,
+    .class = self->class,
+    .id = self->super.super.super.id
+  };
+
+  const gchar *persist_name = python_format_persist_name((LogPipe *)self, "python-source", &options);
   PyLogSource *py_instance = (PyLogSource *) self->py.instance;
   py_instance->persist_name = g_strdup(persist_name);
 
@@ -520,7 +536,16 @@ static const gchar *
 python_source_format_persist_name(const LogPipe *s)
 {
   const PythonSourceDriver *self = (const PythonSourceDriver *)s;
-  return python_format_persist_name(s, self->py.generate_persist_name, self->options, "python-source", self->class);
+
+  PythonPersistMembers options =
+  {
+    .generate_persist_name_method = self->py.generate_persist_name,
+    .options = self->options,
+    .class = self->class,
+    .id = self->super.super.super.id
+  };
+
+  return python_format_persist_name(s, "python-source", &options);
 }
 
 static gboolean

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -66,6 +66,7 @@ typedef struct _PyLogSource
 
 static PyTypeObject py_log_source_type;
 
+static const gchar *python_source_format_persist_name(const LogPipe *s);
 
 void
 python_sd_set_class(LogDriver *s, gchar *filename)
@@ -298,15 +299,7 @@ _py_lookup_generate_persist_name_method(PythonSourceDriver *self)
 static gboolean
 _py_set_persist_name(PythonSourceDriver *self)
 {
-  PythonPersistMembers options =
-  {
-    .generate_persist_name_method = self->py.generate_persist_name,
-    .options = self->options,
-    .class = self->class,
-    .id = self->super.super.super.id
-  };
-
-  const gchar *persist_name = python_format_persist_name((LogPipe *)self, "python-source", &options);
+  const gchar *persist_name = python_source_format_persist_name(&self->super.super.super.super);
   PyLogSource *py_instance = (PyLogSource *) self->py.instance;
   py_instance->persist_name = g_strdup(persist_name);
 

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -94,8 +94,7 @@ static const gchar *
 python_sd_format_stats_instance(LogThreadedSourceDriver *s)
 {
   PythonSourceDriver *self = (PythonSourceDriver *) s;
-  return python_format_stats_instance((LogPipe *)s, "python", self->class);
-
+  return python_format_stats_instance((LogPipe *)s, self->py.generate_persist_name, "python", self->class);
 }
 
 static void

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -51,6 +51,7 @@ struct _PythonSourceDriver
     PyObject *request_exit_method;
     PyObject *suspend_method;
     PyObject *wakeup_method;
+    PyObject *generate_persist_name;
   } py;
 };
 
@@ -167,6 +168,7 @@ _py_free_bindings(PythonSourceDriver *self)
   Py_CLEAR(self->py.request_exit_method);
   Py_CLEAR(self->py.suspend_method);
   Py_CLEAR(self->py.wakeup_method);
+  Py_CLEAR(self->py.generate_persist_name);
 }
 
 static gboolean
@@ -272,11 +274,19 @@ _py_lookup_suspend_and_wakeup_methods(PythonSourceDriver *self)
 }
 
 static gboolean
+_py_lookup_generate_persist_name_method(PythonSourceDriver *self)
+{
+  self->py.generate_persist_name = _py_get_attr_or_null(self->py.instance, "generate_persist_name");
+  return TRUE;
+}
+
+static gboolean
 _py_init_methods(PythonSourceDriver *self)
 {
   return _py_lookup_run_method(self)
          && _py_lookup_request_exit_method(self)
-         && _py_lookup_suspend_and_wakeup_methods(self);
+         && _py_lookup_suspend_and_wakeup_methods(self)
+         && _py_lookup_generate_persist_name_method(self);
 }
 
 static gboolean

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -497,6 +497,13 @@ python_sd_request_exit(LogThreadedSourceDriver *s)
   PyGILState_Release(gstate);
 }
 
+static const gchar *
+python_source_format_persist_name(const LogPipe *s)
+{
+  const PythonSourceDriver *self = (const PythonSourceDriver *)s;
+  return python_format_persist_name(s, self->py.generate_persist_name, "python-source", self->class);
+}
+
 static gboolean
 python_sd_init(LogPipe *s)
 {
@@ -569,6 +576,7 @@ python_sd_new(GlobalConfig *cfg)
   self->super.super.super.super.init = python_sd_init;
   self->super.super.super.super.deinit = python_sd_deinit;
   self->super.super.super.super.free_fn = python_sd_free;
+  self->super.super.super.super.generate_persist_name = python_source_format_persist_name;
 
   self->super.format_stats_instance = python_sd_format_stats_instance;
   self->super.worker_options.super.stats_level = STATS_LEVEL0;

--- a/modules/python/tests/CMakeLists.txt
+++ b/modules/python/tests/CMakeLists.txt
@@ -11,3 +11,10 @@ add_unit_test(LIBTEST CRITERION
   DEPENDS mod-python "${PYTHON_LIBRARIES}" syslogformat)
 
 set_property(TEST test_python_template APPEND PROPERTY ENVIRONMENT "PYTHONMALLOC=malloc_debug")
+
+add_unit_test(LIBTEST CRITERION
+  TARGET test_python_persist_name
+  INCLUDES "${PYTHON_INCLUDE_DIR}" "${PYTHON_INCLUDE_DIRS}"
+  DEPENDS syslogformat mod-python "${PYTHON_LIBRARIES}")
+
+set_property(TEST test_python_persist_name APPEND PROPERTY ENVIRONMENT "PYTHONMALLOC=malloc_debug")

--- a/modules/python/tests/Makefile.am
+++ b/modules/python/tests/Makefile.am
@@ -6,7 +6,8 @@ check_PROGRAMS += \
 
 modules_python_tests_TESTS = \
   modules/python/tests/test_python_logmsg \
-  modules/python/tests/test_python_template
+  modules/python/tests/test_python_template \
+  modules/python/tests/test_python_persist_name
 
 modules_python_tests_test_python_logmsg_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) -I$(top_srcdir)/modules/python
 modules_python_tests_test_python_logmsg_LDADD = $(TEST_LDADD) \
@@ -20,5 +21,10 @@ modules_python_tests_test_python_template_LDADD = $(TEST_LDADD) \
 	-dlpreopen $(top_builddir)/modules/python/libmod-python.la \
 	$(PYTHON_LIBS) $(PREOPEN_SYSLOGFORMAT)
 
+modules_python_tests_test_python_persist_name_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) \
+	-I$(top_srcdir)/modules/python -I$(top_srcdir)/modules/syslogformat
+modules_python_tests_test_python_persist_name_LDADD = $(TEST_LDADD) \
+	-dlpreopen $(top_builddir)/modules/python/libmod-python.la \
+	$(PYTHON_LIBS) $(PREOPEN_SYSLOGFORMAT)
 
 EXTRA_DIST += modules/python/tests/CMakeLists.txt

--- a/modules/python/tests/test_python_persist_name.c
+++ b/modules/python/tests/test_python_persist_name.c
@@ -192,10 +192,21 @@ Test(python_persist_name, test_python_exception_in_generate_persist_name)
                                         "persist_generator_persist");
 
   start_grabbing_messages();
-  cr_assert_str_eq(python_format_stats_instance(p, persist_generator_stats,
-                                                NULL, "module", "class"), "module,class");
-  cr_assert_str_eq(python_format_persist_name(p, persist_generator_persist,
-                                              NULL, "module", "class"), "module(class)");
+
+  PythonPersistMembers options_stats =
+  {
+    .generate_persist_name_method = persist_generator_stats,
+    .class = "class",
+  };
+  cr_assert_str_eq(python_format_stats_instance(p, "module", &options_stats), "module,class");
+
+  PythonPersistMembers options_persist =
+  {
+    .generate_persist_name_method = persist_generator_persist,
+    .class = "class",
+  };
+  cr_assert_str_eq(python_format_persist_name(p, "module", &options_persist), "module(class)");
+
   stop_grabbing_messages();
 
   assert_grabbed_log_contains("Exception: exception for testing stats");

--- a/modules/python/tests/test_python_persist_name.c
+++ b/modules/python/tests/test_python_persist_name.c
@@ -205,3 +205,51 @@ Test(python_persist_name, test_python_exception_in_generate_persist_name)
   Py_DECREF(persist_generator_persist);
   log_pipe_unref((LogPipe *)p);
 }
+
+const gchar *python_fetcher_code_no_generate_persist_name = "\n\
+from _syslogng import LogFetcher\n\
+class Fetcher(LogFetcher):\n\
+    def fetch(self):\n\
+        return LogFetcher.FETCH_NO_DATA, None";
+
+Test(python_persist_name, test_python_fetcher_no_generate_persist_name)
+{
+  _load_code(python_fetcher_code_no_generate_persist_name);
+
+  LogDriver *d = python_fetcher_new(empty_cfg);
+  python_fetcher_set_class(d, "Fetcher");
+  python_fetcher_set_option(d, "key", "value");
+  log_pipe_set_persist_name((LogPipe *)d, "test_persist_name");
+  cr_assert(log_pipe_init((LogPipe *)d));
+
+  cr_assert_str_eq(log_pipe_get_persist_name((LogPipe *)d), "python-fetcher.test_persist_name");
+
+  main_loop_sync_worker_startup_and_teardown();
+  log_pipe_deinit((LogPipe *)d);
+  log_pipe_unref((LogPipe *)d);
+}
+
+const gchar *python_source_code_no_generate_persist_name = "\n\
+from _syslogng import LogSource\n\
+class Source(LogSource):\n\
+    def run(self):\n\
+        pass\n\
+    def request_exit(self):\n\
+        pass";
+
+Test(python_persist_name, test_python_source_no_generate_persist_name)
+{
+  _load_code(python_source_code_no_generate_persist_name);
+
+  LogDriver *d = python_sd_new(empty_cfg);
+  python_sd_set_class(d, "Source");
+  python_sd_set_option(d, "key", "value");
+  log_pipe_set_persist_name((LogPipe *)d, "test_persist_name");
+  cr_assert(log_pipe_init((LogPipe *)d));
+
+  cr_assert_str_eq(log_pipe_get_persist_name((LogPipe *)d), "python-source.test_persist_name");
+
+  main_loop_sync_worker_startup_and_teardown();
+  log_pipe_deinit((LogPipe *)d);
+  log_pipe_unref((LogPipe *)d);
+}

--- a/modules/python/tests/test_python_persist_name.c
+++ b/modules/python/tests/test_python_persist_name.c
@@ -327,3 +327,39 @@ Test(python_persist_name, test_python_fetcher_readonly)
   log_pipe_deinit((LogPipe *)d);
   log_pipe_unref((LogPipe *)d);
 }
+
+/* persist-name takes precedence over generate_persist_name */
+Test(python_persist_name, test_python_fetcher_persist_preference)
+{
+  _load_code(python_fetcher_code);
+
+  LogDriver *d = python_fetcher_new(empty_cfg);
+  log_pipe_set_persist_name(&d->super, "test_persist_name");
+  python_fetcher_set_class(d, "Fetcher");
+  python_fetcher_set_option(d, "key", "value");
+  cr_assert(log_pipe_init((LogPipe *)d));
+
+  cr_assert_str_eq(log_pipe_get_persist_name((LogPipe *)d), "python-fetcher.test_persist_name");
+
+  main_loop_sync_worker_startup_and_teardown();
+  log_pipe_deinit((LogPipe *)d);
+  log_pipe_unref((LogPipe *)d);
+}
+
+/* persist-name takes precedence over generate_persist_name */
+Test(python_persist_name, test_python_source_persist_preference)
+{
+  _load_code(python_source_code);
+
+  LogDriver *d = python_sd_new(empty_cfg);
+  log_pipe_set_persist_name(&d->super, "test_persist_name");
+  python_sd_set_class(d, "Source");
+  python_sd_set_option(d, "key", "value");
+  cr_assert(log_pipe_init((LogPipe *)d));
+
+  cr_assert_str_eq(log_pipe_get_persist_name((LogPipe *)d), "python-source.test_persist_name");
+
+  main_loop_sync_worker_startup_and_teardown();
+  log_pipe_deinit((LogPipe *)d);
+  log_pipe_unref((LogPipe *)d);
+}

--- a/modules/python/tests/test_python_persist_name.c
+++ b/modules/python/tests/test_python_persist_name.c
@@ -253,3 +253,66 @@ Test(python_persist_name, test_python_source_no_generate_persist_name)
   log_pipe_deinit((LogPipe *)d);
   log_pipe_unref((LogPipe *)d);
 }
+
+const gchar *python_source_code_readonly = "\n\
+from _syslogng import LogSource\n\
+class Source(LogSource):\n\
+    @staticmethod\n\
+    def generate_persist_name(options):\n\
+        return 'foo'\n\
+    def init(self, options):\n\
+        self.persist_name = 'readonly...'\n\
+        return True\n\
+    def run(self):\n\
+        pass\n\
+    def request_exit(self):\n\
+        pass";
+
+Test(python_persist_name, test_python_source_readonly)
+{
+  _load_code(python_source_code_readonly);
+
+  LogDriver *d = python_sd_new(empty_cfg);
+  python_sd_set_class(d, "Source");
+  start_grabbing_messages();
+  cr_assert_eq(log_pipe_init((LogPipe *)d), 0);
+  stop_grabbing_messages();
+  display_grabbed_messages();
+
+  assert_grabbed_log_contains("TypeError: readonly attribute");
+
+  main_loop_sync_worker_startup_and_teardown();
+  log_pipe_deinit((LogPipe *)d);
+  log_pipe_unref((LogPipe *)d);
+}
+
+const gchar *python_fetcher_code_readonly = "\n\
+from _syslogng import LogFetcher\n\
+class Fetcher(LogFetcher):\n\
+    @staticmethod\n\
+    def generate_persist_name(options):\n\
+        return 'foo'\n\
+    def init(self, options):\n\
+        self.persist_name = 'readonly ...'\n\
+        return True\n\
+    def fetch(self):\n\
+        return LogFetcher.FETCH_NO_DATA, None";
+
+Test(python_persist_name, test_python_fetcher_readonly)
+{
+  _load_code(python_fetcher_code_readonly);
+
+  LogDriver *d = python_fetcher_new(empty_cfg);
+  python_fetcher_set_class(d, "Fetcher");
+
+  start_grabbing_messages();
+  cr_assert_eq(log_pipe_init((LogPipe *)d), 0);
+  stop_grabbing_messages();
+  display_grabbed_messages();
+
+  assert_grabbed_log_contains("TypeError: readonly attribute");
+
+  main_loop_sync_worker_startup_and_teardown();
+  log_pipe_deinit((LogPipe *)d);
+  log_pipe_unref((LogPipe *)d);
+}

--- a/modules/python/tests/test_python_persist_name.c
+++ b/modules/python/tests/test_python_persist_name.c
@@ -19,9 +19,155 @@
  * COPYING for details.
  */
 
+#include "python-helpers.h"
+#include "apphook.h"
+#include "python-dest.h"
+#include "python-main.h"
+#include "python-fetcher.h"
+#include "python-source.h"
+#include "mainloop-worker.h"
+#include "mainloop.h"
+
 #include <criterion/criterion.h>
 
-Test(python_persist_name, test_python_persist_name)
+MainLoop *main_loop;
+MainLoopOptions main_loop_options = {0};
+
+static PyObject *_python_main;
+static PyObject *_python_main_dict;
+
+YYLTYPE yyltype;
+GlobalConfig *empty_cfg;
+
+static void
+_py_init_interpreter(void)
 {
-  cr_assert(1);
+  Py_Initialize();
+  py_init_argv();
+
+  PyEval_InitThreads();
+  py_log_fetcher_init();
+  py_log_source_init();
+  PyEval_SaveThread();
+}
+
+static void
+_init_python_main(void)
+{
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  {
+    _python_main = PyImport_AddModule("__main__");
+    _python_main_dict = PyModule_GetDict(_python_main);
+  }
+  PyGILState_Release(gstate);
+}
+
+void setup(void)
+{
+  app_startup();
+
+  main_loop = main_loop_get_instance();
+  main_loop_init(main_loop, &main_loop_options);
+
+  _py_init_interpreter();
+  _init_python_main();
+
+  empty_cfg = cfg_new_snippet();
+  empty_cfg->filename  = g_strdup("dummy");
+}
+
+void teardown(void)
+{
+  cfg_free(empty_cfg);
+  main_loop_deinit(main_loop);
+  app_shutdown();
+  Py_DECREF(_python_main);
+  Py_DECREF(_python_main_dict);
+}
+
+static void
+_load_code(const gchar *code)
+{
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+  cr_assert(python_evaluate_global_code(empty_cfg, code, &yyltype));
+  PyGILState_Release(gstate);
+}
+
+TestSuite(python_persist_name, .init = setup, .fini = teardown);
+
+const gchar *python_destination_code = "\n\
+class Dest(object):\n\
+    @staticmethod\n\
+    def generate_persist_name(options):\n\
+        return options['key']\n\
+    def send(self, message):\n\
+        return True";
+
+Test(python_persist_name, test_python_dest)
+{
+  _load_code(python_destination_code);
+
+  LogDriver *d = python_dd_new(empty_cfg);
+  python_dd_set_class(d, "Dest");
+  python_dd_set_option(d, "key", "value");
+  cr_assert(log_pipe_init((LogPipe *)d));
+
+  cr_assert_str_eq(log_pipe_get_persist_name((LogPipe *)d), "python.value");
+
+  main_loop_sync_worker_startup_and_teardown();
+  log_pipe_deinit((LogPipe *)d);
+  log_pipe_unref((LogPipe *)d);
+}
+
+const gchar *python_fetcher_code = "\n\
+from _syslogng import LogFetcher\n\
+class Fetcher(LogFetcher):\n\
+    @staticmethod\n\
+    def generate_persist_name(options):\n\
+        return options['key']\n\
+    def fetch(self):\n\
+        return LogFetcher.FETCH_NO_DATA, None";
+
+Test(python_persist_name, test_python_fetcher)
+{
+  _load_code(python_fetcher_code);
+
+  LogDriver *d = python_fetcher_new(empty_cfg);
+  python_fetcher_set_class(d, "Fetcher");
+  python_fetcher_set_option(d, "key", "value");
+  cr_assert(log_pipe_init((LogPipe *)d));
+
+  cr_assert_str_eq(log_pipe_get_persist_name((LogPipe *)d), "python-fetcher.value");
+
+  main_loop_sync_worker_startup_and_teardown();
+  log_pipe_deinit((LogPipe *)d);
+  log_pipe_unref((LogPipe *)d);
+}
+
+const gchar *python_source_code = "\n\
+from _syslogng import LogSource\n\
+class Source(LogSource):\n\
+    @staticmethod\n\
+    def generate_persist_name(options):\n\
+        return options['key']\n\
+    def run(self):\n\
+        pass\n\
+    def request_exit(self):\n\
+        pass";
+
+Test(python_persist_name, test_python_source)
+{
+  _load_code(python_source_code);
+
+  LogDriver *d = python_sd_new(empty_cfg);
+  python_sd_set_class(d, "Source");
+  python_sd_set_option(d, "key", "value");
+  cr_assert(log_pipe_init((LogPipe *)d));
+
+  cr_assert_str_eq(log_pipe_get_persist_name((LogPipe *)d), "python-source.value");
+
+  main_loop_sync_worker_startup_and_teardown();
+  log_pipe_deinit((LogPipe *)d);
+  log_pipe_unref((LogPipe *)d);
 }

--- a/modules/python/tests/test_python_persist_name.c
+++ b/modules/python/tests/test_python_persist_name.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#include <criterion/criterion.h>
+
+Test(python_persist_name, test_python_persist_name)
+{
+  cr_assert(1);
+}

--- a/news/feature-3016.md
+++ b/news/feature-3016.md
@@ -1,0 +1,15 @@
+`python`: allow specifying persist name from python.
+
+From now on users can specify a persist name template from python code.
+
+```
+@staticmethod
+def generate_persist_name(options):
+    return options["file_name"]
+```
+
+Currently, in python destination, persist name is generated from the python class name. This can cause inconvenience if the same python class is planned to be used multiple times. For example if someone writes a PythonFileDestination, then the persist name would be python(PythonFileDestination). If a user wants to track many files, that causes persist collision, that needs to be resolved manually in configuration. After this change, module developers can specify a persist name template, that can be generate persist name uniquely (file name can be in included during generation)... Hence there is no need for users to manually resolve persist name collision. Similar example works with python source and fetcher too.
+
+Persist name from config takes precedence over `generate_persist_name`.
+
+Persist name is exposed through `self.persist_name`.


### PR DESCRIPTION
Changes:
- Users can provide a  `@staticmethod` `generate_persist_name(options)` function, that will be used for persist name generation or stats generation in python source/fetcher and python destination.
- Syslog-ng provides persist name through self.persist_name member, injected into python source/fetcher and python destination. For python source and fetcher, I could make the member readonly.
- Users can specify persist name both in configuration (`persist_name`) and `generate_persist_name`. The string from configuration is stronger.
- As small reference leak was fixed.

Motivation:
Currently, in python destination, persist name is generated from the python class name. This can cause inconvenience if the same python class is planned to be used multiple times. For example if someone writes a `PythonFileDestination`, then the persist name would be `python(PythonFileDestination)`. If a user wants to track many files, that causes persist collision, that needs to be resolved manually in configuration. Instead, package maintainer can prepare a
```
@staticmethod
def generate_persist_name(options):
    return options["file_name"]
```
function, and with that the persist name will be generated uniquely, as long as filenames differ.

Edit1:
C̶u̶r̶r̶e̶n̶t̶l̶y̶,̶ ̶i̶n̶ ̶p̶y̶t̶h̶o̶n̶ ̶s̶o̶u̶r̶c̶e̶ ̶o̶r̶ ̶f̶e̶t̶c̶h̶e̶r̶,̶ ̶t̶h̶e̶r̶e̶ ̶i̶s̶ ̶n̶o̶ ̶p̶e̶r̶s̶i̶s̶t̶ ̶n̶a̶m̶e̶ ̶g̶e̶n̶e̶r̶a̶t̶e̶d̶,̶ ̶h̶e̶n̶c̶e̶ ̶c̶u̶r̶r̶e̶n̶t̶l̶y̶ ̶w̶e̶ ̶d̶o̶ ̶n̶o̶t̶ ̶d̶e̶t̶e̶c̶t̶ ̶c̶o̶l̶l̶i̶s̶i̶o̶n̶ ̶a̶t̶ ̶a̶l̶l̶.̶ ̶A̶f̶t̶e̶r̶ ̶t̶h̶i̶s̶ ̶c̶h̶a̶n̶g̶e̶s̶e̶t̶,̶ ̶s̶u̶c̶h̶ ̶c̶o̶n̶f̶i̶g̶u̶r̶a̶t̶i̶o̶n̶s̶ ̶t̶h̶a̶t̶ ̶r̶e̶u̶s̶e̶ ̶t̶h̶e̶ ̶s̶a̶m̶e̶ ̶c̶l̶a̶s̶s̶ ̶w̶i̶l̶l̶ ̶n̶o̶t̶ ̶s̶t̶a̶r̶t̶.̶ ̶I̶ ̶a̶m̶ ̶a̶f̶r̶a̶i̶d̶ ̶w̶e̶ ̶c̶a̶n̶n̶o̶t̶ ̶w̶o̶r̶k̶a̶r̶o̶u̶n̶d̶ ̶t̶h̶i̶s̶.̶
Edit2:
I̶f̶ ̶u̶s̶e̶r̶ ̶d̶o̶e̶s̶ ̶n̶o̶t̶ ̶i̶m̶p̶l̶e̶m̶e̶n̶t̶ ̶`̶g̶e̶n̶e̶r̶a̶t̶e̶_̶p̶e̶r̶s̶i̶s̶t̶_̶n̶a̶m̶e̶`̶,̶ ̶e̶v̶e̶r̶y̶t̶h̶i̶n̶g̶ ̶w̶o̶r̶k̶s̶ ̶a̶s̶ ̶o̶r̶i̶g̶i̶n̶a̶l̶l̶y̶.̶ ̶F̶o̶r̶ ̶p̶y̶t̶h̶o̶n̶ ̶s̶o̶u̶r̶c̶e̶ ̶a̶n̶d̶ ̶d̶e̶s̶t̶i̶n̶a̶t̶i̶o̶n̶,̶ ̶`̶s̶e̶l̶f̶.̶p̶e̶r̶s̶i̶s̶t̶_̶n̶a̶m̶e̶`̶ ̶w̶i̶l̶l̶ ̶t̶h̶r̶o̶w̶ ̶a̶t̶t̶r̶i̶b̶u̶t̶e̶ ̶e̶r̶r̶o̶r̶ ̶i̶f̶ ̶n̶o̶ ̶`̶g̶e̶n̶e̶r̶a̶t̶e̶_̶p̶e̶r̶s̶i̶s̶t̶_̶n̶a̶m̶e̶`̶ ̶i̶s̶ ̶p̶r̶o̶v̶i̶d̶e̶d̶.̶
Edit3:
Currently, in python source or fetcher, there is no persist name generated, hence currently we do not detect collision at all. After this changeset, such configurations that reuse the same class will not start. We will make a note about this in the announcement, but we do not support backward compatibility in this matter.

Users/reviewers can check persist names using `self.persist_name`, similarly you can see in the example below.

As for stats instances, all stats names are visible through sysllg-ng-ctl stats/query.

Example:
```
@version: 3.24

log {
  source { python(class(PythonSource) options("foo" "bar")); };
};
python {
from syslogng import LogSource
class PythonSource(LogSource):
    @staticmethod
    def generate_persist_name(options):
        return options['foo']
    def init(self, options):
        print(self.persist_name)
        return True
    def run(self):
        pass
    def request_exit(self):
        pass
};

log {
  destination { python(class(PythonDest) options("foo" "bar")); };
};
python {
class PythonDest(object):
    @staticmethod
    def generate_persist_name(options):
        return options['foo']
    def init(self, options):
        print(self.persist_name)
        return True
    def send(self, message):
        return True
};

log {
  source { python-fetcher(class(PythonFetcher) options("foo" "bar")); };
};
python {
from syslogng import LogFetcher
from syslogng import LogMessage
class PythonFetcher(LogFetcher):
    @staticmethod
    def generate_persist_name(options):
        return options['foo']
    def init(self, options):
        print(self.persist_name)
        return True
    def fetch(self):
        return LogFetcher.FETCH_NO_DATA, None
};
```

results in (persist names)
```
$ ./syslog-ng -Fe -f ../etc/minimal.conf
python-source.bar
python.bar
python-fetcher.bar
[2019-11-15T10:06:50.924386] syslog-ng starting up; version='3.24.1.110.gd1a6a10.dirty'
```

And stats output is:
```
$ ./syslog-ng-ctl query get "*python*"
src.python.#anon-source0#0.python,bar.processed=0
dst.python.#anon-destination0#0.python,bar.queued=0
src.python.#anon-source1#0.python-fetcher,bar.stamp=0
src.python.#anon-source0#0.python,bar.stamp=0
dst.python.#anon-destination0#0.python,bar.dropped=0
dst.python.#anon-destination0#0.python,bar.written=0
src.python.#anon-source1#0.python-fetcher,bar.processed=0
dst.python.#anon-destination0#0.python,bar.processed=0
```