### PR TITLE
create_dirs: some cleanup

### DIFF
--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -492,8 +492,6 @@ affile_dd_init(LogPipe *s)
   if (!log_dest_driver_init_method(s))
     return FALSE;
 
-  if (self->file_opener_options.create_dirs == -1)
-    self->file_opener_options.create_dirs = cfg->create_dirs;
   if (self->time_reap == -1)
     self->time_reap = cfg->time_reap;
 

--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -285,10 +285,9 @@ dest_affile_option
 	| dest_driver_option
         | file_perm_option
 	| KW_OPTIONAL '(' yesno ')'		{ last_driver->optional = $3; }
-	| KW_CREATE_DIRS '(' yesno ')'		{ affile_dd_set_create_dirs(last_driver, $3); }
 	| KW_OVERWRITE_IF_OLDER '(' nonnegative_integer ')'	{ affile_dd_set_overwrite_if_older(last_driver, $3); }
 	| KW_FSYNC '(' yesno ')'		{ affile_dd_set_fsync(last_driver, $3); }
-	| KW_TIME_REAP '(' nonnegative_integer ')'		{ affile_dd_set_time_reap(last_driver, $3); }
+        | dest_affile_common_option
 	;
 
 dest_afpipe_params
@@ -310,8 +309,13 @@ dest_afpipe_option
 	: dest_writer_option
 	| dest_driver_option
 	| file_perm_option
-	| KW_TIME_REAP '(' nonnegative_integer ')'		{ affile_dd_set_time_reap(last_driver, $3); }
+        | dest_affile_common_option
 	;
+
+dest_affile_common_option
+	: KW_TIME_REAP '(' nonnegative_integer ')'		{ affile_dd_set_time_reap(last_driver, $3); }
+	| KW_CREATE_DIRS '(' yesno ')'		{ affile_dd_set_create_dirs(last_driver, $3); }
+        ;
 
 
 /* INCLUDE_RULES */

--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -229,6 +229,7 @@ source_afpipe_options
 source_afpipe_option
 	: KW_OPTIONAL '(' yesno ')'			{ last_driver->optional = $3; }
 	| KW_PAD_SIZE '(' nonnegative_integer ')'	{ last_log_proto_options->pad_size = $3; }
+	| KW_CREATE_DIRS '(' yesno ')'			{ pipe_sd_set_create_dirs(last_driver, $3); }
 	| multi_line_option
 	| file_perm_option
 	| source_reader_option

--- a/modules/affile/affile-source.c
+++ b/modules/affile/affile-source.c
@@ -178,5 +178,6 @@ affile_sd_new(gchar *filename, GlobalConfig *cfg)
 
   self->file_reader_options.restore_state = self->file_reader_options.follow_freq > 0;
   file_opener_options_defaults_dont_change_permissions(&self->file_opener_options);
+  self->file_opener_options.create_dirs = FALSE;
   return &self->super.super;
 }

--- a/modules/affile/affile-source.h
+++ b/modules/affile/affile-source.h
@@ -43,8 +43,4 @@ AFFileSourceDriver *affile_sd_new_instance(gchar *filename, GlobalConfig *cfg);
 LogDriver *affile_sd_new(gchar *filename, GlobalConfig *cfg);
 
 
-void affile_sd_set_recursion(LogDriver *s, const gint recursion);
-void affile_sd_set_pri_level(LogDriver *s, const gint16 severity);
-void affile_sd_set_pri_facility(LogDriver *s, const gint16 facility);
-
 #endif

--- a/modules/affile/file-opener.c
+++ b/modules/affile/file-opener.c
@@ -226,6 +226,8 @@ void
 file_opener_options_init(FileOpenerOptions *options, GlobalConfig *cfg)
 {
   file_perm_options_inherit_from(&options->file_perm_options, &cfg->file_perm_options);
+  if (options->create_dirs == -1)
+    options->create_dirs = cfg->create_dirs;
 }
 
 void

--- a/modules/affile/named-pipe.c
+++ b/modules/affile/named-pipe.c
@@ -97,6 +97,14 @@ _construct_dst_proto(FileOpener *self, LogTransport *transport, LogProtoClientOp
   return log_proto_text_client_new(transport, proto_options);
 }
 
+void
+pipe_sd_set_create_dirs(LogDriver *s, gboolean create_dirs)
+{
+  AFFileSourceDriver *self = (AFFileSourceDriver *) s;
+
+  self->file_opener_options.create_dirs = create_dirs;
+}
+
 FileOpener *
 file_opener_for_named_pipes_new(void)
 {

--- a/modules/affile/named-pipe.h
+++ b/modules/affile/named-pipe.h
@@ -28,6 +28,8 @@
 #include "cfg.h"
 #include "file-opener.h"
 
+void pipe_sd_set_create_dirs(LogDriver *s, gboolean create_dirs);
+
 FileOpener *file_opener_for_named_pipes_new(void);
 LogDriver *pipe_sd_new(gchar *filename, GlobalConfig *cfg);
 LogDriver *pipe_dd_new(gchar *filename, GlobalConfig *cfg);


### PR DESCRIPTION
Fixes #2635 

**Added create_dirs() option to pipe() source**:
Pipe source creates the FIFO where it will read, thus it should be able to create the path as well.

Previously file/pipe sources created the directories (due to a bug), and it was impossible to disable directory creation.

About file source: it does not need the option create-dirs(), as it will poll the path, and it shouldn't create the directories since that is the job of the destination (the one who writes into the file).

Unix-dgram() and unix-stream() dest. drivers does not need create_dirs() option: Even if they could create the directories, they couldn't connect to a not existing socket anyway.

Other changes:
- pipe()/file() source created directories by default, and it was impossible to disable it (global option did not work) -> disabled default directory creation
- added create_dirs() option to pipe() destination (the global option worked)
- add global option inheritance to `FileOpener` users: affile/afpipe.

### Questions to reviewers

- Are there risks to allow directory creation on source side, or in general?
- backward compatibility: is it okay to change an undocumented feature (default directory creation in file/pipe sources)
- backward compatibility: is it a good design to make pipe() source fail on startup if directories dont exist and create_dirs is not enabled?
Currently, unix-dgram() socket works the same way. For pipes, a follow_freq() behaviour could be added, similarly to file() source, periodically checking the existence of the given path, but this can't be done for sockets...

