### PR TITLE
Loggen plugin path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -130,7 +130,7 @@ if test "x$exec_prefix" = "xNONE"; then
 fi
 pidfiledir='${localstatedir}'
 moduledir='${exec_prefix}/lib/syslog-ng'
-loggenplugindir='${moduledir}/loggen'
+loggenplugindir='${exec_prefix}/lib/syslog-ng/loggen'
 toolsdir='${datadir}/syslog-ng/tools'
 xsddir='${datadir}/syslog-ng/xsd'
 

--- a/tests/loggen/CMakeLists.txt
+++ b/tests/loggen/CMakeLists.txt
@@ -52,12 +52,14 @@ set(LOGGEN_SOURCE
     file_reader.h
     logline_generator.c
     logline_generator.h
+    ${PROJECT_SOURCE_DIR}/lib/reloc.c
+    ${PROJECT_SOURCE_DIR}/lib/cache.c
     )
 
 add_executable(loggen ${LOGGEN_SOURCE})
 
 target_compile_definitions(loggen PUBLIC
-  SYSLOG_NG_PATH_LOGGEN_PLUGIN_DIR="${LOGGEN_PLUGIN_INSTALL_DIR}"
+  SYSLOG_NG_PATH_LOGGENPLUGINDIR="${LOGGEN_PLUGIN_INSTALL_DIR}"
   )
 
 include_directories(loggen

--- a/tests/loggen/Makefile.am
+++ b/tests/loggen/Makefile.am
@@ -49,8 +49,7 @@ pkginclude_HEADERS			+= \
 # binary program loggen
 bin_PROGRAMS			+= tests/loggen/loggen
 tests_loggen_loggen_CPPFLAGS	= \
-	-I$(top_srcdir)/lib \
-	-DSYSLOG_NG_PATH_LOGGEN_PLUGIN_DIR='"${loggenplugindir}"'
+	-I$(top_srcdir)/lib
 
 tests_loggen_loggen_SOURCES	=	\
 	tests/loggen/loggen.c	\
@@ -59,7 +58,9 @@ tests_loggen_loggen_SOURCES	=	\
 	tests/loggen/file_reader.c \
 	tests/loggen/file_reader.h \
 	tests/loggen/logline_generator.c \
-	tests/loggen/logline_generator.h
+	tests/loggen/logline_generator.h \
+	lib/reloc.c \
+	lib/cache.c
 
 tests_loggen_loggen_LDADD	= \
 	@GLIB_LIBS@ \


### PR DESCRIPTION
Loggen plugin path was set by compile time. This was a problem when the user wants to install loggen into other directory then the default path.
This PR solves this issue by the reloc API to determine the syslog-ng (loggen) install path by run-time

In case of none standard installation methode, the user can set the SYSLOGNG_PREFIX envvar.