### PR TITLE
http destination ignores global template options values

### DIFF
--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -524,6 +524,7 @@ http_dd_new(GlobalConfig *cfg)
   HTTPDestinationDriver *self = g_new0(HTTPDestinationDriver, 1);
 
   log_threaded_dest_driver_init_instance(&self->super, cfg);
+  log_template_options_defaults(&self->template_options);
 
   self->super.super.super.super.init = http_dd_init;
   self->super.super.super.super.deinit = http_dd_deinit;


### PR DESCRIPTION
The template optinos default value should be the value of global template options.
In case of http destination inheriting the global options was not possible,
as the mechanism relies on:
* First calling the *log_template_options_defaults* setting external values
  indicating nobody configured those fields.
* Processing the grammar rules (potentially values are overwritten)
* Initializing the template values with *log_template_options_init*
  (either using the global value, if the initial external value left, or keeping
  the configured value)

The *log_template_options_defaults* was missing, as a result all of the template
options defaulted to zero in case of http destination driver.
