### PR TITLE
config_database: various features/formatting fixes

### DIFF
--- a/contrib/config_option_database/config_database.py
+++ b/contrib/config_option_database/config_database.py
@@ -46,11 +46,11 @@ def build_db():
         driver_options = {'options': [], 'blocks': {}}
         for driver_alias in driver.split('/'):
             db[context].setdefault(driver_alias, driver_options)
-        add_to = db[context][driver_alias]
+        db_node = db[context][driver_alias]
         for parent in parents:
-            add_to['blocks'].setdefault(parent, {'options': [], 'blocks': {}})
-            add_to = add_to['blocks'][parent]
-        add_to['options'].append((keyword, arguments))
+            db_node['blocks'].setdefault(parent, {'options': [], 'blocks': {}})
+            db_node = db_node['blocks'][parent]
+        db_node['options'].append((keyword, arguments))
     return db
 
 

--- a/contrib/config_option_database/config_database.py
+++ b/contrib/config_option_database/config_database.py
@@ -42,8 +42,11 @@ def parse_args():
 def build_db():
     db = {'source': {}, 'destination': {}}
     for context, driver, keyword, arguments, parents in get_driver_options():
-        db[context].setdefault(driver, {'options': [], 'blocks': {}})
-        add_to = db[context][driver]
+        db.setdefault(context, {})
+        driver_options = {'options': [], 'blocks': {}}
+        for driver_alias in driver.split('/'):
+            db[context].setdefault(driver_alias, driver_options)
+        add_to = db[context][driver_alias]
         for parent in parents:
             add_to['blocks'].setdefault(parent, {'options': [], 'blocks': {}})
             add_to = add_to['blocks'][parent]

--- a/contrib/config_option_database/config_database.py
+++ b/contrib/config_option_database/config_database.py
@@ -42,6 +42,7 @@ def parse_args():
 def build_db():
     db = {'source': {}, 'destination': {}}
     for context, driver, keyword, arguments, parents in get_driver_options():
+        arguments = list(arguments)
         db.setdefault(context, {})
         driver_options = {'options': [], 'blocks': {}}
         for driver_alias in driver.split('/'):
@@ -50,7 +51,7 @@ def build_db():
         for parent in parents:
             db_node['blocks'].setdefault(parent, {'options': [], 'blocks': {}})
             db_node = db_node['blocks'][parent]
-        db_node['options'].append((keyword, arguments))
+        db_node['options'].append([keyword, arguments])
     return db
 
 


### PR DESCRIPTION
### This PR has 3 new features and formatting fixes

---
`config_database: add option to list contexts and drivers`
New usage:
 * `./config_database.py`: print contexts
 * `./config_database.py -c CONTEXT`: print drivers of CONTEXT
 * `./config_database.py -c CONTEXT -d DRIVER`: print options of DRIVER
---
`config_database: support driver name aliases`
From now on the `pipe` `source` will be accessible as:
 * `config_database.py -c source -d pipe`
 * `config_database.py -c source -d fifo`

instead of only:
 * `config_database.py -c source -d fifo/pipe`
---
Change this:
```
tls()
tls(
  ca-dir(<string>)
  peer-verify(<string>)
  peer-verify(<yesno>)
)
```

to this:
```
tls(
  <empty>
  ca-dir(<string>)
  peer-verify(<string> | <yesno>)
)
```