### PR TITLE
Fix loggen plugin directory when `--with-module-dir` is used

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -161,6 +161,10 @@ AC_ARG_WITH(module-dir,
    [  --with-module-dir=path   Use path as the directory to install modules into],
    moduledir=$with_module_dir)
 
+AC_ARG_WITH(loggen-plugin-dir,
+   [  --with-loggen-plugin-dir=path   Use path as the directory to install loggen plugins into],
+   loggenplugindir=$with_loggen_plugin_dir)
+
 AC_ARG_WITH(module-path,
    [  --with-module-path=path   Use path as the list of ':' separated directories looked up when searching for modules],
    module_path=$with_module_path)

--- a/configure.ac
+++ b/configure.ac
@@ -130,7 +130,7 @@ if test "x$exec_prefix" = "xNONE"; then
 fi
 pidfiledir='${localstatedir}'
 moduledir='${exec_prefix}/lib/syslog-ng'
-loggenplugindir='${exec_prefix}/lib/syslog-ng/loggen'
+loggenplugindir='${moduledir}/loggen'
 toolsdir='${datadir}/syslog-ng/tools'
 xsddir='${datadir}/syslog-ng/xsd'
 

--- a/lib/reloc.c
+++ b/lib/reloc.c
@@ -58,6 +58,7 @@ path_resolver_populate_configure_variables(PathResolver *self, const gchar *sysp
   path_resolver_add_configure_variable(&self->super, "${datarootdir}", SYSLOG_NG_PATH_DATAROOTDIR);
   path_resolver_add_configure_variable(&self->super, "${datadir}", SYSLOG_NG_PATH_DATADIR);
   path_resolver_add_configure_variable(&self->super, "${localstatedir}", SYSLOG_NG_PATH_LOCALSTATEDIR);
+  path_resolver_add_configure_variable(&self->super, "${moduledir}", SYSLOG_NG_PATH_MODULEDIR);
 }
 
 


### PR DESCRIPTION
The loggen plugin dir should follow `moduledir`, which can be set, for example, with the `--with-module-dir` configure option.

#3019 changed this behavior, to make the run-time relocation of loggen work, but this way the loggen plugin directory does not depend on `moduledir` anymore.

This PR fixes the problem.
In order not to break the loggen relocation, `${moduledir}` has to be added to the relocation API, so paths containing `${moduledir}` can be resolved correctly with `get_installation_path_for()`.

Fixes #3023