### PR TITLE
[WIP] python-source: warning for possible persist collision in the future

### DIFF
--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -11,6 +11,8 @@ set(PYTHON_SOURCES
     python-module.h
     python-config.h
     python-config.c
+    python-persist.h
+    python-persist.c
     python-helpers.h
     python-helpers.c
     python-main.h

--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -26,6 +26,8 @@ modules_python_libmod_python_la_SOURCES		= \
 	modules/python/python-module.h		  \
 	modules/python/python-config.h		  \
 	modules/python/python-config.c		  \
+	modules/python/python-persist.h		  \
+	modules/python/python-persist.c		  \
 	modules/python/python-helpers.h		  \
 	modules/python/python-helpers.c		  \
 	modules/python/python-main.h		  \

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -34,6 +34,7 @@
 #include "string-list.h"
 #include "str-utils.h"
 #include "messages.h"
+#include "python-persist.h"
 
 typedef struct
 {
@@ -117,14 +118,7 @@ static const gchar *
 python_dd_format_stats_instance(LogThreadedDestDriver *d)
 {
   PythonDestDriver *self = (PythonDestDriver *)d;
-  static gchar persist_name[1024];
-
-  if (d->super.super.super.persist_name)
-    g_snprintf(persist_name, sizeof(persist_name), "python,%s", d->super.super.super.persist_name);
-  else
-    g_snprintf(persist_name, sizeof(persist_name), "python,%s", self->class);
-
-  return persist_name;
+  return python_format_stats_instance((LogPipe *)d, "python", self->class);
 }
 
 static const gchar *

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -119,14 +119,14 @@ static const gchar *
 python_dd_format_stats_instance(LogThreadedDestDriver *d)
 {
   PythonDestDriver *self = (PythonDestDriver *)d;
-  return python_format_stats_instance((LogPipe *)d, self->py.generate_persist_name, "python", self->class);
+  return python_format_stats_instance((LogPipe *)d, self->py.generate_persist_name, self->options, "python", self->class);
 }
 
 static const gchar *
 python_dd_format_persist_name(const LogPipe *s)
 {
   const PythonDestDriver *self = (const PythonDestDriver *)s;
-  return python_format_persist_name(s, self->py.generate_persist_name, "python", self->class);
+  return python_format_persist_name(s, self->py.generate_persist_name, self->options, "python", self->class);
 }
 
 static gboolean

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -57,6 +57,7 @@ typedef struct
     PyObject *flush;
     PyObject *log_template_options;
     PyObject *seqnum;
+    PyObject *generate_persist_name;
     GPtrArray *_refs_to_clean;
   } py;
 } PythonDestDriver;
@@ -356,6 +357,7 @@ _py_init_bindings(PythonDestDriver *self)
   self->py.open = _py_get_attr_or_null(self->py.instance, "open");
   self->py.flush = _py_get_attr_or_null(self->py.instance, "flush");
   self->py.send = _py_get_attr_or_null(self->py.instance, "send");
+  self->py.generate_persist_name = _py_get_attr_or_null(self->py.instance, "generate_persist_name");
   if (!self->py.send)
     {
       msg_error("Error initializing Python destination, class does not have a send() method",
@@ -372,6 +374,7 @@ _py_init_bindings(PythonDestDriver *self)
   g_ptr_array_add(self->py._refs_to_clean, self->py.send);
   g_ptr_array_add(self->py._refs_to_clean, self->py.log_template_options);
   g_ptr_array_add(self->py._refs_to_clean, self->py.seqnum);
+  g_ptr_array_add(self->py._refs_to_clean, self->py.generate_persist_name);
 
   return TRUE;
 }

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -126,7 +126,7 @@ static const gchar *
 python_dd_format_persist_name(const LogPipe *s)
 {
   const PythonDestDriver *self = (const PythonDestDriver *)s;
-  return python_format_persist_name(s, "python", self->class);
+  return python_format_persist_name(s, self->py.generate_persist_name, "python", self->class);
 }
 
 static gboolean

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -343,9 +343,10 @@ _py_init_bindings(PythonDestDriver *self)
 
   self->py.log_template_options = py_log_template_options_new(&self->template_options);
   PyObject_SetAttrString(self->py.class, "template_options", self->py.log_template_options);
+  Py_DECREF(self->py.log_template_options);
   self->py.seqnum = py_integer_pointer_new(&self->super.worker.instance.seq_num);
   PyObject_SetAttrString(self->py.class, "seqnum", self->py.seqnum);
-  Py_DECREF(self->py.log_template_options);
+  Py_DECREF(self->py.seqnum);
 
   self->py.instance = _py_invoke_function(self->py.class, NULL, self->class, self->super.super.super.id);
   if (!self->py.instance)

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -313,6 +313,14 @@ _inject_worker_insert_result_consts(PythonDestDriver *self)
   _inject_worker_insert_result(self, MAX);
 };
 
+static PyObject *
+py_get_persist_name(PythonDestDriver *self)
+{
+  const gchar *persist_name = python_format_persist_name((LogPipe *)self, self->py.generate_persist_name,
+                                                         self->options, "python", self->class);
+  return _py_string_from_string(persist_name, -1);
+}
+
 static gboolean
 _py_init_bindings(PythonDestDriver *self)
 {
@@ -365,6 +373,10 @@ _py_init_bindings(PythonDestDriver *self)
                 evt_tag_str("class", self->class));
       return FALSE;
     }
+
+  PyObject *py_persist_name = py_get_persist_name(self);
+  PyObject_SetAttrString(self->py.class, "persist_name", py_persist_name);
+  Py_DECREF(py_persist_name);
 
   g_ptr_array_add(self->py._refs_to_clean, self->py.class);
   g_ptr_array_add(self->py._refs_to_clean, self->py.instance);

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -65,12 +65,12 @@ typedef struct
 /** Setters & config glue **/
 
 void
-python_dd_set_class(LogDriver *d, gchar *filename)
+python_dd_set_class(LogDriver *d, gchar *class_name)
 {
   PythonDestDriver *self = (PythonDestDriver *)d;
 
   g_free(self->class);
-  self->class = g_strdup(filename);
+  self->class = g_strdup(class_name);
 }
 
 void

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -119,7 +119,7 @@ static const gchar *
 python_dd_format_stats_instance(LogThreadedDestDriver *d)
 {
   PythonDestDriver *self = (PythonDestDriver *)d;
-  return python_format_stats_instance((LogPipe *)d, "python", self->class);
+  return python_format_stats_instance((LogPipe *)d, self->py.generate_persist_name, "python", self->class);
 }
 
 static const gchar *

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -125,14 +125,7 @@ static const gchar *
 python_dd_format_persist_name(const LogPipe *s)
 {
   const PythonDestDriver *self = (const PythonDestDriver *)s;
-  static gchar persist_name[1024];
-
-  if (s->persist_name)
-    g_snprintf(persist_name, sizeof(persist_name), "python.%s", s->persist_name);
-  else
-    g_snprintf(persist_name, sizeof(persist_name), "python(%s)", self->class);
-
-  return persist_name;
+  return python_format_persist_name(s, "python", self->class);
 }
 
 static gboolean

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -469,6 +469,13 @@ python_fetcher_fetch(LogThreadedFetcherDriver *s)
   return fetch_result;
 }
 
+static const gchar *
+python_fetcher_format_persist_name(const LogPipe *s)
+{
+  const PythonFetcherDriver *self = (const PythonFetcherDriver *)s;
+  return python_format_persist_name(s, self->py.generate_persist_name, "python-fetcher", self->class);
+}
+
 static gboolean
 python_fetcher_init(LogPipe *s)
 {
@@ -489,6 +496,9 @@ python_fetcher_init(LogPipe *s)
   msg_verbose("Python fetcher initialized",
               evt_tag_str("driver", self->super.super.super.super.id),
               evt_tag_str("class", self->class));
+
+  if (((LogPipe *)self)->persist_name || self->py.generate_persist_name)
+    s->generate_persist_name = python_fetcher_format_persist_name;
 
   return log_threaded_fetcher_driver_init_method(s);
 }

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -55,7 +55,7 @@ typedef struct _PyLogFetcher
 {
   PyObject_HEAD
   PythonFetcherDriver *driver;
-  gchar *persist_name;
+  PyObject *persist_name;
 } PyLogFetcher;
 
 static PyTypeObject py_log_fetcher_type;
@@ -220,7 +220,7 @@ _py_free_bindings(PythonFetcherDriver *self)
 {
   PyLogFetcher *py_instance = (PyLogFetcher *) self->py.instance;
   if (py_instance)
-    g_free(py_instance->persist_name);
+    Py_CLEAR(py_instance->persist_name);
 
   Py_CLEAR(self->py.class);
   Py_CLEAR(self->py.instance);
@@ -305,7 +305,7 @@ _py_set_persist_name(PythonFetcherDriver *self)
     {
       const gchar *persist_name = python_fetcher_format_persist_name((LogPipe *)self);
       PyLogFetcher *py_instance = (PyLogFetcher *) self->py.instance;
-      py_instance->persist_name = g_strdup(persist_name);
+      py_instance->persist_name = _py_string_from_string(persist_name, -1);
     }
 }
 
@@ -576,7 +576,7 @@ python_fetcher_new(GlobalConfig *cfg)
 
 static PyMemberDef py_log_fetcher_members[] =
 {
-  { "persist_name", T_STRING, offsetof(PyLogFetcher, persist_name), READONLY },
+  { "persist_name", T_OBJECT_EX, offsetof(PyLogFetcher, persist_name), READONLY },
   {NULL}
 };
 

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -88,7 +88,8 @@ static const gchar *
 python_fetcher_format_stats_instance(LogThreadedSourceDriver *s)
 {
   PythonFetcherDriver *self = (PythonFetcherDriver *) s;
-  return python_format_stats_instance((LogPipe *)s, self->py.generate_persist_name, "python-fetcher", self->class);
+  return python_format_stats_instance((LogPipe *)s, self->py.generate_persist_name, self->options,
+                                      "python-fetcher", self->class);
 }
 
 static void
@@ -473,7 +474,7 @@ static const gchar *
 python_fetcher_format_persist_name(const LogPipe *s)
 {
   const PythonFetcherDriver *self = (const PythonFetcherDriver *)s;
-  return python_format_persist_name(s, self->py.generate_persist_name, "python-fetcher", self->class);
+  return python_format_persist_name(s, self->py.generate_persist_name, self->options, "python-fetcher", self->class);
 }
 
 static gboolean

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -45,6 +45,7 @@ typedef struct _PythonFetcherDriver
     PyObject *open_method;
     PyObject *close_method;
     PyObject *request_exit_method;
+    PyObject *generate_persist_name;
   } py;
 } PythonFetcherDriver;
 
@@ -219,6 +220,7 @@ _py_free_bindings(PythonFetcherDriver *self)
   Py_CLEAR(self->py.open_method);
   Py_CLEAR(self->py.close_method);
   Py_CLEAR(self->py.request_exit_method);
+  Py_CLEAR(self->py.generate_persist_name);
 }
 
 static gboolean
@@ -296,6 +298,7 @@ _py_init_methods(PythonFetcherDriver *self)
   self->py.request_exit_method = _py_get_attr_or_null(self->py.instance, "request_exit");
   self->py.open_method = _py_get_attr_or_null(self->py.instance, "open");
   self->py.close_method = _py_get_attr_or_null(self->py.instance, "close");
+  self->py.generate_persist_name = _py_get_attr_or_null(self->py.instance, "generate_persist_name");
 
   return TRUE;
 }

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -88,7 +88,7 @@ static const gchar *
 python_fetcher_format_stats_instance(LogThreadedSourceDriver *s)
 {
   PythonFetcherDriver *self = (PythonFetcherDriver *) s;
-  return python_format_stats_instance((LogPipe *)s, "python-fetcher", self->class);
+  return python_format_stats_instance((LogPipe *)s, self->py.generate_persist_name, "python-fetcher", self->class);
 }
 
 static void

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -27,6 +27,7 @@
 #include "logthrsource/logthrfetcherdrv.h"
 #include "str-utils.h"
 #include "string-list.h"
+#include "python-persist.h"
 
 typedef struct _PythonFetcherDriver
 {
@@ -86,14 +87,7 @@ static const gchar *
 python_fetcher_format_stats_instance(LogThreadedSourceDriver *s)
 {
   PythonFetcherDriver *self = (PythonFetcherDriver *) s;
-  static gchar persist_name[1024];
-
-  if (s->super.super.super.persist_name)
-    g_snprintf(persist_name, sizeof(persist_name), "python-fetcher,%s", s->super.super.super.persist_name);
-  else
-    g_snprintf(persist_name, sizeof(persist_name), "python-fetcher,%s", self->class);
-
-  return persist_name;
+  return python_format_stats_instance((LogPipe *)s, "python-fetcher", self->class);
 }
 
 static void

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -72,11 +72,13 @@ start
         | LL_CONTEXT_SOURCE KW_PYTHON
           {
             last_driver = *instance = python_sd_new(configuration);
+            g_assert(!((LogPipe *)last_driver)->generate_persist_name);
           }
           '(' python_sd_options ')'         { YYACCEPT; }
         | LL_CONTEXT_SOURCE KW_PYTHON_FETCHER
           {
             last_driver = *instance = python_fetcher_new(configuration);
+            g_assert(!((LogPipe *)last_driver)->generate_persist_name);
           }
           '(' python_fetcher_options ')'         { YYACCEPT; }
 	| LL_CONTEXT_ROOT KW_PYTHON

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "python-persist.h"

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -81,13 +81,39 @@ format_default_persist_name_with_class(gchar *buffer, gsize size, const gchar *m
   g_snprintf(buffer, size, "%s(%s)", module, class);
 }
 
+static void
+copy_persist_name(const LogPipe *self, PyObject *generate_persist_name_method, const gchar *module,
+                  const gchar *class, gchar *buffer, gsize size)
+{
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+
+  PyObject *ret;
+  ret = _py_invoke_function(generate_persist_name_method, NULL, class, ((LogDriver *)self)->id);
+  if (ret)
+    g_snprintf(buffer, size, "%s.%s", module, _py_get_string_as_string(ret));
+  else
+    {
+      msg_error("Failed while generating persist name",
+                evt_tag_str("driver", ((LogDriver *)self)->id),
+                evt_tag_str("class", class));
+      format_default_persist_name_with_class(buffer, size, module, class);
+    }
+  Py_XDECREF(ret);
+
+  PyGILState_Release(gstate);
+}
+
 const gchar *
-python_format_persist_name(const LogPipe *p, const gchar *module, const gchar *class)
+python_format_persist_name(const LogPipe *p, PyObject *generate_persist_name_method, const gchar *module,
+                           const gchar *class)
 {
   static gchar persist_name[1024];
 
   if (p->persist_name)
     format_default_persist_name_with_persist_name(persist_name, sizeof(persist_name), module, p->persist_name);
+  else if (generate_persist_name_method)
+    copy_persist_name(p, generate_persist_name_method, module, class, persist_name, sizeof(persist_name));
   else
     format_default_persist_name_with_class(persist_name, sizeof(persist_name), module, class);
 

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -21,3 +21,22 @@
  */
 
 #include "python-persist.h"
+
+static void
+format_default_stats_name(gchar *buffer, gsize size, const gchar *module, const gchar *name)
+{
+  g_snprintf(buffer, size, "%s,%s", module, name);
+}
+
+const gchar *
+python_format_stats_instance(LogPipe *p, const gchar *module, const gchar *class)
+{
+  static gchar persist_name[1024];
+
+  if (p->persist_name)
+    format_default_stats_name(persist_name, sizeof(persist_name), module, p->persist_name);
+  else
+    format_default_stats_name(persist_name, sizeof(persist_name), module, class);
+
+  return persist_name;
+}

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -24,6 +24,16 @@
 #include "python-helpers.h"
 #include "driver.h"
 
+static PyObject *
+_call_generate_persist_name_method(PyObject *generate_persist_name_method, GHashTable *options,
+                                   const gchar *class, const gchar *id)
+{
+  PyObject *py_options = options ? _py_create_arg_dict(options) : NULL;
+  PyObject *ret = _py_invoke_function(generate_persist_name_method, py_options, class, id);
+  Py_XDECREF(py_options);
+  return ret;
+}
+
 static void
 format_default_stats_name(gchar *buffer, gsize size, const gchar *module, const gchar *name)
 {
@@ -31,14 +41,14 @@ format_default_stats_name(gchar *buffer, gsize size, const gchar *module, const 
 }
 
 static void
-copy_stats_instance(const LogPipe *self, PyObject *generate_persist_name_method, const gchar *module,
-                    const gchar *class, gchar *buffer, gsize size)
+copy_stats_instance(const LogPipe *self, PyObject *generate_persist_name_method, GHashTable *options,
+                    const gchar *module, const gchar *class, gchar *buffer, gsize size)
 {
   PyGILState_STATE gstate;
   gstate = PyGILState_Ensure();
 
-  PyObject *ret;
-  ret = _py_invoke_function(generate_persist_name_method, NULL, class, ((LogDriver *)self)->id);
+  PyObject *ret =_call_generate_persist_name_method(generate_persist_name_method,
+                                                    options, class, ((LogDriver *)self)->id);
   if (ret)
     g_snprintf(buffer, size, "%s,%s", module, _py_get_string_as_string(ret));
   else
@@ -54,15 +64,15 @@ copy_stats_instance(const LogPipe *self, PyObject *generate_persist_name_method,
 }
 
 const gchar *
-python_format_stats_instance(LogPipe *p, PyObject *generate_persist_name_method, const gchar *module,
-                             const gchar *class)
+python_format_stats_instance(LogPipe *p, PyObject *generate_persist_name_method, GHashTable *options,
+                             const gchar *module, const gchar *class)
 {
   static gchar persist_name[1024];
 
   if (p->persist_name)
     format_default_stats_name(persist_name, sizeof(persist_name), module, p->persist_name);
   else if (generate_persist_name_method)
-    copy_stats_instance(p, generate_persist_name_method, module, class, persist_name, sizeof(persist_name));
+    copy_stats_instance(p, generate_persist_name_method, options, module, class, persist_name, sizeof(persist_name));
   else
     format_default_stats_name(persist_name, sizeof(persist_name), module, class);
 
@@ -82,14 +92,14 @@ format_default_persist_name_with_class(gchar *buffer, gsize size, const gchar *m
 }
 
 static void
-copy_persist_name(const LogPipe *self, PyObject *generate_persist_name_method, const gchar *module,
-                  const gchar *class, gchar *buffer, gsize size)
+copy_persist_name(const LogPipe *self, PyObject *generate_persist_name_method, GHashTable *options,
+                  const gchar *module, const gchar *class, gchar *buffer, gsize size)
 {
   PyGILState_STATE gstate;
   gstate = PyGILState_Ensure();
 
-  PyObject *ret;
-  ret = _py_invoke_function(generate_persist_name_method, NULL, class, ((LogDriver *)self)->id);
+  PyObject *ret =_call_generate_persist_name_method(generate_persist_name_method,
+                                                    options, class, ((LogDriver *)self)->id);
   if (ret)
     g_snprintf(buffer, size, "%s.%s", module, _py_get_string_as_string(ret));
   else
@@ -105,15 +115,15 @@ copy_persist_name(const LogPipe *self, PyObject *generate_persist_name_method, c
 }
 
 const gchar *
-python_format_persist_name(const LogPipe *p, PyObject *generate_persist_name_method, const gchar *module,
-                           const gchar *class)
+python_format_persist_name(const LogPipe *p, PyObject *generate_persist_name_method, GHashTable *options,
+                           const gchar *module, const gchar *class)
 {
   static gchar persist_name[1024];
 
   if (p->persist_name)
     format_default_persist_name_with_persist_name(persist_name, sizeof(persist_name), module, p->persist_name);
   else if (generate_persist_name_method)
-    copy_persist_name(p, generate_persist_name_method, module, class, persist_name, sizeof(persist_name));
+    copy_persist_name(p, generate_persist_name_method, options, module, class, persist_name, sizeof(persist_name));
   else
     format_default_persist_name_with_class(persist_name, sizeof(persist_name), module, class);
 

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -40,3 +40,28 @@ python_format_stats_instance(LogPipe *p, const gchar *module, const gchar *class
 
   return persist_name;
 }
+
+static void
+format_default_persist_name_with_persist_name(gchar *buffer, gsize size, const gchar *module, const gchar *persist_name)
+{
+  g_snprintf(buffer, size, "%s.%s", module, persist_name);
+}
+
+static void
+format_default_persist_name_with_class(gchar *buffer, gsize size, const gchar *module, const gchar *class)
+{
+  g_snprintf(buffer, size, "%s(%s)", module, class);
+}
+
+const gchar *
+python_format_persist_name(const LogPipe *p, const gchar *module, const gchar *class)
+{
+  static gchar persist_name[1024];
+
+  if (p->persist_name)
+    format_default_persist_name_with_persist_name(persist_name, sizeof(persist_name), module, p->persist_name);
+  else
+    format_default_persist_name_with_class(persist_name, sizeof(persist_name), module, class);
+
+  return persist_name;
+}

--- a/modules/python/python-persist.h
+++ b/modules/python/python-persist.h
@@ -24,5 +24,8 @@
 #define SNG_PYTHON_PERSIST_H_INCLUDED
 
 #include "python-module.h"
+#include "logpipe.h"
+
+const gchar *python_format_stats_instance(LogPipe *p, const gchar *module, const gchar *class);
 
 #endif

--- a/modules/python/python-persist.h
+++ b/modules/python/python-persist.h
@@ -27,5 +27,6 @@
 #include "logpipe.h"
 
 const gchar *python_format_stats_instance(LogPipe *p, const gchar *module, const gchar *class);
+const gchar *python_format_persist_name(const LogPipe *p, const gchar *module, const gchar *class);
 
 #endif

--- a/modules/python/python-persist.h
+++ b/modules/python/python-persist.h
@@ -28,6 +28,8 @@
 
 const gchar *python_format_stats_instance(LogPipe *p, PyObject *generate_persist_name_method,
                                           const gchar *module, const gchar *class);
-const gchar *python_format_persist_name(const LogPipe *p, const gchar *module, const gchar *class);
+const gchar *python_format_persist_name(const LogPipe *p, PyObject *generate_persist_name_method,
+                                        const gchar *module, const gchar *class);
+
 
 #endif

--- a/modules/python/python-persist.h
+++ b/modules/python/python-persist.h
@@ -26,7 +26,8 @@
 #include "python-module.h"
 #include "logpipe.h"
 
-const gchar *python_format_stats_instance(LogPipe *p, const gchar *module, const gchar *class);
+const gchar *python_format_stats_instance(LogPipe *p, PyObject *generate_persist_name_method,
+                                          const gchar *module, const gchar *class);
 const gchar *python_format_persist_name(const LogPipe *p, const gchar *module, const gchar *class);
 
 #endif

--- a/modules/python/python-persist.h
+++ b/modules/python/python-persist.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SNG_PYTHON_PERSIST_H_INCLUDED
+#define SNG_PYTHON_PERSIST_H_INCLUDED
+
+#include "python-module.h"
+
+#endif

--- a/modules/python/python-persist.h
+++ b/modules/python/python-persist.h
@@ -27,9 +27,9 @@
 #include "logpipe.h"
 
 const gchar *python_format_stats_instance(LogPipe *p, PyObject *generate_persist_name_method,
-                                          const gchar *module, const gchar *class);
+                                          GHashTable *options, const gchar *module, const gchar *class);
 const gchar *python_format_persist_name(const LogPipe *p, PyObject *generate_persist_name_method,
-                                        const gchar *module, const gchar *class);
+                                        GHashTable *options, const gchar *module, const gchar *class);
 
 
 #endif

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -28,6 +28,7 @@
 #include "thread-utils.h"
 #include "str-utils.h"
 #include "string-list.h"
+#include "python-persist.h"
 
 typedef struct _PythonSourceDriver PythonSourceDriver;
 
@@ -92,14 +93,8 @@ static const gchar *
 python_sd_format_stats_instance(LogThreadedSourceDriver *s)
 {
   PythonSourceDriver *self = (PythonSourceDriver *) s;
-  static gchar persist_name[1024];
+  return python_format_stats_instance((LogPipe *)s, "python", self->class);
 
-  if (s->super.super.super.persist_name)
-    g_snprintf(persist_name, sizeof(persist_name), "python,%s", s->super.super.super.persist_name);
-  else
-    g_snprintf(persist_name, sizeof(persist_name), "python,%s", self->class);
-
-  return persist_name;
 }
 
 static void

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -61,7 +61,7 @@ typedef struct _PyLogSource
 {
   PyObject_HEAD
   PythonSourceDriver *driver;
-  gchar *persist_name;
+  PyObject *persist_name;
 } PyLogSource;
 
 static PyTypeObject py_log_source_type;
@@ -166,7 +166,7 @@ _py_free_bindings(PythonSourceDriver *self)
 {
   PyLogSource *py_instance = (PyLogSource *) self->py.instance;
   if (py_instance)
-    g_free(py_instance->persist_name);
+    Py_CLEAR(py_instance->persist_name);
 
   Py_CLEAR(self->py.class);
   Py_CLEAR(self->py.instance);
@@ -294,7 +294,7 @@ _py_set_persist_name(PythonSourceDriver *self)
       const gchar *persist_name = python_format_persist_name((LogPipe *)self, self->py.generate_persist_name,
                                                              self->options, "python-source", self->class);
       PyLogSource *py_instance = (PyLogSource *) self->py.instance;
-      py_instance->persist_name = g_strdup(persist_name);
+      py_instance->persist_name = _py_string_from_string(persist_name, -1);
     }
   return TRUE;
 }
@@ -620,7 +620,7 @@ static PyMethodDef py_log_source_methods[] =
 
 static PyMemberDef py_log_source_members[] =
 {
-  { "persist_name", T_STRING, offsetof(PyLogSource, persist_name), READONLY },
+  { "persist_name", T_OBJECT_EX, offsetof(PyLogSource, persist_name), READONLY },
   {NULL}
 };
 

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -497,6 +497,13 @@ python_sd_request_exit(LogThreadedSourceDriver *s)
   PyGILState_Release(gstate);
 }
 
+static const gchar *
+python_source_format_persist_name(const LogPipe *s)
+{
+  const PythonSourceDriver *self = (const PythonSourceDriver *)s;
+  return python_format_persist_name(s, self->py.generate_persist_name, "python-source", self->class);
+}
+
 static gboolean
 python_sd_init(LogPipe *s)
 {
@@ -528,6 +535,9 @@ python_sd_init(LogPipe *s)
       self->post_message = _post_message_non_blocking;
       log_threaded_source_set_wakeup_func(&self->super, python_sd_wakeup);
     }
+
+  if (((LogPipe *)self)->persist_name || self->py.generate_persist_name)
+    s->generate_persist_name = python_source_format_persist_name;
 
   return TRUE;
 }

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -94,7 +94,7 @@ static const gchar *
 python_sd_format_stats_instance(LogThreadedSourceDriver *s)
 {
   PythonSourceDriver *self = (PythonSourceDriver *) s;
-  return python_format_stats_instance((LogPipe *)s, self->py.generate_persist_name, "python", self->class);
+  return python_format_stats_instance((LogPipe *)s, self->py.generate_persist_name, self->options, "python", self->class);
 }
 
 static void
@@ -501,7 +501,7 @@ static const gchar *
 python_source_format_persist_name(const LogPipe *s)
 {
   const PythonSourceDriver *self = (const PythonSourceDriver *)s;
-  return python_format_persist_name(s, self->py.generate_persist_name, "python-source", self->class);
+  return python_format_persist_name(s, self->py.generate_persist_name, self->options, "python-source", self->class);
 }
 
 static gboolean

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -29,8 +29,12 @@
 #include "str-utils.h"
 #include "string-list.h"
 #include "python-persist.h"
+#include "apphook.h"
 
 #include <structmember.h>
+
+static GHashTable *persist_collision_candidates;
+static gboolean is_collision_detection_scheduled;
 
 typedef struct _PythonSourceDriver PythonSourceDriver;
 
@@ -525,6 +529,50 @@ python_source_format_persist_name(const LogPipe *s)
   return python_format_persist_name(s, self->py.generate_persist_name, self->options, "python-source", self->class);
 }
 
+static void
+_clear_collision_detection(gint type, gpointer user_data)
+{
+  is_collision_detection_scheduled = FALSE;
+  g_hash_table_remove_all(persist_collision_candidates);
+}
+
+static void
+_detect_persist_collision(PythonSourceDriver *self)
+{
+  if (((LogPipe *)self)->persist_name || self->py.generate_persist_name)
+    return;
+
+  if (__once())
+    {
+      persist_collision_candidates = g_hash_table_new(g_str_hash, g_str_equal);
+      register_application_hook(AH_RUNNING, (ApplicationHookFunc) _clear_collision_detection, NULL);
+    }
+
+  if (!is_collision_detection_scheduled)
+    {
+      is_collision_detection_scheduled = TRUE;
+      register_application_hook(AH_CONFIG_CHANGED, (ApplicationHookFunc) _clear_collision_detection, NULL);
+    }
+
+  if (g_hash_table_contains(persist_collision_candidates, self->class))
+    {
+      PythonSourceDriver *collider = g_hash_table_lookup(persist_collision_candidates, self->class);
+      msg_warning("Persist name collision detected. Please update "
+                  "your configuration either by adding persist-name in "
+                  "configuration, or specify a "
+                  "@staticmethod generate_persist_name(options) method "
+                  "in the python class. Syslog-ng will not start with "
+                  "this configuration in the next release.",
+                  evt_tag_str("class", self->class),
+                  log_pipe_location_tag((LogPipe *)collider),
+                  log_pipe_location_tag((LogPipe *)self));
+    }
+  else
+    {
+      g_hash_table_insert(persist_collision_candidates, self->class, self);
+    }
+};
+
 static gboolean
 python_sd_init(LogPipe *s)
 {
@@ -559,6 +607,8 @@ python_sd_init(LogPipe *s)
 
   if (((LogPipe *)self)->persist_name || self->py.generate_persist_name)
     s->generate_persist_name = python_source_format_persist_name;
+
+  _detect_persist_collision(self);
 
   return TRUE;
 }

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -94,8 +94,7 @@ static const gchar *
 python_sd_format_stats_instance(LogThreadedSourceDriver *s)
 {
   PythonSourceDriver *self = (PythonSourceDriver *) s;
-  return python_format_stats_instance((LogPipe *)s, "python", self->class);
-
+  return python_format_stats_instance((LogPipe *)s, self->py.generate_persist_name, "python", self->class);
 }
 
 static void

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -51,6 +51,7 @@ struct _PythonSourceDriver
     PyObject *request_exit_method;
     PyObject *suspend_method;
     PyObject *wakeup_method;
+    PyObject *generate_persist_name;
   } py;
 };
 
@@ -167,6 +168,7 @@ _py_free_bindings(PythonSourceDriver *self)
   Py_CLEAR(self->py.request_exit_method);
   Py_CLEAR(self->py.suspend_method);
   Py_CLEAR(self->py.wakeup_method);
+  Py_CLEAR(self->py.generate_persist_name);
 }
 
 static gboolean
@@ -272,11 +274,19 @@ _py_lookup_suspend_and_wakeup_methods(PythonSourceDriver *self)
 }
 
 static gboolean
+_py_lookup_generate_persist_name_method(PythonSourceDriver *self)
+{
+  self->py.generate_persist_name = _py_get_attr_or_null(self->py.instance, "generate_persist_name");
+  return TRUE;
+}
+
+static gboolean
 _py_init_methods(PythonSourceDriver *self)
 {
   return _py_lookup_run_method(self)
          && _py_lookup_request_exit_method(self)
-         && _py_lookup_suspend_and_wakeup_methods(self);
+         && _py_lookup_suspend_and_wakeup_methods(self)
+         && _py_lookup_generate_persist_name_method(self);
 }
 
 static gboolean

--- a/modules/python/tests/CMakeLists.txt
+++ b/modules/python/tests/CMakeLists.txt
@@ -11,3 +11,10 @@ add_unit_test(LIBTEST CRITERION
   DEPENDS mod-python "${PYTHON_LIBRARIES}" syslogformat)
 
 set_property(TEST test_python_template APPEND PROPERTY ENVIRONMENT "PYTHONMALLOC=malloc_debug")
+
+add_unit_test(LIBTEST CRITERION
+  TARGET test_python_persist_name
+  INCLUDES "${PYTHON_INCLUDE_DIR}" "${PYTHON_INCLUDE_DIRS}"
+  DEPENDS syslogformat mod-python "${PYTHON_LIBRARIES}")
+
+set_property(TEST test_python_persist_name APPEND PROPERTY ENVIRONMENT "PYTHONMALLOC=malloc_debug")

--- a/modules/python/tests/Makefile.am
+++ b/modules/python/tests/Makefile.am
@@ -6,7 +6,8 @@ check_PROGRAMS += \
 
 modules_python_tests_TESTS = \
   modules/python/tests/test_python_logmsg \
-  modules/python/tests/test_python_template
+  modules/python/tests/test_python_template \
+  modules/python/tests/test_python_persist_name
 
 modules_python_tests_test_python_logmsg_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) -I$(top_srcdir)/modules/python
 modules_python_tests_test_python_logmsg_LDADD = $(TEST_LDADD) \
@@ -20,5 +21,10 @@ modules_python_tests_test_python_template_LDADD = $(TEST_LDADD) \
 	-dlpreopen $(top_builddir)/modules/python/libmod-python.la \
 	$(PYTHON_LIBS) $(PREOPEN_SYSLOGFORMAT)
 
+modules_python_tests_test_python_persist_name_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) \
+	-I$(top_srcdir)/modules/python -I$(top_srcdir)/modules/syslogformat
+modules_python_tests_test_python_persist_name_LDADD = $(TEST_LDADD) \
+	-dlpreopen $(top_builddir)/modules/python/libmod-python.la \
+	$(PYTHON_LIBS) $(PREOPEN_SYSLOGFORMAT)
 
 EXTRA_DIST += modules/python/tests/CMakeLists.txt

--- a/modules/python/tests/test_python_persist_name.c
+++ b/modules/python/tests/test_python_persist_name.c
@@ -205,3 +205,51 @@ Test(python_persist_name, test_python_exception_in_generate_persist_name)
   Py_DECREF(persist_generator_persist);
   log_pipe_unref((LogPipe *)p);
 }
+
+const gchar *python_fetcher_code_no_generate_persist_name = "\n\
+from _syslogng import LogFetcher\n\
+class Fetcher(LogFetcher):\n\
+    def fetch(self):\n\
+        return LogFetcher.FETCH_NO_DATA, None";
+
+Test(python_persist_name, test_python_fetcher_no_generate_persist_name)
+{
+  _load_code(python_fetcher_code_no_generate_persist_name);
+
+  LogDriver *d = python_fetcher_new(empty_cfg);
+  python_fetcher_set_class(d, "Fetcher");
+  python_fetcher_set_option(d, "key", "value");
+  log_pipe_set_persist_name((LogPipe *)d, "test_persist_name");
+  cr_assert(log_pipe_init((LogPipe *)d));
+
+  cr_assert_str_eq(log_pipe_get_persist_name((LogPipe *)d), "python-fetcher.test_persist_name");
+
+  main_loop_sync_worker_startup_and_teardown();
+  log_pipe_deinit((LogPipe *)d);
+  log_pipe_unref((LogPipe *)d);
+}
+
+const gchar *python_source_code_no_generate_persist_name = "\n\
+from _syslogng import LogSource\n\
+class Source(LogSource):\n\
+    def run(self):\n\
+        pass\n\
+    def request_exit(self):\n\
+        pass";
+
+Test(python_persist_name, test_python_source_no_generate_persist_name)
+{
+  _load_code(python_source_code_no_generate_persist_name);
+
+  LogDriver *d = python_sd_new(empty_cfg);
+  python_sd_set_class(d, "Source");
+  python_sd_set_option(d, "key", "value");
+  log_pipe_set_persist_name((LogPipe *)d, "test_persist_name");
+  cr_assert(log_pipe_init((LogPipe *)d));
+
+  cr_assert_str_eq(log_pipe_get_persist_name((LogPipe *)d), "python-source.test_persist_name");
+
+  main_loop_sync_worker_startup_and_teardown();
+  log_pipe_deinit((LogPipe *)d);
+  log_pipe_unref((LogPipe *)d);
+}

--- a/modules/python/tests/test_python_persist_name.c
+++ b/modules/python/tests/test_python_persist_name.c
@@ -19,9 +19,155 @@
  * COPYING for details.
  */
 
+#include "python-helpers.h"
+#include "apphook.h"
+#include "python-dest.h"
+#include "python-main.h"
+#include "python-fetcher.h"
+#include "python-source.h"
+#include "mainloop-worker.h"
+#include "mainloop.h"
+
 #include <criterion/criterion.h>
 
-Test(python_persist_name, test_python_persist_name)
+MainLoop *main_loop;
+MainLoopOptions main_loop_options = {0};
+
+static PyObject *_python_main;
+static PyObject *_python_main_dict;
+
+YYLTYPE yyltype;
+GlobalConfig *empty_cfg;
+
+static void
+_py_init_interpreter(void)
 {
-  cr_assert(1);
+  Py_Initialize();
+  py_init_argv();
+
+  PyEval_InitThreads();
+  py_log_fetcher_init();
+  py_log_source_init();
+  PyEval_SaveThread();
+}
+
+static void
+_init_python_main(void)
+{
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  {
+    _python_main = PyImport_AddModule("__main__");
+    _python_main_dict = PyModule_GetDict(_python_main);
+  }
+  PyGILState_Release(gstate);
+}
+
+void setup(void)
+{
+  app_startup();
+
+  main_loop = main_loop_get_instance();
+  main_loop_init(main_loop, &main_loop_options);
+
+  _py_init_interpreter();
+  _init_python_main();
+
+  empty_cfg = cfg_new_snippet();
+  empty_cfg->filename  = g_strdup("dummy");
+}
+
+void teardown(void)
+{
+  cfg_free(empty_cfg);
+  main_loop_deinit(main_loop);
+  app_shutdown();
+  Py_DECREF(_python_main);
+  Py_DECREF(_python_main_dict);
+}
+
+static void
+_load_code(const gchar *code)
+{
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+  cr_assert(python_evaluate_global_code(empty_cfg, code, &yyltype));
+  PyGILState_Release(gstate);
+}
+
+TestSuite(python_persist_name, .init = setup, .fini = teardown);
+
+const gchar *python_destination_code = "\n\
+class Dest(object):\n\
+    @staticmethod\n\
+    def generate_persist_name(options):\n\
+        return options['key']\n\
+    def send(self, message):\n\
+        return True";
+
+Test(python_persist_name, test_python_dest)
+{
+  _load_code(python_destination_code);
+
+  LogDriver *d = python_dd_new(empty_cfg);
+  python_dd_set_class(d, "Dest");
+  python_dd_set_option(d, "key", "value");
+  cr_assert(log_pipe_init((LogPipe *)d));
+
+  cr_assert_str_eq(log_pipe_get_persist_name((LogPipe *)d), "python.value");
+
+  main_loop_sync_worker_startup_and_teardown();
+  log_pipe_deinit((LogPipe *)d);
+  log_pipe_unref((LogPipe *)d);
+}
+
+const gchar *python_fetcher_code = "\n\
+from _syslogng import LogFetcher\n\
+class Fetcher(LogFetcher):\n\
+    @staticmethod\n\
+    def generate_persist_name(options):\n\
+        return options['key']\n\
+    def fetch(self):\n\
+        return LogFetcher.FETCH_NO_DATA, None";
+
+Test(python_persist_name, test_python_fetcher)
+{
+  _load_code(python_fetcher_code);
+
+  LogDriver *d = python_fetcher_new(empty_cfg);
+  python_fetcher_set_class(d, "Fetcher");
+  python_fetcher_set_option(d, "key", "value");
+  cr_assert(log_pipe_init((LogPipe *)d));
+
+  cr_assert_str_eq(log_pipe_get_persist_name((LogPipe *)d), "python-fetcher.value");
+
+  main_loop_sync_worker_startup_and_teardown();
+  log_pipe_deinit((LogPipe *)d);
+  log_pipe_unref((LogPipe *)d);
+}
+
+const gchar *python_source_code = "\n\
+from _syslogng import LogSource\n\
+class Source(LogSource):\n\
+    @staticmethod\n\
+    def generate_persist_name(options):\n\
+        return options['key']\n\
+    def run(self):\n\
+        pass\n\
+    def request_exit(self):\n\
+        pass";
+
+Test(python_persist_name, test_python_source)
+{
+  _load_code(python_source_code);
+
+  LogDriver *d = python_sd_new(empty_cfg);
+  python_sd_set_class(d, "Source");
+  python_sd_set_option(d, "key", "value");
+  cr_assert(log_pipe_init((LogPipe *)d));
+
+  cr_assert_str_eq(log_pipe_get_persist_name((LogPipe *)d), "python-source.value");
+
+  main_loop_sync_worker_startup_and_teardown();
+  log_pipe_deinit((LogPipe *)d);
+  log_pipe_unref((LogPipe *)d);
 }

--- a/modules/python/tests/test_python_persist_name.c
+++ b/modules/python/tests/test_python_persist_name.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#include <criterion/criterion.h>
+
+Test(python_persist_name, test_python_persist_name)
+{
+  cr_assert(1);
+}

--- a/modules/python/tests/test_python_persist_name.c
+++ b/modules/python/tests/test_python_persist_name.c
@@ -310,3 +310,66 @@ Test(python_persist_name, test_python_fetcher_no_persist)
   log_pipe_deinit((LogPipe *)d);
   log_pipe_unref((LogPipe *)d);
 }
+
+const gchar *python_source_code_readonly = "\n\
+from _syslogng import LogSource\n\
+class Source(LogSource):\n\
+    @staticmethod\n\
+    def generate_persist_name(options):\n\
+        return 'foo'\n\
+    def init(self, options):\n\
+        self.persist_name = 'readonly...'\n\
+        return True\n\
+    def run(self):\n\
+        pass\n\
+    def request_exit(self):\n\
+        pass";
+
+Test(python_persist_name, test_python_source_readonly)
+{
+  _load_code(python_source_code_readonly);
+
+  LogDriver *d = python_sd_new(empty_cfg);
+  python_sd_set_class(d, "Source");
+  start_grabbing_messages();
+  cr_assert_eq(log_pipe_init((LogPipe *)d), 0);
+  stop_grabbing_messages();
+  display_grabbed_messages();
+
+  assert_grabbed_log_contains("TypeError: readonly attribute");
+
+  main_loop_sync_worker_startup_and_teardown();
+  log_pipe_deinit((LogPipe *)d);
+  log_pipe_unref((LogPipe *)d);
+}
+
+const gchar *python_fetcher_code_readonly = "\n\
+from _syslogng import LogFetcher\n\
+class Fetcher(LogFetcher):\n\
+    @staticmethod\n\
+    def generate_persist_name(options):\n\
+        return 'foo'\n\
+    def init(self, options):\n\
+        self.persist_name = 'readonly ...'\n\
+        return True\n\
+    def fetch(self):\n\
+        return LogFetcher.FETCH_NO_DATA, None";
+
+Test(python_persist_name, test_python_fetcher_readonly)
+{
+  _load_code(python_fetcher_code_readonly);
+
+  LogDriver *d = python_fetcher_new(empty_cfg);
+  python_fetcher_set_class(d, "Fetcher");
+
+  start_grabbing_messages();
+  cr_assert_eq(log_pipe_init((LogPipe *)d), 0);
+  stop_grabbing_messages();
+  display_grabbed_messages();
+
+  assert_grabbed_log_contains("TypeError: readonly attribute");
+
+  main_loop_sync_worker_startup_and_teardown();
+  log_pipe_deinit((LogPipe *)d);
+  log_pipe_unref((LogPipe *)d);
+}


### PR DESCRIPTION
Built on top of https://github.com/syslog-ng/syslog-ng/pull/3016.

We plan to introduce persist api for python source and python fetcher. Unfortunately, currently there is no persist name allocated automatically, which makes introduction of persist api very hard. For now different python source and fetcher instances can start with the same class. If the `persist_name` enforcing would be introduced instantly, those configurations might break.

This patch adds warning if syslog-ng detects a collision. Later the warning will be turned into error, and syslog-ng will not start.

If persist name collision is detected, users can fix it either by:

1. Specify `persist-name` option in the configuration file.
2. Specify `generate_persist_name` static method in the python class (preferable if suitable)

Something similar:

``` python
class SourceOrFetcher(...):
    @staticmethod
    def generate_persist_name(options):
        return options['port']
```

The hidden collision can happen only amongst python sources and fetchers, and if and only if the same class name is used multiple times.

----

#