### PR TITLE
Fix infinite loop when a TLS connection breaks

### DIFF
--- a/lib/logproto/logproto-client.h
+++ b/lib/logproto/logproto-client.h
@@ -148,6 +148,8 @@ log_proto_client_process_in(LogProtoClient *s)
     /*
      * In some clients, flush is used for input processing, but it should not be.
      * Fix these clients, than remove the flush call here.
+     *
+     * SSL_ERROR_WANT_READ in the TLS transport is also built upon this.
      */
     return s->flush(s);
   else

--- a/lib/transport/transport-tls.c
+++ b/lib/transport/transport-tls.c
@@ -161,7 +161,7 @@ log_transport_tls_new(TLSSession *tls_session, gint fd)
   LogTransportTLS *self = g_new0(LogTransportTLS, 1);
 
   log_transport_init_instance(&self->super, fd);
-  self->super.cond = G_IO_IN | G_IO_OUT;
+  self->super.cond = 0;
   self->super.read = log_transport_tls_read_method;
   self->super.write = log_transport_tls_write_method;
   self->super.free_fn = log_transport_tls_free_method;
@@ -179,4 +179,3 @@ log_transport_tls_free_method(LogTransport *s)
   tls_session_free(self->tls_session);
   log_transport_free_method(s);
 }
-


### PR DESCRIPTION
syslog-ng does not call `SSL_connect()` or `SSL_do_handshake()`, so the first `SSL_read()` or `SSL_write()` call is responsible for negotiating the TLS session. Nevertheless, the initial IO `cond` should be `0`, because the `LogProto` layer should choose the initial IO direction.

In case TLS renegotiation is required, OpenSSL returns an error (`SSL_ERROR_WANT_READ` or `SSL_ERROR_WANT_WRITE`). In this case, the same read/write function must be invoked after a IO readiness notification.

With all that being said, the initial `G_IO_IN | G_IO_OUT` transport-level IO-cond is not necessary and even harmful:

If the connection is lost in a TLS destination before sending the first message, an infinite IO loop starts in the main thread. This is because ivykis reports readiness for reading, but we won't read anything as the `LogProto` instance is not in the correct state.

Detecting the breakdown of the connection was not possible because we would have to read from the socket first, and only then could we notice about the closed connection.

Fixes #3009