### PR TITLE
WIP: Light: SyslogNgConfig refactor part 2

### DIFF
--- a/tests/python_functional/src/syslog_ng_config/renderer.py
+++ b/tests/python_functional/src/syslog_ng_config/renderer.py
@@ -61,19 +61,6 @@ class ConfigRenderer(object):
             self.__syslog_ng_config_content += "    {}({});\n".format(option_name, option_value)
         self.__syslog_ng_config_content += globals_options_footer
 
-    def __render_positional_options(self, positional_parameters):
-        for parameter in positional_parameters:
-            self.__syslog_ng_config_content += "        {}\n".format(str(parameter))
-
-    def __render_driver_options(self, driver_options):
-        for option_name, option_value in driver_options.items():
-            if isinstance(option_value, dict):
-                self.__syslog_ng_config_content += "        {}(\n".format(option_name)
-                self.__render_driver_options(option_value)
-                self.__syslog_ng_config_content += "        )\n"
-            else:
-                self.__syslog_ng_config_content += "        {}({})\n".format(option_name, option_value)
-
     def __render_statement_groups(self):
         for statement_group in self.__syslog_ng_config["statement_groups"]:
             # statement header
@@ -86,8 +73,7 @@ class ConfigRenderer(object):
                 self.__syslog_ng_config_content += "    {} (\n".format(statement.driver_name)
 
                 # driver options
-                self.__render_positional_options(statement.positional_parameters)
-                self.__render_driver_options(statement.options)
+                self.__syslog_ng_config_content += statement.render_driver_options()
 
                 # driver footer
                 self.__syslog_ng_config_content += "    );\n"

--- a/tests/python_functional/src/syslog_ng_config/statements/config_statement.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/config_statement.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2015-2019 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+
+DEFAULT_DRIVER_INDENTATION = " " * 2 * 4
+
+
+class ConfigStatement(object):
+    def __init__(self):
+        self.rendered_driver_config = None
+
+    def render_driver_options(self):
+        self.rendered_driver_config = ""
+        self.render_positional_options()
+        self.render_options(self.options)
+        return self.rendered_driver_config
+
+    def render_positional_options(self):
+        if self.positional_parameters and self.positional_parameters[0]:
+            self.rendered_driver_config += "{}{}\n".format(DEFAULT_DRIVER_INDENTATION, self.positional_parameters[0])
+
+    def render_options(self, options, indentation=DEFAULT_DRIVER_INDENTATION):
+        for option_name, option_value in options.items():
+            if isinstance(option_value, dict):
+                inner_block_indentation = " " * 4
+                self.rendered_driver_config += "{}{}(\n".format(indentation, option_name)
+                self.render_options(option_value, indentation=indentation + inner_block_indentation)
+                self.rendered_driver_config += "{})\n".format(indentation)
+            else:
+                self.rendered_driver_config += "{}{}({})\n".format(indentation, option_name, option_value)

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/destination_driver.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/destination_driver.py
@@ -27,7 +27,7 @@ from src.syslog_ng_config.statements.destinations.destination_reader import Dest
 class DestinationDriver(ConfigStatement):
     group_type = "destination"
 
-    def __init__(self, positional_parameters=None, options=None, driver_io_cls=None):
+    def __init__(self, positional_parameters=None, options=None, driver_io_cls=None, line_parser_cls=None):
         if positional_parameters is None:
             positional_parameters = []
         self.positional_parameters = positional_parameters
@@ -36,13 +36,14 @@ class DestinationDriver(ConfigStatement):
         self.options = options
 
         self.driver_io_cls = driver_io_cls
+        self.line_parser_cls = line_parser_cls
         self.destination_reader = None
         self.init_destination_reader()
         super(DestinationDriver, self).__init__()
 
     def init_destination_reader(self):
-        if self.driver_io_cls and self.positional_parameters:
-            self.destination_reader = DestinationReader(self.driver_io_cls)
+        if self.driver_io_cls and self.line_parser_cls and self.positional_parameters:
+            self.destination_reader = DestinationReader(self.driver_io_cls, self.line_parser_cls)
             self.destination_reader.init_driver_io(self.positional_parameters[0])
 
     def read_log(self):

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/destination_driver.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/destination_driver.py
@@ -20,15 +20,31 @@
 # COPYING for details.
 #
 #############################################################################
+from src.syslog_ng_config.statements.destinations.destination_reader import DestinationReader
 
 
 class DestinationDriver(object):
     group_type = "destination"
 
-    def __init__(self, positional_parameters=None, options=None):
+    def __init__(self, positional_parameters=None, options=None, driver_io_cls=None):
         if positional_parameters is None:
             positional_parameters = []
         self.positional_parameters = positional_parameters
         if options is None:
             options = {}
         self.options = options
+
+        self.driver_io_cls = driver_io_cls
+        self.destination_reader = None
+        self.init_destination_reader()
+
+    def init_destination_reader(self):
+        if self.driver_io_cls and self.positional_parameters:
+            self.destination_reader = DestinationReader(self.driver_io_cls)
+            self.destination_reader.init_driver_io(self.positional_parameters[0])
+
+    def read_log(self):
+        return self.destination_reader.read_logs(self.positional_parameters[0], counter=1)[0]
+
+    def read_logs(self, counter):
+        return self.destination_reader.read_logs(self.positional_parameters[0], counter=counter)

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/destination_driver.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/destination_driver.py
@@ -44,7 +44,13 @@ class DestinationDriver(object):
             self.destination_reader.init_driver_io(self.positional_parameters[0])
 
     def read_log(self):
-        return self.destination_reader.read_logs(self.positional_parameters[0], counter=1)[0]
+        if self.destination_reader:
+            return self.destination_reader.read_logs(counter=1)[0]
+        else:
+            raise ValueError("DestinationReader was not initialized")
 
     def read_logs(self, counter):
-        return self.destination_reader.read_logs(self.positional_parameters[0], counter=counter)
+        if self.destination_reader:
+            return self.destination_reader.read_logs(counter=counter)
+        else:
+            raise ValueError("DestinationReader was not initialized")

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/destination_driver.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/destination_driver.py
@@ -20,10 +20,11 @@
 # COPYING for details.
 #
 #############################################################################
+from src.syslog_ng_config.statements.config_statement import ConfigStatement
 from src.syslog_ng_config.statements.destinations.destination_reader import DestinationReader
 
 
-class DestinationDriver(object):
+class DestinationDriver(ConfigStatement):
     group_type = "destination"
 
     def __init__(self, positional_parameters=None, options=None, driver_io_cls=None):
@@ -37,6 +38,7 @@ class DestinationDriver(object):
         self.driver_io_cls = driver_io_cls
         self.destination_reader = None
         self.init_destination_reader()
+        super(DestinationDriver, self).__init__()
 
     def init_destination_reader(self):
         if self.driver_io_cls and self.positional_parameters:

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/destination_reader.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/destination_reader.py
@@ -23,14 +23,14 @@
 import logging
 
 from src.message_reader.message_reader import MessageReader
-from src.message_reader.single_line_parser import SingleLineParser
 
 logger = logging.getLogger(__name__)
 
 
 class DestinationReader(object):
-    def __init__(self, driver_io_cls):
+    def __init__(self, driver_io_cls, line_parser_cls):
         self.__driver_io_cls = driver_io_cls
+        self.__line_parser_cls = line_parser_cls
 
         self.__message_reader = None
         self.__saved_driver_io_parameter = None
@@ -43,7 +43,7 @@ class DestinationReader(object):
 
     def __construct_message_reader(self):
         self.__driver_io.wait_for_creation()
-        self.__message_reader = MessageReader(self.__driver_io.read, SingleLineParser())
+        self.__message_reader = MessageReader(self.__driver_io.read, self.__line_parser_cls())
 
     def read_logs(self, counter):
         self.__construct_message_reader()

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/destination_reader.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/destination_reader.py
@@ -29,25 +29,25 @@ logger = logging.getLogger(__name__)
 
 
 class DestinationReader(object):
-    def __init__(self, IOClass):
-        self.__IOClass = IOClass
-        self.__reader = None
+    def __init__(self, driver_io_cls):
+        self.__driver_io_cls = driver_io_cls
 
+        self.__message_reader = None
         self.__saved_driver_io_parameter = None
         self.__driver_io = None
 
     def init_driver_io(self, driver_io_parameter):
         if self.__saved_driver_io_parameter != driver_io_parameter:
             self.__saved_driver_io_parameter = driver_io_parameter
-            self.__driver_io = self.__IOClass(driver_io_parameter)
+            self.__driver_io = self.__driver_io_cls(driver_io_parameter)
 
     def __construct_message_reader(self):
         self.__driver_io.wait_for_creation()
-        self.__reader = MessageReader(self.__driver_io.read, SingleLineParser())
+        self.__message_reader = MessageReader(self.__driver_io.read, SingleLineParser())
 
     def read_logs(self, path, counter):
         self.__construct_message_reader()
-        messages = self.__reader.pop_messages(counter)
+        messages = self.__message_reader.pop_messages(counter)
         read_description = "Content has been read from\nresource: {}\ncontent: {}\n".format(path, messages)
         logger.info(read_description)
         return messages

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/destination_reader.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/destination_reader.py
@@ -33,14 +33,20 @@ class DestinationReader(object):
         self.__IOClass = IOClass
         self.__reader = None
 
+        self.__saved_driver_io_parameter = None
+        self.__driver_io = None
+
+    def init_driver_io(self, driver_io_parameter):
+        if self.__saved_driver_io_parameter != driver_io_parameter:
+            self.__saved_driver_io_parameter = driver_io_parameter
+            self.__driver_io = self.__IOClass(driver_io_parameter)
+
+    def __construct_message_reader(self):
+        self.__driver_io.wait_for_creation()
+        self.__reader = MessageReader(self.__driver_io.read, SingleLineParser())
+
     def read_logs(self, path, counter):
-        if not self.__reader:
-            io = self.__IOClass(path)
-            io.wait_for_creation()
-            message_reader = MessageReader(
-                io.read, SingleLineParser(),
-            )
-            self.__reader = message_reader
+        self.__construct_message_reader()
         messages = self.__reader.pop_messages(counter)
         read_description = "Content has been read from\nresource: {}\ncontent: {}\n".format(path, messages)
         logger.info(read_description)

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/destination_reader.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/destination_reader.py
@@ -45,9 +45,9 @@ class DestinationReader(object):
         self.__driver_io.wait_for_creation()
         self.__message_reader = MessageReader(self.__driver_io.read, SingleLineParser())
 
-    def read_logs(self, path, counter):
+    def read_logs(self, counter):
         self.__construct_message_reader()
         messages = self.__message_reader.pop_messages(counter)
-        read_description = "Content has been read from\nresource: {}\ncontent: {}\n".format(path, messages)
+        read_description = "Content has been read from\nresource: {}\ncontent: {}\n".format(self.__saved_driver_io_parameter, messages)
         logger.info(read_description)
         return messages

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/file_destination.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/file_destination.py
@@ -24,6 +24,7 @@ from pathlib2 import Path
 
 import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.driver_io.file.file_io import FileIO
+from src.message_reader.single_line_parser import SingleLineParser
 from src.syslog_ng_config.statements.destinations.destination_driver import DestinationDriver
 
 
@@ -31,7 +32,7 @@ class FileDestination(DestinationDriver):
     def __init__(self, file_name, **options):
         self.driver_name = "file"
         self.path = Path(tc_parameters.WORKING_DIR, file_name)
-        super(FileDestination, self).__init__([self.path], options, FileIO)
+        super(FileDestination, self).__init__([self.path], options, FileIO, SingleLineParser)
 
     def get_path(self):
         return self.path

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/file_destination.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/file_destination.py
@@ -25,21 +25,13 @@ from pathlib2 import Path
 import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.driver_io.file.file_io import FileIO
 from src.syslog_ng_config.statements.destinations.destination_driver import DestinationDriver
-from src.syslog_ng_config.statements.destinations.destination_reader import DestinationReader
 
 
 class FileDestination(DestinationDriver):
     def __init__(self, file_name, **options):
         self.driver_name = "file"
         self.path = Path(tc_parameters.WORKING_DIR, file_name)
-        super(FileDestination, self).__init__([self.path], options)
-        self.destination_reader = DestinationReader(FileIO)
+        super(FileDestination, self).__init__([self.path], options, FileIO)
 
     def get_path(self):
         return self.path
-
-    def read_log(self):
-        return self.destination_reader.read_logs(self.get_path(), counter=1)[0]
-
-    def read_logs(self, counter):
-        return self.destination_reader.read_logs(self.get_path(), counter=counter)

--- a/tests/python_functional/src/syslog_ng_config/statements/filters/filter.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/filters/filter.py
@@ -20,12 +20,15 @@
 # COPYING for details.
 #
 #############################################################################
+from src.syslog_ng_config.statements.config_statement import ConfigStatement
 
 
-class Filter(object):
+class Filter(ConfigStatement):
     group_type = "filter"
 
     def __init__(self, **options):
         self.options = options
         self.driver_name = ""
         self.positional_parameters = []
+
+        super(Filter, self).__init__()

--- a/tests/python_functional/src/syslog_ng_config/statements/parsers/parser.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/parsers/parser.py
@@ -20,12 +20,15 @@
 # COPYING for details.
 #
 #############################################################################
+from src.syslog_ng_config.statements.config_statement import ConfigStatement
 
 
-class Parser(object):
+class Parser(ConfigStatement):
     group_type = "parser"
 
     def __init__(self, driver_name, **options):
         self.driver_name = driver_name
         self.options = options
         self.positional_parameters = []
+
+        super(Parser, self).__init__()

--- a/tests/python_functional/src/syslog_ng_config/statements/sources/file_source.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/sources/file_source.py
@@ -25,21 +25,16 @@ from pathlib2 import Path
 import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.driver_io.file.file_io import FileIO
 from src.syslog_ng_config.statements.sources.source_driver import SourceDriver
-from src.syslog_ng_config.statements.sources.source_writer import SourceWriter
 
 
 class FileSource(SourceDriver):
     def __init__(self, file_name, **options):
         self.driver_name = "file"
         self.path = Path(tc_parameters.WORKING_DIR, file_name)
-        super(FileSource, self).__init__([self.path], options)
-        self.source_writer = SourceWriter(FileIO)
+        super(FileSource, self).__init__([self.path], options, FileIO)
 
     def get_path(self):
         return self.path
 
     def set_path(self, pathname):
         self.path = Path(tc_parameters.WORKING_DIR, pathname)
-
-    def write_log(self, formatted_log, counter=1):
-        self.source_writer.write_log(self.get_path(), formatted_log, counter=counter)

--- a/tests/python_functional/src/syslog_ng_config/statements/sources/source_driver.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/sources/source_driver.py
@@ -44,4 +44,7 @@ class SourceDriver(object):
             self.source_writer.init_driver_io(self.positional_parameters[0])
 
     def write_log(self, formatted_log, counter=1):
-        self.source_writer.write_log(self.positional_parameters[0], formatted_log, counter=counter)
+        if self.source_writer:
+            self.source_writer.write_log(formatted_log, counter=counter)
+        else:
+            raise ValueError("SourceWriter was not initialized")

--- a/tests/python_functional/src/syslog_ng_config/statements/sources/source_driver.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/sources/source_driver.py
@@ -20,10 +20,11 @@
 # COPYING for details.
 #
 #############################################################################
+from src.syslog_ng_config.statements.config_statement import ConfigStatement
 from src.syslog_ng_config.statements.sources.source_writer import SourceWriter
 
 
-class SourceDriver(object):
+class SourceDriver(ConfigStatement):
     group_type = "source"
 
     def __init__(self, positional_parameters=None, options=None, driver_io_cls=None):
@@ -37,6 +38,7 @@ class SourceDriver(object):
         self.driver_io_cls = driver_io_cls
         self.source_writer = None
         self.init_source_writer()
+        super(SourceDriver, self).__init__()
 
     def init_source_writer(self):
         if self.driver_io_cls and self.positional_parameters:

--- a/tests/python_functional/src/syslog_ng_config/statements/sources/source_driver.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/sources/source_driver.py
@@ -20,15 +20,28 @@
 # COPYING for details.
 #
 #############################################################################
+from src.syslog_ng_config.statements.sources.source_writer import SourceWriter
 
 
 class SourceDriver(object):
     group_type = "source"
 
-    def __init__(self, positional_parameters=None, options=None):
+    def __init__(self, positional_parameters=None, options=None, driver_io_cls=None):
         if positional_parameters is None:
             positional_parameters = []
         self.positional_parameters = positional_parameters
         if options is None:
             options = {}
         self.options = options
+
+        self.driver_io_cls = driver_io_cls
+        self.source_writer = None
+        self.init_source_writer()
+
+    def init_source_writer(self):
+        if self.driver_io_cls and self.positional_parameters:
+            self.source_writer = SourceWriter(self.driver_io_cls)
+            self.source_writer.init_driver_io(self.positional_parameters[0])
+
+    def write_log(self, formatted_log, counter=1):
+        self.source_writer.write_log(self.positional_parameters[0], formatted_log, counter=counter)

--- a/tests/python_functional/src/syslog_ng_config/statements/sources/source_writer.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/sources/source_writer.py
@@ -25,19 +25,19 @@ logger = logging.getLogger(__name__)
 
 
 class SourceWriter(object):
-    def __init__(self, IOClass):
-        self.__IOClass = IOClass
-        self.__writer = None
+    def __init__(self, driver_io_cls):
+        self.__driver_io_cls = driver_io_cls
 
+        self.__driver_io = None
         self.__saved_driver_io_parameter = None
 
     def init_driver_io(self, driver_io_parameter):
         if self.__saved_driver_io_parameter != driver_io_parameter:
             self.__saved_driver_io_parameter = driver_io_parameter
-            self.__writer = self.__IOClass(driver_io_parameter)
+            self.__driver_io = self.__driver_io_cls(driver_io_parameter)
 
     def write_log(self, path, formatted_log, counter):
         for __i in range(0, counter):
-            self.__writer.write(formatted_log)
+            self.__driver_io.write(formatted_log)
         written_description = "Content has been written to\nresource: {}\nnumber of times: {}\ncontent: {}\n".format(path, counter, formatted_log)
         logger.info(written_description)

--- a/tests/python_functional/src/syslog_ng_config/statements/sources/source_writer.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/sources/source_writer.py
@@ -36,8 +36,8 @@ class SourceWriter(object):
             self.__saved_driver_io_parameter = driver_io_parameter
             self.__driver_io = self.__driver_io_cls(driver_io_parameter)
 
-    def write_log(self, path, formatted_log, counter):
+    def write_log(self, formatted_log, counter):
         for __i in range(0, counter):
             self.__driver_io.write(formatted_log)
-        written_description = "Content has been written to\nresource: {}\nnumber of times: {}\ncontent: {}\n".format(path, counter, formatted_log)
+        written_description = "Content has been written to\nresource: {}\nnumber of times: {}\ncontent: {}\n".format(self.__saved_driver_io_parameter, counter, formatted_log)
         logger.info(written_description)

--- a/tests/python_functional/src/syslog_ng_config/statements/sources/source_writer.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/sources/source_writer.py
@@ -29,12 +29,14 @@ class SourceWriter(object):
         self.__IOClass = IOClass
         self.__writer = None
 
-    def __construct_writer(self, path):
-        if not self.__writer:
-            self.__writer = self.__IOClass(path)
+        self.__saved_driver_io_parameter = None
+
+    def init_driver_io(self, driver_io_parameter):
+        if self.__saved_driver_io_parameter != driver_io_parameter:
+            self.__saved_driver_io_parameter = driver_io_parameter
+            self.__writer = self.__IOClass(driver_io_parameter)
 
     def write_log(self, path, formatted_log, counter):
-        self.__construct_writer(path)
         for __i in range(0, counter):
             self.__writer.write(formatted_log)
         written_description = "Content has been written to\nresource: {}\nnumber of times: {}\ncontent: {}\n".format(path, counter, formatted_log)

--- a/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
@@ -74,8 +74,8 @@ class SyslogNgConfig(object):
     def update_global_options(self, **options):
         self.__syslog_ng_config["global_options"].update(options)
 
-    def create_file_source(self, **options):
-        return FileSource(**options)
+    def create_file_source(self, file_name=None, **options):
+        return FileSource(file_name, **options)
 
     def create_example_msg_generator_source(self, **options):
         return ExampleMsgGeneratorSource(**options)
@@ -89,8 +89,8 @@ class SyslogNgConfig(object):
     def create_syslog_parser(self, **options):
         return Parser("syslog-parser", **options)
 
-    def create_file_destination(self, **options):
-        return FileDestination(**options)
+    def create_file_destination(self, file_name=None, **options):
+        return FileDestination(file_name, **options)
 
     def create_logpath(self, statements=None, flags=None):
         logpath = self.__create_logpath_with_conversion(statements, flags)


### PR DESCRIPTION
Reasons behind the commits and the PR:
- After all we have decided to split this PR again (because I already not yet finished one part)
- The main goal behind this PR set to define (flexible) external and internal API for SyslogNgConfig and the related (drivers, helpers) classes.
- Why this PR needed:
 - Until now there were only a few supported drivers: file source, file destination, example message generator, filter, app-parser, syslog-parser
 - To support other drivers (which can be very different) we should prepare the API for those.

In details:
- After this PR what will be the scopes of config related layers (classes):

- ConfigStatement() class
    - in class hierarchy: this class is a root parent of every statement classes
    - the main scope of this class (in the future):
        - this class will manage those things which are generally related to any config statements:
            - provide an OptionHandler() for every child class (not yet added in this PR)
            - render options for config
    - this class does not exist before

- SourceDriver(), DestinationDriver(), Filter(), Parser() classes
    - in class hierarchy: this classes are child classes of ConfigStatement() class
    - the main scope of this classes (in the future):
        - everything inherited from parent (ConfigStatement()) class
        - this classes will implement functionalities which are related only this layer:
            - instantiate reader and writer classes (SourceWriter(), DestinationReader()) in constructor time
            - provide write_log() and read_log() as wrappers
    - changes:
        - SourceDriver() class will construct a SourceWriter() instance (was moved from FileSource()), (DriverIO information will be passed from child class)
        - DestinationDriver() class will construct a DestinationReader() instance (was moved from FileDestination()), (DriverIO information will be passed from child class)
        - SourceDriver() will provide a write_log() wrapper (was moved from FileSource())
        - DestinationDriver() will provide a read_log() wrapper (was moved from FileDestination())


- FileSource(), FileDestination(), ExampleMessageGenerator() classes
    - in class hierarchy: this classes are child classes of SourceDriver() and DestinationDriver() classes
    - the main scope of this classes (in the future):
        - everything inherited from parents
        - this classes will implement functionalities which are related only for each drivers:
            - setting driver default (mandatory) values
            - setting option formatters ("file_path" -> should prefixed with actual working dir)
            - administratively defines the driver name, and passes the corresponding DriverIO object to the parent
    - changes:
        - move read_log() and write_log() related wrappers from this classes to the parent
        - move DestinationReader() and SourceWriter() compositions to the parent
        - pass DriverIO class to the parent class
        - add a general OptionHandler() composition to this class


- SyslogNgConfig() class
    - in class hierarchy: this is a separate class
    - the main scope of this class:
        - provide create_... like methods for drivers, filters, parsers
        - update global options
        - link drivers, filters, parsers into top level (or inner) logpath
    - changes:
        - the `file_name` parameter was explicilty added to the create_file_source() and create_file_destination() methods.
        Internally this parameter was already taken out from the passed options dict. This change will make cleaner how we
        would like to use this parameter internally, and also addes a hint for those who would like to TAB out the internal
        name of the positional option.

- SourceWriter() and DestinationReader() classes:
    - in class hierarchy: this classes are instantiated in SourceDriver() and DestinationReader() classes in constructor time
    - the main scope of this classes:
        - instantiate specific DriverIO classes
        - provide read_log() and write_log() methods
    - changes:
        - init_driver_io() method was added to be abel to instantiate DriverIO class separately

Todo:
- [x] : Administratively to the first comment: Summarize the goal of the commits


