### PR TITLE
config_database: speed improvement, new features

### DIFF
--- a/contrib/config_option_database/syslog-ng-cfg-db.py
+++ b/contrib/config_option_database/syslog-ng-cfg-db.py
@@ -64,7 +64,7 @@ def merge_blocks_stored_as_options(db):
 
 
 def build_db():
-    db = {'source': {}, 'destination': {}}
+    db = {}
     for context, driver, keyword, arguments, parents in get_driver_options():
         arguments = list(arguments)
         db.setdefault(context, {})

--- a/contrib/config_option_database/utils/BisonGraph.py
+++ b/contrib/config_option_database/utils/BisonGraph.py
@@ -60,6 +60,15 @@ class BisonGraph():
             return False
         return True
 
+    def add_arc(self, from_node, to_node):
+        if self.is_rule(from_node) and not self.is_rule(to_node):
+            index = len(self.get_children(from_node))
+            self.graph.add_edge(from_node, to_node, index=index)
+        elif not self.is_rule(from_node) and self.is_rule(to_node):
+            self.graph.add_edge(from_node, to_node)
+        else:
+            raise Exception('Arc must be added from non-rule to rule or rule to non-rule: ' + from_node + '->' + to_node)
+
     def make_terminal(self, node):
         children = self.get_children(node)
         for child in children:

--- a/contrib/config_option_database/utils/ConfigOptions.py
+++ b/contrib/config_option_database/utils/ConfigOptions.py
@@ -38,13 +38,29 @@ def _make_types_terminal(graph):
         'template_content',
         'yesno'
     ]
+
+    for node in types:
+        graph.make_terminal(node)
+
+
+def _process_helpers(graph):
     helpers = [
+        'inner_dest',
+        'inner_source',
         'filter_content',
         'parser_content'
     ]
+    connections = [
+        ('inner_dest', 'LL_CONTEXT_INNER_DEST'),
+        ('inner_source', 'LL_CONTEXT_INNER_SRC'),
+    ]
 
-    for node in types + helpers:
+    for node in helpers:
         graph.make_terminal(node)
+    for from_node, to_node in connections:
+        for parent in graph.get_parents(to_node):
+            graph.add_arc(from_node, parent)
+        graph.remove(to_node)
 
 
 def _remove_code_blocks(graph):
@@ -64,6 +80,7 @@ def get_driver_options():
         merge_grammars(yaccfile.name)
         graph = BisonGraph(yaccfile.name)
     _make_types_terminal(graph)
+    _process_helpers(graph)
     _remove_code_blocks(graph)
     _remove_ifdef(graph)
     not_empty = filter(lambda path: len(path) > 0, graph.get_paths())

--- a/contrib/config_option_database/utils/ConfigOptions.py
+++ b/contrib/config_option_database/utils/ConfigOptions.py
@@ -67,7 +67,7 @@ def get_driver_options():
     _remove_code_blocks(graph)
     _remove_ifdef(graph)
     not_empty = filter(lambda path: len(path) > 0, graph.get_paths())
-    paths = filter(lambda path: path[0] in ['LL_CONTEXT_SOURCE', 'LL_CONTEXT_DESTINATION'], not_empty)
+    paths = filter(lambda path: path[0] in ['LL_CONTEXT_SOURCE', 'LL_CONTEXT_DESTINATION', 'LL_CONTEXT_PARSER'], not_empty)
     options = set()
     for path in paths:
         options |= path_to_options(path)

--- a/contrib/config_option_database/utils/MergeYm.py
+++ b/contrib/config_option_database/utils/MergeYm.py
@@ -27,11 +27,12 @@ from sys import argv
 
 def get_grammar_files():
     root_dir = Path(__file__).resolve().parents[3]
+    exclude = ['rewrite-expr-grammar.ym']
     files = []
     files.extend(list((root_dir / 'modules').rglob('*.ym')))
     files.extend(list((root_dir / 'lib').rglob('*.ym')))
     files.append(root_dir / 'lib' / 'cfg-grammar.y')
-    return files
+    return list(filter(lambda f: f.name not in exclude, files))
 
 
 def merge_grammars(output_filepath):

--- a/contrib/config_option_database/utils/MergeYm.py
+++ b/contrib/config_option_database/utils/MergeYm.py
@@ -27,7 +27,7 @@ from sys import argv
 
 def get_grammar_files():
     root_dir = Path(__file__).resolve().parents[3]
-    exclude = ['rewrite-expr-grammar.ym']
+    exclude = ['rewrite-expr-grammar.ym', 'native-grammar.ym']
     files = []
     files.extend(list((root_dir / 'modules').rglob('*.ym')))
     files.extend(list((root_dir / 'lib').rglob('*.ym')))

--- a/contrib/config_option_database/utils/test/test_BisonGraph.py
+++ b/contrib/config_option_database/utils/test/test_BisonGraph.py
@@ -135,3 +135,28 @@ def test_get_paths(graph):
         ()
     ]
     assert graph.get_paths() == expected
+
+
+@pytest.mark.parametrize(
+    'from_node,to_node',
+    [
+        ('3', 'test1'),
+        ('test2', '4')
+    ]
+)
+def test_add_arc(graph, from_node, to_node):
+    graph.add_arc(from_node, to_node)
+    assert to_node in graph.get_children(from_node)
+
+
+@pytest.mark.parametrize(
+    'from_node,to_node',
+    [
+        ('3', '4'),
+        ('test1', 'test2')
+    ]
+)
+def test_invalid_add_arc(graph, from_node, to_node):
+    with pytest.raises(Exception) as e:
+        graph.add_arc('3', '4')
+    assert 'Arc must be added from non-rule to rule or rule to non-rule:' in str(e.value)

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1174,8 +1174,7 @@ driver_option
         : KW_PERSIST_NAME '(' string ')' { log_pipe_set_persist_name(&last_driver->super, $3); free($3); }
         ;
 
-/* All source drivers should incorporate this rule, implies driver_option */
-source_driver_option
+inner_source
         : LL_IDENTIFIER
           {
             Plugin *p;
@@ -1198,16 +1197,16 @@ source_driver_option
                 CHECK_ERROR(TRUE, @1, "Error while registering the plugin %s in this destination", $1);
               }
           }
+        ;
+
+/* All source drivers should incorporate this rule, implies driver_option */
+source_driver_option
+        : inner_source
         | driver_option
         ;
 
-/* implies driver_option */
-dest_driver_option
-        /* NOTE: plugins need to set "last_driver" in order to incorporate this rule in their grammar */
-
-	: KW_LOG_FIFO_SIZE '(' positive_integer ')'	{ ((LogDestDriver *) last_driver)->log_fifo_size = $3; }
-	| KW_THROTTLE '(' nonnegative_integer ')'         { ((LogDestDriver *) last_driver)->throttle = $3; }
-        | LL_IDENTIFIER
+inner_dest
+        : LL_IDENTIFIER
           {
             Plugin *p;
             gint context = LL_CONTEXT_INNER_DEST;
@@ -1229,6 +1228,15 @@ dest_driver_option
                 CHECK_ERROR(TRUE, @1, "Error while registering the plugin %s in this destination", $1);
               }
           }
+        ;
+
+/* implies driver_option */
+dest_driver_option
+        /* NOTE: plugins need to set "last_driver" in order to incorporate this rule in their grammar */
+
+	: KW_LOG_FIFO_SIZE '(' positive_integer ')'	{ ((LogDestDriver *) last_driver)->log_fifo_size = $3; }
+	| KW_THROTTLE '(' nonnegative_integer ')'         { ((LogDestDriver *) last_driver)->throttle = $3; }
+        | inner_dest
         | driver_option
         ;
 


### PR DESCRIPTION
### This PR introduces yet another 2 changes
---
`process parsers`
 * valid drivers are:
```
$ ./syslog-ng-cfg-db.py -c parser
Drivers of context "parser":
  add-contextual-data
  csv-parser
  date-parser
  db-parser
  geoip2
  grouping-by
  json-parser
  kv-parser
  linux-audit-parser
  map-value-pairs
  python
  snmptrapd-parser
  syslog-parser
  tags-parser
  xml
Print the options of DRIVER with `--context parser --driver DRIVER`.
```
---
`support inner_source/dst`
 * Process `diskq` and `hook-commands` inside sources or destinations.