### PR TITLE
response-handler: leftover fixes

### DIFF
--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -260,7 +260,7 @@ _default_1XX(HTTPDestinationWorker *self, const gchar *url, glong http_code)
 {
   HTTPDestinationDriver *owner = (HTTPDestinationDriver *) self->super.owner;
   msg_error("Server returned with a 1XX (continuation) status code, which was not handled by curl. ",
-            evt_tag_str("url", owner->url),
+            evt_tag_str("url", url),
             evt_tag_int("status_code", http_code),
             evt_tag_str("driver", owner->super.super.super.id),
             log_pipe_location_tag(&owner->super.super.super.super));
@@ -315,7 +315,7 @@ _default_5XX(HTTPDestinationWorker *self, const gchar *url, glong http_code)
 {
   HTTPDestinationDriver *owner = (HTTPDestinationDriver *) self->super.owner;
   msg_notice("Server returned with a 5XX (server errors) status code, which indicates server failure.",
-             evt_tag_str("url", owner->url),
+             evt_tag_str("url", url),
              evt_tag_int("status_code", http_code),
              evt_tag_str("driver", owner->super.super.super.id),
              log_pipe_location_tag(&owner->super.super.super.super));
@@ -415,7 +415,7 @@ _custom_map_http_result(HTTPDestinationWorker *self, const gchar *url, HttpRespo
     case HTTP_RESULT_SUCCESS:
       msg_debug("http: handled by response_action",
                 evt_tag_str("action", "success"),
-                evt_tag_str("url", owner->url),
+                evt_tag_str("url", url),
                 evt_tag_int("status_code", http_code),
                 evt_tag_str("driver", owner->super.super.super.id),
                 log_pipe_location_tag(&owner->super.super.super.super));
@@ -424,7 +424,7 @@ _custom_map_http_result(HTTPDestinationWorker *self, const gchar *url, HttpRespo
     case HTTP_RESULT_RETRY:
       msg_notice("http: handled by response_action",
                  evt_tag_str("action", "retry"),
-                 evt_tag_str("url", owner->url),
+                 evt_tag_str("url", url),
                  evt_tag_int("status_code", http_code),
                  evt_tag_str("driver", owner->super.super.super.id),
                  log_pipe_location_tag(&owner->super.super.super.super));
@@ -433,7 +433,7 @@ _custom_map_http_result(HTTPDestinationWorker *self, const gchar *url, HttpRespo
     case HTTP_RESULT_DROP:
       msg_notice("http: handled by response_action",
                  evt_tag_str("action", "drop"),
-                 evt_tag_str("url", owner->url),
+                 evt_tag_str("url", url),
                  evt_tag_int("status_code", http_code),
                  evt_tag_str("driver", owner->super.super.super.id),
                  log_pipe_location_tag(&owner->super.super.super.super));
@@ -442,7 +442,7 @@ _custom_map_http_result(HTTPDestinationWorker *self, const gchar *url, HttpRespo
     case HTTP_RESULT_DISCONNECT:
       msg_notice("http: handled by response_action",
                  evt_tag_str("action", "disconnect"),
-                 evt_tag_str("url", owner->url),
+                 evt_tag_str("url", url),
                  evt_tag_int("status_code", http_code),
                  evt_tag_str("driver", owner->super.super.super.id),
                  log_pipe_location_tag(&owner->super.super.super.super));

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -299,7 +299,7 @@ _default_4XX(HTTPDestinationWorker *self, const gchar *url, glong http_code)
              evt_tag_str("driver", owner->super.super.super.id),
              log_pipe_location_tag(&owner->super.super.super.super));
 
-  static glong errors[] = {409, 428, -1};
+  static glong errors[] = {428, -1};
   if (_find_http_code_in_list(http_code, errors))
     return LTR_ERROR;
 

--- a/modules/http/response-handler.c
+++ b/modules/http/response-handler.c
@@ -55,7 +55,7 @@ _free_entry(HttpResponseHandler *self)
 HttpResponseHandlers *
 http_response_handlers_new(void)
 {
-  return g_hash_table_new_full(g_int_hash, g_int_equal, g_free, (GDestroyNotify)_free_entry);
+  return g_hash_table_new_full(g_int_hash, g_int_equal, NULL, (GDestroyNotify)_free_entry);
 }
 
 void
@@ -76,17 +76,7 @@ void
 http_response_handlers_insert(HttpResponseHandlers *self, HttpResponseHandler *response_handler)
 {
   HttpResponseHandler *clone = _clone(response_handler);
-
-  /* It migth be tempting to use status code from the clone, hence we
-  neither need to allocate a gint, nor need a key free function in the
-  hashtable. The problem is, when glib overwrites the value behind the
-  same key, by default it does not replace the old key with the new,
-  only the value changes. In our case, the value will be deallocated,
-  hence the key in the hashtable becomes invalid. */
-
-  gint *status_code = g_new(gint, 1);
-  *status_code = clone->status_code;
-  g_hash_table_insert(self, status_code, clone);
+  g_hash_table_replace(self, &clone->status_code, clone);
 }
 
 HttpResponseHandler *

--- a/modules/http/tests/test_http-response_handlers.c
+++ b/modules/http/tests/test_http-response_handlers.c
@@ -32,10 +32,6 @@ Test(response_handlers, test_response_handlers)
 
   HttpResponseHandler response_handler =  { .status_code = 404 };
   http_response_handlers_insert(self, &response_handler);
-  /* While overwriting, g_hash_table handles the key part in an interesting way:
-  it is easy to get use after free. So I add an additional
-  insert in unit test to test the overwrite. */
-  http_response_handlers_insert(self, &response_handler);
   cr_assert(http_response_handlers_lookup(self, 404));
 
   http_response_handlers_free(self);

--- a/modules/http/tests/test_http.c
+++ b/modules/http/tests/test_http.c
@@ -73,7 +73,7 @@ ParameterizedTestParameters(http, http_code_tests)
     { 406, "Not Acceptable", LTR_NOT_CONNECTED},
     { 407, "Proxy Authentication Required", LTR_NOT_CONNECTED},
     { 408, "Request Timeout", LTR_NOT_CONNECTED},
-    { 409, "Conflict", LTR_ERROR},
+    { 409, "Conflict", LTR_NOT_CONNECTED},
     { 410, "Gone", LTR_DROP},
     { 411, "Length Required", LTR_NOT_CONNECTED},
     { 412, "Precondition Failed", LTR_NOT_CONNECTED},

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -89,7 +89,7 @@ modules/java-modules/(dummy|elastic-v2|hdfs|http|kafka|[^/]*$)
 modules/(afamqp|affile|afmongodb|afprog|afsmtp|afsocket|afsql|afstomp|afstreams|afuser|basicfuncs|cef|confgen|cryptofuncs|csvparser|timestamp|diskq|dbparser|geoip2|graphite|json|kvformat|linux-kmsg-format|pacctformat|pseudofile|python|redis|riemann|syslogformat|systemd-journal|getent|system-source|stardate|snmptrapd-parser|xml|openbsd|examples|kafka|snmp-dest|[^/]*$)
 modules/(add-contextual-data|tagsparser|map-value-pairs|hook-commands|appmodel|[^/]*$)
 modules/http/(http-loadbalancer|http-worker)\.[ch]$
-modules/http/(on-error-handler|response-handler)\.[ch]$
+modules/http/response-handler\.[ch]$
 scl
 scripts
 modules/http/tests


### PR DESCRIPTION
This changeset contains fixes left out from https://github.com/syslog-ng/syslog-ng/pull/3007.

Two  notable changes
- The default action for 409 is changed from retry to disconnect.
As I received an offline comment from @gaborznagy, users might resolve the conflict. The problem is not with the message itself. So we should avoid dropping it.
- The error messages contained wrong url, when the response did not return with 2XX code. Actually this is not a regression from #3007, still I wanted to fix.

Signed-off-by: Antal Nemes <antal.nemes@balabit.com>


----

#