### PR TITLE
timeutils: fix month, day name parsing

### DIFF
--- a/lib/timeutils/scan-timestamp.c
+++ b/lib/timeutils/scan-timestamp.c
@@ -89,38 +89,54 @@ scan_month_abbrev(const gchar **buf, gint *left, gint *mon)
         *mon = 5;
       else if (strncasecmp(*buf, "Jul", 3) == 0)
         *mon = 6;
+      else
+        return FALSE;
       break;
     case 'F':
       if (strncasecmp(*buf, "Feb", 3) == 0)
         *mon = 1;
+      else
+        return FALSE;
       break;
     case 'M':
       if (strncasecmp(*buf, "Mar", 3) == 0)
         *mon = 2;
       else if (strncasecmp(*buf, "May", 3) == 0)
         *mon = 4;
+      else
+        return FALSE;
       break;
     case 'A':
       if (strncasecmp(*buf, "Apr", 3) == 0)
         *mon = 3;
       else if (strncasecmp(*buf, "Aug", 3) == 0)
         *mon = 7;
+      else
+        return FALSE;
       break;
     case 'S':
       if (strncasecmp(*buf, "Sep", 3) == 0)
         *mon = 8;
+      else
+        return FALSE;
       break;
     case 'O':
       if (strncasecmp(*buf, "Oct", 3) == 0)
         *mon = 9;
+      else
+        return FALSE;
       break;
     case 'N':
       if (strncasecmp(*buf, "Nov", 3) == 0)
         *mon = 10;
+      else
+        return FALSE;
       break;
     case 'D':
       if (strncasecmp(*buf, "Dec", 3) == 0)
         *mon = 11;
+      else
+        return FALSE;
       break;
     default:
       return FALSE;

--- a/lib/timeutils/scan-timestamp.c
+++ b/lib/timeutils/scan-timestamp.c
@@ -44,24 +44,34 @@ scan_day_abbrev(const gchar **buf, gint *left, gint *wday)
         *wday = 0;
       else if (strncasecmp(*buf, "Sat", 3) == 0)
         *wday = 6;
+      else
+        return FALSE;
       break;
     case 'M':
       if (strncasecmp(*buf, "Mon", 3) == 0)
         *wday = 1;
+      else
+        return FALSE;
       break;
     case 'T':
       if (strncasecmp(*buf, "Tue", 3) == 0)
         *wday = 2;
       else if (strncasecmp(*buf, "Thu", 3) == 0)
         *wday = 4;
+      else
+        return FALSE;
       break;
     case 'W':
       if (strncasecmp(*buf, "Wed", 3) == 0)
         *wday = 3;
+      else
+        return FALSE;
       break;
     case 'F':
       if (strncasecmp(*buf, "Fri", 3) == 0)
         *wday = 5;
+      else
+        return FALSE;
       break;
     default:
       return FALSE;

--- a/lib/timeutils/scan-timestamp.h
+++ b/lib/timeutils/scan-timestamp.h
@@ -37,6 +37,7 @@ gboolean scan_bsd_timestamp(const gchar **buf, gint *left, WallClockTime *wct);
 gboolean scan_rfc3164_timestamp(const guchar **data, gint *length, WallClockTime *wct);
 gboolean scan_rfc5424_timestamp(const guchar **data, gint *length, WallClockTime *wct);
 
+gboolean scan_day_abbrev(const gchar **buf, gint *left, gint *wday);
 gboolean scan_month_abbrev(const gchar **buf, gint *left, gint *mon);
 
 #endif

--- a/lib/timeutils/scan-timestamp.h
+++ b/lib/timeutils/scan-timestamp.h
@@ -37,4 +37,6 @@ gboolean scan_bsd_timestamp(const gchar **buf, gint *left, WallClockTime *wct);
 gboolean scan_rfc3164_timestamp(const guchar **data, gint *length, WallClockTime *wct);
 gboolean scan_rfc5424_timestamp(const guchar **data, gint *length, WallClockTime *wct);
 
+gboolean scan_month_abbrev(const gchar **buf, gint *left, gint *mon);
+
 #endif

--- a/lib/timeutils/tests/test_scan-timestamp.c
+++ b/lib/timeutils/tests/test_scan-timestamp.c
@@ -397,6 +397,57 @@ Test(scan_month_abbrev, invalid_month_names)
   _parse_invalid_month("DeX");
 }
 
+static void
+_parse_valid_day(const gchar *day, const gint expected_day)
+{
+  gint left = strlen(day);
+  gint daynum = -1;
+
+  cr_assert(scan_day_abbrev(&day, &left, &daynum));
+
+  cr_assert_eq(daynum, expected_day);
+  cr_assert_eq(left, 0);
+}
+
+Test(scan_day_abbrev, valid_days)
+{
+  _parse_valid_day("Sun", 0);
+  _parse_valid_day("Mon", 1);
+  _parse_valid_day("Tue", 2);
+  _parse_valid_day("Wed", 3);
+  _parse_valid_day("Thu", 4);
+  _parse_valid_day("Fri", 5);
+  _parse_valid_day("Sat", 6);
+}
+
+static void
+_parse_invalid_day(const gchar *day)
+{
+  gint left = strlen(day);
+  gint original_left = left;
+  gint daynum = -1;
+
+  cr_assert_not(scan_day_abbrev(&day, &left, &daynum));
+
+  cr_assert_eq(daynum, -1);
+  cr_assert_eq(left, original_left);
+}
+
+Test(scan_day_abbrev, invalid_day_names)
+{
+  _parse_invalid_day("");
+  _parse_invalid_day("Set");
+  _parse_invalid_day("abcdefg");
+
+  _parse_invalid_day("SuX");
+  _parse_invalid_day("MoX");
+  _parse_invalid_day("TuX");
+  _parse_invalid_day("WeX");
+  _parse_invalid_day("ThX");
+  _parse_invalid_day("FrX");
+  _parse_invalid_day("SaX");
+}
+
 
 void
 setup(void)

--- a/lib/timeutils/tests/test_scan-timestamp.c
+++ b/lib/timeutils/tests/test_scan-timestamp.c
@@ -335,6 +335,68 @@ Test(parse_timestamp, rfc5424_performance)
   stop_stopwatch_and_display_result(it, "RFC5424 timestamp parsing speed");
 }
 
+static void
+_parse_valid_month(const gchar *month, const gint expected_month)
+{
+  gint left = strlen(month);
+  gint mon = -1;
+
+  cr_assert(scan_month_abbrev(&month, &left, &mon));
+
+  cr_assert_eq(mon, expected_month);
+  cr_assert_eq(left, 0);
+}
+
+Test(scan_month_abbrev, valid_months)
+{
+  _parse_valid_month("Jan", 0);
+  _parse_valid_month("Feb", 1);
+  _parse_valid_month("Mar", 2);
+  _parse_valid_month("Apr", 3);
+  _parse_valid_month("May", 4);
+  _parse_valid_month("Jun", 5);
+  _parse_valid_month("Jul", 6);
+  _parse_valid_month("Aug", 7);
+  _parse_valid_month("Sep", 8);
+  _parse_valid_month("Oct", 9);
+  _parse_valid_month("Nov", 10);
+  _parse_valid_month("Dec", 11);
+}
+
+static void
+_parse_invalid_month(const gchar *month)
+{
+  gint left = strlen(month);
+  gint original_left = left;
+  gint mon = -1;
+
+  cr_assert_not(scan_month_abbrev(&month, &left, &mon));
+
+  cr_assert_eq(mon, -1);
+  cr_assert_eq(left, original_left);
+}
+
+Test(scan_month_abbrev, invalid_month_names)
+{
+  _parse_invalid_month("");
+  _parse_invalid_month("Set");
+  _parse_invalid_month("Jit");
+  _parse_invalid_month("abcdefg");
+
+  _parse_invalid_month("JaX");
+  _parse_invalid_month("FeX");
+  _parse_invalid_month("MaX");
+  _parse_invalid_month("ApX");
+  _parse_invalid_month("MaX");
+  _parse_invalid_month("JuX");
+  _parse_invalid_month("JuX");
+  _parse_invalid_month("AuX");
+  _parse_invalid_month("SeX");
+  _parse_invalid_month("OcX");
+  _parse_invalid_month("NoX");
+  _parse_invalid_month("DeX");
+}
+
 
 void
 setup(void)


### PR DESCRIPTION
Only the first two letter were checked in month (Jan, Feb, ...) and days (Mon, Fri) as they are sufficient to differentiate valid months, days from each  other.