### PR TITLE
dbld: make the shell command customizable

### DIFF
--- a/dbld/rules
+++ b/dbld/rules
@@ -41,6 +41,8 @@ TARBALL=$(BUILD_DIR)/syslog-ng-$(VERSION).tar.gz
 MODE=snapshot
 CONFIGURE_OPTS=--enable-debug --enable-manpages --with-python=2 --prefix=/install $(CONFIGURE_ADD)
 
+DOCKER_SHELL=$(DOCKER) run $(DOCKER_RUN_ARGS) --rm -ti balabit/syslog-ng-$* /source/dbld/shell
+
 -include dbld/rules.conf
 
 help:
@@ -133,7 +135,7 @@ run-%: setup
 
 shell: shell-$(DEFAULT_IMAGE)
 shell-%: setup
-	$(DOCKER) run $(DOCKER_RUN_ARGS) --rm -ti balabit/syslog-ng-$* /source/dbld/shell
+	$(DOCKER_SHELL)
 
 
 images: $(foreach image,$(IMAGES), image-$(image))


### PR DESCRIPTION
There was a discussion about removing the rm parameter from the shell
target. Thank you all for sharing your opinion in the topic! (See #2982)
With this patch you can override the shell command in your rules.conf file,
so everyone can have their own version of it.

my rules.conf for example (copied from the earlier PR):
```
DOCKER_SHELL=$(DOCKER) inspect $* > /dev/null 2>&1; \
  if [ $$? -eq 0 ]; then \
    $(DOCKER) start -ia $*; \
  else \
    $(DOCKER) run $(DOCKER_RUN_ARGS) -ti --name $* balabit/syslog-ng-$* /source/dbld/shell; \
  fi
```
Question for the reviewers:
Is there any other target which could benefit from this approach?
