### PR TITLE
Signal slot connector

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -30,6 +30,7 @@ add_subdirectory(secret-storage)
 add_subdirectory(logthrsource)
 add_subdirectory(logthrdest)
 add_subdirectory(http-auth)
+add_subdirectory(signal-slot-connector)
 
 set(LIB_SUBDIR_HEADERS
     ${ACK_TRACKER_HEADERS}
@@ -54,6 +55,7 @@ set(LIB_SUBDIR_HEADERS
     ${LOGTHRDEST_HEADERS}
     ${LOGTHRSOURCE_HEADERS}
     ${HTTP_AUTH_HEADERS}
+    ${SIGNAL_SLOT_CONNECTOR_HEADERS}
     ${CMAKE_CURRENT_BINARY_DIR}/filter/filter-expr-grammar.h
     ${CMAKE_CURRENT_BINARY_DIR}/rewrite/rewrite-expr-grammar.h
     ${CMAKE_CURRENT_BINARY_DIR}/parser/parser-expr-grammar.h
@@ -247,6 +249,7 @@ set(LIB_SOURCES
     ${TIMEUTILS_SOURCES}
     ${LOGTHRDEST_SOURCES}
     ${LOGTHRSOURCE_SOURCES}
+    ${SIGNAL_SLOT_CONNECTOR_SOURCES}
     ${PROJECT_BINARY_DIR}/lib/cfg-grammar.c
     ${PROJECT_BINARY_DIR}/lib/block-ref-grammar.c
     ${PROJECT_BINARY_DIR}/lib/cfg-lex.c
@@ -359,6 +362,7 @@ install(FILES ${CSV_SCANNER_HEADERS} DESTINATION include/syslog-ng/scanner/csv-s
 install(FILES ${LOGTHRDEST_HEADERS} DESTINATION include/syslog-ng/logthrdest)
 install(FILES ${LOGTHRSOURCE_HEADERS} DESTINATION include/syslog-ng/logthrsource)
 install(FILES ${HTTP_AUTH_HEADERS} DESTINATION include/syslog-ng/http-auth)
+install(FILES ${SIGNAL_SLOT_CONNECTOR_HEADERS} DESTINATION include/syslog-ng/signal-slot-connector)
 
 set(TOOLS
     merge-grammar.py

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -25,6 +25,7 @@ include lib/secret-storage/Makefile.am
 include lib/logthrsource/Makefile.am
 include lib/logthrdest/Makefile.am
 include lib/http-auth/Makefile.am
+include lib/signal-slot-connector/Makefile.am
 
 LSNG_RELEASE		= $(shell echo @PACKAGE_VERSION@ | cut -d. -f1,2)
 
@@ -288,7 +289,8 @@ lib_libsyslog_ng_la_SOURCES		= \
 	$(str_repr_sources)		\
 	$(timeutils_sources)		\
 	$(logthrsource_sources)		\
-	$(logthrdest_sources)
+	$(logthrdest_sources) \
+	$(signal_slot_connector_sources)
 
 lib_libsyslog_ng_la_CFLAGS		= \
 	$(AM_CFLAGS) \

--- a/lib/logpipe.c
+++ b/lib/logpipe.c
@@ -65,6 +65,7 @@ log_pipe_init_instance(LogPipe *self, GlobalConfig *cfg)
   self->pipe_next = NULL;
   self->persist_name = NULL;
   self->plugin_name = NULL;
+  self->signal_slot_connector = signal_slot_connector_new();
 
   /* NOTE: queue == NULL means that this pipe simply forwards the
    * message along the pipeline, e.g. like it has called
@@ -111,6 +112,7 @@ _free(LogPipe *self)
   g_free((gpointer)self->persist_name);
   g_free(self->plugin_name);
   g_list_free_full(self->info, g_free);
+  signal_slot_connector_free(self->signal_slot_connector);
   g_free(self);
 }
 

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -30,6 +30,7 @@
 #include "cfg.h"
 #include "atomic.h"
 #include "messages.h"
+#include "signal-slot-connector/signal-slot-connector.h"
 
 /* notify code values */
 #define NC_CLOSE       1
@@ -224,6 +225,7 @@ struct _LogPipe
   StatsCounterItem *discarded_messages;
   const gchar *persist_name;
   gchar *plugin_name;
+  SignalSlotConnector *signal_slot_connector;
 
   gboolean (*pre_init)(LogPipe *self);
   gboolean (*init)(LogPipe *self);

--- a/lib/signal-slot-connector/CMakeLists.txt
+++ b/lib/signal-slot-connector/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(SIGNAL_SLOT_CONNECTOR_HEADERS
+    signal-slot-connector/signal-slot-connector.h
+    PARENT_SCOPE)
+
+  set(SIGNAL_SLOT_CONNECTOR_SOURCES
+    signal-slot-connector/signal-slot-connector.c
+    PARENT_SCOPE)
+
+add_test_subdirectory(tests)

--- a/lib/signal-slot-connector/Makefile.am
+++ b/lib/signal-slot-connector/Makefile.am
@@ -1,0 +1,12 @@
+signal_slot_connectorincludedir			= ${pkgincludedir}/signal-slot-connector
+
+EXTRA_DIST += lib/signal-slot-connector/CMakeLists.txt \
+							lib/signal-slot-connector/tests/CMakeLists.txt
+
+signal_slot_connectorinclude_HEADERS = \
+	lib/signal-slot-connector/signal-slot-connector.h	
+
+signal_slot_connector_sources = \
+	lib/signal-slot-connector/signal-slot-connector.c
+
+include lib/signal-slot-connector/tests/Makefile.am

--- a/lib/signal-slot-connector/signal-slot-connector.c
+++ b/lib/signal-slot-connector/signal-slot-connector.c
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2002-2019 One Identity
+ * Copyright (c) 2019 Laszlo Budai <laszlo.budai@oneidentity.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "signal-slot-connector.h"
+
+struct _SignalSlotConnector
+{
+  //TODO: multithread support
+  // map<Signal, set<SlotObject>> connections;
+  GHashTable *connections;
+};
+
+GList *
+_slot_lookup_node(GList *slot_objects, Slot slot)
+{
+  for (GList *it = slot_objects; it != NULL; it = it->next)
+    {
+      Slot s = (Slot) it->data;
+
+      if (s == slot)
+        return it;
+    }
+
+  return NULL;
+}
+
+Slot
+_slot_lookup(GList *slot_objects, Slot slot)
+{
+  GList *slot_node = _slot_lookup_node(slot_objects, slot);
+  if (!slot_node)
+    return NULL;
+
+  return (Slot) slot_node->data;
+}
+
+void
+signal_slot_connect(SignalSlotConnector *self, Signal signal, Slot slot)
+{
+  g_assert(signal != NULL);
+  g_assert(slot != NULL);
+
+  GList *slots = g_hash_table_lookup(self->connections, signal);
+
+  gboolean signal_registered = (slots != NULL);
+
+  if (_slot_lookup(slots, slot))
+    {
+      msg_debug("SignalSlotConnector::connect",
+                evt_tag_printf("already_connected",
+                               "connect(connector=%p,signal=%p,slot=%p)",
+                               self, signal, slot));
+      return;
+    }
+
+  GList *new_slots = g_list_append(slots, slot);
+
+  if (!signal_registered)
+    {
+      g_hash_table_insert(self->connections, signal, new_slots);
+    }
+
+  msg_debug("SignalSlotConnector::connect",
+            evt_tag_printf("new connection registered",
+                           "connect(connector=%p,signal=%p,slot=%p)",
+                           self, signal, slot));
+}
+
+static void
+_hash_table_replace(GHashTable *hash_table, gpointer key, gpointer new_value)
+{
+  g_hash_table_steal(hash_table, key);
+  gboolean inserted_as_new = g_hash_table_insert(hash_table, key, new_value);
+  g_assert(inserted_as_new);
+}
+
+void
+signal_slot_disconnect(SignalSlotConnector *self, Signal signal, Slot slot)
+{
+  g_assert(signal != NULL);
+  g_assert(slot != NULL);
+
+  GList *slots = g_hash_table_lookup(self->connections, signal);
+
+  if (!slots)
+    return;
+
+  GList *new_slots = g_list_remove(slots, slot);
+
+  if (new_slots != slots)
+    _hash_table_replace(self->connections, signal, new_slots);
+
+  if (!new_slots)
+    {
+      g_hash_table_remove(self->connections, signal);
+    }
+}
+
+static void
+_run_slot(gpointer data, gpointer user_data)
+{
+  g_assert(data);
+
+  Slot slot = (Slot)data;
+  slot(user_data);
+}
+
+void
+signal_slot_emit(SignalSlotConnector *self, Signal signal, gpointer user_data)
+{
+  g_assert(signal != NULL);
+
+  GList *slots = g_hash_table_lookup(self->connections, signal);
+
+  if (!slots)
+    {
+      return;
+    }
+
+  signal(user_data);
+
+  g_list_foreach(slots, _run_slot, user_data);
+}
+
+static void
+_destroy_list_of_slots(gpointer data)
+{
+  if (!data)
+    return;
+
+  GList *list = (GList *)data;
+  g_list_free(list);
+}
+
+SignalSlotConnector *
+signal_slot_connector_new(void)
+{
+  SignalSlotConnector *self = g_new0(SignalSlotConnector, 1);
+
+  self->connections = g_hash_table_new_full(g_direct_hash,
+                                            g_direct_equal,
+                                            NULL,
+                                            _destroy_list_of_slots);
+
+  return self;
+}
+
+void
+signal_slot_connector_free(SignalSlotConnector *self)
+{
+  g_hash_table_unref(self->connections);
+  g_free(self);
+}
+

--- a/lib/signal-slot-connector/signal-slot-connector.c
+++ b/lib/signal-slot-connector/signal-slot-connector.c
@@ -117,9 +117,18 @@ signal_slot_disconnect(SignalSlotConnector *self, Signal signal, Slot slot)
   if (new_slots != slots)
     _hash_table_replace(self->connections, signal, new_slots);
 
+  msg_debug("SignalSlotConnector::disconnect",
+            evt_tag_printf("connector", "%p", self),
+            evt_tag_printf("signal", "%p", signal),
+            evt_tag_printf("slot", "%p", slot));
+
   if (!new_slots)
     {
       g_hash_table_remove(self->connections, signal);
+      msg_debug("SignalSlotConnector::disconnect last slot is disconnected, unregister signal",
+                evt_tag_printf("connector", "%p", self),
+                evt_tag_printf("signal", "%p", signal),
+                evt_tag_printf("slot", "%p", slot));
     }
 
 exit_:
@@ -144,6 +153,9 @@ signal_slot_emit(SignalSlotConnector *self, Signal signal, gpointer user_data)
 
   if (!slots)
     {
+      msg_debug("SignalSlotConnector: unregistered signal emitted",
+                evt_tag_printf("connector", "%p", self),
+                evt_tag_printf("signal", "%p", signal));
       return;
     }
 

--- a/lib/signal-slot-connector/signal-slot-connector.h
+++ b/lib/signal-slot-connector/signal-slot-connector.h
@@ -40,12 +40,6 @@ typedef struct _SignalSlotConnector SignalSlotConnector;
       msg_debug("SIGNAL called\n", evt_tag_str("signal", __FUNCTION__)); \
     }
 
-#define SIGNAL(signal_func, data_type) \
-  static inline void signal_func(data_type user_data) \
-    { \
-      msg_debug("SIGNAL called\n", evt_tag_str("signal", __FUNCTION__)); \
-    }
-
 #define CONNECT(connector, signal, slot) \
   signal_slot_connect(connector, (Signal) signal, (Slot) slot);
 

--- a/lib/signal-slot-connector/signal-slot-connector.h
+++ b/lib/signal-slot-connector/signal-slot-connector.h
@@ -30,6 +30,16 @@
 
 typedef struct _SignalSlotConnector SignalSlotConnector;
 
+
+#define SIGNAL_DECL(signal_func, data_type) \
+  void signal_func(data_type user_data);
+
+#define SIGNAL_IMPL(signal_func, data_type)\
+  void signal_func(data_type user_data) \
+    { \
+      msg_debug("SIGNAL called\n", evt_tag_str("signal", __FUNCTION__)); \
+    }
+
 #define SIGNAL(signal_func, data_type) \
   static inline void signal_func(data_type user_data) \
     { \

--- a/lib/signal-slot-connector/signal-slot-connector.h
+++ b/lib/signal-slot-connector/signal-slot-connector.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2019 One Identity
+ * Copyright (c) 2019 Laszlo Budai <laszlo.budai@oneidentity.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SIGNAL_SLOT_CONNECTOR_H_INCLUDED
+#define SIGNAL_SLOT_CONNECTOR_H_INCLUDED
+
+#include "syslog-ng.h"
+#include "messages.h"
+
+typedef struct _SignalSlotConnector SignalSlotConnector;
+
+#define SIGNAL(signal_func, data_type) \
+  static inline void signal_func(data_type user_data) \
+    { \
+      msg_debug("SIGNAL called\n", evt_tag_str("signal", __FUNCTION__)); \
+    }
+
+#define CONNECT(connector, signal, slot) \
+  signal_slot_connect(connector, (Signal) signal, (Slot) slot);
+
+#define DISCONNECT(connector, signal, slot) \
+  signal_slot_disconnect(connector, (Signal) signal, (Slot) slot);
+
+#define EMIT(connector, signal, user_data) \
+  signal_slot_emit(connector, (Signal) signal, (gpointer) user_data);
+
+typedef void (*Signal)(gpointer user_data);
+typedef void (*Slot)(gpointer user_data);
+
+void signal_slot_connect(SignalSlotConnector *self, Signal signal, Slot slot);
+void signal_slot_disconnect(SignalSlotConnector *self, Signal signal, Slot slot);
+
+void signal_slot_emit(SignalSlotConnector *self, Signal signal, gpointer user_data);
+
+SignalSlotConnector *signal_slot_connector_new(void);
+void signal_slot_connector_free(SignalSlotConnector *self);
+
+#endif
+

--- a/lib/signal-slot-connector/signal-slot-connector.h
+++ b/lib/signal-slot-connector/signal-slot-connector.h
@@ -36,19 +36,19 @@ typedef const gchar *Signal;
 #define SIGNAL(modul, signal, signal_param_type) \
   STR(modul) "::signal_" STR(signal) "(" STR(signal_param_type) ")"
 
-#define CONNECT(connector, signal, slot) \
-  signal_slot_connect(connector, signal, (Slot) slot);
+#define CONNECT(connector, signal, slot, slot_obj) \
+  signal_slot_connect(connector, signal, (Slot) slot, (gpointer) slot_obj);
 
-#define DISCONNECT(connector, signal, slot) \
-  signal_slot_disconnect(connector, signal, (Slot) slot);
+#define DISCONNECT(connector, signal, slot, slot_obj) \
+  signal_slot_disconnect(connector, signal, (Slot) slot, (gpointer) slot_obj);
 
 #define EMIT(connector, signal, user_data) \
   signal_slot_emit(connector, signal, (gpointer) user_data);
 
-typedef void (*Slot)(gpointer user_data);
+typedef void (*Slot)(gpointer object, gpointer user_data);
 
-void signal_slot_connect(SignalSlotConnector *self, Signal signal, Slot slot);
-void signal_slot_disconnect(SignalSlotConnector *self, Signal signal, Slot slot);
+void signal_slot_connect(SignalSlotConnector *self, Signal signal, Slot slot, gpointer object);
+void signal_slot_disconnect(SignalSlotConnector *self, Signal signal, Slot slot, gpointer object);
 
 void signal_slot_emit(SignalSlotConnector *self, Signal signal, gpointer user_data);
 

--- a/lib/signal-slot-connector/signal-slot-connector.h
+++ b/lib/signal-slot-connector/signal-slot-connector.h
@@ -30,26 +30,21 @@
 
 typedef struct _SignalSlotConnector SignalSlotConnector;
 
+typedef const gchar *Signal;
 
-#define SIGNAL_DECL(signal_func, data_type) \
-  void signal_func(data_type user_data);
-
-#define SIGNAL_IMPL(signal_func, data_type)\
-  void signal_func(data_type user_data) \
-    { \
-      msg_debug("SIGNAL called\n", evt_tag_str("signal", __FUNCTION__)); \
-    }
+#define STR(x) #x
+#define SIGNAL(modul, signal, signal_param_type) \
+  STR(modul) "::signal_" STR(signal) "(" STR(signal_param_type) ")"
 
 #define CONNECT(connector, signal, slot) \
-  signal_slot_connect(connector, (Signal) signal, (Slot) slot);
+  signal_slot_connect(connector, signal, (Slot) slot);
 
 #define DISCONNECT(connector, signal, slot) \
-  signal_slot_disconnect(connector, (Signal) signal, (Slot) slot);
+  signal_slot_disconnect(connector, signal, (Slot) slot);
 
 #define EMIT(connector, signal, user_data) \
-  signal_slot_emit(connector, (Signal) signal, (gpointer) user_data);
+  signal_slot_emit(connector, signal, (gpointer) user_data);
 
-typedef void (*Signal)(gpointer user_data);
 typedef void (*Slot)(gpointer user_data);
 
 void signal_slot_connect(SignalSlotConnector *self, Signal signal, Slot slot);

--- a/lib/signal-slot-connector/tests/CMakeLists.txt
+++ b/lib/signal-slot-connector/tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_unit_test(CRITERION TARGET test_signal_slots)

--- a/lib/signal-slot-connector/tests/Makefile.am
+++ b/lib/signal-slot-connector/tests/Makefile.am
@@ -1,0 +1,9 @@
+lib_signal_slot_connector_tests_TESTS			=  \
+	lib/signal-slot-connector/tests/test_signal_slots
+
+check_PROGRAMS				+= \
+	${lib_signal_slot_connector_tests_TESTS}
+
+lib_signal_slot_connector_tests_test_signal_slots_LDADD = $(TEST_LDADD)
+lib_signal_slot_connector_tests_test_signal_slots_CFLAGS = $(TEST_CFLAGS)
+

--- a/lib/signal-slot-connector/tests/test_signal_slots.c
+++ b/lib/signal-slot-connector/tests/test_signal_slots.c
@@ -25,6 +25,12 @@
 #include <criterion/criterion.h>
 #include "signal-slot-connector/signal-slot-connector.h"
 
+#define CONNECT_WITH_NULL_SLOTOBJ(connector, signal, slot) \
+  CONNECT(connector, signal, slot, NULL)
+
+#define DISCONNECT_WITH_NULL_SLOTOBJ(connector, signal, slot) \
+  DISCONNECT(connector, signal, slot, NULL)
+
 #define signal_test1 SIGNAL(test, 1, TestData *)
 #define signal_test2 SIGNAL(test, 2, TestData *)
 
@@ -41,12 +47,12 @@ test_data_init(TestData *data)
   data->slot_ctr = 0;
 }
 
-void test1_slot(TestData *user_data)
+void test1_slot(gpointer obj, TestData *user_data)
 {
   user_data->slot_ctr++;
 }
 
-void test2_slot(TestData *user_data)
+void test2_slot(gpointer obj, TestData *user_data)
 {
   user_data->slot_ctr++;
 }
@@ -57,8 +63,8 @@ Test(basic_signal_slots, when_the_signal_is_emitted_then_the_connected_slot_is_e
   TestData test_data;
   test_data_init(&test_data);
 
-  CONNECT(ssc, signal_test1, test1_slot);
-  CONNECT(ssc, signal_test2, test1_slot);
+  CONNECT_WITH_NULL_SLOTOBJ(ssc, signal_test1, test1_slot);
+  CONNECT_WITH_NULL_SLOTOBJ(ssc, signal_test2, test1_slot);
   EMIT(ssc, signal_test1, &test_data);
 
   cr_expect_eq(test_data.slot_ctr, 1);
@@ -77,7 +83,7 @@ Test(basic_signal_slots, when_trying_to_connect_multiple_times_the_same_connecti
   test_data_init(&test_data);
 
   for (gint i = 0; i < 5; i++)
-    CONNECT(ssc, signal_test1, test1_slot);
+    CONNECT_WITH_NULL_SLOTOBJ(ssc, signal_test1, test1_slot);
 
   EMIT(ssc, signal_test1, &test_data);
 
@@ -92,11 +98,11 @@ Test(basic_signal_slots, when_trying_to_disconnect_multiple_times_the_same_conne
   TestData test_data;
   test_data_init(&test_data);
 
-  CONNECT(ssc, signal_test1, test1_slot);
-  CONNECT(ssc, signal_test1, test2_slot);
+  CONNECT_WITH_NULL_SLOTOBJ(ssc, signal_test1, test1_slot);
+  CONNECT_WITH_NULL_SLOTOBJ(ssc, signal_test1, test2_slot);
 
   for (gint i = 0; i < 5; i++)
-    DISCONNECT(ssc, signal_test1, test1_slot);
+    DISCONNECT_WITH_NULL_SLOTOBJ(ssc, signal_test1, test1_slot);
 
   EMIT(ssc, signal_test1, &test_data);
 
@@ -112,10 +118,10 @@ Test(basic_signal_slots,
   TestData test_data;
   test_data_init(&test_data);
 
-  CONNECT(ssc, signal_test1, test1_slot);
-  CONNECT(ssc, signal_test2, test1_slot);
+  CONNECT_WITH_NULL_SLOTOBJ(ssc, signal_test1, test1_slot);
+  CONNECT_WITH_NULL_SLOTOBJ(ssc, signal_test2, test1_slot);
 
-  DISCONNECT(ssc, signal_test1, test1_slot);
+  DISCONNECT_WITH_NULL_SLOTOBJ(ssc, signal_test1, test1_slot);
   EMIT(ssc, signal_test1, &test_data);
 
   cr_expect_eq(test_data.slot_ctr, 0);
@@ -124,7 +130,7 @@ Test(basic_signal_slots,
 
   cr_expect_eq(test_data.slot_ctr, 1);
 
-  DISCONNECT(ssc, signal_test2, test1_slot);
+  DISCONNECT_WITH_NULL_SLOTOBJ(ssc, signal_test2, test1_slot);
   EMIT(ssc, signal_test2, &test_data);
 
   cr_expect_eq(test_data.slot_ctr, 1);
@@ -138,8 +144,8 @@ Test(basic_signal_slots, when_disconnect_the_connected_slot_from_a_signal_then_t
   TestData test_data;
   test_data_init(&test_data);
 
-  CONNECT(ssc, signal_test1, test1_slot);
-  DISCONNECT(ssc, signal_test1, test1_slot);
+  CONNECT_WITH_NULL_SLOTOBJ(ssc, signal_test1, test1_slot);
+  DISCONNECT_WITH_NULL_SLOTOBJ(ssc, signal_test1, test1_slot);
   EMIT(ssc, signal_test1, &test_data);
 
   cr_expect_eq(test_data.slot_ctr, 0);
@@ -148,7 +154,7 @@ Test(basic_signal_slots, when_disconnect_the_connected_slot_from_a_signal_then_t
 }
 
 #define DEFINE_TEST_SLOT(func_name) \
-  void func_name(TestData *user_data) \
+  void func_name(gpointer obj, TestData *user_data) \
   { \
     user_data->slot_ctr++; \
   }
@@ -182,14 +188,14 @@ void
 _connect_a_signal_with_all_test_slots(SignalSlotConnector *ssc, Signal s)
 {
   for (gint i = 0; i < ARRAY_SIZE(slots); i++)
-    CONNECT(ssc, s, slots[i]);
+    CONNECT_WITH_NULL_SLOTOBJ(ssc, s, slots[i]);
 }
 
 void
 _disconnect_all_test_slots_from_a_signal(SignalSlotConnector *ssc, Signal s)
 {
   for (gint i = 0; i < ARRAY_SIZE(slots); i++)
-    DISCONNECT(ssc, s, slots[i]);
+    DISCONNECT_WITH_NULL_SLOTOBJ(ssc, s, slots[i]);
 }
 
 Test(multiple_signals_slots,
@@ -217,17 +223,17 @@ Test(multiple_signals_slots,
   test_data_init(&test_data);
 
   for (gint i = 0; i < 3; i++)
-    CONNECT(ssc, signals[0], slots[i]);
+    CONNECT_WITH_NULL_SLOTOBJ(ssc, signals[0], slots[i]);
 
-  DISCONNECT(ssc, signals[0], slots[0]);
+  DISCONNECT_WITH_NULL_SLOTOBJ(ssc, signals[0], slots[0]);
   EMIT(ssc, signals[0], &test_data);
   cr_expect_eq(test_data.slot_ctr, 2);
 
-  DISCONNECT(ssc, signals[0], slots[1]);
+  DISCONNECT_WITH_NULL_SLOTOBJ(ssc, signals[0], slots[1]);
   EMIT(ssc, signals[0], &test_data);
   cr_expect_eq(test_data.slot_ctr, 3);
 
-  DISCONNECT(ssc, signals[0], slots[2]);
+  DISCONNECT_WITH_NULL_SLOTOBJ(ssc, signals[0], slots[2]);
   EMIT(ssc, signals[0], &test_data);
   cr_expect_eq(test_data.slot_ctr, 3);
 

--- a/lib/signal-slot-connector/tests/test_signal_slots.c
+++ b/lib/signal-slot-connector/tests/test_signal_slots.c
@@ -40,7 +40,8 @@ test_data_init(TestData *data)
   data->slot_ctr = 0;
 }
 
-SIGNAL(test1_default_signal, TestData *);
+SIGNAL_DECL(test1_default_signal, TestData *);
+SIGNAL_IMPL(test1_default_signal, TestData *);
 
 void test1_custom_signal(TestData *user_data)
 {

--- a/lib/signal-slot-connector/tests/test_signal_slots.c
+++ b/lib/signal-slot-connector/tests/test_signal_slots.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2002-2019 One Identity 
+ * Copyright (c) 2019 Laszlo Budai
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include "signal-slot-connector/signal-slot-connector.h"
+
+typedef struct _TestData TestData;
+
+struct _TestData
+{
+  gint custom_signal_ctr;
+  gint slot_ctr;
+};
+
+void
+test_data_init(TestData *data)
+{
+  data->custom_signal_ctr = 0;
+  data->slot_ctr = 0;
+}
+
+SIGNAL(test1_default_signal, TestData *);
+
+void test1_custom_signal(TestData *user_data)
+{
+  user_data->custom_signal_ctr++;
+}
+
+void test1_slot(TestData *user_data)
+{
+  user_data->slot_ctr++;
+}
+
+Test(signal_slots, basic_signal_slot_connections)
+{
+  SignalSlotConnector *ssc = signal_slot_connector_new();
+  TestData test_data;
+  test_data_init(&test_data);
+
+  CONNECT(ssc, test1_default_signal, test1_slot);
+  CONNECT(ssc, test1_custom_signal, test1_slot);
+  EMIT(ssc, test1_default_signal, &test_data);
+
+  cr_expect_eq(test_data.custom_signal_ctr, 0);
+  cr_expect_eq(test_data.slot_ctr, 1);
+
+  EMIT(ssc, test1_custom_signal, &test_data);
+  
+  cr_expect_eq(test_data.custom_signal_ctr, 1);
+  cr_expect_eq(test_data.slot_ctr, 2);
+
+  signal_slot_connector_free(ssc);
+}
+
+Test(signal_slots, emit_after_disconnect)
+{
+  SignalSlotConnector *ssc = signal_slot_connector_new();
+  TestData test_data;
+  test_data_init(&test_data);
+
+  CONNECT(ssc, test1_default_signal, test1_slot);
+  CONNECT(ssc, test1_custom_signal, test1_slot);
+
+  DISCONNECT(ssc, test1_default_signal, test1_slot);
+  EMIT(ssc, test1_default_signal, &test_data);
+
+  cr_expect_eq(test_data.custom_signal_ctr, 0);
+  cr_expect_eq(test_data.slot_ctr, 0);
+
+  EMIT(ssc, test1_custom_signal, &test_data);
+  
+  cr_expect_eq(test_data.custom_signal_ctr, 1);
+  cr_expect_eq(test_data.slot_ctr, 1);
+
+  DISCONNECT(ssc, test1_custom_signal, test1_slot);
+  EMIT(ssc, test1_custom_signal, &test_data);
+
+  cr_expect_eq(test_data.custom_signal_ctr, 1);
+  cr_expect_eq(test_data.slot_ctr, 1);
+
+  signal_slot_connector_free(ssc);
+}
+

--- a/lib/signal-slot-connector/tests/test_signal_slots.c
+++ b/lib/signal-slot-connector/tests/test_signal_slots.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2019 One Identity 
+ * Copyright (c) 2002-2019 One Identity
  * Copyright (c) 2019 Laszlo Budai
  *
  * This library is free software; you can redistribute it and/or
@@ -52,7 +52,12 @@ void test1_slot(TestData *user_data)
   user_data->slot_ctr++;
 }
 
-Test(signal_slots, basic_signal_slot_connections)
+void test2_slot(TestData *user_data)
+{
+  user_data->slot_ctr++;
+}
+
+Test(basic_signal_slots, when_the_signal_is_emitted_then_the_connected_slot_is_executed)
 {
   SignalSlotConnector *ssc = signal_slot_connector_new();
   TestData test_data;
@@ -66,14 +71,52 @@ Test(signal_slots, basic_signal_slot_connections)
   cr_expect_eq(test_data.slot_ctr, 1);
 
   EMIT(ssc, test1_custom_signal, &test_data);
-  
+
   cr_expect_eq(test_data.custom_signal_ctr, 1);
   cr_expect_eq(test_data.slot_ctr, 2);
 
   signal_slot_connector_free(ssc);
 }
 
-Test(signal_slots, emit_after_disconnect)
+Test(basic_signal_slots, when_trying_to_connect_multiple_times_the_same_connection_then_connect_only_the_first)
+{
+  SignalSlotConnector *ssc = signal_slot_connector_new();
+  TestData test_data;
+  test_data_init(&test_data);
+
+  for (gint i = 0; i < 5; i++)
+    CONNECT(ssc, test1_custom_signal, test1_slot);
+
+  EMIT(ssc, test1_custom_signal, &test_data);
+
+  cr_expect_eq(test_data.custom_signal_ctr, 1);
+  cr_expect_eq(test_data.slot_ctr, 1);
+
+  signal_slot_connector_free(ssc);
+}
+
+Test(basic_signal_slots, when_trying_to_disconnect_multiple_times_the_same_connection_disconnect_only_the_first)
+{
+  SignalSlotConnector *ssc = signal_slot_connector_new();
+  TestData test_data;
+  test_data_init(&test_data);
+
+  CONNECT(ssc, test1_custom_signal, test1_slot);
+  CONNECT(ssc, test1_custom_signal, test2_slot);
+
+  for (gint i = 0; i < 5; i++)
+    DISCONNECT(ssc, test1_custom_signal, test1_slot);
+
+  EMIT(ssc, test1_custom_signal, &test_data);
+
+  cr_expect_eq(test_data.custom_signal_ctr, 1);
+  cr_expect_eq(test_data.slot_ctr, 1);
+
+  signal_slot_connector_free(ssc);
+}
+
+Test(basic_signal_slots,
+     when_slot_is_disconnected_from_a_signal_and_the_signal_is_emitted_then_the_slot_should_not_be_executed)
 {
   SignalSlotConnector *ssc = signal_slot_connector_new();
   TestData test_data;
@@ -89,7 +132,7 @@ Test(signal_slots, emit_after_disconnect)
   cr_expect_eq(test_data.slot_ctr, 0);
 
   EMIT(ssc, test1_custom_signal, &test_data);
-  
+
   cr_expect_eq(test_data.custom_signal_ctr, 1);
   cr_expect_eq(test_data.slot_ctr, 1);
 
@@ -98,6 +141,127 @@ Test(signal_slots, emit_after_disconnect)
 
   cr_expect_eq(test_data.custom_signal_ctr, 1);
   cr_expect_eq(test_data.slot_ctr, 1);
+
+  signal_slot_connector_free(ssc);
+}
+
+Test(basic_signal_slots, when_an_unregistered_signal_is_emitted_then_do_not_execute_the_signal)
+{
+  SignalSlotConnector *ssc = signal_slot_connector_new();
+  TestData test_data;
+  test_data_init(&test_data);
+
+  EMIT(ssc, test1_custom_signal, &test_data);
+  cr_expect_eq(test_data.custom_signal_ctr, 0);
+
+  signal_slot_connector_free(ssc);
+}
+
+Test(basic_signal_slots, when_disconnect_the_connected_slot_from_a_signal_then_the_signal_is_unregistered)
+{
+  SignalSlotConnector *ssc = signal_slot_connector_new();
+  TestData test_data;
+  test_data_init(&test_data);
+
+  CONNECT(ssc, test1_custom_signal, test1_slot);
+  DISCONNECT(ssc, test1_custom_signal, test1_slot);
+  EMIT(ssc, test1_custom_signal, &test_data);
+  cr_expect_eq(test_data.custom_signal_ctr, 0);
+
+  signal_slot_connector_free(ssc);
+}
+
+#define CONCAT_STR_3(s1, s2, s3) s1##s2##s3
+
+#define DEFINE_TEST_SIGNAL_WITH_SLOT(func_name, idx) \
+  void CONCAT_STR_3(func_name, _signal_, idx)(TestData *user_data) \
+  { \
+    user_data->custom_signal_ctr++; \
+  } \
+  void CONCAT_STR_3(func_name, _slot_, idx)(TestData *user_data) \
+  { \
+    user_data->slot_ctr++; \
+  }
+
+DEFINE_TEST_SIGNAL_WITH_SLOT(test, 0)
+DEFINE_TEST_SIGNAL_WITH_SLOT(test, 1)
+DEFINE_TEST_SIGNAL_WITH_SLOT(test, 2)
+DEFINE_TEST_SIGNAL_WITH_SLOT(test, 3)
+
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+
+Signal signals[4] =
+{
+  (Signal) test_signal_0,
+  (Signal) test_signal_1,
+  (Signal) test_signal_2,
+  (Signal) test_signal_3
+};
+
+Slot slots[4] =
+{
+  (Slot) test_slot_0,
+  (Slot) test_slot_1,
+  (Slot) test_slot_2,
+  (Slot) test_slot_3
+};
+
+void
+_connect_a_signal_with_all_test_slots(SignalSlotConnector *ssc, Signal s)
+{
+  for (gint i = 0; i < ARRAY_SIZE(slots); i++)
+    CONNECT(ssc, s, slots[i]);
+}
+
+void
+_disconnect_all_test_slots_from_a_signal(SignalSlotConnector *ssc, Signal s)
+{
+  for (gint i = 0; i < ARRAY_SIZE(slots); i++)
+    DISCONNECT(ssc, s, slots[i]);
+}
+
+Test(multiple_signals_slots,
+     given_one_signal_with_multiple_slots_when_the_signal_is_emitted_then_the_slots_are_executed)
+{
+  SignalSlotConnector *ssc = signal_slot_connector_new();
+  TestData test_data;
+  test_data_init(&test_data);
+
+  _connect_a_signal_with_all_test_slots(ssc, signals[0]);
+
+  EMIT(ssc, signals[0], &test_data);
+  cr_expect_eq(test_data.custom_signal_ctr, 1);
+  cr_expect_eq(test_data.slot_ctr, ARRAY_SIZE(slots));
+
+  _disconnect_all_test_slots_from_a_signal(ssc, signals[0]);
+
+  signal_slot_connector_free(ssc);
+}
+
+Test(multiple_signals_slots,
+     given_a_signal_with_multiple_slots_when_slots_are_disconnected_1_by_1_then_remaining_slots_are_still_executed)
+{
+  SignalSlotConnector *ssc = signal_slot_connector_new();
+  TestData test_data;
+  test_data_init(&test_data);
+
+  for (gint i = 0; i < 3; i++)
+    CONNECT(ssc, signals[0], slots[i]);
+
+  DISCONNECT(ssc, signals[0], slots[0]);
+  EMIT(ssc, signals[0], &test_data);
+  cr_expect_eq(test_data.custom_signal_ctr, 1);
+  cr_expect_eq(test_data.slot_ctr, 2);
+
+  DISCONNECT(ssc, signals[0], slots[1]);
+  EMIT(ssc, signals[0], &test_data);
+  cr_expect_eq(test_data.custom_signal_ctr, 2);
+  cr_expect_eq(test_data.slot_ctr, 3);
+
+  DISCONNECT(ssc, signals[0], slots[2]);
+  EMIT(ssc, signals[0], &test_data);
+  cr_expect_eq(test_data.custom_signal_ctr, 2);
+  cr_expect_eq(test_data.slot_ctr, 3);
 
   signal_slot_connector_free(ssc);
 }

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -57,7 +57,7 @@ autogen\.sh$
 sub-configure\.sh$
 configure\.ac$
 Makefile\.am$
-lib/(compat|str-repr|timeutils|control|debugger|filter|logproto|parser|rewrite|stats|template|tests|transport|logmsg|value-pairs|secret-storage|logthrdest|logthrsource|http-auth|ack-tracker|[^/]*$)
+lib/(compat|str-repr|timeutils|control|debugger|filter|logproto|parser|rewrite|stats|template|tests|transport|logmsg|value-pairs|secret-storage|logthrdest|logthrsource|http-auth|ack-tracker|signal-slot-connector|[^/]*$)
 lib/scanner/(csv-scanner|list-scanner|kv-scanner|xml-scanner|[^/]*$)
 libtest
 syslog-ng(-ctl)?


### PR DESCRIPTION
The concept is simple:
 * there is a `SignalSlotConnector` which stores `Signal` - `Slot` connections
 * `Signal` : `Slot` = `1` : `N`, so multiple slots can be assigned to the same `Signal`
 * when a `Signal` is `emitted`, the connected `Slots` are executed
 * `Signals` are strings and each module can define its own signals

* Interface/protocol between `signals` and `slots`
  * A macro (`SIGNAL`) can be used for defining signals as string literals:
   `SIGNAL(module_name, signal, signal_parameter_type)`
    The parameter type is for expressing a kind of contract between signals and slots.

    usage:
```C
   #define signal_cfg_reloaded SIGNAL(config, reloaded, GlobalConfig)
```

    the generated literal:

```C
    "config::signal_reloaded(GlobalConfig *)"
```

  * `emit` passes the argument to the slots connected to the emitted signal
