### PR TITLE
Signal slot connector http

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -127,6 +127,7 @@ pkginclude_HEADERS			+= \
 	lib/gsocket.h			\
 	lib/hostname.h			\
 	lib/host-resolve.h		\
+	lib/list-adt.h \
 	lib/logmatcher.h		\
 	lib/logmpx.h			\
 	lib/logpipe.h			\

--- a/lib/list-adt.h
+++ b/lib/list-adt.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2002-2019 Balabit
+ * Copyright (c) 2019 Laszlo Budai <laszlo.budai@balabit.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef LIST_ADT_H_INCLUDED
+#define LIST_ADT_H_INCLUDED
+
+#include <syslog-ng.h>
+
+typedef struct _List List;
+
+typedef void (*list_foreach_fn)(gconstpointer list_data, gpointer user_data);
+
+struct _List
+{
+  void (*append)(List *self, gconstpointer item);
+  void (*foreach)(List *self, list_foreach_fn foreach_fn, gpointer user_data);
+  gboolean (*is_empty)(List *self);
+  void (*remove_all)(List *self);
+  void (*free_fn)(List *self);
+};
+
+static inline void
+list_append(List *self, gconstpointer item)
+{
+  g_assert(self->append);
+
+  self->append(self, item);
+}
+
+static inline void
+list_foreach(List *self, list_foreach_fn foreach_fn, gpointer user_data)
+{
+  g_assert(self->foreach);
+
+  self->foreach(self, foreach_fn, user_data);
+}
+
+static inline gboolean
+list_is_empty(List *self)
+{
+  g_assert(self->is_empty);
+
+  return self->is_empty(self);
+}
+
+static inline void
+list_remove_all(List *self)
+{
+  g_assert(self->remove_all);
+
+  self->remove_all(self);
+}
+
+static inline void
+list_free(List *self)
+{
+  if (self->free_fn)
+    self->free_fn(self);
+
+  g_free(self);
+}
+
+#endif
+

--- a/modules/http/CMakeLists.txt
+++ b/modules/http/CMakeLists.txt
@@ -28,6 +28,10 @@ set(HTTP_DESTINATION_SOURCES
     ${CMAKE_CURRENT_BINARY_DIR}/http-grammar.h
 )
 
+set(HTTP_MODULE_DEV_HEADERS
+  http-signals.h
+)
+
 generate_y_from_ym(modules/http/http-grammar)
 
 bison_target(HttpParserGrammar
@@ -61,5 +65,6 @@ target_include_directories (http PRIVATE ${Curl_INCLUDE_DIR})
 target_link_libraries(http PRIVATE syslog-ng ${Curl_LIBRARIES})
 
 install(TARGETS http LIBRARY DESTINATION lib/syslog-ng/)
+install(FILES ${HTTP_MODULE_DEV_HEADERS} DESTINATION include/syslog-ng/modules/http/)
 
 add_test_subdirectory(tests)

--- a/modules/http/CMakeLists.txt
+++ b/modules/http/CMakeLists.txt
@@ -21,6 +21,7 @@ set(HTTP_DESTINATION_SOURCES
     http-plugin.c
     response-handler.h
     response-handler.c
+    http-signals.h
     ${CMAKE_CURRENT_BINARY_DIR}/http-grammar.c
     ${CMAKE_CURRENT_BINARY_DIR}/http-grammar.h
 )

--- a/modules/http/CMakeLists.txt
+++ b/modules/http/CMakeLists.txt
@@ -16,6 +16,8 @@ set(HTTP_DESTINATION_SOURCES
     http-worker.c
     http-loadbalancer.h
     http-loadbalancer.c
+    http-curl-header-list.h
+    http-curl-header-list.c
     http-parser.c
     http-parser.h
     http-plugin.c

--- a/modules/http/Makefile.am
+++ b/modules/http/Makefile.am
@@ -18,6 +18,11 @@ modules_http_libhttp_la_SOURCES = \
   modules/http/http-plugin.c        \
   modules/http/http-signals.h
 
+modules_http_libhttp_ladir = ${pkgincludedir}/modules/http
+
+modules_http_libhttp_la_HEADERS = \
+	modules/http/http-signals.h
+
 modules_http_libhttp_la_CPPFLAGS  =     \
   $(AM_CPPFLAGS)            \
   $(LIBCURL_CFLAGS)          \

--- a/modules/http/Makefile.am
+++ b/modules/http/Makefile.am
@@ -13,7 +13,8 @@ modules_http_libhttp_la_SOURCES = \
   modules/http/http-grammar.y       \
   modules/http/http-parser.c        \
   modules/http/http-parser.h        \
-  modules/http/http-plugin.c
+  modules/http/http-plugin.c        \
+  modules/http/http-signals.h
 
 modules_http_libhttp_la_CPPFLAGS  =     \
   $(AM_CPPFLAGS)            \

--- a/modules/http/Makefile.am
+++ b/modules/http/Makefile.am
@@ -10,6 +10,8 @@ modules_http_libhttp_la_SOURCES = \
   modules/http/http-worker.h	    \
   modules/http/http-loadbalancer.c  \
   modules/http/http-loadbalancer.h  \
+  modules/http/http-curl-header-list.h \
+  modules/http/http-curl-header-list.c \
   modules/http/http-grammar.y       \
   modules/http/http-parser.c        \
   modules/http/http-parser.h        \

--- a/modules/http/http-curl-header-list.c
+++ b/modules/http/http-curl-header-list.c
@@ -71,7 +71,6 @@ _remove_all(List *s)
 static void
 _free_fn(List *s)
 {
-  HttpCurlHeaderList *self = (HttpCurlHeaderList *)s;
   _remove_all(s);
 }
 

--- a/modules/http/http-curl-header-list.c
+++ b/modules/http/http-curl-header-list.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2002-2019 Balabit
+ * Copyright (c) 2019 Laszlo Budai <laszlo.budai@balabit.com>
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "http-curl-header-list.h"
+
+typedef struct _HttpCurlHeaderList HttpCurlHeaderList;
+
+struct _HttpCurlHeaderList
+{
+  List super;
+  struct curl_slist *list;
+};
+
+static void
+_append(List *s, gconstpointer item)
+{
+  HttpCurlHeaderList *self = (HttpCurlHeaderList *)s;
+  self->list = curl_slist_append(self->list, item);
+}
+
+static void
+_foreach(List *s, list_foreach_fn foreach_fn, gpointer user_data)
+{
+  HttpCurlHeaderList *self = (HttpCurlHeaderList *)s;
+  struct curl_slist *it = self->list;
+  while (it != NULL)
+    {
+      struct curl_slist *next = it->next;
+      foreach_fn(it->data, user_data);
+      it = next;
+    }
+}
+
+static gboolean
+_is_empty(List *s)
+{
+  HttpCurlHeaderList *self = (HttpCurlHeaderList *)s;
+
+  return self->list == NULL;
+}
+
+static void
+_remove_all(List *s)
+{
+  HttpCurlHeaderList *self = (HttpCurlHeaderList *)s;
+  curl_slist_free_all(self->list);
+  self->list = NULL;
+}
+
+static void
+_free_fn(List *s)
+{
+  HttpCurlHeaderList *self = (HttpCurlHeaderList *)s;
+  _remove_all(s);
+}
+
+List *
+http_curl_header_list_new(void)
+{
+  HttpCurlHeaderList *self = g_new0(HttpCurlHeaderList, 1);
+
+  self->super.append = _append;
+  self->super.foreach = _foreach;
+  self->super.is_empty = _is_empty;
+  self->super.remove_all = _remove_all;
+  self->super.free_fn = _free_fn;
+
+  return &self->super;
+}
+
+struct curl_slist *
+http_curl_header_list_as_slist(List *s)
+{
+  HttpCurlHeaderList *self = (HttpCurlHeaderList *)s;
+
+  return self->list;
+}
+

--- a/modules/http/http-curl-header-list.h
+++ b/modules/http/http-curl-header-list.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2019 Balabit
+ * Copyright (c) 2019 Laszlo Budai <laszlo.budai@balabit.com>
+ *
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef HTTP_CURL_HEADER_LIST_H_INCLUDED
+#define HTTP_CURL_HEADER_LIST_H_INCLUDED
+
+#include "list-adt.h"
+
+#define CURL_NO_OLDIES 1
+#include <curl/curl.h>
+
+List *http_curl_header_list_new(void);
+struct curl_slist *http_curl_header_list_as_slist(List *list);
+
+#endif

--- a/modules/http/http-signals.h
+++ b/modules/http/http-signals.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2019 One Identity
+ * Copyright (c) 2019 Laszlo Budai <laszlo.budai@oneidentity.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SIGNAL_SLOT_CONNECTOR_HTTP_SIGNALS_H_INCLUDED
+#define SIGNAL_SLOT_CONNECTOR_HTTP_SIGNALS_H_INCLUDED
+
+#include "signal-slot-connector/signal-slot-connector.h"
+#include "list-adt.h"
+
+typedef struct _HttpHeaderRequestSignalData HttpHeaderRequestSignalData;
+
+struct _HttpHeaderRequestSignalData
+{
+  List *request_headers;
+  GString *request_body;
+};
+
+#define signal_http_header_request SIGNAL(http, header_request, HttpHeaderRequestSignalData *)
+
+#endif

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -26,6 +26,7 @@
 
 #include "syslog-names.h"
 #include "scratch-buffers.h"
+#include "http-signals.h"
 
 
 /* HTTPDestinationWorker */
@@ -169,7 +170,7 @@ _append_auth_header(List *list, HTTPDestinationDriver *owner)
                       log_pipe_location_tag(&owner->super.super.super.super));
           return;
         }
-      auth_header_str = http_auth_header_get_str(owner->auth_header);
+      auth_header_str = http_auth_header_get_as_string(owner->auth_header);
     }
 
   if (auth_header_str)
@@ -219,6 +220,14 @@ _format_request_headers(HTTPDestinationWorker *self, LogMessage *msg)
 
   if (owner->auth_header)
     _append_auth_header(self->request_headers, owner);
+
+  HttpHeaderRequestSignalData signal_data =
+  {
+    .request_headers = self->request_headers,
+    .request_body = self->request_body
+  };
+
+  EMIT(owner->super.super.super.super.signal_slot_connector, signal_http_header_request, &signal_data);
 }
 
 static void

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -186,6 +186,20 @@ _append_auth_header(List *list, HTTPDestinationDriver *owner)
 }
 
 static void
+_collect_rest_headers(HTTPDestinationWorker *self)
+{
+  HttpHeaderRequestSignalData signal_data =
+  {
+    .request_headers = self->request_headers,
+    .request_body = self->request_body
+  };
+
+  HTTPDestinationDriver *owner = (HTTPDestinationDriver *) self->super.owner;
+
+  EMIT(owner->super.super.super.super.signal_slot_connector, signal_http_header_request, &signal_data);
+}
+
+static void
 _format_request_headers(HTTPDestinationWorker *self, LogMessage *msg)
 {
   HTTPDestinationDriver *owner = (HTTPDestinationDriver *) self->super.owner;
@@ -221,13 +235,7 @@ _format_request_headers(HTTPDestinationWorker *self, LogMessage *msg)
   if (owner->auth_header)
     _append_auth_header(self->request_headers, owner);
 
-  HttpHeaderRequestSignalData signal_data =
-  {
-    .request_headers = self->request_headers,
-    .request_body = self->request_body
-  };
-
-  EMIT(owner->super.super.super.super.signal_slot_connector, signal_http_header_request, &signal_data);
+  _collect_rest_headers(self);
 }
 
 static void

--- a/modules/http/http-worker.h
+++ b/modules/http/http-worker.h
@@ -27,10 +27,7 @@
 
 #include "logthrdest/logthrdestdrv.h"
 #include "http-loadbalancer.h"
-
-#define CURL_NO_OLDIES 1
-#include <curl/curl.h>
-
+#include "http-curl-header-list.h"
 
 typedef struct _HTTPDestinationWorker
 {
@@ -38,7 +35,7 @@ typedef struct _HTTPDestinationWorker
   HTTPLoadBalancerClient lbc;
   CURL *curl;
   GString *request_body;
-  struct curl_slist *request_headers;
+  List *request_headers;
 } HTTPDestinationWorker;
 
 LogThreadedResult default_map_http_status_to_worker_status(HTTPDestinationWorker *self, const gchar *url,

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -64,6 +64,7 @@ syslog-ng(-ctl)?
 modules/java-modules/common
 modules/java/(native|proxies|src)
 modules/native
+modules/http/http-signals.h
 tests/loggen
 persist-tool
  GPLv2+_SSL,non-balabit
@@ -90,6 +91,7 @@ modules/(afamqp|affile|afmongodb|afprog|afsmtp|afsocket|afsql|afstomp|afstreams|
 modules/(add-contextual-data|tagsparser|map-value-pairs|hook-commands|appmodel|[^/]*$)
 modules/http/(http-loadbalancer|http-worker)\.[ch]$
 modules/http/response-handler\.[ch]$
+modules/http/http-curl-header-list\.[ch]$
 scl
 scripts
 modules/http/tests


### PR DESCRIPTION
This PR defines the Signal interface for HTTP - with one signal at this time, but before continue the work, I'd need review to the signal-slot concept (see #3043)

What's in the PR?

* List ADT (abstract data type for list implementations) added to `lib`. 
Interface:
  *  `append`
  *  `foreach`
  *  `is_empty`
  *  `remove_all`

* Implement the List ADT in http module with `struct curl_slist` for storing the headers.

* HTTP signal(s):
  Currently only one signal is added, `header_request`.
Note, that the  license for `http-signals.h` is _LGPL_ .