### PR TITLE
basicfuncs: add `$(dns-resolve-ip)` template function

### DIFF
--- a/lib/gsockaddr.c
+++ b/lib/gsockaddr.c
@@ -459,15 +459,21 @@ g_sockaddr_inet6_check(GSockAddr *a)
 GSockAddr *
 g_sockaddr_inet6_new(const gchar *ip, guint16 port)
 {
-  GSockAddrInet6 *addr = g_slice_new0(GSockAddrInet6);
+  GSockAddrInet6 *addr = NULL;
+  struct in6_addr sin6_addr;
 
-  g_atomic_counter_set(&addr->refcnt, 1);
-  addr->flags = 0;
-  addr->salen = sizeof(struct sockaddr_in6);
-  addr->sin6.sin6_family = AF_INET6;
-  inet_pton(AF_INET6, ip, &addr->sin6.sin6_addr);
-  addr->sin6.sin6_port = htons(port);
-  addr->sa_funcs = &inet6_sockaddr_funcs;
+  if (inet_pton(AF_INET6, ip, &sin6_addr))
+    {
+      addr = g_slice_new0(GSockAddrInet6);
+
+      g_atomic_counter_set(&addr->refcnt, 1);
+      addr->flags = 0;
+      addr->salen = sizeof(struct sockaddr_in6);
+      addr->sin6.sin6_family = AF_INET6;
+      addr->sin6.sin6_addr = sin6_addr;
+      addr->sin6.sin6_port = htons(port);
+      addr->sa_funcs = &inet6_sockaddr_funcs;
+    }
 
   return (GSockAddr *) addr;
 }

--- a/lib/gsockaddr.c
+++ b/lib/gsockaddr.c
@@ -507,6 +507,17 @@ g_sockaddr_inet6_new2(struct sockaddr_in6 *sin6)
 
 #endif
 
+GSockAddr *
+g_sockaddr_inet_or_inet6_new(const gchar *name, guint16 port)
+{
+  GSockAddr *addr = g_sockaddr_inet_new(name, port);
+#if SYSLOG_NG_ENABLE_IPV6
+  if (!addr)
+    addr = g_sockaddr_inet6_new(name, port);
+#endif
+  return addr;
+}
+
 /* AF_UNIX socket address */
 
 /*+

--- a/lib/gsockaddr.h
+++ b/lib/gsockaddr.h
@@ -158,6 +158,8 @@ g_sockaddr_inet6_set_address(GSockAddr *s, struct in6_addr *addr)
 }
 #endif
 
+GSockAddr *g_sockaddr_inet_or_inet6_new(const gchar *name, guint16 port);
+
 GSockAddr *g_sockaddr_unix_new(const gchar *name);
 GSockAddr *g_sockaddr_unix_new2(struct sockaddr_un *s_un, int sunlen);
 

--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -121,6 +121,7 @@ static Plugin basicfuncs_plugins[] =
   /* ip-funcs */
   TEMPLATE_FUNCTION_PLUGIN(tf_ipv4_to_int, "ipv4-to-int"),
   TEMPLATE_FUNCTION_PLUGIN(tf_indent_multi_line, "indent-multi-line"),
+  TEMPLATE_FUNCTION_PLUGIN(tf_dns_resolve_ip, "dns-resolve-ip"),
 
   /* misc funcs */
   TEMPLATE_FUNCTION_PLUGIN(tf_env, "env"),

--- a/modules/basicfuncs/ip-funcs.c
+++ b/modules/basicfuncs/ip-funcs.c
@@ -22,6 +22,8 @@
  */
 
 #include "gsocket.h"
+#include "host-resolve.h"
+#include "cfg-parser.h"
 
 static void
 tf_ipv4_to_int(LogMessage *msg, gint argc, GString *argv[], GString *result)
@@ -40,3 +42,124 @@ tf_ipv4_to_int(LogMessage *msg, gint argc, GString *argv[], GString *result)
 }
 
 TEMPLATE_FUNCTION_SIMPLE(tf_ipv4_to_int);
+
+typedef struct _DnsResolveIpState
+{
+  TFSimpleFuncState super;
+  HostResolveOptions host_resolve_options;
+} DnsResolveIpState;
+
+static gboolean
+_process_use_fqdn(const gchar *option_name, const gchar *value, gpointer data, GError **error)
+{
+  HostResolveOptions *host_resolve_options = (HostResolveOptions *)data;
+  host_resolve_options->use_fqdn = cfg_process_yesno(value);
+  return TRUE;
+}
+
+static gboolean
+_process_use_dns(const gchar *option_name, const gchar *value, gpointer data, GError **error)
+{
+  HostResolveOptions *host_resolve_options = (HostResolveOptions *)data;
+  host_resolve_options->use_dns = cfg_process_yesno(value);
+  return TRUE;
+}
+
+static gboolean
+_process_dns_cache(const gchar *option_name, const gchar *value, gpointer data, GError **error)
+{
+  HostResolveOptions *host_resolve_options = (HostResolveOptions *)data;
+  host_resolve_options->use_dns_cache = cfg_process_yesno(value);
+  return TRUE;
+}
+
+static gboolean
+_process_normalize_hostnames(const gchar *option_name, const gchar *value, gpointer data, GError **error)
+{
+  HostResolveOptions *host_resolve_options = (HostResolveOptions *)data;
+  host_resolve_options->normalize_hostnames = cfg_process_yesno(value);
+  return TRUE;
+}
+
+static gboolean
+_parse_host_resolve_options(gint *argc, gchar **argv[], HostResolveOptions *host_resolve_options, GError **error)
+{
+  gboolean result = FALSE;
+  GOptionEntry entries[] =
+  {
+    { "use-fqdn", 'f', 0, G_OPTION_ARG_CALLBACK, _process_use_fqdn, NULL, NULL },
+    { "use-dns", 'd', 0, G_OPTION_ARG_CALLBACK, _process_use_dns, NULL, NULL },
+    { "dns-cache", 'c', 0, G_OPTION_ARG_CALLBACK, _process_dns_cache, NULL, NULL },
+    { "normalize-hostnames", 'n', 0, G_OPTION_ARG_CALLBACK, _process_normalize_hostnames, NULL, NULL },
+    { NULL }
+  };
+
+  GOptionContext *ctx = g_option_context_new(*argv[0]);
+  GOptionGroup *group = g_option_group_new("host-resolve-options", NULL, NULL, host_resolve_options, NULL);
+  g_option_group_add_entries(group, entries);
+  g_option_context_set_main_group(ctx, group);
+
+  if (!g_option_context_parse(ctx, argc, argv, error))
+    goto exit;
+
+  result = TRUE;
+exit:
+  g_option_context_free(ctx);
+  return result;
+}
+
+static gboolean
+_setup_host_resolve_options(DnsResolveIpState *state, LogTemplate *parent, gint *argc, gchar **argv[], GError **error)
+{
+  host_resolve_options_defaults(&state->host_resolve_options);
+
+  if (!_parse_host_resolve_options(argc, argv, &state->host_resolve_options, error))
+    return FALSE;
+
+  host_resolve_options_init(&state->host_resolve_options, &parent->cfg->host_resolve_options);
+
+  return TRUE;
+}
+
+static gboolean
+tf_dns_resolve_ip_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, gint argc, gchar *argv[],
+                          GError **error)
+{
+  DnsResolveIpState *state = (DnsResolveIpState *)s;
+
+  if (!_setup_host_resolve_options(state, parent, &argc, &argv, error))
+    return FALSE;
+
+  if (argc > 2)
+    {
+      g_set_error(error, LOG_TEMPLATE_ERROR, 0,
+                  "dns-resolve-ip: too many arguments provided. usage: $(dns-resolve-ip [OPTIONS] IP)");
+      return FALSE;
+    }
+
+  if (!tf_simple_func_prepare(self, s, parent, argc, argv, error))
+    return FALSE;
+
+  return TRUE;
+}
+
+static void
+tf_dns_resolve_ip_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArgs *args, GString *result)
+{
+  DnsResolveIpState *state = (DnsResolveIpState *)s;
+  const gchar *hostname;
+  gsize result_len;
+
+  gchar *ip = args->argv[0]->str;
+  GSockAddr *addr = g_sockaddr_inet_or_inet6_new(ip, 0);
+  if (!addr)
+    return;
+
+  hostname = resolve_sockaddr_to_hostname(&result_len, addr, &state->host_resolve_options);
+  g_string_append_len(result, hostname, result_len);
+
+  g_sockaddr_unref(addr);
+}
+
+TEMPLATE_FUNCTION(DnsResolveIpState, tf_dns_resolve_ip, tf_dns_resolve_ip_prepare, tf_simple_func_eval,
+                  tf_dns_resolve_ip_call, tf_simple_func_free_state, NULL);


### PR DESCRIPTION
Fixes #3011

---

Resolves the given IP(v4/v6) address to a hostname.

Usage:
```
$(dns-resolve-ip [OPTIONS] ${IP})
```

Valid options are:
```
--use-fqdn=yesno
--use-dns=yesno
--dns-cache=yesno
--normalize-hostnames=yesno
```

The options inherit the global options.

**WARNING**: 
`$(dns-resolve-ip)` uses the same blocking implementation as the source-side DNS resolution.
While the IP is being resolved by the DNS server, message processing might stop even on paths where `$(dns-resolve-ip)` is not present/not used. For more information, see ["Multithreading and scaling in syslog-ng OSE"](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.25/administration-guide/88#TOPIC-1349634)

The main use case for `$(dns-resolve-ip)` is to granulate the DNS resolution to a subset of messages. It is advised to turn off `use-dns()` from global options, and use `$(dns-resolve-ip)` in a (conditional) `rewrite` block.

---
Signed-off-by: Attila Szakacs <attila.szakacs@balabit.com>