### PR TITLE
PR: add PR template to help creating the NEWS file

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+
+
+
+------------------------------------------------------------------
+_Summary:_
+<!--
+This section will be present in the NEWS file.
+Remove it, if you do not want to mention this PR in the NEWS file.
+`module`: Description of the change. (#PR, #ISSUE)
+-->


### PR DESCRIPTION
Creating/reviewing the NEWS file takes more time than it should.

It would worth a try to come up with the NEWS file entries when the PR is reviewed, so we do not miss any PR. Also the knowledge about the PR is the fullest at that time, thus we can make the NEWS entry content quicker.

Signed-off-by: Attila Szakacs <attila.szakacs@balabit.com>