### PR TITLE
Improve name resolution in loggen

### DIFF
--- a/tests/loggen/loggen_helper.c
+++ b/tests/loggen/loggen_helper.c
@@ -95,9 +95,7 @@ connect_ip_socket(int sock_type, const char *target, const char *port, int use_i
   memset(&hints, 0, sizeof(hints));
   hints.ai_family = use_ipv6 ? AF_INET6 : AF_INET;
   hints.ai_socktype = sock_type;
-#ifdef AI_ADDRCONFIG
   hints.ai_flags = AI_ADDRCONFIG;
-#endif
   hints.ai_protocol = 0;
   if (getaddrinfo(target, port, &hints, &res) != 0)
     {

--- a/tests/loggen/loggen_helper.c
+++ b/tests/loggen/loggen_helper.c
@@ -138,7 +138,13 @@ connect_ip_socket(int sock_type, const char *target, const char *port, int use_i
   dest_addr_len = sizeof(s_in);
 #endif
 
-  return connect_to_server(dest_addr, dest_addr_len, sock_type);
+  int socket = connect_to_server(dest_addr, dest_addr_len, sock_type);
+
+#if SYSLOG_NG_HAVE_GETADDRINFO
+  freeaddrinfo(res);
+#endif
+
+  return socket;
 }
 
 int connect_unix_domain_socket(int sock_type, const char *path)


### PR DESCRIPTION
This is a fix for the same problem that #2933 resolves in syslog-ng.
The PR fixes a small memory leak as well.

> When AI_ADDRCONFIG is used, then IPv4 addresses are returned in the list
pointed to by res only if the local system has at least one IPv4 address
configured,  and  IPv6 addresses  are  returned only if the local system
has at least one IPv6 address configured. The loopback address is not
considered for this case as valid as a configured address.

> This flag is useful  on,  for  example,  IPv4-only systems, to ensure
that getaddrinfo() does not return IPv6 socket addresses that would
always fail in connect(2).

Retrying an unsuccessful resolution without `AI_ADDRCONFIG` is necessary because `::1` or `127.0.0.1` might not be resolved when the `AI_ADDRCONFIG` flag is set.

`AI_V4MAPPED` has also been added to support IPv4-mapped IPv6 addresses when no matching IPv6 addresses could be found.