### PR TITLE
geoip2: extend with template option

### DIFF
--- a/modules/geoip2/geoip-parser-grammar.ym
+++ b/modules/geoip2/geoip-parser-grammar.ym
@@ -64,17 +64,23 @@ parser_expr_maxminddb
           {
             last_parser = *instance = (LogParser *) maxminddb_parser_new(configuration);
           }
-          string
+          optional_direct_template
+          parser_geoip_opts
+          ')'					{ $$ = last_parser; }
+        ;
+
+optional_direct_template
+	: string
           {
             LogTemplate *template;
             GError *error = NULL;
 
-            template = cfg_tree_check_inline_template(&configuration->tree, $4, &error);
-            CHECK_ERROR_GERROR(template != NULL, @4, error, "Error compiling template");
+            template = cfg_tree_check_inline_template(&configuration->tree, $1, &error);
+            CHECK_ERROR_GERROR(template != NULL, @1, error, "Error compiling template");
             log_parser_set_template(last_parser, template);
+            free($1);
           }
-          parser_geoip_opts
-          ')'					{ $$ = last_parser; free($4); }
+	|
 	;
 
 parser_geoip_opts

--- a/modules/geoip2/geoip-parser-grammar.ym
+++ b/modules/geoip2/geoip-parser-grammar.ym
@@ -59,11 +59,6 @@ start
         : LL_CONTEXT_PARSER parser_expr_maxminddb                  { YYACCEPT; }
         ;
 
-parser_geoip_opts
-        : parser_geoip_opt parser_geoip_opts
-        |
-        ;
-
 parser_expr_maxminddb
         : KW_GEOIP2 '('
           {
@@ -80,13 +75,16 @@ parser_expr_maxminddb
           }
           parser_geoip_opts
           ')'					{ $$ = last_parser; free($4); }
+	;
+
+parser_geoip_opts
+        : parser_geoip_opt parser_geoip_opts
+        |
         ;
 
 parser_geoip_opt
-        : KW_PREFIX '(' string ')'
-          { geoip_parser_set_prefix(last_parser, $3); free($3); }
-        | KW_DATABASE '(' path_check ')'
-          { geoip_parser_set_database_path(last_parser, $3); free($3); }
+        : KW_PREFIX '(' string ')' { geoip_parser_set_prefix(last_parser, $3); free($3); }
+        | KW_DATABASE '(' path_check ')' { geoip_parser_set_database_path(last_parser, $3); free($3); }
         ;
 
 /* INCLUDE_RULES */

--- a/modules/geoip2/geoip-parser-grammar.ym
+++ b/modules/geoip2/geoip-parser-grammar.ym
@@ -85,6 +85,7 @@ parser_geoip_opts
 parser_geoip_opt
         : KW_PREFIX '(' string ')' { geoip_parser_set_prefix(last_parser, $3); free($3); }
         | KW_DATABASE '(' path_check ')' { geoip_parser_set_database_path(last_parser, $3); free($3); }
+        | parser_opt
         ;
 
 /* INCLUDE_RULES */

--- a/modules/geoip2/geoip-parser.c
+++ b/modules/geoip2/geoip-parser.c
@@ -159,6 +159,12 @@ maxminddb_parser_init(LogPipe *s)
 {
   GeoIPParser *self = (GeoIPParser *) s;
 
+  if (!self->super.template)
+    {
+      msg_error("geoip2(): template is a mandatory parameter", log_pipe_location_tag(s));
+      return FALSE;
+    }
+
   if (!self->database_path)
     self->database_path = mmdb_default_database();
 

--- a/modules/geoip2/tests/test_geoip_parser.c
+++ b/modules/geoip2/tests/test_geoip_parser.c
@@ -89,6 +89,15 @@ parse_geoip_into_log_message(const gchar *template_format)
   return msg;
 }
 
+Test(geoip2, template_is_mandatory)
+{
+  LogParser *geoip2_parser = maxminddb_parser_new(configuration);
+
+  cr_assert_not(log_pipe_init(&geoip2_parser->super));
+
+  log_pipe_unref(&geoip2_parser->super);
+}
+
 Test(geoip2, test_basics)
 {
   LogMessage *msg;

--- a/modules/geoip2/tests/test_geoip_parser.c
+++ b/modules/geoip2/tests/test_geoip_parser.c
@@ -98,18 +98,19 @@ Test(geoip2, template_is_mandatory)
   log_pipe_unref(&geoip2_parser->super);
 }
 
-Test(geoip2, test_basics)
+Test(geoip2, set_prefix)
 {
   LogMessage *msg;
-
-  msg = parse_geoip_into_log_message("2.125.160.216");
-  assert_log_message_value(msg, log_msg_get_value_handle(".geoip2.country.iso_code"), "GB");
-  log_msg_unref(msg);
 
   geoip_parser_set_prefix(geoip_parser, ".prefix.");
   msg = parse_geoip_into_log_message("2.125.160.216");
   assert_log_message_value(msg, log_msg_get_value_handle(".prefix.country.iso_code"), "GB");
   log_msg_unref(msg);
+}
+
+Test(geoip2, empty_prefix)
+{
+  LogMessage *msg;
 
   geoip_parser_set_prefix(geoip_parser, "");
   msg = parse_geoip_into_log_message("2.125.160.216");
@@ -117,7 +118,7 @@ Test(geoip2, test_basics)
   log_msg_unref(msg);
 }
 
-Test(geoip2, test_using_template_to_parse_input)
+Test(geoip2, test_basic)
 {
   LogMessage *msg;
 


### PR DESCRIPTION
Opposed to parsers that by default uses `MESSAGE` and that could be further specialised with `template()` options, the `geoip2` always uses `template`. That is enforced with the grammar rule always requiring a template in a form of string: `geoip2("template-format")`.

The PR includes the following changes:
* Extend the `geoip2` grammer with general `parse_opt` rules (currently only includes `template()`
* In init phase enforces the existence of `template`
* Changed UT according to always using `template()` opposed to using `MESSAGE` field, that works for any parser, but never actually used in case of `geoip2`

As a results both are possible configuration option:
```
 geoip2("$HOST");
 geoip2(template("$HOST"));

 # geoip2();  # this is still not valid
```