### PR TITLE
travis/arm: fix criterion version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -226,7 +226,7 @@ matrix:
       before_script:
       script:
         - set -e
-        - git clone https://github.com/Snaipe/Criterion.git
+        - git clone https://github.com/Snaipe/Criterion.git -b v2.3.3
         - cd Criterion
         - git submodule update --init
         - cmake .


### PR DESCRIPTION
The ARM build used the bleeding criterion, where the cmake build is broken (switched to meson).
As I do not see any CI or instruction for meson with Criterion, it is better to stick to the released version.
(This was the plan, that as soon as "master" breaks, switch to something fix.)