### PR TITLE
snmp adjust engineid length

### DIFF
--- a/modules/snmp-dest/snmpdest-grammar.ym
+++ b/modules/snmp-dest/snmpdest-grammar.ym
@@ -112,14 +112,10 @@ dest_snmpdest_option
             {
               msg_warning("WARNING: SNMP: the 'engine_id' is a v3 option");
             }
-          else 
+          else
             {
-              gchar *s = $3;
-              gchar *end_ptr;
-              CHECK_ERROR(strlen(s) == 10 || (strlen(s) == 12 && s[0] == '0' && s[1] == 'x'), @1, "SNMP: engine id (%s) shall be 10 char length", $3);
-              CHECK_ERROR((strtol(s, &end_ptr, 16) > 0) && (end_ptr[0] == '\0'), @1, "SNMP: engine id (%s) shall be a valid hex number", $3);
-
-              snmpdest_dd_set_engine_id(last_driver, $3); 
+              CHECK_ERROR(snmpdest_dd_set_engine_id(last_driver, $3), @1,
+                "SNMP: engine id (%s) shall be a hexadecimal number with a length between 5 and 32 (plus the 0x prefix), see RFC5343 for further details", $3);
               free($3);
             }
           }

--- a/modules/snmp-dest/snmpdest.c
+++ b/modules/snmp-dest/snmpdest.c
@@ -220,12 +220,49 @@ void snmpdest_dd_set_community(LogDriver *d, const gchar *community)
   self->community = g_strdup(community);
 }
 
-void snmpdest_dd_set_engine_id(LogDriver *d, const gchar *eid)
+static gboolean
+_has_hexadecimal_prefix(const gchar *s)
+{
+  return (s[0] == '0') && (s[1] == 'x');
+}
+
+static gboolean
+_is_hexadecimal(const gchar *s, gint length)
+{
+  gint i;
+  for (i = 0; i < length; ++i)
+    {
+      if (!g_ascii_isxdigit(s[i]))
+        {
+          return FALSE;
+        }
+    }
+  return TRUE;
+}
+
+gboolean snmpdest_dd_set_engine_id(LogDriver *d, const gchar *eid)
 {
   SNMPDestDriver *self = (SNMPDestDriver *)d;
+  gsize eidlength = strlen(eid);
+
+  if (eidlength < ENGINE_ID_MIN_LENGTH)
+    return FALSE;
+
+  if (_has_hexadecimal_prefix(eid))
+    {
+      eidlength = eidlength -2;
+      eid = eid + 2;
+    }
+
+  if (eidlength < ENGINE_ID_MIN_LENGTH || eidlength > ENGINE_ID_MAX_LENGTH)
+    return FALSE;
+
+  if (!_is_hexadecimal(eid, eidlength))
+    return FALSE;
 
   g_free(self->engine_id);
   self->engine_id = g_strdup(eid);
+  return TRUE;
 }
 
 void snmpdest_dd_set_auth_username(LogDriver *d, const gchar *auth_username)

--- a/modules/snmp-dest/snmpdest.c
+++ b/modules/snmp-dest/snmpdest.c
@@ -49,7 +49,6 @@ const gchar *s_v3 = "v3";
 const gchar *s_sha = "SHA";
 const gchar *s_aes = "AES";
 const gchar *s_snmp_name = "syslog-ng";
-const gchar *s_err_engine_id = "Wrong SNMP engine id (must be a 10 char hex value)";
 
 static gboolean snmpdest_dd_session_init(SNMPDestDriver *);
 

--- a/modules/snmp-dest/snmpdest.h
+++ b/modules/snmp-dest/snmpdest.h
@@ -31,8 +31,7 @@
 #include "mainloop-worker.h"
 
 extern const gchar *s_v2c,
-       *s_v3,
-       *s_err_engine_id;
+       *s_v3;
 
 typedef struct
 {

--- a/modules/snmp-dest/snmpdest.h
+++ b/modules/snmp-dest/snmpdest.h
@@ -30,6 +30,9 @@
 #include "driver.h"
 #include "mainloop-worker.h"
 
+#define ENGINE_ID_MAX_LENGTH 32
+#define ENGINE_ID_MIN_LENGTH 5
+
 extern const gchar *s_v2c,
        *s_v3;
 
@@ -90,7 +93,7 @@ gboolean snmpdest_dd_set_snmp_obj(LogDriver *d, GlobalConfig *cfg, const gchar *
 void snmpdest_dd_set_trap_obj(LogDriver *d, GlobalConfig *cfg, const gchar *objectid, const gchar *type,
                               const gchar *value);
 void snmpdest_dd_set_community(LogDriver *d, const gchar *community);
-void snmpdest_dd_set_engine_id(LogDriver *d, const gchar *eid);
+gboolean snmpdest_dd_set_engine_id(LogDriver *d, const gchar *eid);
 void snmpdest_dd_set_auth_username(LogDriver *d, const gchar *auth_username);
 void snmpdest_dd_set_auth_algorithm(LogDriver *d, const gchar *auth_algo);
 void snmpdest_dd_set_auth_password(LogDriver *d, const gchar *auth_pwd);

--- a/modules/snmp-dest/tests/test_snmp_dest.c
+++ b/modules/snmp-dest/tests/test_snmp_dest.c
@@ -85,8 +85,15 @@ Test(test_snmp_dest, set_engine_id)
 {
   LogDriver *driver = (LogDriver *)snmp_driver;
 
-  snmpdest_dd_set_engine_id(driver, "engine_id");
-  cr_assert_str_eq(snmp_driver->engine_id, "engine_id");
+  cr_assert_not(snmpdest_dd_set_engine_id(driver, "bar"));    // not number
+  cr_assert_not(snmpdest_dd_set_engine_id(driver, "0x42"));   // too short
+  cr_assert_not(snmpdest_dd_set_engine_id(driver, "0x0123456789abcdef0123456789abcdef0")); // too long
+
+  cr_assert(snmpdest_dd_set_engine_id(driver, "123abc")); // missing prefix
+  cr_assert_str_eq(snmp_driver->engine_id, "123abc");
+
+  cr_assert(snmpdest_dd_set_engine_id(driver, "0x12345"));
+  cr_assert_str_eq(snmp_driver->engine_id, "12345");
 }
 
 Test(test_snmp_dest, set_auth_username)
@@ -170,7 +177,7 @@ Test(test_snmp_dest, check_required_params)
 
   /* for v3 version the engine_id shall be set as well*/
   snmpdest_dd_set_version(driver, "v3");
-  snmpdest_dd_set_engine_id(driver, "engine_id");
+  snmpdest_dd_set_engine_id(driver, "0x12345");
   cr_assert(snmpdest_check_required_params(driver, err_msg));
 }
 


### PR DESCRIPTION
Original code accepted only 10 character long hexadecimal values.
Checked the snmp library and the RFC, we should accept any hexadecimal
number between 5 to 32 characters.
To validate it, moved the checking part from the grammar into the
snmpdest_dd_set_engine_id function, and wrote tests against it.
