### PR TITLE
WIP: Unmerge reference and inlined template in configuration

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -287,6 +287,7 @@ extern struct _LogRewrite *last_rewrite;
 %token KW_TEMPLATE                    10270
 %token KW_TEMPLATE_ESCAPE             10271
 %token KW_TEMPLATE_FUNCTION           10272
+%token KW_TEMPLATE_REF                10273
 
 %token KW_DEFAULT_FACILITY            10300
 %token KW_DEFAULT_SEVERITY            10301
@@ -1159,7 +1160,7 @@ facility_string
         ;
 
 parser_opt
-        : KW_TEMPLATE '(' LL_STRING ')'		{
+        : KW_TEMPLATE '(' string ')'		{
                                                   GError *error = NULL;
 
                                                   LogTemplate *template = cfg_tree_check_inline_template(&configuration->tree, $3, &error);
@@ -1167,7 +1168,7 @@ parser_opt
                                                   log_parser_set_template(last_parser, template);
                                                   free($3);
                                                 }
-        | KW_TEMPLATE '(' LL_IDENTIFIER ')'	{
+        | KW_TEMPLATE_REF '(' string ')'	{
                                                   LogTemplate *template = cfg_tree_lookup_template(&configuration->tree, $3);
                                                   CHECK_ERROR(template != NULL, @3, "Error compiling template");
                                                   log_parser_set_template(last_parser, template);
@@ -1360,7 +1361,7 @@ dest_writer_option
 	| KW_FLUSH_LINES '(' nonnegative_integer ')'		{ last_writer_options->flush_lines = $3; }
 	| KW_FLUSH_TIMEOUT '(' positive_integer ')'	{ }
         | KW_SUPPRESS '(' nonnegative_integer ')'            { last_writer_options->suppress = $3; }
-	| KW_TEMPLATE '(' LL_STRING ')'
+	| KW_TEMPLATE '(' string ')'
 	  {
 		GError *error = NULL;
 
@@ -1368,7 +1369,7 @@ dest_writer_option
 		CHECK_ERROR_GERROR(last_writer_options->template != NULL, @3, error, "Error compiling template");
 		free($3);
 	  }
-	| KW_TEMPLATE '(' LL_IDENTIFIER ')'
+	| KW_TEMPLATE_REF '(' string ')'
 	  {
 		last_writer_options->template = cfg_tree_lookup_template(&configuration->tree, $3);
 		CHECK_ERROR(last_writer_options->template != NULL, @3, "Error missing template definition");

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1159,11 +1159,10 @@ facility_string
         ;
 
 parser_opt
-        : KW_TEMPLATE '(' string ')'            {
-                                                  LogTemplate *template;
+        : KW_TEMPLATE '(' string ')'		{
                                                   GError *error = NULL;
 
-                                                  template = cfg_tree_check_inline_template(&configuration->tree, $3, &error);
+                                                  LogTemplate *template = cfg_tree_check_inline_template(&configuration->tree, $3, &error);
                                                   CHECK_ERROR_GERROR(template != NULL, @3, error, "Error compiling template");
                                                   log_parser_set_template(last_parser, template);
                                                   free($3);
@@ -1355,13 +1354,14 @@ dest_writer_option
 	| KW_FLUSH_LINES '(' nonnegative_integer ')'		{ last_writer_options->flush_lines = $3; }
 	| KW_FLUSH_TIMEOUT '(' positive_integer ')'	{ }
         | KW_SUPPRESS '(' nonnegative_integer ')'            { last_writer_options->suppress = $3; }
-	| KW_TEMPLATE '(' string ')'       	{
-                                                  GError *error = NULL;
+	| KW_TEMPLATE '(' string ')'
+	  {
+		GError *error = NULL;
 
-                                                  last_writer_options->template = cfg_tree_check_inline_template(&configuration->tree, $3, &error);
-                                                  CHECK_ERROR_GERROR(last_writer_options->template != NULL, @3, error, "Error compiling template");
-	                                          free($3);
-	                                        }
+		last_writer_options->template = cfg_tree_check_inline_template(&configuration->tree, $3, &error);
+		CHECK_ERROR_GERROR(last_writer_options->template != NULL, @3, error, "Error compiling template");
+		free($3);
+	  }
 	| KW_TEMPLATE_ESCAPE '(' yesno ')'	{ log_writer_options_set_template_escape(last_writer_options, $3); }
 	| KW_PAD_SIZE '(' nonnegative_integer ')'         { last_writer_options->padding = $3; }
 	| KW_MARK_FREQ '(' nonnegative_integer ')'        { last_writer_options->mark_freq = $3; }

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -149,6 +149,7 @@ static CfgLexerKeyword main_keywords[] =
   { "dir_group",          KW_DIR_GROUP },
   { "dir_perm",           KW_DIR_PERM },
   { "template",           KW_TEMPLATE },
+  { "template_ref",       KW_TEMPLATE_REF },
   { "template_escape",    KW_TEMPLATE_ESCAPE },
   { "template_function",  KW_TEMPLATE_FUNCTION },
   { "on_error",           KW_ON_ERROR },

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -1316,20 +1316,17 @@ cfg_tree_lookup_template(CfgTree *self, const gchar *name)
 }
 
 LogTemplate *
-cfg_tree_check_inline_template(CfgTree *self, const gchar *template_or_name, GError **error)
+cfg_tree_check_inline_template(CfgTree *self, const gchar *template_format, GError **error)
 {
-  LogTemplate *template = cfg_tree_lookup_template(self, template_or_name);
+  LogTemplate *template = log_template_new(self->cfg, NULL);
 
-  if (template == NULL)
+  if (!log_template_compile(template, template_format, error))
     {
-      template = log_template_new(self->cfg, NULL);
-      if (!log_template_compile(template, template_or_name, error))
-        {
-          log_template_unref(template);
-          return NULL;
-        }
-      template->def_inline = TRUE;
+      log_template_unref(template);
+      return NULL;
     }
+  template->def_inline = TRUE;
+
   return template;
 }
 

--- a/lib/cfg-tree.h
+++ b/lib/cfg-tree.h
@@ -176,7 +176,7 @@ GList *cfg_tree_get_objects(CfgTree *self);
 
 gboolean cfg_tree_add_template(CfgTree *self, LogTemplate *template);
 LogTemplate *cfg_tree_lookup_template(CfgTree *self, const gchar *name);
-LogTemplate *cfg_tree_check_inline_template(CfgTree *self, const gchar *template_or_name, GError **error);
+LogTemplate *cfg_tree_check_inline_template(CfgTree *self, const gchar *template_format, GError **error);
 
 gchar *cfg_tree_get_rule_name(CfgTree *self, gint content, LogExprNode *node);
 gchar *cfg_tree_get_child_id(CfgTree *self, gint content, LogExprNode *node);

--- a/modules/geoip2/geoip-parser-grammar.ym
+++ b/modules/geoip2/geoip-parser-grammar.ym
@@ -70,7 +70,7 @@ parser_expr_maxminddb
         ;
 
 optional_direct_template
-	: string
+	: LL_STRING
           {
             LogTemplate *template;
             GError *error = NULL;


### PR DESCRIPTION
In many places the current `template()` option handled semi-transparent the quoted and non-quoted templates.

The result in both cases are expanding the macro into `foo`. (inlined template)
```
file("/dev/stdout" template(foo)); //non-quoted
file("/dev/stdout" template("foo")); //quoted
```

The result in both cases are expanding the macro into `bar`. (referenced template)
```
template foo "bar";
file("/dev/stdout" template(foo)); //non-quoted
file("/dev/stdout" template("foo")); //quoted
```

The template in this case prefers: referenced over inline template regardless of the quoting.

The proposal is to remove the behaviour with qoute and non-qouted templates.
The qouted template `template("foo")` should always imply inlined template.
The non-qouted template `template(foo)` should always imply referenced template.

