### PR TITLE
[WIP] cmake: compile with openssl from nonstandard location

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -310,6 +310,8 @@ target_include_directories(syslog-ng
 target_include_directories(syslog-ng
   SYSTEM PUBLIC
     ${CORE_INCLUDE_DIRS}
+  PRIVATE
+    ${OPENSSL_INCLUDE_DIR}
 )
 
 target_link_libraries(

--- a/modules/afsocket/CMakeLists.txt
+++ b/modules/afsocket/CMakeLists.txt
@@ -55,7 +55,7 @@ find_package(systemd)
 add_library(afsocket SHARED ${AFSOCKET_SOURCES})
 target_include_directories(afsocket
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+  PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${OPENSSL_INCLUDE_DIR}
 )
 target_link_libraries(afsocket PRIVATE
 	${WRAP_LIBRARIES}

--- a/modules/afsql/CMakeLists.txt
+++ b/modules/afsql/CMakeLists.txt
@@ -22,7 +22,7 @@ if (ENABLE_SQL)
 
     add_library(afsql MODULE ${AFSQL_SOURCES})
     target_link_libraries (afsql PUBLIC ${LIBDBI_LIBRARIES} OpenSSL::SSL)
-    target_include_directories (afsql SYSTEM PRIVATE ${LIBDBI_INCLUDE_DIRS})
+    target_include_directories (afsql SYSTEM PRIVATE ${LIBDBI_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR})
     target_include_directories (afsql PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
     target_link_libraries(afsql PRIVATE syslog-ng)
 

--- a/modules/cryptofuncs/CMakeLists.txt
+++ b/modules/cryptofuncs/CMakeLists.txt
@@ -4,7 +4,7 @@ set (CRYPTOFUNCS_SOURCES
 
 
 add_library(cryptofuncs SHARED ${CRYPTOFUNCS_SOURCES})
-target_include_directories (cryptofuncs PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories (cryptofuncs PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${OPENSSL_INCLUDE_DIR})
 target_link_libraries(cryptofuncs
     PRIVATE
     syslog-ng

--- a/tests/loggen/CMakeLists.txt
+++ b/tests/loggen/CMakeLists.txt
@@ -3,6 +3,7 @@ set(LOGGEN_HELPER_SOURCE
   loggen_helper.c
   loggen_helper.h
   ${PROJECT_SOURCE_DIR}/lib/crypto.c
+  ${PROJECT_SOURCE_DIR}/lib/compat/openssl_support.h
   ${PROJECT_SOURCE_DIR}/lib/compat/openssl_support.c
   )
 
@@ -46,8 +47,6 @@ install(TARGETS loggen_plugin ARCHIVE DESTINATION ${LOGGEN_PLUGIN_INSTALL_DIR})
 # ########### loggen binary #################
 set(LOGGEN_SOURCE
     loggen.c
-    loggen_helper.c
-    loggen_helper.h
     loggen_plugin.h
     file_reader.c
     file_reader.h
@@ -73,6 +72,7 @@ include_directories(loggen
 
 target_link_libraries(
   loggen
+  loggen_helper
   ${GLIB_GMODULE_LIBRARIES}
   ${GLIB_GTHREAD_LIBRARIES}
   ${GLIB_LIBRARIES}

--- a/tests/loggen/CMakeLists.txt
+++ b/tests/loggen/CMakeLists.txt
@@ -13,6 +13,7 @@ include_directories(loggen_helper PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${GLIB_INCLUDE_DIRS}
   ${PROJECT_SOURCE_DIR}/lib
+  ${OPENSSL_INCLUDE_DIR}
   )
 
 set_target_properties(loggen_helper
@@ -67,6 +68,7 @@ include_directories(loggen
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${GLIB_INCLUDE_DIRS}
   ${PROJECT_SOURCE_DIR}/lib
+  ${OPENSSL_INCLUDE_DIR}
   )
 
 target_link_libraries(

--- a/tests/loggen/loggen_helper.c
+++ b/tests/loggen/loggen_helper.c
@@ -22,6 +22,7 @@
  */
 
 #include "loggen_helper.h"
+#include "compat/openssl_support.h"
 
 #include <syslog-ng-config.h>
 #include <string.h>

--- a/tests/loggen/ssl_plugin/CMakeLists.txt
+++ b/tests/loggen/ssl_plugin/CMakeLists.txt
@@ -2,6 +2,7 @@ include_directories(loggen_ssl_plugin
   ${CORE_INCLUDE_DIRS}
   ${GLIB_INCLUDE_DIRS}
   ${LOGGEN_INCLUDE_DIR}
+  ${OPENSSL_INCLUDE_DIR}
   )
 
 set (LOGGEN_SSL_PLUGIN_SOURCE


### PR DESCRIPTION
While experimenting with openssl 1.1.1, I noticed the compilation with cmake does not work. I compiled openssl with nonstandard location, and used PKG_CONFIG_PATH. I received the following error:

```
tests/loggen/libloggen_helper.a(loggen_helper.c.o): In function `open_ssl_connection':
/home/furiel/workspace/test-syslogng/syslog-ng/tests/loggen/loggen_helper.c:256: undefined reference to `SSLv23_client_method'
```

The problem was that we only used the detected openssl so only during linking: (`target_link_libraries`: `OpenSSL:SSL`). The include directories of the detected openssl were not added (`include_directories`).
The reason is: in openssl1.1.1, `SSLv23_client_method` became a define for `TLS_client_method`. So if you do not use the correct include file, loggen_helper will look for `SSLv23_client_method` symbol, which is not available in 1.1.1. If the correct include is used, loggen_helper will look for `TLS_client_method` due to the rename in define, and everything works as expected.

There were other cases where `include_directories` for openssl was missing. Those occurrences are also fixed.

The second part of the of the PR is an improvement in loggen: the `loggen_helper` module was created but was not used by `loggen` target. The source files were just added originally. From now, `loggen` will link to `loggen_helper`.