### PR TITLE
loggen: fix dependency error with cmake + openssl from nonstandard location

### DIFF
--- a/tests/loggen/CMakeLists.txt
+++ b/tests/loggen/CMakeLists.txt
@@ -15,6 +15,14 @@ include_directories(loggen_helper PUBLIC
   ${PROJECT_SOURCE_DIR}/lib
   )
 
+target_link_libraries(
+  loggen_helper
+  ${GLIB_GMODULE_LIBRARIES}
+  ${GLIB_GTHREAD_LIBRARIES}
+  ${GLIB_LIBRARIES}
+  OpenSSL::SSL
+  )
+
 set_target_properties(loggen_helper
     PROPERTIES VERSION ${SYSLOG_NG_VERSION}
     SOVERSION ${SYSLOG_NG_VERSION})

--- a/tests/loggen/CMakeLists.txt
+++ b/tests/loggen/CMakeLists.txt
@@ -53,8 +53,6 @@ install(TARGETS loggen_plugin ARCHIVE DESTINATION ${LOGGEN_PLUGIN_INSTALL_DIR})
 # ########### loggen binary #################
 set(LOGGEN_SOURCE
     loggen.c
-    loggen_helper.c
-    loggen_helper.h
     loggen_plugin.h
     file_reader.c
     file_reader.h
@@ -79,10 +77,10 @@ include_directories(loggen
 
 target_link_libraries(
   loggen
+  loggen_helper
   ${GLIB_GMODULE_LIBRARIES}
   ${GLIB_GTHREAD_LIBRARIES}
   ${GLIB_LIBRARIES}
-  OpenSSL::SSL
   )
 
 install(TARGETS loggen RUNTIME DESTINATION bin)


### PR DESCRIPTION
This PR fixes an openssl dependency problem that only affects loggen, only when compiled with cmake, and openssl is installed on nonstandard location.

One can reproduce a compile error with the following: openssl 1.0.2 is installed on system (for example using ubuntu-xenial), openssl1.1.1 installed on nonstandard location, that is fed to syslog-ng by exporting `PKG_CONFIG_PATH` to the openssl pc file directory.

`loggen_helper` is intended to be a library. It contains openssl related code. Hence it needs to link to openssl. But in cmake, we do not add link target explicitely, it links only transitively to openssl.

During compiling `test_loggen_filereader`, we link only to `loggen_helper`, that only
transitively links to openssl. This means it will link to openssl1.1.1, but will use 1.0.2 headers from system.

This results in a compile error:
```
tests/loggen/libloggen_helper.a(loggen_helper.c.o): In function `open_ssl_connection':
/home/furiel/workspace/test-syslogng/syslog-ng/tests/loggen/loggen_helper.c:256: undefined reference to `SSLv23_client_method'
```

If proper 1.1.1 headers were used, `SSLv23_client_method` would be a
`#define` for `TLS_client_method`, and everything would compile correctly.

The second part of the PR is a minor improvement: `loggen` will also link to `loggen_helper`, instead of just reusing the source files.