### PR TITLE
Openssl: Allow to disable TLSv1.3 and force using TLSv1.3 in configuration options

### DIFF
--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -457,6 +457,10 @@ tls_context_setup_ssl_options(TLSContext *self)
       if(self->ssl_options & TSO_NOTLSv12)
         ssl_options |= SSL_OP_NO_TLSv1_2;
 #endif
+#ifdef SSL_OP_NO_TLSv1_3
+      if(self->ssl_options & TSO_NOTLSv13)
+        ssl_options |= SSL_OP_NO_TLSv1_3;
+#endif
 #ifdef SSL_OP_CIPHER_SERVER_PREFERENCE
       if (self->mode == TM_SERVER)
         ssl_options |= SSL_OP_CIPHER_SERVER_PREFERENCE;
@@ -931,6 +935,10 @@ tls_context_set_ssl_options_by_name(TLSContext *self, GList *options)
         self->ssl_options |= TSO_NOTLSv11;
       else if (strcasecmp(l->data, "no-tlsv12") == 0 || strcasecmp(l->data, "no_tlsv12") == 0)
         self->ssl_options |= TSO_NOTLSv12;
+#endif
+#ifdef SSL_OP_NO_TLSv1_3
+      else if (strcasecmp(l->data, "no-tlsv13") == 0 || strcasecmp(l->data, "no_tlsv13") == 0)
+        self->ssl_options |= TSO_NOTLSv13;
 #endif
       else
         return FALSE;

--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -53,6 +53,7 @@ typedef enum
   TSO_NOTLSv1=0x0004,
   TSO_NOTLSv11=0x0008,
   TSO_NOTLSv12=0x0010,
+  TSO_NOTLSv13=0x0020,
 } TLSSslOptions;
 
 typedef enum

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -241,6 +241,13 @@ http_dd_set_ssl_version(LogDriver *d, const gchar *value)
       self->ssl_version = CURL_SSLVERSION_TLSv1_2;
     }
 #endif
+#ifdef CURL_SSLVERSION_TLSv1_3
+  else if (strcmp(value, "tlsv1_3") == 0)
+    {
+      /* TLS 1.3 only */
+      self->ssl_version = CURL_SSLVERSION_TLSv1_3;
+    }
+#endif
   else
     {
       msg_warning("curl: unsupported SSL version",


### PR DESCRIPTION
This patch set allows to use TLS v1.3 protocol version in TLS contexts and in ssl_version() option 

- ssl_version() option has been expanded with "tlsv1_3" value
- with this value syslog-ng can force using TLS v1.3 protocol with server
```
http(
    url("https://localhost:8081") 
    ssl_version("tlsv1_3")
)
```

- ssl_option() option has been expanded with "no-tlsv13" value
- with this value syslog-ng can disable TLS v1.3 protocol usage
```
    network(
         "172.16.177.147" port(6514)
        transport("tls")
        tls(
            ca-dir("/etc/syslog-ng/ca.d")
            key-file("/etc/syslog-ng/cert.d/clientkey.pem")
            cert-file("/etc/syslog-ng/cert.d/clientcert.pem")
            ssl-options(no-tlsv13)
        )
    );
```