### PR TITLE
Fix TLS 1.3, memory leaks, and race condition in loggen

### DIFF
--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -140,10 +140,9 @@ gboolean is_plugin_already_loaded(GPtrArray *plugin_array, const gchar *name)
 static int
 enumerate_plugins(const gchar *plugin_path, GPtrArray *plugin_array, GOptionContext *ctx)
 {
-  GDir *dir;
   const gchar *fname;
 
-  dir = g_dir_open(plugin_path, 0, NULL);
+  GDir *dir = g_dir_open(plugin_path, 0, NULL);
   if (!dir)
     {
       ERROR("unable to open plugin directory %s (err=%s)\n", plugin_path, strerror(errno));
@@ -164,6 +163,8 @@ enumerate_plugins(const gchar *plugin_path, GPtrArray *plugin_array, GOptionCont
 
       gchar *full_lib_path = g_build_filename(plugin_path, fname, NULL);
       module = g_module_open(full_lib_path, G_MODULE_BIND_LAZY);
+      g_free(full_lib_path);
+
       if (!module)
         {
           ERROR("error opening plugin module %s (%s)\n", fname, g_module_error());
@@ -199,6 +200,8 @@ enumerate_plugins(const gchar *plugin_path, GPtrArray *plugin_array, GOptionCont
 
       DEBUG("%s in %s is a loggen plugin\n", plugin->name, fname);
     }
+
+  g_dir_close(dir);
 
   if (plugin_array->len == 0)
     {
@@ -539,6 +542,7 @@ main(int argc, char *argv[])
     g_mutex_free(message_counter_lock);
   g_free((gpointer)global_plugin_option.target);
   g_free((gpointer)global_plugin_option.port);
+  g_option_context_free(ctx);
   g_ptr_array_free(plugin_array, TRUE);
   g_free(thread_stat_count_last);
   g_free(thread_stat_count);

--- a/tests/loggen/loggen_helper.c
+++ b/tests/loggen/loggen_helper.c
@@ -267,7 +267,7 @@ open_ssl_connection(int sock_fd)
     }
 
   SSL_set_fd (ssl, sock_fd);
-  if (-1 == SSL_connect(ssl))
+  if (SSL_connect(ssl) <= 0)
     {
       ERROR("SSL connect failed\n");
       ERR_print_errors_fp(stderr);

--- a/tests/loggen/loggen_helper.c
+++ b/tests/loggen/loggen_helper.c
@@ -259,6 +259,8 @@ open_ssl_connection(int sock_fd)
       return NULL;
     }
 
+  SSL_CTX_set_mode(ctx, SSL_MODE_AUTO_RETRY);
+
   SSL *ssl = NULL;
   if (NULL == (ssl = SSL_new(ctx)))
     {

--- a/tests/loggen/socket_plugin/socket_plugin.c
+++ b/tests/loggen/socket_plugin/socket_plugin.c
@@ -298,6 +298,7 @@ idle_thread_func(gpointer user_data)
   idle_thread_count--;
   g_mutex_unlock(thread_lock);
 
+  shutdown(fd, SHUT_RDWR);
   close(fd);
 
   g_free(thread_context);
@@ -408,6 +409,7 @@ active_thread_func(gpointer user_data)
   active_thread_count--;
   g_mutex_unlock(thread_lock);
 
+  shutdown(fd, SHUT_RDWR);
   close(fd);
 
   g_free(thread_context);

--- a/tests/loggen/socket_plugin/socket_plugin.c
+++ b/tests/loggen/socket_plugin/socket_plugin.c
@@ -133,6 +133,9 @@ start(PluginOption *option)
       return;
     }
 
+  if (!is_plugin_activated())
+    return;
+
   if (unix_socket_x)
     {
       if (!option->target)
@@ -160,17 +163,8 @@ start(PluginOption *option)
   thread_start = g_cond_new();
   thread_connected = g_cond_new();
 
-  if (!is_plugin_activated())
-    {
-      active_thread_count  = 0;
-      idle_thread_count  = 0;
-      return;
-    }
-  else
-    {
-      active_thread_count  = option->active_connections;
-      idle_thread_count = option->idle_connections;
-    }
+  active_thread_count  = option->active_connections;
+  idle_thread_count = option->idle_connections;
 
   connect_finished = 0;
 
@@ -222,6 +216,9 @@ stop(PluginOption *option)
       ERROR("invalid option reference\n");
       return;
     }
+
+  if (!is_plugin_activated())
+    return;
 
   DEBUG("plugin stop\n");
   thread_run = FALSE;

--- a/tests/loggen/socket_plugin/socket_plugin.c
+++ b/tests/loggen/socket_plugin/socket_plugin.c
@@ -247,8 +247,9 @@ stop(PluginOption *option)
 gpointer
 idle_thread_func(gpointer user_data)
 {
-  PluginOption *option = ((ThreadData *)user_data)->option;
-  int thread_index = ((ThreadData *)user_data)->index;
+  ThreadData *thread_context = (ThreadData *)user_data;
+  PluginOption *option = thread_context->option;
+  int thread_index = thread_context->index;
 
   int sock_type = SOCK_STREAM;
 
@@ -301,6 +302,8 @@ idle_thread_func(gpointer user_data)
   g_mutex_unlock(thread_lock);
 
   close(fd);
+
+  g_free(thread_context);
   g_thread_exit(NULL);
   return NULL;
 }
@@ -409,6 +412,8 @@ active_thread_func(gpointer user_data)
   g_mutex_unlock(thread_lock);
 
   close(fd);
+
+  g_free(thread_context);
   g_thread_exit(NULL);
   return NULL;
 }

--- a/tests/loggen/ssl_plugin/ssl_plugin.c
+++ b/tests/loggen/ssl_plugin/ssl_plugin.c
@@ -127,6 +127,9 @@ start(PluginOption *option)
       return;
     }
 
+  if (!is_plugin_activated())
+    return;
+
   if (!option->target || !option->port)
     {
       ERROR("please specify target and port parameters\n");
@@ -146,19 +149,9 @@ start(PluginOption *option)
   thread_start = g_cond_new();
   thread_connected = g_cond_new();
 
-  if (!is_plugin_activated())
-    {
-      active_thread_count  = 0;
-      idle_thread_count  = 0;
-      return;
-    }
-  else
-    {
-      active_thread_count  = option->active_connections;
-      idle_thread_count  = option->idle_connections;
-      /* call syslog-ng's crypto init */
-      crypto_init();
-    }
+  active_thread_count = option->active_connections;
+  idle_thread_count = option->idle_connections;
+  crypto_init();
 
   connect_finished = 0;
 
@@ -213,6 +206,9 @@ stop(PluginOption *option)
       return;
     }
 
+  if (!is_plugin_activated())
+    return;
+
   DEBUG("plugin stop\n");
   thread_run = FALSE;
 
@@ -226,9 +222,7 @@ stop(PluginOption *option)
       g_thread_join(thread_id);
     }
 
-  /* call syslog-ng's crypto deinit */
-  if (active_thread_count+idle_thread_count>0)
-    crypto_deinit();
+  crypto_deinit();
 
   if (thread_lock)
     g_mutex_free(thread_lock);

--- a/tests/loggen/ssl_plugin/ssl_plugin.c
+++ b/tests/loggen/ssl_plugin/ssl_plugin.c
@@ -286,6 +286,7 @@ idle_thread_func(gpointer user_data)
   g_mutex_unlock(thread_lock);
 
   close_ssl_connection(ssl);
+  shutdown(sock_fd, SHUT_RDWR);
   close(sock_fd);
 
   g_free(thread_context);
@@ -388,6 +389,7 @@ active_thread_func(gpointer user_data)
 
   g_free((gpointer)message);
   close_ssl_connection(ssl);
+  shutdown(sock_fd, SHUT_RDWR);
   close(sock_fd);
 
   g_free(thread_context);

--- a/tests/loggen/ssl_plugin/ssl_plugin.c
+++ b/tests/loggen/ssl_plugin/ssl_plugin.c
@@ -247,8 +247,9 @@ stop(PluginOption *option)
 gpointer
 idle_thread_func(gpointer user_data)
 {
-  PluginOption *option = ((ThreadData *)user_data)->option;
-  int thread_index = ((ThreadData *)user_data)->index;
+  ThreadData *thread_context = (ThreadData *)user_data;
+  PluginOption *option = thread_context->option;
+  int thread_index = thread_context->index;
 
   int sock_fd = connect_ip_socket(SOCK_STREAM, option->target, option->port, option->use_ipv6);;
 
@@ -292,6 +293,8 @@ idle_thread_func(gpointer user_data)
 
   close_ssl_connection(ssl);
   close(sock_fd);
+
+  g_free(thread_context);
   g_thread_exit(NULL);
   return NULL;
 }
@@ -393,6 +396,7 @@ active_thread_func(gpointer user_data)
   close_ssl_connection(ssl);
   close(sock_fd);
 
+  g_free(thread_context);
   g_thread_exit(NULL);
   return NULL;
 }


### PR DESCRIPTION
The main goal of this PR is to make loggen work with TLS 1.3 correctly.

We've noticed that not all of the messages that loggen sent were read by syslog-ng.

More info:
openssl/openssl#6904

----


> TLSv1.3 sessions are not established during the main handshake.
> Instead, after the main handshake is complete, a server may send some
> NewSessionTicket messages to the client.

If a client sends messages and then closes the connection immediately
without reading any NewSessionTickets from the server, the server may
not read the messages that were already sent by the client.

This issue has been fixed in openssl/openssl#6944,
but a full TCP shutdown is still required to make the server read the data.

