### PR TITLE
news: add news directory and script to create NEWS.md

### DIFF
--- a/news/README.md
+++ b/news/README.md
@@ -1,0 +1,29 @@
+How to create a newsfile entry
+==============================
+
+ 1. Create a file in the `news/` directory called `<type>-<pr-num>.md`, where `<type>` is either:
+     * `feature`: New functionality.
+     * `bugfix`: Fix to a reported bug.
+     * `developer-note`: Changes, that are only interesting to developers. (internal API change, etc...)
+     * `other`: Other important, but not categorized change.
+    You can calculate your PR number, by checking the most recent Issue or PR on github,
+    but it could be a good practice to add the commit, containing the news entry, after you
+    have opened your PR, as you know your PR number already.
+ 2. Fill it with the summary of the PR.
+     * You can use any markdown formatting.
+     * Please make sure, that there are no lines longer than 120 characters.
+     * Make it 2-3 sentences at most.
+     * Start the entry with the affected modules then a colon. For example: "`network-dest`: Added..."
+ 3. Commit it with the message: "news: <type>-<pr-num>", for example: "news: bugfix-1234"
+
+
+How to create the `NEWS.md` file for the release
+================================================
+
+ 1. Run `news/create-newsfile.py` (`python3` required)
+ 2. Fill the `Highlights` section in the newly created `NEWS.md` file.
+ 3. Fill the contributors part of the `Credits` section.
+    The internal news file creating tool can generate it for you.
+
+Note, the script uses the `VERSION` file, so it is advised to run the script, after the version is bumped,
+or make sure, that you fill the version correctly by yourself.

--- a/news/create-newsfile.py
+++ b/news/create-newsfile.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+#############################################################################
+# Copyright (c) 2020 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+import re
+import sys
+from argparse import ArgumentParser
+from pathlib import Path
+from subprocess import PIPE, Popen
+
+news_dir = Path(__file__).resolve().parent
+root_dir = news_dir.parent
+newsfile = root_dir / 'NEWS.md'
+
+
+def print_usage_if_needed():
+    ArgumentParser(usage="\rCreates NEWS.md file from the entries in the news/ folder.\n"
+                         "It also deletes the entry files.").parse_args()
+
+
+def create_block(block_name, files):
+    block = '## {}\n\n'.format(block_name)
+    for f in files:
+        entry = ''
+        try:
+            pr_id = re.findall(r'\d+.md$', f.name)[0][:-3]
+        except IndexError:
+            sys.exit('Invalid filename: {}'.format(f.name))
+        entry += ' * {} (#{})'.format(f.read_text().rstrip(), pr_id)
+        entry = entry.replace('\n', '\n   ')
+        block += entry + '\n'
+    block += '\n'
+    return block
+
+
+def get_news_version():
+    proc = Popen(r'git show HEAD:NEWS.md'.split(), cwd=str(root_dir), stdout=PIPE)
+    stdout, _ = proc.communicate()
+    stdout = stdout.decode()
+    return stdout[:stdout.index('\n')]
+
+
+def create_version():
+    version = (root_dir / 'VERSION').read_text().rstrip()
+    news_version = get_news_version()
+    if version == news_version:
+        print('VERSION file contains the same version as the current NEWS.md file.\n' \
+              'Probably you are trying to create the newsfile before bumping the `VERSION` file.\n' \
+              'Please provide version to be released.')
+        version = input('Version to be released: ')
+    return '{}\n{}\n\n'.format(version, len(version) * '=')
+
+
+def create_highlights_block():
+    return '## Highlights\n' \
+           '\n' \
+           '<Fill this block manually from the blocks below>\n' \
+           '\n'
+
+
+def create_standard_blocks():
+    standard_blocks = ''
+    blocks = [
+        ('Features', 'feature-*.md'),
+        ('Bugfixes', 'bugfix-*.md'),
+        ('Notes to developers', 'developer-note-*.md'),
+        ('Other changes', 'other-*.md'),
+    ]
+    for block_name, glob in blocks:
+        entries = list(news_dir.glob(glob))
+        if len(entries) > 0:
+            standard_blocks += create_block(block_name, entries)
+    return standard_blocks
+
+
+def create_credits_block():
+    return '## Credits\n' \
+           '\n' \
+           'syslog-ng is developed as a community project, and as such it relies\n' \
+           'on volunteers, to do the work necessarily to produce syslog-ng.\n' \
+           '\n' \
+           'Reporting bugs, testing changes, writing code or simply providing\n' \
+           'feedback are all important contributions, so please if you are a user\n' \
+           'of syslog-ng, contribute.\n' \
+           '\n' \
+           'We would like to thank the following people for their contribution:\n' \
+           '\n' \
+           '<Fill this by the internal news file creating tool>\n'
+
+
+def create_newsfile(news):
+    newsfile.write_text(news)
+    print('Newsfile created at {}\n'.format(newsfile.resolve()))
+
+
+def cleanup():
+    print("Cleaning up entry files with `git rm news/*-*.md`:")
+    Popen("git rm news/*-*.md".split(), cwd=str(root_dir))
+
+
+def create_news_content():
+    news = create_version()
+    news += create_highlights_block()
+    news += create_standard_blocks()
+    news += create_credits_block()
+    return news
+
+
+def main():
+    print_usage_if_needed()
+    news = create_news_content()
+    create_newsfile(news)
+    cleanup()
+
+
+if __name__ == '__main__':
+    main()

--- a/news/developer-note-3066.md
+++ b/news/developer-note-3066.md
@@ -1,0 +1,2 @@
+`NEWS.md`: From now on, for every PR that we want to include in the newsfile,
+we must create the news entry with the PR itself. See `news/README.md`.

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -75,6 +75,7 @@ modules/add-contextual-data/tests/test_glob_selector\.c$
 modules/affile/tests/test_file_writer\.c$
  GPLv2+_SSL
 contib/config_option_database
+news/create-newsfile.py
 dev-utils/plugin_skeleton_creator/create_plugin.sh
 tests/functional
 tests/unit


### PR DESCRIPTION
How to create a newsfile entry
==============================

 1. Create a file in the `news/` directory called `<type>-<pr-num>.md`, where `<type>` is either:
     * `feature`: New functionality.
     * `bugfix`: Fix to a reported bug.
     * `developer-note`: Changes, that are only interesting to developers. (internal API change, etc...)
     * `other`: Other important, but not categorized change.
    You can calculate your PR number, by checking the most recent Issue or PR on github,
    but it could be a good practice to add the commit, containing the news entry, after you
    have opened your PR, as you know your PR number already.
 2. Fill it with the summary of the PR.
     * You can use any markdown formatting.
     * Please make sure, that there are no lines longer than 120 characters.
     * Make it 2-3 sentences at most.
     * Start the entry with the affected modules then a colon. For example: "`network-dest`: Added..."
 3. Commit it with the message: "news: <type>-<pr-num>", for example: "news: bugfix-1234"


How to create the `NEWS.md` file for the release
================================================

 1. Run `news/create-newsfile.py` (`python3` required)
 2. Fill the `Highlights` section in the newly created `NEWS.md` file.
 3. Fill the contributors part of the `Credits` section.
    The internal news file creating tool can generate it for you.

Note, the script uses the `VERSION` file, so it is advised to run the script, after the version is bumped,
or make sure, that you fill the version correctly by yourself.