### PR TITLE
loggen, dqtool: use g_path_get_basename() instead of basename()

### DIFF
--- a/modules/diskq/dqtool.c
+++ b/modules/diskq/dqtool.c
@@ -436,7 +436,8 @@ _relocate_qfile(PersistState *state, const gchar *name)
     {
       gchar *qfile = persist_state_lookup_string(state, name, NULL, NULL);
       printf("found qfile, key: %s, path: %s\n", name, qfile);
-      gchar *relocated_qfile = g_build_filename(new_diskq_path, basename(qfile), NULL);
+      gchar *base = g_path_get_basename(qfile);
+      gchar *relocated_qfile = g_build_filename(new_diskq_path, base, NULL);
       if (!relocated_qfile)
         {
           fprintf(stderr, "Invalid path. new_diskq_dir: %s, qfile: %s\n", new_diskq_path, qfile);
@@ -452,6 +453,7 @@ _relocate_qfile(PersistState *state, const gchar *name)
         {
           fprintf(stderr, "Failed to move file to new qfile_path: %s\n", relocated_qfile);
         }
+      g_free(base);
       g_free(qfile);
       g_free(relocated_qfile);
     }

--- a/news/bugfix-3069.md
+++ b/news/bugfix-3069.md
@@ -1,0 +1,1 @@
+`loggen, dqtool`: Fixed a crash, when writing error/debug message or relocating qfile.

--- a/tests/loggen/loggen_helper.h
+++ b/tests/loggen/loggen_helper.h
@@ -54,16 +54,20 @@ SSL *open_ssl_connection(int sock_fd);
 void close_ssl_connection(SSL *ssl);
 
 #define ERROR(format,...) do {\
-  fprintf(stderr, "error [%s:%s:%d] ", basename(__FILE__), __func__, __LINE__);\
+  gchar *base = g_path_get_basename(__FILE__);\
+  fprintf(stderr, "error [%s:%s:%d] ", base, __func__, __LINE__);\
   fprintf(stderr, format, ##__VA_ARGS__);\
+  g_free(base);\
 } while (0)
 
 /* debug messages can be turned on by "--debug" command line option */
 #define DEBUG(format,...) do {\
   if (!get_debug_level()) \
     break; \
-  fprintf(stdout, "debug [%s:%s:%d] ", basename(__FILE__), __func__, __LINE__); \
+  gchar *base = g_path_get_basename(__FILE__);\
+  fprintf(stdout, "debug [%s:%s:%d] ", base, __func__, __LINE__); \
   fprintf(stdout, format, ##__VA_ARGS__);\
+  g_free(base);\
 } while(0)
 
 #endif


### PR DESCRIPTION
Fixes #3065