### PR TITLE
compat/getent: fix compile error on solaris

### DIFF
--- a/lib/compat/getent.h
+++ b/lib/compat/getent.h
@@ -28,21 +28,21 @@
 
 #ifndef SYSLOG_NG_HAVE_GETPROTOBYNUMBER_R
 
+#include "getent-generic.h"
+
 #define getprotobynumber_r _compat_generic__getprotobynumber_r
 #define getprotobyname_r _compat_generic__getprotobyname_r
 #define getservbyport_r _compat_generic__getservbyport_r
 #define getservbyname_r _compat_generic__getservbyname_r
 
-#include "getent-generic.h"
-
 #elif defined(sun) || defined(__sun)
+
+#include "getent-sun.h"
 
 #define getprotobynumber_r _compat_sun__getprotobynumber_r
 #define getprotobyname_r _compat_sun__getprotobyname_r
 #define getservbyport_r _compat_sun__getservbyport_r
 #define getservbyname_r _compat_sun__getservbyname_r
-
-#include "getent-sun.h"
 
 #endif
 #endif


### PR DESCRIPTION
The actual functions look like this:

```
#define getprotobynumber_r _compat_sun__getprotobynumber_r

/* From getent-sun.h */
/* From netdb.h (Solaris type) */

struct protoent *getprotobyname_r(const char *name,
                                  struct protoent *result, char *buffer,
                                  int buflen);

/* End from netdb.h */

int _compat_sun__getprotobynumber_r(int proto,
                                    struct protoent *result_buf, char *buf,
                                    size_t buflen, struct protoent **result);

/* End from getent-sun.h */
```

The signature are different in the 2 functions, and that is what we are fixing in the `compat` layer. We would like to use the `_compat_sun__getprotobynumber_r()` signature for `getprotobynumber_r()`.
`_compat_sun__getprotobynumber_r()` itself is just a wrapper:

```
int
_compat_sun__getprotobynumber_r(int proto,
                                struct protoent *result_buf, char *buf,
                                size_t buflen, struct protoent **result)
{
  *result = getprotobynumber_r(proto, result_buf, buf, buflen);
  return (*result ? NULL : errno);
}
```

We should not write `#define getprotobynumber_r _compat_sun__getprotobynumber_r` before declaring these functions, because it is intended to change the `getprotobyname_r()` at the call site, and not the declaration site.

Fixes #2631

Signed-off-by: Attila Szakacs <attila.szakacs@balabit.com>