### PR TITLE
Only complain about older config version if there was a change

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -401,7 +401,7 @@ cfg_set_version(GlobalConfig *self, gint version)
       return FALSE;
     }
 
-  if (cfg_is_config_version_older(self, VERSION_VALUE))
+  if (cfg_is_config_version_older(self, VERSION_VALUE_LAST_SEMANTIC_CHANGE))
     {
       msg_warning("WARNING: Configuration file format is too old, syslog-ng is running in compatibility mode. "
                   "Please update it to use the " VERSION_PRODUCT_CURRENT " format at your time of convenience. "

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -425,6 +425,7 @@ cfg_set_version(GlobalConfig *self, gint version)
                   " to reflect log_iw_size() changes for tcp()/udp() window size changes",
                   cfg_format_config_version_tag(self));
     }
+
   return TRUE;
 }
 

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -404,19 +404,19 @@ cfg_set_version(GlobalConfig *self, gint version)
   if (cfg_is_config_version_older(self, VERSION_VALUE))
     {
       msg_warning("WARNING: Configuration file format is too old, syslog-ng is running in compatibility mode. "
-                  "Please update it to use the " VERSION_CURRENT " format at your time of convenience. "
+                  "Please update it to use the " VERSION_PRODUCT_CURRENT " format at your time of convenience. "
                   "To upgrade the configuration, please review the warnings about incompatible changes printed "
                   "by syslog-ng, and once completed change the @version header at the top of the configuration "
                   "file",
                   cfg_format_config_version_tag(self));
     }
-  else if (version_convert_from_user(self->user_version) > VERSION_VALUE)
+  else if (version_convert_from_user(self->user_version) > VERSION_VALUE_CURRENT)
     {
       msg_warning("WARNING: Configuration file format is newer than the current version, please specify the "
-                  "current version number ("  VERSION_CURRENT_VER_ONLY ") in the @version directive. "
+                  "current version number ("  VERSION_STR_CURRENT ") in the @version directive. "
                   "syslog-ng will operate at its highest supported version in this mode",
                   cfg_format_config_version_tag(self));
-      self->user_version = VERSION_VALUE;
+      self->user_version = VERSION_VALUE_CURRENT;
     }
 
   if (cfg_is_config_version_older(self, VERSION_VALUE_3_3))
@@ -509,7 +509,7 @@ cfg_new(gint version)
 GlobalConfig *
 cfg_new_snippet(void)
 {
-  GlobalConfig *self = cfg_new(VERSION_VALUE);
+  GlobalConfig *self = cfg_new(VERSION_VALUE_CURRENT);
 
   self->use_plugin_discovery = FALSE;
   self->enable_forced_modules = FALSE;

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -393,7 +393,7 @@ cfg_set_version(GlobalConfig *self, gint version)
       return TRUE;
     }
   cfg_set_version_without_validation(self, version);
-  if (cfg_is_config_version_older(self, 0x0300))
+  if (cfg_is_config_version_older(self, VERSION_VALUE_3_0))
     {
       msg_error("ERROR: compatibility with configurations below 3.0 was dropped in " VERSION_3_13
                 ", please update your configuration accordingly",
@@ -419,7 +419,7 @@ cfg_set_version(GlobalConfig *self, gint version)
       self->user_version = VERSION_VALUE;
     }
 
-  if (cfg_is_config_version_older(self, 0x0303))
+  if (cfg_is_config_version_older(self, VERSION_VALUE_3_3))
     {
       msg_warning("WARNING: global: the default value of log_fifo_size() has changed to 10000 in " VERSION_3_3
                   " to reflect log_iw_size() changes for tcp()/udp() window size changes",
@@ -433,7 +433,7 @@ cfg_allow_config_dups(GlobalConfig *self)
 {
   const gchar *s;
 
-  if (cfg_is_config_version_older(self, 0x0303))
+  if (cfg_is_config_version_older(self, VERSION_VALUE_3_3))
     return TRUE;
 
   s = cfg_args_get(self->globals, "allow-config-dups");

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -172,7 +172,7 @@ void register_source_mangle_callback(GlobalConfig *src, mangle_callback cb);
 void uregister_source_mangle_callback(GlobalConfig *src, mangle_callback cb);
 
 static inline gboolean
-cfg_is_config_version_older(GlobalConfig *cfg, gint req)
+__cfg_is_config_version_older(GlobalConfig *cfg, gint req)
 {
   if (!cfg)
     return FALSE;
@@ -180,6 +180,16 @@ cfg_is_config_version_older(GlobalConfig *cfg, gint req)
     return FALSE;
   return TRUE;
 }
+
+/* VERSION_VALUE_LAST_SEMANTIC_CHANGE needs to be bumped in versioning.h whenever
+ * we add a conditional on the config version anywhere in the codebase.  The
+ * G_STATIC_ASSERT checks that we indeed did that */
+
+#define cfg_is_config_version_older(__cfg, __req) \
+  ({ \
+    /* check that VERSION_VALUE_LAST_SEMANTIC_CHANGE is set correctly */ G_STATIC_ASSERT((__req) <= VERSION_VALUE_LAST_SEMANTIC_CHANGE); \
+    __cfg_is_config_version_older(__cfg, __req); \
+  })
 
 static inline void
 cfg_set_use_uniqid(gboolean flag)

--- a/lib/template/compiler.c
+++ b/lib/template/compiler.c
@@ -381,9 +381,9 @@ log_template_compiler_process_token(LogTemplateCompiler *self, GError **error)
     }
   if (*self->cursor == '\\')
     {
-      if (cfg_is_config_version_older(self->template->cfg, 0x305))
+      if (cfg_is_config_version_older(self->template->cfg, VERSION_VALUE_3_5))
         {
-          msg_warning("Template escaping changed in version 3.5. Use '$$' to specify a literal dollar sign instead of '\\$' and remove the escaping of the backslash character when you upgrade your configuration",
+          msg_warning("Template escaping changed in version " VERSION_3_5 ". Use '$$' to specify a literal dollar sign instead of '\\$' and remove the escaping of the backslash character when you upgrade your configuration",
                       evt_tag_str("Template", self->template->template));
           self->cursor++;
         }

--- a/lib/template/compiler.c
+++ b/lib/template/compiler.c
@@ -383,7 +383,10 @@ log_template_compiler_process_token(LogTemplateCompiler *self, GError **error)
     {
       if (cfg_is_config_version_older(self->template->cfg, VERSION_VALUE_3_5))
         {
-          msg_warning("Template escaping changed in version " VERSION_3_5 ". Use '$$' to specify a literal dollar sign instead of '\\$' and remove the escaping of the backslash character when you upgrade your configuration",
+          msg_warning("Template escaping changed in version " VERSION_3_5 ". "
+                      "Use '$$' to specify a literal dollar sign instead of '\\$' and "
+                      "remove the escaping of the backslash character when you upgrade "
+                      "your configuration",
                       evt_tag_str("Template", self->template->template));
           self->cursor++;
         }

--- a/lib/versioning.h
+++ b/lib/versioning.h
@@ -156,6 +156,13 @@
 #define VERSION_STR_CURRENT     "3.25"
 #define VERSION_PRODUCT_CURRENT VERSION_3_25
 
+/* this value points to the last syslog-ng version where we changed the
+ * meaning of any setting in the configuration file.  Basically, it is the
+ * highest value passed to any cfg_is_config_version_older() call.
+ */
+#define VERSION_VALUE_LAST_SEMANTIC_CHANGE  VERSION_VALUE_3_22
+#define VERSION_STR_LAST_SEMANTIC_CHANGE    "3.22"
+
 #define version_convert_from_user(v)  (v)
 
 #include "pe-versioning.h"

--- a/lib/versioning.h
+++ b/lib/versioning.h
@@ -121,6 +121,9 @@
 #define VERSION_3_24 "syslog-ng 3.24"
 #define VERSION_3_25 "syslog-ng 3.25"
 
+/* VERSION_VALUE_* references versions as integers to be compared against stuff like cfg->user_version */
+/* VERSION_STR_* references versions as strings to be shown to the user */
+
 #define VERSION_VALUE_3_0  0x0300
 #define VERSION_VALUE_3_1  0x0301
 #define VERSION_VALUE_3_2  0x0302
@@ -148,11 +151,10 @@
 #define VERSION_VALUE_3_24 0x0318
 #define VERSION_VALUE_3_25 0x0319
 
-
 /* config version code, in the same format as GlobalConfig->version */
-#define VERSION_VALUE   0x0319
-#define VERSION_CURRENT VERSION_3_25
-#define VERSION_CURRENT_VER_ONLY "3.25"
+#define VERSION_VALUE_CURRENT   0x0319
+#define VERSION_STR_CURRENT     "3.25"
+#define VERSION_PRODUCT_CURRENT VERSION_3_25
 
 #define version_convert_from_user(v)  (v)
 

--- a/modules/affile/named-pipe.c
+++ b/modules/affile/named-pipe.c
@@ -125,7 +125,7 @@ pipe_sd_new(gchar *filename, GlobalConfig *cfg)
 
   self->file_reader_options.reader_options.super.stats_source = stats_register_type("pipe");
 
-  if (cfg_is_config_version_older(cfg, 0x0302))
+  if (cfg_is_config_version_older(cfg, VERSION_VALUE_3_2))
     {
       msg_warning_once("WARNING: the expected message format is being changed for pipe() to improve "
                        "syslogd compatibity with " VERSION_3_2 ". If you are using custom "

--- a/modules/afsocket/afunix-source.c
+++ b/modules/afsocket/afunix-source.c
@@ -58,7 +58,7 @@ static gboolean
 afunix_sd_adjust_reader_options(AFUnixSourceDriver *self, GlobalConfig *cfg)
 {
   self->super.reader_options.parse_options.flags |= LP_LOCAL;
-  if (cfg_is_config_version_older(cfg, 0x0302))
+  if (cfg_is_config_version_older(cfg, VERSION_VALUE_3_2))
     {
       msg_warning_once("WARNING: the expected message format is being changed for unix-domain transports to improve "
                        "syslogd compatibity with " VERSION_3_2 ". If you are using custom "

--- a/modules/afsocket/transport-mapper-inet.c
+++ b/modules/afsocket/transport-mapper-inet.c
@@ -421,7 +421,7 @@ transport_mapper_syslog_apply_transport(TransportMapper *s, GlobalConfig *cfg)
 
   if (strcasecmp(transport, "udp") == 0)
     {
-      if (cfg_is_config_version_older(cfg, 0x0303))
+      if (cfg_is_config_version_older(cfg, VERSION_VALUE_3_3))
         {
           self->server_port_change_warning = "WARNING: Default port for syslog(transport(udp)) has changed from 601 to 514 in "
                                              VERSION_3_3 ", please update your configuration";
@@ -443,7 +443,7 @@ transport_mapper_syslog_apply_transport(TransportMapper *s, GlobalConfig *cfg)
     }
   else if (strcasecmp(transport, "tls") == 0)
     {
-      if (cfg_is_config_version_older(cfg, 0x0303))
+      if (cfg_is_config_version_older(cfg, VERSION_VALUE_3_3))
         {
           self->server_port_change_warning = "WARNING: Default port for syslog(transport(tls))  has changed from 601 to 6514 in "
                                              VERSION_3_3 ", please update your configuration";

--- a/modules/dbparser/dbparser.c
+++ b/modules/dbparser/dbparser.c
@@ -298,7 +298,7 @@ log_db_parser_new(GlobalConfig *cfg)
   self->super.super.process = log_db_parser_process;
   self->db_file = g_strdup(get_installation_path_for(PATH_PATTERNDB_FILE));
   g_static_mutex_init(&self->lock);
-  if (cfg_is_config_version_older(cfg, 0x0303))
+  if (cfg_is_config_version_older(cfg, VERSION_VALUE_3_3))
     {
       msg_warning_once("WARNING: The default behaviour for injecting messages in db-parser() has changed in " VERSION_3_3
                        " from internal to pass-through, use an explicit inject-mode(internal) option for old behaviour");

--- a/modules/getent/tfgetent.c
+++ b/modules/getent/tfgetent.c
@@ -200,7 +200,7 @@ const ModuleInfo module_info =
   .canonical_name = "getent-plugin",
   .version = SYSLOG_NG_VERSION,
   .description = "The getent module provides getent template functions for syslog-ng.",
-  .core_revision = VERSION_CURRENT_VER_ONLY,
+  .core_revision = SYSLOG_NG_SOURCE_REVISION,
   .plugins = getent_plugins,
   .plugins_len = G_N_ELEMENTS(getent_plugins),
 };

--- a/modules/map-value-pairs/map-value-pairs-plugin.c
+++ b/modules/map-value-pairs/map-value-pairs-plugin.c
@@ -47,7 +47,7 @@ const ModuleInfo module_info =
   .canonical_name = "map-value-pairs",
   .version = SYSLOG_NG_VERSION,
   .description = "The map-names module provides the map-names() parser for syslog-ng.",
-  .core_revision = VERSION_CURRENT_VER_ONLY,
+  .core_revision = SYSLOG_NG_SOURCE_REVISION,
   .plugins = map_value_pairs_plugins,
   .plugins_len = G_N_ELEMENTS(map_value_pairs_plugins),
 };

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -130,7 +130,7 @@ const ModuleInfo module_info =
   .canonical_name = "python",
   .version = SYSLOG_NG_VERSION,
   .description = "The python ("PYTHON_MODULE_VERSION") module provides Python scripting support for syslog-ng.",
-  .core_revision = VERSION_CURRENT_VER_ONLY,
+  .core_revision = SYSLOG_NG_SOURCE_REVISION,
   .plugins = python_plugins,
   .plugins_len = G_N_ELEMENTS(python_plugins),
 };

--- a/modules/timestamp/timestamp-plugin.c
+++ b/modules/timestamp/timestamp-plugin.c
@@ -64,7 +64,7 @@ const ModuleInfo module_info =
   .canonical_name = "timestamp",
   .version = SYSLOG_NG_VERSION,
   .description = "The timestamp module provides support for manipulating timestamps in syslog-ng.",
-  .core_revision = VERSION_CURRENT_VER_ONLY,
+  .core_revision = SYSLOG_NG_SOURCE_REVISION,
   .plugins = timestamp_plugins,
   .plugins_len = G_N_ELEMENTS(timestamp_plugins),
 };

--- a/news/feature-3074.md
+++ b/news/feature-3074.md
@@ -1,0 +1,5 @@
+`config version`: make the config version check of the configuration more
+liberal by accepting version numbers that had no changes relative to the
+current version.  This means that if you are running 3.25 and the last
+semantic change in the configuration was 3.22, then anything between 3.22
+and 3.25 (inclusive) is accepted by syslog-ng without a warning at startup.

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -137,7 +137,7 @@ version(void)
       installer_version = g_strdup(SYSLOG_NG_VERSION);
     }
   printf(SYSLOG_NG_PACKAGE_NAME " " SYSLOG_NG_COMBINED_VERSION "\n"
-         "Config version: " VERSION_STR_CURRENT "\n"
+         "Config version: " VERSION_STR_LAST_SEMANTIC_CHANGE "\n"
          "Installer-Version: %s\n"
          "Revision: " SYSLOG_NG_SOURCE_REVISION "\n",
          installer_version);

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -137,7 +137,7 @@ version(void)
       installer_version = g_strdup(SYSLOG_NG_VERSION);
     }
   printf(SYSLOG_NG_PACKAGE_NAME " " SYSLOG_NG_COMBINED_VERSION "\n"
-         "Config version: " VERSION_CURRENT_VER_ONLY "\n"
+         "Config version: " VERSION_STR_CURRENT "\n"
          "Installer-Version: %s\n"
          "Revision: " SYSLOG_NG_SOURCE_REVISION "\n",
          installer_version);


### PR DESCRIPTION
Resolves #3068 

On syslog-ng upgrade, if the `@version:` number in the config file left on the older version, a warning `WARNING: Configuration file format is too old, syslog-ng is running in compatibility mode. Please update it to use the syslog-ng ...` can be seen.

This PR makes it possible that a syslog-ng upgrade does not have to be followed by a version number upgrade in the config file, except there is a change in compatibility.
In a lot of cases there is no compatibility changes between 2 versions, so this saves some unnecessary config editing.

It's important, that users should still use the installed syslog-ng version number in their configuration,
even if the `syslog-ng -V` `Config Version` reports the version which is compatible with.