### PR TITLE
Fix file source not able to process new message after log-msg-size increase

### DIFF
--- a/lib/logproto/logproto-buffered-server.c
+++ b/lib/logproto/logproto-buffered-server.c
@@ -181,7 +181,9 @@ log_proto_buffered_server_apply_state(LogProtoBufferedServer *self, PersistEntry
 
   if (!self->buffer)
     {
-      self->buffer = g_malloc(state->buffer_size);
+      gssize buffer_size = MAX(state->buffer_size, self->super.options->init_buffer_size);
+      self->buffer = g_malloc(buffer_size);
+      state->buffer_size = buffer_size;
     }
   state->pending_buffer_end = 0;
 


### PR DESCRIPTION
The reproduction steps are the following:
* Add a simple file source (default configuration everything)
* Send a larger message than the default log-msg-size
* syslog-ng correctly split that message (and everything works as expected)
* Change log-msg-size (insert a msg size that now larger then the sent large message before)
* Reload or Restart syslog-ng
* Send the large message again

Before this patch syslog-ng cannot process the messages from this file.

The persist file in fact stores the log-msg-size, and it is not possible to change for a file source even in case of restart.
A proposed solution is simply increasing the buffer, and updating internal buffer size so it can accommodate the bigger message size.