### PR TITLE
Allow the LogMessage to be compacted before storing it in disk-buffer

### DIFF
--- a/lib/logmsg/logmsg-serialize-fixup.c
+++ b/lib/logmsg/logmsg-serialize-fixup.c
@@ -148,8 +148,7 @@ _allocate_handle_for_entry_name(NVHandle old_handle, NVEntry *entry)
 static NVHandle
 _allocate_handle_of_referenced_entry(NVTable *self, NVHandle ref_handle)
 {
-  NVIndexEntry *index_entry;
-  NVEntry *ref_entry = nv_table_get_entry(self, ref_handle, &index_entry);
+  NVEntry *ref_entry = nv_table_get_entry(self, ref_handle, NULL, NULL);
 
   return _allocate_handle_for_entry_name(ref_handle, ref_entry);
 }

--- a/lib/logmsg/logmsg-serialize.c
+++ b/lib/logmsg/logmsg-serialize.c
@@ -74,7 +74,7 @@ _serialize_message(LogMessageSerializationState *state)
 }
 
 gboolean
-log_msg_serialize_with_ts_processed(LogMessage *self, SerializeArchive *sa, const UnixTime *processed)
+log_msg_serialize_with_ts_processed(LogMessage *self, SerializeArchive *sa, const UnixTime *processed, guint32 flags)
 {
   LogMessageSerializationState state = { 0 };
 
@@ -82,13 +82,14 @@ log_msg_serialize_with_ts_processed(LogMessage *self, SerializeArchive *sa, cons
   state.msg = self;
   state.sa = sa;
   state.processed = processed;
+  state.flags = flags;
   return _serialize_message(&state);
 }
 
 gboolean
-log_msg_serialize(LogMessage *self, SerializeArchive *sa)
+log_msg_serialize(LogMessage *self, SerializeArchive *sa, guint32 flags)
 {
-  return log_msg_serialize_with_ts_processed(self, sa, NULL);
+  return log_msg_serialize_with_ts_processed(self, sa, NULL, flags);
 }
 
 static gboolean

--- a/lib/logmsg/logmsg-serialize.c
+++ b/lib/logmsg/logmsg-serialize.c
@@ -69,7 +69,16 @@ _serialize_message(LogMessageSerializationState *state)
   serialize_write_uint8(sa, msg->num_sdata);
   serialize_write_uint8(sa, msg->alloc_sdata);
   serialize_write_uint32_array(sa, (guint32 *) msg->sdata, msg->num_sdata);
-  nv_table_serialize(state, msg->payload);
+
+  NVTable *payload;
+
+  if (state->flags & LMSF_COMPACTION)
+    payload = nv_table_compact(msg->payload);
+  else
+    payload = nv_table_ref(msg->payload);
+
+  nv_table_serialize(state, payload);
+  nv_table_unref(payload);
   return TRUE;
 }
 

--- a/lib/logmsg/logmsg-serialize.h
+++ b/lib/logmsg/logmsg-serialize.h
@@ -50,7 +50,7 @@
  *   26      use 32 bit values nvtable
  */
 
-typedef enum _LogMessageVersion
+enum _LogMessageVersion
 {
   LGM_V01 = 1,
   LGM_V10 = 10,
@@ -63,7 +63,7 @@ typedef enum _LogMessageVersion
   LGM_V24 = 24,
   LGM_V25 = 25,
   LGM_V26 = 26
-} LogMessageVersion;
+};
 
 gboolean log_msg_deserialize(LogMessage *self, SerializeArchive *sa);
 gboolean log_msg_serialize_with_ts_processed(LogMessage *self, SerializeArchive *sa, const UnixTime *processed);

--- a/lib/logmsg/logmsg-serialize.h
+++ b/lib/logmsg/logmsg-serialize.h
@@ -66,7 +66,8 @@ enum _LogMessageVersion
 };
 
 gboolean log_msg_deserialize(LogMessage *self, SerializeArchive *sa);
-gboolean log_msg_serialize_with_ts_processed(LogMessage *self, SerializeArchive *sa, const UnixTime *processed);
-gboolean log_msg_serialize(LogMessage *self, SerializeArchive *sa);
+gboolean log_msg_serialize_with_ts_processed(LogMessage *self, SerializeArchive *sa, const UnixTime *processed,
+                                             guint32 flags);
+gboolean log_msg_serialize(LogMessage *self, SerializeArchive *sa, guint32 flags);
 
 #endif

--- a/lib/logmsg/logmsg-serialize.h
+++ b/lib/logmsg/logmsg-serialize.h
@@ -65,6 +65,11 @@ enum _LogMessageVersion
   LGM_V26 = 26
 };
 
+enum _LogMessageSerializationFlags
+{
+  LMSF_COMPACTION = 0x0001,
+};
+
 gboolean log_msg_deserialize(LogMessage *self, SerializeArchive *sa);
 gboolean log_msg_serialize_with_ts_processed(LogMessage *self, SerializeArchive *sa, const UnixTime *processed,
                                              guint32 flags);

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -199,6 +199,7 @@ const gchar *builtin_value_names[] =
   "MSGID",
   "SOURCE",
   "LEGACY_MSGHDR",
+  "__RESERVED_LM_V_MAX",
   NULL,
 };
 

--- a/lib/logmsg/nvtable.c
+++ b/lib/logmsg/nvtable.c
@@ -433,6 +433,10 @@ nv_table_add_value(NVTable *self, NVHandle handle, const gchar *name, gsize name
    * size needed for a dynamic table slot */
   if (!nv_table_reserve_table_entry(self, handle, &index_entry))
     return FALSE;
+
+  if (nv_table_is_handle_static(self, handle))
+    name_len = 0;
+
   entry = nv_table_alloc_value(self, NV_ENTRY_DIRECT_HDR + name_len + value_len + 2);
   if (G_UNLIKELY(!entry))
     {
@@ -441,14 +445,12 @@ nv_table_add_value(NVTable *self, NVHandle handle, const gchar *name, gsize name
 
   ofs = nv_table_get_ofs_for_an_entry(self, entry);
   entry->vdirect.value_len = value_len;
-  if (!nv_table_is_handle_static(self, handle))
+  entry->name_len = name_len;
+  if (entry->name_len != 0)
     {
-      /* we only store the name for non-builtin values */
-      entry->name_len = name_len;
+      /* we only store the name for dynamic values */
       memmove(entry->vdirect.data, name, name_len + 1);
     }
-  else
-    entry->name_len = 0;
   memmove(entry->vdirect.data + entry->name_len + 1, value, value_len);
   entry->vdirect.data[entry->name_len + 1 + value_len] = 0;
 

--- a/lib/logmsg/nvtable.c
+++ b/lib/logmsg/nvtable.c
@@ -430,7 +430,7 @@ nv_table_add_value(NVTable *self, NVHandle handle, const gchar *name, gsize name
 
   ofs = nv_table_get_ofs_for_an_entry(self, entry);
   entry->vdirect.value_len = value_len;
-  if (handle >= self->num_static_entries)
+  if (!nv_table_is_handle_static(self, handle))
     {
       /* we only store the name for non-builtin values */
       entry->name_len = name_len;
@@ -485,7 +485,7 @@ nv_table_set_indirect_entry(NVTable *self, NVHandle handle, NVEntry *entry, cons
   /* previously a non-indirect entry, convert it */
   entry->indirect = 1;
 
-  if (handle >= self->num_static_entries)
+  if (!nv_table_is_handle_static(self, handle))
     {
       entry->name_len = name_len;
       memmove(entry->vindirect.name, name, name_len + 1);

--- a/lib/logmsg/nvtable.c
+++ b/lib/logmsg/nvtable.c
@@ -228,12 +228,11 @@ _find_index_entry(NVIndexEntry *index_table, gint index_size, NVHandle handle, N
   gint l, h, m;
   NVHandle mv;
 
-  if (index_size == 0)
-    {
-      *index_slot = &index_table[0];
-      return NULL;
-    }
-  if (index_table[index_size - 1].handle < handle)
+  /* short-cut, check if "handle" is larger than the last - sorted -
+   * element.  If it is, we won't be finding it in this table.  The loop
+   * below would conclude the same, but only after a log2(N) iterations */
+
+  if (index_size > 0 && index_table[index_size - 1].handle < handle)
     {
       *index_slot = &index_table[index_size];
       return NULL;

--- a/lib/logmsg/nvtable.c
+++ b/lib/logmsg/nvtable.c
@@ -413,7 +413,7 @@ nv_table_add_value(NVTable *self, NVHandle handle, const gchar *name, gsize name
           return FALSE;
         }
     }
-  if (G_UNLIKELY(entry && (((guint) entry->alloc_len)) >= value_len + NV_ENTRY_DIRECT_HDR + entry->name_len + 2))
+  if (G_UNLIKELY(entry && (((guint) entry->alloc_len)) >= NV_ENTRY_DIRECT_SIZE(entry->name_len, value_len)))
     {
       _overwrite_with_a_direct_entry(self, handle, entry, name, name_len, value, value_len);
       return TRUE;
@@ -429,7 +429,7 @@ nv_table_add_value(NVTable *self, NVHandle handle, const gchar *name, gsize name
   if (nv_table_is_handle_static(self, handle))
     name_len = 0;
 
-  entry = nv_table_alloc_value(self, NV_ENTRY_DIRECT_HDR + name_len + value_len + 2);
+  entry = nv_table_alloc_value(self, NV_ENTRY_DIRECT_SIZE(name_len, value_len));
   if (G_UNLIKELY(!entry))
     {
       return FALSE;
@@ -576,7 +576,7 @@ nv_table_add_value_indirect(NVTable *self, NVHandle handle, const gchar *name, g
         return FALSE;
     }
 
-  if (entry && (((guint) entry->alloc_len) >= NV_ENTRY_INDIRECT_HDR + name_len + 1))
+  if (entry && (((guint) entry->alloc_len) >= NV_ENTRY_INDIRECT_SIZE(name_len)))
     {
       /* this value already exists and the new reference fits in the old space */
       nv_table_set_indirect_entry(self, handle, entry, name, name_len, referenced_slice);
@@ -590,7 +590,7 @@ nv_table_add_value_indirect(NVTable *self, NVHandle handle, const gchar *name, g
 
   if (!nv_table_reserve_table_entry(self, handle, &index_entry))
     return FALSE;
-  entry = nv_table_alloc_value(self, NV_ENTRY_INDIRECT_HDR + name_len + 1);
+  entry = nv_table_alloc_value(self, NV_ENTRY_INDIRECT_SIZE(name_len));
   if (!entry)
     {
       return FALSE;

--- a/lib/logmsg/nvtable.c
+++ b/lib/logmsg/nvtable.c
@@ -178,6 +178,8 @@ nv_table_resolve_indirect(NVTable *self, NVEntry *entry, gssize *length)
   const gchar *referenced_value;
   gssize referenced_length;
 
+  g_assert(entry->indirect);
+
   referenced_value = nv_table_get_value(self, entry->vindirect.handle, &referenced_length);
   if (entry->vindirect.ofs > referenced_length)
     {
@@ -197,6 +199,16 @@ nv_table_resolve_indirect(NVTable *self, NVEntry *entry, gssize *length)
 }
 
 static inline const gchar *
+nv_table_resolve_direct(NVTable *self, NVEntry *entry, gssize *length)
+{
+  g_assert(!entry->indirect);
+
+  if (length)
+    *length = entry->vdirect.value_len;
+  return entry->vdirect.data + entry->name_len + 1;
+}
+
+static inline const gchar *
 nv_table_resolve_entry(NVTable *self, NVEntry *entry, gssize *length)
 {
   if (entry->unset)
@@ -205,14 +217,10 @@ nv_table_resolve_entry(NVTable *self, NVEntry *entry, gssize *length)
         *length = 0;
       return null_string;
     }
-  else if (!entry->indirect)
-    {
-      if (length)
-        *length = entry->vdirect.value_len;
-      return entry->vdirect.data + entry->name_len + 1;
-    }
-  else
+  else if (entry->indirect)
     return nv_table_resolve_indirect(self, entry, length);
+  else
+    return nv_table_resolve_direct(self, entry, length);
 }
 
 NVEntry *

--- a/lib/logmsg/nvtable.c
+++ b/lib/logmsg/nvtable.c
@@ -484,7 +484,7 @@ nv_table_unset_value(NVTable *self, NVHandle handle)
   NVEntry *entry = nv_table_get_entry(self, handle, &index_entry);
 
   if (!entry)
-    return;
+    return TRUE;
 
   if (G_UNLIKELY(!entry->indirect && entry->referenced))
     {

--- a/lib/logmsg/nvtable.c
+++ b/lib/logmsg/nvtable.c
@@ -147,7 +147,6 @@ nv_registry_free(NVRegistry *self)
   g_free(self);
 }
 
-
 /* return the offset to a newly allocated payload string */
 static inline NVEntry *
 nv_table_alloc_value(NVTable *self, gsize alloc_size)
@@ -269,7 +268,7 @@ nv_table_get_entry_slow(NVTable *self, NVHandle handle, NVIndexEntry **index_ent
 static gboolean
 nv_table_reserve_table_entry(NVTable *self, NVHandle handle, NVIndexEntry **index_entry)
 {
-  if (G_UNLIKELY(!(*index_entry) && handle > self->num_static_entries))
+  if (G_UNLIKELY(!(*index_entry) && !nv_table_is_handle_static(self, handle)))
     {
       /* this is a dynamic value */
       NVIndexEntry *index_table = nv_table_get_index(self);;
@@ -329,7 +328,7 @@ nv_table_reserve_table_entry(NVTable *self, NVHandle handle, NVIndexEntry **inde
 static inline void
 nv_table_set_table_entry(NVTable *self, NVHandle handle, guint32 ofs, NVIndexEntry *index_entry)
 {
-  if (G_LIKELY(handle <= self->num_static_entries))
+  if (G_LIKELY(nv_table_is_handle_static(self, handle)))
     {
       /* this is a statically allocated value, simply store the offset */
       self->static_entries[handle-1] = ofs;

--- a/lib/logmsg/nvtable.c
+++ b/lib/logmsg/nvtable.c
@@ -413,7 +413,7 @@ nv_table_add_value(NVTable *self, NVHandle handle, const gchar *name, gsize name
           return FALSE;
         }
     }
-  if (G_UNLIKELY(entry && (((guint) entry->alloc_len)) >= NV_ENTRY_DIRECT_SIZE(entry->name_len, value_len)))
+  if (entry && entry->alloc_len >= NV_ENTRY_DIRECT_SIZE(entry->name_len, value_len))
     {
       _overwrite_with_a_direct_entry(self, handle, entry, name, name_len, value, value_len);
       return TRUE;
@@ -576,7 +576,7 @@ nv_table_add_value_indirect(NVTable *self, NVHandle handle, const gchar *name, g
         return FALSE;
     }
 
-  if (entry && (((guint) entry->alloc_len) >= NV_ENTRY_INDIRECT_SIZE(name_len)))
+  if (entry && (entry->alloc_len >= NV_ENTRY_INDIRECT_SIZE(name_len)))
     {
       /* this value already exists and the new reference fits in the old space */
       nv_table_set_indirect_entry(self, handle, entry, name, name_len, referenced_slice);

--- a/lib/logmsg/nvtable.c
+++ b/lib/logmsg/nvtable.c
@@ -291,8 +291,8 @@ nv_table_get_entry_slow(NVTable *self, NVHandle handle, NVIndexEntry **index_ent
   return NULL;
 }
 
-static gboolean
-nv_table_reserve_table_entry(NVTable *self, NVHandle handle, NVIndexEntry **index_entry, NVIndexEntry *index_slot)
+static inline gboolean
+_alloc_index_entry(NVTable *self, NVHandle handle, NVIndexEntry **index_entry, NVIndexEntry *index_slot)
 {
   if (G_UNLIKELY(!(*index_entry) && !nv_table_is_handle_static(self, handle)))
     {
@@ -443,7 +443,7 @@ nv_table_add_value(NVTable *self, NVHandle handle, const gchar *name, gsize name
 
   /* check if there's enough free space: size of the struct plus the
    * size needed for a dynamic table slot */
-  if (!nv_table_reserve_table_entry(self, handle, &index_entry, index_slot))
+  if (!_alloc_index_entry(self, handle, &index_entry, index_slot))
     return FALSE;
 
   if (nv_table_is_handle_static(self, handle))
@@ -592,7 +592,7 @@ nv_table_add_value_indirect(NVTable *self, NVHandle handle, const gchar *name, g
       *new_entry = TRUE;
     }
 
-  if (!nv_table_reserve_table_entry(self, handle, &index_entry, index_slot))
+  if (!_alloc_index_entry(self, handle, &index_entry, index_slot))
     return FALSE;
   entry = nv_table_alloc_value(self, NV_ENTRY_INDIRECT_SIZE(name_len));
   if (!entry)

--- a/lib/logmsg/nvtable.h
+++ b/lib/logmsg/nvtable.h
@@ -274,6 +274,12 @@ NVTable *nv_table_clone(NVTable *self, gint additional_space);
 NVTable *nv_table_ref(NVTable *self);
 void nv_table_unref(NVTable *self);
 
+static inline gboolean
+nv_table_is_handle_static(NVTable *self, NVHandle handle)
+{
+  return (handle <= self->num_static_entries);
+}
+
 static inline gsize
 nv_table_get_alloc_size(gint num_static_entries, gint index_size_hint, gint init_length)
 {
@@ -332,7 +338,7 @@ __nv_table_get_entry(NVTable *self, NVHandle handle, guint16 num_static_entries,
       return NULL;
     }
 
-  if (G_LIKELY(handle <= num_static_entries))
+  if (G_LIKELY(nv_table_is_handle_static(self, handle)))
     {
       ofs = self->static_entries[handle - 1];
       *index_entry = NULL;

--- a/lib/logmsg/nvtable.h
+++ b/lib/logmsg/nvtable.h
@@ -156,7 +156,9 @@ struct _NVEntry
 };
 
 #define NV_ENTRY_DIRECT_HDR ((gsize) (&((NVEntry *) NULL)->vdirect.data))
+#define NV_ENTRY_DIRECT_SIZE(name_len, value_len) ((value_len) + NV_ENTRY_DIRECT_HDR + (name_len) + 2)
 #define NV_ENTRY_INDIRECT_HDR (sizeof(NVEntry))
+#define NV_ENTRY_INDIRECT_SIZE(name_len) (NV_ENTRY_INDIRECT_HDR + name_len + 1)
 
 static inline const gchar *
 nv_entry_get_name(NVEntry *self)

--- a/lib/logmsg/nvtable.h
+++ b/lib/logmsg/nvtable.h
@@ -270,6 +270,7 @@ gboolean nv_table_foreach_entry(NVTable *self, NVTableForeachEntryFunc func, gpo
 NVTable *nv_table_new(gint num_static_values, gint index_size_hint, gint init_length);
 NVTable *nv_table_init_borrowed(gpointer space, gsize space_len, gint num_static_entries);
 gboolean nv_table_realloc(NVTable *self, NVTable **new);
+NVTable *nv_table_compact(NVTable *self);
 NVTable *nv_table_clone(NVTable *self, gint additional_space);
 NVTable *nv_table_ref(NVTable *self);
 void nv_table_unref(NVTable *self);

--- a/lib/logmsg/nvtable.h
+++ b/lib/logmsg/nvtable.h
@@ -260,7 +260,7 @@ struct _NVTable
 
 gboolean nv_table_add_value(NVTable *self, NVHandle handle, const gchar *name, gsize name_len, const gchar *value,
                             gsize value_len, gboolean *new_entry);
-void nv_table_unset_value(NVTable *self, NVHandle handle);
+gboolean nv_table_unset_value(NVTable *self, NVHandle handle);
 gboolean nv_table_add_value_indirect(NVTable *self, NVHandle handle, const gchar *name, gsize name_len,
                                      NVReferencedSlice *referenced_slice, gboolean *new_entry);
 

--- a/lib/logmsg/serialization.h
+++ b/lib/logmsg/serialization.h
@@ -41,6 +41,7 @@ typedef struct _LogMessageSerializationState
   NVHandle *updated_sdata_handles;
   NVIndexEntry *updated_index;
   const UnixTime *processed;
+  guint32 flags;
 } LogMessageSerializationState;
 
 #endif

--- a/lib/logmsg/tests/test_logmsg_serialize.c
+++ b/lib/logmsg/tests/test_logmsg_serialize.c
@@ -370,7 +370,26 @@ Test(logmsg_serialize, serialization_performance)
       g_string_truncate(stream, 0);
       log_msg_serialize(msg, sa, 0);
     }
-  stop_stopwatch_and_display_result(iterations, "serializing %d times took", iterations);
+  stop_stopwatch_and_display_result(iterations, "serializing (without compaction) %d times took", iterations);
+  serialize_archive_free(sa);
+  log_msg_unref(msg);
+  g_string_free(stream, TRUE);
+}
+
+Test(logmsg_serialize, serialization_with_compaction_performance)
+{
+  LogMessage *msg = _create_message_to_be_serialized(RAW_MSG, strlen(RAW_MSG));
+  GString *stream = g_string_sized_new(512);
+  const int iterations = 100000;
+
+  SerializeArchive *sa = serialize_string_archive_new(stream);
+  start_stopwatch();
+  for (int i = 0; i < iterations; i++)
+    {
+      g_string_truncate(stream, 0);
+      log_msg_serialize(msg, sa, LMSF_COMPACTION);
+    }
+  stop_stopwatch_and_display_result(iterations, "serializing (with compaction) %d times took", iterations);
   serialize_archive_free(sa);
   log_msg_unref(msg);
   g_string_free(stream, TRUE);

--- a/lib/logmsg/tests/test_logmsg_serialize.c
+++ b/lib/logmsg/tests/test_logmsg_serialize.c
@@ -391,7 +391,7 @@ Test(logmsg_serialize, deserialization_performance)
       log_msg_deserialize(msg, sa);
       log_msg_unref(msg);
     }
-  stop_stopwatch_and_display_result(iterations, "serializing %d times took", iterations);
+  stop_stopwatch_and_display_result(iterations, "deserializing %d times took", iterations);
   serialize_archive_free(sa);
   g_string_free(stream, TRUE);
 }

--- a/lib/logmsg/tests/test_logmsg_serialize.c
+++ b/lib/logmsg/tests/test_logmsg_serialize.c
@@ -167,7 +167,7 @@ _serialize_message_for_test(GString *stream, const gchar *raw_msg)
   SerializeArchive *sa = serialize_string_archive_new(stream);
 
   LogMessage *msg = _create_message_to_be_serialized(raw_msg, strlen(raw_msg));
-  log_msg_serialize(msg, sa);
+  log_msg_serialize(msg, sa, 0);
   log_msg_unref(msg);
   return sa;
 }
@@ -232,7 +232,7 @@ Test(logmsg_serialize, simple_serialization)
   GString *stream = g_string_sized_new(512);
   SerializeArchive *sa = serialize_string_archive_new(stream);
 
-  log_msg_serialize(msg, sa);
+  log_msg_serialize(msg, sa, 0);
 
   log_msg_unref(msg);
   msg = log_msg_new_empty();
@@ -266,7 +266,7 @@ Test(logmsg_serialize, given_ts_processed)
     .ut_gmtoff = 13
   };
 
-  log_msg_serialize_with_ts_processed(msg, sa, &ls);
+  log_msg_serialize_with_ts_processed(msg, sa, &ls, 0);
 
   log_msg_unref(msg);
   msg = log_msg_new_empty();
@@ -293,7 +293,7 @@ Test(logmsg_serialize, existing_ts_processed)
   GString *stream = g_string_sized_new(512);
   SerializeArchive *sa = serialize_string_archive_new(stream);
 
-  log_msg_serialize(msg, sa);
+  log_msg_serialize(msg, sa, 0);
 
   log_msg_unref(msg);
   msg = log_msg_new_empty();
@@ -324,7 +324,7 @@ Test(logmsg_serialize, existing_and_given_ts_processed)
   ls.ut_usec = 12;
   ls.ut_gmtoff = 13;
 
-  log_msg_serialize_with_ts_processed(msg, sa, &ls);
+  log_msg_serialize_with_ts_processed(msg, sa, &ls, 0);
 
   log_msg_unref(msg);
   msg = log_msg_new_empty();
@@ -368,7 +368,7 @@ Test(logmsg_serialize, serialization_performance)
   for (int i = 0; i < iterations; i++)
     {
       g_string_truncate(stream, 0);
-      log_msg_serialize(msg, sa);
+      log_msg_serialize(msg, sa, 0);
     }
   stop_stopwatch_and_display_result(iterations, "serializing %d times took", iterations);
   serialize_archive_free(sa);

--- a/lib/logmsg/tests/test_nvtable.c
+++ b/lib/logmsg/tests/test_nvtable.c
@@ -1021,3 +1021,34 @@ Test(nvtable, test_nvtable_unset_values)
 
   nv_table_unref(tab);
 }
+
+Test(nvtable, test_nvtable_unset_copies_indirect_references)
+{
+  NVTable *tab;
+  gssize size = 9999;
+  const gchar *value;
+  const gchar *indirect_nv_name = "indirect-name";
+
+  tab = nv_table_new(STATIC_VALUES, STATIC_VALUES, 1024);
+  nv_table_add_value(tab, STATIC_HANDLE, STATIC_NAME, strlen(DYN_NAME), "static-foo", 10, NULL);
+  nv_table_add_value_indirect(tab, DYN_HANDLE, indirect_nv_name, strlen(indirect_nv_name),
+                              &(NVReferencedSlice)
+  {
+    STATIC_HANDLE, 1, 5, 0
+  },
+  NULL);
+
+  value = nv_table_get_value(tab, DYN_HANDLE, &size);
+  cr_assert_not_null(value);
+  cr_assert(strncmp(value, "tatic", 5) == 0);
+  cr_assert_eq(size, 5);
+
+  nv_table_unset_value(tab, STATIC_HANDLE);
+
+  value = nv_table_get_value(tab, DYN_HANDLE, &size);
+  cr_assert_not_null(value);
+  cr_assert(strncmp(value, "tatic", 5) == 0);
+  cr_assert_eq(size, 5);
+
+  nv_table_unref(tab);
+}

--- a/libtest/queue_utils_lib.c
+++ b/libtest/queue_utils_lib.c
@@ -41,7 +41,7 @@ get_one_message_serialized_size(void)
   SerializeArchive *sa = serialize_string_archive_new(serialized);
   LogMessage *msg = log_msg_new_empty();
 
-  log_msg_serialize(msg, sa);
+  log_msg_serialize(msg, sa, 0);
   gsize message_length = serialized->len;
 
   log_msg_unref(msg);

--- a/modules/diskq/diskq-grammar.ym
+++ b/modules/diskq/diskq-grammar.ym
@@ -62,6 +62,7 @@ DiskQueueOptions *last_options;
 %token KW_MEM_BUF_LENGTH
 %token KW_DISK_BUF_SIZE
 %token KW_RELIABLE
+%token KW_COMPACTION
 %token KW_MEM_BUF_SIZE
 %token KW_QOUT_SIZE
 %token KW_DIR
@@ -89,12 +90,13 @@ dest_diskq_options
         ;
 
 dest_diskq_option
-        : KW_RELIABLE '(' yesno ')'            { disk_queue_options_reliable_set(last_options, $3); }
+        : KW_RELIABLE '(' yesno ')'                      { disk_queue_options_reliable_set(last_options, $3); }
+        | KW_COMPACTION '(' yesno ')'                    { disk_queue_options_compaction_set(last_options, $3); }
         | KW_MEM_BUF_SIZE '(' nonnegative_integer ')'    { disk_queue_options_mem_buf_size_set(last_options, $3); }
         | KW_MEM_BUF_LENGTH '(' nonnegative_integer ')'  { disk_queue_options_mem_buf_length_set(last_options, $3); }
-        | KW_DISK_BUF_SIZE '(' nonnegative_integer64 ')'   { disk_queue_options_disk_buf_size_set(last_options, $3); }
+        | KW_DISK_BUF_SIZE '(' nonnegative_integer64 ')' { disk_queue_options_disk_buf_size_set(last_options, $3); }
         | KW_QOUT_SIZE '(' nonnegative_integer ')'       { disk_queue_options_qout_size_set(last_options, $3); }
-        | KW_DIR '(' string ')'                { disk_queue_options_set_dir(last_options, $3); free($3); }
+        | KW_DIR '(' string ')'                          { disk_queue_options_set_dir(last_options, $3); free($3); }
         ;
 
 /* INCLUDE_RULES */

--- a/modules/diskq/diskq-options.c
+++ b/modules/diskq/diskq-options.c
@@ -61,6 +61,12 @@ disk_queue_options_reliable_set(DiskQueueOptions *self, gboolean reliable)
 }
 
 void
+disk_queue_options_compaction_set(DiskQueueOptions *self, gboolean compaction)
+{
+  self->compaction = compaction;
+}
+
+void
 disk_queue_options_mem_buf_size_set(DiskQueueOptions *self, gint mem_buf_size)
 {
   self->mem_buf_size = mem_buf_size;

--- a/modules/diskq/diskq-options.h
+++ b/modules/diskq/diskq-options.h
@@ -35,6 +35,7 @@ typedef struct _DiskQueueOptions
   gint qout_size;
   gboolean read_only;
   gboolean reliable;
+  gboolean compaction;
   gint mem_buf_size;
   gint mem_buf_length;
   gchar *dir;
@@ -43,6 +44,7 @@ typedef struct _DiskQueueOptions
 void disk_queue_options_qout_size_set(DiskQueueOptions *self, gint qout_size);
 void disk_queue_options_disk_buf_size_set(DiskQueueOptions *self, gint64 disk_buf_size);
 void disk_queue_options_reliable_set(DiskQueueOptions *self, gboolean reliable);
+void disk_queue_options_compaction_set(DiskQueueOptions *self, gboolean compaction);
 void disk_queue_options_mem_buf_size_set(DiskQueueOptions *self, gint mem_buf_size);
 void disk_queue_options_mem_buf_length_set(DiskQueueOptions *self, gint mem_buf_length);
 void disk_queue_options_check_plugin_settings(DiskQueueOptions *self);

--- a/modules/diskq/diskq-parser.c
+++ b/modules/diskq/diskq-parser.c
@@ -34,6 +34,7 @@ static CfgLexerKeyword diskq_keywords[] =
   { "mem_buf_length",    KW_MEM_BUF_LENGTH },
   { "disk_buf_size",     KW_DISK_BUF_SIZE },
   { "reliable",          KW_RELIABLE },
+  { "compaction",        KW_COMPACTION },
   { "mem_buf_size",      KW_MEM_BUF_SIZE },
   { "qout_size",         KW_QOUT_SIZE },
   { "dir",               KW_DIR },

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -288,12 +288,13 @@ _write_message(LogQueueDisk *self, LogMessage *msg)
 {
   GString *serialized;
   SerializeArchive *sa;
+  DiskQueueOptions *options = qdisk_get_options(self->qdisk);
   gboolean consumed = FALSE;
   if (qdisk_started(self->qdisk) && qdisk_is_space_avail(self->qdisk, 64))
     {
       serialized = g_string_sized_new(64);
       sa = serialize_string_archive_new(serialized);
-      log_msg_serialize(msg, sa);
+      log_msg_serialize(msg, sa, options->compaction ? LMSF_COMPACTION : 0);
       consumed = qdisk_push_tail(self->qdisk, serialized);
       serialize_archive_free(sa);
       g_string_free(serialized, TRUE);

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -679,7 +679,7 @@ _save_queue(QDisk *self, GQueue *q, QDiskQueuePosition *q_pos)
        * disk anyway. */
 
       POINTER_TO_LOG_PATH_OPTIONS(g_queue_pop_head(q), &path_options);
-      log_msg_serialize(msg, sa);
+      log_msg_serialize(msg, sa, self->options->compaction ? LMSF_COMPACTION : 0);
       log_msg_ack(msg, &path_options, AT_PROCESSED);
       log_msg_unref(msg);
       if (string_reached_memory_limit(serialized))

--- a/modules/diskq/tests/test_reliable_backlog.c
+++ b/modules/diskq/tests/test_reliable_backlog.c
@@ -93,7 +93,7 @@ get_serialized_message_size(LogMessage *msg)
   serialized = g_string_sized_new(64);
   sa = serialize_string_archive_new(serialized);
 
-  assert_true(log_msg_serialize(msg, sa), NULL);
+  assert_true(log_msg_serialize(msg, sa, 0), NULL);
 
   result = serialized->len;
 


### PR DESCRIPTION
    This branch introduces a new parameter for disk based buffers, for example:
    
        tcp("127.0.0.1" port(2001) disk-buffer(compaction(yes) disk-buf-size(10M)));
    
    Note the "compaction" argument, it can either be "yes" or "no". With
    compaction(yes), syslog-ng will prune the unused space in the LogMessage
    representation, making the representation of the LogMessage more
    compact. This is useful when syslog-ng uses a lot of name-value pairs during
    processing that become unused when delivering to a destination.
    
    Simply unsetting these values using the unset() rewrite operation does not
    help, as the internal representation of a LogMessage will not release
    the memory associated with these name-value pairs due to performance
    reasons that help when syslog-ng is CPU bound.
    
    In some cases however, the size of this overhead becomes significant (I've
    heard of 4x raw message size in some cases), which becomes unbearable.
    
    For these cases, the compaction will drop "unset" values, making the Logessage
    representation smaller at the cost of some CPU time that is needed to
    perform compaction


The branch also contains a couple of fixes and code improvements in NVTable, which I tried to describe in their respective commit messages, so please review the branch patch-by-patch.

At this point I have added a number of follow-up patches to the compaction related changes that improve readability or performance. Let me know if you want me to shove them into a separate PR.
