### PR TITLE
commit-check: support whitespaces around commas

### DIFF
--- a/tests/commits/check.sh
+++ b/tests/commits/check.sh
@@ -35,7 +35,7 @@ git log --no-merges --pretty="%H" $commit_range -- | (
 
     subject=$(git show -s --format='%s' $commit)
 
-    if ! echo "$subject" | egrep -q '^Revert |^[a-zA-Z0-9/(){}$,._-]+:'; then
+    if ! echo "$subject" | egrep -q '^Revert |^([a-zA-Z0-9/(){}$,._-]{1,}\s*){1,}:'; then
       commit_has_valid_subject=0
     fi
 


### PR DESCRIPTION
Our commit-check script is still too strict.

This pattern failed on commit-check due to the space between elements:
'lib, modules: don't use numeric version identifiers'

From now on, even these are supported:

'lib,    modules,	: fixup'
"li b, ,modules: fixup"

I would prefer a more relaxed commit-check,
as the basic motivation for commit-check was to enforce this pattern:
`modulename: short description of the commit`

I dedicate this PR to the failed Travis job of #3074  :+1: 