### PR TITLE
http: fix curl ssl version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1306,6 +1306,15 @@ if test "x$enable_http" != "xno" && test "x$with_libcurl" != "xno"; then
 		AC_MSG_ERROR(libcurl not found)
 	fi
 	enable_http=$libcurl
+
+        if test "$enable_http" = "yes"; then
+           old_CFLAGS=$CFLAGS
+           CFLAGS=$LIBCURL_CFLAGS
+           AC_CHECK_DECLS([CURL_SSLVERSION_TLSv1_0, CURL_SSLVERSION_TLSv1_1, CURL_SSLVERSION_TLSv1_2, CURL_SSLVERSION_TLSv1_3],
+                          [], [],
+                          [[#include <curl/curl.h>]])
+           CFLAGS=$old_CFLAGS
+        fi
 fi
 
 dnl ***************************************************************************

--- a/modules/http/CMakeLists.txt
+++ b/modules/http/CMakeLists.txt
@@ -34,6 +34,24 @@ bison_target(HttpParserGrammar
 
 add_library(http SHARED ${HTTP_DESTINATION_SOURCES})
 
+function (curl_detect_compile_option NAME)
+  set(CMAKE_REQUIRED_INCLUDES "${Curl_INCLUDE_DIR}")
+  set(CMAKE_EXTRA_INCLUDE_FILES "curl/curl.h")
+  string(TOUPPER ${NAME} NAME_CAPITAL)
+
+  check_type_size(${NAME} SYSLOG_NG_HAVE_DECL_${NAME_CAPITAL})
+  if (SYSLOG_NG_HAVE_DECL_${NAME_CAPITAL})
+    target_compile_definitions(http PRIVATE "-DSYSLOG_NG_HAVE_DECL_${NAME_CAPITAL}=1")
+  else()
+    target_compile_definitions(http PRIVATE "-DSYSLOG_NG_HAVE_DECL_${NAME_CAPITAL}=0")
+  endif()
+endfunction ()
+
+curl_detect_compile_option(CURL_SSLVERSION_TLSv1_0)
+curl_detect_compile_option(CURL_SSLVERSION_TLSv1_1)
+curl_detect_compile_option(CURL_SSLVERSION_TLSv1_2)
+curl_detect_compile_option(CURL_SSLVERSION_TLSv1_3)
+
 target_include_directories (http PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories (http PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories (http PRIVATE ${Curl_INCLUDE_DIR})

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -173,7 +173,9 @@ http_tls_option
     | KW_KEY_FILE   '(' path_secret ')'       { http_dd_set_key_file(last_driver, $3); free($3); }
     | KW_CIPHER_SUITE '(' string ')'          { http_dd_set_cipher_suite(last_driver, $3); free($3); }
     | KW_USE_SYSTEM_CERT_STORE '(' yesno ')'  { http_dd_set_use_system_cert_store(last_driver, $3); }
-    | KW_SSL_VERSION '(' string ')'           { http_dd_set_ssl_version(last_driver, $3); free($3); }
+    | KW_SSL_VERSION '(' string ')'           { CHECK_ERROR(http_dd_set_ssl_version(last_driver, $3), @3,
+                                                            "curl: unsupported SSL version: %s", $3);
+                                                free($3); }
     | KW_PEER_VERIFY '(' yesno ')'            { http_dd_set_peer_verify(last_driver, $3); }
     ;
 

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -220,28 +220,28 @@ http_dd_set_ssl_version(LogDriver *d, const gchar *value)
       /* SSL 3 only */
       self->ssl_version = CURL_SSLVERSION_SSLv3;
     }
-#ifdef CURL_SSLVERSION_TLSv1_0
+#if SYSLOG_NG_HAVE_DECL_CURL_SSLVERSION_TLSV1_0
   else if (strcmp(value, "tlsv1_0") == 0)
     {
       /* TLS 1.0 only */
       self->ssl_version = CURL_SSLVERSION_TLSv1_0;
     }
 #endif
-#ifdef CURL_SSLVERSION_TLSv1_1
+#if SYSLOG_NG_HAVE_DECL_CURL_SSLVERSION_TLSV1_1
   else if (strcmp(value, "tlsv1_1") == 0)
     {
       /* TLS 1.1 only */
       self->ssl_version = CURL_SSLVERSION_TLSv1_1;
     }
 #endif
-#ifdef CURL_SSLVERSION_TLSv1_2
+#if SYSLOG_NG_HAVE_DECL_CURL_SSLVERSION_TLSV1_2
   else if (strcmp(value, "tlsv1_2") == 0)
     {
       /* TLS 1.2 only */
       self->ssl_version = CURL_SSLVERSION_TLSv1_2;
     }
 #endif
-#ifdef CURL_SSLVERSION_TLSv1_3
+#if SYSLOG_NG_HAVE_DECL_CURL_SSLVERSION_TLSV1_3
   else if (strcmp(value, "tlsv1_3") == 0)
     {
       /* TLS 1.3 only */

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -189,7 +189,7 @@ http_dd_set_cipher_suite(LogDriver *d, const gchar *ciphers)
   self->ciphers = g_strdup(ciphers);
 }
 
-void
+gboolean
 http_dd_set_ssl_version(LogDriver *d, const gchar *value)
 {
   HTTPDestinationDriver *self = (HTTPDestinationDriver *) d;
@@ -249,10 +249,9 @@ http_dd_set_ssl_version(LogDriver *d, const gchar *value)
     }
 #endif
   else
-    {
-      msg_warning("curl: unsupported SSL version",
-                  evt_tag_str("ssl_version", value));
-    }
+    return FALSE;
+
+  return TRUE;
 }
 
 void

--- a/modules/http/http.h
+++ b/modules/http/http.h
@@ -88,7 +88,7 @@ void http_dd_set_ca_file(LogDriver *d, const gchar *ca_file);
 void http_dd_set_cert_file(LogDriver *d, const gchar *cert_file);
 void http_dd_set_key_file(LogDriver *d, const gchar *key_file);
 void http_dd_set_cipher_suite(LogDriver *d, const gchar *ciphers);
-void http_dd_set_ssl_version(LogDriver *d, const gchar *value);
+gboolean http_dd_set_ssl_version(LogDriver *d, const gchar *value);
 void http_dd_set_peer_verify(LogDriver *d, gboolean verify);
 void http_dd_set_timeout(LogDriver *d, glong timeout);
 void http_dd_set_batch_bytes(LogDriver *d, glong batch_bytes);


### PR DESCRIPTION
Some `ssl-version` options were not accepted by http destination, even though they should have been:
- tlsv1_0
- tlsv1_1
- tlsv1_2
- tlsv1_3

The reason was that the used compiler switches did not exist. They were an enum instead.

Hence the relevant code was disabled.

The previous behaviour was that syslog-ng starts no matter what was the `ssl-version`, just emit a warning if something unexpected is detected.

This patch fixes:
- The compiler switches
- Syslog-ng will not start if invalid `ssl-version` string was added.

This latter might break some existing configuration: if users accidentally mistyped the option, syslog-ng will not start. I think this is acceptable, considering, this options specifies the minimum version of used ssl version, and thus might have security impact.