### PR TITLE
elasticsearch-java: fix `requires` in scl

### DIFF
--- a/scl/elasticsearch/elastic-java.conf
+++ b/scl/elasticsearch/elastic-java.conf
@@ -21,7 +21,6 @@
 #############################################################################
 
 @requires json-plugin
-@requires mod-java
 
 block destination elasticsearch2(
   index()
@@ -52,7 +51,7 @@ block destination elasticsearch2(
 )
 {
 
-@requires java "The elasticsearch2() driver depends on the syslog-ng java module, please install the syslog-ng-mod-java (Debian & derivatives) or the syslog-ng-java (RHEL & co) package"
+@requires mod-java "The elasticsearch2() driver depends on the syslog-ng java module, please install the syslog-ng-mod-java (Debian & derivatives) or the syslog-ng-java (RHEL & co) package"
 
 
   java(


### PR DESCRIPTION
It was `java` instead of `mod-java`. Also the `requires` on the top is not needed now.

Signed-off-by: Attila Szakacs <attila.szakacs@balabit.com>