### PR TITLE
Autodetect system cert store

### DIFF
--- a/modules/http/CMakeLists.txt
+++ b/modules/http/CMakeLists.txt
@@ -24,6 +24,8 @@ set(HTTP_DESTINATION_SOURCES
     response-handler.h
     response-handler.c
     http-signals.h
+    autodetect-ca-location.h
+    autodetect-ca-location.c
     ${CMAKE_CURRENT_BINARY_DIR}/http-grammar.c
     ${CMAKE_CURRENT_BINARY_DIR}/http-grammar.h
 )

--- a/modules/http/Makefile.am
+++ b/modules/http/Makefile.am
@@ -2,6 +2,8 @@ if ENABLE_HTTP
 
 module_LTLIBRARIES      += modules/http/libhttp.la
 modules_http_libhttp_la_SOURCES = \
+  modules/http/autodetect-ca-location.h \
+  modules/http/autodetect-ca-location.c \
   modules/http/response-handler.h   \
   modules/http/response-handler.c   \
   modules/http/http.h 		    \

--- a/modules/http/autodetect-ca-location.c
+++ b/modules/http/autodetect-ca-location.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020 One Identity
+ * Copyright (c) 2020 Antal Nemes
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "autodetect-ca-location.h"
+#include "glib/gstdio.h"
+
+#include <unistd.h>
+
+const gchar *
+auto_detect_ca_file(void)
+{
+  static gchar *bundles[] =
+  {
+    "/etc/ssl/certs/ca-certificates.crt",
+    "/etc/pki/tls/certs/ca-bundle.crt",
+    "/usr/share/ssl/certs/ca-bundle.crt",
+    "/usr/local/share/certs/ca-root-nss.crt",
+    "/etc/ssl/cert.pem",
+    NULL
+  };
+
+  for (int i = 0; bundles[i]; i++)
+    {
+      if (!g_access(bundles[i], R_OK))
+        {
+          return bundles[i];
+        }
+    }
+  return NULL;
+}
+
+const gchar *
+auto_detect_ca_dir(void)
+{
+  static gchar *ca_dirs[] =
+  {
+    "/etc/ssl/certs",
+    NULL
+  };
+
+  for (int i = 0; ca_dirs[i]; i++)
+    {
+      if (!g_access(ca_dirs[i], R_OK))
+        {
+          return ca_dirs[i];
+        }
+    }
+
+  return NULL;
+}

--- a/modules/http/autodetect-ca-location.h
+++ b/modules/http/autodetect-ca-location.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020 One Identity
+ * Copyright (c) 2020 Antal Nemes
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef AUTODETECT_CA_LOCATION_INCLUDED_H
+#define AUTODETECT_CA_LOCATION_INCLUDED_H
+
+#include "syslog-ng.h"
+
+const gchar *auto_detect_ca_file(void);
+const gchar *auto_detect_ca_dir(void);
+
+#endif

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -33,6 +33,7 @@
 #include "http.h"
 #include "http-grammar.h"
 #include "response-handler.h"
+#include "autodetect-ca-location.h"
 #include "plugin.h"
 
 #include <string.h>
@@ -172,10 +173,19 @@ http_tls_option
     | KW_CERT_FILE  '(' path_check ')'        { http_dd_set_cert_file(last_driver, $3); free($3); }
     | KW_KEY_FILE   '(' path_secret ')'       { http_dd_set_key_file(last_driver, $3); free($3); }
     | KW_CIPHER_SUITE '(' string ')'          { http_dd_set_cipher_suite(last_driver, $3); free($3); }
-    | KW_USE_SYSTEM_CERT_STORE '(' yesno ')'  { http_dd_set_use_system_cert_store(last_driver, $3); }
     | KW_SSL_VERSION '(' string ')'           { CHECK_ERROR(http_dd_set_ssl_version(last_driver, $3), @3,
                                                             "curl: unsupported SSL version: %s", $3);
                                                 free($3); }
+    | KW_USE_SYSTEM_CERT_STORE '(' yesno ')'  {
+        if ($3)
+          {
+            const gchar *ca_dir = auto_detect_ca_dir();
+            const gchar *ca_file = auto_detect_ca_file();
+            if (!ca_dir && !ca_file) YYERROR;
+            http_dd_set_ca_file(last_driver, ca_file);
+            http_dd_set_ca_dir(last_driver, ca_dir);
+          }
+      }
     | KW_PEER_VERIFY '(' yesno ')'            { http_dd_set_peer_verify(last_driver, $3); }
     ;
 

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -181,7 +181,8 @@ http_tls_option
           {
             const gchar *ca_dir = auto_detect_ca_dir();
             const gchar *ca_file = auto_detect_ca_file();
-            if (!ca_dir && !ca_file) YYERROR;
+            CHECK_ERROR(!ca_dir && !ca_file, @3,
+                        "Failed to autodect system cert store");
             http_dd_set_ca_file(last_driver, ca_file);
             http_dd_set_ca_dir(last_driver, ca_dir);
           }

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -108,10 +108,10 @@ _setup_static_options_in_curl(HTTPDestinationWorker *self)
   if (owner->user_agent)
     curl_easy_setopt(self->curl, CURLOPT_USERAGENT, owner->user_agent);
 
-  if (owner->ca_dir || !owner->use_system_cert_store)
+  if (owner->ca_dir)
     curl_easy_setopt(self->curl, CURLOPT_CAPATH, owner->ca_dir);
 
-  if (owner->ca_file || !owner->use_system_cert_store)
+  if (owner->ca_file)
     curl_easy_setopt(self->curl, CURLOPT_CAINFO, owner->ca_file);
 
   if (owner->cert_file)

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -146,14 +146,6 @@ http_dd_set_ca_dir(LogDriver *d, const gchar *ca_dir)
 }
 
 void
-http_dd_set_use_system_cert_store(LogDriver *d, gboolean enable)
-{
-  HTTPDestinationDriver *self = (HTTPDestinationDriver *) d;
-
-  self->use_system_cert_store = enable;
-}
-
-void
 http_dd_set_ca_file(LogDriver *d, const gchar *ca_file)
 {
   HTTPDestinationDriver *self = (HTTPDestinationDriver *) d;

--- a/modules/http/http.h
+++ b/modules/http/http.h
@@ -48,7 +48,6 @@ typedef struct
   HttpAuthHeader *auth_header;
   gchar *user_agent;
   gchar *ca_dir;
-  gboolean use_system_cert_store;
   gchar *ca_file;
   gchar *cert_file;
   gchar *key_file;
@@ -83,7 +82,6 @@ void http_dd_set_auth_header(LogDriver *d, HttpAuthHeader *auth_header);
 void http_dd_set_body(LogDriver *d, LogTemplate *body);
 void http_dd_set_accept_redirects(LogDriver *d, gboolean accept_redirects);
 void http_dd_set_ca_dir(LogDriver *d, const gchar *ca_dir);
-void http_dd_set_use_system_cert_store(LogDriver *d, gboolean enable);
 void http_dd_set_ca_file(LogDriver *d, const gchar *ca_file);
 void http_dd_set_cert_file(LogDriver *d, const gchar *cert_file);
 void http_dd_set_key_file(LogDriver *d, const gchar *key_file);

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -92,6 +92,7 @@ modules/(add-contextual-data|tagsparser|map-value-pairs|hook-commands|appmodel|[
 modules/http/(http-loadbalancer|http-worker)\.[ch]$
 modules/http/response-handler\.[ch]$
 modules/http/http-curl-header-list\.[ch]$
+modules/http/autodetect-ca-location\.[ch]$
 scl
 scripts
 modules/http/tests


### PR DESCRIPTION
Change `use-system-cert-store` : this option was added in order to support monolithic installations that ships even libcurl...  But later, as it came out, it's not enough. 
What we really need is to do some autodetection regarding ca-file and ca-dir.
In monolithic installations that ships even libcurl we need to enable this by default in the related SCLs.

@furiel: could you check this?