### PR TITLE
Rephrase COPYING

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -24,6 +24,8 @@ License version 2 as published by the Free Software Foundation,
 or (at your option) any later version
 (please refer to the file GPL.txt for more details).
 
+For file-level license details, check tests/copyright/policy.
+
 FAQ:
 ====
 

--- a/COPYING
+++ b/COPYING
@@ -17,8 +17,8 @@ syslog-ng-ctl/
 persist-tool/
 tests/loggen/
 
-The syslog-ng modules (modules/ subdirectory except the ones that declare
-LGPL-2.1-or-later in their license notices) is free software; you can
+The syslog-ng modules (modules/ and scl/ subdirectories, except the ones that
+declare LGPL-2.1-or-later in their license notices) is free software; you can
 redistribute it and/or modify it under the terms of the GNU General Public
 License version 2 as published by the Free Software Foundation,
 or (at your option) any later version

--- a/COPYING
+++ b/COPYING
@@ -13,6 +13,9 @@ version 2.1 of the License, or (at your option) any later version
 lib/
 libtest/
 syslog-ng/
+syslog-ng-ctl/
+persist-tool/
+tests/loggen/
 
 The syslog-ng modules (modules/ subdirectory except the ones that declare
 LGPL-2.1-or-later in their license notices) is free software; you can

--- a/COPYING
+++ b/COPYING
@@ -13,15 +13,13 @@ version 2.1 of the License, or (at your option) any later version
 lib/
 libtest/
 syslog-ng/
-modules/java-common/
-modules/java/(native|proxies|src)/
-modules/native/
 
-The syslog-ng modules (modules/ subdirectory except the ones mentioned above)
-is free software; you can redistribute it and/or modify it
-under the terms of the GNU General Public License version 2 as published
-by the Free Software Foundation, or (at your option) any later version
-(please refer to the file LGPL.txt for more details).
+The syslog-ng modules (modules/ subdirectory except the ones that declare
+LGPL-2.1-or-later in their license notices) is free software; you can
+redistribute it and/or modify it under the terms of the GNU General Public
+License version 2 as published by the Free Software Foundation,
+or (at your option) any later version
+(please refer to the file GPL.txt for more details).
 
 FAQ:
 ====


### PR DESCRIPTION
Maintaining the list of modules licensed under LGPL-2.0-or-later (along with `tests/copyright/policy`) is error-prone.

For example, we forgot to add certain units from the Python language binding, appmodel, basicfuncs (tf-template), and http-signals.

Instead of maintaining this list, I've rephrased the license text to express our original intention:

```diff
-modules/ subdirectory except the ones mentioned above)
+modules/ subdirectory except the ones that declare LGPL-2.1-or-later
+in their license notices
```

I've also listed  `syslog-ng-ctl`, `persist-tool`, and `loggen` as `LGPL-2.1-or-later`; and `scl/` subdirectories as `GPL-2.0-or-later` (with the above exception).

@bazsi Is this acceptable?