### PR TITLE
snmp destination driver: make it threaded

### DIFF
--- a/lib/seqnum.h
+++ b/lib/seqnum.h
@@ -45,7 +45,11 @@ step_sequence_number(gint32 *seqnum)
 static inline gint32
 step_sequence_number_atomic(gint32 *seqnum)
 {
-  return (gint32) g_atomic_int_exchange_and_add(seqnum, 1);
+#if GLIB_CHECK_VERSION(2, 30, 0)
+  return (gint32)g_atomic_int_add(seqnum, 1);
+#else
+  return (gint32)g_atomic_int_exchange_and_add(seqnum, 1);
+#endif
 }
 
 

--- a/modules/snmp-dest/snmpdest.h
+++ b/modules/snmp-dest/snmpdest.h
@@ -29,6 +29,7 @@
 
 #include "driver.h"
 #include "mainloop-worker.h"
+#include "logthrdest/logthrdestdrv.h"
 
 #define ENGINE_ID_MAX_LENGTH 32
 #define ENGINE_ID_MIN_LENGTH 5
@@ -38,7 +39,7 @@ extern const gchar *s_v2c,
 
 typedef struct
 {
-  LogDestDriver super;
+  LogThreadedDestDriver super;
 
   gchar *version;
   gchar *host;
@@ -59,16 +60,6 @@ typedef struct
   gchar *enc_password;
   gchar *transport;
 
-  StatsCounterItem *dropped_messages;
-  StatsCounterItem *queued_messages;
-  StatsCounterItem *processed_messages;
-
-  GMutex *queue_mutex;
-  GCond *writer_thread_wakeup_cond;
-
-  gboolean writer_thread_terminate;
-  gboolean writer_thread_suspended;
-
   netsnmp_session session,
                   *ss;
   gboolean session_initialized;
@@ -76,10 +67,6 @@ typedef struct
   LogTemplate *message;
   LogTemplateOptions template_options;
   WorkerOptions worker_options;
-
-  StatsClusterKey sc_key_queued;
-  StatsClusterKey sc_key_dropped;
-  StatsClusterKey sc_key_processed;
 
 } SNMPDestDriver;
 


### PR DESCRIPTION
Refactor snmp destination driver to be based on threaded destination driver.
During the development it turned out that we use g_atomic_int_exchange_and_add in seqnum.h which is deprecated since glib version 2.30. A commit has been created to fix this deprecated function.