### PR TITLE
examples: add http-test-slots

### DIFF
--- a/modules/examples/CMakeLists.txt
+++ b/modules/examples/CMakeLists.txt
@@ -5,9 +5,13 @@ add_subdirectory(sources/msg-generator)
 add_subdirectory(sources/threaded-random-generator)
 add_subdirectory(sources/threaded-diskq-source)
 
+add_subdirectory(inner-destinations/http-test-slots)
+
 target_link_libraries(examples PRIVATE msg-generator)
 target_link_libraries(examples PRIVATE threaded-random-generator)
 target_link_libraries(examples PRIVATE threaded-diskq-source)
+
+target_link_libraries(examples PRIVATE http-test-slots)
 
 
 target_link_libraries(examples PRIVATE syslog-ng)

--- a/modules/examples/Makefile.am
+++ b/modules/examples/Makefile.am
@@ -1,10 +1,12 @@
 include modules/examples/sources/msg-generator/Makefile.am
 include modules/examples/sources/threaded-diskq-source/Makefile.am
 include modules/examples/sources/threaded-random-generator/Makefile.am
+include modules/examples/inner-destinations/http-test-slots/Makefile.am
 
 EXAMPLE_PLUGINS = \
   $(top_builddir)/modules/examples/sources/libmsg-generator.la \
-  $(top_builddir)/modules/examples/sources/libthreaded-diskq-source.la
+  $(top_builddir)/modules/examples/sources/libthreaded-diskq-source.la \
+	$(top_builddir)/modules/examples/inner-destinations/http-test-slots/libhttp-test-slots.la
 
 if HAVE_GETRANDOM
 EXAMPLE_PLUGINS += $(top_builddir)/modules/examples/sources/libthreaded-random-generator.la

--- a/modules/examples/example-plugins.c
+++ b/modules/examples/example-plugins.c
@@ -33,6 +33,8 @@ extern CfgParser threaded_random_generator_parser;
 
 extern CfgParser threaded_diskq_source_parser;
 
+extern CfgParser http_test_slots_parser;
+
 static Plugin example_plugins[] =
 {
   {
@@ -52,6 +54,11 @@ static Plugin example_plugins[] =
     .name = "example_diskq_source",
     .parser = &threaded_diskq_source_parser,
   },
+  {
+    .type = LL_CONTEXT_INNER_DEST,
+    .name = "http_test_slots",
+    .parser = &http_test_slots_parser
+  }
 };
 
 gboolean

--- a/modules/examples/inner-destinations/http-test-slots/CMakeLists.txt
+++ b/modules/examples/inner-destinations/http-test-slots/CMakeLists.txt
@@ -1,0 +1,29 @@
+set(HTTP_TEST_SLOTS_HEADERS
+    "${CMAKE_CURRENT_BINARY_DIR}/http-test-slots-grammar.h"
+    "http-test-slots-parser.h"
+    "http-test-slots.h"
+)
+
+set(HTTP_TEST_SLOTS_SOURCES
+    "${CMAKE_CURRENT_BINARY_DIR}/http-test-slots-grammar.c"
+    "http-test-slots-parser.c"
+    "http-test-slots.c"
+)
+
+generate_y_from_ym(modules/examples/inner-destinations/http-test-slots/http-test-slots-grammar)
+
+bison_target(HttpTestSlotsGrammar
+      ${CMAKE_CURRENT_BINARY_DIR}/http-test-slots-grammar.y
+      ${CMAKE_CURRENT_BINARY_DIR}/http-test-slots-grammar.c
+      COMPILE_FLAGS ${BISON_FLAGS})
+
+add_library(http-test-slots STATIC ${HTTP_TEST_SLOTS_SOURCES})
+
+target_include_directories(http-test-slots
+  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+  PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+  PUBLIC ${PROJECT_SOURCE_DIR}
+)
+
+target_link_libraries(http-test-slots PUBLIC syslog-ng)
+

--- a/modules/examples/inner-destinations/http-test-slots/Makefile.am
+++ b/modules/examples/inner-destinations/http-test-slots/Makefile.am
@@ -1,0 +1,22 @@
+noinst_LTLIBRARIES += modules/examples/inner-destinations/http-test-slots/libhttp-test-slots.la
+
+modules_examples_inner_destinations_http_test_slots_libhttp_test_slots_la_SOURCES = \
+  modules/examples/inner-destinations/http-test-slots/http-test-slots.c \
+  modules/examples/inner-destinations/http-test-slots/http-test-slots.h \
+  modules/examples/inner-destinations/http-test-slots/http-test-slots-grammar.y \
+  modules/examples/inner-destinations/http-test-slots/http-test-slots-parser.c \
+  modules/examples/inner-destinations/http-test-slots/http-test-slots-parser.h
+
+BUILT_SOURCES += \
+  modules/examples/inner-destinations/http-test-slots/http-test-slots-grammar.y \
+  modules/examples/inner-destinations/http-test-slots/http-test-slots-grammar.c \
+  modules/examples/inner-destinations/http-test-slots/http-test-slots-grammar.h
+
+EXTRA_DIST += modules/examples/inner-destinations/http-test-slots/http-test-slots-grammar.ym
+
+modules_examples_inner_destinations_http_test_slots_libhttp_test_slots_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/modules/examples/inner-destinations/http-test-slots -I$(top_builddir)/modules/examples/inner-destinations/http-test-slots
+modules_examples_inner_destinations_http_test_slots_libhttp_test_slots_la_LIBADD = $(MODULE_DEPS_LIBS)
+modules_examples_inner_destinations_http_test_slots_libhttp_test_slots_la_LDFLAGS = $(MODULE_LDFLAGS)
+modules_examples_inner_destinations_http_test_slots_libhttp_test_slots_la_DEPENDENCIES = $(MODULE_DEPS_LIBS)
+
+PHONY: modules/examples/inner-destinations/http-test-slots/ mod-http-test-slots

--- a/modules/examples/inner-destinations/http-test-slots/http-test-slots-grammar.ym
+++ b/modules/examples/inner-destinations/http-test-slots/http-test-slots-grammar.ym
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2020 One Identity
+ * Copyright (c) 2020 Laszlo Budai <laszlo.budai@outlook.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+%code top {
+#include "driver.h"
+#include "cfg-lexer.h"
+#include "http-test-slots-parser.h"
+}
+
+%code {
+
+#pragma GCC diagnostic ignored "-Wswitch-default"
+
+#include "http-test-slots.h"
+
+HttpTestSlotsPlugin *last_http_test_slots;
+
+}
+
+%name-prefix "http_test_slots_"
+
+/* this parameter is needed in order to instruct bison to use a complete
+ * argument list for yylex/yyerror */
+
+%lex-param {CfgLexer *lexer}
+%parse-param {CfgLexer *lexer}
+%parse-param {LogDriverPlugin **instance}
+%parse-param {gpointer arg}
+
+/* INCLUDE_DECLS */
+
+%token KW_HTTP_TEST_SLOTS
+%token KW_HEADER
+
+%%
+
+start
+  : LL_CONTEXT_INNER_DEST http_test_slots_start { YYACCEPT; }
+  ;
+
+http_test_slots_start
+  : KW_HTTP_TEST_SLOTS '('
+  {
+    last_http_test_slots = http_test_slots_plugin_new();
+    *instance = (LogDriverPlugin *) last_http_test_slots;
+    }
+    http_test_slots_options
+  ')'
+  ;
+
+http_test_slots_options
+	: http_test_slots_option http_test_slots_options
+	|
+	;
+
+
+http_test_slots_option
+  : KW_HEADER '(' string ')'		{ http_test_slots_plugin_set_header(last_http_test_slots, $3); free($3); }
+
+  ;
+
+/* INCLUDE_RULES */
+
+%%

--- a/modules/examples/inner-destinations/http-test-slots/http-test-slots-parser.c
+++ b/modules/examples/inner-destinations/http-test-slots/http-test-slots-parser.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 One Identity
+ * Copyright (c) 2020 Laszlo Budai <laszlo.budai@outlook.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "http-test-slots.h"
+#include "cfg-parser.h"
+#include "http-test-slots-grammar.h"
+
+extern int http_test_slots_debug;
+int http_test_slots_parse(CfgLexer *lexer, LogDriverPlugin **instance, gpointer arg);
+
+static CfgLexerKeyword http_test_slots_keywords[] =
+{
+  { "http_test_slots",  KW_HTTP_TEST_SLOTS },
+  { "header", KW_HEADER },
+  { NULL }
+};
+
+CfgParser http_test_slots_parser =
+{
+#if SYSLOG_NG_ENABLE_DEBUG
+  .debug_flag = &http_test_slots_debug,
+#endif
+  .name = "http_test_slots",
+  .keywords = http_test_slots_keywords,
+  .parse = (int (*)(CfgLexer *lexer, gpointer *instance, gpointer arg)) http_test_slots_parse,
+  .cleanup = (void (*)(gpointer)) log_driver_plugin_free
+};
+
+CFG_PARSER_IMPLEMENT_LEXER_BINDING(http_test_slots_, LogDriverPlugin **)

--- a/modules/examples/inner-destinations/http-test-slots/http-test-slots-parser.h
+++ b/modules/examples/inner-destinations/http-test-slots/http-test-slots-parser.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 One Identity
+ * Copyright (c) 2020 Laszlo Budai <laszlo.budai@outlook.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef HTTP_TEST_SLOTS_PARSER_H_INCLUDED
+#define HTTP_TEST_SLOTS_PARSER_H_INCLUDED
+
+#include "cfg-parser.h"
+#include "driver.h"
+
+extern CfgParser http_test_slots_parser;
+
+CFG_PARSER_DECLARE_LEXER_BINDING(http_test_slots_, LogDriverPlugin **);
+
+#endif

--- a/modules/examples/inner-destinations/http-test-slots/http-test-slots.c
+++ b/modules/examples/inner-destinations/http-test-slots/http-test-slots.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2020 One Identity
+ * Copyright (c) 2020 Laszlo Budai <laszlo.budai@outlook.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "http-test-slots.h"
+#include "modules/http/http-signals.h"
+
+#define HTTP_TEST_SLOTS_PLUGIN "http-test-slots"
+
+struct _HttpTestSlotsPlugin
+{
+  LogDriverPlugin super;
+  gchar *header;
+};
+
+void
+http_test_slots_plugin_set_header(HttpTestSlotsPlugin *self, const gchar *header)
+{
+  g_free(self->header);
+  self->header = g_strdup(header);
+}
+
+static void
+_slot_append_test_headers(HttpTestSlotsPlugin *self, HttpHeaderRequestSignalData *data)
+{
+  list_append(data->request_headers, self->header);
+}
+
+static gboolean
+_attach(LogDriverPlugin *s, LogDriver *driver)
+{
+  SignalSlotConnector *ssc = driver->super.signal_slot_connector;
+
+  msg_debug("HttpTestSlotsPlugin::attach()",
+            evt_tag_printf("SignalSlotConnector", "%p", ssc));
+
+  /* DISCONNECT: the whole SignalSlotConnector is destroyed when the owner LogDriver is freed up, so DISCONNECT is not required */
+  CONNECT(ssc, signal_http_header_request, _slot_append_test_headers, s);
+
+  return TRUE;
+}
+
+static void
+_free(LogDriverPlugin *s)
+{
+  msg_debug("HttpTestSlotsPlugin::free");
+  HttpTestSlotsPlugin *self = (HttpTestSlotsPlugin *)s;
+  g_free(self->header);
+  log_driver_plugin_free_method(s);
+}
+
+HttpTestSlotsPlugin *
+http_test_slots_plugin_new(void)
+{
+  HttpTestSlotsPlugin *self = g_new0(HttpTestSlotsPlugin, 1);
+
+  log_driver_plugin_init_instance(&self->super, HTTP_TEST_SLOTS_PLUGIN);
+
+  self->super.attach = _attach;
+  self->super.free_fn = _free;
+
+  return self;
+}

--- a/modules/examples/inner-destinations/http-test-slots/http-test-slots.h
+++ b/modules/examples/inner-destinations/http-test-slots/http-test-slots.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020 One Identity
+ * Copyright (c) 2020 Laszlo Budai <laszlo.budai@outlook.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef HTTP_TEST_SLOTS_H_INCLUDED
+#define HTTP_TEST_SLOTS_H_INCLUDED
+
+#include "driver.h"
+
+typedef struct _HttpTestSlotsPlugin HttpTestSlotsPlugin;
+
+HttpTestSlotsPlugin *http_test_slots_plugin_new(void);
+
+void http_test_slots_plugin_set_header(HttpTestSlotsPlugin *self, const gchar *header);
+
+#endif

--- a/news/developer-note-3093.md
+++ b/news/developer-note-3093.md
@@ -1,0 +1,42 @@
+`example-modules`: add example http slot plugin
+
+This plugin is an example plugin that implements a slot for a HTTP signal (`signal_http_header_request`).
+
+When the plugin is `attached`, it `CONNECT` itself to the signal.
+When the signal is emitted by the http module, the slot is executed and append the `header` to the http headers.
+
+`header` is set in the config file.
+
+<details>
+  <summary>Example config, click to expand!</summary>
+
+```
+version:3.25
+
+@include "scl.conf"
+
+destination d_http {
+  http(
+    url("http://127.0.0.1:8888")
+    method("PUT")
+    user_agent("syslog-ng User Agent")
+    http-test-slots(
+      header("xxx:aaa") # this will be appended to the http headers
+    )
+    body("${ISODATE} ${MESSAGE}")
+  );
+};
+
+source s_generator {
+  example-msg-generator(num(1) template("test msg\n") );}
+;
+source s_net {
+  network(port(5555));
+};
+
+log {
+  source(s_generator);
+  destination(d_http);
+};
+```
+</details>


### PR DESCRIPTION
as @gaborznagy requested, I added this test slot module to examples

example config:
```
@version:3.25

@include "scl.conf"

destination d_http {
  http(
    url("http://127.0.0.1:8888")
    method("PUT")
    user_agent("syslog-ng User Agent")
    user("user")
    password("password")
    headers("HEADER1: header1", "HEADER2: header2")
    http-test-slots(
      header("xxx:aaa")
    )
    body("${ISODATE} ${MESSAGE}")
  );
};

source s_generator {
  example-msg-generator(num(1) template("test msg\n") );}
;
source s_net {
  network(port(5555));
};

log {
  source(s_generator);
  destination(d_http);
};

```