### PR TITLE
travis: force python2, add --cache-dir=$PWD/cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,8 @@ addons:
       - libsnmp-dev
       - ninja-build
 install:
-      - pip install --user --cache-dir=$PWD/pip-cache -r requirements.txt
-      - pip list
+      - python2 -m pip install --user --cache-dir=$PWD/pip-cache -r requirements.txt
+      - python2 -m pip list
 before_script:
   - echo 'Europe/Budapest' | sudo tee /etc/timezone
   - sudo dpkg-reconfigure --frontend noninteractive tzdata
@@ -95,7 +95,7 @@ matrix:
       compiler: clang
       script:
         - set -e
-        - pip install --user --cache-dir=$PWD/pip-cache pre-commit-hooks
+        - python2 -m pip install --user --cache-dir=$PWD/pip-cache pre-commit-hooks
         - make --keep-going -j $(nproc) || make V=1 install;
         - make install
         - . scripts/get-libjvm-path.sh;
@@ -150,7 +150,7 @@ matrix:
         submodules: true
       script:
         - set -e
-        - pip install --user --cache-dir=$PWD/pip-cache pre-commit-hooks
+        - python2 -m pip install --user --cache-dir=$PWD/pip-cache pre-commit-hooks
         - mkdir build
         - cd build
         - cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ addons:
       - libsnmp-dev
       - ninja-build
 install:
-      - pip install --user -r requirements.txt
+      - pip install --user --cache-dir=$PWD/pip-cache -r requirements.txt
       - pip list
 before_script:
   - echo 'Europe/Budapest' | sudo tee /etc/timezone
@@ -95,7 +95,7 @@ matrix:
       compiler: clang
       script:
         - set -e
-        - pip install --user pre-commit-hooks
+        - pip install --user --cache-dir=$PWD/pip-cache pre-commit-hooks
         - make --keep-going -j $(nproc) || make V=1 install;
         - make install
         - . scripts/get-libjvm-path.sh;
@@ -150,7 +150,7 @@ matrix:
         submodules: true
       script:
         - set -e
-        - pip install --user pre-commit-hooks
+        - pip install --user --cache-dir=$PWD/pip-cache pre-commit-hooks
         - mkdir build
         - cd build
         - cmake


### PR DESCRIPTION
Our python codebase (tests) is based on python2, and it was assumed, that `python` will point to `python2`.

Newer distros (the arm based runner in travis) redirect `python` to `python3`, which was not our intention.

For some reason python3 does not have all the packages we need in pip, so our travis job breaks.

This patch forces `python2` for `pip`.

I also added `--cache-dir=$PWD/cache`, because the arm travis runner does not grant the default cache dir with proper capabilities.

Signed-off-by: Attila Szakacs <attila.szakacs@balabit.com>