### PR TITLE
http: fix auto-detect

### DIFF
--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -181,7 +181,7 @@ http_tls_option
           {
             const gchar *ca_dir = auto_detect_ca_dir();
             const gchar *ca_file = auto_detect_ca_file();
-            CHECK_ERROR(!ca_dir && !ca_file, @3,
+            CHECK_ERROR(ca_dir || ca_file, @3,
                         "Failed to autodect system cert store");
             http_dd_set_ca_file(last_driver, ca_file);
             http_dd_set_ca_dir(last_driver, ca_dir);


### PR DESCRIPTION
`CHECK_ERROR` is like assert: we need to pass true. If the predicate is
false, only then will syslog-ng generate error.

The original code breaks 001-check-scl.zts, that tests telegram. This was not executed by kira, because it is not run-local test.

No need to add change note. This is a quick fix for https://github.com/syslog-ng/syslog-ng/pull/3086