### PR TITLE
python: persist api

### DIFF
--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -11,6 +11,11 @@ set(PYTHON_SOURCES
     python-module.h
     python-config.h
     python-config.c
+    serial-hash.h
+    serial-hash-internal.h
+    serial-hash.c
+    serial-list.h
+    serial-list.c
     python-persist.h
     python-persist.c
     python-helpers.h

--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -26,6 +26,11 @@ modules_python_libmod_python_la_SOURCES		= \
 	modules/python/python-module.h		  \
 	modules/python/python-config.h		  \
 	modules/python/python-config.c		  \
+	modules/python/serial-hash.h		  \
+	modules/python/serial-hash-internal.h     \
+	modules/python/serial-hash.c		  \
+	modules/python/serial-list.h		  \
+	modules/python/serial-list.c		  \
 	modules/python/python-persist.h		  \
 	modules/python/python-persist.c		  \
 	modules/python/python-helpers.h		  \

--- a/modules/python/compat/compat-python-v2.c
+++ b/modules/python/compat/compat-python-v2.c
@@ -66,3 +66,9 @@ pyobject_as_int(PyObject *object)
 {
   return PyInt_AsLong(object);
 };
+
+gboolean
+py_object_is_integer(PyObject *object)
+{
+  return PyLong_Check(object) || PyInt_Check(object);
+}

--- a/modules/python/compat/compat-python-v3.c
+++ b/modules/python/compat/compat-python-v3.c
@@ -66,3 +66,9 @@ pyobject_as_int(PyObject *object)
 {
   return PyLong_AsLong(object);
 };
+
+gboolean
+py_object_is_integer(PyObject *object)
+{
+  return PyLong_Check(object);
+}

--- a/modules/python/compat/compat-python.h
+++ b/modules/python/compat/compat-python.h
@@ -47,4 +47,6 @@ void py_init_argv(void);
 PyObject *int_as_pyobject(gint num);
 
 gint pyobject_as_int(PyObject *object);
+gboolean py_object_is_integer(PyObject *object);
+
 #endif

--- a/modules/python/pylib/syslogng/__init__.py
+++ b/modules/python/pylib/syslogng/__init__.py
@@ -27,6 +27,16 @@ try:
     from _syslogng import LogSource, LogFetcher
     from _syslogng import LogTemplate, LogTemplateException, LTZ_LOCAL, LTZ_SEND
     from _syslogng import Logger
-    from _syslogng import Persist
+    from _syslogng import Persist as SlngPersist
+
+    class Persist(SlngPersist):
+        def __init__(self, persist_name, defaults=None):
+            super(Persist, self).__init__(persist_name)
+
+            if defaults:
+                for key, value in defaults.items():
+                    if key not in self:
+                        self[key] = value
+
 except ImportError:
     print("The syslogng package can only be used in syslog-ng.")

--- a/modules/python/pylib/syslogng/__init__.py
+++ b/modules/python/pylib/syslogng/__init__.py
@@ -27,5 +27,6 @@ try:
     from _syslogng import LogSource, LogFetcher
     from _syslogng import LogTemplate, LogTemplateException, LTZ_LOCAL, LTZ_SEND
     from _syslogng import Logger
+    from _syslogng import Persist
 except ImportError:
     print("The syslogng package can only be used in syslog-ng.")

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -25,6 +25,8 @@
 #include "driver.h"
 #include "mainloop.h"
 
+#include <structmember.h>
+
 static PyObject *
 _call_generate_persist_name_method(PythonPersistMembers *options)
 {
@@ -168,6 +170,13 @@ py_persist_dealloc(PyObject *s)
   py_slng_generic_dealloc(s);
 }
 
+static PyMemberDef
+py_persist_type_members[] =
+{
+  {"persist_name", T_STRING, offsetof(PyPersist, persist_name), READONLY},
+  {NULL}
+};
+
 PyTypeObject py_persist_type =
 {
   PyVarObject_HEAD_INIT(&PyType_Type, 0)
@@ -178,6 +187,7 @@ PyTypeObject py_persist_type =
   .tp_doc = "Persist class encapsulates persist handling",
   .tp_new = _persist_type_new,
   .tp_init = _persist_type_init,
+  .tp_members = py_persist_type_members,
   0,
 };
 

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -127,3 +127,21 @@ python_format_persist_name(const LogPipe *p, const gchar *module, PythonPersistM
 
   return persist_name;
 }
+
+PyTypeObject py_persist_type =
+{
+  PyVarObject_HEAD_INIT(&PyType_Type, 0)
+  .tp_name = "Persist",
+  .tp_basicsize = sizeof(PyPersist),
+  .tp_dealloc = py_slng_generic_dealloc,
+  .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+  .tp_doc = "Persist class encapsulates persist handling",
+  .tp_new = PyType_GenericNew,
+  0,
+};
+
+void
+py_persist_init(void)
+{
+  PyType_Ready(&py_persist_type);
+}

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -336,6 +336,16 @@ static PyMappingMethods py_persist_type_mapping =
   .mp_ass_subscript = (objobjargproc) _py_persist_type_set
 };
 
+PyObject *py_persist_type_iter(PyObject *o)
+{
+  PyPersist *self = (PyPersist *)o;
+
+  GHashTable *index = serial_hash_get_index(self->entries);
+  PyObject *index_dict = _py_create_arg_dict(index);
+  PyObject *iter = PyObject_GetIter(index_dict);
+  Py_DECREF(index_dict);
+  return iter;
+}
 
 PyTypeObject py_persist_type =
 {
@@ -349,6 +359,7 @@ PyTypeObject py_persist_type =
   .tp_init = _persist_type_init,
   .tp_members = py_persist_type_members,
   .tp_as_mapping = &py_persist_type_mapping,
+  .tp_iter = &py_persist_type_iter,
   0,
 };
 

--- a/modules/python/python-persist.h
+++ b/modules/python/python-persist.h
@@ -25,6 +25,7 @@
 
 #include "python-module.h"
 #include "logpipe.h"
+#include "serial-hash.h"
 
 typedef struct
 {
@@ -32,6 +33,7 @@ typedef struct
   PersistState *persist_state;
   PersistEntryHandle persist_handle;
   gchar *persist_name;
+  SerialHash *entries;
 } PyPersist;
 
 extern PyTypeObject py_persist_type;

--- a/modules/python/python-persist.h
+++ b/modules/python/python-persist.h
@@ -28,12 +28,20 @@
 
 typedef struct
 {
+  PyObject_HEAD
+} PyPersist;
+
+extern PyTypeObject py_persist_type;
+
+typedef struct
+{
   PyObject *generate_persist_name_method;
   GHashTable *options;
   const gchar *class;
   const gchar *id;
 } PythonPersistMembers;
 
+void py_persist_init(void);
 const gchar *python_format_stats_instance(LogPipe *p, const gchar *module, PythonPersistMembers *options);
 const gchar *python_format_persist_name(const LogPipe *p, const gchar *module, PythonPersistMembers *options);
 

--- a/modules/python/python-persist.h
+++ b/modules/python/python-persist.h
@@ -29,6 +29,9 @@
 typedef struct
 {
   PyObject_HEAD
+  PersistState *persist_state;
+  PersistEntryHandle persist_handle;
+  gchar *persist_name;
 } PyPersist;
 
 extern PyTypeObject py_persist_type;

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -35,6 +35,7 @@
 #include "python-global-code-loader.h"
 #include "python-debugger.h"
 #include "python-http-header.h"
+#include "python-persist.h"
 
 #include "plugin.h"
 #include "plugin-types.h"
@@ -114,6 +115,7 @@ _py_init_interpreter(void)
       py_integer_pointer_init();
       py_log_source_init();
       py_log_fetcher_init();
+      py_persist_init();
       py_global_code_loader_init();
       py_logger_init();
       PyEval_SaveThread();

--- a/modules/python/serial-hash-internal.h
+++ b/modules/python/serial-hash-internal.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SERIAL_HASH_INTERNAL_H
+#define SERIAL_HASH_INTERNAL_H
+
+#endif

--- a/modules/python/serial-hash-internal.h
+++ b/modules/python/serial-hash-internal.h
@@ -23,4 +23,9 @@
 #ifndef SERIAL_HASH_INTERNAL_H
 #define SERIAL_HASH_INTERNAL_H
 
+void payload_new(gchar *key, guchar *value, gsize value_len, guchar **payload, gsize *payload_len);
+gchar *payload_get_key(guchar *payload);
+void payload_get_value(guchar *payload, guchar **value, gsize *value_len);
+void payload_free(guchar *payload);
+
 #endif

--- a/modules/python/serial-hash.c
+++ b/modules/python/serial-hash.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "serial-hash.h"

--- a/modules/python/serial-hash.c
+++ b/modules/python/serial-hash.c
@@ -175,3 +175,14 @@ serial_hash_lookup(SerialHash *self, gchar *key, const guchar **value, gsize *va
 
   payload_get_value((guchar *)payload, (guchar **)value, value_len);
 };
+
+void
+serial_hash_remove(SerialHash *self, gchar *key)
+{
+  if (!g_hash_table_contains(self->index, key))
+    return;
+
+  SerialListHandle *handle = g_hash_table_lookup(self->index, key);
+  serial_list_remove(self->storage, *handle);
+  g_hash_table_remove(self->index, key);
+}

--- a/modules/python/serial-hash.c
+++ b/modules/python/serial-hash.c
@@ -216,3 +216,9 @@ serial_hash_load(guchar *base, gsize max_size)
 
   return self;
 }
+
+void
+serial_hash_rebase(SerialHash *self, guchar *base, gsize max_size)
+{
+  serial_list_rebase(self->storage, base, max_size);
+}

--- a/modules/python/serial-hash.c
+++ b/modules/python/serial-hash.c
@@ -157,3 +157,21 @@ serial_hash_insert(SerialHash *self, gchar *key, guchar *value, gsize value_len)
   else
     return _insert(self, key, value, value_len);
 };
+
+void
+serial_hash_lookup(SerialHash *self, gchar *key, const guchar **value, gsize *value_len)
+{
+  SerialListHandle *handle = g_hash_table_lookup(self->index, key);
+  if (!handle)
+    {
+      *value = NULL;
+      *value_len = 0;
+      return;
+    }
+
+  const guchar *payload = NULL;
+  gsize payload_len = 0;
+  serial_list_get_data(self->storage, *handle, &payload, &payload_len);
+
+  payload_get_value((guchar *)payload, (guchar **)value, value_len);
+};

--- a/modules/python/serial-hash.c
+++ b/modules/python/serial-hash.c
@@ -222,3 +222,9 @@ serial_hash_rebase(SerialHash *self, guchar *base, gsize max_size)
 {
   serial_list_rebase(self->storage, base, max_size);
 }
+
+GHashTable *
+serial_hash_get_index(SerialHash *self)
+{
+  return self->index;
+}

--- a/modules/python/serial-hash.c
+++ b/modules/python/serial-hash.c
@@ -21,3 +21,31 @@
  */
 
 #include "serial-hash.h"
+#include "serial-list.h"
+
+struct _SerialHash
+{
+  GHashTable *index;
+  SerialList *storage;
+};
+
+SerialHash *
+serial_hash_new(guchar *base, gsize max_size)
+{
+  SerialHash *self = g_new0(SerialHash, 1);
+  self->index = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+  self->storage = serial_list_new(base, max_size);
+  return self;
+}
+
+void
+serial_hash_free(SerialHash *self)
+{
+  if (!self)
+    return;
+
+  g_hash_table_destroy(self->index);
+  self->index = NULL;
+  serial_list_free(self->storage);
+  self->storage = NULL;
+}

--- a/modules/python/serial-hash.c
+++ b/modules/python/serial-hash.c
@@ -49,3 +49,24 @@ serial_hash_free(SerialHash *self)
   serial_list_free(self->storage);
   self->storage = NULL;
 }
+
+static gboolean
+_update(SerialHash *self, gchar *key, guchar *value, gsize value_len)
+{
+  return TRUE;
+};
+
+static gboolean
+_insert(SerialHash *self, gchar *key, guchar *value, gsize value_len)
+{
+  return TRUE;
+};
+
+gboolean
+serial_hash_insert(SerialHash *self, gchar *key, guchar *value, gsize value_len)
+{
+  if (g_hash_table_contains(self->index, key))
+    return _update(self, key, value, value_len);
+  else
+    return _insert(self, key, value, value_len);
+};

--- a/modules/python/serial-hash.h
+++ b/modules/python/serial-hash.h
@@ -33,5 +33,6 @@ gboolean serial_hash_insert(SerialHash *self, gchar *key, guchar *value, gsize v
 void serial_hash_lookup(SerialHash *self, gchar *key, const guchar **value, gsize *value_len);
 void serial_hash_remove(SerialHash *self, gchar *key);
 SerialHash *serial_hash_load(guchar *base, gsize max_size);
+void serial_hash_rebase(SerialHash *self, guchar *base, gsize max_size);
 
 #endif

--- a/modules/python/serial-hash.h
+++ b/modules/python/serial-hash.h
@@ -25,4 +25,9 @@
 
 #include "syslog-ng.h"
 
+typedef struct _SerialHash SerialHash;
+
+SerialHash *serial_hash_new(guchar *base, gsize max_size);
+void serial_hash_free(SerialHash *self);
+
 #endif

--- a/modules/python/serial-hash.h
+++ b/modules/python/serial-hash.h
@@ -34,5 +34,6 @@ void serial_hash_lookup(SerialHash *self, gchar *key, const guchar **value, gsiz
 void serial_hash_remove(SerialHash *self, gchar *key);
 SerialHash *serial_hash_load(guchar *base, gsize max_size);
 void serial_hash_rebase(SerialHash *self, guchar *base, gsize max_size);
+GHashTable *serial_hash_get_index(SerialHash *self);
 
 #endif

--- a/modules/python/serial-hash.h
+++ b/modules/python/serial-hash.h
@@ -30,5 +30,6 @@ typedef struct _SerialHash SerialHash;
 SerialHash *serial_hash_new(guchar *base, gsize max_size);
 void serial_hash_free(SerialHash *self);
 gboolean serial_hash_insert(SerialHash *self, gchar *key, guchar *value, gsize value_len);
+void serial_hash_lookup(SerialHash *self, gchar *key, const guchar **value, gsize *value_len);
 
 #endif

--- a/modules/python/serial-hash.h
+++ b/modules/python/serial-hash.h
@@ -31,5 +31,6 @@ SerialHash *serial_hash_new(guchar *base, gsize max_size);
 void serial_hash_free(SerialHash *self);
 gboolean serial_hash_insert(SerialHash *self, gchar *key, guchar *value, gsize value_len);
 void serial_hash_lookup(SerialHash *self, gchar *key, const guchar **value, gsize *value_len);
+void serial_hash_remove(SerialHash *self, gchar *key);
 
 #endif

--- a/modules/python/serial-hash.h
+++ b/modules/python/serial-hash.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SERIAL_HASH_H
+#define SERIAL_HASH_H
+
+#include "syslog-ng.h"
+
+#endif

--- a/modules/python/serial-hash.h
+++ b/modules/python/serial-hash.h
@@ -29,5 +29,6 @@ typedef struct _SerialHash SerialHash;
 
 SerialHash *serial_hash_new(guchar *base, gsize max_size);
 void serial_hash_free(SerialHash *self);
+gboolean serial_hash_insert(SerialHash *self, gchar *key, guchar *value, gsize value_len);
 
 #endif

--- a/modules/python/serial-hash.h
+++ b/modules/python/serial-hash.h
@@ -32,5 +32,6 @@ void serial_hash_free(SerialHash *self);
 gboolean serial_hash_insert(SerialHash *self, gchar *key, guchar *value, gsize value_len);
 void serial_hash_lookup(SerialHash *self, gchar *key, const guchar **value, gsize *value_len);
 void serial_hash_remove(SerialHash *self, gchar *key);
+SerialHash *serial_hash_load(guchar *base, gsize max_size);
 
 #endif

--- a/modules/python/serial-list.c
+++ b/modules/python/serial-list.c
@@ -227,6 +227,13 @@ serial_list_get_data(SerialList *self, SerialListHandle handle, const guchar **d
   return node->data;
 }
 
+static void
+join_free_spaces(SerialList *self, Node *first, Node *second)
+{
+  first->next = second->next;
+  first->data_len = get_available_space(self, first);
+}
+
 void
 serial_list_remove(SerialList *self, SerialListHandle handle)
 {
@@ -235,6 +242,15 @@ serial_list_remove(SerialList *self, SerialListHandle handle)
 
   node->type = FREE_SPACE;
   node->data_len = new_free_space;
+
+  Node *next = get_node_at_offset(self, node->next);
+  if (next->type == FREE_SPACE)
+    join_free_spaces(self, node, next);
+
+  Node *prev = get_node_at_offset(self, node->prev);
+
+  if (prev->type == FREE_SPACE)
+    join_free_spaces(self, prev, node);
 }
 
 SerialListHandle

--- a/modules/python/serial-list.c
+++ b/modules/python/serial-list.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "serial-list.h"

--- a/modules/python/serial-list.c
+++ b/modules/python/serial-list.c
@@ -196,3 +196,20 @@ serial_list_insert(SerialList *self, guchar *data, gsize data_len)
       return convert_free_space(self, free_space, data, data_len);
     }
 }
+
+SerialListHandle
+serial_list_find(SerialList *self, SerialListFindFunc func, gpointer user_data)
+{
+  Node *node = get_node_at_offset(self, get_head(self)->next);
+
+  while (TRUE)
+    {
+      if (node->type == HEAD)
+        return 0;
+
+      if (node->type == DATA && func(node->data, node->data_len, user_data))
+        return node->offset;
+
+      node = get_node_at_offset(self, node->next);
+    }
+}

--- a/modules/python/serial-list.c
+++ b/modules/python/serial-list.c
@@ -22,12 +22,42 @@
 
 #include "serial-list.h"
 
+typedef struct
+{
+  Offset prev;
+  Offset next;
+  gsize data_len;
+  guchar data[];
+} Node;
+
+static Node *
+get_node_at_offset(SerialList *self, Offset offset)
+{
+  g_assert((offset & 3) == 0);
+
+  return (Node *)&self->base[offset];
+}
+
+static void
+initialize_head(SerialList *self)
+{
+  Node *head = get_node_at_offset(self, 0);
+  head->prev = 0;
+  head->next = 0;
+  head->data_len = 0;
+}
+
 SerialList *
 serial_list_new(guchar *base, gsize size)
 {
+  g_assert(size > sizeof(Node));
+
   SerialList *self = g_new0(SerialList, 1);
   self->base = base;
   self->max_size = size;
+
+  initialize_head(self);
+
   return self;
 }
 

--- a/modules/python/serial-list.c
+++ b/modules/python/serial-list.c
@@ -21,3 +21,18 @@
  */
 
 #include "serial-list.h"
+
+SerialList *
+serial_list_new(guchar *base, gsize size)
+{
+  SerialList *self = g_new0(SerialList, 1);
+  self->base = base;
+  self->max_size = size;
+  return self;
+}
+
+void
+serial_list_free(SerialList *self)
+{
+  g_free(self);
+}

--- a/modules/python/serial-list.c
+++ b/modules/python/serial-list.c
@@ -352,3 +352,20 @@ serial_list_load(guchar *base, gsize size)
 
   return self;
 }
+
+void
+serial_list_handle_foreach(SerialList *self, SerialListHandleFunc func, gpointer user_data)
+{
+  Node *node = get_node_at_offset(self, get_head(self)->next);
+
+  while (TRUE)
+    {
+      if (node->type == DATA)
+        func(self, node->offset, user_data);
+
+      if (node->type == HEAD)
+        return;
+
+      node = get_node_at_offset(self, node->next);
+    }
+}

--- a/modules/python/serial-list.c
+++ b/modules/python/serial-list.c
@@ -260,6 +260,23 @@ serial_list_update(SerialList *self, SerialListHandle handle, guchar *data, gsiz
 }
 
 void
+serial_list_foreach(SerialList *self, SerialListFunc func, gpointer user_data)
+{
+  Node *node = get_node_at_offset(self, get_head(self)->next);
+
+  while (TRUE)
+    {
+      if (node->type == DATA)
+        func(node->data, node->data_len, user_data);
+
+      if (node->type == HEAD)
+        return;
+
+      node = get_node_at_offset(self, node->next);
+    }
+}
+
+void
 serial_list_print(SerialList *self)
 {
   Node *node = get_node_at_offset(self, get_head(self)->next);

--- a/modules/python/serial-list.c
+++ b/modules/python/serial-list.c
@@ -213,3 +213,15 @@ serial_list_find(SerialList *self, SerialListFindFunc func, gpointer user_data)
       node = get_node_at_offset(self, node->next);
     }
 }
+
+const guchar *
+serial_list_get_data(SerialList *self, SerialListHandle handle, const guchar **data, gsize *data_len)
+{
+  Node *node = get_node_at_offset(self, handle);
+  if (data)
+    *data = node->data;
+  if (data_len)
+    *data_len = node->data_len;
+
+  return node->data;
+}

--- a/modules/python/serial-list.c
+++ b/modules/python/serial-list.c
@@ -342,3 +342,13 @@ serial_list_rebase(SerialList *self, guchar *new_base, gsize orig_new_size)
         join_free_spaces(self, prev, new_free_space);
     }
 }
+
+SerialList *
+serial_list_load(guchar *base, gsize size)
+{
+  SerialList *self = g_new0(SerialList, 1);
+  self->base = base;
+  self->max_size = size;
+
+  return self;
+}

--- a/modules/python/serial-list.c
+++ b/modules/python/serial-list.c
@@ -22,6 +22,7 @@
 
 #include "serial-list.h"
 
+#include <stdio.h>
 #include <string.h>
 
 typedef enum
@@ -256,4 +257,23 @@ serial_list_update(SerialList *self, SerialListHandle handle, guchar *data, gsiz
       serial_list_remove(self, handle);
       return new_handle;
     }
+}
+
+void
+serial_list_print(SerialList *self)
+{
+  Node *node = get_node_at_offset(self, get_head(self)->next);
+
+  while (TRUE)
+    {
+      fprintf(stderr, "Node: offset: %lu, prev: %lu, next: %lu, type: %d, data_len: %lu, data: %.*s\n",
+              node->offset, node->prev, node->next, node->type, node->data_len,
+              node->type != FREE_SPACE ? (int)node->data_len : 0, node->data);
+
+      if (node->type == HEAD)
+        return;
+
+      node = get_node_at_offset(self, node->next);
+    }
+
 }

--- a/modules/python/serial-list.c
+++ b/modules/python/serial-list.c
@@ -33,6 +33,7 @@ typedef struct
 {
   Offset prev;
   Offset next;
+  Offset offset;
   NodeType type;
   gsize data_len;
   guchar data[];
@@ -67,6 +68,7 @@ initialize_head(SerialList *self)
   Node *head = get_node_at_offset(self, 0);
   head->prev = 0;
   head->next = 0;
+  head->offset = 0;
   head->type = HEAD;
   head->data_len = 0;
 }
@@ -80,6 +82,7 @@ initialize_free_space(SerialList *self)
 
   free_space->prev = 0;
   free_space->next = 0;
+  free_space->offset = free_space_offset;
   free_space->type = FREE_SPACE;
   free_space->data_len = self->max_size - 2 * sizeof(Node);
 

--- a/modules/python/serial-list.h
+++ b/modules/python/serial-list.h
@@ -25,4 +25,13 @@
 
 #include "syslog-ng.h"
 
+typedef struct
+{
+  guchar *base;
+  gsize max_size;
+} SerialList;
+
+SerialList *serial_list_new(guchar *base, gsize size);
+void serial_list_free(SerialList *self);
+
 #endif

--- a/modules/python/serial-list.h
+++ b/modules/python/serial-list.h
@@ -34,8 +34,11 @@ typedef struct
 typedef gsize Offset;
 typedef gsize SerialListHandle;
 
+typedef gboolean (SerialListFindFunc)(guchar *data, gsize data_len, gpointer user_data);
+
 SerialList *serial_list_new(guchar *base, gsize size);
 void serial_list_free(SerialList *self);
 SerialListHandle serial_list_insert(SerialList *self, guchar *data, gsize data_len);
+SerialListHandle serial_list_find(SerialList *self, SerialListFindFunc func, gpointer user_data);
 
 #endif

--- a/modules/python/serial-list.h
+++ b/modules/python/serial-list.h
@@ -31,6 +31,8 @@ typedef struct
   gsize max_size;
 } SerialList;
 
+typedef gsize Offset;
+
 SerialList *serial_list_new(guchar *base, gsize size);
 void serial_list_free(SerialList *self);
 

--- a/modules/python/serial-list.h
+++ b/modules/python/serial-list.h
@@ -32,8 +32,10 @@ typedef struct
 } SerialList;
 
 typedef gsize Offset;
+typedef gsize SerialListHandle;
 
 SerialList *serial_list_new(guchar *base, gsize size);
 void serial_list_free(SerialList *self);
+SerialListHandle serial_list_insert(SerialList *self, guchar *data, gsize data_len);
 
 #endif

--- a/modules/python/serial-list.h
+++ b/modules/python/serial-list.h
@@ -43,5 +43,6 @@ SerialListHandle serial_list_find(SerialList *self, SerialListFindFunc func, gpo
 const guchar *serial_list_get_data(SerialList *self, SerialListHandle handle, const guchar **data, gsize *data_len);
 void serial_list_remove(SerialList *self, SerialListHandle handle);
 SerialListHandle serial_list_update(SerialList *self, SerialListHandle handle, guchar *data, gsize data_len);
+void serial_list_print(SerialList *self);
 
 #endif

--- a/modules/python/serial-list.h
+++ b/modules/python/serial-list.h
@@ -40,5 +40,6 @@ SerialList *serial_list_new(guchar *base, gsize size);
 void serial_list_free(SerialList *self);
 SerialListHandle serial_list_insert(SerialList *self, guchar *data, gsize data_len);
 SerialListHandle serial_list_find(SerialList *self, SerialListFindFunc func, gpointer user_data);
+const guchar *serial_list_get_data(SerialList *self, SerialListHandle handle, const guchar **data, gsize *data_len);
 
 #endif

--- a/modules/python/serial-list.h
+++ b/modules/python/serial-list.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SERIAL_LIST_H
+#define SERIAL_LIST_H
+
+#include "syslog-ng.h"
+
+#endif

--- a/modules/python/serial-list.h
+++ b/modules/python/serial-list.h
@@ -46,5 +46,7 @@ void serial_list_remove(SerialList *self, SerialListHandle handle);
 SerialListHandle serial_list_update(SerialList *self, SerialListHandle handle, guchar *data, gsize data_len);
 void serial_list_foreach(SerialList *self, SerialListFunc func, gpointer user_data);
 void serial_list_print(SerialList *self);
+void serial_list_rebase(SerialList *self, guchar *new_base, gsize orig_new_size);
+
 
 #endif

--- a/modules/python/serial-list.h
+++ b/modules/python/serial-list.h
@@ -47,6 +47,6 @@ SerialListHandle serial_list_update(SerialList *self, SerialListHandle handle, g
 void serial_list_foreach(SerialList *self, SerialListFunc func, gpointer user_data);
 void serial_list_print(SerialList *self);
 void serial_list_rebase(SerialList *self, guchar *new_base, gsize orig_new_size);
-
+SerialList *serial_list_load(guchar *base, gsize size);
 
 #endif

--- a/modules/python/serial-list.h
+++ b/modules/python/serial-list.h
@@ -41,5 +41,7 @@ void serial_list_free(SerialList *self);
 SerialListHandle serial_list_insert(SerialList *self, guchar *data, gsize data_len);
 SerialListHandle serial_list_find(SerialList *self, SerialListFindFunc func, gpointer user_data);
 const guchar *serial_list_get_data(SerialList *self, SerialListHandle handle, const guchar **data, gsize *data_len);
+void serial_list_remove(SerialList *self, SerialListHandle handle);
+SerialListHandle serial_list_update(SerialList *self, SerialListHandle handle, guchar *data, gsize data_len);
 
 #endif

--- a/modules/python/serial-list.h
+++ b/modules/python/serial-list.h
@@ -36,6 +36,7 @@ typedef gsize SerialListHandle;
 
 typedef gboolean (SerialListFindFunc)(guchar *data, gsize data_len, gpointer user_data);
 typedef void (SerialListFunc)(guchar *data, gsize data_len, gpointer user_data);
+typedef void (SerialListHandleFunc)(SerialList *self, SerialListHandle hande, gpointer user_data);
 
 SerialList *serial_list_new(guchar *base, gsize size);
 void serial_list_free(SerialList *self);
@@ -48,5 +49,6 @@ void serial_list_foreach(SerialList *self, SerialListFunc func, gpointer user_da
 void serial_list_print(SerialList *self);
 void serial_list_rebase(SerialList *self, guchar *new_base, gsize orig_new_size);
 SerialList *serial_list_load(guchar *base, gsize size);
+void serial_list_handle_foreach(SerialList *self, SerialListHandleFunc func, gpointer user_data);
 
 #endif

--- a/modules/python/serial-list.h
+++ b/modules/python/serial-list.h
@@ -35,6 +35,7 @@ typedef gsize Offset;
 typedef gsize SerialListHandle;
 
 typedef gboolean (SerialListFindFunc)(guchar *data, gsize data_len, gpointer user_data);
+typedef void (SerialListFunc)(guchar *data, gsize data_len, gpointer user_data);
 
 SerialList *serial_list_new(guchar *base, gsize size);
 void serial_list_free(SerialList *self);
@@ -43,6 +44,7 @@ SerialListHandle serial_list_find(SerialList *self, SerialListFindFunc func, gpo
 const guchar *serial_list_get_data(SerialList *self, SerialListHandle handle, const guchar **data, gsize *data_len);
 void serial_list_remove(SerialList *self, SerialListHandle handle);
 SerialListHandle serial_list_update(SerialList *self, SerialListHandle handle, guchar *data, gsize data_len);
+void serial_list_foreach(SerialList *self, SerialListFunc func, gpointer user_data);
 void serial_list_print(SerialList *self);
 
 #endif

--- a/modules/python/tests/CMakeLists.txt
+++ b/modules/python/tests/CMakeLists.txt
@@ -25,3 +25,13 @@ add_unit_test(LIBTEST CRITERION
   DEPENDS syslogformat mod-python "${PYTHON_LIBRARIES}")
 
 set_property(TEST test_python_persist APPEND PROPERTY ENVIRONMENT "PYTHONMALLOC=malloc_debug")
+
+add_unit_test(LIBTEST CRITERION
+  INCLUDES "${PYTHON_INCLUDE_DIR}" "${PYTHON_INCLUDE_DIRS}"
+  TARGET test_serial_hash
+  DEPENDS mod-python)
+
+add_unit_test(LIBTEST CRITERION
+  INCLUDES "${PYTHON_INCLUDE_DIR}" "${PYTHON_INCLUDE_DIRS}"
+  TARGET test_serial_list
+  DEPENDS mod-python)

--- a/modules/python/tests/CMakeLists.txt
+++ b/modules/python/tests/CMakeLists.txt
@@ -18,3 +18,10 @@ add_unit_test(LIBTEST CRITERION
   DEPENDS syslogformat mod-python "${PYTHON_LIBRARIES}")
 
 set_property(TEST test_python_persist_name APPEND PROPERTY ENVIRONMENT "PYTHONMALLOC=malloc_debug")
+
+add_unit_test(LIBTEST CRITERION
+  TARGET test_python_persist
+  INCLUDES "${PYTHON_INCLUDE_DIR}" "${PYTHON_INCLUDE_DIRS}"
+  DEPENDS syslogformat mod-python "${PYTHON_LIBRARIES}")
+
+set_property(TEST test_python_persist APPEND PROPERTY ENVIRONMENT "PYTHONMALLOC=malloc_debug")

--- a/modules/python/tests/Makefile.am
+++ b/modules/python/tests/Makefile.am
@@ -27,4 +27,10 @@ modules_python_tests_test_python_persist_name_LDADD = $(TEST_LDADD) \
 	-dlpreopen $(top_builddir)/modules/python/libmod-python.la \
 	$(PYTHON_LIBS) $(PREOPEN_SYSLOGFORMAT)
 
+modules_python_tests_test_python_persist_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) \
+	-I$(top_srcdir)/modules/python -I$(top_srcdir)/modules/syslogformat
+modules_python_tests_test_python_persist_LDADD = $(TEST_LDADD) \
+	-dlpreopen $(top_builddir)/modules/python/libmod-python.la \
+	$(PYTHON_LIBS) $(PREOPEN_SYSLOGFORMAT)
+
 EXTRA_DIST += modules/python/tests/CMakeLists.txt

--- a/modules/python/tests/Makefile.am
+++ b/modules/python/tests/Makefile.am
@@ -7,7 +7,9 @@ check_PROGRAMS += \
 modules_python_tests_TESTS = \
   modules/python/tests/test_python_logmsg \
   modules/python/tests/test_python_template \
-  modules/python/tests/test_python_persist_name
+  modules/python/tests/test_python_persist_name \
+  modules/python/tests/test_serial_hash \
+  modules/python/tests/test_serial_list
 
 modules_python_tests_test_python_logmsg_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) -I$(top_srcdir)/modules/python
 modules_python_tests_test_python_logmsg_LDADD = $(TEST_LDADD) \
@@ -30,6 +32,18 @@ modules_python_tests_test_python_persist_name_LDADD = $(TEST_LDADD) \
 modules_python_tests_test_python_persist_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) \
 	-I$(top_srcdir)/modules/python -I$(top_srcdir)/modules/syslogformat
 modules_python_tests_test_python_persist_LDADD = $(TEST_LDADD) \
+	-dlpreopen $(top_builddir)/modules/python/libmod-python.la \
+	$(PYTHON_LIBS) $(PREOPEN_SYSLOGFORMAT)
+
+modules_python_tests_test_serial_hash_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) \
+	-I$(top_srcdir)/modules/python
+modules_python_tests_test_serial_hash_LDADD = $(TEST_LDADD) \
+	-dlpreopen $(top_builddir)/modules/python/libmod-python.la \
+	$(PYTHON_LIBS) $(PREOPEN_SYSLOGFORMAT)
+
+modules_python_tests_test_serial_list_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) \
+	-I$(top_srcdir)/modules/python
+modules_python_tests_test_serial_list_LDADD = $(TEST_LDADD) \
 	-dlpreopen $(top_builddir)/modules/python/libmod-python.la \
 	$(PYTHON_LIBS) $(PREOPEN_SYSLOGFORMAT)
 

--- a/modules/python/tests/test_python_persist.c
+++ b/modules/python/tests/test_python_persist.c
@@ -134,3 +134,15 @@ Test(python_persist, test_python_persist_basic)
   _load_code("assert persist['key'] == 'value'");
   persist_state_stop(cfg->state);
 }
+
+Test(python_persist, test_python_persist_iterator)
+{
+  PersistState *state = clean_and_create_persist_state_for_test("test-python-iterator.persist");
+  cfg->state = state;
+  _load_code("persist = Persist('persist_name')");
+  _load_code("persist['key1'] = 'value1'");
+  _load_code("persist['key2'] = 'value2'");
+  _load_code("persist['key3'] = 'value3'");
+  _load_code("assert sorted(persist) == ['key1', 'key2', 'key3']");
+  persist_state_stop(state);
+}

--- a/modules/python/tests/test_python_persist.c
+++ b/modules/python/tests/test_python_persist.c
@@ -146,3 +146,15 @@ Test(python_persist, test_python_persist_iterator)
   _load_code("assert sorted(persist) == ['key1', 'key2', 'key3']");
   persist_state_stop(state);
 }
+
+Test(python_persist, test_python_persist_proper_types)
+{
+  PersistState *state = clean_and_create_persist_state_for_test("test-python-proper_types.persist");
+  cfg->state = state;
+  _load_code("persist = Persist('persist_name')");
+  _load_code("persist['str'] = 'value'");
+  _load_code("persist['number'] = 5");
+  _load_code("assert persist['str'] == 'value'");
+  _load_code("assert persist['number'] == 5");
+  persist_state_stop(state);
+}

--- a/modules/python/tests/test_python_persist.c
+++ b/modules/python/tests/test_python_persist.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#include "python-persist.h"
+
+#include <criterion/criterion.h>
+
+void setup(void)
+{
+}
+
+void teardown(void)
+{
+}
+
+TestSuite(python_persist, .init = setup, .fini = teardown);
+
+Test(python_persist, test_python_persist)
+{
+  cr_assert(TRUE);
+}

--- a/modules/python/tests/test_python_persist.c
+++ b/modules/python/tests/test_python_persist.c
@@ -158,3 +158,20 @@ Test(python_persist, test_python_persist_proper_types)
   _load_code("assert persist['number'] == 5");
   persist_state_stop(state);
 }
+
+const gchar *should_throw_exception = "\
+exception_happened = False\n\
+try:\n\
+    persist['missing']\n\
+except KeyError:\n\
+    exception_happened = True\n\
+assert exception_happened";
+
+Test(python_persist, test_python_persist_lookup_missing_key)
+{
+  PersistState *state = clean_and_create_persist_state_for_test("test-python-lookup-missing-key.persist");
+  cfg->state = state;
+  _load_code("persist = Persist('persist_name')");
+  _load_code(should_throw_exception);
+  persist_state_stop(state);
+};

--- a/modules/python/tests/test_python_persist.c
+++ b/modules/python/tests/test_python_persist.c
@@ -80,6 +80,8 @@ void setup(void)
 
   _py_init_interpreter();
   _init_python_main();
+
+  _load_code("from _syslogng import Persist");
 }
 
 void teardown(void)
@@ -91,7 +93,6 @@ void teardown(void)
 TestSuite(python_persist, .init = setup, .fini = teardown);
 
 const gchar *simple_persist = "\n\
-from _syslogng import Persist\n\
 class SubPersist(Persist):\n\
     def __init__(self, persist_name):\n\
         super(SubPersist, self).__init__(persist_name = persist_name)\n\
@@ -116,4 +117,20 @@ Test(python_persist, test_python_persist_name)
   cfg->state = state;
   _load_code(simple_persist);
   persist_state_stop(state);
+}
+
+Test(python_persist, test_python_persist_basic)
+{
+  PersistState *state = clean_and_create_persist_state_for_test("test-python.persist");
+  cfg->state = state;
+  _load_code("persist = Persist('persist_name')");
+  _load_code("assert 'key' not in persist");
+  _load_code("persist['key'] = 'value'");
+  _load_code("assert 'key' in persist");
+  cfg->state = restart_persist_state(state);
+  _load_code("persist = Persist('persist_name')");
+  _load_code("persist['key'] = 'value'");
+  _load_code("assert 'key' in persist");
+  _load_code("assert persist['key'] == 'value'");
+  persist_state_stop(cfg->state);
 }

--- a/modules/python/tests/test_serial_hash.c
+++ b/modules/python/tests/test_serial_hash.c
@@ -88,3 +88,29 @@ Test(serial_hash, test_serial_remove)
 
   serial_hash_free(self);
 }
+
+Test(serial_hash, test_serial_update)
+{
+  gchar buffer[400];
+
+  SerialHash *self = serial_hash_new((guchar *)buffer, sizeof(buffer));
+
+  const guchar *data = NULL;
+  gsize data_len = 0;
+  serial_hash_insert(self, "key", (guchar *)"value", sizeof("value"));
+  serial_hash_lookup(self, "key", &data, &data_len);
+  cr_assert_str_eq((gchar *)data, "value");
+  cr_assert_eq(data_len, sizeof("value"));
+
+  serial_hash_insert(self, "key", (guchar *)"value-longer", sizeof("value-longer"));
+  serial_hash_lookup(self, "key", &data, &data_len);
+  cr_assert_str_eq((gchar *)data, "value-longer");
+  cr_assert_eq(data_len, sizeof("value-longer"));
+
+  serial_hash_insert(self, "key", (guchar *)"v", sizeof("v"));
+  serial_hash_lookup(self, "key", &data, &data_len);
+  cr_assert_str_eq((gchar *)data, "v");
+  cr_assert_eq(data_len, sizeof("v"));
+
+  serial_hash_free(self);
+}

--- a/modules/python/tests/test_serial_hash.c
+++ b/modules/python/tests/test_serial_hash.c
@@ -141,3 +141,25 @@ Test(serial_hash, test_serial_multi_insert)
 
   serial_hash_free(self);
 }
+
+Test(serial_hash, test_serial_hash_load)
+{
+  gchar buffer[400];
+  SerialHash *self = serial_hash_new((guchar *)buffer, sizeof(buffer));
+  serial_hash_insert(self, "key", (guchar *)"value", sizeof("value"));
+  serial_hash_free(self);
+
+  gchar other_buffer[400];
+  memcpy(other_buffer, buffer, sizeof(other_buffer));
+  memset(buffer, 0, sizeof(buffer));
+
+  SerialHash *loaded = serial_hash_load((guchar *)other_buffer, sizeof(other_buffer));
+
+  const guchar *data = NULL;
+  gsize data_len = 0;
+  serial_hash_lookup(loaded, "key", &data, &data_len);
+  cr_assert_str_eq((gchar *)data, "value");
+  cr_assert_eq(data_len, sizeof("value"));
+
+  serial_hash_free(loaded);
+}

--- a/modules/python/tests/test_serial_hash.c
+++ b/modules/python/tests/test_serial_hash.c
@@ -68,3 +68,23 @@ Test(serial_hash, test_payload)
   cr_assert_str_eq((gchar *)value, "value");
   payload_free(payload);
 }
+
+Test(serial_hash, test_serial_remove)
+{
+  gchar buffer[400];
+
+  SerialHash *self = serial_hash_new((guchar *)buffer, sizeof(buffer));
+
+  const guchar *data = NULL;
+  gsize data_len = 0;
+  serial_hash_lookup(self, "key", &data, &data_len);
+  cr_assert_null(data);
+  cr_assert_eq(data_len, 0);
+
+  serial_hash_insert(self, "key", (guchar *)"value", sizeof("value"));
+  serial_hash_lookup(self, "key", &data, &data_len);
+  cr_assert_str_eq((gchar *)data, "value");
+  cr_assert_eq(data_len, sizeof("value"));
+
+  serial_hash_free(self);
+}

--- a/modules/python/tests/test_serial_hash.c
+++ b/modules/python/tests/test_serial_hash.c
@@ -20,6 +20,7 @@
  */
 
 #include "serial-hash.h"
+#include "serial-hash-internal.h"
 #include <criterion/criterion.h>
 
 void setup(void)
@@ -38,4 +39,23 @@ Test(serial_hash, test_serial_hash)
 
   SerialHash *self = serial_hash_new((guchar *)buffer, sizeof(buffer));
   serial_hash_free(self);
+}
+
+Test(serial_hash, test_payload)
+{
+  guchar *payload = NULL;
+  gsize payload_len = 0;
+
+  payload_new("key", (guchar *)"value", sizeof("value"), &payload, &payload_len);
+  cr_assert(payload);
+  cr_assert(payload_len);
+
+  cr_assert_str_eq(payload_get_key(payload), "key");
+
+  guchar *value = NULL;
+  gsize value_len = 0;
+  payload_get_value(payload, &value, &value_len);
+  cr_assert_eq(value_len, sizeof("value"));
+  cr_assert_str_eq((gchar *)value, "value");
+  payload_free(payload);
 }

--- a/modules/python/tests/test_serial_hash.c
+++ b/modules/python/tests/test_serial_hash.c
@@ -38,6 +38,9 @@ Test(serial_hash, test_serial_hash)
   gchar buffer[400];
 
   SerialHash *self = serial_hash_new((guchar *)buffer, sizeof(buffer));
+
+  serial_hash_insert(self, "key", (guchar *)"value", sizeof("value"));
+
   serial_hash_free(self);
 }
 

--- a/modules/python/tests/test_serial_hash.c
+++ b/modules/python/tests/test_serial_hash.c
@@ -34,5 +34,8 @@ TestSuite(serial_hash, .init = setup, .fini = teardown);
 
 Test(serial_hash, test_serial_hash)
 {
-  cr_assert(TRUE);
+  gchar buffer[400];
+
+  SerialHash *self = serial_hash_new((guchar *)buffer, sizeof(buffer));
+  serial_hash_free(self);
 }

--- a/modules/python/tests/test_serial_hash.c
+++ b/modules/python/tests/test_serial_hash.c
@@ -114,3 +114,30 @@ Test(serial_hash, test_serial_update)
 
   serial_hash_free(self);
 }
+
+Test(serial_hash, test_serial_multi_insert)
+{
+  gchar buffer[400];
+
+  SerialHash *self = serial_hash_new((guchar *)buffer, sizeof(buffer));
+
+  const guchar *data = NULL;
+  gsize data_len = 0;
+  serial_hash_insert(self, "key1", (guchar *)"value1", sizeof("value1"));
+  serial_hash_insert(self, "key2", (guchar *)"value2", sizeof("value2"));
+  serial_hash_insert(self, "key3", (guchar *)"value3", sizeof("value3"));
+
+  serial_hash_lookup(self, "key1", &data, &data_len);
+  cr_assert_str_eq((gchar *)data, "value1");
+  cr_assert_eq(data_len, sizeof("value1"));
+
+  serial_hash_lookup(self, "key2", &data, &data_len);
+  cr_assert_str_eq((gchar *)data, "value2");
+  cr_assert_eq(data_len, sizeof("value2"));
+
+  serial_hash_lookup(self, "key3", &data, &data_len);
+  cr_assert_str_eq((gchar *)data, "value3");
+  cr_assert_eq(data_len, sizeof("value3"));
+
+  serial_hash_free(self);
+}

--- a/modules/python/tests/test_serial_hash.c
+++ b/modules/python/tests/test_serial_hash.c
@@ -41,6 +41,12 @@ Test(serial_hash, test_serial_hash)
 
   serial_hash_insert(self, "key", (guchar *)"value", sizeof("value"));
 
+  const guchar *data = NULL;
+  gsize data_len = 0;
+  serial_hash_lookup(self, "key", &data, &data_len);
+  cr_assert_str_eq((gchar *)data, "value");
+  cr_assert_eq(data_len, sizeof("value"));
+
   serial_hash_free(self);
 }
 

--- a/modules/python/tests/test_serial_hash.c
+++ b/modules/python/tests/test_serial_hash.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#include "serial-hash.h"
+#include <criterion/criterion.h>
+
+void setup(void)
+{
+}
+
+void teardown(void)
+{
+}
+
+TestSuite(serial_hash, .init = setup, .fini = teardown);
+
+Test(serial_hash, test_serial_hash)
+{
+  cr_assert(TRUE);
+}

--- a/modules/python/tests/test_serial_list.c
+++ b/modules/python/tests/test_serial_list.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#include "serial-list.h"
+#include <criterion/criterion.h>
+
+void setup(void)
+{
+}
+
+void teardown(void)
+{
+}
+
+TestSuite(serial_list, .init = setup, .fini = teardown);
+
+Test(serial_list, test_serial_list)
+{
+  cr_assert(TRUE);
+}

--- a/modules/python/tests/test_serial_list.c
+++ b/modules/python/tests/test_serial_list.c
@@ -82,3 +82,57 @@ Test(serial_list, test_two_data)
 
   serial_list_free(self);
 }
+
+Test(serial_list, test_simple_remove)
+{
+  guchar buffer[400];
+  SerialList *self = serial_list_new(buffer, sizeof(buffer));
+
+  SerialListHandle handle = serial_list_insert(self, (guchar *)"foo", sizeof("foo"));
+  cr_assert(handle);
+  cr_assert(serial_list_find(self, is_same_string, "foo"));
+
+  serial_list_remove(self, handle);
+  cr_assert_eq(serial_list_find(self, is_same_string, "foo"), 0);
+
+  handle = serial_list_insert(self, (guchar *)"foo", sizeof("foo"));
+  cr_assert(handle);
+  cr_assert(serial_list_find(self, is_same_string, "foo"));
+
+  serial_list_free(self);
+}
+
+Test(serial_list, test_simple_update)
+{
+  guchar buffer[400];
+  SerialList *self = serial_list_new(buffer, sizeof(buffer));
+
+  SerialListHandle handle1 = serial_list_insert(self, (guchar *)"foobar", strlen("foobar"));
+  cr_assert(handle1);
+  SerialListHandle same_length = serial_list_update(self, handle1, (guchar *)"barfoo", strlen("barfoo"));
+  cr_assert(same_length);
+  cr_assert_eq(handle1, same_length);
+
+  SerialListHandle handle2 = serial_list_update(self, handle1, (guchar *)"foo", strlen("foo"));
+  cr_assert(handle2);
+  cr_assert_eq(handle1, handle2);
+  SerialListHandle handle3 = serial_list_update(self, handle1, (guchar *)"foobar", strlen("foobar"));
+  cr_assert(handle3);
+  cr_assert_eq(handle2, handle3);
+
+  serial_list_free(self);
+}
+
+Test(serial_list, test_remove_then_reuse_free_space)
+{
+  guchar buffer[400];
+  SerialList *self = serial_list_new(buffer, sizeof(buffer));
+
+  SerialListHandle handle1 = serial_list_insert(self, (guchar *)"foobar", strlen("foobar"));
+  cr_assert(handle1);
+  serial_list_remove(self, handle1);
+  SerialListHandle handle2 = serial_list_insert(self, (guchar *)"foobar", strlen("foobar"));
+  cr_assert_eq(handle1, handle2);
+
+  serial_list_free(self);
+}

--- a/modules/python/tests/test_serial_list.c
+++ b/modules/python/tests/test_serial_list.c
@@ -34,5 +34,7 @@ TestSuite(serial_list, .init = setup, .fini = teardown);
 
 Test(serial_list, test_serial_list)
 {
-  cr_assert(TRUE);
+  guchar buffer[100];
+  SerialList *self = serial_list_new(buffer, sizeof(buffer));
+  serial_list_free(self);
 }

--- a/modules/python/tests/test_serial_list.c
+++ b/modules/python/tests/test_serial_list.c
@@ -221,3 +221,29 @@ Test(serial_list, test_rebase)
 
   serial_list_free(self);
 }
+
+Test(serial_list, test_load)
+{
+  guchar buffer[400];
+  guchar other_buffer[400];
+
+  SerialList *self = serial_list_new(buffer, sizeof(buffer));
+  static gchar *str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+  SerialListHandle handle = serial_list_insert(self, (guchar *)str, strlen(str)+1);
+
+  memcpy(other_buffer, buffer, sizeof(buffer));
+  memset(buffer, 0, sizeof(buffer));
+  serial_list_free(self);
+
+  SerialList *loaded = serial_list_load(other_buffer, sizeof(other_buffer));
+  SerialListHandle same_handle = serial_list_find(loaded, is_same_string, str);
+  cr_assert_eq(handle, same_handle);
+
+  const guchar *data;
+  gsize data_len;
+  serial_list_get_data(loaded, same_handle, &data, &data_len);
+  cr_assert_eq(data_len, strlen(str)+1);
+  cr_assert_eq(strncmp((gchar *)data, str, strlen(str)+1), 0);
+
+  serial_list_free(loaded);
+}

--- a/news/feature-3100.md
+++ b/news/feature-3100.md
@@ -1,0 +1,3 @@
+`python`: persist support for python
+
+This feature enables users to persist data between reloads or restarts. The intended usage is to support bookmarking and acknowledgement in the future. It is not suitable for local database use cases.


### PR DESCRIPTION
This patchset exposes persist api into python code.

This is the continuation of #3016, towards the road of having proper acknowledgement support in python.

Similar to #3016, this PR neither has any usage on its own, until bookmark handling is implemented in the future.

Features:
- A `Persist` class is importable from `syslogng` module
- The object looks like a dictionary: users can store values behind keys. The difference is it is backed by an entry in the persist file, so data is persisted between restarts.
- If no persist file created yet, `defaults` constructor parameter specifies can specify values for keys.
- Handles integers and strings.
- Inheritable
- Iterable

Limitations:
- Only a limited size of data can be added at a time. The length of the key+value must be below 4K, I do not have the exact values for now. As this module is intended for bookmarking, it does not make sense to store large values anyway. To store large number of local data securely, users need to use local database or other mechanism.
The limitation comes from the persist file in c, it can be only increased 4K at a time. This limitation can be workarounded if really needed: by storing only a small portion of the value, and incrementally append the rest of the data in small chunks.

Examples:

The code below prints five numbers, each restart/reload. Continuing from the last number of the previous execution.

```python
from syslogng import Persist, LogSource
class RangeSource(LogSource):
    def init(self, options):
        self.persist = Persist("persist_name", defaults={"bookmark" : 1})
        return True
    def run(self):
        first_item = self.persist["bookmark"]
        for i in range(first_item, first_item + 5):
            print("Item: {}".format(i))
            self.persist["bookmark"] = i + 1
    def request_exit(self):
        pass
```

You can iterate through keys:
```python
persist = Persist("persist_name", defaults={"foo" : "bar"})
for i in persist:
    print(i)
```

Developer notes:
- This patch contains a first example for actually developing core in python (see `defaults` parsing in the last patch.
- Could I have reuse nvtable? That has very similar use case: relocatable hashtable.
I concluded that it would not be a good idea. NVTable contains some features that are not necessary for persist. Also some code must have been added for the realloc to work. Besides, persist structure has a little different requirements. For example there is no defragmentation support in NVTable (due to performance reasons), which is, on the other hand, important when we are working in a limited space on disk. Also, NVTable needs to be fast on adding new items. This is not necessary for persist api. In that case adding new entries is a rare operation.
- A lot of complexity comes from the fact that syslog-ng can relocate a persist entry basically anytime. This means if the hashtable is based on pointers, the relocation can become very hard.
- A new structure SerialHash is introduced to be able to resolve the challenges of this requirement.
The idea is simple. Each key+value will be stored in nodes. These nodes are stored in a new structure called SerialList: which is essentially a doubly linked list. The speciality is that the previous and next members are not pointers, but offsets from a base pointer. From that a relocation is very easy, only the base pointer needs to be updated and the data can be memcopied. This will not corrupt the data structure.
- Defragmentation: there are two node types: DATA type nodes with data, and SPACE nodes for empty available space.
If a node is deleted, it is marked as SPACE. Then we check if the previous or next node is SPACE, and in either cases we merge the space nodes into a common node.
- Adding new elements to SerialList: the first large enough SPACE is searched serially (`O(N)`). This is not a problem, because we do not expect that addition will be a common operation.
- The other operations are speeded up. `SerialHash` encapsulates a `SerialList`, and also a regular `GHashTable` for index table: if we want to find a key-value, we can quickly lookup the index in the hashtable.
- Modification: if the data is smaller or equal in length, then we can reuse the same node -> fast operation due to the index table. If the data is larger, then the data needs to be added to a new free space, and the original node is freed. Again, finding new space is linear search, but we do not expect the data to ever increase -> uncommon operation.
- The Persist entry always stores data as string, no matter if integer or string is specified. Integers are serialized trivially. To differentiate, we also store the type of the entry, so that proper type could be returned during lookup.
