### PR TITLE
python: fix test_python_persist_name

### DIFF
--- a/modules/python/tests/test_python_persist_name.c
+++ b/modules/python/tests/test_python_persist_name.c
@@ -290,7 +290,9 @@ Test(python_persist_name, test_python_source_readonly)
   stop_grabbing_messages();
   display_grabbed_messages();
 
-  assert_grabbed_log_contains("TypeError: readonly attribute");
+  // Python2: TypeError: readonly attribute
+  // Python3: AttributeError: readonly attribute
+  assert_grabbed_log_contains("readonly attribute");
 
   main_loop_sync_worker_startup_and_teardown();
   log_pipe_deinit((LogPipe *)d);
@@ -321,7 +323,9 @@ Test(python_persist_name, test_python_fetcher_readonly)
   stop_grabbing_messages();
   display_grabbed_messages();
 
-  assert_grabbed_log_contains("TypeError: readonly attribute");
+  // Python2: TypeError: readonly attribute
+  // Python3: AttributeError: readonly attribute
+  assert_grabbed_log_contains("readonly attribute");
 
   main_loop_sync_worker_startup_and_teardown();
   log_pipe_deinit((LogPipe *)d);

--- a/modules/python/tests/test_python_persist_name.c
+++ b/modules/python/tests/test_python_persist_name.c
@@ -83,8 +83,11 @@ void teardown(void)
   cfg_free(empty_cfg);
   main_loop_deinit(main_loop);
   app_shutdown();
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
   Py_DECREF(_python_main);
   Py_DECREF(_python_main_dict);
+  PyGILState_Release(gstate);
 }
 
 static void
@@ -186,10 +189,13 @@ Test(python_persist_name, test_python_exception_in_generate_persist_name)
   _load_code(python_persist_generator_code);
 
   LogPipe *p = (LogPipe *)python_sd_new(empty_cfg);
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
   PyObject *persist_generator_stats = PyObject_GetAttrString(_py_get_main_module(python_config_get(empty_cfg)),
                                                              "persist_generator_stats");
   PyObject *persist_generator_persist = PyObject_GetAttrString(_py_get_main_module(python_config_get(empty_cfg)),
                                         "persist_generator_persist");
+  PyGILState_Release(gstate);
 
   start_grabbing_messages();
 


### PR DESCRIPTION
With python3, `test_python_persist_name` crashes and there is an assertion error.

- Forgot to add gilstate lock in some places.
- Different error type is raised when trying to write readonly member.

news file change not needed. This just a fixup for #3016 