### PR TITLE
lgtm: install autoconf-archive

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -8,3 +8,8 @@ extraction:
     prepare:
       packages:
         - autoconf-archive
+        - openjdk-8-jdk-headless
+    after_prepare:
+      - export PATH=/usr/lib/jvm/java-8-openjdk-amd64/bin/:$PATH
+      - export LD_LIBRARY_PATH=/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server:$LD_LIBRARY_PATH
+      - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -2,3 +2,9 @@
 # custom query to check for that
 queries:
   - exclude: cpp/potentially-dangerous-function
+
+extraction:
+  cpp:
+    prepare:
+      packages:
+        - autoconf-archive


### PR DESCRIPTION
When cmake install fails, LGTM falls back to automake and automake build
fails when autoconf-archive is missing (it's not detected
automatically).

Update: I have a reason of merge this over #3109 : currently syslog-ng cannot be built in lgtm environment with automake... and I think we should fix it (and make it possible to use as a fallback when cmake build fails).