### PR TITLE
[wip] Lgtm cmake disable afmongodb

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -2,3 +2,15 @@
 # custom query to check for that
 queries:
   - exclude: cpp/potentially-dangerous-function
+
+extraction:
+  cpp:
+    configure:
+      command:
+        - mkdir build
+        - cd build
+        - cmake ../ -DIVYKIS_SOURCE=system -DJSONC_SOURCE=system -DSYSLOG_NG_ENABLE_DEBUG=ON -DENABLE_JAVA=OFF
+    index:
+      build_command:
+        - cd build
+        - make

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -9,7 +9,7 @@ extraction:
       command:
         - mkdir build
         - cd build
-        - cmake ../ -DIVYKIS_SOURCE=system -DJSONC_SOURCE=system -DSYSLOG_NG_ENABLE_DEBUG=ON -DENABLE_JAVA=OFF
+        - cmake ../ -DIVYKIS_SOURCE=system -DJSONC_SOURCE=system -DSYSLOG_NG_ENABLE_DEBUG=ON -DENABLE_JAVA=OFF -DENABLE_MONGODB=DISABLE
     index:
       build_command:
         - cd build

--- a/modules/afmongodb/CMakeLists.txt
+++ b/modules/afmongodb/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (ENABLE_MONGODB STREQUAL DISABLE)
+  return()
+endif()
+
 find_package(libmongoc-1.0)
 
 module_switch(ENABLE_MONGODB "Enable mongodb destination driver" libmongoc-1.0_FOUND)


### PR DESCRIPTION
Another way of resolving the LGTM failure issue...

 #3108 seems simpler (to me). But... I think it would be nice if we would be able to completely disable unwanted modules when we are building syslog-ng with cmake.
This PR 
 * shows a possible example of completely disable these modules... 
 * is more complex as we tell lgtm how to configure and how to build syslog-ng...
 * as we are customizing configure, we can disable not only the afmongodb module, but also the java
which could speed up an LGTM job (of course in this case JNI related C code also skipped) 

What do you think? :
 * support 'complete' disabling of modules when building with cmake
 * disable java in LGTM
 * which solution(solution... better to say workaround) do you prefer? this one or #3108 
