### PR TITLE
format-gelf: add --omit-empty-values

### DIFF
--- a/news/bugfix-3112.md
+++ b/news/bugfix-3112.md
@@ -1,0 +1,2 @@
+`graylog2`, `format-gelf`: Fixed sending empty message, when ${PID} is not set.
+Also added a default value "-" to empty `short_message` and `host` as they are mandatory fields.

--- a/scl/graylog2/plugin.conf
+++ b/scl/graylog2/plugin.conf
@@ -23,7 +23,7 @@
 
 @requires json-plugin
 
-template-function "format-gelf" "$(format-json version='1.1' host='${HOST}' short_message='${MSG}' level=int(${LEVEL_NUM}) timestamp=int64(${R_UNIXTIME}) _program='${PROGRAM}' _pid=int(${PID}) _facility='${FACILITY}' _class='${.classifier.class}' --key .* --key _*)$(binary 0x00)";
+template-function "format-gelf" "$(format-json --omit-empty-values version='1.1' host='${HOST:--}' short_message='${MSG:--}' level=int(${LEVEL_NUM}) timestamp=int64(${R_UNIXTIME}) _program='${PROGRAM}' _pid=int(${PID}) _facility='${FACILITY}' _class='${.classifier.class}' --key .* --key _*)$(binary 0x00)";
 
 block destination graylog2(host("127.0.0.1") port(12201) transport(tcp) template("$(format-gelf)") ...) {
 	network("`host`"


### PR DESCRIPTION
Fixes #3110

---

There are sources, which do not set the `${PID}`, so it stays empty.

We use `$(format-json)` in `$(format-gelf)` with `int` type hinted `${PID}`. If `${PID}` is empty, the whole `$(format-json)` call will fail, and it will produce an empty message:

```
[2020-02-03T10:27:08.261055] Casting error; value='', type-hint='int32'
[2020-02-03T10:27:08.261116] Outgoing message; message=''
```

`_pid` is just and additional field in GELF, so it can be skipped:
https://docs.graylog.org/en/3.1/pages/gelf.html

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>