### PR TITLE
Fix multiple-definition issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,8 +331,7 @@ endif()
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -j $$(nproc) --output-on-failure)
 
 set(IMPORTANT_WARNINGS
-  -Wshadow
-  -fcommon)
+  -Wshadow)
 
 set(ACCEPTABLE_WARNINGS
   -Wno-stack-protector

--- a/Makefile.am
+++ b/Makefile.am
@@ -54,8 +54,7 @@ AM_CPPFLAGS		= -I$(top_srcdir)/lib -I$(top_srcdir)/modules -I$(top_builddir)/lib
 
 # Important warnings
 AM_CFLAGS = \
-	-Wshadow \
-	-fcommon
+	-Wshadow
 
 # Acceptable warnings
 AM_CFLAGS += \

--- a/lib/logmsg/tests/test_log_message.c
+++ b/lib/logmsg/tests/test_log_message.c
@@ -32,6 +32,8 @@
 #include <stdlib.h>
 #include <glib/gprintf.h>
 
+MsgFormatOptions parse_options;
+
 typedef struct _LogMessageTestParams
 {
   LogMessage *message;
@@ -151,7 +153,7 @@ void
 setup(void)
 {
   app_startup();
-  init_and_load_syslogformat_module();
+  init_and_load_syslogformat_module(&parse_options);
 }
 
 void

--- a/lib/logmsg/tests/test_log_message.c
+++ b/lib/logmsg/tests/test_log_message.c
@@ -153,7 +153,7 @@ void
 setup(void)
 {
   app_startup();
-  init_and_load_syslogformat_module(&parse_options);
+  init_parse_options_and_load_syslogformat(&parse_options);
 }
 
 void

--- a/libtest/cr_template.c
+++ b/libtest/cr_template.c
@@ -34,10 +34,12 @@
 
 #include "msg_parse_lib.h"
 
+static MsgFormatOptions parse_options;
+
 void
 init_template_tests(void)
 {
-  init_and_load_syslogformat_module();
+  init_and_load_syslogformat_module(&parse_options);
 }
 
 void

--- a/libtest/cr_template.c
+++ b/libtest/cr_template.c
@@ -39,7 +39,7 @@ static MsgFormatOptions parse_options;
 void
 init_template_tests(void)
 {
-  init_and_load_syslogformat_module(&parse_options);
+  init_parse_options_and_load_syslogformat(&parse_options);
 }
 
 void

--- a/libtest/msg_parse_lib.c
+++ b/libtest/msg_parse_lib.c
@@ -27,15 +27,13 @@
 
 #include <criterion/criterion.h>
 
-MsgFormatOptions parse_options;
-
 void
-init_and_load_syslogformat_module(void)
+init_and_load_syslogformat_module(MsgFormatOptions *parse_options)
 {
   configuration = cfg_new_snippet();
   cfg_load_module(configuration, "syslogformat");
-  msg_format_options_defaults(&parse_options);
-  msg_format_options_init(&parse_options, configuration);
+  msg_format_options_defaults(parse_options);
+  msg_format_options_init(parse_options, configuration);
 }
 
 void

--- a/libtest/msg_parse_lib.c
+++ b/libtest/msg_parse_lib.c
@@ -28,7 +28,7 @@
 #include <criterion/criterion.h>
 
 void
-init_and_load_syslogformat_module(MsgFormatOptions *parse_options)
+init_parse_options_and_load_syslogformat(MsgFormatOptions *parse_options)
 {
   configuration = cfg_new_snippet();
   cfg_load_module(configuration, "syslogformat");

--- a/libtest/msg_parse_lib.h
+++ b/libtest/msg_parse_lib.h
@@ -30,7 +30,7 @@
 #include "cfg.h"
 #include "logmsg/logmsg.h"
 
-void init_and_load_syslogformat_module(MsgFormatOptions *parse_options);
+void init_parse_options_and_load_syslogformat(MsgFormatOptions *parse_options);
 void deinit_syslogformat_module(void);
 
 void assert_log_messages_equal(LogMessage *log_message_a, LogMessage *log_message_b);

--- a/libtest/msg_parse_lib.h
+++ b/libtest/msg_parse_lib.h
@@ -30,9 +30,7 @@
 #include "cfg.h"
 #include "logmsg/logmsg.h"
 
-extern MsgFormatOptions parse_options;
-
-void init_and_load_syslogformat_module(void);
+void init_and_load_syslogformat_module(MsgFormatOptions *parse_options);
 void deinit_syslogformat_module(void);
 
 void assert_log_messages_equal(LogMessage *log_message_a, LogMessage *log_message_b);

--- a/libtest/proto_lib.c
+++ b/libtest/proto_lib.c
@@ -23,7 +23,7 @@
  */
 
 #include "proto_lib.h"
-#include "msg_parse_lib.h"
+#include "cfg.h"
 
 #include <string.h>
 #include <criterion/criterion.h>
@@ -164,7 +164,8 @@ assert_proto_server_fetch_ignored_eof(LogProtoServer *proto)
 void
 init_proto_tests(void)
 {
-  init_and_load_syslogformat_module();
+  configuration = cfg_new_snippet();
+  cfg_load_module(configuration, "syslogformat");
   log_proto_server_options_defaults(&proto_server_options);
 }
 
@@ -172,5 +173,7 @@ void
 deinit_proto_tests(void)
 {
   log_proto_server_options_destroy(&proto_server_options);
-  deinit_syslogformat_module();
+
+  if (configuration)
+    cfg_free(configuration);
 }

--- a/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
+++ b/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
@@ -31,6 +31,8 @@
 
 #include <criterion/criterion.h>
 
+MsgFormatOptions parse_options;
+
 static LogMessage *
 kmsg_parse_message(const gchar *raw_message_str)
 {

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -97,7 +97,7 @@ void setup(void)
 {
   app_startup();
 
-  init_and_load_syslogformat_module(&parse_options);
+  init_parse_options_and_load_syslogformat(&parse_options);
 
   _py_init_interpreter();
   _init_python_main();

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -30,6 +30,8 @@
 static PyObject *_python_main;
 static PyObject *_python_main_dict;
 
+MsgFormatOptions parse_options;
+
 static void
 _py_init_interpreter(void)
 {
@@ -95,7 +97,7 @@ void setup(void)
 {
   app_startup();
 
-  init_and_load_syslogformat_module();
+  init_and_load_syslogformat_module(&parse_options);
 
   _py_init_interpreter();
   _init_python_main();

--- a/modules/stardate/tests/test_stardate.c
+++ b/modules/stardate/tests/test_stardate.c
@@ -33,6 +33,8 @@
 
 #include "msg_parse_lib.h"
 
+MsgFormatOptions parse_options;
+
 void
 stardate_assert(const gchar *msg_str, const int precision, const gchar *expected)
 {
@@ -58,6 +60,7 @@ void
 setup(void)
 {
   app_startup();
+  init_and_load_syslogformat_module(&parse_options);
   init_template_tests();
   cfg_load_module(configuration, "stardate");
 }
@@ -66,6 +69,7 @@ void
 teardown(void)
 {
   deinit_template_tests();
+  deinit_syslogformat_module();
   app_shutdown();
 }
 

--- a/modules/stardate/tests/test_stardate.c
+++ b/modules/stardate/tests/test_stardate.c
@@ -60,7 +60,7 @@ void
 setup(void)
 {
   app_startup();
-  init_and_load_syslogformat_module(&parse_options);
+  init_parse_options_and_load_syslogformat(&parse_options);
   init_template_tests();
   cfg_load_module(configuration, "stardate");
 }

--- a/persist-tool/add.h
+++ b/persist-tool/add.h
@@ -32,8 +32,8 @@
 #include "cfg.h"
 #include "persist-tool.h"
 
-gchar *persist_state_dir;
-gchar *persist_state_name;
+extern gchar *persist_state_dir;
+extern gchar *persist_state_name;
 
 gint add_main(int argc, char *argv[]);
 

--- a/persist-tool/generate.h
+++ b/persist-tool/generate.h
@@ -32,8 +32,8 @@
 #include "persist-state.h"
 #include "cfg.h"
 
-gboolean force_generate;
-gchar *generate_output_dir;
+extern gboolean force_generate;
+extern gchar *generate_output_dir;
 
 gint generate_main(int argc, char *argv[]);
 

--- a/persist-tool/persist-tool.c
+++ b/persist-tool/persist-tool.c
@@ -135,10 +135,16 @@ void persist_tool_free(PersistTool *self)
   g_free(self);
 }
 
+gchar *persist_state_dir;
+gchar *persist_state_name;
+gboolean force_generate;
+gchar *generate_output_dir;
+
 static GOptionEntry dump_options[] =
 {
   { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL }
 };
+
 
 static GOptionEntry add_options[] =
 {

--- a/tests/unit/test_clone_logmsg.c
+++ b/tests/unit/test_clone_logmsg.c
@@ -71,7 +71,7 @@ void
 setup(void)
 {
   app_startup();
-  init_and_load_syslogformat_module(&parse_options);
+  init_parse_options_and_load_syslogformat(&parse_options);
 }
 
 void

--- a/tests/unit/test_clone_logmsg.c
+++ b/tests/unit/test_clone_logmsg.c
@@ -38,6 +38,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+MsgFormatOptions parse_options;
+
 void
 assert_new_log_message_attributes(LogMessage *log_message)
 {
@@ -69,7 +71,7 @@ void
 setup(void)
 {
   app_startup();
-  init_and_load_syslogformat_module();
+  init_and_load_syslogformat_module(&parse_options);
 }
 
 void

--- a/tests/unit/test_matcher.c
+++ b/tests/unit/test_matcher.c
@@ -31,6 +31,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+MsgFormatOptions parse_options;
+
 static LogMessage *
 _create_log_message(const gchar *log)
 {
@@ -128,7 +130,7 @@ void
 setup(void)
 {
   app_startup();
-  init_and_load_syslogformat_module();
+  init_and_load_syslogformat_module(&parse_options);
 }
 
 void

--- a/tests/unit/test_matcher.c
+++ b/tests/unit/test_matcher.c
@@ -130,7 +130,7 @@ void
 setup(void)
 {
   app_startup();
-  init_and_load_syslogformat_module(&parse_options);
+  init_parse_options_and_load_syslogformat(&parse_options);
 }
 
 void

--- a/tests/unit/test_msgparse.c
+++ b/tests/unit/test_msgparse.c
@@ -132,7 +132,7 @@ setup(void)
   app_startup();
   setenv("TZ", "MET-1METDST", TRUE);
   tzset();
-  init_and_load_syslogformat_module(&parse_options);
+  init_parse_options_and_load_syslogformat(&parse_options);
   /* Fri Feb  8 09:37:49 CET 2019 */
   fake_time(1549615069);
 }

--- a/tests/unit/test_msgparse.c
+++ b/tests/unit/test_msgparse.c
@@ -49,6 +49,8 @@ struct sdata_pair
 struct sdata_pair ignore_sdata_pairs[] = { { NULL, NULL } };
 struct sdata_pair empty_sdata_pairs[] = { { NULL, NULL } };
 
+MsgFormatOptions parse_options;
+
 static unsigned long
 _absolute_value(signed long diff)
 {
@@ -130,7 +132,7 @@ setup(void)
   app_startup();
   setenv("TZ", "MET-1METDST", TRUE);
   tzset();
-  init_and_load_syslogformat_module();
+  init_and_load_syslogformat_module(&parse_options);
   /* Fri Feb  8 09:37:49 CET 2019 */
   fake_time(1549615069);
 }


### PR DESCRIPTION
This PR removes the `-fcommon` flag from CMake and autotools builds.

The `-fcommon` option hides (merges) multiple definition issues such as the persist-tool global variable redefinition (bc3fcb4) .

Such multi-definitions are not intentional in the syslog-ng codebase.

> The -fcommon places uninitialized global variables in a common block. This allows the linker to resolve all tentative definitions of the same variable in different compilation units to the same object.

In new GCC versions, `-fno-common` is the default:

>GCC now defaults to -fno-common. As a result, global variable accesses are more efficient on various targets. In C, global variables with multiple tentative definitions now result in linker errors. With -fcommon such definitions are silently merged during linking. 


Fixes #3101