### PR TITLE
HTTP: workers() must be positive numbers

### DIFF
--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -154,7 +154,7 @@ http_option
     | KW_ACCEPT_REDIRECTS '(' yesno ')'       { http_dd_set_accept_redirects(last_driver, $3); }
     | KW_TIMEOUT '(' nonnegative_integer ')'  { http_dd_set_timeout(last_driver, $3); }
     | KW_BATCH_BYTES '(' nonnegative_integer ')' { http_dd_set_batch_bytes(last_driver, $3); }
-    | KW_WORKERS '(' nonnegative_integer ')'  { log_threaded_dest_driver_set_num_workers(last_driver, $3); }
+    | KW_WORKERS '(' positive_integer ')'  { log_threaded_dest_driver_set_num_workers(last_driver, $3); }
     | threaded_dest_driver_option
     | http_tls_option
     | KW_TLS '(' http_tls_options ')'

--- a/news/bugfix-3116.md
+++ b/news/bugfix-3116.md
@@ -1,0 +1,1 @@
+http: Fixed a crash, when worker was set to 0. We do not allow nonnegative values anymore.


### PR DESCRIPTION
If we starts syslog-ng with the following minimal config syslog-ng will crash on first input log:

```
@version: 3.25
source s_example {
    example-msg-generator(num(1) template("<34>Oct 11 22:14:15 tristram su: 'su root' failed for lonvick on /dev/pts/8\n") );
};
destination d_http {
    http(
        method(post)
        url("http://127.0.0.1:61292") 
        workers(0)
    );
};
log {
source(s_example);
destination(d_http);
};
```

console log:
```
...
[2020-02-04T13:28:35.086386] syslog-ng starting up; version='3.25.1.188.g4226fa1'
[2020-02-04T13:28:35.086397] Running application hooks; hook='2'
[2020-02-04T13:28:35.086420] Setting value; name='MESSAGE', value='-- Generated message. --', msg='0x562832083d80'
[2020-02-04T13:28:35.086431] Setting value; name='MESSAGE', value='<34>Oct 11 22:14:15 tristram su: \'su root\' failed for lonvick on /dev/pts/8\x0a', msg='0x562832083d80'
[2020-02-04T13:28:35.086438] Incoming generated message; msg='<34>Oct 11 22:14:15 tristram su: \'su root\' failed for lonvick on /dev/pts/8\x0a'
[2020-02-04T13:28:35.086446] >>>>>> Source side message processing begin; instance='internal', location='etc/slng-http.conf:10:5', msg='0x562832083d80'
[2020-02-04T13:28:35.086451] Setting value; name='HOST_FROM', value='tristram', msg='0x562832083d80'
[2020-02-04T13:28:35.086456] Setting value; name='HOST', value='tristram', msg='0x562832083d80'
[2020-02-04T13:28:35.086471] Setting value; name='SOURCE', value='s_network_c2ffd45e339f4ff885f0560b9ab60e8f', msg='0x562832083d80'
[2020-02-04T13:28:35.086476] Requesting flow control; location='etc/slng-http.conf:18:1'
Floating point exception (core dumped)
```

We should not accept workers(0), it does not make sense.

gdb backtrace:
```
Program received signal SIGFPE, Arithmetic exception.
0x00007ffff7b755f4 in _lookup_worker (self=0x555555806880, msg=0x5555557801c0) at /source/lib/logthrdest/logthrdestdrv.c:953
953	  gint worker_index = self->last_worker % self->num_workers;
(gdb) bt
#0  0x00007ffff7b755f4 in _lookup_worker (self=0x555555806880, msg=0x5555557801c0) at /source/lib/logthrdest/logthrdestdrv.c:953
#1  0x00007ffff7b7566d in log_threaded_dest_driver_queue (s=0x555555806880, msg=0x5555557801c0, path_options=0x7fffffffe290) at /source/lib/logthrdest/logthrdestdrv.c:968
#2  0x00007ffff7b04144 in log_pipe_queue (s=0x555555806880, msg=0x5555557801c0, path_options=0x7fffffffe290) at /source/lib/logpipe.h:366
#3  0x00007ffff7b043a2 in log_multiplexer_queue (s=0x5555558071c0, msg=0x5555557801c0, path_options=0x7fffffffe350) at /source/lib/logmpx.c:97
#4  0x00007ffff7b04144 in log_pipe_queue (s=0x5555558071c0, msg=0x5555557801c0, path_options=0x7fffffffe350) at /source/lib/logpipe.h:366
#5  0x00007ffff7b043a2 in log_multiplexer_queue (s=0x555555807410, msg=0x5555557801c0, path_options=0x7fffffffe510) at /source/lib/logmpx.c:97
#6  0x00007ffff7b04144 in log_pipe_queue (s=0x555555807410, msg=0x5555557801c0, path_options=0x7fffffffe510) at /source/lib/logpipe.h:366
#7  0x00007ffff7b03ff2 in log_pipe_forward_msg (self=0x5555558070a0, msg=0x5555557801c0, path_options=0x7fffffffe510) at /source/lib/logpipe.h:331
#8  0x00007ffff7b0415d in log_pipe_queue (s=0x5555558070a0, msg=0x5555557801c0, path_options=0x7fffffffe510) at /source/lib/logpipe.h:370
#9  0x00007ffff7b03ff2 in log_pipe_forward_msg (self=0x5555558088b0, msg=0x5555557801c0, path_options=0x7fffffffe510) at /source/lib/logpipe.h:331
#10 0x00007ffff7b0415d in log_pipe_queue (s=0x5555558088b0, msg=0x5555557801c0, path_options=0x7fffffffe510) at /source/lib/logpipe.h:370
#11 0x00007ffff7b043a2 in log_multiplexer_queue (s=0x555555806fa0, msg=0x5555557801c0, path_options=0x7fffffffe860) at /source/lib/logmpx.c:97
#12 0x00007ffff7afc218 in log_pipe_queue (s=0x555555806fa0, msg=0x5555557801c0, path_options=0x7fffffffe860) at /source/lib/logpipe.h:366
#13 0x00007ffff7afc0c6 in log_pipe_forward_msg (self=0x555555808810, msg=0x5555557801c0, path_options=0x7fffffffe860) at /source/lib/logpipe.h:331
#14 0x00007ffff7afc231 in log_pipe_queue (s=0x555555808810, msg=0x5555557801c0, path_options=0x7fffffffe860) at /source/lib/logpipe.h:370
#15 0x00007ffff7afc0c6 in log_pipe_forward_msg (self=0x555555808b30, msg=0x5555557801c0, path_options=0x7fffffffe860) at /source/lib/logpipe.h:331
#16 0x00007ffff7afc231 in log_pipe_queue (s=0x555555808b30, msg=0x5555557801c0, path_options=0x7fffffffe860) at /source/lib/logpipe.h:370
#17 0x00007ffff7afc0c6 in log_pipe_forward_msg (self=0x5555557c19e0, msg=0x5555557801c0, path_options=0x7fffffffe860) at /source/lib/logpipe.h:331
#18 0x00007ffff7afcba0 in log_src_driver_queue_method (s=0x5555557c19e0, msg=0x5555557801c0, path_options=0x7fffffffe860) at /source/lib/driver.c:222
#19 0x00007ffff7b0923d in log_pipe_queue (s=0x5555557c19e0, msg=0x5555557801c0, path_options=0x7fffffffe860) at /source/lib/logpipe.h:366
#20 0x00007ffff7b090eb in log_pipe_forward_msg (self=0x555555807850, msg=0x5555557801c0, path_options=0x7fffffffe860) at /source/lib/logpipe.h:331
#21 0x00007ffff7b0af67 in log_source_queue (s=0x555555807850, msg=0x5555557801c0, path_options=0x7fffffffe860) at /source/lib/logsource.c:620
#22 0x00007ffff7b0923d in log_pipe_queue (s=0x555555807850, msg=0x5555557801c0, path_options=0x7fffffffe860) at /source/lib/logpipe.h:366
#23 0x00007ffff7b0ab47 in log_source_post (self=0x555555807850, msg=0x5555557801c0) at /source/lib/logsource.c:536
#24 0x00007ffff497a2d7 in _send_generated_message (self=0x555555807850) at /source/modules/examples/sources/msg-generator/msg-generator-source.c:114
#25 0x00007ffff497a2fc in _timer_expired (cookie=0x555555807850) at /source/modules/examples/sources/msg-generator/msg-generator-source.c:122
#26 0x00007ffff7b77899 in iv_run_timers (st=0x555555761cb0) at /source/lib/ivykis/src/iv_timer.c:124
#27 0x00007ffff7b7ac78 in iv_main () at /source/lib/ivykis/src/iv_main_posix.c:98
#28 0x00007ffff7b10ab2 in main_loop_run (self=0x7ffff7dd3600 <main_loop>) at /source/lib/mainloop.c:659
#29 0x0000555555556358 in main (argc=1, argv=0x7fffffffeb08) at /source/syslog-ng/main.c:313
```

Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>