### PR TITLE
dbld: freeze last version that supports python2

### DIFF
--- a/dbld/images/helpers/pip_packages.manifest
+++ b/dbld/images/helpers/pip_packages.manifest
@@ -3,7 +3,8 @@ nose                    [centos, fedora, debian, ubuntu]
 ply                     [centos, fedora, debian, ubuntu]
 
 # pip packages for kira tests
-hy			[devshell, ubuntu-xenial]
+# 0.17: Last version that suppports python2
+hy==0.17                [devshell, ubuntu-xenial]
 
 # pip packages for python functional tests
 pathlib2                [centos, fedora, debian, ubuntu]


### PR DESCRIPTION
With newer versions of hy, 008-python-destination-loaders.zts
fails, because from 0.18 python3 is not supported by hy.

If syslog-ng is compiled with `--with-python=3` or
`-DPYTHON_VERSION=3`, then hy==0.18 works.

But for now we are compiling with python2, so 0.17 needs until python2
support is dropped.

No need to add this to changenote.