### PR TITLE
http: fix signal slot headers with non-batching but prefix-suffix case

### DIFF
--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -235,12 +235,9 @@ _add_common_headers(HTTPDestinationWorker *self)
 }
 
 static void
-_format_request_headers(HTTPDestinationWorker *self, LogMessage *msg)
+_format_request_headers(HTTPDestinationWorker *self)
 {
   HTTPDestinationDriver *owner = (HTTPDestinationDriver *) self->super.owner;
-
-  if (msg)
-    _add_msg_specific_headers(self, msg);
 
   _add_common_headers(self);
 
@@ -605,9 +602,7 @@ _flush(LogThreadedDestWorker *s, LogThreadedFlushMode mode)
     return LTR_RETRY;
 
   _finish_request_body(self);
-
-  if (list_is_empty(self->request_headers))
-    _format_request_headers(self, NULL);
+  _format_request_headers(self);
 
   target = http_load_balancer_choose_target(owner->load_balancer, &self->lbc);
 
@@ -677,7 +672,7 @@ _insert_single(LogThreadedDestWorker *s, LogMessage *msg)
   HTTPDestinationWorker *self = (HTTPDestinationWorker *) s;
 
   _add_message_to_batch(self, msg);
-  _format_request_headers(self, msg);
+  _add_msg_specific_headers(self, msg);
 
   return log_threaded_dest_worker_flush(&self->super, LTF_FLUSH_NORMAL);
 }

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -199,38 +199,50 @@ _collect_rest_headers(HTTPDestinationWorker *self)
   EMIT(owner->super.super.super.super.signal_slot_connector, signal_http_header_request, &signal_data);
 }
 
+
+static void
+_add_msg_specific_headers(HTTPDestinationWorker *self, LogMessage *msg)
+{
+  /* NOTE: I have my doubts that these headers make sense at all.  None of
+   * the HTTP collectors I know of, extract this information from the
+   * headers and it makes batching several messages into the same request a
+   * bit more complicated than it needs to be.  I didn't want to break
+   * backward compatibility when batching was introduced, however I think
+   * this should eventually be removed */
+
+  _add_header(self->request_headers,
+              "X-Syslog-Host",
+              log_msg_get_value(msg, LM_V_HOST, NULL));
+  _add_header(self->request_headers,
+              "X-Syslog-Program",
+              log_msg_get_value(msg, LM_V_PROGRAM, NULL));
+  _add_header(self->request_headers,
+              "X-Syslog-Facility",
+              syslog_name_lookup_name_by_value(msg->pri & LOG_FACMASK, sl_facilities));
+  _add_header(self->request_headers,
+              "X-Syslog-Level",
+              syslog_name_lookup_name_by_value(msg->pri & LOG_PRIMASK, sl_levels));
+}
+
+static void
+_add_common_headers(HTTPDestinationWorker *self)
+{
+  HTTPDestinationDriver *owner = (HTTPDestinationDriver *) self->super.owner;
+
+  _add_header(self->request_headers, "Expect", "");
+  for (GList *l = owner->headers; l; l = l->next)
+    list_append(self->request_headers, l->data);
+}
+
 static void
 _format_request_headers(HTTPDestinationWorker *self, LogMessage *msg)
 {
   HTTPDestinationDriver *owner = (HTTPDestinationDriver *) self->super.owner;
-  GList *l;
 
-  _add_header(self->request_headers, "Expect", "");
   if (msg)
-    {
-      /* NOTE: I have my doubts that these headers make sense at all.  None of
-       * the HTTP collectors I know of, extract this information from the
-       * headers and it makes batching several messages into the same request a
-       * bit more complicated than it needs to be.  I didn't want to break
-       * backward compatibility when batching was introduced, however I think
-       * this should eventually be removed */
+    _add_msg_specific_headers(self, msg);
 
-      _add_header(self->request_headers,
-                  "X-Syslog-Host",
-                  log_msg_get_value(msg, LM_V_HOST, NULL));
-      _add_header(self->request_headers,
-                  "X-Syslog-Program",
-                  log_msg_get_value(msg, LM_V_PROGRAM, NULL));
-      _add_header(self->request_headers,
-                  "X-Syslog-Facility",
-                  syslog_name_lookup_name_by_value(msg->pri & LOG_FACMASK, sl_facilities));
-      _add_header(self->request_headers,
-                  "X-Syslog-Level",
-                  syslog_name_lookup_name_by_value(msg->pri & LOG_PRIMASK, sl_levels));
-    }
-
-  for (l = owner->headers; l; l = l->next)
-    list_append(self->request_headers, l->data);
+  _add_common_headers(self);
 
   if (owner->auth_header)
     _append_auth_header(self->request_headers, owner);

--- a/modules/http/tests/CMakeLists.txt
+++ b/modules/http/tests/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_unit_test(CRITERION TARGET test_http DEPENDS http)
 add_unit_test(LIBTEST CRITERION TARGET test_http-loadbalancer DEPENDS http)
 add_unit_test(CRITERION TARGET test_http-response_handlers DEPENDS http)
+add_unit_test(CRITERION TARGET test_http-signal_slot DEPENDS http)

--- a/modules/http/tests/Makefile.am
+++ b/modules/http/tests/Makefile.am
@@ -3,7 +3,8 @@ if ENABLE_HTTP
 modules_http_tests_TESTS			= \
 	modules/http/tests/test_http			\
 	modules/http/tests/test_http-loadbalancer	\
-	modules/http/tests/test_http-response_handlers
+	modules/http/tests/test_http-response_handlers	\
+	modules/http/tests/test_http-signal_slot
 
 check_PROGRAMS					+= ${modules_http_tests_TESTS}
 
@@ -28,6 +29,13 @@ modules_http_tests_test_http_response_handlers_DEPENDENCIES = \
 modules_http_tests_test_http_response_handlers_CFLAGS	= $(TEST_CFLAGS) -I$(top_srcdir)/modules/http
 modules_http_tests_test_http_response_handlers_LDADD = $(TEST_LDADD)
 modules_http_tests_test_http_response_handlers_LDFLAGS	= \
+	-dlpreopen $(top_builddir)/modules/http/libhttp.la
+
+modules_http_tests_test_http_signal_slot_DEPENDENCIES = \
+	$(top_builddir)/modules/http/libhttp.la
+modules_http_tests_test_http_signal_slot_CFLAGS	= $(TEST_CFLAGS) -I$(top_srcdir)/modules/http
+modules_http_tests_test_http_signal_slot_LDADD = $(TEST_LDADD)
+modules_http_tests_test_http_signal_slot_LDFLAGS	= \
 	-dlpreopen $(top_builddir)/modules/http/libhttp.la
 endif
 

--- a/modules/http/tests/test_http-signal_slot.c
+++ b/modules/http/tests/test_http-signal_slot.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "syslog-ng.h"
+#include <criterion/criterion.h>
+
+Test(test_http_signal_slot, basic)
+{
+  cr_assert(TRUE);
+}

--- a/modules/http/tests/test_http-signal_slot.c
+++ b/modules/http/tests/test_http-signal_slot.c
@@ -21,9 +21,133 @@
  */
 
 #include "syslog-ng.h"
+#include <apphook.h>
+#include "http.h"
+#include "http-worker.h"
+#include "http-signals.h"
 #include <criterion/criterion.h>
+
+MainLoop *main_loop;
+MsgFormatOptions parse_options;
+MainLoopOptions main_loop_options;
+
+HTTPDestinationDriver *driver;
+
+static void
+setup(void)
+{
+  debug_flag = TRUE;
+  log_stderr = TRUE;
+  app_startup();
+
+  main_loop = main_loop_get_instance();
+  main_loop_init(main_loop, &main_loop_options);
+
+  driver = (HTTPDestinationDriver *) http_dd_new(main_loop_get_current_config(main_loop));
+}
+
+static void
+teardown(void)
+{
+  main_loop_sync_worker_startup_and_teardown();
+  log_pipe_deinit((LogPipe *)driver);
+  log_pipe_unref((LogPipe *)driver);
+
+  main_loop_deinit(main_loop);
+  app_shutdown();
+}
+
+TestSuite(test_http_signal_slot, .init = setup, .fini = teardown);
+
+static void
+_generate_message(HTTPDestinationDriver *dd, const gchar *msg_str)
+{
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT_NOACK;
+  LogMessage *msg = log_msg_new_empty();
+  log_msg_set_value_by_name(msg, "MSG", msg_str, -1);
+  log_pipe_queue(&dd->super.super.super.super, msg, &path_options);
+}
+
+gboolean signal_slot_executed;
+
+static void
+_sleep_msec(long msec)
+{
+  struct timespec sleep_time = { msec / 1000, (msec % 1000) * 1000000 };
+  nanosleep(&sleep_time, NULL);
+}
+
+static void
+wait_for_signal_slot_to_finish(void)
+{
+  const int MAX_SPIN_ITERATIONS = 10000;
+  int c = 0;
+  while (!signal_slot_executed && c++ < MAX_SPIN_ITERATIONS)
+    _sleep_msec(1);
+  cr_assert(signal_slot_executed, "signal slot did not execute");
+}
+
+static void
+notify_signal_slot_finish(void)
+{
+  signal_slot_executed = TRUE;
+}
+
+static void
+_check(const gchar *expected_body, HttpHeaderRequestSignalData *data)
+{
+  cr_assert_str_eq(data->request_body->str, expected_body);
+
+  notify_signal_slot_finish();
+}
 
 Test(test_http_signal_slot, basic)
 {
-  cr_assert(TRUE);
+  SignalSlotConnector *ssc = driver->super.super.super.super.signal_slot_connector;
+
+  const gchar *test_msg = "test message";
+  CONNECT(ssc, signal_http_header_request, _check, test_msg);
+
+  cr_assert(log_pipe_init((LogPipe *)driver));
+
+  _generate_message(driver, test_msg);
+
+  wait_for_signal_slot_to_finish();
+}
+
+Test(test_http_signal_slot, single_with_prefix_suffix)
+{
+  http_dd_set_body_prefix((LogDriver *)driver, "[");
+  http_dd_set_body_suffix((LogDriver *)driver, "]");
+  http_dd_set_delimiter((LogDriver *)driver, ",");
+
+  SignalSlotConnector *ssc = driver->super.super.super.super.signal_slot_connector;
+
+  CONNECT(ssc, signal_http_header_request, _check, "[almafa]");
+
+  cr_assert(log_pipe_init((LogPipe *)driver));
+
+  _generate_message(driver, "almafa");
+
+  wait_for_signal_slot_to_finish();
+}
+
+Test(test_http_signal_slot, batch_with_prefix_suffix)
+{
+  http_dd_set_body_prefix((LogDriver *)driver, "[");
+  http_dd_set_body_suffix((LogDriver *)driver, "]");
+  http_dd_set_delimiter((LogDriver *)driver, ",");
+  log_threaded_dest_driver_set_batch_lines((LogDriver *)driver, 2);
+  log_threaded_dest_driver_set_batch_timeout((LogDriver *)driver, 1000);
+
+  SignalSlotConnector *ssc = driver->super.super.super.super.signal_slot_connector;
+
+  CONNECT(ssc, signal_http_header_request, _check, "[1,2]");
+
+  cr_assert(log_pipe_init((LogPipe *)driver));
+
+  _generate_message(driver, "1");
+  _generate_message(driver, "2");
+
+  wait_for_signal_slot_to_finish();
 }


### PR DESCRIPTION
In case batching is not enabled, but prefix and suffix is used, http-worker (`_insert_single`) calculated headers before the body is finshed (body-suffix is added).

After this patch, the msg specific headers are added in `_insert_single`, and everything else during flush, unconditionally.

No need for changenote, just a small addition to #3103.