### PR TITLE
Python http header

### DIFF
--- a/modules/http/http-signals.h
+++ b/modules/http/http-signals.h
@@ -30,8 +30,16 @@
 
 typedef struct _HttpHeaderRequestSignalData HttpHeaderRequestSignalData;
 
+typedef enum
+{
+  HTTP_HEADER_REQUEST_SLOT_SUCCESS,
+  HTTP_HEADER_REQUEST_SLOT_CRITICAL_ERROR,
+  HTTP_HEADER_REQUEST_SLOT_PLUGIN_ERROR
+} HttpHeaderRequestSlotResultType;
+
 struct _HttpHeaderRequestSignalData
 {
+  HttpHeaderRequestSlotResultType result;
   List *request_headers;
   GString *request_body;
 };

--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -15,6 +15,8 @@ set(PYTHON_SOURCES
     python-persist.c
     python-helpers.h
     python-helpers.c
+    python-http-header.h
+    python-http-header.c
     python-main.h
     python-main.c
     python-plugin.c
@@ -53,6 +55,7 @@ add_module(
   TARGET mod-python
   GRAMMAR python-grammar
   INCLUDES ${PYTHON_INCLUDE_DIRS}
+           ${PROJECT_SOURCE_DIR}
   DEPENDS ${PYTHON_LIBRARIES}
           ${Eventlog_LIBRARIES}
           ${IVYKIS_LIBRARIES}

--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -61,7 +61,10 @@ modules_python_libmod_python_la_SOURCES		= \
 	modules/python/python-source.h	  \
 	modules/python/python-source.c	  \
 	modules/python/python-fetcher.h	  \
-	modules/python/python-fetcher.c
+	modules/python/python-fetcher.c   \
+	modules/python/python-http-header.h   \
+	modules/python/python-http-header.c
+
 
 modules_python_libmod_python_la_LDFLAGS		 = \
 	$(MODULE_LDFLAGS) \

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -60,6 +60,7 @@ PythonHttpHeaderPlugin *last_header;
 %token KW_CLASS
 %token KW_IMPORTS
 %token KW_LOADERS
+%token KW_MARK_ERRORS_AS_CRITICAL
 
 %%
 
@@ -248,6 +249,10 @@ python_http_header_option
           }
         | KW_LOADERS python_http_header_loaders
         | KW_OPTIONS '(' python_http_header_custom_options ')'
+        | KW_MARK_ERRORS_AS_CRITICAL '(' yesno ')'
+          {
+            python_http_header_set_mark_errors_as_critical(last_header, $3);
+          }
         ;
 
 python_http_header_custom_options

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -56,7 +56,7 @@ PythonHttpHeaderPlugin *last_header;
 
 %token KW_PYTHON
 %token KW_PYTHON_FETCHER
-%token KW_PYTHON_HEADER
+%token KW_PYTHON_HTTP_HEADER
 %token KW_CLASS
 %token KW_IMPORTS
 %token KW_LOADERS
@@ -84,7 +84,7 @@ start
             last_driver = *instance = python_fetcher_new(configuration);
           }
           '(' python_fetcher_options ')'         { YYACCEPT; }
-        | LL_CONTEXT_INNER_DEST KW_PYTHON_HEADER
+        | LL_CONTEXT_INNER_DEST KW_PYTHON_HTTP_HEADER
           {
             last_header = *instance = python_http_header_new();
           }

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -28,6 +28,7 @@
 #include "python-source.h"
 #include "python-fetcher.h"
 #include "python-logparser.h"
+#include "python-http-header.h"
 #include "python-main.h"
 #include "value-pairs/value-pairs.h"
 #include "logthrsource/logthrsourcedrv.h"
@@ -40,6 +41,9 @@
 #include "cfg-parser.h"
 #include "plugin.h"
 #include "syslog-names.h"
+
+PythonHttpHeaderPlugin *last_header;
+
 }
 
 %name-prefix "python_"
@@ -52,6 +56,7 @@
 
 %token KW_PYTHON
 %token KW_PYTHON_FETCHER
+%token KW_PYTHON_HEADER
 %token KW_CLASS
 %token KW_IMPORTS
 %token KW_LOADERS
@@ -65,8 +70,8 @@ start
           }
           '(' python_dd_options ')'         { YYACCEPT; }
         | LL_CONTEXT_PARSER KW_PYTHON
-	  {
-	    last_parser = *instance = python_parser_new(configuration);
+	      {
+	        last_parser = *instance = python_parser_new(configuration);
           }
           '(' python_parser_options ')' { YYACCEPT; }
         | LL_CONTEXT_SOURCE KW_PYTHON
@@ -79,15 +84,20 @@ start
             last_driver = *instance = python_fetcher_new(configuration);
           }
           '(' python_fetcher_options ')'         { YYACCEPT; }
-	| LL_CONTEXT_ROOT KW_PYTHON
+        | LL_CONTEXT_INNER_DEST KW_PYTHON_HEADER
+          {
+            last_header = *instance = python_http_header_new();
+          }
+          '(' python_http_header_options ')'    { YYACCEPT; }
+        | LL_CONTEXT_ROOT KW_PYTHON
           { cfg_lexer_push_context(lexer, LL_CONTEXT_BLOCK_CONTENT, NULL, "Python code"); }
           LL_BLOCK
           { cfg_lexer_pop_context(lexer); }
           {
             gboolean result;
 
-	    result = python_evaluate_global_code(configuration, $4, &@2);
-	    free($4);
+            result = python_evaluate_global_code(configuration, $4, &@2);
+            free($4);
             CHECK_ERROR(result, @1, "Error processing global python block");
             *instance = (void *) 1;
             YYACCEPT;
@@ -222,6 +232,37 @@ python_parser_custom_option
           free($1);
           free($2);
         }
+        ;
+
+
+python_http_header_options
+        : python_http_header_option python_http_header_options
+        |
+        ;
+
+python_http_header_option
+        : KW_CLASS '(' string ')'
+          {
+            python_http_header_set_class(last_header, $3);
+            free($3);
+          }
+        | KW_LOADERS python_http_header_loaders
+        | KW_OPTIONS '(' python_http_header_custom_options ')'
+        ;
+
+python_http_header_custom_options
+        : python_http_header_custom_option python_http_header_custom_options
+        |
+        ;
+
+python_http_header_custom_option
+        : string string_or_number
+        {
+          python_http_header_set_option(last_header, $1, $2);
+          free($1);
+          free($2);
+        }
+        ;
 
 
 python_dd_loaders
@@ -242,11 +283,18 @@ python_fetcher_loaders
             python_fetcher_set_loaders(last_driver, $2);
           }
 
+python_http_header_loaders
+          : '(' string_list ')'
+          {
+            python_http_header_set_loaders(last_header, $2);
+          }
+
 python_parser_loaders
           : '(' string_list ')'
           {
             python_parser_set_loaders(last_parser, $2);
           }
+
 
 /* INCLUDE_RULES */
 

--- a/modules/python/python-helpers.c
+++ b/modules/python/python-helpers.c
@@ -242,6 +242,27 @@ _py_invoke_function(PyObject *func, PyObject *arg, const gchar *class, const gch
   return ret;
 }
 
+PyObject *
+_py_invoke_function_with_args(PyObject *func, PyObject *args, const gchar *class, const gchar *caller_context)
+{
+  PyObject *ret;
+
+  ret = PyObject_CallObject(func, args);
+  if (!ret)
+    {
+      gchar buf1[256], buf2[256];
+
+      msg_error("Exception while calling a Python function",
+                evt_tag_str("caller", caller_context),
+                evt_tag_str("class", class),
+                evt_tag_str("function", _py_get_callable_name(func, buf1, sizeof(buf1))),
+                evt_tag_str("exception", _py_format_exception_text(buf2, sizeof(buf2))));
+      _py_finish_exception_handling();
+      return NULL;
+    }
+  return ret;
+}
+
 void
 _py_invoke_void_function(PyObject *func, PyObject *arg, const gchar *class, const gchar *caller_context)
 {

--- a/modules/python/python-helpers.h
+++ b/modules/python/python-helpers.h
@@ -34,6 +34,7 @@ PyObject *_py_do_import(const gchar *modname);
 PyObject *_py_resolve_qualified_name(const gchar *name);
 PyObject *_py_create_arg_dict(GHashTable *args);
 PyObject *_py_invoke_function(PyObject *func, PyObject *arg, const gchar *class, const gchar *caller_context);
+PyObject *_py_invoke_function_with_args(PyObject *func, PyObject *args, const gchar *class, const gchar *caller_context);
 void _py_invoke_void_function(PyObject *func, PyObject *arg, const gchar *class, const gchar *caller_context);
 gboolean _py_invoke_bool_function(PyObject *func, PyObject *arg, const gchar *class, const gchar *caller_context);
 PyObject *_py_get_method(PyObject *instance, const gchar *method_name, const gchar *module);

--- a/modules/python/python-helpers.h
+++ b/modules/python/python-helpers.h
@@ -34,7 +34,8 @@ PyObject *_py_do_import(const gchar *modname);
 PyObject *_py_resolve_qualified_name(const gchar *name);
 PyObject *_py_create_arg_dict(GHashTable *args);
 PyObject *_py_invoke_function(PyObject *func, PyObject *arg, const gchar *class, const gchar *caller_context);
-PyObject *_py_invoke_function_with_args(PyObject *func, PyObject *args, const gchar *class, const gchar *caller_context);
+PyObject *_py_invoke_function_with_args(PyObject *func, PyObject *args, const gchar *class,
+                                        const gchar *caller_context);
 void _py_invoke_void_function(PyObject *func, PyObject *arg, const gchar *class, const gchar *caller_context);
 gboolean _py_invoke_bool_function(PyObject *func, PyObject *arg, const gchar *class, const gchar *caller_context);
 PyObject *_py_get_method(PyObject *instance, const gchar *method_name, const gchar *module);

--- a/modules/python/python-http-header.c
+++ b/modules/python/python-http-header.c
@@ -70,7 +70,7 @@ _py_append_pylist_to_list(PyObject *py_list, GList **list)
       if (!py_str || !PyUnicode_Check(py_str))
         goto exit;
 
-      if (!(str = PyUnicode_AsUTF8(py_str)))
+      if (!(str = _py_get_string_as_string(py_str)))
         goto exit;
 
       *list = g_list_append(*list, g_strdup(str));
@@ -86,7 +86,7 @@ static void
 _py_append_str_to_pylist(gconstpointer data, gpointer user_data)
 {
   PyObject *py_str = PyUnicode_FromString((gchar *) data);
-  if (!py_str || !PyUnicode_Check(py_str))
+  if (!py_str)
     {
       gchar buf[256];
 

--- a/modules/python/python-http-header.c
+++ b/modules/python/python-http-header.c
@@ -1,0 +1,366 @@
+#include "python-module.h"
+#include "python-helpers.h"
+
+#include "lib/driver.h"
+#include "lib/str-utils.h"
+#include "lib/list-adt.h"
+#include "modules/http/http-signals.h"
+#include "modules/http/http-curl-header-list.h"
+
+#include "python-http-header.h"
+
+#include <time.h>
+
+#define PYTHON_HTTP_HEADER_PLUGIN "python-http-header"
+
+struct _PythonHttpHeaderPlugin {
+  LogDriverPlugin super;
+
+  gchar *class;
+  GList *loaders;
+
+  List *last_headers;
+  time_t last_run;
+  int timeout;
+  
+  GHashTable *options;
+
+  struct {
+    PyObject *class;
+    PyObject *instance;
+    PyObject *get_headers;
+  } py;
+};
+
+static gboolean
+_py_append_pylist_to_list(PyObject *py_list, List *list)
+{
+  gchar *str;
+  PyObject *py_str;
+
+  if (!py_list || !PyList_Check(py_list))
+    goto exit;
+
+  Py_ssize_t len = PyList_Size(py_list);
+  for (int i = 0; i < len; i++)
+  {
+    py_str = PyList_GetItem(py_list, i); // Borrowed reference
+    if (!py_str || !PyUnicode_Check(py_str))
+      goto exit;
+
+    if (!(str = PyUnicode_AsUTF8(py_str)))
+      goto exit;
+
+    list_append(list, g_strdup(str));
+  }
+
+  return TRUE;
+
+exit:
+  return FALSE;
+}
+
+static void
+_py_append_str_to_pylist(gconstpointer data, gpointer user_data)
+{
+  PyObject *py_str = PyUnicode_FromString((gchar *) data);
+  if (!py_str || !PyUnicode_Check(py_str))
+  {
+    gchar buf[256];
+
+    msg_error("Error creating Python String object from C string",
+              evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+    _py_finish_exception_handling();
+
+    goto exit;
+  }
+
+  PyObject *py_list = (PyObject *) user_data;
+  if (PyList_Append(py_list, py_str) != 0)
+  {
+    gchar buf[256];
+
+    msg_error("Error adding new item to Python List",
+              evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+    _py_finish_exception_handling();
+  }
+
+exit:
+  Py_XDECREF(py_str); // Even if append() succeeds, it doesn't steal the reference to py_str.
+}
+
+static PyObject*
+_py_convert_list_to_pylist(List *list)
+{
+  PyObject *py_list = PyList_New(0);
+  if (!py_list)
+  {
+    gchar buf[256];
+
+    msg_error("Error creating new Python List object",
+              evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+    _py_finish_exception_handling();
+
+    return NULL;
+  }
+
+  if (list)
+    list_foreach(list, _py_append_str_to_pylist, py_list);
+
+  return py_list;
+}
+
+static gboolean
+_py_attach_bindings(PythonHttpHeaderPlugin *self)
+{
+  PyObject *py_args;
+
+  self->py.class = _py_resolve_qualified_name(self->class);
+  if (!self->py.class)
+  {
+    gchar buf[256];
+
+    msg_error("Error looking up Python class",
+              evt_tag_str("class", self->class),
+              evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+    _py_finish_exception_handling();
+
+    goto exit;
+  }
+
+  py_args = _py_create_arg_dict(self->options);
+  if (!py_args)
+  {
+    gchar buf[256];
+
+    msg_error("Error creating argument dictionary",
+              evt_tag_str("class", self->class),
+              evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+    _py_finish_exception_handling();
+
+    goto exit;
+  }
+
+  self->py.instance = _py_invoke_function(self->py.class, py_args, self->class, self->super.name);
+  if (!self->py.instance)
+  {   
+    gchar buf[256];
+
+    msg_error("Error instantiating Python class",
+              evt_tag_str("class", self->class),
+              evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+    _py_finish_exception_handling();
+
+    goto exit;
+  }
+
+  self->py.get_headers = _py_get_attr_or_null(self->py.instance, "get_headers");
+  if (!self->py.get_headers)
+  {   
+    msg_error("Error initializing plugin, required method not found",
+              evt_tag_str("class", self->class),
+              evt_tag_str("method", "get_headers"));
+  }
+
+exit:
+  Py_XDECREF(py_args);
+  return self->py.get_headers != NULL;
+}
+
+static void
+_py_detach_bindings(PythonHttpHeaderPlugin *self)
+{
+  Py_CLEAR(self->py.class);
+  Py_CLEAR(self->py.instance);
+  Py_CLEAR(self->py.get_headers);
+}
+
+static void
+_append_str_to_list(gconstpointer data, gpointer user_data)
+{
+  List *list = (List *) user_data;
+  list_append(list, data);
+}
+
+static void
+_append_headers(PythonHttpHeaderPlugin *self, HttpHeaderRequestSignalData *data)
+{
+  PyObject *py_ret, *py_list, *py_args, *py_ret_list;
+
+  time_t now = time(NULL);
+  if ((now - self->last_run) < self->timeout)
+    goto exit;
+
+  // The GIL also guards non-Python plugin struct members from concurrent changes below.
+  PyGILState_STATE gstate = PyGILState_Ensure();
+
+  self->timeout = 0;
+  list_remove_all(self->last_headers);
+
+  py_list = _py_convert_list_to_pylist(data->request_headers);
+  if (!py_list)
+    goto cleanup;
+
+  py_args = Py_BuildValue("(sO)", data->request_body->str, py_list);
+  if (!py_args)
+  {
+    gchar buf[256];
+
+    msg_error("Error creating Python arguments",
+              evt_tag_str("class", self->class),
+              evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+    _py_finish_exception_handling();
+
+    goto cleanup;
+  }
+
+  py_ret = _py_invoke_function_with_args(self->py.get_headers, py_args, self->class, "_append_headers");
+  if (!py_ret || !PyArg_ParseTuple(py_ret, "iO", &self->timeout, &py_ret_list))
+  {
+    gchar buf[256];
+
+    msg_error("Invalid response returned by Python call",
+              evt_tag_str("class", self->class),
+              evt_tag_str("method", "get_headers"),
+              evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+    _py_finish_exception_handling();
+
+    goto cleanup;
+  }
+
+  msg_debug("Python call returned valid response",
+            evt_tag_str("class", self->class),
+            evt_tag_str("method", "get_headers"),
+            evt_tag_str("return_type", "Tuple"),
+            evt_tag_int("len", PyTuple_Size(py_ret)));
+
+  if (!_py_append_pylist_to_list(py_ret_list, self->last_headers))
+  {
+    gchar buf[256];
+
+    msg_error("Converting Python List failed",
+              evt_tag_str("class", self->class),
+              evt_tag_str("method", "get_headers"),
+              evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+    _py_finish_exception_handling();
+  }
+
+cleanup:
+  Py_XDECREF(py_args);
+  Py_XDECREF(py_ret);
+  Py_XDECREF(py_list);
+  Py_XDECREF(py_ret_list);
+
+  self->last_run = now;
+
+  PyGILState_Release(gstate);
+
+exit:
+  g_assert(self->last_headers);
+  list_foreach(self->last_headers, _append_str_to_list, data->request_headers);
+}
+
+static gboolean
+_init(PythonHttpHeaderPlugin *self)
+{
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  _py_perform_imports(self->loaders);
+
+  if (!_py_attach_bindings(self))
+    goto fail;
+
+  PyGILState_Release(gstate);
+  return TRUE;
+
+fail:
+  PyGILState_Release(gstate);
+  return FALSE;
+}
+
+static gboolean
+_attach(LogDriverPlugin *s, LogDriver *driver)
+{
+  PythonHttpHeaderPlugin *self = (PythonHttpHeaderPlugin *) s;
+
+  if (!_init(self))
+  {
+    msg_error("Plugin initialization failed",
+              evt_tag_str("plugin", PYTHON_HTTP_HEADER_PLUGIN));
+
+    return FALSE;
+  }
+
+  SignalSlotConnector *ssc = driver->super.signal_slot_connector;
+
+  CONNECT(ssc, signal_http_header_request, _append_headers, self);
+
+  msg_debug("SignalSlotConnector slot registered",
+      evt_tag_printf("signal", "%p", ssc),
+      evt_tag_printf("plugin_name", "%s", PYTHON_HTTP_HEADER_PLUGIN),
+      evt_tag_printf("plugin_instance", "%p", s));
+
+  return TRUE;
+}
+
+static void
+_free(LogDriverPlugin *s)
+{
+  PythonHttpHeaderPlugin *self = (PythonHttpHeaderPlugin *) s;
+
+  g_free(self->class);
+  
+  if (self->options)
+    g_hash_table_unref(self->options);
+
+  if (self->loaders)
+    g_list_free_full(self->loaders, g_free);
+
+  if (self->last_headers)
+    list_free(self->last_headers);
+
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  _py_detach_bindings(self);
+  PyGILState_Release(gstate);
+
+  log_driver_plugin_free_method(s);
+}
+
+PythonHttpHeaderPlugin *
+python_http_header_new(void)
+{
+  PythonHttpHeaderPlugin *self = g_new0(PythonHttpHeaderPlugin, 1);
+
+  log_driver_plugin_init_instance(&(self->super), PYTHON_HTTP_HEADER_PLUGIN);
+
+  self->last_headers = http_curl_header_list_new();
+  self->last_run = 0;
+  self->timeout = 0;
+  self->options = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+  self->py.class = self->py.instance = self->py.get_headers = NULL;
+  
+  self->super.attach = _attach;
+  self->super.free_fn = _free;
+
+  return self;
+}
+
+void
+python_http_header_set_loaders(PythonHttpHeaderPlugin *self, GList *loaders)
+{
+  g_list_free_full(self->loaders, g_free);
+  self->loaders = loaders;
+}
+
+void
+python_http_header_set_class(PythonHttpHeaderPlugin *self, gchar *class)
+{
+  g_free(self->class);
+  self->class = g_strdup(class);
+}
+
+void
+python_http_header_set_option(PythonHttpHeaderPlugin *self, gchar *key, gchar *value)
+{
+  gchar *normalized_key = __normalize_key(key);
+  g_hash_table_insert(self->options, normalized_key, g_strdup(value));
+}

--- a/modules/python/python-http-header.c
+++ b/modules/python/python-http-header.c
@@ -126,7 +126,7 @@ _py_convert_list_to_pylist(List *list)
 static gboolean
 _py_attach_bindings(PythonHttpHeaderPlugin *self)
 {
-  PyObject *py_args;
+  PyObject *py_args = NULL;
 
   self->py.class = _py_resolve_qualified_name(self->class);
   if (!self->py.class)
@@ -198,7 +198,10 @@ _append_str_to_list(gpointer data, gpointer user_data)
 static void
 _append_headers(PythonHttpHeaderPlugin *self, HttpHeaderRequestSignalData *data)
 {
-  PyObject *py_ret, *py_list, *py_args, *py_ret_list;
+  PyObject *py_ret = NULL,
+            *py_list = NULL,
+             *py_args = NULL,
+              *py_ret_list = NULL;
 
   time_t now = time(NULL);
   if ((now - self->last_run) < self->timeout)

--- a/modules/python/python-http-header.c
+++ b/modules/python/python-http-header.c
@@ -115,16 +115,7 @@ static PyObject *
 _py_convert_list_to_pylist(List *list)
 {
   PyObject *py_list = PyList_New(0);
-  if (!py_list)
-    {
-      gchar buf[256];
-
-      msg_error("Error creating new Python List object",
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
-      _py_finish_exception_handling();
-
-      return NULL;
-    }
+  g_assert(py_list);
 
   if (list)
     list_foreach(list, _py_append_str_to_pylist, py_list);

--- a/modules/python/python-http-header.c
+++ b/modules/python/python-http-header.c
@@ -67,7 +67,7 @@ _py_append_pylist_to_list(PyObject *py_list, GList **list)
   for (int i = 0; i < len; i++)
     {
       py_str = PyList_GetItem(py_list, i); // Borrowed reference
-      if (!py_str || !PyUnicode_Check(py_str))
+      if (!_py_is_string(py_str))
         goto exit;
 
       if (!(str = _py_get_string_as_string(py_str)))

--- a/modules/python/python-http-header.c
+++ b/modules/python/python-http-header.c
@@ -273,7 +273,6 @@ cleanup:
   PyGILState_Release(gstate);
 
 exit:
-  g_assert(self->last_headers);
   g_list_foreach(self->last_headers, _append_str_to_list, data->request_headers);
 }
 

--- a/modules/python/python-http-header.c
+++ b/modules/python/python-http-header.c
@@ -85,7 +85,7 @@ exit:
 static void
 _py_append_str_to_pylist(gconstpointer data, gpointer user_data)
 {
-  PyObject *py_str = PyUnicode_FromString((gchar *) data);
+  PyObject *py_str = _py_string_from_string((gchar *) data, -1);
   if (!py_str)
     {
       gchar buf[256];

--- a/modules/python/python-http-header.c
+++ b/modules/python/python-http-header.c
@@ -20,15 +20,14 @@
  *
  */
 
-#include "python-module.h"
+#include "python-http-header.h"
 #include "python-helpers.h"
 
-#include "lib/driver.h"
-#include "lib/str-utils.h"
-#include "lib/list-adt.h"
-#include "modules/http/http-signals.h"
+#include "driver.h"
+#include "str-utils.h"
+#include "list-adt.h"
 
-#include "python-http-header.h"
+#include "modules/http/http-signals.h"
 
 #include <time.h>
 

--- a/modules/python/python-http-header.c
+++ b/modules/python/python-http-header.c
@@ -214,6 +214,8 @@ _append_headers(PythonHttpHeaderPlugin *self, HttpHeaderRequestSignalData *data)
              *py_ret_list = NULL;
   GList *headers = NULL;
 
+  data->result = HTTP_HEADER_REQUEST_SLOT_PLUGIN_ERROR;
+
   // The GIL also guards non-Python plugin struct members from concurrent changes below.
   PyGILState_STATE gstate = PyGILState_Ensure();
 
@@ -262,7 +264,10 @@ _append_headers(PythonHttpHeaderPlugin *self, HttpHeaderRequestSignalData *data)
                 evt_tag_str("method", "get_headers"),
                 evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
+      goto cleanup;
     }
+
+  data->result = HTTP_HEADER_REQUEST_SLOT_SUCCESS;
 
 cleanup:
   Py_XDECREF(py_args);

--- a/modules/python/python-http-header.c
+++ b/modules/python/python-http-header.c
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2020 One Identity
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #include "python-module.h"
 #include "python-helpers.h"
 

--- a/modules/python/python-http-header.c
+++ b/modules/python/python-http-header.c
@@ -60,18 +60,33 @@ _py_append_pylist_to_list(PyObject *py_list, GList **list)
   const gchar *str;
   PyObject *py_str;
 
-  if (!py_list || !PyList_Check(py_list))
-    goto exit;
+  if (!py_list)
+    {
+      msg_debug("Trying to append a NULL-valued PyList to GList");
+      goto exit;
+    }
+
+  if (PyList_Check(py_list))
+    {
+      msg_debug("PyList_Check failed when trying to append PyList to GList.");
+      goto exit;
+    }
 
   Py_ssize_t len = PyList_Size(py_list);
   for (int i = 0; i < len; i++)
     {
       py_str = PyList_GetItem(py_list, i); // Borrowed reference
       if (!_py_is_string(py_str))
-        goto exit;
+        {
+          msg_debug("PyList contained a non-string object when trying to append to GList");
+          goto exit;
+        }
 
       if (!(str = _py_get_string_as_string(py_str)))
-        goto exit;
+        {
+          msg_debug("_py_get_string_as_string failed when trying to append PyList to GList");
+          goto exit;
+        }
 
       *list = g_list_append(*list, g_strdup(str));
     }

--- a/modules/python/python-http-header.h
+++ b/modules/python/python-http-header.h
@@ -32,5 +32,7 @@ PythonHttpHeaderPlugin *python_http_header_new(void);
 void python_http_header_set_loaders(PythonHttpHeaderPlugin *self, GList *loaders);
 void python_http_header_set_class(PythonHttpHeaderPlugin *self, gchar *class);
 void python_http_header_set_option(PythonHttpHeaderPlugin *self, gchar *key, gchar *value);
+void python_http_header_set_mark_errors_as_critical(PythonHttpHeaderPlugin *self, gboolean enable);
+
 
 #endif

--- a/modules/python/python-http-header.h
+++ b/modules/python/python-http-header.h
@@ -23,6 +23,8 @@
 #ifndef _SNG_PYTHON_AUTH_HEADERS_H
 #define _SNG_PYTHON_AUTH_HEADERS_H
 
+#include "python-module.h"
+
 typedef struct _PythonHttpHeaderPlugin PythonHttpHeaderPlugin;
 
 PythonHttpHeaderPlugin *python_http_header_new(void);

--- a/modules/python/python-http-header.h
+++ b/modules/python/python-http-header.h
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2020 One Identity
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #ifndef _SNG_PYTHON_AUTH_HEADERS_H
 #define _SNG_PYTHON_AUTH_HEADERS_H
 

--- a/modules/python/python-http-header.h
+++ b/modules/python/python-http-header.h
@@ -1,0 +1,12 @@
+#ifndef _SNG_PYTHON_AUTH_HEADERS_H
+#define _SNG_PYTHON_AUTH_HEADERS_H
+
+typedef struct _PythonHttpHeaderPlugin PythonHttpHeaderPlugin;
+
+PythonHttpHeaderPlugin *python_http_header_new(void);
+
+void python_http_header_set_loaders(PythonHttpHeaderPlugin *self, GList *loaders);
+void python_http_header_set_class(PythonHttpHeaderPlugin *self, gchar *class);
+void python_http_header_set_option(PythonHttpHeaderPlugin *self, gchar *key, gchar *value);
+
+#endif

--- a/modules/python/python-logger.c
+++ b/modules/python/python-logger.c
@@ -67,7 +67,10 @@ PyObject *
 py_msg_debug(PyObject *obj, PyObject *args)
 {
   if (!debug_flag)
+  {
+    Py_INCREF(Py_None);
     return Py_None;
+  }
 
   char *message = NULL;
   if (!PyArg_ParseTuple(args, "s", &message))

--- a/modules/python/python-logger.c
+++ b/modules/python/python-logger.c
@@ -67,10 +67,10 @@ PyObject *
 py_msg_debug(PyObject *obj, PyObject *args)
 {
   if (!debug_flag)
-  {
-    Py_INCREF(Py_None);
-    return Py_None;
-  }
+    {
+      Py_INCREF(Py_None);
+      return Py_None;
+    }
 
   char *message = NULL;
   if (!PyArg_ParseTuple(args, "s", &message))

--- a/modules/python/python-parser.c
+++ b/modules/python/python-parser.c
@@ -33,7 +33,7 @@ static CfgLexerKeyword python_keywords[] =
 {
   { "python",                   KW_PYTHON  },
   { "python_fetcher",           KW_PYTHON_FETCHER },
-  { "python_header",            KW_PYTHON_HEADER },
+  { "python_http_header",       KW_PYTHON_HTTP_HEADER },
   { "class",                    KW_CLASS   },
   {
     "imports",                  KW_IMPORTS, KWS_OBSOLETE,

--- a/modules/python/python-parser.c
+++ b/modules/python/python-parser.c
@@ -33,6 +33,7 @@ static CfgLexerKeyword python_keywords[] =
 {
   { "python",                   KW_PYTHON  },
   { "python_fetcher",           KW_PYTHON_FETCHER },
+  { "python_header",            KW_PYTHON_HEADER },
   { "class",                    KW_CLASS   },
   {
     "imports",                  KW_IMPORTS, KWS_OBSOLETE,

--- a/modules/python/python-parser.c
+++ b/modules/python/python-parser.c
@@ -40,6 +40,7 @@ static CfgLexerKeyword python_keywords[] =
     "imports() has been deprecated, please use loaders()"
   },
   { "loaders",                    KW_LOADERS   },
+  { "mark_errors_as_critical",  KW_MARK_ERRORS_AS_CRITICAL },
   { NULL }
 };
 

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -55,7 +55,7 @@ static Plugin python_plugins[] =
   },
   {
     .type = LL_CONTEXT_INNER_DEST,
-    .name = "python_header",
+    .name = "python_http_header",
     .parser = &python_parser,
   },
   {

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -34,6 +34,7 @@
 #include "python-fetcher.h"
 #include "python-global-code-loader.h"
 #include "python-debugger.h"
+#include "python-http-header.h"
 
 #include "plugin.h"
 #include "plugin-types.h"
@@ -50,6 +51,11 @@ static Plugin python_plugins[] =
   {
     .type = LL_CONTEXT_DESTINATION,
     .name = "python",
+    .parser = &python_parser,
+  },
+  {
+    .type = LL_CONTEXT_INNER_DEST,
+    .name = "python_header",
     .parser = &python_parser,
   },
   {

--- a/news/feature-3123.md
+++ b/news/feature-3123.md
@@ -50,7 +50,7 @@ source s_network {
 
 destination d_http {
     http(
-        python_header(
+        python_http_header(
             class("TestCounter")
             options("header", "X-Test-Python-Counter")
             options("counter", 11)

--- a/news/feature-3123.md
+++ b/news/feature-3123.md
@@ -1,0 +1,70 @@
+
+The `python-http-header` plugin makes it possible for users to implement HTTP header plugins in Python language. It is built on top of signal-slot mechanism: currently HTTP module defines only one signal, that is `signal_http_header_request` and `python-http-header` plugin implements a python binding for this signal. This means that when the `signal_http_header_request` signal is emitted then the connected slot executes the Python code.
+
+The Python interface is :
+```
+def get_headers(self, body, headers):
+```
+
+It should return a tuple that has two elements:
+ * a timeout (when the signal is emitted again within `timeout`,  a cached list is returned - this can be used for caching Authorization header tokens that has an expiration time and as the check of the value of the timeout is done at C site, it can improve the performance: Python code runs only when it is required) 
+ * a string list (the headers that will be appended to the request's header)
+
+Code, or naming is not final, but it's working. Just wanted to open the PR and get some feedback (...and run CI tests).
+
+Original code was written by Ferenc Sipos.
+
+<details>
+  <summary>Example config, click to expand!</summary>
+
+```
+
+@version: 3.25
+
+python {
+from syslogng import Logger
+
+logger = Logger()
+
+class TestCounter():
+    def __init__(self, options):
+        self.header = options["header"]
+        self.counter = int(options["counter"])
+        self.timeout = 0
+        logger.debug(f"TestCounter class instantiated; options={options}")
+
+    def get_headers(self, body, headers):
+        logger.debug(f"get_headers() called, received body={body}, headers={headers}")
+       
+        response = (self.timeout, [f"{self.header}: {self.counter}"])
+        self.counter += 1
+        return response
+
+    def __del__(self):
+        logger.debug("Deleting TestCounter class instance")
+};
+
+source s_network {
+  network(port(5555));
+};
+
+destination d_http {
+    http(
+        python_header(
+            class("TestCounter")
+            options("header", "X-Test-Python-Counter")
+            options("counter", 11)
+        )
+        url("http://127.0.0.1:8888")
+    );
+};
+
+log {
+    source(s_network);
+    destination(d_http);
+    flags(flow-control);
+};
+```
+</details>
+
+

--- a/news/feature-3123.md
+++ b/news/feature-3123.md
@@ -6,12 +6,8 @@ The Python interface is :
 def get_headers(self, body, headers):
 ```
 
-It should return a tuple that has two elements:
- * a timeout (when the signal is emitted again within `timeout`,  a cached list is returned - this can be used for caching Authorization header tokens that has an expiration time and as the check of the value of the timeout is done at C site, it can improve the performance: Python code runs only when it is required) 
- * a string list (the headers that will be appended to the request's header)
-
-Code, or naming is not final, but it's working. Just wanted to open the PR and get some feedback (...and run CI tests).
-
+It should return string List. The headers that will be appended to the request's header.
+ 
 Original code was written by Ferenc Sipos.
 
 <details>
@@ -30,13 +26,12 @@ class TestCounter():
     def __init__(self, options):
         self.header = options["header"]
         self.counter = int(options["counter"])
-        self.timeout = 0
         logger.debug(f"TestCounter class instantiated; options={options}")
 
     def get_headers(self, body, headers):
         logger.debug(f"get_headers() called, received body={body}, headers={headers}")
        
-        response = (self.timeout, [f"{self.header}: {self.counter}"])
+        response = ["{}: {}".format(self.header, self.counter)]
         self.counter += 1
         return response
 

--- a/news/feature-3123.md
+++ b/news/feature-3123.md
@@ -7,6 +7,8 @@ def get_headers(self, body, headers):
 ```
 
 It should return string List. The headers that will be appended to the request's header.
+When the plugin fails, http module won't0 try to send the http request without the header items by default.
+If you want http module to trying to send the request without these headers, just disble `mark-errors-as-critical` function.
  
 Original code was written by Ferenc Sipos.
 
@@ -49,6 +51,8 @@ destination d_http {
             class("TestCounter")
             options("header", "X-Test-Python-Counter")
             options("counter", 11)
+            # this means that syslog-ng will trying to send the http request even when this module fails
+            mark-errors-as-critical(no)
         )
         url("http://127.0.0.1:8888")
     );


### PR DESCRIPTION
The `python-http-header` plugin makes it possible for users to implement HTTP header plugins in Python language. It is built on top of signal-slot mechanism: currently HTTP module defines only one signal, that is `signal_http_header_request` and `python-http-header` plugin implements a python binding for this signal. This means that when the `signal_http_header_request` signal is emitted then the connected slot executes the Python code.

The Python interface is :
```
def get_headers(self, body, headers):
```

It should return a string List.
When the plugin fails, http module won't send the http request without the header items by default. 
If you want http module to trying to send the request without these headers, just disable `mark-errors-as-critical` function.

Code, or naming is not final, but it's working. Just wanted to open the PR and get some feedback (...and run CI tests).

Original code was written by Ferenc Sipos.

<details>
  <summary>Example config, click to expand!</summary>

```

@version: 3.25

python {
from syslogng import Logger

logger = Logger()

class TestCounter():
    def __init__(self, options):
        self.header = options["header"]
        self.counter = int(options["counter"])
        logger.debug(f"TestCounter class instantiated; options={options}")

    def get_headers(self, body, headers):
        logger.debug(f"get_headers() called, received body={body}, headers={headers}")
       
        response = ["{}: {}".format(self.header, self.counter)]
        self.counter += 1
        return response

    def __del__(self):
        logger.debug("Deleting TestCounter class instance")
};

source s_network {
  network(port(5555));
};

destination d_http {
    http(
        python_http_header(
            class("TestCounter")
            options("header", "X-Test-Python-Counter")
            options("counter", 11)
            mark-errors-as-critical(no)
        )
        url("http://127.0.0.1:8888")
    );
};

log {
    source(s_network);
    destination(d_http);
    flags(flow-control);
};
```
</details>

