### PR TITLE
ConfigOptionDatabase: Use 'UTF-8' encoding while reading from files

### DIFF
--- a/contrib/config_option_database/utils/MergeYm.py
+++ b/contrib/config_option_database/utils/MergeYm.py
@@ -41,7 +41,7 @@ def merge_grammars(output_filepath):
     blocks = r'%%' + '\n'
 
     for filepath in files[1:]:
-        with filepath.open() as f:
+        with filepath.open(encoding='UTF-8') as f:
             in_block = False
             for line in f:
                 if line.startswith('%token') or line.startswith(r'%left') or line.startswith('%type'):

--- a/contrib/config_option_database/utils/OptionParser.py
+++ b/contrib/config_option_database/utils/OptionParser.py
@@ -103,7 +103,7 @@ def _get_resolve_db():
         struct_regex = re.compile(r'CfgLexerKeyword[^;]*')
         entry_regex = re.compile(r'{[^{}]+,[^{}]+}')
         for f in root_dir.rglob('*-parser.c'):
-            for struct_match in struct_regex.finditer(f.read_text().replace('\n', '')):
+            for struct_match in struct_regex.finditer(f.read_text(encoding='UTF-8').replace('\n', '')):
                 for entry_match in entry_regex.finditer(struct_match.group(0)):
                     entry = entry_match.group(0)[1:-1].replace(' ', '').split(',')
                     token = entry[1]

--- a/news/bugfix-3125.md
+++ b/news/bugfix-3125.md
@@ -1,0 +1,1 @@
+ConfigOptionDatabase: Fixed reading 'grammar' and 'parser' files on 'POSIX' environment


### PR DESCRIPTION
I have run into the following problem, when I run `python3 syslog-ng-cfg-db.py` from a docker container (ubuntu:18.04)

For the notice, by deafult docker images have 'POSIX' as locale settings.
```console
$ locale
LANG=
LANGUAGE=
LC_CTYPE="POSIX"
LC_NUMERIC="POSIX"
LC_TIME="POSIX"
LC_COLLATE="POSIX"
LC_MONETARY="POSIX"
LC_MESSAGES="POSIX"
LC_PAPER="POSIX"
LC_NAME="POSIX"
LC_ADDRESS="POSIX"
LC_TELEPHONE="POSIX"
LC_MEASUREMENT="POSIX"
LC_IDENTIFICATION="POSIX"
LC_ALL=
```

The following errors I run into:
1, can not read from grammar files (like: modules/snmp-dest/snmpdest-grammar.ym)
```console
$ python3 syslog-ng-cfg-db.py 
Traceback (most recent call last):
  File "syslog-ng-cfg-db.py", line 195, in <module>
    main()
  File "syslog-ng-cfg-db.py", line 183, in main
    db = get_db(args.rebuild)
  File "syslog-ng-cfg-db.py", line 87, in get_db
    db = build_db()
  File "syslog-ng-cfg-db.py", line 68, in build_db
    for context, driver, keyword, arguments, parents in get_driver_options():
  File "/home/micek/git_projects/github_mitzkia/syslog-ng/contrib/config_option_database/utils/ConfigOptions.py", line 80, in get_driver_options
    merge_grammars(yaccfile.name)
  File "/home/micek/git_projects/github_mitzkia/syslog-ng/contrib/config_option_database/utils/MergeYm.py", line 46, in merge_grammars
    for line in f:
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 58: ordinal not in range(128)
```

2, can not read from parser.c files (like: modules/snmp-dest/snmpdest-parser.c)
```console
$ python3 syslog-ng-cfg-db.py 
Traceback (most recent call last):
  File "syslog-ng-cfg-db.py", line 195, in <module>
    main()
  File "syslog-ng-cfg-db.py", line 183, in main
    db = get_db(args.rebuild)
  File "syslog-ng-cfg-db.py", line 87, in get_db
    db = build_db()
  File "syslog-ng-cfg-db.py", line 68, in build_db
    for context, driver, keyword, arguments, parents in get_driver_options():
  File "/home/micek/git_projects/github_mitzkia/syslog-ng/contrib/config_option_database/utils/ConfigOptions.py", line 90, in get_driver_options
    options |= path_to_options(path)
  File "/home/micek/git_projects/github_mitzkia/syslog-ng/contrib/config_option_database/utils/OptionParser.py", line 153, in path_to_options
    options.add(_resolve_option(context, driver, keyword, arguments, parents))
  File "/home/micek/git_projects/github_mitzkia/syslog-ng/contrib/config_option_database/utils/OptionParser.py", line 139, in _resolve_option
    driver = _resolve_token(driver)
  File "/home/micek/git_projects/github_mitzkia/syslog-ng/contrib/config_option_database/utils/OptionParser.py", line 122, in _resolve_token
    db = _get_resolve_db()
  File "/home/micek/git_projects/github_mitzkia/syslog-ng/contrib/config_option_database/utils/OptionParser.py", line 106, in _get_resolve_db
    for struct_match in struct_regex.finditer(f.read_text().replace('\n', '')):
  File "/usr/lib/python3.6/pathlib.py", line 1197, in read_text
    return f.read()
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 58: ordinal not in range(128)
```

Signed-off-by: Andras Mitzki <andras.mitzki@balabit.com>