### PR TITLE
poll-events: introduce suspend_watches virtual function

### DIFF
--- a/lib/poll-events.h
+++ b/lib/poll-events.h
@@ -37,6 +37,7 @@ struct _PollEvents
   void (*start_watches)(PollEvents *self);
   void (*stop_watches)(PollEvents *self);
   void (*update_watches)(PollEvents *self, GIOCondition cond);
+  void (*suspend_watches)(PollEvents *self);
   void (*free_fn)(PollEvents *self);
 };
 
@@ -62,7 +63,9 @@ poll_events_update_watches(PollEvents *self, GIOCondition cond)
 static inline void
 poll_events_suspend_watches(PollEvents *self)
 {
-  poll_events_update_watches(self, 0);
+  if (self->suspend_watches)
+    return self->suspend_watches(self);
+  poll_events_stop_watches(self);
 }
 
 void poll_events_invoke_callback(PollEvents *self);

--- a/modules/affile/poll-file-changes.c
+++ b/modules/affile/poll-file-changes.c
@@ -203,9 +203,6 @@ poll_file_changes_update_watches(PollEvents *s, GIOCondition cond)
 
   poll_file_changes_stop_watches(s);
 
-  if (!(cond & G_IO_IN))
-    return;
-
   if (poll_file_changes_check_eof(self))
     {
       msg_trace("End of file, following file",

--- a/modules/affile/poll-multiline-file-changes.c
+++ b/modules/affile/poll-multiline-file-changes.c
@@ -131,17 +131,6 @@ poll_multiline_file_changes_on_read(PollFileChanges *s)
 }
 
 static void
-poll_multiline_file_changes_update_watches(PollEvents *s, GIOCondition cond)
-{
-  PollMultilineFileChanges *self = (PollMultilineFileChanges *) s;
-
-  if (!cond)
-    poll_multiline_file_changes_stop_timer(self);
-
-  poll_file_changes_update_watches(s, cond);
-}
-
-static void
 poll_multiline_file_changes_stop_watches(PollEvents *s)
 {
   PollMultilineFileChanges *self = (PollMultilineFileChanges *) s;
@@ -167,7 +156,7 @@ poll_multiline_file_changes_new(gint fd, const gchar *follow_filename, gint foll
   self->super.on_eof = poll_multiline_file_changes_on_eof;
   self->super.on_file_moved = poll_multiline_file_changes_on_file_moved;
 
-  self->super.super.update_watches = poll_multiline_file_changes_update_watches;
+  self->super.super.update_watches = poll_file_changes_update_watches;
   self->super.super.stop_watches = poll_multiline_file_changes_stop_watches;
 
   return &self->super.super;

--- a/news/feature-2963.md
+++ b/news/feature-2963.md
@@ -1,0 +1,16 @@
+file-source: new option to multi-line file sources: `multi-line-timeout()`
+
+After waiting multi-line-timeout() seconds without reading new data from the file, the last (potentially partial) message will be flushed and sent through the pipeline as a LogMessage.
+Since the multi-line file source detects the end of a message after finding the beginning of the subsequent message (indented or no-garbage/suffix mode), this option can be used to flush the last multi-line message in the file after a multi-line-timeout()-second timeout.
+
+There is no default value, i.e. this timeout needs to be explicitly configured.
+
+Example config:
+```
+file("/some/folder/events"
+    multi-line-mode("prefix-garbage")
+    multi-line-prefix('^EVENT: ')
+    multi-line-timeout(10)
+    flags("no-parse")
+);
+```


### PR DESCRIPTION
update_watches is a mandatory virtual function,
which was used for update- and suspend cases too.

Usually a suspend_watches() call would be simply
a stop_watches(), but in some cases stop_watches()
and suspend_watches() differ.

Previously, poll_events_suspend_watches() called update_watches with 0.
Therefore every update_watches implementation had to be aware of this use case.

News file is not affected.