### PR TITLE
Affile, pipe time reap

### DIFF
--- a/lib/logproto/logproto-client.c
+++ b/lib/logproto/logproto-client.c
@@ -65,6 +65,18 @@ log_proto_client_options_set_drop_input(LogProtoClientOptions *options, gboolean
 }
 
 void
+log_proto_client_options_set_timeout(LogProtoClientOptions *options, gint timeout)
+{
+  options->timeout = timeout;
+}
+
+gint
+log_proto_client_options_get_timeout(LogProtoClientOptions *options)
+{
+  return options->timeout;
+}
+
+void
 log_proto_client_options_defaults(LogProtoClientOptions *options)
 {
   options->drop_input = FALSE;

--- a/lib/logproto/logproto-client.h
+++ b/lib/logproto/logproto-client.h
@@ -35,6 +35,7 @@ typedef struct _LogProtoClient LogProtoClient;
 typedef struct _LogProtoClientOptions
 {
   gboolean drop_input;
+  gint timeout;
 } LogProtoClientOptions;
 
 typedef union _LogProtoClientOptionsStorage
@@ -54,6 +55,8 @@ typedef struct
 } LogProtoClientFlowControlFuncs;
 
 void log_proto_client_options_set_drop_input(LogProtoClientOptions *options, gboolean drop_input);
+void log_proto_client_options_set_timeout(LogProtoClientOptions *options, gint timeout);
+gint log_proto_client_options_get_timeout(LogProtoClientOptions *options);
 
 void log_proto_client_options_defaults(LogProtoClientOptions *options);
 void log_proto_client_options_init(LogProtoClientOptions *options, GlobalConfig *cfg);

--- a/lib/logproto/logproto-text-client.c
+++ b/lib/logproto/logproto-text-client.c
@@ -37,7 +37,13 @@ log_proto_text_client_prepare(LogProtoClient *s, gint *fd, GIOCondition *cond, g
   /* if there's no pending I/O in the transport layer, then we want to do a write */
   if (*cond == 0)
     *cond = G_IO_OUT;
-  return self->partial != NULL;
+
+  const gboolean pending_write = self->partial != NULL;
+
+  if (!pending_write && s->options->timeout > 0)
+    *timeout = s->options->timeout;
+
+  return pending_write;
 }
 
 static LogProtoStatus

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -391,6 +391,13 @@ affile_dd_set_time_reap(LogDriver *s, gint time_reap)
 {
   AFFileDestDriver *self = (AFFileDestDriver *) s;
 
+  log_proto_client_options_set_timeout(&self->writer_options.proto_options.super, time_reap);
+}
+
+static gint
+affile_dd_get_time_reap(AFFileDestDriver *self)
+{
+  return log_proto_client_options_get_timeout(&self->writer_options.proto_options.super);
 }
 
 static inline const gchar *
@@ -471,6 +478,9 @@ affile_dd_init(LogPipe *s)
   file_opener_options_init(&self->file_opener_options, cfg);
   file_opener_set_options(self->file_opener, &self->file_opener_options);
   log_writer_options_init(&self->writer_options, cfg, 0);
+
+  if (affile_dd_get_time_reap(self) == -1)
+    affile_dd_set_time_reap(&self->super.super, cfg->time_reap);
 
   if (self->filename_is_a_template)
     {
@@ -764,6 +774,7 @@ affile_dd_new_instance(gchar *filename, GlobalConfig *cfg)
     }
   file_opener_options_defaults(&self->file_opener_options);
 
+  affile_dd_set_time_reap(&self->super.super, self->filename_is_a_template ? -1 : 0);
   g_static_mutex_init(&self->lock);
 
   affile_dest_drivers = g_list_append(affile_dest_drivers, self);

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -98,7 +98,6 @@ struct _AFFileDestWriter
   time_t last_msg_stamp;
   time_t last_open_stamp;
   time_t time_reopen;
-  struct iv_timer reap_timer;
   gboolean reopen_pending, queue_pending;
 };
 
@@ -116,17 +115,6 @@ affile_dw_format_persist_name(AFFileDestWriter *self)
 static void affile_dd_reap_writer(AFFileDestDriver *self, AFFileDestWriter *dw);
 
 static void
-affile_dw_arm_reaper(AFFileDestWriter *self)
-{
-  g_assert(self->owner->time_reap > 0);
-  /* not yet reaped, set up the next callback */
-  iv_validate_now();
-  self->reap_timer.expires = iv_now;
-  timespec_add_msec(&self->reap_timer.expires, self->owner->time_reap * 1000L);
-  iv_timer_register(&self->reap_timer);
-}
-
-static void
 affile_dw_reap(gpointer s)
 {
   AFFileDestWriter *self = (AFFileDestWriter *) s;
@@ -141,13 +129,8 @@ affile_dw_reap(gpointer s)
                   evt_tag_str("template", self->owner->filename_template->template),
                   evt_tag_str("filename", self->filename));
       affile_dd_reap_writer(self->owner, self);
-      g_static_mutex_unlock(&owner->lock);
     }
-  else
-    {
-      g_static_mutex_unlock(&owner->lock);
-      affile_dw_arm_reaper(self);
-    }
+  g_static_mutex_unlock(&owner->lock);
 }
 
 static gboolean
@@ -183,9 +166,6 @@ affile_dw_reopen(AFFileDestWriter *self)
 
       proto = file_opener_construct_dst_proto(self->owner->file_opener, transport,
                                               &self->owner->writer_options.proto_options.super);
-
-      if (self->owner->time_reap > 0 && !iv_timer_registered(&self->reap_timer))
-        main_loop_call((void *(*)(void *)) affile_dw_arm_reaper, self, TRUE);
     }
   else
     {
@@ -243,8 +223,6 @@ affile_dw_deinit(LogPipe *s)
 
   log_writer_set_queue(self->writer, NULL);
 
-  if (iv_timer_registered(&self->reap_timer))
-    iv_timer_unregister(&self->reap_timer);
   return TRUE;
 }
 
@@ -349,10 +327,6 @@ affile_dw_new(const gchar *filename, GlobalConfig *cfg)
   self->super.notify = affile_dw_notify;
   self->time_reopen = 60;
 
-  IV_TIMER_INIT(&self->reap_timer);
-  self->reap_timer.cookie = self;
-  self->reap_timer.handler = affile_dw_reap;
-
   /* we have to take care about freeing filename later.
      This avoids a move of the filename. */
   self->filename = g_strdup(filename);
@@ -414,7 +388,6 @@ affile_dd_set_time_reap(LogDriver *s, gint time_reap)
 {
   AFFileDestDriver *self = (AFFileDestDriver *) s;
 
-  self->time_reap = time_reap;
 }
 
 static inline const gchar *
@@ -491,9 +464,6 @@ affile_dd_init(LogPipe *s)
 
   if (!log_dest_driver_init_method(s))
     return FALSE;
-
-  if (self->time_reap == -1)
-    self->time_reap = cfg->time_reap;
 
   file_opener_options_init(&self->file_opener_options, cfg);
   file_opener_set_options(self->file_opener, &self->file_opener_options);
@@ -791,7 +761,6 @@ affile_dd_new_instance(gchar *filename, GlobalConfig *cfg)
     }
   file_opener_options_defaults(&self->file_opener_options);
 
-  self->time_reap = self->filename_is_a_template ? -1 : 0;
   g_static_mutex_init(&self->lock);
 
   affile_dest_drivers = g_list_append(affile_dest_drivers, self);

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -115,9 +115,8 @@ affile_dw_format_persist_name(AFFileDestWriter *self)
 static void affile_dd_reap_writer(AFFileDestDriver *self, AFFileDestWriter *dw);
 
 static void
-affile_dw_reap(gpointer s)
+affile_dw_reap(AFFileDestWriter *self)
 {
-  AFFileDestWriter *self = (AFFileDestWriter *) s;
   AFFileDestDriver *owner = self->owner;
 
   main_loop_assert_main_thread();
@@ -303,10 +302,14 @@ affile_dw_free(LogPipe *s)
 static void
 affile_dw_notify(LogPipe *s, gint notify_code, gpointer user_data)
 {
+  AFFileDestWriter *self = (AFFileDestWriter *)s;
   switch(notify_code)
     {
     case NC_REOPEN_REQUIRED:
-      affile_dw_reopen((AFFileDestWriter *)s);
+      affile_dw_reopen(self);
+      break;
+    case NC_CLOSE:
+      affile_dw_reap(self);
       break;
     default:
       break;

--- a/modules/affile/affile-dest.h
+++ b/modules/affile/affile-dest.h
@@ -48,7 +48,6 @@ typedef struct _AFFileDestDriver
 
   gint overwrite_if_older;
   gboolean use_time_recvd;
-  gint time_reap;
 } AFFileDestDriver;
 
 AFFileDestDriver *affile_dd_new_instance(gchar *filename, GlobalConfig *cfg);

--- a/modules/affile/logproto-file-writer.c
+++ b/modules/affile/logproto-file-writer.c
@@ -209,7 +209,12 @@ log_proto_file_writer_prepare(LogProtoClient *s, gint *fd, GIOCondition *cond, g
   /* if there's no pending I/O in the transport layer, then we want to do a write */
   if (*cond == 0)
     *cond = G_IO_OUT;
-  return self->buf_count > 0 || self->partial;
+  const gboolean pending_write = self->buf_count > 0 || self->partial;
+
+  if (!pending_write && s->options->timeout > 0)
+    *timeout = s->options->timeout;
+
+  return pending_write;
 }
 
 LogProtoClient *

--- a/news/bugfix-3133.md
+++ b/news/bugfix-3133.md
@@ -1,0 +1,1 @@
+file: changed time-reap() timer's schedule to respect the documentation (expires after last message)


### PR DESCRIPTION
According to the documentation the current `time-reap()` option describes the amount of seconds to wait before closing the destination file. The time between now and the last message to save
to a specific file (it can be different in case of templated path).

The current implementation schedule a timer at every `time-reap()` seconds and checks if there are messages in the queue to save into a file. The timer and the last message has no correlation.

This PR aims to replace the current behaviour with the one in the documentation[1]. The implementation taps into an already existing functionality of `LogWriter`'s `idle_timer`. A `LogProtoClient` could indicate a timeout value within its `_prepare` method, after that timer expires (if no message is sent till that time).

The timeout option should be implemented for multiple `LogProtoClient`:
* `lib/logproto/logproto-text-client` for pipe
* `modules/affile/logproto-file-writer` for file

The `LogProtoTextClient` is a general implementation that could be used for other destinations, currently it is needed for the `pipe` implementation.

[1] https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.25/administration-guide/34#TOPIC-1349418