### PR TITLE
Add python-home configure option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -328,6 +328,14 @@ AC_ARG_WITH(python,
               [  --with-python=VERSION    Build with a specific version of python]
               ,,with_python="auto")
 
+AC_ARG_WITH(python3-home,
+              [  --with-python3-home=path Use path as a hard-coded Python home directory that can not be overwritten by the PYTHONHOME environment variable],
+              python3_home_dir=$with_python3_home)
+
+AC_ARG_WITH(python2-home,
+              [  --with-python2-home=path Use path as a hard-coded Python home directory that can not be overwritten by the PYTHONHOME environment variable],
+              python2_home_dir=$with_python2_home)
+
 AC_ARG_WITH(nosetests,
               [  --with-nosetests=ABSOLUTE_PATH    Specify nosetests location])
 
@@ -1833,6 +1841,8 @@ if test -n "$env_ld_library_path"; then
 fi
 AC_DEFINE_UNQUOTED(PATH_MODULEDIR, "$moduledir", [module installation directory])
 AC_DEFINE_UNQUOTED(PYTHON_MODULE_DIR, "$python_moduledir", [Python module installation directory])
+AC_DEFINE_UNQUOTED(PYTHON3_HOME_DIR, "$python3_home_dir", [Hard-coded Python 3 home directory])
+AC_DEFINE_UNQUOTED(PYTHON2_HOME_DIR, "$python2_home_dir", [Hard-coded Python 2 home directory])
 AC_DEFINE_UNQUOTED(PATH_LOGGENPLUGINDIR, "$loggenplugindir", [loggenplugin installation directory])
 AC_DEFINE_UNQUOTED(MODULE_PATH, "$module_path", [module search path])
 AC_DEFINE_UNQUOTED(JAVA_MODULE_PATH, "$java_module_path", [java module search path])

--- a/configure.ac
+++ b/configure.ac
@@ -317,7 +317,7 @@ AC_ARG_WITH(systemd-journal,
               ,,with_systemd_journal="auto")
 
 AC_ARG_ENABLE(python,
-              [  --disable-python       Disable python destination]
+              [  --disable-python       Disable Python module]
               ,,enable_python="auto")
 
 AC_ARG_ENABLE(kafka,

--- a/modules/python/compat/compat-python-v2.c
+++ b/modules/python/compat/compat-python-v2.c
@@ -23,6 +23,30 @@
 
 #include "compat-python.h"
 #include "python-helpers.h"
+#include "syslog-ng.h"
+#include "reloc.h"
+
+void
+_set_python_home(const gchar *python_home)
+{
+  Py_SetPythonHome((gchar *) python_home);
+}
+
+void
+_force_python_home(const gchar *python_home)
+{
+  const gchar *resolved_python_home = get_installation_path_for(python_home);
+  _set_python_home(resolved_python_home);
+}
+
+void
+py_setup_python_home(void)
+{
+#ifdef SYSLOG_NG_PYTHON2_HOME_DIR
+  if (strlen(SYSLOG_NG_PYTHON2_HOME_DIR) > 0)
+    _force_python_home(SYSLOG_NG_PYTHON2_HOME_DIR);
+#endif
+}
 
 void
 py_init_argv(void)

--- a/modules/python/compat/compat-python-v3.c
+++ b/modules/python/compat/compat-python-v3.c
@@ -23,6 +23,30 @@
 
 #include "compat-python.h"
 #include "python-helpers.h"
+#include "syslog-ng.h"
+#include "reloc.h"
+
+void
+_set_python_home(const gchar *python_home)
+{
+  Py_SetPythonHome(Py_DecodeLocale(python_home, NULL));
+}
+
+void
+_force_python_home(const gchar *python_home)
+{
+  const gchar *resolved_python_home = get_installation_path_for(python_home);
+  _set_python_home(resolved_python_home);
+}
+
+void
+py_setup_python_home(void)
+{
+#ifdef SYSLOG_NG_PYTHON3_HOME_DIR
+  if (strlen(SYSLOG_NG_PYTHON3_HOME_DIR) > 0)
+    _force_python_home(SYSLOG_NG_PYTHON3_HOME_DIR);
+#endif
+}
 
 void
 py_init_argv(void)

--- a/modules/python/compat/compat-python.h
+++ b/modules/python/compat/compat-python.h
@@ -42,6 +42,7 @@
 #define PYTHON_MODULE_VERSION "python3"
 #endif
 
+void py_setup_python_home(void);
 void py_init_argv(void);
 PyObject *int_as_pyobject(gint num);
 

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -129,7 +129,7 @@ const ModuleInfo module_info =
 {
   .canonical_name = "python",
   .version = SYSLOG_NG_VERSION,
-  .description = "The python ("PYTHON_MODULE_VERSION") module provides Python scripted destination support for syslog-ng.",
+  .description = "The python ("PYTHON_MODULE_VERSION") module provides Python scripting support for syslog-ng.",
   .core_revision = VERSION_CURRENT_VER_ONLY,
   .plugins = python_plugins,
   .plugins_len = G_N_ELEMENTS(python_plugins),

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -40,6 +40,7 @@
 #include "reloc.h"
 
 #include <stdlib.h>
+#include <string.h>
 
 extern CfgParser python_parser;
 extern CfgParser python_parser_parser;
@@ -96,6 +97,7 @@ _py_init_interpreter(void)
     {
       python_debugger_append_inittab();
 
+      py_setup_python_home();
       _set_python_path();
       Py_Initialize();
       py_init_argv();

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -35,6 +35,7 @@ MsgFormatOptions parse_options;
 static void
 _py_init_interpreter(void)
 {
+  py_setup_python_home();
   Py_Initialize();
   py_init_argv();
 

--- a/modules/python/tests/test_python_template.c
+++ b/modules/python/tests/test_python_template.c
@@ -43,6 +43,7 @@ PyObject *py_template_options;
 static void
 _py_init_interpreter(void)
 {
+  py_setup_python_home();
   Py_Initialize();
   py_init_argv();
 


### PR DESCRIPTION
```
--with-python3-home=path Use path as a hard-coded Python home directory that
can not be overwritten by the PYTHONHOME environment variable.
```

This can be useful when a Python interpreter is bundled with syslog-ng.
Relocation is supported, for example: `--with-python3-home='${exec_prefix}'`