### PR TITLE
fix gethostbyname detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -761,7 +761,7 @@ dnl Checks for libraries
 AC_CHECK_LIB(door, door_create, BASE_LIBS="$BASE_LIBS -ldoor")
 AC_CHECK_LIB(socket, socket, BASE_LIBS="$BASE_LIBS -lsocket")
 AC_CHECK_LIB(rt, nanosleep, BASE_LIBS="$BASE_LIBS -lrt")
-AC_CHECK_LIB(nsl, gethostbyname, BASE_LIBS="$BASE_LIBS -lnsl")
+AC_CHECK_FUNC(gethostbyname, [], AC_CHECK_LIB(nsl, gethostbyname, BASE_LIBS="$BASE_LIBS -lnsl"))
 AC_CHECK_LIB(regex, regexec, REGEX_LIBS="-lregex")
 AC_CHECK_LIB(resolv, res_init, RESOLV_LIBS="-lresolv")
 

--- a/news/bugfix-3135.md
+++ b/news/bugfix-3135.md
@@ -1,0 +1,1 @@
+`configure.ac`: fixed gethostbyname function location detection


### PR DESCRIPTION
The detection of the location of the `gethostbyname` function was faulty. (except on Solaris) `gethostbyname` can be found under `libc`.

This check caused unnecessary linking against `libnsl`, now it only links if gethostbyname can be found under libnsl.

This unnecessary linking was hidden from us for several reasons:

- On Debian-based distributions libnsl is part of the libc package, so it was loaded without any problem.
- If the linker is using the `--as-needed` option (turned on by default on Debian-based distributions), than `libnsl` was removed during the final linking since nothing uses it inside Syslog-ng.