### PR TITLE
add set facility rewrite op

### DIFF
--- a/lib/rewrite/CMakeLists.txt
+++ b/lib/rewrite/CMakeLists.txt
@@ -7,6 +7,7 @@ set(REWRITE_HEADERS
     rewrite/rewrite-groupset.h
     rewrite/rewrite-unset.h
     rewrite/rewrite-set-severity.h
+    rewrite/rewrite-set-facility.h
     PARENT_SCOPE
     )
 
@@ -19,6 +20,7 @@ set(REWRITE_SOURCES
     rewrite/rewrite-groupset.c
     rewrite/rewrite-unset.c
     rewrite/rewrite-set-severity.c
+    rewrite/rewrite-set-facility.c
     PARENT_SCOPE
     )
 

--- a/lib/rewrite/Makefile.am
+++ b/lib/rewrite/Makefile.am
@@ -10,7 +10,8 @@ rewriteinclude_HEADERS = 			\
 	lib/rewrite/rewrite-subst.h		\
 	lib/rewrite/rewrite-expr-parser.h	\
 	lib/rewrite/rewrite-groupset.h		\
-	lib/rewrite/rewrite-set-severity.h
+	lib/rewrite/rewrite-set-severity.h	\
+	lib/rewrite/rewrite-set-facility.h
 
 
 rewrite_sources = 				\
@@ -22,7 +23,8 @@ rewrite_sources = 				\
 	lib/rewrite/rewrite-expr-parser.c	\
 	lib/rewrite/rewrite-expr-grammar.y	\
 	lib/rewrite/rewrite-groupset.c		\
-	lib/rewrite/rewrite-set-severity.c
+	lib/rewrite/rewrite-set-severity.c	\
+	lib/rewrite/rewrite-set-facility.c
 
 BUILT_SOURCES += 				\
 	lib/rewrite/rewrite-expr-grammar.y	\

--- a/lib/rewrite/rewrite-expr-grammar.ym
+++ b/lib/rewrite/rewrite-expr-grammar.ym
@@ -118,7 +118,7 @@ rewrite_expr
             last_rewrite = log_rewrite_set_tag_new($3, FALSE, configuration);
             free($3);
           }
-          ')'                                   { $$ = last_rewrite; }
+          rewrite_settag_opts ')'               { $$ = last_rewrite; }
         | KW_GROUP_SET '(' template_content
           {
             last_rewrite = log_rewrite_groupset_new($3, configuration);

--- a/lib/rewrite/rewrite-expr-grammar.ym
+++ b/lib/rewrite/rewrite-expr-grammar.ym
@@ -110,21 +110,36 @@ rewrite_expr
 	| KW_SET_TAG '(' string 
 	  { 
 	    last_rewrite = log_rewrite_set_tag_new($3, TRUE, configuration);
+            free($3);
           }
-	  rewrite_settag_opts ')'             	{ $$ = last_rewrite; free($3); }
-	| KW_CLEAR_TAG '(' string ')'           { $$ = log_rewrite_set_tag_new($3, FALSE, configuration); free($3); }
+	  rewrite_settag_opts ')'             	{ $$ = last_rewrite; }
+	| KW_CLEAR_TAG '(' string
+          {
+            last_rewrite = log_rewrite_set_tag_new($3, FALSE, configuration);
+            free($3);
+          }
+          ')'                                   { $$ = last_rewrite; }
         | KW_GROUP_SET '(' template_content
-        {
+          {
             last_rewrite = log_rewrite_groupset_new($3, configuration);
             log_template_unref($3);
-            }
-        rewrite_groupset_opts ')' { $$ = last_rewrite; }
+          }
+          rewrite_groupset_opts ')'             { $$ = last_rewrite; }
         | KW_GROUP_UNSET '('
-        {
+          {
             last_rewrite = log_rewrite_groupunset_new(configuration);
-        } rewrite_groupset_opts ')' { $$ = last_rewrite; }
-        | KW_SET_SEVERITY '(' template_content ')' { $$ = log_rewrite_set_severity_new($3, configuration);  }
-        | KW_SET_FACILITY '(' template_content ')' { $$ = log_rewrite_set_facility_new($3, configuration);  }
+          }
+          rewrite_groupset_opts ')'             { $$ = last_rewrite; }
+        | KW_SET_SEVERITY '(' template_content
+          {
+            last_rewrite = log_rewrite_set_severity_new($3, configuration);
+            log_template_unref($3);
+          } ')'					{ $$ = last_rewrite; };
+        | KW_SET_FACILITY '(' template_content
+          {
+            last_rewrite = log_rewrite_set_facility_new($3, configuration);
+            log_template_unref($3);
+          } ')'                                 { $$ = last_rewrite; };
         | LL_IDENTIFIER
           {
             Plugin *p;

--- a/lib/rewrite/rewrite-expr-grammar.ym
+++ b/lib/rewrite/rewrite-expr-grammar.ym
@@ -134,12 +134,12 @@ rewrite_expr
           {
             last_rewrite = log_rewrite_set_severity_new($3, configuration);
             log_template_unref($3);
-          } ')'					{ $$ = last_rewrite; };
+          } rewrite_set_severity_opts ')'	{ $$ = last_rewrite; };
         | KW_SET_FACILITY '(' template_content
           {
             last_rewrite = log_rewrite_set_facility_new($3, configuration);
             log_template_unref($3);
-          } ')'                                 { $$ = last_rewrite; };
+          } rewrite_set_facility_opts ')'       { $$ = last_rewrite; };
         | LL_IDENTIFIER
           {
             Plugin *p;
@@ -204,6 +204,25 @@ rewrite_expr_opts
         : rewrite_expr_opt rewrite_expr_opts
         |
         ;
+
+rewrite_set_severity_opts
+        : rewrite_set_severity_opt rewrite_set_severity_opts
+        |
+        ;
+
+rewrite_set_severity_opt
+        : rewrite_condition_opt
+        ;
+
+rewrite_set_facility_opts
+        : rewrite_set_facility_opt rewrite_set_facility_opts
+        |
+        ;
+
+rewrite_set_facility_opt
+        : rewrite_condition_opt
+        ;
+
 
 /* INCLUDE_RULES */
 

--- a/lib/rewrite/rewrite-expr-grammar.ym
+++ b/lib/rewrite/rewrite-expr-grammar.ym
@@ -37,6 +37,7 @@
 #include "rewrite/rewrite-subst.h"
 #include "rewrite/rewrite-groupset.h"
 #include "rewrite/rewrite-set-severity.h"
+#include "rewrite/rewrite-set-facility.h"
 #include "filter/filter-expr.h"
 #include "filter/filter-expr-parser.h"
 #include "cfg-grammar.h"
@@ -67,6 +68,7 @@
 %token KW_SUBST
 %token KW_VALUES
 %token KW_SET_SEVERITY
+%token KW_SET_FACILITY
 
 %%
 
@@ -122,6 +124,7 @@ rewrite_expr
             last_rewrite = log_rewrite_groupunset_new(configuration);
         } rewrite_groupset_opts ')' { $$ = last_rewrite; }
         | KW_SET_SEVERITY '(' template_content ')' { $$ = log_rewrite_set_severity_new($3, configuration);  }
+        | KW_SET_FACILITY '(' template_content ')' { $$ = log_rewrite_set_facility_new($3, configuration);  }
         | LL_IDENTIFIER
           {
             Plugin *p;

--- a/lib/rewrite/rewrite-expr-parser.c
+++ b/lib/rewrite/rewrite-expr-parser.c
@@ -37,6 +37,7 @@ static CfgLexerKeyword rewrite_expr_keywords[] =
   { "set_tag",            KW_SET_TAG },
   { "clear_tag",          KW_CLEAR_TAG },
   { "set_severity",       KW_SET_SEVERITY },
+  { "set_facility",       KW_SET_FACILITY },
 
   { "groupset",           KW_GROUP_SET },
   { "groupunset",         KW_GROUP_UNSET },

--- a/lib/rewrite/rewrite-set-facility.c
+++ b/lib/rewrite/rewrite-set-facility.c
@@ -139,6 +139,6 @@ log_rewrite_set_facility_new(LogTemplate *facility, GlobalConfig *cfg)
   self->super.super.free_fn = log_rewrite_set_facility_free;
   self->super.super.clone = log_rewrite_set_facility_clone;
   self->super.process = log_rewrite_set_facility_process;
-  self->facility = facility;
+  self->facility = log_template_ref(facility);
   return &self->super;
 }

--- a/lib/rewrite/rewrite-set-facility.c
+++ b/lib/rewrite/rewrite-set-facility.c
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2020 Balazs Scheidler <bazsi77@gmail.com>
+ * Copyright (c) 2019 Balabit
+ * Copyright (c) 2019 Kokan <kokaipeter@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "rewrite-set-facility.h"
+#include "template/templates.h"
+#include "syslog-names.h"
+#include "scratch-buffers.h"
+#include "parse-number.h"
+
+#include <stdlib.h>
+
+typedef struct _LogRewriteSetFacility LogRewriteSetFacility;
+
+struct _LogRewriteSetFacility
+{
+  LogRewrite super;
+  LogTemplate *facility;
+};
+
+static gint
+_convert_facility_as_number(const gchar *facility_text)
+{
+  gint64 facility = 0;
+
+  if (!parse_dec_number(facility_text, &facility))
+    return -1;
+
+  if (facility > 127)
+    return -1;
+
+  return FACILITY_CODE(facility);
+}
+
+static gint
+_convert_facility_as_text(const gchar *facility_text)
+{
+  return syslog_name_lookup_facility_by_name(facility_text);
+}
+
+static gint
+_convert_facility(const gchar *facility_text)
+{
+  gint facility = _convert_facility_as_number(facility_text);
+  if (facility >= 0)
+    return facility;
+
+  facility = _convert_facility_as_text(facility_text);
+  if (facility >= 0)
+    return facility;
+
+  return -1;
+}
+
+static void
+_set_msg_facility(LogMessage *msg, const guint32 facility)
+{
+  msg->pri = (msg->pri & ~LOG_FACMASK) | facility;
+}
+
+static void
+log_rewrite_set_facility_process(LogRewrite *s, LogMessage **pmsg, const LogPathOptions *path_options)
+{
+  ScratchBuffersMarker marker;
+  GString *result = scratch_buffers_alloc_and_mark(&marker);
+  LogRewriteSetFacility *self = (LogRewriteSetFacility *) s;
+
+  log_msg_make_writable(pmsg, path_options);
+
+  log_template_format(self->facility, *pmsg, NULL, LTZ_LOCAL, 0, NULL, result);
+
+  const gint facility = _convert_facility(result->str);
+  if (facility < 0)
+    {
+      msg_debug("Warning: invalid value passed to set-facility()",
+                evt_tag_str("facility", result->str),
+                log_pipe_location_tag(&s->super));
+      goto error;
+    }
+
+  msg_trace("Setting syslog facility",
+            evt_tag_int("old_facility", (*pmsg)->pri & LOG_FACMASK),
+            evt_tag_int("new_facility", facility),
+            evt_tag_printf("msg", "%p", *pmsg));
+  _set_msg_facility(*pmsg, facility);
+
+error:
+  scratch_buffers_reclaim_marked(marker);
+}
+
+static LogPipe *
+log_rewrite_set_facility_clone(LogPipe *s)
+{
+  LogRewriteSetFacility *self = (LogRewriteSetFacility *) s;
+  LogRewriteSetFacility *cloned = (LogRewriteSetFacility *)log_rewrite_set_facility_new(log_template_ref(self->facility),
+                                  s->cfg);
+
+  if (self->super.condition)
+    cloned->super.condition = filter_expr_ref(self->super.condition);
+
+  return &cloned->super.super;
+}
+
+void
+log_rewrite_set_facility_free(LogPipe *s)
+{
+  LogRewriteSetFacility *self = (LogRewriteSetFacility *) s;
+  log_template_unref(self->facility);
+  log_rewrite_free_method(s);
+}
+
+LogRewrite *
+log_rewrite_set_facility_new(LogTemplate *facility, GlobalConfig *cfg)
+{
+  LogRewriteSetFacility *self = g_new0(LogRewriteSetFacility, 1);
+
+  log_rewrite_init_instance(&self->super, cfg);
+  self->super.super.free_fn = log_rewrite_set_facility_free;
+  self->super.super.clone = log_rewrite_set_facility_clone;
+  self->super.process = log_rewrite_set_facility_process;
+  self->facility = facility;
+  return &self->super;
+}

--- a/lib/rewrite/rewrite-set-facility.h
+++ b/lib/rewrite/rewrite-set-facility.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2020 Balazs Scheidler <bazsi77@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef REWRITE_SET_FACILITY_H_INCLUDED
+#define REWRITE_SET_FACILITY_H_INCLUDED
+
+#include "rewrite-expr.h"
+
+LogRewrite *log_rewrite_set_facility_new(LogTemplate *facility, GlobalConfig *cfg);
+
+#endif

--- a/lib/rewrite/rewrite-set-severity.c
+++ b/lib/rewrite/rewrite-set-severity.c
@@ -140,6 +140,6 @@ log_rewrite_set_severity_new(LogTemplate *severity, GlobalConfig *cfg)
   self->super.super.free_fn = log_rewrite_set_severity_free;
   self->super.super.clone = log_rewrite_set_severity_clone;
   self->super.process = log_rewrite_set_severity_process;
-  self->severity = severity;
+  self->severity = log_template_ref(severity);
   return &self->super;
 }

--- a/lib/rewrite/rewrite-set-severity.c
+++ b/lib/rewrite/rewrite-set-severity.c
@@ -94,7 +94,9 @@ log_rewrite_set_severity_process(LogRewrite *s, LogMessage **pmsg, const LogPath
   const gint severity = _convert_severity(result);
   if (severity < 0)
     {
-      msg_debug("Warning: invalid severity to set", evt_tag_str("severity", result->str), log_pipe_location_tag(&s->super));
+      msg_debug("Warning: invalid value passed to set-severity()",
+                evt_tag_str("severity", result->str),
+                log_pipe_location_tag(&s->super));
       goto error;
     }
 

--- a/lib/rewrite/rewrite-set-severity.c
+++ b/lib/rewrite/rewrite-set-severity.c
@@ -98,6 +98,10 @@ log_rewrite_set_severity_process(LogRewrite *s, LogMessage **pmsg, const LogPath
       goto error;
     }
 
+  msg_trace("Setting syslog severity",
+            evt_tag_int("old_severity", LOG_PRI((*pmsg)->pri)),
+            evt_tag_int("new_severity", severity),
+            evt_tag_printf("msg", "%p", *pmsg));
   _set_msg_severity(*pmsg, severity);
 
 error:

--- a/lib/rewrite/tests/CMakeLists.txt
+++ b/lib/rewrite/tests/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_unit_test(LIBTEST CRITERION TARGET test_rewrite)
 add_unit_test(LIBTEST CRITERION TARGET test_set_severity)
+add_unit_test(LIBTEST CRITERION TARGET test_set_facility)

--- a/lib/rewrite/tests/Makefile.am
+++ b/lib/rewrite/tests/Makefile.am
@@ -1,6 +1,7 @@
 lib_rewrite_tests_TESTS = \
     lib/rewrite/tests/test_rewrite \
-    lib/rewrite/tests/test_set_severity
+    lib/rewrite/tests/test_set_severity \
+    lib/rewrite/tests/test_set_facility
 
 EXTRA_DIST += lib/rewrite/tests/CMakeLists.txt
 
@@ -16,3 +17,8 @@ lib_rewrite_tests_test_set_severity_CFLAGS = $(TEST_CFLAGS)
 lib_rewrite_tests_test_set_severity_LDADD = $(TEST_LDADD)
 lib_rewrite_tests_test_set_severity_SOURCES =    \
     lib/rewrite/tests/test_set_severity.c
+
+lib_rewrite_tests_test_set_facility_CFLAGS = $(TEST_CFLAGS)
+lib_rewrite_tests_test_set_facility_LDADD = $(TEST_LDADD)
+lib_rewrite_tests_test_set_facility_SOURCES =    \
+    lib/rewrite/tests/test_set_facility.c

--- a/lib/rewrite/tests/test_set_facility.c
+++ b/lib/rewrite/tests/test_set_facility.c
@@ -59,6 +59,7 @@ static void
 _perform_set_facility(LogTemplate *template, LogMessage *msg_)
 {
   LogRewrite *rewrite = log_rewrite_set_facility_new(template, cfg);
+  log_template_unref(template);
 
   _perform_rewrite(rewrite, msg_);
 }

--- a/lib/rewrite/tests/test_set_facility.c
+++ b/lib/rewrite/tests/test_set_facility.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2020 Balazs Scheidler <bazsi77@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+
+#include "syslog-names.h"
+#include "apphook.h"
+#include "rewrite/rewrite-set-facility.h"
+#include "logmsg/logmsg.h"
+#include "grab-logging.h"
+
+GlobalConfig *cfg = NULL;
+LogMessage *msg;
+
+static LogTemplate *
+_create_template(const gchar *str)
+{
+  GError *error = NULL;
+  LogTemplate *template = log_template_new(cfg, NULL);
+  log_template_compile(template, str, &error);
+
+  cr_expect_null(error);
+
+  return template;
+}
+
+static void
+_perform_rewrite(LogRewrite *rewrite, LogMessage *msg_)
+{
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+
+  log_pipe_init(&rewrite->super);
+  log_pipe_queue(&rewrite->super, log_msg_ref(msg_), &path_options);
+  log_pipe_deinit(&rewrite->super);
+  log_pipe_unref(&rewrite->super);
+}
+
+static void
+_perform_set_facility(LogTemplate *template, LogMessage *msg_)
+{
+  LogRewrite *rewrite = log_rewrite_set_facility_new(template, cfg);
+
+  _perform_rewrite(rewrite, msg_);
+}
+
+static gboolean
+_msg_facility_equals(LogMessage *msg_, gint fac)
+{
+  return (msg_->pri & LOG_FACMASK) == fac;
+}
+
+Test(set_facility, text)
+{
+  _perform_set_facility(_create_template("mail"), msg);
+  cr_assert(_msg_facility_equals(msg, LOG_MAIL));
+
+  _perform_set_facility(_create_template("news"), msg);
+  cr_assert(_msg_facility_equals(msg, LOG_NEWS));
+
+  _perform_set_facility(_create_template("kern"), msg);
+  cr_assert(_msg_facility_equals(msg, LOG_KERN));
+}
+
+Test(set_facility, numeric)
+{
+  _perform_set_facility(_create_template("1"), msg);
+  cr_assert(_msg_facility_equals(msg, FACILITY_CODE(1)));
+
+  _perform_set_facility(_create_template("2"), msg);
+  cr_assert(_msg_facility_equals(msg, FACILITY_CODE(2)));
+}
+
+Test(set_facility, test_set_facility_with_template_evaluating_to_empty_string)
+{
+  debug_flag = 1;
+
+  gint default_facility = msg->pri & LOG_FACMASK;
+
+  _perform_set_facility(_create_template("${nonexistentvalue}"), msg);
+
+  cr_assert(_msg_facility_equals(msg, default_facility), "empty templates should not change the original facility");
+  assert_grabbed_log_contains("invalid value passed to set-facility()");
+}
+
+Test(set_facility, large_number)
+{
+  debug_flag = 1;
+
+  gint default_facility = msg->pri & LOG_FACMASK;
+
+  _perform_set_facility(_create_template("128"), msg);
+
+  cr_assert(_msg_facility_equals(msg, default_facility), "too large values should not change the original facility");
+  assert_grabbed_log_contains("invalid value passed to set-facility()");
+}
+
+Test(set_facility, invalid)
+{
+  debug_flag = 1;
+
+  gint default_facility = msg->pri & LOG_FACMASK;
+
+  _perform_set_facility(_create_template("random-text"), msg);
+
+  cr_assert(_msg_facility_equals(msg, default_facility), "too large values should not change the original facility");
+  assert_grabbed_log_contains("invalid value passed to set-facility()");
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  cfg = cfg_new_snippet();
+  start_grabbing_messages();
+  msg = log_msg_new_empty();
+}
+
+static void
+teardown(void)
+{
+  log_msg_unref(msg);
+  stop_grabbing_messages();
+  cfg_free(cfg);
+  app_shutdown();
+}
+
+TestSuite(set_facility, .init = setup, .fini = teardown);

--- a/lib/rewrite/tests/test_set_severity.c
+++ b/lib/rewrite/tests/test_set_severity.c
@@ -93,22 +93,22 @@ Test(set_severity, test_set_severity_with_various_invalid_values)
 
   int default_severity = msg->pri & LOG_PRIMASK;
   _perform_set_severity(_create_template("${nonexistentvalue}"), msg);
-  assert_grabbed_log_contains("invalid severity to set");
+  assert_grabbed_log_contains("invalid value passed to set-severity()");
   cr_assert(_msg_severity_equals(msg, default_severity), "empty templates should not change the original severity");
 
   reset_grabbed_messages();
   _perform_set_severity(_create_template("8"), msg);
-  assert_grabbed_log_contains("invalid severity to set");
-
+  assert_grabbed_log_contains("invalid value passed to set-severity()");
   cr_assert(_msg_severity_equals(msg, default_severity), "too large numeric values should not change the original severity");
+
   reset_grabbed_messages();
   _perform_set_severity(_create_template("-1"), msg);
-  assert_grabbed_log_contains("invalid severity to set");
+  assert_grabbed_log_contains("invalid value passed to set-severity()");
   cr_assert(_msg_severity_equals(msg, default_severity), "negative values should not change the original severity");
 
   reset_grabbed_messages();
   _perform_set_severity(_create_template("random-text"), msg);
-  assert_grabbed_log_contains("invalid severity to set");
+  assert_grabbed_log_contains("invalid value passed to set-severity()");
   cr_assert(_msg_severity_equals(msg, default_severity), "non-numeric data should not change the original severity");
 }
 

--- a/lib/rewrite/tests/test_set_severity.c
+++ b/lib/rewrite/tests/test_set_severity.c
@@ -94,22 +94,26 @@ Test(set_severity, test_set_severity_with_various_invalid_values)
   int default_severity = msg->pri & LOG_PRIMASK;
   _perform_set_severity(_create_template("${nonexistentvalue}"), msg);
   assert_grabbed_log_contains("invalid value passed to set-severity()");
-  cr_assert(_msg_severity_equals(msg, default_severity), "empty templates should not change the original severity");
+  cr_assert(_msg_severity_equals(msg, default_severity),
+            "empty templates should not change the original severity");
 
   reset_grabbed_messages();
   _perform_set_severity(_create_template("8"), msg);
   assert_grabbed_log_contains("invalid value passed to set-severity()");
-  cr_assert(_msg_severity_equals(msg, default_severity), "too large numeric values should not change the original severity");
+  cr_assert(_msg_severity_equals(msg, default_severity),
+            "too large numeric values should not change the original severity");
 
   reset_grabbed_messages();
   _perform_set_severity(_create_template("-1"), msg);
   assert_grabbed_log_contains("invalid value passed to set-severity()");
-  cr_assert(_msg_severity_equals(msg, default_severity), "negative values should not change the original severity");
+  cr_assert(_msg_severity_equals(msg, default_severity),
+            "negative values should not change the original severity");
 
   reset_grabbed_messages();
   _perform_set_severity(_create_template("random-text"), msg);
   assert_grabbed_log_contains("invalid value passed to set-severity()");
-  cr_assert(_msg_severity_equals(msg, default_severity), "non-numeric data should not change the original severity");
+  cr_assert(_msg_severity_equals(msg, default_severity),
+            "non-numeric data should not change the original severity");
 }
 
 static void

--- a/lib/rewrite/tests/test_set_severity.c
+++ b/lib/rewrite/tests/test_set_severity.c
@@ -59,6 +59,7 @@ static void
 _perform_set_severity(LogTemplate *template, LogMessage *msg_)
 {
   LogRewrite *rewrite = log_rewrite_set_severity_new(template, cfg);
+  log_template_unref(template);
 
   _perform_rewrite(rewrite, msg_);
 }

--- a/lib/syslog-names.c
+++ b/lib/syslog-names.c
@@ -26,10 +26,6 @@
 #include "syslog-ng.h"
 #include <string.h>
 
-#define SEVERITY_CODE(n)    ((n) & 7)
-#define FACILITY_CODE(n) ((n) << 3)
-
-
 struct sl_name sl_severities[] =
 {
   {"emerg",     SEVERITY_CODE(0) },

--- a/lib/syslog-names.h
+++ b/lib/syslog-names.h
@@ -36,6 +36,9 @@
 /* extract priority */
 #define LOG_PRI(p)  ((p) & LOG_PRIMASK)
 
+#define SEVERITY_CODE(n)    ((n) & 7)
+#define FACILITY_CODE(n) ((n) << 3)
+
 struct sl_name
 {
   const char *name;

--- a/news/feature-3136.md
+++ b/news/feature-3136.md
@@ -1,0 +1,18 @@
+`set-facility()`: add new rewrite operation to change the syslog facility
+associated with the message.
+
+<details>
+  <summary>Example config, click to expand!</summary>
+
+```
+
+log {
+    source { system(); };
+    if (program("postfix")) {
+      rewrite { set-facility("mail"); };
+    };
+    destination { file("/var/log/mail.log"); };
+    flags(flow-control);
+};
+```
+</details>

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -57,6 +57,8 @@ modules/secure-logging/tests
 modules/secure-logging/slogimport
 modules/secure-logging/slogverify
 modules/secure-logging/slogkey
+lib/rewrite/rewrite-set-facility\.h
+lib/rewrite/tests/test_set_facility\.c
  LGPLv2.1+_SSL
 autogen\.sh$
 sub-configure\.sh$


### PR DESCRIPTION
This PR is a followup to #3115 namely that added set-severity() and this one adds set-facility().
Apart from the new feature, this also refactors the set-severity() test program and adds a log message to set-severity(), similar to what we have in other rewrite ops (and similar to what I have added to set-facility() as  a part of this PR).

Hopefully the gods of travis et al find these patches worthwhile and give me the holy price of being "green". Apart from that this should be pretty straight-forward to get merged.
