### PR TITLE
travis: add bionic-python3 job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -244,6 +244,91 @@ matrix:
         - make --keep-going -j $(nproc) all install
         - ctest -j $(nproc) --output-on-failure
 
+    - env: B=bionic-python3
+      compiler: gcc
+      dist: bionic
+      sudo: required
+      addons:
+        apt:
+          sources:
+            - sourceline: 'deb http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/xUbuntu_18.04 ./'
+              key_url: 'http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/xUbuntu_18.04/Release.key'
+          packages:
+            - autoconf-archive
+            - bison
+            - docbook-xsl
+            - flex
+            - gradle
+            - libcap-dev
+            - libdbd-sqlite3
+            - libdbi0-dev
+            - libesmtp-dev
+            - libgeoip-dev
+            - libglib2.0-dev
+            - libhiredis-dev
+            - librabbitmq-dev
+            - libmongoc-dev
+            - libjson-c-dev
+            - libnet1-dev
+            - libriemann-client-dev
+            - librdkafka-dev
+            - libwrap0-dev
+            - pkg-config
+            - sqlite3
+            - xsltproc
+            - criterion-dev
+            - libmaxminddb-dev
+            - libxml2-utils
+            - doxygen
+            - libsnmp-dev
+            - snmptrapd
+            - python3
+            - python3-pip
+            - python3-setuptools
+            - openjdk-8-jdk
+            - openjdk-8-jre
+      install:
+        - python3 -m pip install --user -r requirements.txt
+        - export PATH=`echo $PATH | sed -r 's|:/usr/local/lib/jvm/openjdk11/bin||'`
+        - sudo update-java-alternatives --set java-1.8.0-openjdk-amd64
+      git:
+        submodules: true
+      before_script:
+        - echo 'Europe/Budapest' | sudo tee /etc/timezone
+        - sudo dpkg-reconfigure --frontend noninteractive tzdata
+        - ./autogen.sh
+        - unset PYTHON_CFLAGS # HACK
+        - CONFIGURE_FLAGS="
+            CFLAGS=-Werror
+            --prefix=$HOME/install/syslog-ng
+            --with-ivykis=internal
+            --with-jsonc=system
+            --disable-env-wrapper
+            --disable-memtrace
+            --enable-tcp-wrapper
+            --enable-linux-caps
+            --disable-sun-streams
+            --enable-all-modules
+            --disable-mongodb
+            --disable-sql
+            --enable-pacct
+            --enable-manpages
+            --enable-force-gnu99
+            --with-python=3
+            "
+        - ./configure $CONFIGURE_FLAGS
+      script:
+        - set -e
+        - make V=1 -j $(nproc)
+        - make V=1 check
+        - make install
+        - make pytest-self-check
+        - make python-pep8
+        - make python-pylint
+        - make pytest-linters
+        - make VERBOSE=1 func-test
+        - make pytest-check
+
 branches:
   except:
     - /wip/

--- a/lib/secret-storage/nondumpable-allocator.c
+++ b/lib/secret-storage/nondumpable-allocator.c
@@ -50,16 +50,16 @@ nondumpable_setlogger(NonDumpableLogger _debug, NonDumpableLogger _fatal)
 
 #define logger_debug(summary, fmt, ...) \
 { \
- char reason[32] = { 0 }; \
- snprintf(reason, sizeof(reason), fmt, __VA_ARGS__); \
- logger_debug_fn(summary, reason);   \
+ gchar *reason = g_strdup_printf(fmt, __VA_ARGS__); \
+ logger_debug_fn(summary, reason); \
+ g_free(reason); \
 }
 
 #define logger_fatal(summary, fmt, ...) \
 { \
- char reason[32] = { 0 }; \
- snprintf(reason, sizeof(reason), fmt, __VA_ARGS__); \
- logger_fatal_fn(summary, reason);   \
+ gchar *reason = g_strdup_printf(fmt, __VA_ARGS__); \
+ logger_fatal_fn(summary, reason); \
+ g_free(reason); \
 }
 
 typedef struct

--- a/news/bugfix-3141.md
+++ b/news/bugfix-3141.md
@@ -1,0 +1,1 @@
+`secret-storage`: Fixed some cases, where diagnostical logs were truncated.


### PR DESCRIPTION
With this job we can test `--with-python=3`. Additional extra, that it runs on `bionic`, and it seems, that the only thing that needed extra care is to use an older `java` (I installed 1.8 in this case).

There are 2 things to fix, both are disabled right now:
- [x] The platform is `bionic`, and we get some packages from [OBS](https://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/xUbuntu_18.04/amd64/). If we use `--enable-mongodb`, we use `libmongoc-dev-1.15`, which has deprecated `mongoc_client_get_server_status()`, and we cannot build because of that.
- [x] `make func-test` currently does not work, as it wants to run with `python3`, too, but the syntax is only valid with `python2`. @mitzkia is currently working on the port (#3144)

There was a small bug, which showed itself now, when building with fresher `gcc`, the PR has he fix for it, too.

This PR is an alternative of #3104, this one uses TravisCI.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>