### PR TITLE
FuncTests: Make func-test Python3 compatible

### DIFF
--- a/news/developer-note-3144.md
+++ b/news/developer-note-3144.md
@@ -1,0 +1,1 @@
+FunctionalTests: Make functional tests Python3 compatible

--- a/tests/functional/func_test.py
+++ b/tests/functional/func_test.py
@@ -71,7 +71,7 @@ VW5iRZrvI0sdxt5Ud0TjNqXRGxuVczSuwpQwwxBn0ogr9DoRnp375PwGGh1/yqimW/+OStwP3cRR
 yXEg6Zq1CvuYF/E6el4h9GylxkU7wEM2Ti9QJY4n3YsHyesalERqdd9xx5t7ADRodpMpZXoZGbrS
 vccp3zMzS/aEZRuxky1/qjrAEh8OVA58e82jQqTdY8OQ/kKOu/gUgKBnHAvLkB/020p0CNbq6HjY
 l625DLckaYmOPTh0ECFKzhaPF+/LNmzD36ToOAeuNjfbUjiUVGfntr2mc4E8mUFyo+TskrkSfw==
-""")
+""".encode())
         ssl.RAND_add(rnd, 1024)
         if not ssl.RAND_status():
             raise "PRNG not seeded"

--- a/tests/functional/func_test.py
+++ b/tests/functional/func_test.py
@@ -52,6 +52,7 @@ def seed_rnd():
     try:
         import base64
         import socket
+        import ssl
         rnd = base64.decodestring("""k/zFvqjGWdhStmhfOeTNtTs89P8soknF1J9kSQrz8hKdrjIutqTXMfIqCNUb7DXrMykMW+wKd1Pg
 DwaUwxKmlaU1ItOek+jNUWVw9ZOSI1EmsXVgu+Hu7URgmeyY0A3WsDmMzR0Z2wTcRFSuINgBP8LC
 8SG27gJZVOoVv09pfY9WyjvUYwg1jBdTfEM+qcDQKOACx4DH+SzO0bOOJMfMbR2iFaq18b/TCeQN
@@ -71,8 +72,8 @@ yXEg6Zq1CvuYF/E6el4h9GylxkU7wEM2Ti9QJY4n3YsHyesalERqdd9xx5t7ADRodpMpZXoZGbrS
 vccp3zMzS/aEZRuxky1/qjrAEh8OVA58e82jQqTdY8OQ/kKOu/gUgKBnHAvLkB/020p0CNbq6HjY
 l625DLckaYmOPTh0ECFKzhaPF+/LNmzD36ToOAeuNjfbUjiUVGfntr2mc4E8mUFyo+TskrkSfw==
 """)
-        socket._ssl.RAND_add(rnd, 1024)
-        if not socket._ssl.RAND_status():
+        ssl.RAND_add(rnd, 1024)
+        if not ssl.RAND_status():
             raise "PRNG not seeded"
     except ImportError:
         return

--- a/tests/functional/func_test.py
+++ b/tests/functional/func_test.py
@@ -41,7 +41,7 @@ def init_env():
         os.mkfifo(pipe)
     try:
         os.mkdir("wildcard")
-    except OSError, e:
+    except OSError as e:
         if e.errno != errno.EEXIST:
             raise
 

--- a/tests/functional/log.py
+++ b/tests/functional/log.py
@@ -23,7 +23,7 @@
 import time
 
 def print_user(msg):
-    print '    ', time.strftime('%Y-%m-%dT%H:%M:%S'), msg
+    print('     %s %s' % (time.strftime('%Y-%m-%dT%H:%M:%S'), msg))
 
 def print_start(testcase):
     print("\n\n##############################################")

--- a/tests/functional/messagecheck.py
+++ b/tests/functional/messagecheck.py
@@ -75,7 +75,7 @@ def check_contents(f, messages, syslog_prefix, skip_prefix):
         msg = m.group(1)
         session = int(m.group(2))
         id = int(m.group(3))
-        if not matches.has_key((msg, session)):
+        if (msg, session) not in matches:
             if id != 1:
                 print_user("the id of the first message in a session is not 1, session=%d, id=%d, file=%s:%d, line=%s"  % (session, id, f, lineno, read_line))
                 return False
@@ -89,7 +89,7 @@ def check_contents(f, messages, syslog_prefix, skip_prefix):
 
     for (msg, session, count) in messages:
 
-        if not matches.has_key((msg, session)):
+        if (msg, session) not in matches:
             print_user("output log files lack this kind of message: %s session: %d, count: %d" % (msg, session, count))
             return False
         if matches[(msg, session)] != count - 1:

--- a/tests/functional/messagecheck.py
+++ b/tests/functional/messagecheck.py
@@ -28,20 +28,20 @@ from messagegen import syslog_prefix
 def logstore_reader(fname):
     try:
         return os.popen("../../src/logcat %s.lgs" % fname, "r")
-    except OSError, e:
+    except OSError as e:
         print_user("Error opening file: %s, %s" % (fname, str(e)))
 
 def file_reader(fname):
     try:
         return open(fname + ".log", "r")
-    except IOError, e:
+    except IOError as e:
         print_user("Error opening file: %s, %s" % (fname, str(e)))
 
 def sql_reader(name):
     (db, table) = name
     try:
         return os.popen("""echo "select * from %s order by msg;" | sqlite3 -separator " "  %s """ % (table, db), "r")
-    except OSError, e:
+    except OSError as e:
         print_user("Error opening file: %s, %s" % (fname, str(e)))
 
 

--- a/tests/functional/messagegen.py
+++ b/tests/functional/messagegen.py
@@ -102,7 +102,7 @@ class SocketSender(MessageSender):
                         self.sock.write(c)
                     else:
                         self.sock.send(c)
-                except error, e:
+                except error as e:
                     if e[0] == errno.ENOBUFS:
                         print_user('got ENOBUFS, sleeping...')
                         time.sleep(0.5)
@@ -124,7 +124,7 @@ class SocketSender(MessageSender):
 
                     if self.dgram:
                         time.sleep(0.01)
-                except error, e:
+                except error as e:
                     if e[0] == errno.ENOBUFS:
                         print_user('got ENOBUFS, sleeping...')
                         time.sleep(0.5)

--- a/tests/functional/messagegen.py
+++ b/tests/functional/messagegen.py
@@ -22,7 +22,7 @@
 
 import struct, stat, re
 from socket import *
-from socket import ssl
+import ssl
 import os, sys, errno
 
 from log import *
@@ -90,7 +90,7 @@ class SocketSender(MessageSender):
         if sys.platform == 'linux2':
                 self.sock.setsockopt(SOL_SOCKET, SO_SNDTIMEO, struct.pack('ll', 3, 0))
         if not self.dgram and self.ssl:
-                self.sock = ssl(self.sock)
+                self.sock = ssl.wrap_socket(self.sock)
 
 
     def sendMessage(self, msg):

--- a/tests/functional/messagegen.py
+++ b/tests/functional/messagegen.py
@@ -86,7 +86,7 @@ class SocketSender(MessageSender):
 
         self.sock.connect(self.sock_name)
         if self.dgram:
-                self.sock.send('')
+                self.sock.send(''.encode())
         if sys.platform == 'linux2':
                 self.sock.setsockopt(SOL_SOCKET, SO_SNDTIMEO, struct.pack('ll', 3, 0))
         if not self.dgram and self.ssl:
@@ -99,9 +99,9 @@ class SocketSender(MessageSender):
             for c in line:
                 try:
                     if self.ssl:
-                        self.sock.write(c)
+                        self.sock.write(c.encode())
                     else:
-                        self.sock.send(c)
+                        self.sock.send(c.encode())
                 except error as e:
                     if e[0] == errno.ENOBUFS:
                         print_user('got ENOBUFS, sleeping...')
@@ -118,9 +118,9 @@ class SocketSender(MessageSender):
 
                     # WTF? SSLObject only has write, whereas sockets only have send methods
                     if self.ssl:
-                        self.sock.write(line)
+                        self.sock.write(line.encode())
                     else:
-                        self.sock.send(line)
+                        self.sock.send(line.encode())
 
                     if self.dgram:
                         time.sleep(0.01)

--- a/tests/functional/test_performance.py
+++ b/tests/functional/test_performance.py
@@ -49,7 +49,7 @@ def test_performance():
     rate = float(re.sub('^.*rate = ([0-9.]+).*$', '\\1', out))
 
     hostname = os.uname()[1]
-    if expected_rate.has_key(hostname):
+    if hostname in expected_rate:
         return rate > expected_rate[hostname]
 
     # we expect to be able to process at least 1000 msgs/sec even on our venerable HP-UX

--- a/tests/functional/test_python.py
+++ b/tests/functional/test_python.py
@@ -73,15 +73,15 @@ def get_source_dir():
 def check_env():
 
     if not has_module('mod-python'):
-        print 'Python module is not available, skipping Python test'
+        print('Python module is not available, skipping Python test')
         return False
 
     src_dir = get_source_dir()
-    print src_dir
+    print(src_dir)
     if 'PYTHONPATH' not in os.environ or src_dir not in os.environ['PYTHONPATH']:
         os.environ['PYTHONPATH'] = os.environ.get('PYTHONPATH', '') + ':' + src_dir
 
-    print 'Python module found, proceeding to Python tests'
+    print('Python module found, proceeding to Python tests')
     return True
 
 

--- a/tests/functional/test_sql.py
+++ b/tests/functional/test_sql.py
@@ -51,7 +51,7 @@ log { source(s_tcp); destination(d_sql); };
 def check_env():
 
     if not has_module('afsql'):
-        print 'afsql module is not available, skipping SQL test'
+        print('afsql module is not available, skipping SQL test')
         return False
     paths=('/opt/syslog-ng/bin', '/usr/bin', '/usr/local/bin')
     found=False
@@ -77,7 +77,7 @@ def check_env():
         print_user('No sqlite3 backend for libdbi. Skipping SQL test.\nSearched: %s\n' % ':'.join(paths))
         return False
 
-    print 'sqlite3 found, proceeding to SQL tests'
+    print('sqlite3 found, proceeding to SQL tests')
     return True
 
 


### PR DESCRIPTION
These changes are the minimal set to run tests with Python3.
Tests are still compatible with Python2
Tested with DBLD: balabit/syslog-ng-ubuntu-bionic image, where currently the following Python versions are available:
```console
root@092a7a58dbf5:/# python
Python 2.7.17 (default, Nov  7 2019, 10:07:09) 
```

```console
root@092a7a58dbf5:/# python3
Python 3.6.9 (default, Nov  7 2019, 10:44:02)
```

Func-tests will run with Python3 interpreter when `${PYTHON}` and `${PYTHON_EXECUTABLE}` variables are expounds to python3 in `tests/functional/Makefile.am` and in `tests/functional/CMakeLists.txt`