### PR TITLE
tls: add ca-file() option

### DIFF
--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -49,6 +49,7 @@ struct _TLSContext
   gchar *pkcs12_file;
   gchar *ca_dir;
   gchar *crl_dir;
+  gchar *ca_file;
   gchar *cipher_suite;
   gchar *ecdh_curve_list;
   gchar *sni;
@@ -731,6 +732,9 @@ tls_context_setup_context(TLSContext *self)
   if (_is_file_accessible(self, self->ca_dir) && !SSL_CTX_load_verify_locations(self->ssl_ctx, NULL, self->ca_dir))
     goto error;
 
+  if (_is_file_accessible(self, self->ca_file) && !SSL_CTX_load_verify_locations(self->ssl_ctx, self->ca_file, NULL))
+    goto error;
+
   if (_is_file_accessible(self, self->crl_dir) && !SSL_CTX_load_verify_locations(self->ssl_ctx, NULL, self->crl_dir))
     goto error;
 
@@ -835,6 +839,7 @@ _tls_context_free(TLSContext *self)
   g_free(self->dhparam_file);
   g_free(self->ca_dir);
   g_free(self->crl_dir);
+  g_free(self->ca_file);
   g_free(self->cipher_suite);
   g_free(self->ecdh_curve_list);
   g_free(self->sni);
@@ -1027,6 +1032,13 @@ tls_context_set_crl_dir(TLSContext *self, const gchar *crl_dir)
 {
   g_free(self->crl_dir);
   self->crl_dir = g_strdup(crl_dir);
+}
+
+void
+tls_context_set_ca_file(TLSContext *self, const gchar *ca_file)
+{
+  g_free(self->ca_file);
+  self->ca_file = g_strdup(ca_file);
 }
 
 void

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -675,15 +675,15 @@ _are_key_and_cert_files_accessible(TLSContext *self)
 }
 
 static gboolean
-_key_and_cert_files_are_not_specified(TLSContext *self)
+_key_or_cert_file_is_not_specified(TLSContext *self)
 {
-  return (!self->key_file && !self->cert_file);
+  return (!self->key_file || !self->cert_file);
 }
 
 static TLSContextLoadResult
 tls_context_load_key_and_cert(TLSContext *self)
 {
-  if (_key_and_cert_files_are_not_specified(self))
+  if (_key_or_cert_file_is_not_specified(self))
     {
       if (self->mode == TM_SERVER)
         msg_warning("You have a TLS enabled source without a X.509 keypair. Make sure you have tls(key-file() and cert-file()) options, TLS handshake to this source will fail",

--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -121,6 +121,7 @@ void tls_context_set_cert_file(TLSContext *self, const gchar *cert_file);
 void tls_context_set_pkcs12_file(TLSContext *self, const gchar *pkcs12_file);
 void tls_context_set_ca_dir(TLSContext *self, const gchar *ca_dir);
 void tls_context_set_crl_dir(TLSContext *self, const gchar *crl_dir);
+void tls_context_set_ca_file(TLSContext *self, const gchar *ca_file);
 void tls_context_set_cipher_suite(TLSContext *self, const gchar *cipher_suite);
 void tls_context_set_ecdh_curve_list(TLSContext *self, const gchar *ecdh_curve_list);
 void tls_context_set_dhparam_file(TLSContext *self, const gchar *dhparam_file);

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -182,6 +182,7 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 %token KW_PKCS12_FILE
 %token KW_CA_DIR
 %token KW_CRL_DIR
+%token KW_CA_FILE
 %token KW_TRUSTED_KEYS
 %token KW_TRUSTED_DN
 %token KW_CIPHER_SUITE
@@ -822,6 +823,11 @@ tls_option
 	| KW_CRL_DIR '(' string ')'
 	  {
 	    tls_context_set_crl_dir(last_tls_context, $3);
+            free($3);
+          }
+        | KW_CA_FILE '(' path_check ')'
+          {
+            tls_context_set_ca_file(last_tls_context, $3);
             free($3);
           }
         | KW_TRUSTED_KEYS '(' string_list ')'

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -51,6 +51,7 @@ static CfgLexerKeyword afsocket_keywords[] =
   { "pkcs12_file",        KW_PKCS12_FILE },
   { "ca_dir",             KW_CA_DIR },
   { "crl_dir",            KW_CRL_DIR },
+  { "ca_file",            KW_CA_FILE },
   { "trusted_keys",       KW_TRUSTED_KEYS },
   { "trusted_dn",         KW_TRUSTED_DN },
   { "cipher_suite",       KW_CIPHER_SUITE },

--- a/news/bugfix-3145.md
+++ b/news/bugfix-3145.md
@@ -1,0 +1,1 @@
+`network tls`: Properly log an error message, when `key-file()` or `cert-file()` is missing.

--- a/news/feature-3145.md
+++ b/news/feature-3145.md
@@ -1,0 +1,1 @@
+`network tls`: Added `ca-file()` option. With this option the user can set a bundled CA-file to verify the peer.


### PR DESCRIPTION
With this option, users can specify a CA-file, which holds the certificates in a bundle file.
e.g.: `ca-file("/etc/pki/tls/certs/ca-bundle.crt")`

Can be used parallelly with the `ca-dir()` option.

Fixes #3111

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>