### PR TITLE
loggen: fix crash with invalid parameterization

### DIFF
--- a/news/bugfix-3146.md
+++ b/news/bugfix-3146.md
@@ -1,0 +1,1 @@
+loggen: fix crash with invalid parameterization

--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -230,7 +230,7 @@ stop_plugins(GPtrArray *plugin_array)
         plugin->stop_plugin((gpointer)&global_plugin_option);
     }
 
-  DEBUG("all plugins have been stoped\n");
+  DEBUG("all plugins have been stopped\n");
 }
 
 static void

--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -322,7 +322,9 @@ start_plugins(GPtrArray *plugin_array)
 
       if (plugin->start_plugin && plugin->is_plugin_activated())
         {
-          plugin->start_plugin((gpointer)&global_plugin_option);
+          if (!plugin->start_plugin((gpointer)&global_plugin_option))
+            return 0;
+
           break;
         }
     }

--- a/tests/loggen/loggen_plugin.h
+++ b/tests/loggen/loggen_plugin.h
@@ -55,7 +55,7 @@ typedef struct _thread_data
 } ThreadData;
 
 typedef GOptionEntry *(*get_option_func)(void);
-typedef void (*start_plugin_func)(PluginOption *option);
+typedef gboolean (*start_plugin_func)(PluginOption *option);
 typedef void (*stop_plugin_func)(PluginOption *option);
 typedef int (*generate_message_func)(char *buffer, int buffer_size, int thread_id, unsigned long seq);
 typedef void (*set_generate_message_func)(generate_message_func gen_message);

--- a/tests/loggen/socket_plugin/socket_plugin.c
+++ b/tests/loggen/socket_plugin/socket_plugin.c
@@ -238,7 +238,7 @@ stop(PluginOption *option)
   if (thread_lock)
     g_mutex_free(thread_lock);
 
-  DEBUG("all %d+%d threads have been stoped\n",
+  DEBUG("all %d+%d threads have been stopped\n",
         option->active_connections,
         option->idle_connections);
 }

--- a/tests/loggen/socket_plugin/socket_plugin.c
+++ b/tests/loggen/socket_plugin/socket_plugin.c
@@ -41,7 +41,7 @@
 #include <stdlib.h>
 #include <errno.h>
 
-static void           start(PluginOption *option);
+static gboolean       start(PluginOption *option);
 static void           stop(PluginOption *option);
 static gpointer       active_thread_func(gpointer user_data);
 static gpointer       idle_thread_func(gpointer user_data);
@@ -124,30 +124,30 @@ get_options(void)
   return loggen_options;
 }
 
-static void
+static gboolean
 start(PluginOption *option)
 {
   if (!option)
     {
       ERROR("invalid option refernce\n");
-      return;
+      return FALSE;
     }
 
   if (!is_plugin_activated())
-    return;
+    return TRUE;
 
   if (unix_socket_x)
     {
       if (!option->target)
         {
           ERROR("in case of unix domain socket please specify target parameter\n");
-          return;
+          return FALSE;
         }
     }
   else if (!option->target || !option->port)
     {
       ERROR("in case of TCP or UDP socket please specify target and port parameters\n");
-      return;
+      return FALSE;
     }
 
   DEBUG("plugin (%d,%d,%d,%d)start\n",
@@ -206,6 +206,8 @@ start(PluginOption *option)
   g_cond_broadcast(thread_start);
   thread_run = TRUE;
   g_mutex_unlock(thread_lock);
+
+  return TRUE;
 }
 
 static void

--- a/tests/loggen/ssl_plugin/ssl_plugin.c
+++ b/tests/loggen/ssl_plugin/ssl_plugin.c
@@ -42,7 +42,7 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
-static void           start(PluginOption *option);
+static gboolean       start(PluginOption *option);
 static void           stop(PluginOption *option);
 static gpointer       active_thread_func(gpointer user_data);
 static gpointer       idle_thread_func(gpointer user_data);
@@ -118,22 +118,22 @@ get_options(void)
   return loggen_options;
 }
 
-static void
+static gboolean
 start(PluginOption *option)
 {
   if (!option)
     {
       ERROR("invalid option refernce\n");
-      return;
+      return FALSE;
     }
 
   if (!is_plugin_activated())
-    return;
+    return TRUE;
 
   if (!option->target || !option->port)
     {
       ERROR("please specify target and port parameters\n");
-      return;
+      return FALSE;
     }
 
   DEBUG("plugin (%d,%d,%d,%d)start\n",
@@ -195,6 +195,8 @@ start(PluginOption *option)
   thread_run = TRUE;
 
   g_mutex_unlock(thread_lock);
+
+  return TRUE;
 }
 
 static void

--- a/tests/loggen/ssl_plugin/ssl_plugin.c
+++ b/tests/loggen/ssl_plugin/ssl_plugin.c
@@ -235,7 +235,7 @@ stop(PluginOption *option)
   if (thread_connected)
     g_cond_free(thread_connected);
 
-  DEBUG("all %d+%d threads have been stoped\n",
+  DEBUG("all %d+%d threads have been stopped\n",
         option->active_connections,
         option->idle_connections);
 }


### PR DESCRIPTION
`../bin/loggen -S --active-connections=10 -I 120` caused crash in
loggen, because mandatory parameters were not passed: ip and port.

The reason is even if a module cannot start, stop was still called. In
our specific case, thread_array was accessed in stop, even though it
was not initialized in start (because start returned earlier due to error).

The fix is that start returns boolean now. Stop is only called a
plugin is started.
