### PR TITLE
python3: store strings as str instead of bytes

### DIFF
--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -100,7 +100,7 @@ _py_log_message_subscript(PyObject *o, PyObject *key)
 
   APPEND_ZERO(value, value, value_len);
 
-  return PyBytes_FromString(value);
+  return _py_string_from_string(value, -1);
 }
 
 static int
@@ -200,7 +200,7 @@ _collect_nvpair_names_from_logmsg(NVHandle handle, const gchar *name, const gcha
 {
   PyObject *list = (PyObject *)user_data;
 
-  PyObject *py_name = PyBytes_FromString(name);
+  PyObject *py_name = _py_string_from_string(name, -1);
   PyList_Append(list, py_name);
   Py_XDECREF(py_name);
 
@@ -241,7 +241,7 @@ _collect_macro_names(gpointer key, gpointer value, gpointer user_data)
 
   if (_is_macro_name_visible_to_user(logmsg, name))
     {
-      PyObject *py_name = PyBytes_FromString(name);
+      PyObject *py_name = _py_string_from_string(name, -1);
       PyList_Append(list, py_name);
       Py_XDECREF(py_name);
     }

--- a/modules/python/python-tf.c
+++ b/modules/python/python-tf.c
@@ -38,7 +38,7 @@ _py_construct_args_tuple(LogMessage *msg, gint argc, GString *argv[])
   PyTuple_SetItem(args, 0, py_log_message_new(msg));
   for (i = 1; i < argc; i++)
     {
-      PyTuple_SetItem(args, i, PyBytes_FromString(argv[i]->str));
+      PyTuple_SetItem(args, i, _py_string_from_string(argv[i]->str, -1));
     }
   return args;
 }

--- a/modules/python/python-value-pairs.c
+++ b/modules/python/python-value-pairs.c
@@ -51,7 +51,7 @@ add_string_to_dict(PyObject *dict, const gchar *name, const char *value, gsize v
 {
   gchar buf[256];
 
-  PyObject *pyobject_to_add = PyBytes_FromStringAndSize(value, value_len);
+  PyObject *pyobject_to_add = _py_string_from_string(value, value_len);
   if (!pyobject_to_add)
     {
       msg_error("Error while constructing python object",

--- a/news/bugfix-3153.md
+++ b/news/bugfix-3153.md
@@ -1,0 +1,4 @@
+`python`: message interface changed to unicode from bytes in Python 3
+
+Prior this change, the type of an object like `msg["MSG"]` was Bytes in Python. However, typically `LogMessage` carries strings, which causes inconvenience, because users need to explicitely convert to string (unicode), using `str()` or `.decode()`. This change simplifies the api by converting to unicode automatically.
+Only Python3 is affected. In Python2 Bytes and string is the same, so there was no need for explicit conversion.


### PR DESCRIPTION
Previously, we used `PyBytes_FromStringAndSize()`, and it was only tested with `python2`.

Our example `python()` destination has this `send()`:
```
def send(self, msg):
    with open('test-python.log', 'a') as f:
        f.write('{DATE} {HOST} {MSGHDR}{MSG}\n'.format(**msg))
```

In `python2` it does not matter, if we fill the `msg` dict with `bytes`-like data (which is generated with `PyBytes_FromStringAndSize()`), the `test-python.log` file will be written in `text` mode insead of `byte` mode, because it is the default.
However, in `python3` when we open the file in the default `text` mode, and we write `bytes`-like object in it, the output will still be in `byte` mode.

This causes a different behavior, which is fixed by storing the data in `text` mode, with `_py_string_from_string()`.

The same logic applies to the other uses of `PyBytes_FromStringAndSize()` as well. 

**! IMPORTANT !
Please note that this change might need a change in your existing `python3` based class regarding string handling.**

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>