### PR TITLE
LightReportDir: Support to define report dir with any path

### DIFF
--- a/news/developer-note-3157.md
+++ b/news/developer-note-3157.md
@@ -1,0 +1,3 @@
+LightReports: Support to relocate reports dir other than current base dir
+This will work:
+`python -m pytest -lvs functional_tests/source_drivers/file_source/test_acceptance.py --installdir=/install --reports /tmp/`

--- a/tests/python_functional/functional_tests/conftest.py
+++ b/tests/python_functional/functional_tests/conftest.py
@@ -37,8 +37,12 @@ def calculate_report_file_path(working_dir):
 
 
 def calculate_working_dir(pytest_config_object, testcase_name):
-    report_dir = Path(pytest_config_object.getoption("--reports")).absolute()
+    report_dir = Path(pytest_config_object.getoption("--reports")).resolve().absolute()
     return Path(report_dir, calculate_testcase_name(testcase_name))
+
+
+def working_dir_and_current_dir_has_common_base(working_dir):
+    return str(working_dir).startswith(str(Path.cwd()))
 
 
 def pytest_runtest_setup(item):
@@ -46,7 +50,16 @@ def pytest_runtest_setup(item):
     tc_parameters.WORKING_DIR = working_dir = calculate_working_dir(item.config, item.name)
     logging_plugin.set_log_path(calculate_report_file_path(working_dir))
     item.user_properties.append(("working_dir", working_dir))
-    item.user_properties.append(("relative_working_dir", working_dir.relative_to(Path.cwd())))
+    if working_dir_and_current_dir_has_common_base(working_dir):
+        # relative path for working dir could be calculeted from current directory
+        relative_working_dir = working_dir.relative_to(Path.cwd())
+        item.user_properties.append(("relative_working_dir", relative_working_dir))
+    else:
+        # relative path for working dir could not be calculeted from current directory
+        if len(str(working_dir)) + len("syslog_ng_server.ctl") > 108:
+            # #define UNIX_PATH_MAX	108 (cat /usr/include/linux/un.h | grep "define UNIX_PATH_MAX)"
+            raise ValueError("Working directory lenght is too long, some socket files could not be saved, please make it shorter")
+        item.user_properties.append(("relative_working_dir", working_dir))
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Before this patch we can not started Light with such report dir (the given directory has different base  than current directoy): `/tmp`
```consoe
python -m pytest -lvs functional_tests/source_drivers/file_source/test_acceptance.py --installdir=/install --reports /tmp/
```

we have got such an exception:
```
        n = len(to_abs_parts)
        cf = self._flavour.casefold_parts
        if (root or drv) if n == 0 else cf(abs_parts[:n]) != cf(to_abs_parts):
            formatted = self._format_parsed_parts(to_drv, to_root, to_parts)
            raise ValueError("{0!r} does not start with {1!r}"
>                            .format(str(self), str(formatted)))
E           ValueError: '/tmp/test_acceptance_with_ten_logs_' does not start with '/source/tests/python_functional'
```

After this patch it will work correctly, this report dir will work also: `../../../tmp`
