### PR TITLE
Http/response received signal

### DIFF
--- a/modules/http/http-signals.h
+++ b/modules/http/http-signals.h
@@ -29,6 +29,7 @@
 #include "list-adt.h"
 
 typedef struct _HttpHeaderRequestSignalData HttpHeaderRequestSignalData;
+typedef struct _HttpResponseReceivedSignalData HttpResponseReceivedSignalData;
 
 typedef enum
 {
@@ -44,6 +45,13 @@ struct _HttpHeaderRequestSignalData
   GString *request_body;
 };
 
+struct _HttpResponseReceivedSignalData
+{
+  glong http_code;
+};
+
 #define signal_http_header_request SIGNAL(http, header_request, HttpHeaderRequestSignalData *)
+
+#define signal_http_response_received SIGNAL(http, response_received, HttpResponseReceivedSignalData *)
 
 #endif

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -618,6 +618,13 @@ _flush_on_target(HTTPDestinationWorker *self, HTTPLoadBalancerTarget *target)
   if (debug_flag)
     _debug_response_info(self, target, http_code);
 
+  HttpResponseReceivedSignalData signal_data =
+  {
+    .http_code = http_code
+  };
+
+  EMIT(owner->super.super.super.super.signal_slot_connector, signal_http_response_received, &signal_data);
+
   if (http_code == 401 && owner->auth_header)
     return _renew_header(owner);
 

--- a/modules/python/python-http-header.c
+++ b/modules/python/python-http-header.c
@@ -48,6 +48,7 @@ struct _PythonHttpHeaderPlugin
     PyObject *class;
     PyObject *instance;
     PyObject *get_headers;
+    PyObject *on_http_response_received;
   } py;
 };
 
@@ -216,11 +217,23 @@ _py_attach_get_headers(PythonHttpHeaderPlugin *self)
 }
 
 static gboolean
+_py_attach_on_http_response_received(PythonHttpHeaderPlugin *self)
+{
+  self->py.on_http_response_received = _py_get_attr_or_null(self->py.instance, "on_http_response_received");
+
+  /*
+   * on_http_response_received is an optional method
+   * */
+  return TRUE;
+}
+
+static gboolean
 _py_attach_bindings(PythonHttpHeaderPlugin *self)
 {
   return _py_attach_class(self) &&
          _py_instantiate_class(self) &&
-         _py_attach_get_headers(self);
+         _py_attach_get_headers(self) &&
+         _py_attach_on_http_response_received(self);
 }
 
 static void
@@ -229,6 +242,7 @@ _py_detach_bindings(PythonHttpHeaderPlugin *self)
   Py_CLEAR(self->py.class);
   Py_CLEAR(self->py.instance);
   Py_CLEAR(self->py.get_headers);
+  Py_CLEAR(self->py.on_http_response_received);
 }
 
 static void

--- a/modules/python/python-http-header.c
+++ b/modules/python/python-http-header.c
@@ -355,6 +355,18 @@ fail:
   return FALSE;
 }
 
+static void
+_connect_http_header_request_slot(LogDriverPlugin *s, SignalSlotConnector *ssc)
+{
+  PythonHttpHeaderPlugin *self = (PythonHttpHeaderPlugin *) s;
+  CONNECT(ssc, signal_http_header_request, _append_headers, self);
+
+  msg_debug("SignalSlotConnector slot registered",
+            evt_tag_printf("signal", "%p", ssc),
+            evt_tag_printf("plugin_name", "%s", PYTHON_HTTP_HEADER_PLUGIN),
+            evt_tag_printf("plugin_instance", "%p", s));
+}
+
 static gboolean
 _attach(LogDriverPlugin *s, LogDriver *driver)
 {
@@ -369,13 +381,7 @@ _attach(LogDriverPlugin *s, LogDriver *driver)
     }
 
   SignalSlotConnector *ssc = driver->super.signal_slot_connector;
-
-  CONNECT(ssc, signal_http_header_request, _append_headers, self);
-
-  msg_debug("SignalSlotConnector slot registered",
-            evt_tag_printf("signal", "%p", ssc),
-            evt_tag_printf("plugin_name", "%s", PYTHON_HTTP_HEADER_PLUGIN),
-            evt_tag_printf("plugin_instance", "%p", s));
+  _connect_http_header_request_slot(s, ssc);
 
   return TRUE;
 }

--- a/modules/python/python-http-header.c
+++ b/modules/python/python-http-header.c
@@ -368,7 +368,8 @@ _connect_http_header_request_slot(LogDriverPlugin *s, SignalSlotConnector *ssc)
   CONNECT(ssc, signal_http_header_request, _append_headers, self);
 
   msg_debug("SignalSlotConnector slot registered",
-            evt_tag_printf("signal", "%p", ssc),
+            evt_tag_printf("connector", "%p", ssc),
+            evt_tag_printf("signal", "%s", signal_http_header_request),
             evt_tag_printf("plugin_name", "%s", PYTHON_HTTP_HEADER_PLUGIN),
             evt_tag_printf("plugin_instance", "%p", s));
 }

--- a/modules/python/python-http-header.c
+++ b/modules/python/python-http-header.c
@@ -338,6 +338,12 @@ cleanup:
     }
 }
 
+static void
+_on_http_response_received(PythonHttpHeaderPlugin *self, HttpResponseReceivedSignalData *data)
+{
+  //TODO
+}
+
 static gboolean
 _init(PythonHttpHeaderPlugin *self)
 {
@@ -367,6 +373,19 @@ _connect_http_header_request_slot(LogDriverPlugin *s, SignalSlotConnector *ssc)
             evt_tag_printf("plugin_instance", "%p", s));
 }
 
+static void
+_connect_http_response_received_slot(LogDriverPlugin *s, SignalSlotConnector *ssc)
+{
+  PythonHttpHeaderPlugin *self = (PythonHttpHeaderPlugin *) s;
+  CONNECT(ssc, signal_http_response_received, _on_http_response_received, self);
+
+  msg_debug("SignalSlotConnector slot registered",
+            evt_tag_printf("connector", "%p", ssc),
+            evt_tag_printf("signal", "%s", signal_http_response_received),
+            evt_tag_printf("plugin_name", "%s", PYTHON_HTTP_HEADER_PLUGIN),
+            evt_tag_printf("plugin_instance", "%p", s));
+}
+
 static gboolean
 _attach(LogDriverPlugin *s, LogDriver *driver)
 {
@@ -382,6 +401,7 @@ _attach(LogDriverPlugin *s, LogDriver *driver)
 
   SignalSlotConnector *ssc = driver->super.signal_slot_connector;
   _connect_http_header_request_slot(s, ssc);
+  _connect_http_response_received_slot(s, ssc);
 
   return TRUE;
 }

--- a/news/feature-3159.md
+++ b/news/feature-3159.md
@@ -1,0 +1,64 @@
+http: When a HTTP response is received, emit a signal with the HTTP response code.
+(Later it can be extended to read the response and parse it in a slot...).
+
+This PR also extends the Python HTTP header module with the possibility of writing custom HTTP response code handlers. When someone implements an auth header plugin in Python, it could be useful (for example invalidating a cache).
+
+<details>
+  <summary>Example config, click to expand!</summary>
+
+```
+
+@version: 3.25
+
+python {
+from syslogng import Logger
+
+logger = Logger()
+
+class TestCounter():
+    def __init__(self, options):
+        self.header = options["header"]
+        self.counter = int(options["counter"])
+        logger.debug(f"TestCounter class instantiated; options={options}")
+
+    def get_headers(self, body, headers):
+        logger.debug(f"get_headers() called, received body={body}, headers={headers}")
+       
+        response = ["{}: {}".format(self.header, self.counter)]
+        self.counter += 1
+        return response
+
+    def on_http_response_received(self, http_code):
+        self.counter += http_code
+        logger.debug("HTTP response code received: {}".format(http_code))
+
+    def __del__(self):
+        logger.debug("Deleting TestCounter class instance")
+};
+
+source s_network {
+  network(port(5555));
+};
+
+destination d_http {
+    http(
+        python_http_header(
+            class("TestCounter")
+            options("header", "X-Test-Python-Counter")
+            options("counter", 11)
+            # this means that syslog-ng will trying to send the http request even when this module fails
+            mark-errors-as-critical(no)
+        )
+        url("http://127.0.0.1:8888")
+    );
+};
+
+log {
+    source(s_network);
+    destination(d_http);
+    flags(flow-control);
+};
+```
+</details>
+
+


### PR DESCRIPTION
When a HTTP response is received, emit a signal with the HTTP response code.
(Later HTTP module could be extended to read the response and parse it in a slot...).

This PR also extends the Python HTTP header module with the possibility of writing custom HTTP response code handlers. When someone implements an auth header plugin in Python, it could be useful (for example invalidating a cache).

<details>
  <summary>Example config, click to expand!</summary>

```

@version: 3.25

python {
from syslogng import Logger

logger = Logger()

class TestCounter():
    def __init__(self, options):
        self.header = options["header"]
        self.counter = int(options["counter"])
        logger.debug(f"TestCounter class instantiated; options={options}")

    def get_headers(self, body, headers):
        logger.debug(f"get_headers() called, received body={body}, headers={headers}")
       
        response = ["{}: {}".format(self.header, self.counter)]
        self.counter += 1
        return response

    def on_http_response_received(self, http_code):
        self.counter += http_code
        logger.debug("HTTP response code received: {}".format(http_code))

    def __del__(self):
        logger.debug("Deleting TestCounter class instance")
};

source s_network {
  network(port(5555));
};

destination d_http {
    http(
        python_http_header(
            class("TestCounter")
            options("header", "X-Test-Python-Counter")
            options("counter", 11)
            # this means that syslog-ng will trying to send the http request even when this module fails
            mark-errors-as-critical(no)
        )
        url("http://127.0.0.1:8888")
    );
};

log {
    source(s_network);
    destination(d_http);
    flags(flow-control);
};
```
</details>

