### PR TITLE
java/python: added support for the "arrow" syntax

### DIFF
--- a/modules/java/native/java-grammar.ym
+++ b/modules/java/native/java-grammar.ym
@@ -49,7 +49,7 @@
 %token KW_JAVA
 %token KW_CLASS_PATH
 %token KW_CLASS_NAME
-%token KW_OPTION
+%token KW_OPTIONS
 %token KW_JVM_OPTIONS
 
 %%
@@ -85,7 +85,7 @@ java_dest_option
                         "named templates are not supported in java destination");
             java_dd_set_template_string(last_driver, $3); free($3);
           }
-        | KW_OPTION '(' java_dest_custom_options ')'
+        | KW_OPTIONS '(' java_dest_custom_options ')'
         | threaded_dest_driver_option
         | { last_template_options = java_dd_get_template_options(last_driver); } template_option
         ;
@@ -97,6 +97,8 @@ java_dest_custom_options
 
 java_dest_custom_option
   : string string_or_number { java_dd_set_option(last_driver, $1, $2); free($1); free($2); }
+  | string LL_ARROW string_or_number { java_dd_set_option(last_driver, $1, $3); free($1); free($3); }
+  ;
 
 java_global_option
         : KW_JVM_OPTIONS '(' string ')' {java_config_set_jvm_options(configuration, g_strdup($3)); free($3);}

--- a/modules/java/native/java-parser.c
+++ b/modules/java/native/java-parser.c
@@ -32,8 +32,8 @@ static CfgLexerKeyword java_keywords[] =
   { "java",        KW_JAVA },
   { "class_path",  KW_CLASS_PATH},
   { "class_name",  KW_CLASS_NAME},
-  { "option",      KW_OPTION},
-
+  { "option",      KW_OPTIONS, KWS_OBSOLETE, "The option() argument has been obsoleted in favour of options()" },
+  { "options",     KW_OPTIONS},
   { "jvm_options", KW_JVM_OPTIONS},
   { NULL }
 };

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -139,8 +139,13 @@ python_dd_custom_option
           free($1);
           free($2);
         }
+	| string LL_ARROW string_or_number
+        {
+          python_dd_set_option(last_driver, $1, $3);
+          free($1);
+          free($3);
+        }
         ;
-
 
 python_sd_options
         : python_sd_option python_sd_options

--- a/news/feature-3161.md
+++ b/news/feature-3161.md
@@ -1,0 +1,1 @@
+`java/python`: add support for the "arrow" syntax.


### PR DESCRIPTION
resolves #3105 