### PR TITLE
python: Revert #3153

### DIFF
--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -100,7 +100,7 @@ _py_log_message_subscript(PyObject *o, PyObject *key)
 
   APPEND_ZERO(value, value, value_len);
 
-  return _py_string_from_string(value, -1);
+  return PyBytes_FromString(value);
 }
 
 static int
@@ -200,7 +200,7 @@ _collect_nvpair_names_from_logmsg(NVHandle handle, const gchar *name, const gcha
 {
   PyObject *list = (PyObject *)user_data;
 
-  PyObject *py_name = _py_string_from_string(name, -1);
+  PyObject *py_name = PyBytes_FromString(name);
   PyList_Append(list, py_name);
   Py_XDECREF(py_name);
 
@@ -241,7 +241,7 @@ _collect_macro_names(gpointer key, gpointer value, gpointer user_data)
 
   if (_is_macro_name_visible_to_user(logmsg, name))
     {
-      PyObject *py_name = _py_string_from_string(name, -1);
+      PyObject *py_name = PyBytes_FromString(name);
       PyList_Append(list, py_name);
       Py_XDECREF(py_name);
     }

--- a/modules/python/python-tf.c
+++ b/modules/python/python-tf.c
@@ -38,7 +38,7 @@ _py_construct_args_tuple(LogMessage *msg, gint argc, GString *argv[])
   PyTuple_SetItem(args, 0, py_log_message_new(msg));
   for (i = 1; i < argc; i++)
     {
-      PyTuple_SetItem(args, i, _py_string_from_string(argv[i]->str, -1));
+      PyTuple_SetItem(args, i, PyBytes_FromString(argv[i]->str));
     }
   return args;
 }

--- a/modules/python/python-value-pairs.c
+++ b/modules/python/python-value-pairs.c
@@ -51,7 +51,7 @@ add_string_to_dict(PyObject *dict, const gchar *name, const char *value, gsize v
 {
   gchar buf[256];
 
-  PyObject *pyobject_to_add = _py_string_from_string(value, value_len);
+  PyObject *pyobject_to_add = PyBytes_FromStringAndSize(value, value_len);
   if (!pyobject_to_add)
     {
       msg_error("Error while constructing python object",

--- a/tests/functional/sngtestmod.py
+++ b/tests/functional/sngtestmod.py
@@ -39,6 +39,7 @@ class DestTest(object):
 
     def send(self, msg):
         with open('test-python.log', 'a') as f:
+            msg = dict(map(lambda entry: (entry[0], entry[1].decode()), msg.items()))
             f.write('{DATE} {HOST} {MSGHDR}{MSG}\n'.format(**msg))
 
         return True


### PR DESCRIPTION
We decided to keep the `bytes` type data.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>