### PR TITLE
signal-slot-connector: fix compile error with old glib

### DIFF
--- a/lib/compat/glib.c
+++ b/lib/compat/glib.c
@@ -303,4 +303,15 @@ g_base64_encode_fixed(const guchar *data, gsize len)
 
   return (gchar *) out;
 }
+
+#endif
+
+#if !GLIB_CHECK_VERSION(2, 40, 0)
+gboolean
+slng_g_hash_table_insert(GHashTable *hash_table, gpointer key, gpointer value)
+{
+  gboolean exists = g_hash_table_contains(hash_table, key);
+  g_hash_table_insert(hash_table, key, value);
+  return exists;
+}
 #endif

--- a/lib/compat/glib.h
+++ b/lib/compat/glib.h
@@ -104,4 +104,9 @@ g_hash_table_contains (GHashTable    *hash_table,
 gchar *g_base64_encode_fixed(const guchar *data, gsize len);
 #endif
 
+#if !GLIB_CHECK_VERSION(2, 40, 0)
+#define g_hash_table_insert slng_g_hash_table_insert
+gboolean slng_g_hash_table_insert (GHashTable *hash_table, gpointer key, gpointer value);
+#endif
+
 #endif

--- a/lib/signal-slot-connector/signal-slot-connector.c
+++ b/lib/signal-slot-connector/signal-slot-connector.c
@@ -267,4 +267,3 @@ signal_slot_connector_free(SignalSlotConnector *self)
   g_hash_table_unref(self->connections);
   g_free(self);
 }
-

--- a/tests/loggen/CMakeLists.txt
+++ b/tests/loggen/CMakeLists.txt
@@ -60,6 +60,7 @@ set(LOGGEN_SOURCE
     logline_generator.h
     ${PROJECT_SOURCE_DIR}/lib/reloc.c
     ${PROJECT_SOURCE_DIR}/lib/cache.c
+    ${PROJECT_SOURCE_DIR}/lib/compat/glib.c
     )
 
 add_executable(loggen ${LOGGEN_SOURCE})

--- a/tests/loggen/Makefile.am
+++ b/tests/loggen/Makefile.am
@@ -60,7 +60,8 @@ tests_loggen_loggen_SOURCES	=	\
 	tests/loggen/logline_generator.c \
 	tests/loggen/logline_generator.h \
 	lib/reloc.c \
-	lib/cache.c
+	lib/cache.c \
+	lib/compat/glib.c
 
 tests_loggen_loggen_LDADD	= \
 	@GLIB_LIBS@ \


### PR DESCRIPTION
In glib 2.28 (centos6), g_hash_table_insert is a void function

No change note is necessary.