### PR TITLE
python: persist api

### DIFF
--- a/modules/python/compat/compat-python-v2.c
+++ b/modules/python/compat/compat-python-v2.c
@@ -66,3 +66,9 @@ pyobject_as_int(PyObject *object)
 {
   return PyInt_AsLong(object);
 };
+
+gboolean
+py_object_is_integer(PyObject *object)
+{
+  return PyLong_Check(object) || PyInt_Check(object);
+}

--- a/modules/python/compat/compat-python-v3.c
+++ b/modules/python/compat/compat-python-v3.c
@@ -66,3 +66,9 @@ pyobject_as_int(PyObject *object)
 {
   return PyLong_AsLong(object);
 };
+
+gboolean
+py_object_is_integer(PyObject *object)
+{
+  return PyLong_Check(object);
+}

--- a/modules/python/compat/compat-python.h
+++ b/modules/python/compat/compat-python.h
@@ -47,4 +47,6 @@ void py_init_argv(void);
 PyObject *int_as_pyobject(gint num);
 
 gint pyobject_as_int(PyObject *object);
+gboolean py_object_is_integer(PyObject *object);
+
 #endif

--- a/modules/python/pylib/syslogng/__init__.py
+++ b/modules/python/pylib/syslogng/__init__.py
@@ -27,6 +27,16 @@ try:
     from _syslogng import LogSource, LogFetcher
     from _syslogng import LogTemplate, LogTemplateException, LTZ_LOCAL, LTZ_SEND
     from _syslogng import Logger
-    from _syslogng import Persist
+    from _syslogng import Persist as SlngPersist
+
+    class Persist(SlngPersist):
+        def __init__(self, persist_name, defaults=None):
+            super(Persist, self).__init__(persist_name)
+
+            if defaults:
+                for key, value in defaults.items():
+                    if key not in self:
+                        self[key] = value
+
 except ImportError:
     print("The syslogng package can only be used in syslog-ng.")

--- a/modules/python/pylib/syslogng/__init__.py
+++ b/modules/python/pylib/syslogng/__init__.py
@@ -27,5 +27,6 @@ try:
     from _syslogng import LogSource, LogFetcher
     from _syslogng import LogTemplate, LogTemplateException, LTZ_LOCAL, LTZ_SEND
     from _syslogng import Logger
+    from _syslogng import Persist
 except ImportError:
     print("The syslogng package can only be used in syslog-ng.")

--- a/modules/python/python-config.c
+++ b/modules/python/python-config.c
@@ -32,8 +32,9 @@ python_config_init(ModuleConfig *s, GlobalConfig *cfg)
 {
   PythonConfig *self = (PythonConfig *) s;
 
-  PyGILState_STATE gstate;
+  propagate_persist_state(cfg);
 
+  PyGILState_STATE gstate;
   gstate = PyGILState_Ensure();
   _py_switch_main_module(self);
   PyGILState_Release(gstate);

--- a/modules/python/python-main.c
+++ b/modules/python/python-main.c
@@ -193,3 +193,14 @@ python_evaluate_global_code(GlobalConfig *cfg, const gchar *code, YYLTYPE *yyllo
 
   return result;
 }
+
+void
+propagate_persist_state(GlobalConfig *cfg)
+{
+  g_assert(cfg->state);
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  g_assert(PyModule_AddObject(PyImport_AddModule("_syslogng"),
+                              "persist_state",
+                              PyCapsule_New(cfg->state, "_syslogng.persist_state", NULL)) == 0);
+  PyGILState_Release(gstate);
+}

--- a/modules/python/python-main.h
+++ b/modules/python/python-main.h
@@ -30,6 +30,6 @@ PyObject *_py_get_current_main_module(void);
 PyObject *_py_get_main_module(PythonConfig *pc);
 void _py_switch_main_module(PythonConfig *pc);
 gboolean python_evaluate_global_code(GlobalConfig *cfg, const gchar *code, YYLTYPE *yylloc);
-
+void propagate_persist_state(GlobalConfig *cfg);
 
 #endif

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -46,8 +46,11 @@ typedef enum
 typedef struct
 {
   guint8 type;
-  gchar data[];
+  gchar data[0];
 } Entry;
+
+/* Ensure there is no padding between type and data */
+G_STATIC_ASSERT(offsetof(Entry, data) == sizeof(guint8) + offsetof(Entry, type));
 
 static PyObject *
 entry_to_pyobject(guint8 type, gchar *value)

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -26,6 +26,8 @@
 #include "driver.h"
 #include "mainloop.h"
 
+#include <structmember.h>
+
 static PyObject *
 _call_generate_persist_name_method(PythonPersistMembers *options)
 {
@@ -168,6 +170,13 @@ py_persist_dealloc(PyObject *s)
   py_slng_generic_dealloc(s);
 }
 
+static PyMemberDef
+py_persist_type_members[] =
+{
+  {"persist_name", T_STRING, offsetof(PyPersist, persist_name), READONLY},
+  {NULL}
+};
+
 PyTypeObject py_persist_type =
 {
   PyVarObject_HEAD_INIT(&PyType_Type, 0)
@@ -178,6 +187,7 @@ PyTypeObject py_persist_type =
   .tp_doc = "Persist class encapsulates persist handling",
   .tp_new = PyType_GenericNew,
   .tp_init = _persist_type_init,
+  .tp_members = py_persist_type_members,
   0,
 };
 

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -23,6 +23,7 @@
 #include "python-persist.h"
 #include "python-helpers.h"
 #include "driver.h"
+#include "mainloop.h"
 
 static PyObject *
 _call_generate_persist_name_method(PythonPersistMembers *options)
@@ -128,15 +129,47 @@ python_format_persist_name(const LogPipe *p, const gchar *module, PythonPersistM
   return persist_name;
 }
 
+static int
+_persist_type_init(PyObject *s, PyObject *args, PyObject *kwds)
+{
+  PyPersist *self =(PyPersist *)s;
+  const gchar *persist_name=NULL;
+
+  GlobalConfig *cfg = main_loop_get_current_config(main_loop_get_instance());
+  self->persist_state = cfg->state;
+
+  static char *kwlist[] = {"persist_name", NULL};
+
+  if (! PyArg_ParseTupleAndKeywords(args, kwds, "s", kwlist, &persist_name))
+    return -1;
+
+  if (!self->persist_name)
+    self->persist_name = g_strdup(persist_name);
+
+  return 0;
+}
+
+static void
+py_persist_dealloc(PyObject *s)
+{
+  PyPersist *self =(PyPersist *)s;
+
+  g_free(self->persist_name);
+  self->persist_name = NULL;
+
+  py_slng_generic_dealloc(s);
+}
+
 PyTypeObject py_persist_type =
 {
   PyVarObject_HEAD_INIT(&PyType_Type, 0)
   .tp_name = "Persist",
   .tp_basicsize = sizeof(PyPersist),
-  .tp_dealloc = py_slng_generic_dealloc,
+  .tp_dealloc = py_persist_dealloc,
   .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
   .tp_doc = "Persist class encapsulates persist handling",
   .tp_new = PyType_GenericNew,
+  .tp_init = _persist_type_init,
   0,
 };
 
@@ -144,4 +177,5 @@ void
 py_persist_init(void)
 {
   PyType_Ready(&py_persist_type);
+  PyModule_AddObject(PyImport_AddModule("_syslogng"), "Persist", (PyObject *) &py_persist_type);
 }

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -127,3 +127,21 @@ python_format_persist_name(const LogPipe *p, const gchar *module, PythonPersistM
 
   return persist_name;
 }
+
+PyTypeObject py_persist_type =
+{
+  PyVarObject_HEAD_INIT(&PyType_Type, 0)
+  .tp_name = "Persist",
+  .tp_basicsize = sizeof(PyPersist),
+  .tp_dealloc = py_slng_generic_dealloc,
+  .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+  .tp_doc = "Persist class encapsulates persist handling",
+  .tp_new = PyType_GenericNew,
+  0,
+};
+
+void
+py_persist_init(void)
+{
+  PyType_Ready(&py_persist_type);
+}

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -220,8 +220,16 @@ _persist_type_init(PyObject *s, PyObject *args, PyObject *kwds)
   PyPersist *self =(PyPersist *)s;
   const gchar *persist_name=NULL;
 
-  GlobalConfig *cfg = main_loop_get_current_config(main_loop_get_instance());
-  self->persist_state = cfg->state;
+  self->persist_state = PyCapsule_Import("_syslogng.persist_state", FALSE);
+  if (!self->persist_state)
+    {
+      gchar buf[256];
+      msg_error("Error importing persist_state",
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+      _py_finish_exception_handling();
+
+      g_assert_not_reached();
+    }
 
   static char *kwlist[] = {"persist_name", NULL};
 

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -22,6 +22,7 @@
 
 #include "python-persist.h"
 #include "python-helpers.h"
+#include "syslog-ng.h"
 #include "driver.h"
 #include "mainloop.h"
 
@@ -142,6 +143,13 @@ _persist_type_init(PyObject *s, PyObject *args, PyObject *kwds)
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "s", kwlist, &persist_name))
     return -1;
+
+  if (g_strstr_len(persist_name, -1, "##"))
+    {
+      // Internally, we will store subkeys as persist_name##subkey
+      PyErr_Format(PyExc_ValueError, "persist name cannot contain ##");
+      return -1;
+    }
 
   if (!self->persist_name)
     self->persist_name = g_strdup(persist_name);

--- a/modules/python/python-persist.h
+++ b/modules/python/python-persist.h
@@ -28,12 +28,20 @@
 
 typedef struct
 {
+  PyObject_HEAD
+} PyPersist;
+
+extern PyTypeObject py_persist_type;
+
+typedef struct
+{
   PyObject *generate_persist_name_method;
   GHashTable *options;
   const gchar *class;
   const gchar *id;
 } PythonPersistMembers;
 
+void py_persist_init(void);
 const gchar *python_format_stats_instance(LogPipe *p, const gchar *module, PythonPersistMembers *options);
 const gchar *python_format_persist_name(const LogPipe *p, const gchar *module, PythonPersistMembers *options);
 

--- a/modules/python/python-persist.h
+++ b/modules/python/python-persist.h
@@ -29,6 +29,8 @@
 typedef struct
 {
   PyObject_HEAD
+  PersistState *persist_state;
+  gchar *persist_name;
 } PyPersist;
 
 extern PyTypeObject py_persist_type;

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -35,6 +35,7 @@
 #include "python-global-code-loader.h"
 #include "python-debugger.h"
 #include "python-http-header.h"
+#include "python-persist.h"
 
 #include "plugin.h"
 #include "plugin-types.h"
@@ -114,6 +115,7 @@ _py_init_interpreter(void)
       py_integer_pointer_init();
       py_log_source_init();
       py_log_fetcher_init();
+      py_persist_init();
       py_global_code_loader_init();
       py_logger_init();
       PyEval_SaveThread();

--- a/modules/python/tests/CMakeLists.txt
+++ b/modules/python/tests/CMakeLists.txt
@@ -18,3 +18,10 @@ add_unit_test(LIBTEST CRITERION
   DEPENDS syslogformat mod-python "${PYTHON_LIBRARIES}")
 
 set_property(TEST test_python_persist_name APPEND PROPERTY ENVIRONMENT "PYTHONMALLOC=malloc_debug")
+
+add_unit_test(LIBTEST CRITERION
+  TARGET test_python_persist
+  INCLUDES "${PYTHON_INCLUDE_DIR}" "${PYTHON_INCLUDE_DIRS}"
+  DEPENDS syslogformat mod-python "${PYTHON_LIBRARIES}")
+
+set_property(TEST test_python_persist APPEND PROPERTY ENVIRONMENT "PYTHONMALLOC=malloc_debug")

--- a/modules/python/tests/Makefile.am
+++ b/modules/python/tests/Makefile.am
@@ -27,4 +27,10 @@ modules_python_tests_test_python_persist_name_LDADD = $(TEST_LDADD) \
 	-dlpreopen $(top_builddir)/modules/python/libmod-python.la \
 	$(PYTHON_LIBS) $(PREOPEN_SYSLOGFORMAT)
 
+modules_python_tests_test_python_persist_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) \
+	-I$(top_srcdir)/modules/python -I$(top_srcdir)/modules/syslogformat
+modules_python_tests_test_python_persist_LDADD = $(TEST_LDADD) \
+	-dlpreopen $(top_builddir)/modules/python/libmod-python.la \
+	$(PYTHON_LIBS) $(PREOPEN_SYSLOGFORMAT)
+
 EXTRA_DIST += modules/python/tests/CMakeLists.txt

--- a/modules/python/tests/test_python_persist.c
+++ b/modules/python/tests/test_python_persist.c
@@ -134,3 +134,15 @@ Test(python_persist, test_python_persist_basic)
   _load_code("assert persist['key'] == 'value'");
   persist_state_stop(cfg->state);
 }
+
+Test(python_persist, test_python_persist_iterator)
+{
+  PersistState *state = clean_and_create_persist_state_for_test("test-python-iterator.persist");
+  cfg->state = state;
+  _load_code("persist = Persist('persist_name')");
+  _load_code("persist['key1'] = 'value1'");
+  _load_code("persist['key2'] = 'value2'");
+  _load_code("persist['key3'] = 'value3'");
+  _load_code("assert sorted(persist) == ['key1', 'key2', 'key3']");
+  persist_state_stop(state);
+}

--- a/modules/python/tests/test_python_persist.c
+++ b/modules/python/tests/test_python_persist.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#include "python-persist.h"
+
+#include <criterion/criterion.h>
+
+void setup(void)
+{
+}
+
+void teardown(void)
+{
+}
+
+TestSuite(python_persist, .init = setup, .fini = teardown);
+
+Test(python_persist, test_python_persist)
+{
+  cr_assert(TRUE);
+}

--- a/modules/python/tests/test_python_persist.c
+++ b/modules/python/tests/test_python_persist.c
@@ -146,3 +146,15 @@ Test(python_persist, test_python_persist_iterator)
   _load_code("assert sorted(persist) == ['key1', 'key2', 'key3']");
   persist_state_stop(state);
 }
+
+Test(python_persist, test_python_persist_proper_types)
+{
+  PersistState *state = clean_and_create_persist_state_for_test("test-python-proper_types.persist");
+  cfg->state = state;
+  _load_code("persist = Persist('persist_name')");
+  _load_code("persist['str'] = 'value'");
+  _load_code("persist['number'] = 5");
+  _load_code("assert persist['str'] == 'value'");
+  _load_code("assert persist['number'] == 5");
+  persist_state_stop(state);
+}

--- a/modules/python/tests/test_python_persist.c
+++ b/modules/python/tests/test_python_persist.c
@@ -175,3 +175,17 @@ Test(python_persist, test_python_persist_lookup_missing_key)
   _load_code(should_throw_exception);
   persist_state_stop(state);
 };
+
+const gchar *iter_returns_proper_types = "\n\
+persist = Persist('persist_name')\n\
+persist['integer'] = 1\n\
+persist['str'] = 'str'\n\
+assert sorted([1, 'str']) == sorted([persist[k] for k in persist])";
+
+Test(python_persist, test_python_persist_iter_returns_proper_types)
+{
+  PersistState *state = clean_and_create_persist_state_for_test("test-python-iter-returns-proper-types.persist");
+  cfg->state = state;
+  _load_code(iter_returns_proper_types);
+  persist_state_stop(state);
+};

--- a/modules/python/tests/test_python_persist.c
+++ b/modules/python/tests/test_python_persist.c
@@ -80,6 +80,8 @@ void setup(void)
 
   _py_init_interpreter();
   _init_python_main();
+
+  _load_code("from _syslogng import Persist");
 }
 
 void teardown(void)
@@ -91,7 +93,6 @@ void teardown(void)
 TestSuite(python_persist, .init = setup, .fini = teardown);
 
 const gchar *simple_persist = "\n\
-from _syslogng import Persist\n\
 class SubPersist(Persist):\n\
     def __init__(self, persist_name):\n\
         super(SubPersist, self).__init__(persist_name = persist_name)\n\
@@ -116,4 +117,20 @@ Test(python_persist, test_python_persist_name)
   cfg->state = state;
   _load_code(simple_persist);
   persist_state_stop(state);
+}
+
+Test(python_persist, test_python_persist_basic)
+{
+  PersistState *state = clean_and_create_persist_state_for_test("test-python.persist");
+  cfg->state = state;
+  _load_code("persist = Persist('persist_name')");
+  _load_code("assert 'key' not in persist");
+  _load_code("persist['key'] = 'value'");
+  _load_code("assert 'key' in persist");
+  cfg->state = restart_persist_state(state);
+  _load_code("persist = Persist('persist_name')");
+  _load_code("persist['key'] = 'value'");
+  _load_code("assert 'key' in persist");
+  _load_code("assert persist['key'] == 'value'");
+  persist_state_stop(cfg->state);
 }

--- a/modules/python/tests/test_python_persist.c
+++ b/modules/python/tests/test_python_persist.c
@@ -180,7 +180,8 @@ const gchar *iter_returns_proper_types = "\n\
 persist = Persist('persist_name')\n\
 persist['integer'] = 1\n\
 persist['str'] = 'str'\n\
-assert sorted([1, 'str']) == sorted([persist[k] for k in persist])";
+persist['bytes'] = b'bytes'\n\
+assert sorted([1, 'str', b'bytes']) == sorted([persist[k] for k in persist])";
 
 Test(python_persist, test_python_persist_iter_returns_proper_types)
 {

--- a/modules/python/tests/test_python_persist.c
+++ b/modules/python/tests/test_python_persist.c
@@ -158,3 +158,20 @@ Test(python_persist, test_python_persist_proper_types)
   _load_code("assert persist['number'] == 5");
   persist_state_stop(state);
 }
+
+const gchar *should_throw_exception = "\
+persist = Persist('persist_name')\n\
+exception_happened = False\n\
+try:\n\
+    persist['missing']\n\
+except KeyError:\n\
+    exception_happened = True\n\
+assert exception_happened";
+
+Test(python_persist, test_python_persist_lookup_missing_key)
+{
+  PersistState *state = clean_and_create_persist_state_for_test("test-python-lookup-missing-key.persist");
+  cfg->state = state;
+  _load_code(should_throw_exception);
+  persist_state_stop(state);
+};

--- a/news/feature-3171.md
+++ b/news/feature-3171.md
@@ -1,0 +1,3 @@
+`python`: persist support for python
+
+This feature enables users to persist data between reloads or restarts. The intended usage is to support bookmarking and acknowledgement in the future. It is not suitable for local database use cases.


### PR DESCRIPTION
This patchset exposes persist api into python code.

This is the continuation of #3016, towards the road of having proper acknowledgement support in python.

Similar to #3016, this PR neither has any usage on its own, until bookmark handling is implemented in the future.

Features:
- A `Persist` class is importable from `syslogng` module
- The object looks like a dictionary: users can store values behind keys. The difference is it is backed by an entry in the persist file, so data is persisted between restarts.
- If no persist file created yet, `defaults` constructor parameter specifies can specify values for keys.
- Handles integers and strings.
- Iterable

Limitations:
- This patchset does not support editing multiple keys in the same transaction. This means if the persist data is complex and the parts need to be mutated together: like (`last-blob` + offset`), partial update may happen. As a workaround, users need to serialize the complex data into a single entry, and while using/updating, they need to deserialize and re-serialize. I plan to support this use case later.
- Only a limited size of data can be added at a time. The length of the key+value must be below 4K, I do not have the exact values for now. As this module is intended for bookmarking, it does not make sense to store large values anyway. To store large number of local data securely, users need to use local database or other mechanism.
The limitation comes from the persist file in c, it can be only increased 4K at a time. This limitation can be workarounded if really needed: by storing only a small portion of the value, and incrementally append the rest of the data in small chunks.
- In python2, there are two integral types: integer and long (for large numbers). In python3, there is only one integral type: long. The current implementation uses only long. For **python2** users, this means an integer is automatically converted to long.
- Explicit key deletion is not supported. Though there is a global cleanup mechanism in persist. If a persist entry is not referred between two restarts, the entry is automatically removed.

Examples:

The code below prints five numbers, each restart/reload. Continuing from the last number of the previous execution.

```python
from syslogng import Persist, LogSource
class RangeSource(LogSource):
    def init(self, options):
        self.persist = Persist("persist_name", defaults={"bookmark" : 1})
        return True
    def run(self):
        first_item = self.persist["bookmark"]
        for i in range(first_item, first_item + 5):
            print("Item: {}".format(i))
            self.persist["bookmark"] = i + 1
    def request_exit(self):
        pass
```

You can iterate through keys:
```python
persist = Persist("persist_name", defaults={"foo" : "bar"})
for i in persist:
    print(i)
```

Developer notes:
- The Persist entry always stores data as string, no matter if integer or string is specified. Integers are serialized trivially. To differentiate, we also store the type of the entry, so that proper type could be returned during lookup.
- The subkeys are stored on the global level of the persist. Users provide a basename and a subkey. The resulting entry will be accessed using a key builder: `basename##subkey`.