### PR TITLE
update contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ easier.
  1. [Reporting issues](#reporting-issues)
  2. [Feature requests](#feature-requests)
  3. [Testing](#testing)
-2. [Patches](#patches)
+2. [Pull requests](#pull-requests)
 3. [Additional resources](#additional-resources)
 
 ## Issues
@@ -56,34 +56,117 @@ requests - there's only so much [automated testing][ar:travis] can do.
 For example, you can help testing on platforms the developers do not
 have access to, or try configurations not thought of before.
 
-## Patches
+## Pull requests
 
-Of course, we also accept patches. If you want to submit a patch, the
-guidelines are very, very simple:
+If you plan to open a pull request, please follow the guideline below.
 
- 1. Open an issue first, if there is none open for the particular
-    issue for the topic already in the
-    [issue tracker][ar:issue-tracker]. That way, other contributors
-    and developers can comment the issue and the patch.
- 2. If you submit a pull request that fixes an existing issue, mention
-    the issue somewhere in the pull request, so we can close the
-    original issue as well.
- 3. We are using a coding style very similar to
-    [GNU Coding Standards](https://www.gnu.org/prep/standards/standards.html#Writing-C)
-    for syslog-ng. Please try to follow the existing conventions.
- 4. Start your commit message with the following format:
-    `block-name: short description of the applied changes`.
+### Branch
 
-    Always add a `Signed-off-by` tag to the end of **every** commit
-    message you submit.
- 5. Always create a separate branch for the pull request, forked off
-    from the appropriate syslog-ng branch.
- 6. If your patch should be applied to multiple branches, submit
-    against the latest one only, and mention which other branches are
-    affected. There is no need to submit pull requests for each
-    branch.
- 7. If possible, write tests! We love tests.
- 8. A well-documented pull request is much easier to review and merge.
+You need to fork syslog-ng in github, and create a working branch from master in your fork.
+
+After writing the code, just before opening the pull request,
+make sure your working branch is rebased against master.
+
+### PR description
+In the description, please explain (if applicable):
+- The problem your pull request intends to solve.
+- A general overview about the implementation, or any information that can help
+reviewers to understand your code.
+- Please explain how one can try out your code: configuration snippets,
+or deployment information.
+- You can mention if you were considering alternative solutions or explain
+problems you ran into.
+- If you submit a pull request that fixes an existing issue, please mention
+the issue somewhere in the pull request, so we can close the
+original issue as well.
+
+
+The documentation is created from the description. Please provide
+a description that can be a good input for the admin guide as well.
+
+### Commits
+#### Commit messages
+
+```
+The commit messages be formatted according to this:
+
+module: short description
+
+Long description, that may be
+formatted in markdown.
+
+Signed-off-by: your name <youremail@address.com>
+```
+
+This format is checked by the CI.
+
+If you do not want to share your email address due to privacy reasons,
+you can use `some-id+yourgithubusername@users.noreply.github.com`,
+which is automatically generated and tracked by github. You can check the exact
+address in your github settings->email->primary email address, if you enabled email privacy.
+
+`module` refers to the part of syslog-ng that the patch intends to change. For example
+python, redis, persist, scratch-buffers, etc.
+
+#### Patches
+
+We are using a coding style very similar to
+[GNU Coding Standards](https://www.gnu.org/prep/standards/standards.html#Writing-C)
+for syslog-ng.
+
+You can use `make style-check` or `make style-format` to check or format automatically your code.
+These commands are executed by our CI as well.
+
+If possible, please organize your code into a set of small and self contained patches,
+with clear descriptions each, that can help to understand the patch. This greatly helps the review process.
+
+Please follow clean code guidelines whenever possible. Functions should be small and responsible for one thing.
+Try to avoid code duplication. Add descriptive names for functions and variables. Etc...
+
+#### News file
+
+We are automatically generating the news file before each release. So that to work,
+please add a news entry for your change under the news directory.
+
+The file name should be news/type-PR_ID.md (for example: news/bugfix-1234.md).
+For now the following types are supported:
+feature, bugfix, packaging, developer-note, other.
+
+If you think there is no need for a news file (for example it is a small
+fix for an earlier pull request of the same release),
+you can leave a note about it in the pull request description.
+
+The generated news file will contain a link to the pull request, where the interested
+users can find detailed information in the description.
+This means your news entry does not need to be too descriptive.
+
+The news file format should look like this:
+
+```
+`module`: short description
+
+long description
+```
+
+See news/README.md for more information.
+
+### Testing
+
+If possible please add tests for your change. You can add unit tests in c (tests directory in most of syslog-ng modules),
+or there is an initiative so that contributors write tests in python (for now the feature set is limited).
+You can check `tests/python_functional/functional_tests/source_drivers/generator_source/` as an example.
+
+### CI
+
+After opening the pull requests, one of the maintainers will enable
+the tests to run for your pull requests. So that the pull request
+could be merged, all tests must pass, and the PR needs two approvals from the maintainers.
+
+You do not need to find reviewers. The maintainers continuously monitor the project,
+and will assign themselves. We try to add feedback as soon as possible.
+
+If you get stuck with a regression test, feel free to ask for help. Sometimes it is difficult to understand the test logs.
+
 
 ## Licensing
 

--- a/news/developer-note-3174.md
+++ b/news/developer-note-3174.md
@@ -1,0 +1,1 @@
+`CONTRIBUTING.md`: contribution guide updated


### PR DESCRIPTION
There were a few things missing from the guide: like news file, how deal with style-check problems, mentioning light.
There are things I think is not necessary: for example opening an issue before pull request.

If you want to see the html-formatted version, just open:
https://github.com/furiel/syslog-ng/blob/update-contribution-doc/CONTRIBUTING.md.