### PR TITLE
format-json: fix embedded zeroes, fix github actions

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,7 +6,7 @@ jobs:
   build-and-check:
     runs-on: macOS-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: build-and-check
         run: |
           set -e

--- a/lib/compat/glib.c
+++ b/lib/compat/glib.c
@@ -315,3 +315,18 @@ slng_g_hash_table_insert(GHashTable *hash_table, gpointer key, gpointer value)
   return exists;
 }
 #endif
+
+
+#if !GLIB_CHECK_VERSION(2, 64, 0)
+gunichar
+g_utf8_get_char_validated_fixed(const gchar *p, gssize max_len)
+{
+  // https://github.com/GNOME/glib/commit/1963821a57584b4674c20895e8a5adccd2d9effd
+
+#undef g_utf8_get_char_validated
+  if (*p == '\0' && max_len > 0)
+    return (gunichar)-2;
+
+  return g_utf8_get_char_validated(p, max_len);
+}
+#endif

--- a/lib/compat/glib.h
+++ b/lib/compat/glib.h
@@ -109,4 +109,9 @@ gchar *g_base64_encode_fixed(const guchar *data, gsize len);
 gboolean slng_g_hash_table_insert (GHashTable *hash_table, gpointer key, gpointer value);
 #endif
 
+#if !GLIB_CHECK_VERSION(2, 64, 0)
+#define g_utf8_get_char_validated g_utf8_get_char_validated_fixed
+gunichar g_utf8_get_char_validated_fixed (const gchar *p, gssize max_len);
+#endif
+
 #endif

--- a/modules/cef/tests/test-format-cef-extension.c
+++ b/modules/cef/tests/test-format-cef-extension.c
@@ -104,7 +104,7 @@ Test(format_cef, test_null_in_value)
 
   configuration->template_options.on_error = ON_ERROR_DROP_MESSAGE | ON_ERROR_SILENT;
   log_msg_set_value_by_name(msg, ".cef.k", "a\0b", 3);
-  assert_template_format_msg("$(format-cef-extension --subkeys .cef.)", "k=a\\u0000b", msg);
+  assert_template_format_msg("$(format-cef-extension --subkeys .cef.)", "k=a\\x00b", msg);
   log_msg_unref(msg);
 }
 

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -55,7 +55,7 @@ Test(format_json, test_format_json)
   assert_template_format("$(format-json MSG=$escaping)",
                          "{\"MSG\":\"binary stuff follows \\\"\\\\xad árvíztűrőtükörfúrógép\"}");
   assert_template_format("$(format-json MSG=$escaping2)", "{\"MSG\":\"\\\\xc3\"}");
-  assert_template_format("$(format-json MSG=$null)", "{\"MSG\":\"binary\\u0000stuff\"}");
+  assert_template_format("$(format-json MSG=$null)", "{\"MSG\":\"binary\\\\x00stuff\"}");
   assert_template_format_with_context("$(format-json MSG=$MSG)",
                                       "{\"MSG\":\"árvíztűrőtükörfúrógép\"}{\"MSG\":\"árvíztűrőtükörfúrógép\"}");
   assert_template_format("$(format-json --scope rfc3164)",

--- a/news/bugfix-3175.md
+++ b/news/bugfix-3175.md
@@ -1,0 +1,3 @@
+`format-json`: fix printing of embedded zeros
+
+Prior to 2.64.1, `g_utf8_get_char_validated()` in glib falsely identified embedded zeros as valid utf8 characters. As a result, format json printed the embedded zeroes as `\u0000` instead of `\x00`. This change fixes this problem.


### PR DESCRIPTION
Prior to 2.64.1, `g_utf8_get_char_validated()` in glib falsely identified embedded zeroes as valid utf8 characters. As a result, format json printed the embedded zeroes as `\u0000` instead of `\x00`.

The macOS ci job fails due to this change (test_format_json). The same unit test failure happens in archlinux. https://github.com/GNOME/glib/commit/1963821a57584b4674c20895e8a5adccd2d9effd

This is a breaking change as the output of format-json may change. Alternatively, I could maintain the original behavior, and make `g_utf8_get_char_validated()` the original value in the compat layer. Personally, I agree with glib here. That's why I am proposing this version.