### PR TITLE
fix config reload crash via introducing on_config_inited in LogPipe

### DIFF
--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -1451,8 +1451,8 @@ cfg_tree_on_inited(CfgTree *self)
   for (i = 0; i < self->initialized_pipes->len; i++)
     {
       LogPipe *pipe = g_ptr_array_index(self->initialized_pipes, i);
-      
-      if (pipe->on_config_inited && !pipe->on_config_inited(pipe))
+
+      if (!log_pipe_on_config_inited(pipe))
         {
           msg_error("Error executing on_config_inited hook",
                     evt_tag_str("plugin_name", pipe->plugin_name ? pipe->plugin_name : "not a plugin"),

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -1443,6 +1443,27 @@ cfg_tree_stop(CfgTree *self)
   return success;
 }
 
+gboolean
+cfg_tree_on_inited(CfgTree *self)
+{
+  gint i;
+
+  for (i = 0; i < self->initialized_pipes->len; i++)
+    {
+      LogPipe *pipe = g_ptr_array_index(self->initialized_pipes, i);
+      
+      if (pipe->on_config_inited && !pipe->on_config_inited(pipe))
+        {
+          msg_error("Error executing on_config_inited hook",
+                    evt_tag_str("plugin_name", pipe->plugin_name ? pipe->plugin_name : "not a plugin"),
+                    log_pipe_location_tag(pipe));
+          return FALSE;
+        }
+    }
+
+  return TRUE;
+}
+
 void
 cfg_tree_init_instance(CfgTree *self, GlobalConfig *cfg)
 {

--- a/lib/cfg-tree.h
+++ b/lib/cfg-tree.h
@@ -183,6 +183,7 @@ gchar *cfg_tree_get_child_id(CfgTree *self, gint content, LogExprNode *node);
 
 gboolean cfg_tree_start(CfgTree *self);
 gboolean cfg_tree_stop(CfgTree *self);
+gboolean cfg_tree_on_inited(CfgTree *self);
 
 void cfg_tree_init_instance(CfgTree *self, GlobalConfig *cfg);
 void cfg_tree_free_instance(CfgTree *self);

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -365,7 +365,11 @@ cfg_init(GlobalConfig *cfg)
   log_template_options_init(&cfg->template_options, cfg);
   if (!cfg_init_modules(cfg))
     return FALSE;
-  return cfg_tree_start(&cfg->tree);
+  if (!cfg_tree_start(&cfg->tree))
+    return FALSE;
+
+  g_assert(cfg_tree_on_inited(&cfg->tree));
+  return TRUE;
 }
 
 gboolean

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -326,6 +326,14 @@ log_pipe_deinit(LogPipe *s)
   return TRUE;
 }
 
+static inline gboolean
+log_pipe_on_config_inited(LogPipe *s)
+{
+  if (s->on_config_inited)
+    return s->on_config_inited(s);
+  return TRUE;
+}
+
 static inline void
 log_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options);
 

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -232,6 +232,12 @@ struct _LogPipe
   gboolean (*deinit)(LogPipe *self);
   void (*post_deinit)(LogPipe *self);
 
+  /* this event function is used to perform necessary operation, such as
+   * starting worker thread, and etc. therefore, syslog-ng will terminate if
+   * return value is false.
+   */
+  gboolean (*on_config_inited)(LogPipe *self);
+
   const gchar *(*generate_persist_name)(const LogPipe *self);
   GList *(*arcs)(LogPipe *self);
 

--- a/lib/logthrdest/logthrdestdrv.h
+++ b/lib/logthrdest/logthrdestdrv.h
@@ -228,7 +228,7 @@ void log_threaded_dest_worker_free(LogThreadedDestWorker *self);
 
 gboolean log_threaded_dest_driver_deinit_method(LogPipe *s);
 gboolean log_threaded_dest_driver_init_method(LogPipe *s);
-gboolean log_threaded_dest_driver_start_workers(LogThreadedDestDriver *self);
+gboolean log_threaded_dest_driver_start_workers(LogPipe *s);
 
 void log_threaded_dest_driver_init_instance(LogThreadedDestDriver *self, GlobalConfig *cfg);
 void log_threaded_dest_driver_free(LogPipe *s);

--- a/lib/logthrdest/tests/test_logthrdestdrv.c
+++ b/lib/logthrdest/tests/test_logthrdestdrv.c
@@ -146,6 +146,7 @@ _setup_dd(void)
   dd = test_threaded_dd_new(main_loop_get_current_config(main_loop));
 
   cr_assert(log_pipe_init(&dd->super.super.super.super));
+  cr_assert(log_pipe_on_config_inited(&dd->super.super.super.super));
 }
 
 static void
@@ -720,6 +721,7 @@ Test(logthrdestdrv, test_connect_failure_kicks_in_suspend_retry_logic_which_keep
   dd->super.worker.insert = _insert_single_message_success;
   dd->super.worker.instance.time_reopen = 0;
   cr_assert(log_pipe_init(&dd->super.super.super.super));
+  cr_assert(log_pipe_on_config_inited(&dd->super.super.super.super));
 
   _generate_message_and_wait_for_processing(dd, dd->super.written_messages);
   cr_assert(dd->connect_counter == 11, "%d", dd->connect_counter);

--- a/lib/logthrsource/tests/test_logthrfetcherdrv.c
+++ b/lib/logthrsource/tests/test_logthrfetcherdrv.c
@@ -130,6 +130,7 @@ static void
 start_test_threaded_fetcher(TestThreadedFetcherDriver *s)
 {
   cr_assert(log_pipe_init(&s->super.super.super.super.super));
+  cr_assert(log_pipe_on_config_inited(&s->super.super.super.super.super));
   app_config_changed();
 }
 

--- a/lib/logthrsource/tests/test_logthrsourcedrv.c
+++ b/lib/logthrsource/tests/test_logthrsourcedrv.c
@@ -122,6 +122,7 @@ static void
 start_test_threaded_source(TestThreadedSourceDriver *s)
 {
   cr_assert(log_pipe_init(&s->super.super.super.super));
+  cr_assert(log_pipe_on_config_inited(&s->super.super.super.super));
   app_config_changed();
 }
 

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -142,7 +142,6 @@ struct _MainLoop
   struct iv_signal sigusr1_poll;
 
   struct iv_event exit_requested;
-  struct iv_task revert_config;
 
   struct iv_timer exit_timer;
 
@@ -254,13 +253,6 @@ main_loop_reload_config_revert(gpointer user_data)
   main_loop_reload_config_finished(self);
 }
 
-static void
-_revert_config(gpointer user_data)
-{
-  MainLoop *self = (MainLoop *) user_data;
-  main_loop_worker_sync_call(main_loop_reload_config_revert, self);
-}
-
 /* called to apply the new configuration once all I/O worker threads have finished */
 static void
 main_loop_reload_config_apply(gpointer user_data)
@@ -286,7 +278,7 @@ main_loop_reload_config_apply(gpointer user_data)
     {
       msg_error("Error initializing new configuration, reverting to old config");
       service_management_publish_status("Error initializing new configuration, using the old config");
-      iv_task_register(&self->revert_config);
+      main_loop_reload_config_revert(self);
       return;
     }
 
@@ -593,10 +585,6 @@ main_loop_init(MainLoop *self, MainLoopOptions *options)
 
   main_loop_init_events(self);
   setup_signals(self);
-
-  IV_TASK_INIT(&self->revert_config);
-  self->revert_config.handler = _revert_config;
-  self->revert_config.cookie = self;
 
   self->current_configuration = cfg_new(0);
 }

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -737,7 +737,7 @@ afamqp_dd_init(LogPipe *s)
               evt_tag_str("exchange", self->exchange),
               evt_tag_str("exchange_type", self->exchange_type));
 
-  return log_threaded_dest_driver_start_workers(&self->super);
+  return TRUE;
 }
 
 static void

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -515,7 +515,7 @@ _init(LogPipe *s)
   if (!afmongodb_dd_private_uri_init(&self->super.super.super))
     return FALSE;
 
-  return log_threaded_dest_driver_start_workers(&self->super);
+  return TRUE;
 }
 
 static void

--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -606,7 +606,7 @@ afsmtp_dd_init(LogPipe *s)
     return FALSE;
 
   log_template_options_init(&self->template_options, cfg);
-  return log_threaded_dest_driver_start_workers(&self->super);
+  return TRUE;
 }
 
 static void

--- a/modules/afsnmp/afsnmpdest.c
+++ b/modules/afsnmp/afsnmpdest.c
@@ -639,7 +639,7 @@ snmpdest_dd_init(LogPipe *s)
     }
 
   log_template_options_init(&self->template_options, cfg);
-  return log_threaded_dest_driver_start_workers(&self->super);
+  return TRUE;
 }
 
 static void

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1142,7 +1142,7 @@ afsql_dd_init(LogPipe *s)
   if (afsql_dd_is_transaction_handling_enabled(self))
     log_threaded_dest_driver_set_batch_lines((LogDriver *)self, _batch_lines(self));
 
-  return log_threaded_dest_driver_start_workers(&self->super);
+  return TRUE;
 }
 
 static void

--- a/modules/afstomp/afstomp.c
+++ b/modules/afstomp/afstomp.c
@@ -358,7 +358,7 @@ afstomp_dd_init(LogPipe *s)
               evt_tag_int("port", self->port),
               evt_tag_str("destination", self->destination));
 
-  return log_threaded_dest_driver_start_workers(&self->super);
+  return TRUE;
 }
 
 static void

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -364,7 +364,7 @@ http_dd_init(LogPipe *s)
 
   http_load_balancer_set_recovery_timeout(self->load_balancer, self->super.time_reopen);
 
-  return log_threaded_dest_driver_start_workers(&self->super);
+  return TRUE;
 }
 
 static void

--- a/modules/http/tests/test_http-signal_slot.c
+++ b/modules/http/tests/test_http-signal_slot.c
@@ -109,6 +109,7 @@ Test(test_http_signal_slot, basic)
   CONNECT(ssc, signal_http_header_request, _check, test_msg);
 
   cr_assert(log_pipe_init((LogPipe *)driver));
+  cr_assert(log_pipe_on_config_inited((LogPipe *)driver));
 
   _generate_message(driver, test_msg);
 
@@ -126,6 +127,7 @@ Test(test_http_signal_slot, single_with_prefix_suffix)
   CONNECT(ssc, signal_http_header_request, _check, "[almafa]");
 
   cr_assert(log_pipe_init((LogPipe *)driver));
+  cr_assert(log_pipe_on_config_inited((LogPipe *)driver));
 
   _generate_message(driver, "almafa");
 
@@ -145,6 +147,7 @@ Test(test_http_signal_slot, batch_with_prefix_suffix)
   CONNECT(ssc, signal_http_header_request, _check, "[1,2]");
 
   cr_assert(log_pipe_init((LogPipe *)driver));
+  cr_assert(log_pipe_on_config_inited((LogPipe *)driver));
 
   _generate_message(driver, "1");
   _generate_message(driver, "2");

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -160,7 +160,7 @@ java_dd_init(LogPipe *s)
   if (!java_destination_proxy_init(self->proxy))
     return FALSE;
 
-  return log_threaded_dest_driver_start_workers(&self->super);
+  return TRUE;
 }
 
 gboolean

--- a/modules/kafka/kafka-dest-driver.c
+++ b/modules/kafka/kafka-dest-driver.c
@@ -375,7 +375,7 @@ kafka_dd_init(LogPipe *s)
               evt_tag_str("driver", self->super.super.super.id),
               log_pipe_location_tag(&self->super.super.super.super));
 
-  return log_threaded_dest_driver_start_workers(&self->super);
+  return TRUE;
 }
 
 static gboolean

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -576,7 +576,7 @@ python_dd_init(LogPipe *d)
               evt_tag_str("driver", self->super.super.super.id),
               evt_tag_str("class", self->class));
 
-  return log_threaded_dest_driver_start_workers(&self->super);
+  return TRUE;
 
 fail:
   PyGILState_Release(gstate);

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -405,7 +405,7 @@ redis_dd_init(LogPipe *s)
               evt_tag_str("host", self->host),
               evt_tag_int("port", self->port));
 
-  return log_threaded_dest_driver_start_workers(&self->super);
+  return TRUE;
 }
 
 static void

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -293,7 +293,7 @@ riemann_dd_init(LogPipe *s)
               evt_tag_str("driver", self->super.super.super.id),
               log_pipe_location_tag(&self->super.super.super.super));
 
-  return log_threaded_dest_driver_start_workers(&self->super);
+  return TRUE;
 }
 
 static void

--- a/news/bugfix-3176.md
+++ b/news/bugfix-3176.md
@@ -1,0 +1,1 @@
+`cfg`: fix config reload crash via introducing `on_config_inited` in LogPipe


### PR DESCRIPTION
In current version, syslog-ng registers revert_config task after cfg_init.
When applying config failed, ivykis task list can be illustrated as the following:

```
  | _reenable_worker_jobs | _io_process_input | ... | _revert_config |
  ^
  | ivykis task list
```

If there is a log before `_revert_config` finished, syslog-ng will use uninitialized log pipe to process it. This will lead to a crash.

Therefore, `main_loop_reload_config_revert` is scheduled to be called immediately via `main_loop_worker_sync_call` after applying config failed.

To avoid recursion in `main_loop_worker_sync_call`, there is a global flag named `sync_call_running`.
According to this flag, syslog-ng can determine whether it has to call `_invoke_sync_call_actions`.

fixes: https://github.com/syslog-ng/syslog-ng/issues/3173
closes #3196