### PR TITLE
python: fix Py_None reference counting

### DIFF
--- a/modules/python/python-logger.c
+++ b/modules/python/python-logger.c
@@ -38,7 +38,7 @@ py_msg_error(PyObject *obj, PyObject *args)
     return NULL;
 
   msg_error(message);
-  return Py_None;
+  Py_RETURN_NONE;
 }
 
 PyObject *
@@ -49,7 +49,7 @@ py_msg_warning(PyObject *obj, PyObject *args)
     return NULL;
 
   msg_warning(message);
-  return Py_None;
+  Py_RETURN_NONE;
 }
 
 PyObject *
@@ -60,38 +60,35 @@ py_msg_info(PyObject *obj, PyObject *args)
     return NULL;
 
   msg_info(message);
-  return Py_None;
+  Py_RETURN_NONE;
 }
 
 PyObject *
 py_msg_debug(PyObject *obj, PyObject *args)
 {
   if (!debug_flag)
-    {
-      Py_INCREF(Py_None);
-      return Py_None;
-    }
+    Py_RETURN_NONE;
 
   char *message = NULL;
   if (!PyArg_ParseTuple(args, "s", &message))
     return NULL;
 
   msg_debug(message);
-  return Py_None;
+  Py_RETURN_NONE;
 }
 
 PyObject *
 py_msg_trace(PyObject *obj, PyObject *args)
 {
   if (!trace_flag)
-    return Py_None;
+    Py_RETURN_NONE;
 
   char *message = NULL;
   if (!PyArg_ParseTuple(args, "s", &message))
     return NULL;
 
   msg_trace(message);
-  return Py_None;
+  Py_RETURN_NONE;
 }
 
 

--- a/news/bugfix-3187.md
+++ b/news/bugfix-3187.md
@@ -1,0 +1,1 @@
+python: fix Py_None reference counting in logger methods (trace, debug, info, warning, error)


### PR DESCRIPTION
Py_RETURN_NONE is a macro that
 * increments ref counter for the Py_None object
 * return with Py_None

Signed-off-by: Laszlo Budai <laszlo.budai@outlook.com>