### PR TITLE
afmongodb: cmake: do not build module when ENABLE_MONGODB=off

### DIFF
--- a/modules/afmongodb/CMakeLists.txt
+++ b/modules/afmongodb/CMakeLists.txt
@@ -2,7 +2,7 @@ find_package(libmongoc-1.0)
 
 module_switch(ENABLE_MONGODB "Enable mongodb destination driver" libmongoc-1.0_FOUND)
 
-if (libmongoc-1.0_FOUND)
+if (ENABLE_MONGODB)
 
   set(AFMONGODB_SOURCES
     "afmongodb.h"

--- a/modules/afmongodb/CMakeLists.txt
+++ b/modules/afmongodb/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (ENABLE_MONGODB STREQUAL OFF)
+  return()
+endif()
+
 find_package(libmongoc-1.0)
 
 module_switch(ENABLE_MONGODB "Enable mongodb destination driver" libmongoc-1.0_FOUND)

--- a/news/bugfix-3188.md
+++ b/news/bugfix-3188.md
@@ -1,0 +1,3 @@
+afmongodb: do not build module when ENABLE_MONGODB=OFF
+
+fixes #3184


### PR DESCRIPTION
fixes: #3184

