### PR TITLE
logpipe-source: disable multi-line-timeout

### DIFF
--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -23,7 +23,6 @@
 
 %code top {
 #include "affile-parser.h"
-
 }
 
 
@@ -181,6 +180,7 @@ source_affile_option
 	| KW_FOLLOW_FREQ '(' nonnegative_integer ')'	{ file_reader_options_set_follow_freq(last_file_reader_options, ($3 * 1000)); }
 	| KW_PAD_SIZE '(' nonnegative_integer ')'	{ last_log_proto_options->pad_size = $3; }
 	| multi_line_option
+	| multi_line_timeout
 	| file_perm_option
         | source_reader_option
 	| source_driver_option
@@ -257,12 +257,15 @@ multi_line_option
 	  {
             GError *error = NULL;
 
-	    CHECK_ERROR_GERROR(log_proto_multi_line_server_options_set_garbage(&last_log_proto_options->super, $3, &error), @3, error, "error compiling multi-line regexp");
-	    free($3);
+	    	CHECK_ERROR_GERROR(log_proto_multi_line_server_options_set_garbage(&last_log_proto_options->super, $3, &error), @3, error, "error compiling multi-line regexp");
+	    	free($3);
 	  }
-	| KW_MULTI_LINE_TIMEOUT '(' nonnegative_integer ')'
+	;
+
+multi_line_timeout
+	: KW_MULTI_LINE_TIMEOUT '(' nonnegative_integer ')'
 	  {
-	    file_reader_options_set_multi_line_timeout(last_file_reader_options, ($3 * 1000));
+	    	file_reader_options_set_multi_line_timeout(last_file_reader_options, ($3 * 1000));
 	  }
 	;
 


### PR DESCRIPTION
I have taken care of the earlier changes. Sorry for the issues that inadvertently popped up

Fixes: https://github.com/syslog-ng/syslog-ng/issues/3178