### PR TITLE
set-tag: add test

### DIFF
--- a/tests/python_functional/functional_tests/rewrites/set-tag/test_set_tag.py
+++ b/tests/python_functional/functional_tests/rewrites/set-tag/test_set_tag.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2020 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+
+def test_set_tag(config, syslog_ng):
+    generator_source = config.create_example_msg_generator_source(num=1, template=config.stringify("input with MATCHSTRING in it"))
+    set_tag_with_matching = config.create_rewrite_set_tag("SHOULDMATCH", condition='match("MATCHSTRING" value("MSG"))')
+    set_tag_without_matching = config.create_rewrite_set_tag("DONOTMATCH", condition='match("NONE" value("MSG"))')
+    file_destination = config.create_file_destination(file_name="output.log", template=config.stringify('${TAGS}\n'))
+    config.create_logpath(statements=[generator_source, set_tag_with_matching, set_tag_without_matching, file_destination])
+
+    syslog_ng.start(config)
+    log_line = file_destination.read_log().strip()
+    assert "SHOULDMATCH" in log_line
+    assert "DONOTMATCH" not in log_line

--- a/tests/python_functional/functional_tests/rewrites/set-tag/test_set_tag.py
+++ b/tests/python_functional/functional_tests/rewrites/set-tag/test_set_tag.py
@@ -20,12 +20,16 @@
 # COPYING for details.
 #
 #############################################################################
+from src.syslog_ng_config.statements.filters.filter import Match
 
 
 def test_set_tag(config, syslog_ng):
+    match = Match(config.stringify("MATCHSTRING"), value=config.stringify("MSG"))
+    notmatch = Match(config.stringify("NONE"), value=config.stringify("MSG"))
+
     generator_source = config.create_example_msg_generator_source(num=1, template=config.stringify("input with MATCHSTRING in it"))
-    set_tag_with_matching = config.create_rewrite_set_tag("SHOULDMATCH", condition='match("MATCHSTRING" value("MSG"))')
-    set_tag_without_matching = config.create_rewrite_set_tag("DONOTMATCH", condition='match("NONE" value("MSG"))')
+    set_tag_with_matching = config.create_rewrite_set_tag("SHOULDMATCH", condition=match)
+    set_tag_without_matching = config.create_rewrite_set_tag("DONOTMATCH", condition=notmatch)
     file_destination = config.create_file_destination(file_name="output.log", template=config.stringify('${TAGS}\n'))
     config.create_logpath(statements=[generator_source, set_tag_with_matching, set_tag_without_matching, file_destination])
 

--- a/tests/python_functional/src/syslog_ng_config/renderer.py
+++ b/tests/python_functional/src/syslog_ng_config/renderer.py
@@ -20,6 +20,7 @@
 # COPYING for details.
 #
 #############################################################################
+from src.syslog_ng_config.statements.filters.filter import Filter
 
 
 def render_version(version):
@@ -73,6 +74,10 @@ def render_name_value(name, value):
     return "        {}({})\n".format(name, value)
 
 
+def render_driver(name, driver):
+    return "        {}({})\n".format(name, render_statement(driver))
+
+
 def render_driver_options(driver_options):
     config_snippet = ""
 
@@ -81,6 +86,8 @@ def render_driver_options(driver_options):
             config_snippet += render_options(option_name, option_value)
         elif (isinstance(option_value, tuple) or isinstance(option_value, list)):
             config_snippet += render_list(option_name, option_value)
+        elif isinstance(option_value, Filter):
+            config_snippet += render_driver(option_name, option_value)
         else:
             config_snippet += render_name_value(option_name, option_value)
 
@@ -89,8 +96,11 @@ def render_driver_options(driver_options):
 
 def render_statement(statement):
     config_snippet = ""
+    config_snippet += "    {} (\n".format(statement.driver_name)
     config_snippet += render_positional_options(statement.positional_parameters)
     config_snippet += render_driver_options(statement.options)
+    config_snippet += "    )"
+
     return config_snippet
 
 
@@ -105,12 +115,10 @@ def render_statement_groups(statement_groups):
 
         for statement in statement_group:
             # driver header
-            config_snippet += "    {} (\n".format(statement.driver_name)
-
             config_snippet += render_statement(statement)
 
             # driver footer
-            config_snippet += "    );\n"
+            config_snippet += ";\n"
 
             # statement footer
         config_snippet += "};\n"

--- a/tests/python_functional/src/syslog_ng_config/renderer.py
+++ b/tests/python_functional/src/syslog_ng_config/renderer.py
@@ -22,6 +22,96 @@
 #############################################################################
 
 
+def render_version(version):
+    return "@version: {}\n".format(version)
+
+
+def render_includes(includes):
+    include_lines = ['@include "{}"'.format(include) for include in includes]
+    return "\n".join(include_lines)
+
+
+def render_global_options(global_options):
+    globals_options_header = "options {\n"
+    globals_options_footer = "};\n"
+
+    config_snippet = globals_options_header
+    for option_name, option_value in global_options.items():
+        config_snippet += "    {}({});\n".format(option_name, option_value)
+    config_snippet += globals_options_footer
+
+    return config_snippet
+
+
+def render_positional_options(positional_parameters):
+    config_snippet = ""
+    for parameter in positional_parameters:
+        config_snippet += "        {}\n".format(str(parameter))
+    return config_snippet
+
+
+def render_driver_options(driver_options):
+    config_snippet = ""
+
+    for option_name, option_value in driver_options.items():
+        if isinstance(option_value, dict):
+            config_snippet += "        {}(\n".format(option_name)
+            config_snippet += render_driver_options(option_value)
+            config_snippet += "        )\n"
+        elif (isinstance(option_value, tuple) or isinstance(option_value, list)):
+            for element in option_value:
+                config_snippet += "        {}({})\n".format(option_name, element)
+        else:
+            config_snippet += "        {}({})\n".format(option_name, option_value)
+
+    return config_snippet
+
+
+def render_statement_groups(statement_groups):
+    config_snippet = ""
+
+    for statement_group in statement_groups:
+        # statement header
+        config_snippet += "\n{} {} {{\n".format(
+            statement_group.group_type, statement_group.group_id,
+        )
+
+        for statement in statement_group:
+            # driver header
+            config_snippet += "    {} (\n".format(statement.driver_name)
+
+            # driver options
+            config_snippet += render_positional_options(statement.positional_parameters)
+            config_snippet += render_driver_options(statement.options)
+
+            # driver footer
+            config_snippet += "    );\n"
+
+            # statement footer
+        config_snippet += "};\n"
+
+    return config_snippet
+
+
+def render_logpath_groups(logpath_groups):
+    config_snippet = ""
+
+    for logpath_group in logpath_groups:
+        config_snippet += "\nlog {\n"
+        for statement_group in logpath_group.logpath:
+            if statement_group.group_type == "log":
+                config_snippet += render_logpath_groups(logpath_groups=[statement_group])
+            else:
+                config_snippet += "    {}({});\n".format(
+                    statement_group.group_type, statement_group.group_id,
+                )
+        if logpath_group.flags:
+            config_snippet += "    flags({});\n".format("".join(logpath_group.flags))
+        config_snippet += "};\n"
+
+    return config_snippet
+
+
 class ConfigRenderer(object):
     def __init__(self, syslog_ng_config):
         self.__syslog_ng_config = syslog_ng_config
@@ -42,101 +132,17 @@ class ConfigRenderer(object):
         config = ""
 
         if version:
-            config += self.__render_version(version)
+            config += render_version(version)
         if includes:
-            config += self.__render_includes(includes)
+            config += render_includes(includes)
         if global_options:
-            config += self.__render_global_options(global_options)
+            config += render_global_options(global_options)
         if statement_groups:
-            config += self.__render_statement_groups(statement_groups)
+            config += render_statement_groups(statement_groups)
         if logpath_groups:
-            config += self.__render_logpath_groups(logpath_groups)
+            config += render_logpath_groups(logpath_groups)
 
         if re_create_config:
             self.__syslog_ng_config_content = config
         else:
             self.__syslog_ng_config_content += config
-
-    def __render_version(self, version):
-        return "@version: {}\n".format(version)
-
-    def __render_includes(self, includes):
-        include_lines = ['@include "{}"'.format(include) for include in includes]
-        return "\n".join(include_lines)
-
-    def __render_global_options(self, global_options):
-        globals_options_header = "options {\n"
-        globals_options_footer = "};\n"
-
-        config_snippet = globals_options_header
-        for option_name, option_value in global_options.items():
-            config_snippet += "    {}({});\n".format(option_name, option_value)
-        config_snippet += globals_options_footer
-
-        return config_snippet
-
-    def __render_positional_options(self, positional_parameters):
-        config_snippet = ""
-        for parameter in positional_parameters:
-            config_snippet += "        {}\n".format(str(parameter))
-        return config_snippet
-
-    def __render_driver_options(self, driver_options):
-
-        config_snippet = ""
-
-        for option_name, option_value in driver_options.items():
-            if isinstance(option_value, dict):
-                config_snippet += "        {}(\n".format(option_name)
-                config_snippet += self.__render_driver_options(option_value)
-                config_snippet += "        )\n"
-            elif (isinstance(option_value, tuple) or isinstance(option_value, list)):
-                for element in option_value:
-                    config_snippet += "        {}({})\n".format(option_name, element)
-            else:
-                config_snippet += "        {}({})\n".format(option_name, option_value)
-
-        return config_snippet
-
-    def __render_statement_groups(self, statement_groups):
-        config_snippet = ""
-
-        for statement_group in statement_groups:
-            # statement header
-            config_snippet += "\n{} {} {{\n".format(
-                statement_group.group_type, statement_group.group_id,
-            )
-
-            for statement in statement_group:
-                # driver header
-                config_snippet += "    {} (\n".format(statement.driver_name)
-
-                # driver options
-                config_snippet += self.__render_positional_options(statement.positional_parameters)
-                config_snippet += self.__render_driver_options(statement.options)
-
-                # driver footer
-                config_snippet += "    );\n"
-
-            # statement footer
-            config_snippet += "};\n"
-
-        return config_snippet
-
-    def __render_logpath_groups(self, logpath_groups):
-        config_snippet = ""
-
-        for logpath_group in logpath_groups:
-            config_snippet += "\nlog {\n"
-            for statement_group in logpath_group.logpath:
-                if statement_group.group_type == "log":
-                    config_snippet += self.__render_logpath_groups(logpath_groups=[statement_group])
-                else:
-                    config_snippet += "    {}({});\n".format(
-                        statement_group.group_type, statement_group.group_id,
-                    )
-            if logpath_group.flags:
-                config_snippet += "    flags({});\n".format("".join(logpath_group.flags))
-            config_snippet += "};\n"
-
-        return config_snippet

--- a/tests/python_functional/src/syslog_ng_config/renderer.py
+++ b/tests/python_functional/src/syslog_ng_config/renderer.py
@@ -34,16 +34,23 @@ class ConfigRenderer(object):
     def __render(self, re_create_config=None):
         if re_create_config:
             self.__syslog_ng_config_content = ""
-        if self.__syslog_ng_config["version"]:
+
+        version = self.__syslog_ng_config["version"]
+        includes = self.__syslog_ng_config["includes"]
+        global_options = self.__syslog_ng_config["global_options"]
+        statement_groups = self.__syslog_ng_config["statement_groups"]
+        logpath_groups = self.__syslog_ng_config["logpath_groups"]
+
+        if version:
             self.__render_version()
-        if self.__syslog_ng_config["includes"]:
+        if includes:
             self.__render_includes()
-        if self.__syslog_ng_config["global_options"]:
+        if global_options:
             self.__render_global_options()
-        if self.__syslog_ng_config["statement_groups"]:
+        if statement_groups:
             self.__render_statement_groups()
-        if self.__syslog_ng_config["logpath_groups"]:
-            self.__render_logpath_groups(self.__syslog_ng_config["logpath_groups"])
+        if logpath_groups:
+            self.__render_logpath_groups(logpath_groups)
 
     def __render_version(self):
         self.__syslog_ng_config_content += "@version: {}\n".format(self.__syslog_ng_config["version"])

--- a/tests/python_functional/src/syslog_ng_config/renderer.py
+++ b/tests/python_functional/src/syslog_ng_config/renderer.py
@@ -42,29 +42,28 @@ class ConfigRenderer(object):
         logpath_groups = self.__syslog_ng_config["logpath_groups"]
 
         if version:
-            self.__render_version()
+            self.__render_version(version)
         if includes:
-            self.__render_includes()
+            self.__render_includes(includes)
         if global_options:
-            self.__render_global_options()
+            self.__render_global_options(global_options)
         if statement_groups:
-            self.__render_statement_groups()
+            self.__render_statement_groups(statement_groups)
         if logpath_groups:
             self.__render_logpath_groups(logpath_groups)
 
-    def __render_version(self):
-        self.__syslog_ng_config_content += "@version: {}\n".format(self.__syslog_ng_config["version"])
+    def __render_version(self, version):
+        self.__syslog_ng_config_content += "@version: {}\n".format(version)
 
-    def __render_includes(self):
-        includes = self.__syslog_ng_config["includes"]
+    def __render_includes(self, includes):
         for include in includes:
             self.__syslog_ng_config_content += '@include "{}"\n'.format(include)
 
-    def __render_global_options(self):
+    def __render_global_options(self, global_options):
         globals_options_header = "options {\n"
         globals_options_footer = "};\n"
         self.__syslog_ng_config_content += globals_options_header
-        for option_name, option_value in self.__syslog_ng_config["global_options"].items():
+        for option_name, option_value in global_options.items():
             self.__syslog_ng_config_content += "    {}({});\n".format(option_name, option_value)
         self.__syslog_ng_config_content += globals_options_footer
 
@@ -84,8 +83,8 @@ class ConfigRenderer(object):
             else:
                 self.__syslog_ng_config_content += "        {}({})\n".format(option_name, option_value)
 
-    def __render_statement_groups(self):
-        for statement_group in self.__syslog_ng_config["statement_groups"]:
+    def __render_statement_groups(self, statement_groups):
+        for statement_group in statement_groups:
             # statement header
             self.__syslog_ng_config_content += "\n{} {} {{\n".format(
                 statement_group.group_type, statement_group.group_id,

--- a/tests/python_functional/src/syslog_ng_config/renderer.py
+++ b/tests/python_functional/src/syslog_ng_config/renderer.py
@@ -87,6 +87,13 @@ def render_driver_options(driver_options):
     return config_snippet
 
 
+def render_statement(statement):
+    config_snippet = ""
+    config_snippet += render_positional_options(statement.positional_parameters)
+    config_snippet += render_driver_options(statement.options)
+    return config_snippet
+
+
 def render_statement_groups(statement_groups):
     config_snippet = ""
 
@@ -100,9 +107,7 @@ def render_statement_groups(statement_groups):
             # driver header
             config_snippet += "    {} (\n".format(statement.driver_name)
 
-            # driver options
-            config_snippet += render_positional_options(statement.positional_parameters)
-            config_snippet += render_driver_options(statement.options)
+            config_snippet += render_statement(statement)
 
             # driver footer
             config_snippet += "    );\n"

--- a/tests/python_functional/src/syslog_ng_config/renderer.py
+++ b/tests/python_functional/src/syslog_ng_config/renderer.py
@@ -50,19 +50,39 @@ def render_positional_options(positional_parameters):
     return config_snippet
 
 
+def render_options(name, options):
+
+    config_snippet = ""
+    config_snippet += "        {}(\n".format(name)
+    config_snippet += render_driver_options(options)
+    config_snippet += "        )\n"
+
+    return config_snippet
+
+
+def render_list(name, options):
+    config_snippet = ""
+
+    for element in options:
+        config_snippet += "        {}({})\n".format(name, element)
+
+    return config_snippet
+
+
+def render_name_value(name, value):
+    return "        {}({})\n".format(name, value)
+
+
 def render_driver_options(driver_options):
     config_snippet = ""
 
     for option_name, option_value in driver_options.items():
         if isinstance(option_value, dict):
-            config_snippet += "        {}(\n".format(option_name)
-            config_snippet += render_driver_options(option_value)
-            config_snippet += "        )\n"
+            config_snippet += render_options(option_name, option_value)
         elif (isinstance(option_value, tuple) or isinstance(option_value, list)):
-            for element in option_value:
-                config_snippet += "        {}({})\n".format(option_name, element)
+            config_snippet += render_list(option_name, option_value)
         else:
-            config_snippet += "        {}({})\n".format(option_name, option_value)
+            config_snippet += render_name_value(option_name, option_value)
 
     return config_snippet
 

--- a/tests/python_functional/src/syslog_ng_config/statements/filters/filter.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/filters/filter.py
@@ -25,7 +25,13 @@
 class Filter(object):
     group_type = "filter"
 
-    def __init__(self, **options):
+    def __init__(self, positional_parameters, **options):
         self.options = options
         self.driver_name = ""
-        self.positional_parameters = []
+        self.positional_parameters = positional_parameters
+
+
+class Match(Filter):
+    def __init__(self, match_string, **options):
+        super(Match, self).__init__([match_string], **options)
+        self.driver_name = "match"

--- a/tests/python_functional/src/syslog_ng_config/statements/rewrite/rewrite.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/rewrite/rewrite.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2020 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+
+class Rewrite(object):
+    group_type = "rewrite"
+
+    def __init__(self, driver_name, positional_parameters, **options):
+        self.driver_name = driver_name
+        self.options = options
+        self.positional_parameters = positional_parameters
+
+
+class SetTag(Rewrite):
+    def __init__(self, tag, **options):
+        super(SetTag, self).__init__("set_tag", [tag], **options)

--- a/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
@@ -31,6 +31,7 @@ from src.syslog_ng_config.statements.destinations.snmp_destination import SnmpDe
 from src.syslog_ng_config.statements.filters.filter import Filter
 from src.syslog_ng_config.statements.logpath.logpath import LogPath
 from src.syslog_ng_config.statements.parsers.parser import Parser
+from src.syslog_ng_config.statements.rewrite.rewrite import SetTag
 from src.syslog_ng_config.statements.sources.example_msg_generator_source import ExampleMsgGeneratorSource
 from src.syslog_ng_config.statements.sources.file_source import FileSource
 
@@ -80,6 +81,9 @@ class SyslogNgConfig(object):
 
     def create_example_msg_generator_source(self, **options):
         return ExampleMsgGeneratorSource(**options)
+
+    def create_rewrite_set_tag(self, tag, **options):
+        return SetTag(tag, **options)
 
     def create_filter(self, **options):
         return Filter(**options)

--- a/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
@@ -86,7 +86,7 @@ class SyslogNgConfig(object):
         return SetTag(tag, **options)
 
     def create_filter(self, **options):
-        return Filter(**options)
+        return Filter([], **options)
 
     def create_app_parser(self, **options):
         return Parser("app-parser", **options)


### PR DESCRIPTION
No changenote necessary.

`condition='match("MATCHSTRING" value("MSG"))'` is a little awkward (the value is a verbatim string).

This is the first time a driver needs positional parameter inside an option block. (If there were no `"MATCHSTRING"`, light could handle it with a dictionary though.)

 I was wondering if I could use a tuple format + small modification in the rendering logic, like
`condition = {"match" : ("MATCHSTRING", {"value" : "MSG"}}`, but tuple is already reserved for different logic for snmptrapd.

Unfortunately I do not know any simple way to fix this in the current architecture.

Edit: introduced a filter object that can be passed to condition