### PR TITLE
[WIP] example-msg-generator: crash during failed reload

### DIFF
--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -94,6 +94,34 @@ register_application_hook(gint type, ApplicationHookFunc func, gpointer user_dat
     }
 }
 
+void
+unregister_application_hook(gint type, ApplicationHookFunc func, gpointer user_data)
+{
+  GList *l, *l_next;
+
+  msg_debug("Unregistering hook",
+            evt_tag_int("type", type),
+            evt_tag_ptr("func", func),
+            evt_tag_ptr("user_data", user_data));
+
+  for (l = application_hooks; l; l = l_next)
+    {
+      ApplicationHookEntry *e = l->data;
+
+      if (e->type == type && e->func == func && e->user_data == user_data)
+        {
+          l_next = l->next;
+          application_hooks = g_list_remove_link(application_hooks, l);
+          g_free(e);
+          g_list_free_1(l);
+        }
+      else
+        {
+          l_next = l->next;
+        }
+    }
+}
+
 static void
 _update_current_state(gint type)
 {

--- a/lib/apphook.h
+++ b/lib/apphook.h
@@ -63,6 +63,7 @@ gboolean app_is_starting_up(void);
 gboolean app_is_shutting_down(void);
 
 void register_application_hook(gint type, ApplicationHookFunc func, gpointer user_data);
+void unregister_application_hook(gint type, ApplicationHookFunc func, gpointer user_data);
 
 void app_thread_start(void);
 void app_thread_stop(void);

--- a/lib/eventlog/src/evtlog.h
+++ b/lib/eventlog/src/evtlog.h
@@ -141,6 +141,7 @@ void evt_rec_free(EVTREC *e);
  **/
 EVTTAG *evt_tag_str(const char *tag, const char *value);
 EVTTAG *evt_tag_int(const char *tag, int value);
+EVTTAG *evt_tag_ptr(const char *tag, void *ptr);
 EVTTAG *evt_tag_long(const char *tag, long long value);
 EVTTAG *evt_tag_errno(const char *tag, int err);
 EVTTAG *evt_tag_printf(const char *tag, const char *format, ...) G_GNUC_PRINTF(2, 3);

--- a/lib/eventlog/src/evttags.c
+++ b/lib/eventlog/src/evttags.c
@@ -90,6 +90,15 @@ evt_tag_int(const char *tag, int value)
 }
 
 EVTTAG *
+evt_tag_ptr(const char *tag, void *ptr)
+{
+  char buf[32]; /* a 64 bit int fits into 20 characters */
+
+  snprintf(buf, sizeof(buf), "%p", ptr);
+  return evt_tag_str(tag, buf);
+}
+
+EVTTAG *
 evt_tag_long(const char *tag, long long value)
 {
   char buf[32]; /* a 64 bit int fits into 20 characters */

--- a/modules/examples/sources/msg-generator/msg-generator-source.c
+++ b/modules/examples/sources/msg-generator/msg-generator-source.c
@@ -24,6 +24,7 @@
 #include "msg-generator-source.h"
 
 #include "logsource.h"
+#include "apphook.h"
 #include "logpipe.h"
 #include "logmsg/logmsg.h"
 #include "template/templates.h"
@@ -65,6 +66,13 @@ _start_timer_immediately(MsgGeneratorSource *self)
   iv_timer_register(&self->timer);
 }
 
+void
+_start_timer_hook(gint hook, gpointer user_data)
+{
+  MsgGeneratorSource *self = (MsgGeneratorSource *)user_data;
+  _start_timer_immediately(self);
+}
+
 static gboolean
 _init(LogPipe *s)
 {
@@ -72,7 +80,7 @@ _init(LogPipe *s)
   if (!log_source_init(s))
     return FALSE;
 
-  _start_timer_immediately(self);
+  register_application_hook(AH_CONFIG_CHANGED, _start_timer_hook, self);
 
   return TRUE;
 }
@@ -82,6 +90,7 @@ _deinit(LogPipe *s)
 {
   MsgGeneratorSource *self = (MsgGeneratorSource *) s;
 
+  unregister_application_hook(AH_CONFIG_CHANGED, _start_timer_hook, self);
   _stop_timer(self);
 
   return log_source_deinit(s);

--- a/news/bugfix-3196.md
+++ b/news/bugfix-3196.md
@@ -1,0 +1,1 @@
+`example-msg-generator`: fix crash during failed reload


### PR DESCRIPTION
`example-msg-generator` starts it's timer during init. The timer triggers a `log_source_post`, which may push the message down the graph even before the entire `cfg_init()` finishes. This means the pushed message may arrive to uninitialized pipes. In this patch, the timer is started by apphook, instead of init.

I can steadily reproduce the crash with a failed reload:
```
@version: 3.26

filter f_my_info { level(info); }; # comment this line before reload

log {
  source { example-msg-generator(num(1)); };
  filter { filter(f_my_info); };

};
```

The problem found while testing: https://github.com/syslog-ng/syslog-ng/pull/3176