### PR TITLE
mongodb: replace deprecated API get_server_status()

### DIFF
--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -180,10 +180,11 @@ _connect(MongoDBDestDriver *self, gboolean reconnect)
 
   bson_t reply;
   bson_error_t error;
+  bson_t *cmd = BCON_NEW("serverStatus", "1");
   const mongoc_read_prefs_t *read_prefs = mongoc_collection_get_read_prefs(self->coll_obj);
-  gboolean ok = mongoc_client_get_server_status(self->client, (mongoc_read_prefs_t *)read_prefs,
-                                                &reply, &error);
+  gboolean ok = mongoc_client_command_simple(self->client, self->const_db ? : "", cmd, read_prefs, &reply, &error);
   bson_destroy(&reply);
+  bson_destroy(cmd);
   if (!ok)
     {
       msg_error("Error connecting to MongoDB",

--- a/news/developer-note-3199.md
+++ b/news/developer-note-3199.md
@@ -1,0 +1,2 @@
+`mongodb`: Replaced the deprecated `get_server_status()` API with `command_simple()`.
+This means, that `syslog-ng` can now be built with `-Werror` on systems with 1.15 `libmongoc`.


### PR DESCRIPTION
Deprecation information: http://mongoc.org/libmongoc/current/mongoc_client_get_server_status.html

The documentation above suggests to use [mongoc_client_read_command_with_opts()](http://mongoc.org/libmongoc/current/mongoc_client_read_command_with_opts.html), but its documentation suggests, that if the usage of `opts` is not needed, it is enough to use [mongoc_client_command_simple()](http://mongoc.org/libmongoc/current/mongoc_client_command_simple.html).

[mongoc_client_command_simple()](http://mongoc.org/libmongoc/1.0.0/mongoc_client_command_simple.html) is available in `libmongoc` version `1.0.0`, which is set in our `configure.ac` file as the minimum needed version: `LMC_MIN_VERSION="1.0.0"`

Please do not merge, until internal tests validated the change.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>