### PR TITLE
exec-prop-check: fix execution in devshell

### DIFF
--- a/tests/build-log-cflags-propagation.sh
+++ b/tests/build-log-cflags-propagation.sh
@@ -100,9 +100,9 @@ ignore_submodule_gcc_ivykis() {
 gcc -DHAVE_CONFIG_H -I\. -I\.\./\.\. +-D_GNU_SOURCE -I\.\./\.\./src/include -I\.\./\.\./src/include |\
 gcc -DHAVE_CONFIG_H -I\. -I\.\./\.\.  -I\.\./\.\./src/include -I\.\./\.\./src/include |\
 gcc -DHAVE_CONFIG_H -I\. -I\.\. +-D_GNU_SOURCE -I\.\./src/include -I\.\./src/include |\
-gcc( -std=gnu99)? -DHAVE_CONFIG_H -I\. -I\.\./\.\./\.\./\.\./lib/ivykis/src |\
-gcc( -std=gnu99)? -DHAVE_CONFIG_H -I\. -I\.\./\.\./\.\./\.\./lib/ivykis/test(.mt)? |\
-gcc( -std=gnu99)? -DHAVE_CONFIG_H -I\. -I\.\./\.\./\.\./\.\./\.\./lib/ivykis/contrib/iv_getaddrinfo |\
-gcc -std=gnu99 -DHAVE_CONFIG_H -I\. -I\.\./\.\./\.\./\.\./\.\./lib/ivykis/contrib/kojines \
+gcc( -std=gnu99)? -DHAVE_CONFIG_H -I\. -I(\.\./)+lib/ivykis/src |\
+gcc( -std=gnu99)? -DHAVE_CONFIG_H -I\. -I(\.\./)+lib/ivykis/test(.mt)? |\
+gcc( -std=gnu99)? -DHAVE_CONFIG_H -I\. -I(\.\./)+lib/ivykis/contrib/iv_getaddrinfo |\
+gcc( -std=gnu99)? -DHAVE_CONFIG_H -I\. -I(\.\./)+lib/ivykis/contrib/kojines \
 )" "$@"
 }


### PR DESCRIPTION
In the `syslog-ng-devshell` docker image `exec_prop_check` fails, because it does not correctly determines the ivykis related compile commands. For some reason in the docker image the ivykis source dir has one more `../` in it, which does not get removed by the regex
given.

Although, I did not find the reason behind the dir level anomaly, I believe this change will not make false positive regex matches, the regex is strict enough with the change, too.

Fixes #3182

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>