### PR TITLE
iterate: new template function

### DIFF
--- a/modules/basicfuncs/Makefile.am
+++ b/modules/basicfuncs/Makefile.am
@@ -24,6 +24,7 @@ EXTRA_DIST					+=	\
 	modules/basicfuncs/misc-funcs.c			\
 	modules/basicfuncs/list-funcs.c			\
 	modules/basicfuncs/tf-template.c		\
+	modules/basicfuncs/tf-iterate.c			\
 	modules/basicfuncs/CMakeLists.txt
 
 modules/basicfuncs modules/basicfuncs/ mod-basicfuncs: modules/basicfuncs/libbasicfuncs.la

--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -64,6 +64,7 @@ _append_args_with_separator(gint argc, GString *argv[], GString *result, gchar s
 #include "tf-template.c"
 #include "context-funcs.c"
 #include "fname-funcs.c"
+#include "tf-iterate.c"
 
 static Plugin basicfuncs_plugins[] =
 {
@@ -129,7 +130,11 @@ static Plugin basicfuncs_plugins[] =
   TEMPLATE_FUNCTION_PLUGIN(tf_template, "template"),
   TEMPLATE_FUNCTION_PLUGIN(tf_urlencode, "url-encode"),
   TEMPLATE_FUNCTION_PLUGIN(tf_urldecode, "url-decode"),
-  TEMPLATE_FUNCTION_PLUGIN(tf_base64encode, "base64-encode")
+  TEMPLATE_FUNCTION_PLUGIN(tf_base64encode, "base64-encode"),
+
+  /* functional */
+  TEMPLATE_FUNCTION_PLUGIN(tf_iterate, "iterate"),
+
 };
 
 gboolean

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -567,3 +567,27 @@ Test(basicfuncs, test_tfurldecode)
   assert_template_format("$(url-decode %)", "");
   assert_template_format("$(url-decode %00a)", "");
 }
+
+Test(basicfuncs, test_functional)
+{
+  LogMessage *msg = log_msg_new_empty();
+  GString *result = g_string_new("");
+
+  LogTemplate *template = log_template_new(configuration, NULL);
+  cr_assert(log_template_compile(template, "Some prefix $(iterate \"$(+ 1 $_)\" 0)", NULL));
+
+  log_template_format(template, msg, NULL, LTZ_LOCAL, 999, "", result);
+  cr_assert_str_eq(result->str, "Some prefix 0");
+
+  g_string_assign(result, "");
+  log_template_format(template, msg, NULL, LTZ_LOCAL, 999, "", result);
+  cr_assert_str_eq(result->str, "Some prefix 1");
+
+  g_string_assign(result, "");
+  log_template_format(template, msg, NULL, LTZ_LOCAL, 999, "", result);
+  cr_assert_str_eq(result->str, "Some prefix 2");
+
+  g_string_free(result, TRUE);
+  log_template_unref(template);
+  log_msg_unref(msg);
+}

--- a/modules/basicfuncs/tf-iterate.c
+++ b/modules/basicfuncs/tf-iterate.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2020 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+typedef struct _IterateState
+{
+  TFSimpleFuncState super;
+  GMutex mutex;
+  GString *current;
+  LogTemplate *template;
+} IterateState;
+
+static gboolean
+tf_iterate_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, gint argc, gchar *argv[],
+                   GError **error)
+{
+  IterateState *state = (IterateState *)s;
+
+  GOptionContext *ctx = g_option_context_new("iterate");
+
+  if (!g_option_context_parse(ctx, &argc, &argv, error))
+    {
+      g_option_context_free(ctx);
+      return FALSE;
+    }
+
+  if (argc != 3)
+    {
+      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
+                  "Wrong number of arguments. Example: $(iterate template initial-value).\n");
+      g_option_context_free(ctx);
+      return FALSE;
+    }
+
+  state->template = log_template_new(configuration, "iterate");
+  if (!log_template_compile(state->template, argv[1], error))
+    {
+      log_template_unref(state->template);
+      state->template = NULL;
+      g_option_context_free(ctx);
+      return FALSE;
+    }
+
+  state->current = g_string_new(argv[2]);
+  g_option_context_free(ctx);
+
+  g_mutex_init(&state->mutex);
+
+  return TRUE;
+}
+
+static void
+update_current(LogTemplateFunction *self, IterateState *state, LogMessage *msg)
+{
+  gchar *current_value = g_strdup(state->current->str);
+
+  g_string_assign(state->current, "");
+  log_template_format(state->template, msg, NULL, LTZ_LOCAL, 0, current_value, state->current);
+
+  g_free(current_value);
+}
+
+static void
+tf_iterate_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArgs *args, GString *result)
+{
+  IterateState *state = (IterateState *)s;
+
+  g_mutex_lock(&state->mutex);
+  g_string_append(result, state->current->str);
+  update_current(self, state, args->messages[0]);
+  g_mutex_unlock(&state->mutex);
+}
+
+static void
+tf_iterate_free_state(gpointer s)
+{
+  IterateState *state = (IterateState *)s;
+
+  log_template_unref(state->template);
+  state->template = NULL;
+  g_string_free(state->current, TRUE);
+  state->current = NULL;
+
+  tf_simple_func_free_state(&state->super);
+  g_mutex_clear(&state->mutex);
+}
+
+TEMPLATE_FUNCTION(IterateState, tf_iterate, tf_iterate_prepare, NULL,
+                  tf_iterate_call, tf_iterate_free_state, NULL);

--- a/news/feature-3205.md
+++ b/news/feature-3205.md
@@ -1,0 +1,14 @@
+`iterate`: new template function
+
+The iterate template function generates a series from an initial number and a `next` function.
+
+For example you can generate a sequence of nonnegative numbers with
+
+```
+source {
+  example-msg-generator(
+    num(3)
+    template("$(iterate $(+ 1 $_) 0)")
+  );
+};
+```


### PR DESCRIPTION
This patchset adds a new template function: `iterate`.

You can think of `iterate` as a generator. The idea is the `iterate` function receives an initial value `x`, and an `f` function, and stores a current value in `$_`. When evaluated, `iterate` prints the current value, and also updates current value to `f(it)`. In other words, through evaluation, `iterate` prints `x`, `f(x)`, `f(f(x))`, ...

```
$(iterate $(+ 1 $_) 0)
```

With that, you can implement interesting stuff with syslog-ng, for example a sequence number.
Or even you can use this to loop through a list.

I would like to use these for tests: I want to generate different messages with `example-msg-generator`.

# Examples

## Sequence number
```
@version: 3.26

log {
    source { example-msg-generator(num(3) freq(0.001) template("$(iterate $(+ 1 $_) 0)")); };
    destination { file(/dev/stdout); };
};
```
will print
```
$ timeout 1 ./syslog-ng -Fe -f ../etc/iterate.conf 
[2020-03-29T11:54:13.488177] syslog-ng starting up; version='3.26.1.140.g2ff84d4'
Mar 29 11:54:13 furiel 0
Mar 29 11:54:13 furiel 1
Mar 29 11:54:13 furiel 2
[2020-03-29T11:54:14.460958] syslog-ng shutting down; version='3.26.1.140.g2ff84d4'
$ 
```

## Loop through list

```
@version: 3.26

log {
    source { example-msg-generator(num(6) freq(0.001)
             template("$(list-nth
                           $(iterate
                               $(% $(+ 1 $_) 3) 0)
                               \"msg1\",\"msg2\",\"msg3\")")); };
    destination { file(/dev/stdout); };
};
```

results in

```
$ timeout 1 ./syslog-ng -Fe -f ../etc/iterate.conf 
[2020-03-29T11:57:08.561749] syslog-ng starting up; version='3.26.1.140.g2ff84d4'
Mar 29 11:57:08 furiel msg1
Mar 29 11:57:08 furiel msg2
Mar 29 11:57:08 furiel msg3
Mar 29 11:57:08 furiel msg1
Mar 29 11:57:08 furiel msg2
Mar 29 11:57:08 furiel msg3
[2020-03-29T11:57:09.540061] syslog-ng shutting down; version='3.26.1.140.g2ff84d4'
$ 
```