### PR TITLE
telegram: truncate message to 4096 length to avoid destination getting stuck

### DIFF
--- a/news/bugfix-3206.md
+++ b/news/bugfix-3206.md
@@ -1,0 +1,1 @@
+`telegram`: automatically truncate messages larger than 4096 utf8 characters to avoid telegram destination to get stuck

--- a/news/feature-3206.md
+++ b/news/feature-3206.md
@@ -1,0 +1,3 @@
+`telegram`: new `max-size` option
+
+Telegram message will be truncated for `max-size` size. Telegram does not accept message larger than 4096 utf8 characters. The default value is 4096.

--- a/scl/telegram/telegram.conf
+++ b/scl/telegram/telegram.conf
@@ -23,6 +23,7 @@
 @requires http
 
 # Throttle: https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this
+# max-size: message size maximum is 4096. Other fields than message do not count.
 block destination telegram(
       bot-id()
       chat-id()
@@ -31,6 +32,7 @@ block destination telegram(
       throttle(1)
       disable-web-page-preview("true")
       use-system-cert-store(yes)
+      max-size(4096)
       ...)
 {
 
@@ -39,7 +41,7 @@ block destination telegram(
     http(
         url("https://api.telegram.org/bot`bot-id`/sendMessage")
         method("POST")
-        body("disable_web_page_preview=`disable-web-page-preview`&parse_mode=`parse-mode`&chat_id=`chat-id`&text=$(url-encode \"`template`\")\n")
+        body("disable_web_page_preview=`disable-web-page-preview`&parse_mode=`parse-mode`&chat_id=`chat-id`&text=$(url-encode $(substr \"`template`\" 0 `max-size`))\n")
         throttle(`throttle`)
         use-system-cert-store(`use-system-cert-store`)
         `__VARARGS__`


### PR DESCRIPTION
Telegram returns with 400 http response with `MESSAGE_TOO_LONG`, if the telegram message is longer than 4096 utf8 characters. I could not find this value in the official documentation, but unofficially I could find it here and there. I also tested, and 4096 long message passes, but 4097 fails. The request itself can be longer (we send other fields). Only the message field is restricted to 4096.

This patchset adds to telegram destination an additional parameter: `truncate` which tells the truncate length, which will be applied to the message. Initial value is 4096.

I wish there were `maximum` template function, that I could apply, if users provide larger length than 4096. (There is a `max` template function, but that works on message contexts instead of raw numbers. I will create a good first issue feature request for it).

Since 3.25, syslog-ng disconnects for 400 by default. It means the problematic message is put back to the queue, then retried after time-reopen, infinitely blocking telegram notifications.

Prior to 3.26, the 400 error code was mapped to drop, instead of disconnect, so in those versions only the message is lost, but the connection did not get stuck. I was thinking if we may change the default action of 400 of telegram destination, but the other 400-related events seems fine for disconnect. https://core.telegram.org/method/messages.sendMessage