### PR TITLE
rpm: fix --without maxminddb option

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,7 +24,6 @@ jobs:
             --disable-systemd \
             --disable-pacct \
             --disable-smtp \
-            --disable-geoip \
             --enable-all-modules
 
           make --keep-going -j $(sysctl -n hw.physicalcpu) || \

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ addons:
       - libdbd-sqlite3
       - libdbi0-dev
       - libesmtp-dev
-      - libgeoip-dev
       - libglib2.0-dev
       - libhiredis-dev
       - libivykis-dev
@@ -201,7 +200,6 @@ matrix:
             - libdbd-sqlite3
             - libdbi0-dev
             - libesmtp-dev
-            - libgeoip-dev
             - libglib2.0-dev
             - libhiredis-dev
             - libivykis-dev
@@ -263,7 +261,6 @@ matrix:
             - libdbd-sqlite3
             - libdbi0-dev
             - libesmtp-dev
-            - libgeoip-dev
             - libglib2.0-dev
             - libhiredis-dev
             - librabbitmq-dev

--- a/news/packaging-3208.md
+++ b/news/packaging-3208.md
@@ -1,0 +1,3 @@
+`rpm`: fix --without maxminddb option
+
+If maxminddb development package was installed on the build system: rpmbuild fails if `--without maxminddb` was used.

--- a/packaging/debian/syslog-ng-mod-geoip.install
+++ b/packaging/debian/syslog-ng-mod-geoip.install
@@ -1,1 +1,0 @@
-usr/lib/syslog-ng/*/libgeoip-plugin.so

--- a/packaging/rhel/syslog-ng.spec
+++ b/packaging/rhel/syslog-ng.spec
@@ -305,7 +305,6 @@ developing applications that use %{name}.
 
 %build
 
-export GEOIP_LIBS=-lGeoIP
 %configure \
     --prefix=%{_prefix} \
     --sysconfdir=%{_sysconfdir}/%{name} \
@@ -335,6 +334,7 @@ export GEOIP_LIBS=-lGeoIP
     %{?with_kafka:--enable-kafka} \
     %{?with_afsnmp:--enable-afsnmp} %{!?with_afsnmp:--disable-afsnmp} \
     %{?with_java:--enable-java} %{!?with_java:--disable-java} \
+    %{?with_maxminddb:--enable-geoip2} %{!?with_maxminddb:--disable-geoip2} \
     %{?with_sql:--enable-sql} \
     %{?with_systemd:--enable-systemd} \
     %{?with_mongodb:--enable-mongodb} \
@@ -555,8 +555,8 @@ fi
 %{_libdir}/%{name}/java-modules/*
 %endif
 
-%files geoip
 %if %{with maxminddb}
+%files geoip
 %{_libdir}/%{name}/libgeoip2-plugin.so
 %endif
 


### PR DESCRIPTION
This change fixes rpmbuild, if `--without maxminddb` was used. If the maxminddb development files are installed on the system, after autodetection in syslog-ng, libgeoip2-plugin.so will be compiled and installed. However it will not be picked up by any packages. Hence command failure.
@czanik FYI

This patchset also contains a minor cleanup leftover after the geoip2 removal.