### PR TITLE
fixing incompatibilities with old glib versions (<2.32)

### DIFF
--- a/lib/compat/glib-g_mkdtemp.c
+++ b/lib/compat/glib-g_mkdtemp.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2020 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+// This code was copied from https://github.com/GNOME/glib/blob/mainline/glib/gfileutils.c
+
+/* gfileutils.c - File utility functions
+ *
+ *  Copyright 2000 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <errno.h>
+#include <glib/gstdio.h>
+
+static gint
+wrap_g_mkdir (const gchar *filename,
+              int          flags G_GNUC_UNUSED,
+              int          mode)
+{
+  /* tmpl is in UTF-8 on Windows, thus use g_mkdir() */
+  return g_mkdir (filename, mode);
+}
+
+typedef gint (*GTmpFileCallback) (const gchar *, gint, gint);
+
+static gint
+get_tmp_file (gchar            *tmpl,
+              GTmpFileCallback  f,
+              int               flags,
+              int               mode)
+{
+  char *XXXXXX;
+  int count, fd;
+  static const char letters[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  static const int NLETTERS = sizeof (letters) - 1;
+  glong value;
+  gint64 now_us;
+  static int counter = 0;
+
+  g_return_val_if_fail (tmpl != NULL, -1);
+
+  /* find the last occurrence of "XXXXXX" */
+  XXXXXX = g_strrstr (tmpl, "XXXXXX");
+
+  if (!XXXXXX || strncmp (XXXXXX, "XXXXXX", 6))
+    {
+      errno = EINVAL;
+      return -1;
+    }
+
+  /* Get some more or less random data.  */
+  now_us = g_get_real_time ();
+  value = ((now_us % G_USEC_PER_SEC) ^ (now_us / G_USEC_PER_SEC)) + counter++;
+
+  for (count = 0; count < 100; value += 7777, ++count)
+    {
+      glong v = value;
+
+      /* Fill in the random bits.  */
+      XXXXXX[0] = letters[v % NLETTERS];
+      v /= NLETTERS;
+      XXXXXX[1] = letters[v % NLETTERS];
+      v /= NLETTERS;
+      XXXXXX[2] = letters[v % NLETTERS];
+      v /= NLETTERS;
+      XXXXXX[3] = letters[v % NLETTERS];
+      v /= NLETTERS;
+      XXXXXX[4] = letters[v % NLETTERS];
+      v /= NLETTERS;
+      XXXXXX[5] = letters[v % NLETTERS];
+
+      fd = f (tmpl, flags, mode);
+
+      if (fd >= 0)
+        return fd;
+      else if (errno != EEXIST)
+        /* Any other error will apply also to other names we might
+         *  try, and there are 2^32 or so of them, so give up now.
+         */
+        return -1;
+    }
+
+  /* We got out of the loop because we ran out of combinations to try.  */
+  errno = EEXIST;
+  return -1;
+}
+
+gchar *
+g_mkdtemp_full (gchar *tmpl,
+                gint   mode)
+{
+  if (get_tmp_file (tmpl, wrap_g_mkdir, 0, mode) == -1)
+    return NULL;
+  else
+    return tmpl;
+}
+
+gchar *
+g_mkdtemp (gchar *tmpl)
+{
+  return g_mkdtemp_full (tmpl, 0700);
+}

--- a/lib/compat/glib.c
+++ b/lib/compat/glib.c
@@ -339,3 +339,13 @@ g_thread_new(const gchar *name, GThreadFunc func, gpointer data)
   return g_thread_create(func, data, TRUE, NULL);
 }
 #endif
+
+#if !GLIB_CHECK_VERSION(2, 32, 0)
+gboolean
+g_cond_wait_until (GCond *cond, GMutex *mutex, gint64 end_time)
+{
+  glong diff_in_sec = (end_time - g_get_monotonic_time())/G_TIME_SPAN_SECOND;
+  GTimeVal tv = {.tv_sec = g_get_monotonic_time() + diff_in_sec, .tv_usec = 0};
+  return g_cond_timed_wait(cond, mutex, &tv);
+}
+#endif

--- a/lib/compat/glib.c
+++ b/lib/compat/glib.c
@@ -349,3 +349,7 @@ g_cond_wait_until (GCond *cond, GMutex *mutex, gint64 end_time)
   return g_cond_timed_wait(cond, mutex, &tv);
 }
 #endif
+
+#if !GLIB_CHECK_VERSION(2, 30, 0)
+#include "glib-g_mkdtemp.c"
+#endif

--- a/lib/compat/glib.c
+++ b/lib/compat/glib.c
@@ -331,3 +331,11 @@ g_utf8_get_char_validated_fixed(const gchar *p, gssize max_len)
   return g_utf8_get_char_validated(p, max_len);
 }
 #endif
+
+#if !GLIB_CHECK_VERSION(2, 32, 0)
+GThread *
+g_thread_new(const gchar *name, GThreadFunc func, gpointer data)
+{
+  return g_thread_create(func, data, TRUE, NULL);
+}
+#endif

--- a/lib/compat/glib.c
+++ b/lib/compat/glib.c
@@ -313,7 +313,7 @@ slng_g_hash_table_insert(GHashTable *hash_table, gpointer key, gpointer value)
   gboolean exists = g_hash_table_contains(hash_table, key);
 #undef g_hash_table_insert
   g_hash_table_insert(hash_table, key, value);
-  return exists;
+  return !exists;
 }
 #endif
 

--- a/lib/compat/glib.h
+++ b/lib/compat/glib.h
@@ -114,4 +114,8 @@ gboolean slng_g_hash_table_insert (GHashTable *hash_table, gpointer key, gpointe
 gunichar g_utf8_get_char_validated_fixed (const gchar *p, gssize max_len);
 #endif
 
+#if !GLIB_CHECK_VERSION(2, 32, 0)
+GThread *g_thread_new(const gchar *name, GThreadFunc func, gpointer data);
+#endif
+
 #endif

--- a/lib/compat/glib.h
+++ b/lib/compat/glib.h
@@ -118,4 +118,8 @@ gunichar g_utf8_get_char_validated_fixed (const gchar *p, gssize max_len);
 GThread *g_thread_new(const gchar *name, GThreadFunc func, gpointer data);
 #endif
 
+#if !GLIB_CHECK_VERSION(2, 32, 0)
+gboolean g_cond_wait_until (GCond *cond, GMutex *mutex, gint64 end_time);
+#endif
+
 #endif

--- a/lib/compat/glib.h
+++ b/lib/compat/glib.h
@@ -122,4 +122,9 @@ GThread *g_thread_new(const gchar *name, GThreadFunc func, gpointer data);
 gboolean g_cond_wait_until (GCond *cond, GMutex *mutex, gint64 end_time);
 #endif
 
+#if !GLIB_CHECK_VERSION(2, 30, 0)
+gchar *g_mkdtemp_full (gchar *tmpl, gint mode);
+gchar *g_mkdtemp (gchar *tmpl);
+#endif
+
 #endif

--- a/lib/signal-slot-connector/tests/test_signal_slots.c
+++ b/lib/signal-slot-connector/tests/test_signal_slots.c
@@ -316,3 +316,12 @@ Test(multiple_signals_slots,
   signal_slot_connector_free(ssc);
 }
 
+static void
+setup(void)
+{
+  // Optional after glib 2.32
+  g_thread_init(NULL);
+}
+
+TestSuite(basic_signal_slots, .init = setup);
+TestSuite(multiple_signals_slots, .init = setup);

--- a/lib/tests/test_scratch_buffers.c
+++ b/lib/tests/test_scratch_buffers.c
@@ -159,8 +159,8 @@ Test(scratch_buffers, stats_counters_are_updated)
 static void
 setup(void)
 {
-  main_loop_thread_resource_init();
   g_thread_init(NULL);
+  main_loop_thread_resource_init();
   stats_init();
   scratch_buffers_global_init();
   scratch_buffers_allocator_init();

--- a/modules/afmongodb/tests/test-mongodb-config.c
+++ b/modules/afmongodb/tests/test-mongodb-config.c
@@ -190,10 +190,10 @@ _test_uri_error(void)
 static void
 _setup(void)
 {
+  g_thread_init(NULL);
   main_loop_thread_resource_init();
   stats_cluster_init();
   msg_init(FALSE);
-  g_thread_init(NULL);
 
   debug_flag = TRUE;
   verbose_flag = TRUE;

--- a/tests/loggen/CMakeLists.txt
+++ b/tests/loggen/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LOGGEN_HELPER_SOURCE
   loggen_helper.h
   ${PROJECT_SOURCE_DIR}/lib/crypto.c
   ${PROJECT_SOURCE_DIR}/lib/compat/openssl_support.c
+  ${PROJECT_SOURCE_DIR}/lib/compat/glib.c
   )
 
 add_library(loggen_helper STATIC ${LOGGEN_HELPER_SOURCE})
@@ -17,6 +18,7 @@ include_directories(loggen_helper PUBLIC
 
 target_link_libraries(
   loggen_helper
+  PUBLIC
   ${GLIB_GMODULE_LIBRARIES}
   ${GLIB_GTHREAD_LIBRARIES}
   ${GLIB_LIBRARIES}
@@ -37,12 +39,7 @@ set(LOGGEN_PLUGIN_SOURCE
 
 add_library(loggen_plugin STATIC ${LOGGEN_HELPER_SOURCE})
 
-include_directories(loggen_plugin PUBLIC
-  ${CORE_INCLUDE_DIRS}
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${GLIB_INCLUDE_DIRS}
-  ${PROJECT_SOURCE_DIR}/lib
-  )
+include_directories(loggen_plugin PUBLIC loggen_helper)
 
 set_target_properties(loggen_plugin
     PROPERTIES VERSION ${SYSLOG_NG_VERSION}
@@ -60,7 +57,6 @@ set(LOGGEN_SOURCE
     logline_generator.h
     ${PROJECT_SOURCE_DIR}/lib/reloc.c
     ${PROJECT_SOURCE_DIR}/lib/cache.c
-    ${PROJECT_SOURCE_DIR}/lib/compat/glib.c
     )
 
 add_executable(loggen ${LOGGEN_SOURCE})
@@ -69,20 +65,9 @@ target_compile_definitions(loggen PUBLIC
   SYSLOG_NG_PATH_LOGGENPLUGINDIR="${LOGGEN_PLUGIN_INSTALL_DIR}"
   )
 
-include_directories(loggen
-  ${CORE_INCLUDE_DIRS}
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${GLIB_INCLUDE_DIRS}
-  ${PROJECT_SOURCE_DIR}/lib
-  )
-
 target_link_libraries(
   loggen
-  loggen_helper
-  ${GLIB_GMODULE_LIBRARIES}
-  ${GLIB_GTHREAD_LIBRARIES}
-  ${GLIB_LIBRARIES}
-  )
+  loggen_helper)
 
 install(TARGETS loggen RUNTIME DESTINATION bin)
 

--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -466,6 +466,8 @@ setup_rate_change_signals(void)
 int
 main(int argc, char *argv[])
 {
+  g_thread_init(NULL);
+
   GPtrArray *plugin_array = g_ptr_array_new();
   GOptionContext *ctx = g_option_context_new(" target port");
 

--- a/tests/loggen/socket_plugin/CMakeLists.txt
+++ b/tests/loggen/socket_plugin/CMakeLists.txt
@@ -1,28 +1,12 @@
-include_directories(loggen_socket_plugin
-  ${CORE_INCLUDE_DIRS}
-  ${GLIB_INCLUDE_DIRS}
-  ${LOGGEN_INCLUDE_DIR}
-  )
-
 set (LOGGEN_SOCKET_PLUGIN_SOURCE
-  socket_plugin.c
-  ${LOGGEN_INCLUDE_DIR}/loggen_plugin.h
-  ${LOGGEN_INCLUDE_DIR}/loggen_helper.h
-  ${LOGGEN_INCLUDE_DIR}/loggen_plugin.c
-  ${LOGGEN_INCLUDE_DIR}/loggen_helper.c
-  )
+  socket_plugin.c)
 
 add_library(loggen_socket_plugin
   SHARED
   ${LOGGEN_SOCKET_PLUGIN_SOURCE}
   )
 
-target_link_libraries(
-  loggen_socket_plugin
-  ${GLIB_GMODULE_LIBRARIES}
-  ${GLIB_GTHREAD_LIBRARIES}
-  ${GLIB_LIBRARIES}
-  )
+target_link_libraries(loggen_socket_plugin loggen_plugin)
 
 set_target_properties(loggen_socket_plugin
     PROPERTIES VERSION ${SYSLOG_NG_VERSION}

--- a/tests/loggen/socket_plugin/socket_plugin.c
+++ b/tests/loggen/socket_plugin/socket_plugin.c
@@ -197,7 +197,7 @@ start(PluginOption *option)
     {
       if (! g_cond_wait_until(thread_connected, thread_lock, end_time))
         {
-          ERROR("timeout ocured while waiting for connections\n");
+          ERROR("timeout occured while waiting for connections\n");
           break;
         }
     }

--- a/tests/loggen/ssl_plugin/CMakeLists.txt
+++ b/tests/loggen/ssl_plugin/CMakeLists.txt
@@ -7,11 +7,7 @@ include_directories(loggen_ssl_plugin
 set (LOGGEN_SSL_PLUGIN_SOURCE
   ssl_plugin.c
   ${LOGGEN_INCLUDE_DIR}/loggen_plugin.h
-  ${LOGGEN_INCLUDE_DIR}/loggen_helper.h
   ${LOGGEN_INCLUDE_DIR}/loggen_plugin.c
-  ${LOGGEN_INCLUDE_DIR}/loggen_helper.c
-	${CMAKE_SOURCE_DIR}/lib/crypto.c
-	${CMAKE_SOURCE_DIR}/lib/compat/openssl_support.c
   )
 
 add_library(loggen_ssl_plugin
@@ -21,6 +17,7 @@ add_library(loggen_ssl_plugin
 
 target_link_libraries(
   loggen_ssl_plugin
+  loggen_helper
   ${GLIB_GMODULE_LIBRARIES}
   ${GLIB_GTHREAD_LIBRARIES}
   ${GLIB_LIBRARIES}

--- a/tests/loggen/ssl_plugin/ssl_plugin.c
+++ b/tests/loggen/ssl_plugin/ssl_plugin.c
@@ -185,7 +185,7 @@ start(PluginOption *option)
     {
       if (! g_cond_wait_until(thread_connected, thread_lock, end_time))
         {
-          ERROR("timeout ocured while waiting for connections\n");
+          ERROR("timeout occured while waiting for connections\n");
           break;
         }
     }


### PR DESCRIPTION
This patchset fixes incompatiblilities with old glib versions. After this, unit tests and the python functinal tests pass.
https://ci.syslog-ng.com/jenkins/job/daily-compile-with-glib-2.26/2002/console

Retested with the g_mkdtemp compat change:
https://ci.syslog-ng.com/jenkins/job/daily-compile-with-glib-2.26/2007/console