### PR TITLE
WIP: pastebin: new destination

### DIFF
--- a/scl/CMakeLists.txt
+++ b/scl/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SCL_DIRS
     nodejs
     osquery
     pacct
+    pastebin
     rewrite
     slack
     snmptrap

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -22,6 +22,7 @@ SCL_SUBDIRS	= \
 	nodejs		\
 	osquery	\
 	pacct		\
+	pastebin	\
 	rewrite	\
 	slack \
 	snmptrap	\

--- a/scl/pastebin/plugin.conf
+++ b/scl/pastebin/plugin.conf
@@ -1,0 +1,41 @@
+#############################################################################
+# Copyright (c) 2020 Kokan <kokaipeter@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+# For details see the pastebin API doc: https://pastebin.com/api
+
+block destination pastebin(
+  api-dev-key()
+  private(0)
+  expire-date("10M")
+  ...)
+{
+
+@requires http "The elasticsearch-http() driver depends on the syslog-ng http module, please install the syslog-ng-mod-http (Debian & derivatives) or the syslog-ng-http (RHEL & co) package"
+
+    http(
+        url("https://pastebin.com/api/api_post.php")
+        workers(1)
+        batch_lines(1)
+        body("api_paste_code=$(url-encode $MESSAGE)&api_option=paste&api_dev_key=`api-dev-key`&api_paste_private=`private`&api_paste_expire_date=`expire-date`")
+        `__VARARGS__`
+    );
+};


### PR DESCRIPTION
I've been working on a way to store my logs in a cheap storage, where I could easily access without any hassle.

The idea just came today that https://pastebin.com provides us storage, and could store any textual data which the logs are. So here we go, please enjoy.

Example configuration:
```
pastebin(
  api-dev-key("<prive key from your https://pastebin.com/api page after login")
  expire-date("10M")
)
```
Further development could include the use of authenticating header, so the logs could be saved under a user and not as anonime.