### PR TITLE
configure/cmake: support python configuration with "python" prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,8 @@ set(SYSLOG_NG_HAVE_INOTIFY "${Inotify_FOUND}")
 
 set (PYTHON_VERSION "AUTO" CACHE STRING "Version of the installed development library" )
 
+string(REGEX REPLACE "^(python|PYTHON)" "" PYTHON_VERSION ${PYTHON_VERSION})
+
 if ("${PYTHON_VERSION}" STREQUAL "AUTO")
   find_package(PythonInterp)
   find_package(PythonLibs)

--- a/configure.ac
+++ b/configure.ac
@@ -410,6 +410,9 @@ LT_INIT([dlopen disable-static])
 if test "x$with_python" = "xauto"; then
   AM_PATH_PYTHON(,,[:])
 else
+  if [[[ "$with_python" == python* ]]] || [[[ "$with_python" == PYTHON* ]]]; then
+    with_python=`echo $with_python | cut -c7-`
+  fi
   AM_PATH_PYTHON([$with_python],,[:])
 fi
 

--- a/news/developer-note-3220.md
+++ b/news/developer-note-3220.md
@@ -1,0 +1,2 @@
+`configuration`: python now can be configured with "python/PYTHON" prefix.
+E.g.: -DPYTHON_VERSION=python2 in case of cmake or --with-python=python2 in case of autotools


### PR DESCRIPTION
A little background of my motivation:

I am working on introducing GitHub Actions to the syslog-ng repo, where we have an option to run jobs with multiple variable options. These options get added to the jobs name during run like:
> job (foo, bar)

I would like to use two options:
```
python: python2/python3
build-tool: autotools/cmake
```

I am using the `python` option in the configure step, where if we do not allow `--with-python=python2` just `--with-python=2`, I have to change the option to:
```
python: 2/3
```
, which would name the job like 
> job (2, autotools)

, which is not so pretty as 
>job (python2, autotools)

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>