### PR TITLE
Stats external counter

### DIFF
--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -233,8 +233,22 @@ stats_cluster_untrack_counter(StatsCluster *self, gint type, StatsCounterItem **
 {
   g_assert(self && (self->live_mask & (1 << type)) && &self->counter_group.counters[type] == (*counter));
   g_assert(self->use_count > 0);
-
   self->use_count--;
+
+  /*TODO:?
+     if (self->use_count == 0)
+      {
+        gint type_mask = 1 << type;
+        self->live_mask &= ~type_mask;
+      }*/
+
+  if (self->use_count == 0 && (*counter)->external)
+    {
+      (*counter)->external = FALSE;
+      (*counter)->value_ref = NULL;
+      gint type_mask = 1 << type;
+      self->live_mask &= ~type_mask;
+    }
   *counter = NULL;
 }
 

--- a/lib/stats/stats-counter.c
+++ b/lib/stats/stats-counter.c
@@ -28,7 +28,8 @@
 static void
 _reset_counter(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data)
 {
-  stats_counter_set(counter, 0);
+  if (!counter->external)
+    stats_counter_set(counter, 0);
 }
 
 static inline void

--- a/lib/stats/stats-counter.c
+++ b/lib/stats/stats-counter.c
@@ -28,7 +28,7 @@
 static void
 _reset_counter(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data)
 {
-  if (!counter->external)
+  if (!stats_counter_read_only(counter))
     stats_counter_set(counter, 0);
 }
 

--- a/lib/stats/stats-counter.h
+++ b/lib/stats/stats-counter.h
@@ -40,65 +40,46 @@ typedef struct _StatsCounterItem
 } StatsCounterItem;
 
 
+static gboolean
+stats_counter_read_only(StatsCounterItem *counter)
+{
+  return counter->external;
+}
+
 static inline void
 stats_counter_add(StatsCounterItem *counter, gssize add)
 {
-  if (counter)
-    {
-      if (!counter->external)
-        atomic_gssize_add(&counter->value, add);
-      else
-        atomic_gssize_add(counter->value_ref, add);
-    }
+  if (counter && !stats_counter_read_only(counter))
+    atomic_gssize_add(&counter->value, add);
 }
 
 static inline void
 stats_counter_sub(StatsCounterItem *counter, gssize sub)
 {
-  if (counter)
-    {
-      if (!counter->external)
-        atomic_gssize_sub(&counter->value, sub);
-      else
-        atomic_gssize_sub(counter->value_ref, sub);
-    }
+  if (counter && !stats_counter_read_only(counter))
+    atomic_gssize_sub(&counter->value, sub);
 }
 
 static inline void
 stats_counter_inc(StatsCounterItem *counter)
 {
-  if (counter)
-    {
-      if (!counter->external)
-        atomic_gssize_inc(&counter->value);
-      else
-        atomic_gssize_inc(counter->value_ref);
-    }
+  if (counter && !stats_counter_read_only(counter))
+    atomic_gssize_inc(&counter->value);
 }
 
 static inline void
 stats_counter_dec(StatsCounterItem *counter)
 {
-  if (counter)
-    {
-      if (!counter->external)
-        atomic_gssize_dec(&counter->value);
-      else
-        atomic_gssize_dec(counter->value_ref);
-    }
+  if (counter && !stats_counter_read_only(counter))
+    atomic_gssize_dec(&counter->value);
 }
 
 /* NOTE: this is _not_ atomic and doesn't have to be as sets would race anyway */
 static inline void
 stats_counter_set(StatsCounterItem *counter, gsize value)
 {
-  if (counter)
-    {
-      if (!counter->external)
-        atomic_gssize_racy_set(&counter->value, value);
-      else
-        atomic_gssize_racy_set(counter->value_ref, value);
-    }
+  if (counter && !stats_counter_read_only(counter))
+    atomic_gssize_racy_set(&counter->value, value);
 }
 
 /* NOTE: this is _not_ atomic and doesn't have to be as sets would race anyway */

--- a/lib/stats/stats-counter.h
+++ b/lib/stats/stats-counter.h
@@ -29,9 +29,14 @@
 
 typedef struct _StatsCounterItem
 {
-  atomic_gssize value;
+  union
+  {
+    atomic_gssize value;
+    atomic_gssize *value_ref;
+  };
   gchar *name;
   gint type;
+  gboolean external;
 } StatsCounterItem;
 
 
@@ -39,28 +44,48 @@ static inline void
 stats_counter_add(StatsCounterItem *counter, gssize add)
 {
   if (counter)
-    atomic_gssize_add(&counter->value, add);
+    {
+      if (!counter->external)
+        atomic_gssize_add(&counter->value, add);
+      else
+        atomic_gssize_add(counter->value_ref, add);
+    }
 }
 
 static inline void
 stats_counter_sub(StatsCounterItem *counter, gssize sub)
 {
   if (counter)
-    atomic_gssize_sub(&counter->value, sub);
+    {
+      if (!counter->external)
+        atomic_gssize_sub(&counter->value, sub);
+      else
+        atomic_gssize_sub(counter->value_ref, sub);
+    }
 }
 
 static inline void
 stats_counter_inc(StatsCounterItem *counter)
 {
   if (counter)
-    atomic_gssize_inc(&counter->value);
+    {
+      if (!counter->external)
+        atomic_gssize_inc(&counter->value);
+      else
+        atomic_gssize_inc(counter->value_ref);
+    }
 }
 
 static inline void
 stats_counter_dec(StatsCounterItem *counter)
 {
   if (counter)
-    atomic_gssize_dec(&counter->value);
+    {
+      if (!counter->external)
+        atomic_gssize_dec(&counter->value);
+      else
+        atomic_gssize_dec(counter->value_ref);
+    }
 }
 
 /* NOTE: this is _not_ atomic and doesn't have to be as sets would race anyway */
@@ -68,7 +93,12 @@ static inline void
 stats_counter_set(StatsCounterItem *counter, gsize value)
 {
   if (counter)
-    atomic_gssize_racy_set(&counter->value, value);
+    {
+      if (!counter->external)
+        atomic_gssize_racy_set(&counter->value, value);
+      else
+        atomic_gssize_racy_set(counter->value_ref, value);
+    }
 }
 
 /* NOTE: this is _not_ atomic and doesn't have to be as sets would race anyway */
@@ -78,7 +108,12 @@ stats_counter_get(StatsCounterItem *counter)
   gsize result = 0;
 
   if (counter)
-    result = atomic_gssize_get_unsigned(&counter->value);
+    {
+      if (!counter->external)
+        result = atomic_gssize_get_unsigned(&counter->value);
+      else
+        result = atomic_gssize_get_unsigned(counter->value_ref);
+    }
   return result;
 }
 

--- a/lib/stats/stats-registry.h
+++ b/lib/stats/stats-registry.h
@@ -34,6 +34,10 @@ void stats_lock(void);
 void stats_unlock(void);
 gboolean stats_check_level(gint level);
 StatsCluster *stats_register_counter(gint level, const StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
+
+StatsCluster *stats_register_external_counter(gint level, const StatsClusterKey *sc_key, gint type,
+                                              StatsCounterItem **counter, atomic_gssize *external_counter);
+
 StatsCluster *stats_register_counter_and_index(gint level, const StatsClusterKey *sc_key, gint type,
                                                StatsCounterItem **counter);
 StatsCluster *stats_register_dynamic_counter(gint stats_level, const StatsClusterKey *sc_key, gint type,
@@ -41,6 +45,8 @@ StatsCluster *stats_register_dynamic_counter(gint stats_level, const StatsCluste
 void stats_register_and_increment_dynamic_counter(gint stats_level, const StatsClusterKey *sc_key, time_t timestamp);
 void stats_register_associated_counter(StatsCluster *handle, gint type, StatsCounterItem **counter);
 void stats_unregister_counter(const StatsClusterKey *sc_key, gint type, StatsCounterItem **counter);
+void stats_unregister_external_counter(const StatsClusterKey *sc_key, gint type,
+                                       StatsCounterItem **counter, atomic_gssize *external_counter);
 void stats_unregister_dynamic_counter(StatsCluster *handle, gint type, StatsCounterItem **counter);
 
 gboolean stats_contains_counter(const StatsClusterKey *sc_key, gint type);

--- a/lib/stats/tests/CMakeLists.txt
+++ b/lib/stats/tests/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_unit_test(CRITERION TARGET test_stats_cluster)
 add_unit_test(CRITERION TARGET test_stats_query)
 add_unit_test(CRITERION TARGET test_dynamic_ctr_reg)
+add_unit_test(CRITERION TARGET test_external_ctr_reg)

--- a/lib/stats/tests/Makefile.am
+++ b/lib/stats/tests/Makefile.am
@@ -16,7 +16,8 @@ stats_test_extra_modules			= \
 
 lib_stats_tests_TESTS		+= \
 	lib/stats/tests/test_stats_query \
-	lib/stats/tests/test_dynamic_ctr_reg
+	lib/stats/tests/test_dynamic_ctr_reg \
+	lib/stats/tests/test_external_ctr_reg
 
 lib_stats_tests_test_stats_query_CFLAGS	= $(TEST_CFLAGS)
 lib_stats_tests_test_stats_query_LDADD	= \
@@ -24,4 +25,8 @@ lib_stats_tests_test_stats_query_LDADD	= \
 
 lib_stats_tests_test_dynamic_ctr_reg_CFLAGS = $(TEST_CFLAGS)
 lib_stats_tests_test_dynamic_ctr_reg_LDADD = \
+	$(TEST_LDADD) $(stats_test_extra_modules)
+
+lib_stats_tests_test_external_ctr_reg_CFLAGS = $(TEST_CFLAGS)
+lib_stats_tests_test_external_ctr_reg_LDADD = \
 	$(TEST_LDADD) $(stats_test_extra_modules)

--- a/lib/stats/tests/test_external_ctr_reg.c
+++ b/lib/stats/tests/test_external_ctr_reg.c
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2020 One Identity
+ * Copyright (c) 2019 Laszlo Budai <laszlo.budai@oneidentity.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+
+#include "apphook.h"
+#include "logmsg/logmsg.h"
+#include "stats/stats-cluster.h"
+#include "stats/stats-cluster-single.h"
+#include "stats/stats-counter.h"
+#include "stats/stats-query.h"
+#include "stats/stats-registry.h"
+#include "syslog-ng.h"
+
+#include <criterion/criterion.h>
+
+#include <limits.h>
+#include <time.h>
+
+TestSuite(stats_external_counter, .init = app_startup, .fini = app_shutdown);
+
+Test(stats_external_counter, register_logpipe_cluster_ctr)
+{
+  atomic_gssize test_ctr;
+  atomic_gssize_set(&test_ctr, 11);
+  StatsCounterItem *counter = NULL;
+
+  stats_lock();
+  {
+    StatsClusterKey sc_key;
+    stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "test_ctr", NULL);
+    StatsCluster *sc = stats_register_external_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter, &test_ctr);
+    cr_assert_not_null(sc);
+  }
+  stats_unlock();
+
+  cr_expect_eq(atomic_gssize_get(&test_ctr), 11);
+  cr_expect_eq(&test_ctr, counter->value_ref);
+  cr_expect_eq(stats_counter_get(counter), 11);
+}
+
+Test(stats_external_counter, external_ctr_is_read_only_for_stats)
+{
+  atomic_gssize test_ctr;
+  atomic_gssize_set(&test_ctr, 11);
+  StatsCounterItem *counter = NULL;
+
+  stats_lock();
+  {
+    StatsClusterKey sc_key;
+    stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "test_ctr", NULL);
+    StatsCluster *sc = stats_register_external_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter, &test_ctr);
+    cr_assert_not_null(sc);
+  }
+  stats_unlock();
+
+  stats_counter_set(counter, 1);
+  cr_expect_eq(stats_counter_get(counter), 11);
+  cr_expect_eq(atomic_gssize_get(&test_ctr), 11);
+
+  stats_counter_dec(counter);
+  cr_expect_eq(stats_counter_get(counter), 11);
+  cr_expect_eq(atomic_gssize_get(&test_ctr), 11);
+
+  stats_counter_inc(counter);
+  cr_expect_eq(stats_counter_get(counter), 11);
+  cr_expect_eq(atomic_gssize_get(&test_ctr), 11);
+
+  stats_counter_add(counter, 1);
+  cr_expect_eq(stats_counter_get(counter), 11);
+  cr_expect_eq(atomic_gssize_get(&test_ctr), 11);
+
+  stats_counter_sub(counter, 1);
+  cr_expect_eq(stats_counter_get(counter), 11);
+  cr_expect_eq(atomic_gssize_get(&test_ctr), 11);
+
+  atomic_gssize_inc(&test_ctr);
+  cr_expect_eq(stats_counter_get(counter), 12);
+}
+
+Test(stats_external_counter, reset_counter_is_disabled_for_external_counters)
+{
+  atomic_gssize test_ctr;
+  atomic_gssize_set(&test_ctr, 11);
+  StatsCounterItem *counter = NULL;
+
+  stats_lock();
+  {
+    StatsClusterKey sc_key;
+    stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "test_ctr", NULL);
+    StatsCluster *sc = stats_register_external_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter, &test_ctr);
+    cr_expect_eq(&sc->counter_group.counters[SC_TYPE_PROCESSED], counter);
+    stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &counter);
+    cr_expect_null(counter);
+    cr_expect_neq(sc->counter_group.counters[SC_TYPE_PROCESSED].value_ref, &test_ctr);
+    atomic_gssize *embedded_ctr = &(sc->counter_group.counters[SC_TYPE_PROCESSED].value);
+    cr_expect_eq(atomic_gssize_get(embedded_ctr), 0);
+    cr_expect_eq(atomic_gssize_get(&test_ctr), 11);
+    stats_register_external_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter, &test_ctr);
+    cr_expect_eq(counter->value_ref, &test_ctr);
+    stats_register_external_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter, &test_ctr);
+    cr_expect_eq(&test_ctr, counter->value_ref);
+  }
+  stats_unlock();
+}
+
+Test(stats_external_counter, register_same_ctr_as_internal_after_external_unregistered)
+{
+  atomic_gssize test_ctr;
+  atomic_gssize_set(&test_ctr, 11);
+  StatsCounterItem *counter = NULL;
+
+  stats_lock();
+  {
+    StatsClusterKey sc_key;
+    stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "test_ctr", NULL);
+    stats_register_external_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter, &test_ctr);
+    stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &counter);
+    stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter);
+    cr_expect_neq(counter->value_ref, &test_ctr);
+    stats_counter_inc(counter);
+    cr_expect_eq(stats_counter_get(counter), 1);
+  }
+  stats_unlock();
+}
+
+Test(stats_external_counter, register_same_ctr_as_external_after_internal_unregistered)
+{
+  atomic_gssize test_ctr;
+  atomic_gssize_set(&test_ctr, 11);
+  StatsCounterItem *counter = NULL;
+
+  stats_lock();
+  {
+    StatsClusterKey sc_key;
+    stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "test_ctr", NULL);
+    stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter);
+    stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &counter);
+    stats_register_external_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter, &test_ctr);
+    cr_expect_null(counter);
+    // this is beacuse we are not unset the live mask even when the use_ctr is 0...
+    // I'm not sure if it is correct, but we have other unit tests, where we expect the same behaviour
+    /*    cr_expect_eq(counter->value_ref, &test_ctr);
+        stats_counter_inc(counter);
+        cr_expect_eq(stats_counter_get(counter), 11);
+        atomic_gssize_inc(&test_ctr);
+        cr_expect_eq(stats_counter_get(counter), 12);*/
+  }
+  stats_unlock();
+}
+
+Test(stats_external_counter, re_register_internal_ctr_as_external)
+{
+  atomic_gssize test_ctr;
+  atomic_gssize_set(&test_ctr, 11);
+  StatsCounterItem *internal_counter = NULL,
+                    *external_counter = NULL;
+
+  stats_lock();
+  {
+    StatsClusterKey sc_key;
+    stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "test_ctr", NULL);
+    stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &internal_counter);
+    stats_register_external_counter(0, &sc_key, SC_TYPE_PROCESSED, &external_counter, &test_ctr);
+    cr_expect_null(external_counter);
+    stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &internal_counter);
+    cr_expect_null(internal_counter);
+    stats_register_external_counter(0, &sc_key, SC_TYPE_PROCESSED, &external_counter, &test_ctr);
+    cr_expect_null(external_counter);
+  }
+  stats_unlock();
+}
+
+Test(stats_external_counter, re_register_external_ctr_as_internal)
+{
+  atomic_gssize test_ctr;
+  atomic_gssize_set(&test_ctr, 11);
+  StatsCounterItem *external_counter = NULL,
+                    *internal_counter = NULL,
+                     *tmp_counter = NULL;
+
+  stats_lock();
+  {
+    StatsClusterKey sc_key;
+    stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "test_ctr", "counter");
+    stats_register_external_counter(0, &sc_key, SC_TYPE_PROCESSED, &external_counter, &test_ctr);
+    tmp_counter = external_counter;
+    stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &internal_counter);
+    cr_expect_eq(internal_counter, external_counter);
+    stats_counter_inc(internal_counter);
+    cr_expect_eq(stats_counter_get(internal_counter), 11);
+    stats_unregister_external_counter(&sc_key, SC_TYPE_PROCESSED, &external_counter, &test_ctr);
+    cr_expect_null(external_counter);
+    stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &internal_counter);
+    stats_counter_inc(internal_counter);
+    cr_expect_eq(stats_counter_get(internal_counter), 11);
+    stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &internal_counter);
+    stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &tmp_counter);
+    stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &internal_counter);
+    stats_counter_inc(internal_counter);
+    cr_expect_eq(stats_counter_get(internal_counter), 1);
+  }
+  stats_unlock();
+}
+
+Test(stats_external_counter, re_register_external_ctr)
+{
+  atomic_gssize test_ctr;
+  atomic_gssize_set(&test_ctr, 11);
+  StatsCounterItem *counter1 = NULL,
+                    *counter2 = NULL;
+
+  stats_lock();
+  {
+    StatsClusterKey sc_key;
+    stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "test_ctr", NULL);
+    stats_register_external_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter1, &test_ctr);
+    stats_register_external_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter2, &test_ctr);
+    cr_expect_eq(counter1, counter2);
+    cr_expect_eq(counter1->value_ref, &test_ctr);
+    stats_counter_inc(counter1);
+    cr_expect_eq(stats_counter_get(counter1), 11);
+    cr_expect_eq(stats_counter_get(counter2), 11);
+    atomic_gssize_inc(&test_ctr);
+    cr_expect_eq(stats_counter_get(counter1), 12);
+    cr_expect_eq(stats_counter_get(counter2), 12);
+  }
+  stats_unlock();
+}
+


### PR DESCRIPTION
external counter: when someone wants to control the ownership of the lifecycle/permission of the embedded counter, it could be a useful extension to the existing stats-counter model.

The re-registration is little bit weird, but one might hold a `StatsCounterItem` for accessing the value of an external counter.

A question regarding to the live mask: when the `use_count` reaches 0 during an unregister/untrack, live mask remain unchanged - we have unit tests that are checking this behaviour.
Why do we need this?

@bazsi : could you check this?