### PR TITLE
Limit the size of internal()'s temporary queue

### DIFF
--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -95,6 +95,7 @@ struct _AFInterSource
 {
   LogSource super;
   gint mark_freq;
+  const AFInterSourceOptions *options;
   struct iv_event post;
   struct iv_event schedule_wakeup;
   struct iv_timer mark_timer;
@@ -313,17 +314,20 @@ afinter_source_deinit(LogPipe *s)
 }
 
 static LogSource *
-afinter_source_new(AFInterSourceDriver *owner, LogSourceOptions *options)
+afinter_source_new(AFInterSourceDriver *owner, AFInterSourceOptions *options)
 {
   AFInterSource *self = g_new0(AFInterSource, 1);
 
   log_source_init_instance(&self->super, owner->super.super.super.cfg);
-  log_source_set_options(&self->super, options, owner->super.super.id, NULL, FALSE, FALSE,
+  log_source_set_options(&self->super, &options->super, owner->super.super.id, NULL, FALSE, FALSE,
                          owner->super.super.super.expr_node);
   afinter_source_init_watches(self);
   self->super.super.init = afinter_source_init;
   self->super.super.deinit = afinter_source_deinit;
   self->super.wakeup = afinter_source_wakeup;
+
+  self->options = options;
+
   return &self->super;
 }
 
@@ -343,9 +347,9 @@ afinter_sd_init(LogPipe *s)
       return FALSE;
     }
 
-  log_source_options_init(&self->source_options, cfg, self->super.super.group);
-  self->source_options.stats_level = STATS_LEVEL0;
-  self->source_options.stats_source = stats_register_type("internal");
+  log_source_options_init(&self->source_options.super, cfg, self->super.super.group);
+  self->source_options.super.stats_level = STATS_LEVEL0;
+  self->source_options.super.stats_source = stats_register_type("internal");
   self->source = afinter_source_new(self, &self->source_options);
   log_pipe_append(&self->source->super, s);
 
@@ -397,7 +401,7 @@ afinter_sd_new(GlobalConfig *cfg)
   self->super.super.super.init = afinter_sd_init;
   self->super.super.super.deinit = afinter_sd_deinit;
   self->super.super.super.free_fn = afinter_sd_free;
-  log_source_options_defaults(&self->source_options);
+  log_source_options_defaults(&self->source_options.super);
   return (LogDriver *)&self->super.super;
 }
 

--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -454,8 +454,8 @@ afinter_message_posted(LogMessage *msg)
 
       stats_lock();
       StatsClusterKey sc_key;
-      stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "internal_queue_length", NULL );
-      stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &internal_queue_length);
+      stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "internal_source", NULL );
+      stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &internal_queue_length);
       stats_unlock();
     }
 
@@ -487,8 +487,8 @@ afinter_global_deinit(void)
     {
       stats_lock();
       StatsClusterKey sc_key;
-      stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "internal_queue_length", NULL );
-      stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &internal_queue_length);
+      stats_cluster_logpipe_key_set(&sc_key, SCS_GLOBAL, "internal_source", NULL );
+      stats_unregister_counter(&sc_key, SC_TYPE_QUEUED, &internal_queue_length);
       stats_unlock();
       g_queue_free_full(internal_msg_queue, (GDestroyNotify)log_msg_unref);
       internal_msg_queue = NULL;

--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -441,7 +441,9 @@ _release_internal_msg_queue(void)
   LogMessage *internal_message = g_queue_pop_head(internal_msg_queue);
   while (internal_message)
     {
+      stats_counter_dec(internal_queue_length);
       log_msg_unref(internal_message);
+
       internal_message = g_queue_pop_head(internal_msg_queue);
     }
   g_queue_free(internal_msg_queue);

--- a/lib/afinter.h
+++ b/lib/afinter.h
@@ -31,6 +31,7 @@
 typedef struct AFInterSourceOptions
 {
   LogSourceOptions super;
+  gint queue_capacity;
 } AFInterSourceOptions;
 
 /*

--- a/lib/afinter.h
+++ b/lib/afinter.h
@@ -28,6 +28,11 @@
 #include "driver.h"
 #include "logsource.h"
 
+typedef struct AFInterSourceOptions
+{
+  LogSourceOptions super;
+} AFInterSourceOptions;
+
 /*
  * This is the actual source driver, linked into the configuration tree.
  */
@@ -35,7 +40,7 @@ typedef struct _AFInterSourceDriver
 {
   LogSrcDriver super;
   LogSource *source;
-  LogSourceOptions source_options;
+  AFInterSourceOptions source_options;
 } AFInterSourceDriver;
 
 void afinter_postpone_mark(gint mark_freq);

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -647,7 +647,7 @@ source_afinter
 source_afinter_params
         : {
             last_driver = afinter_sd_new(configuration);
-            last_source_options = &((AFInterSourceDriver *) last_driver)->source_options;
+            last_source_options = &((AFInterSourceDriver *) last_driver)->source_options.super;
           }
           source_afinter_options { $$ = last_driver; }
         ;

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -658,7 +658,8 @@ source_afinter_options
         ;
 
 source_afinter_option
-        : source_option
+        : KW_LOG_FIFO_SIZE '(' positive_integer ')'	{ ((AFInterSourceOptions *) last_source_options)->queue_capacity = $3; }
+        | source_option
         ;
 
 
@@ -1130,20 +1131,20 @@ path
             CHECK_ERROR((ret == 0), @1, "File \"%s\" not found: %s", $1, strerror(errno));
             $$ = $1;
 	  }
-	;	
+	;
 
 path_check
     : path { cfg_path_track_file(configuration, $1, "path_check"); }
     ;
-	
+
 path_secret
     : path { cfg_path_track_file(configuration, $1, "path_secret"); }
     ;
-		
+
 path_no_check
     : string { cfg_path_track_file(configuration, $1, "path_no_check"); }
     ;
-	
+
 normalized_flag
         : string                                { $$ = normalize_flag($1); free($1); }
         ;

--- a/lib/versioning.h
+++ b/lib/versioning.h
@@ -123,6 +123,7 @@
 #define VERSION_3_26 "syslog-ng 3.26"
 #define VERSION_3_27 "syslog-ng 3.27"
 #define VERSION_3_28 "syslog-ng 3.28"
+#define VERSION_3_29 "syslog-ng 3.29"
 
 /* VERSION_VALUE_* references versions as integers to be compared against stuff like cfg->user_version */
 /* VERSION_STR_* references versions as strings to be shown to the user */
@@ -156,18 +157,19 @@
 #define VERSION_VALUE_3_26 0x031a
 #define VERSION_VALUE_3_27 0x031b
 #define VERSION_VALUE_3_28 0x031c
+#define VERSION_VALUE_3_29 0x031d
 
 /* config version code, in the same format as GlobalConfig->version */
-#define VERSION_VALUE_CURRENT   VERSION_VALUE_3_28
-#define VERSION_STR_CURRENT     "3.28"
-#define VERSION_PRODUCT_CURRENT VERSION_3_28
+#define VERSION_VALUE_CURRENT   VERSION_VALUE_3_29
+#define VERSION_STR_CURRENT     "3.29"
+#define VERSION_PRODUCT_CURRENT VERSION_3_29
 
 /* this value points to the last syslog-ng version where we changed the
  * meaning of any setting in the configuration file.  Basically, it is the
  * highest value passed to any cfg_is_config_version_older() call.
  */
-#define VERSION_VALUE_LAST_SEMANTIC_CHANGE  VERSION_VALUE_3_22
-#define VERSION_STR_LAST_SEMANTIC_CHANGE    "3.22"
+#define VERSION_VALUE_LAST_SEMANTIC_CHANGE  VERSION_VALUE_3_29
+#define VERSION_STR_LAST_SEMANTIC_CHANGE    "3.29"
 
 #define version_convert_from_user(v)  (v)
 

--- a/news/other-3229.md
+++ b/news/other-3229.md
@@ -1,0 +1,7 @@
+`internal()`:  limit the size of internal()'s temporary queue
+
+The `internal()` source uses a temporary queue to buffer messages.
+From now on, the queue has a maximum capacity, the `log-fifo-size()` option
+can be used to change the default limit (10000).
+
+This change prevents consuming all the available memory in special rare cases.


### PR DESCRIPTION
This PR is a proposal that adds a limit to the `internal()` source's temporary queue.

The max capacity is hard-coded in the proposal, but a config option can be added easily, if needed.

Why do I want this?
syslog-ng currently uses message queues only on the destination side. The size and behavior of those queues can be configured with the `log-fifo-size()` destination, and the `flags(flow-control), log-iw-size()` source options. syslog-ng drops new messages when flow control is not configured and the destination queue exceeds the `log-fifo-size()` limit. When flow control is configured and syslog-ng reaches `log-iw-size()` number of messages kept in memory per source, it stops the given source.

In both cases, the memory footprint has an upper limit and it can be calculated based on the mentioned options.

The `internal()` source is different. When flow-control is not configured, it operates in a similar way as I described above. In case `flags(flow-control)` is set, or when file-based destinations are used (soft-flow-control) together with `internal()`, something else happens:

The internal source has an additional temporary source-side queue in addition to the destination queues. This is because internal() messages can be created anywhere, in any worker/dedicated threads, on any log path; and those threads and paths should never be blocked/stopped just because something is congested on the `internal()` log paths. The temporary queue is there to overcome this problem, and for other performance reasons.

Unfortunately, this temporary queue has no maximum capacity, so it can consume all available memory. During the investigation of another high-memory-usage issue, it was difficult to notice this side-issue, because we properly free the queue before shutting down syslog-ng (so technically, it's not a memory leak), and the only information about the current length of the queue was a statistic counter with the name "processed", which was a bit misleading for me:
```
global;internal_queue_length;;a;processed;482363
```
I've also renamed this counter to `global;internal_queue;;a;queued` and added `global;internal_queue;;a;dropped` in this MR.

My proposal is to have an upper limit on the internal source's temporary queue and drop messages when the capacity is reached.
My MR has an obvious effect: syslog-ng will lose internal messages if flow-control is used and both destination queues and the internal queue reach their capacity. If you don't want to block all logpaths because of `internal()`, and you also want a proper memory limit, I think you can't do better.