### PR TITLE
eliminate infinite loop in case of a spurious file path

### DIFF
--- a/modules/affile/file-opener.h
+++ b/modules/affile/file-opener.h
@@ -47,6 +47,13 @@ typedef struct _FileOpenerOptions
   gint create_dirs;
 } FileOpenerOptions;
 
+typedef enum
+{
+  FILE_OPENER_RESULT_SUCCESS,
+  FILE_OPENER_RESULT_ERROR_TRANSIENT,
+  FILE_OPENER_RESULT_ERROR_PERMANENT
+} FileOpenerResult;
+
 typedef struct _FileOpener FileOpener;
 struct _FileOpener
 {
@@ -78,7 +85,7 @@ file_opener_construct_dst_proto(FileOpener *self, LogTransport *transport, LogPr
   return self->construct_dst_proto(self, transport, proto_options);
 }
 
-gboolean file_opener_open_fd(FileOpener *self, const gchar *name, FileDirection dir, gint *fd);
+FileOpenerResult file_opener_open_fd(FileOpener *self, const gchar *name, FileDirection dir, gint *fd);
 
 void file_opener_set_options(FileOpener *self, FileOpenerOptions *options);
 void file_opener_init_instance(FileOpener *self);

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -189,9 +189,11 @@ _reader_open_file(LogPipe *s, gboolean recover_state)
   FileReader *self = (FileReader *) s;
   GlobalConfig *cfg = log_pipe_get_config(s);
   gint fd;
-  gboolean file_opened, open_deferred = FALSE;
+  gboolean open_deferred = FALSE;
 
-  file_opened = file_opener_open_fd(self->opener, self->filename->str, AFFILE_DIR_READ, &fd);
+  FileOpenerResult res = file_opener_open_fd(self->opener, self->filename->str, AFFILE_DIR_READ, &fd);
+  gboolean file_opened =  res == FILE_OPENER_RESULT_SUCCESS;
+
   if (!file_opened && self->options->follow_freq > 0)
     {
       msg_info("Follow-mode file source not found, deferring open",

--- a/modules/affile/tests/test_file_opener.c
+++ b/modules/affile/tests/test_file_opener.c
@@ -68,7 +68,7 @@ open_fd(FileOpener *file_opener, gchar *fname, gint extra_flags, gint *fd)
 
   file_opener_set_options(file_opener, &open_opts);
 
-  gboolean success = file_opener_open_fd(file_opener, fname, dir, fd);
+  gboolean success = file_opener_open_fd(file_opener, fname, dir, fd) == FILE_OPENER_RESULT_SUCCESS;
   file_opener_free(file_opener);
   return success;
 }

--- a/news/bugfix-3230.md
+++ b/news/bugfix-3230.md
@@ -1,0 +1,8 @@
+`affile`: eliminate infinite loop in case of a spurious file path
+
+If the template evaluation of a log message will result to a spurious
+path in the file destination, syslog-ng refuses to create that file.
+However the problematic log message was left in the msg queue, so
+syslog-ng was trying to create that file again in time-reopen periods.
+From now on syslog-ng will handle "permanent" file errors, and drop
+the relevant msg.


### PR DESCRIPTION
Instead of a simple boolean result, file_opener_open_fd will return
that the error was temporary or permanent. (Currently spurious paths
is the only permanent error.)
If the error is permanent we can do nothing about it, so we skip the
logwriter_reopen method too, thus there will be no further attempt to
open the file, and the log message will be skipped by the file
destination.

WIP:
- [x] perftest
- [x] news file