### PR TITLE
WIP: refactor affile dest

### DIFF
--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -598,27 +598,19 @@ affile_dd_open_writer(gpointer args[])
   main_loop_assert_main_thread();
   if (!self->filename_is_a_template)
     {
-      if (!self->single_writer)
+      next = affile_dw_new(self->filename_template->template, log_pipe_get_config(&self->super.super.super));
+      affile_dw_set_owner(next, self);
+      if (next && log_pipe_init(&next->super))
         {
-          next = affile_dw_new(self->filename_template->template, log_pipe_get_config(&self->super.super.super));
-          affile_dw_set_owner(next, self);
-          if (next && log_pipe_init(&next->super))
-            {
-              log_pipe_ref(&next->super);
-              g_static_mutex_lock(&self->lock);
-              self->single_writer = next;
-              g_static_mutex_unlock(&self->lock);
-            }
-          else
-            {
-              log_pipe_unref(&next->super);
-              next = NULL;
-            }
+          log_pipe_ref(&next->super);
+          g_static_mutex_lock(&self->lock);
+          self->single_writer = next;
+          g_static_mutex_unlock(&self->lock);
         }
       else
         {
-          next = self->single_writer;
-          log_pipe_ref(&next->super);
+          log_pipe_unref(&next->super);
+          next = NULL;
         }
     }
   else


### PR DESCRIPTION
While investigating spurious path, I refactored affile_dd_queue and the related functions. Since they do not affect each other, I putted it in a different PR.

These are **not only** equivalent changes! (i.e: writer_hash life cycle) I tried to organize commits in a way, that they are easier to review one-by-one. Where I mention "extract", I only extracted a function, no other changes intended.

Question for the reviewers:
 IMHO we can eliminate "filename_is_a_template" check on the "fast path" with a minimal code duplication, by creating a different affile_dd_queue for the `single_writer` / `writer_hash` cases.

WIP:
- [ ] perftest
- [ ] news file
- [ ] open question regarding to affile_dd_queue