### PR TITLE
New panos-parser() source as SCL

### DIFF
--- a/news/feature-3234.md
+++ b/news/feature-3234.md
@@ -1,0 +1,16 @@
+@include "scl.conf"
+
+log {
+  source { network(transport("udp")); };
+  parser { panos-parser(); };
+  destination {     
+	elasticsearch-http(
+	index("syslog-ng-${YEAR}-${MONTH}-${DAY}")
+	type("")
+	url("http://localhost:9200/_bulk")
+	template("$(format-json
+	--scope rfc5424 
+	--scope dot-nv-pairs --rekey .* --shift 1 --exclude *future_* --exclude *devicegroup_* 
+	--scope nv-pairs --exclude DATE --key ISODATE @timestamp=${ISODATE})")
+    );};
+};

--- a/scl/CMakeLists.txt
+++ b/scl/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SCL_DIRS
     nodejs
     osquery
     pacct
+    paloalto
     rewrite
     slack
     snmptrap

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -22,6 +22,7 @@ SCL_SUBDIRS	= \
 	nodejs		\
 	osquery	\
 	pacct		\
+  paloalto \
 	rewrite	\
 	slack \
 	snmptrap	\

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -22,7 +22,7 @@ SCL_SUBDIRS	= \
 	nodejs		\
 	osquery	\
 	pacct		\
-  paloalto \
+	paloalto 	\
 	rewrite	\
 	slack \
 	snmptrap	\

--- a/scl/paloalto/panos.conf
+++ b/scl/paloalto/panos.conf
@@ -53,7 +53,8 @@ block parser panos-parser (prefix(".panos.") ...) {
     elif (match('CONFIG', value('`prefix`type'))) {    
       parser {
         csv-parser(
-          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","host_name","vsys","command","admin","client","result","configuration_path","sequence_number","action_flags","before_change_detail","after_change_detail","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","host_name","vsys","command","admin","client","result","configuration_path","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          # Note if using custom logs insert "before_change_detail","after_change_detail" after "action_flags"
           prefix("`prefix`")
           delimiters(',')
         );

--- a/scl/paloalto/panos.conf
+++ b/scl/paloalto/panos.conf
@@ -107,3 +107,7 @@ block parser panos-parser (prefix(".panos.") ...) {
     };
   };
 };
+application panos[syslog] {
+    filter { message(".*,paloalto.*"); };
+    parser { panos-parser(); };
+};

--- a/scl/paloalto/panos.conf
+++ b/scl/paloalto/panos.conf
@@ -1,0 +1,108 @@
+#############################################################################
+# Copyright (c) 2020 Balabit
+# Copyright (c) 2020 MileK <mileek@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+#
+#scl/paloalto/panos.conf -- Paloalto PAN-OS parser fro syslog-ng
+#
+#<12>Apr 14 16:48:54 paloalto.test.net 1,2020/04/14 16:48:54,unknown,SYSTEM,auth,0,2020/04/14 16:48:54,,auth-fail,,0,0,general,medium,failed authentication for user \'admin\'. Reason: Invalid username/password. From: 10.0.10.55.,1718,0x0,0,0,0,0,,paloalto
+#<14>Apr 14 16:54:18 paloalto.test.net 1,2020/04/14 16:54:18,unknown,CONFIG,0,0,2020/04/14 16:54:18,10.0.10.55,,set,admin,Web,Succeeded, deviceconfig system,127,0x0,0,0,0,0,,paloalto
+
+block parser panos-parser (prefix(".panos.") ...) {
+  channel {
+    rewrite {
+      set("${LEGACY_MSGHDR}${MESSAGE}" value("MESSAGE"));
+      set("paloalto_panos" value("PROGRAM"));
+    };
+# Common fields - set dot-nv-pairs
+    parser {
+      csv-parser(
+        columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time")
+        delimiters(',')
+        prefix("`prefix`")
+      );
+    };
+# Parse logs according to "type" field
+    if (match('SYSTEM', value('`prefix`type'))) {
+      parser {
+        csv-parser(
+          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","vsys","event_id","object","future_use3","future_use4","module","severity","description","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          prefix("`prefix`")
+          delimiters(',')
+        );
+      };
+    } 
+    elif (match('CONFIG', value('`prefix`type'))) {    
+      parser {
+        csv-parser(
+          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","host_name","vsys","command","admin","client","result","configuration_path","sequence_number","action_flags","before_change_detail","after_change_detail","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          prefix("`prefix`")
+          delimiters(',')
+        );
+      };
+    } 
+    elif (match('THREAT', value('`prefix`type'))) {
+      parser {
+        csv-parser(
+          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","src_ip","dest_ip","src_translated_ip","dest_translated_ip","rule","src_user","dest_user","app","vsys","src_zone","dest_zone","src_interface","dest_interface","log_forwarding_profile","future_use3","session_id","repeat_count","src_port","dest_port","src_translated_port","dest_translated_port","session_flags","transport","action","misc","threat","raw_category","severity","direction","sequence_number","action_flags","src_location","dest_location","future_use4","content_type","pcap_id","file_hash","cloud_address","url_index","user_agent","file_type","xff","referrer","sender","subject","recipient","report_id","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          prefix("`prefix`")
+          delimiters(',')
+        );
+      };
+    } 
+    elif (match('TRAFFIC', value('`prefix`type'))) {
+      parser {
+        csv-parser(
+          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","src_ip","dest_ip","src_translated_ip","dest_translated_ip","rule","src_user","dest_user","app","vsys","src_zone","dest_zone","src_interface","dest_interface","log_forwarding_profile","future_use3","session_id","repeat_count","src_port","dest_port","src_translated_port","dest_translated_port","session_flags","transport","action","bytes","bytes_out","bytes_in","packets","start_time","duration","http_category","future_use4","sequence_number","action_flags","src_location","dest_location","future_use5","packets_out","packets_in","session_end_reason","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          prefix("`prefix`")
+          delimiters(',')
+        );
+      };
+    } 
+    elif (match('HIPWATCH', value('`prefix`type'))) {
+      parser {
+        csv-parser(
+          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","src_user","vsys","host_name","os","src_ip","hip_name","hip_count","hip_type","future_use3","future_use4","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          prefix("`prefix`")
+          delimiters(',')
+        );
+      };
+    } 
+    elif (match('CORRELATION', value('`prefix`type'))) {
+      parser {
+        csv-parser(
+          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","src_ip","src_user","vsys","category","severity","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name","vsys_id","object","object_id","evidence")
+          prefix("`prefix`")
+          delimiters(',')
+        );
+      };
+    } 
+    elif (match('USERID', value('`prefix`type'))) {
+      parser {
+        csv-parser(
+          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","vsys","src_ip","source_name","event_id","repeat_count","timeout_threshold","src_port","dest_port","source","source_type","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          prefix("`prefix`")
+          delimiters(',')
+        );
+      };
+    };
+  };
+};


### PR DESCRIPTION
scl: new panos-parser() parser for paloalto panOS logs

Add a new scl: panos-parser() parser. It reads and automatically parses the paloalto panos logs.
You can override prefix for the created name-value pairs using the prefix() parameter.
Example:
parser p_panos-parser {
	panos-parser(
	prefix("test."));
	};

Signed-off-by: MileK <mileek@gmail.com>