### PR TITLE
transport-udp-socket: fixing small memory leak

### DIFF
--- a/lib/transport/transport-udp-socket.c
+++ b/lib/transport/transport-udp-socket.c
@@ -203,6 +203,14 @@ log_transport_udp_setup_fd(LogTransportUDP *self, gint fd)
 
 }
 
+static void
+log_transport_udp_socket_free(LogTransport *s)
+{
+  LogTransportUDP *self = (LogTransportUDP *)s;
+  g_sockaddr_unref(self->bind_addr);
+  log_transport_free_method(s);
+}
+
 LogTransport *
 log_transport_udp_socket_new(gint fd)
 {
@@ -210,6 +218,7 @@ log_transport_udp_socket_new(gint fd)
 
   log_transport_dgram_socket_init_instance(&self->super, fd);
   self->super.super.read = log_transport_udp_socket_read_method;
+  self->super.super.free_fn = log_transport_udp_socket_free;
 
   log_transport_udp_setup_fd(self, fd);
   return &self->super.super;


### PR DESCRIPTION
No releases are affected. It is a minor regression from: https://github.com/syslog-ng/syslog-ng/pull/2899/

No changenote is necessary.

```
log {
  source { example-msg-generator(num(1)); };
  destination { syslog("localhost" transport("udp") port(5555)); };
};
```

<details>

```
==1316== 40 bytes in 1 blocks are definitely lost in loss record 31 of 59
==1316==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==1316==    by 0x519D7B8: g_malloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==1316==    by 0x51B49C2: g_slice_alloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==1316==    by 0x51B505D: g_slice_alloc0 (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.2)
==1316==    by 0x4E80098: g_sockaddr_inet_new2 (gsockaddr.c:336)
==1316==    by 0x4E7FB3F: g_sockaddr_new (gsockaddr.c:70)
==1316==    by 0x4E80BB7: g_socket_get_local_name (gsocket.c:180)
==1316==    by 0x4EC792E: log_transport_udp_setup_fd (transport-udp-socket.c:187)
==1316==    by 0x4EC7A25: log_transport_udp_socket_new (transport-udp-socket.c:214)
==1316==    by 0x894289F: _construct_plain_tcp_transport (transport-mapper-inet.c:137)
==1316==    by 0x8942925: transport_mapper_inet_construct_log_transport (transport-mapper-inet.c:157)
==1316==    by 0x893D38E: transport_mapper_construct_log_transport (transport-mapper.h:83)
==1316==    by 0x893DDEB: afsocket_dd_construct_transport (afsocket-dest.c:255)
==1316==    by 0x893DF11: afsocket_dd_connected (afsocket-dest.c:273)
==1316==    by 0x893E4BB: afsocket_dd_start_connect (afsocket-dest.c:364)
==1316==    by 0x893E672: _dd_reconnect (afsocket-dest.c:396)
==1316==    by 0x893E70A: _dd_reconnect_with_current_addresses (afsocket-dest.c:413)
==1316==    by 0x893EBDC: afsocket_dd_setup_connection (afsocket-dest.c:558)
==1316==    by 0x893E750: afsocket_dd_try_connect (afsocket-dest.c:425)
==1316==    by 0x893EC11: _finalize_init (afsocket-dest.c:568)
==1316==    by 0x893ECA8: _dd_init_dgram (afsocket-dest.c:594)
==1316==    by 0x893ED1C: _dd_init_socket (afsocket-dest.c:616)
==1316==    by 0x893ED7C: afsocket_dd_init (afsocket-dest.c:634)
==1316==    by 0x8941A47: afinet_dd_init (afinet-dest.c:383)
==1316==    by 0x4E77EE5: log_pipe_init (logpipe.h:295)
==1316==    by 0x4E7A516: cfg_tree_start (cfg-tree.c:1419)
==1316==    by 0x4E71B0F: cfg_init (cfg.c:368)
==1316==    by 0x4E8F3D0: main_loop_initialize_state (mainloop.c:203)
==1316==    by 0x4E901A8: main_loop_read_and_init_config (mainloop.c:611)
==1316==    by 0x401C96: main (main.c:285)
```

</details>