### PR TITLE
 example-message-generator: add support for values(name1 => value1, ...) syntax where value follows template syntax

### DIFF
--- a/modules/examples/sources/msg-generator/msg-generator-grammar.ym
+++ b/modules/examples/sources/msg-generator/msg-generator-grammar.ym
@@ -60,6 +60,7 @@ MsgGeneratorSourceOptions *last_msg_generator_source_options;
 %token KW_FREQ
 %token KW_NUM
 %token KW_TEMPLATE
+%token KW_VALUES
 
 %type <ptr> source_msg_generator
 
@@ -102,10 +103,24 @@ source_msg_generator_option
       msg_generator_source_options_set_template(last_msg_generator_source_options, $3);
       log_template_unref($3);
     }
+  | KW_VALUES '(' options_name_value_pairs ')'
   | source_option
   | source_driver_option
   ;
 
+options_name_value_pairs
+  : option_name_value_pairs options_name_value_pairs
+  |
+  ;
+
+option_name_value_pairs
+  : string LL_ARROW template_content
+    {      
+      msg_generator_source_options_set_value_pair(last_msg_generator_source_options, $1, $3);
+      log_template_unref($3);
+      free($1);
+    }
+  ;
 /* INCLUDE_RULES */
 
 %%

--- a/modules/examples/sources/msg-generator/msg-generator-parser.c
+++ b/modules/examples/sources/msg-generator/msg-generator-parser.c
@@ -35,6 +35,7 @@ static CfgLexerKeyword msg_generator_keywords[] =
   { "freq", KW_FREQ },
   { "num", KW_NUM },
   { "template", KW_TEMPLATE },
+  { "values", KW_VALUES },
   { NULL }
 };
 

--- a/modules/examples/sources/msg-generator/msg-generator-source-options.h
+++ b/modules/examples/sources/msg-generator/msg-generator-source-options.h
@@ -26,6 +26,8 @@
 
 #include "logsource.h"
 #include "template/templates.h"
+#include "logmsg/logmsg.h"
+#include <compat/glib.h>
 
 typedef struct
 {
@@ -33,6 +35,7 @@ typedef struct
   guint freq;
   gint max_num;
   LogTemplate *template;
+  GHashTable *name_value;
 } MsgGeneratorSourceOptions;
 
 static inline void
@@ -73,5 +76,9 @@ msg_generator_source_options_set_template(MsgGeneratorSourceOptions *self, LogTe
   log_template_unref(self->template);
   self->template = log_template_ref(template);
 }
-
+static inline void
+msg_generator_source_options_set_value_pair(MsgGeneratorSourceOptions *self, const gchar *name, LogTemplate *value)
+{
+  g_hash_table_insert(self->name_value, g_strdup(name), log_template_ref(value));
+}
 #endif

--- a/modules/examples/sources/msg-generator/msg-generator.c
+++ b/modules/examples/sources/msg-generator/msg-generator.c
@@ -74,7 +74,7 @@ static void
 msg_generator_sd_free(LogPipe *s)
 {
   MsgGeneratorSourceDriver *self = (MsgGeneratorSourceDriver *) s;
-
+  g_hash_table_unref(self->source_options.name_value);
   msg_generator_source_options_destroy(&self->source_options);
   log_src_driver_free(s);
 }
@@ -92,9 +92,9 @@ msg_generator_sd_new(GlobalConfig *cfg)
 {
   MsgGeneratorSourceDriver *self = g_new0(MsgGeneratorSourceDriver, 1);
   log_src_driver_init_instance(&self->super, cfg);
-
   msg_generator_source_options_defaults(&self->source_options);
-
+  self->source_options.name_value = g_hash_table_new_full(g_str_hash, g_str_equal, g_free,
+                                                          (GDestroyNotify) log_template_unref);
   self->super.super.super.init = msg_generator_sd_init;
   self->super.super.super.deinit = msg_generator_sd_deinit;
   self->super.super.super.free_fn = msg_generator_sd_free;


### PR DESCRIPTION
fixes: #3215