### PR TITLE
network destinations: fix invalid memory access after reload

### DIFF
--- a/lib/logproto/logproto-client.c
+++ b/lib/logproto/logproto-client.c
@@ -80,6 +80,7 @@ void
 log_proto_client_options_defaults(LogProtoClientOptions *options)
 {
   options->drop_input = FALSE;
+  options->timeout = 0;
 }
 
 void

--- a/lib/logproto/logproto-client.h
+++ b/lib/logproto/logproto-client.h
@@ -101,6 +101,12 @@ log_proto_client_msg_rewind(LogProtoClient *self)
     self->flow_control_funcs.rewind_callback(self->flow_control_funcs.user_data);
 }
 
+static inline void
+log_proto_client_set_options(LogProtoClient *self, const LogProtoClientOptions *options)
+{
+  self->options = options;
+}
+
 static inline gboolean
 log_proto_client_validate_options(LogProtoClient *self)
 {

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1528,6 +1528,7 @@ log_writer_set_proto(LogWriter *self, LogProtoClient *proto)
       flow_control_funcs.user_data = self;
 
       log_proto_client_set_client_flow_control(self->proto, &flow_control_funcs);
+      log_proto_client_set_options(self->proto, &self->options->proto_options.super);
     }
 }
 


### PR DESCRIPTION
`LogProtoClientOptions` is just a reference in the `LogProtoClient` class, owners are usually driver instances, and the ownership is not transferred to the proto client.

This is true for all `*Options` in syslog-ng.

The lifetime of these `*Options` objects are clear:
The owner of the options object outlives the user. For example, `AFSocketDestDriver` is freed only after its `LogWriter`/`LogProtoClient` is deinitialized.

There are exceptions, of course. For example, the `keep-alive()` functionality of network drivers saves a deinitialized but open `LogWriter` instance in the "ReloadStore".
The reload mechanism creates a new driver instance (with new writer/proto options), and restores the `LogWriter` instance from the reload store.

This involves a `log_writer_set_options()` call, that reinitializes the
`LogWriter` by setting all borrowed references (options, control pipe, etc.).

Unfortunately, the `LogProtoClient` object (which is owned by `LogWriter`) has a borrowed proto_options field as well, so it has to be updated too, not just the writer.

This is an old issue, but we've triggered a valgrind "invalid read" with the following commit: 558ddd8.

----

I think we don't need an OSE news entry, because only an internal (non-OSE) module is affected. `drop_input` was not affected by this problem, only `timeout` triggered the issue, but it is an unreleased functionality.

<details>
  <summary>Reproduction/call order (click to expand)</summary>

Reproduction:

```
log {
  source { example-msg-generator(num(1)); };
  destination { syslog("localhost" transport("tcp") port(5555)); };
};
```

Reload syslog-ng with the above configuration.

Call order:
```
- _afsocket_dd_try_to_restore_writer() restores writer from the reload store
- log_writer_set_options(writer, writer_options, ...) sets writeropts (and proto options too) in the writer
- log_writer_init(writer, ...)
  - log_writer_reopen(writer, proto)
    - ...
    - log_writer_set_proto(write, proto)
```
</details>