### PR TITLE
accepting longer sdata keys

### DIFF
--- a/news/feature-3244.md
+++ b/news/feature-3244.md
@@ -1,0 +1,5 @@
+`syslog-format`: accepting longer sdata keys
+
+Triggered by https://github.com/syslog-ng/syslog-ng/issues/3197
+At the end of the discussion in the mentioned issue, we decided
+to change the parser and accept longer than 32 character ID's.

--- a/tests/unit/test_msgparse.c
+++ b/tests/unit/test_msgparse.c
@@ -795,6 +795,12 @@ Test(msgparse, test_expected_sd_pairs_long)
     {  NULL, NULL }
   };
 
+  struct sdata_pair expected_sd_pairs_test_5e[] =
+  {
+    { ".SDATA.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "long_33"},
+    {  NULL, NULL }
+  };
+
   struct msgparse_params params[] =
   {
     {
@@ -837,6 +843,35 @@ Test(msgparse, test_expected_sd_pairs_long)
       0,//msgid
       expected_sd_pairs_test_5d
     },
+
+    // parse longer than 32 sd id and name together
+    {
+      "<132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=\"long_33\"] An application event log entry...",  LP_SYSLOG_PROTOCOL, NULL,
+      132,             // pri
+      1162083599, 156000, 3600,    // timestamp (sec/usec/zone)
+      "mymachine",        // host
+      "evntslog", //app
+      "An application event log entry...", // msg
+      "[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=\"long_33\"]", //sd_str
+      0,//processid
+      0,//msgid
+      expected_sd_pairs_test_5e
+    },
+
+    // parse longer than 255 sd id
+    {
+      "<132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa i=\"long\"] An application event log entry...",  LP_SYSLOG_PROTOCOL, NULL,
+      43,                         // pri
+      0, 0, 0,    // timestamp (sec/usec/zone)
+      "",         // host
+      "syslog-ng", //app
+      "Error processing log message: <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa>@<aaaaaaaa i=\"long\"] An application event log entry...", // msg
+      "", //sd_str      0,//processid
+      0,//processid
+      0,//msgid
+      empty_sdata_pairs
+    },
+
 
     // too long sdata value gets truncated
     {

--- a/tests/unit/test_msgparse.c
+++ b/tests/unit/test_msgparse.c
@@ -769,7 +769,7 @@ Test(msgparse, test_expected_sd_pairs_3)
   run_parameterized_test(params);
 }
 
-Test(msgparse, test_expected_sd_pairs_too_long)
+Test(msgparse, test_expected_sd_pairs_long)
 {
   struct sdata_pair expected_sd_pairs_test_5[] =
   {
@@ -780,6 +780,18 @@ Test(msgparse, test_expected_sd_pairs_too_long)
   struct sdata_pair expected_sd_pairs_test_5b[] =
   {
     { ".SDATA.a.i", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+    {  NULL, NULL }
+  };
+
+  struct sdata_pair expected_sd_pairs_test_5c[] =
+  {
+    { ".SDATA.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.i", "long_33"},
+    {  NULL, NULL }
+  };
+
+  struct sdata_pair expected_sd_pairs_test_5d[] =
+  {
+    { ".SDATA.a.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "long_33"},
     {  NULL, NULL }
   };
 
@@ -798,32 +810,32 @@ Test(msgparse, test_expected_sd_pairs_too_long)
       expected_sd_pairs_test_5
     },
 
-    // failed to parse to long sd id
+    // parse longer than 32 sd id
     {
-      "<132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa i=\"long_33\"] An application event log entry...",  LP_SYSLOG_PROTOCOL, NULL,
-      43,                         // pri
-      0, 0, 0,    // timestamp (sec/usec/zone)
-      "",         // host
-      "syslog-ng", //app
-      "Error processing log message: <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa>@<aaa i=\"long_33\"] An application event log entry...", // msg
-      "", //sd_str
+      "<132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa i=\"long_33\"] An application event log entry...",  LP_SYSLOG_PROTOCOL, NULL,
+      132,             // pri
+      1162083599, 156000, 3600,    // timestamp (sec/usec/zone)
+      "mymachine",        // host
+      "evntslog", //app
+      "An application event log entry...", // msg
+      "[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa i=\"long_33\"]", //sd_str
       0,//processid
       0,//msgid
-      empty_sdata_pairs
+      expected_sd_pairs_test_5c
     },
 
-    // failed to parse to long sd name
+    // parse longer than 32 sd name
     {
-      "<132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=\"long_33\"] An application event log entry...",  LP_SYSLOG_PROTOCOL, NULL,
-      43,             // pri
-      0, 0, 0,    // timestamp (sec/usec/zone)
-      "",        // host
-      "syslog-ng", //app
-      "Error processing log message: <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa>@<aaa=\"long_33\"] An application event log entry...", // msg
-      "", //sd_str
+      "<132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=\"long_33\"] An application event log entry...",  LP_SYSLOG_PROTOCOL, NULL,
+      132,             // pri
+      1162083599, 156000, 3600,    // timestamp (sec/usec/zone)
+      "mymachine",        // host
+      "evntslog", //app
+      "An application event log entry...", // msg
+      "[a aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=\"long_33\"]", //sd_str
       0,//processid
       0,//msgid
-      empty_sdata_pairs
+      expected_sd_pairs_test_5d
     },
 
     // too long sdata value gets truncated

--- a/tests/unit/test_msgparse.c
+++ b/tests/unit/test_msgparse.c
@@ -204,22 +204,30 @@ run_parameterized_test(struct msgparse_params *params)
     test_log_messages_can_be_parsed(param);
 }
 
-Test(msgparse, test_failed_to_parse_too_long_sd_id)
+Test(msgparse, test_parse_longer_than_32_sd_id)
 {
+
+  struct sdata_pair expected_sd_pairs_test_long_sd_id[] =
+  {
+    { ".SDATA.timeQuality.isSynced", "0"},
+    { ".SDATA.1234567890123456789012345678901234.i", "long_33"},
+    { NULL, NULL },
+  };
+
   struct msgparse_params params[] =
   {
     {
       "<5>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [timeQuality isSynced=\"0\"][1234567890123456789012345678901234 i=\"long_33\"] An application event log entry...",
       LP_SYSLOG_PROTOCOL, NULL,
-      43,        //pri
-      0, 0, 0,  // timestamp (sec/usec/zone)
-      "", //host
-      "syslog-ng", //app
-      "Error processing log message: <5>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [timeQuality isSynced=\"0\"][1234567890123456789012345678901>@<234 i=\"long_33\"] An application event log entry...", // msg
-      "", // sd str,
+      5,        //pri
+      1162083599, 156000, 3600,    // timestamp (sec/usec/zone)
+      "mymachine", //host
+      "evntslog", //app
+      "An application event log entry...", // msg
+      "[timeQuality isSynced=\"0\"][1234567890123456789012345678901234 i=\"long_33\"]", // sd str,
       0, // processid
       0, // msgid,
-      empty_sdata_pairs
+      expected_sd_pairs_test_long_sd_id
     },
     {NULL}
   };

--- a/tests/unit/test_msgparse.c
+++ b/tests/unit/test_msgparse.c
@@ -769,46 +769,6 @@ Test(msgparse, test_expected_sd_pairs_3)
   run_parameterized_test(params);
 }
 
-Test(msgparse, test_expected_sd_pairs_4)
-{
-  struct sdata_pair expected_sd_pairs_test_4[] =
-  {
-    { ".SDATA.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.i", "ok_32"},
-    {  NULL, NULL }
-  };
-
-  struct msgparse_params params[] =
-  {
-    {
-      "<132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa i=\"ok_32\"] An application event log entry...",  LP_SYSLOG_PROTOCOL, NULL,
-      132,             // pri
-      1162083599, 156000, 3600,    // timestamp (sec/usec/zone)
-      "mymachine",        // host
-      "evntslog", //app
-      "An application event log entry...", // msg
-      "[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa i=\"ok_32\"]", //sd_str
-      "",//processid
-      "",//msgid
-      expected_sd_pairs_test_4
-    },
-    {
-      "<132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa i=\"long_33\"] An application event log entry...",  LP_SYSLOG_PROTOCOL, NULL,
-      43,                         // pri
-      0, 0, 0,    // timestamp (sec/usec/zone)
-      "",         // host
-      "syslog-ng", //app
-      "Error processing log message: <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa>@<aaa i=\"long_33\"] An application event log entry...", // msg
-      "", //sd_str
-      0,//processid
-      0,//msgid
-      empty_sdata_pairs
-    },
-    {NULL}
-  };
-
-  run_parameterized_test(params);
-}
-
 Test(msgparse, test_expected_sd_pairs_too_long)
 {
   struct sdata_pair expected_sd_pairs_test_5[] =
@@ -836,6 +796,20 @@ Test(msgparse, test_expected_sd_pairs_too_long)
       "",//processid
       "",//msgid
       expected_sd_pairs_test_5
+    },
+
+    // failed to parse to long sd id
+    {
+      "<132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa i=\"long_33\"] An application event log entry...",  LP_SYSLOG_PROTOCOL, NULL,
+      43,                         // pri
+      0, 0, 0,    // timestamp (sec/usec/zone)
+      "",         // host
+      "syslog-ng", //app
+      "Error processing log message: <132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa>@<aaa i=\"long_33\"] An application event log entry...", // msg
+      "", //sd_str
+      0,//processid
+      0,//msgid
+      empty_sdata_pairs
     },
 
     // failed to parse to long sd name


### PR DESCRIPTION
While the RFC5424 states that the maximum length for the SD-ID and PARAM-NAME fields is 32 characters. It also states that a syslog relay should forward messages, even if the SDATA is mailformed.

With this patch, syslog-ng will accept SDATA fields longer than 32 characters, using the message size as the upper limit.

Fixes #3197 
