### PR TITLE
python: added support for arrow syntax

### DIFF
--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -175,6 +175,12 @@ python_sd_custom_option
           free($1);
           free($2);
         }
+        | string LL_ARROW string_or_number
+        {
+          python_sd_set_option(last_driver, $1, $3);
+          free($1);
+          free($3);
+        }
         ;
 
 
@@ -207,6 +213,12 @@ python_fetcher_custom_option
           free($1);
           free($2);
         }
+        | string LL_ARROW string_or_number
+        {
+          python_fetcher_set_option(last_driver, $1, $3);
+          free($1);
+          free($3);
+        }
         ;
 
 
@@ -238,6 +250,13 @@ python_parser_custom_option
           free($1);
           free($2);
         }
+        | string LL_ARROW string_or_number
+        {
+          python_parser_set_option(last_parser, $1, $3);
+          free($1);
+          free($3);
+        }
+
         ;
 
 
@@ -271,6 +290,13 @@ python_http_header_custom_option
           python_http_header_set_option(last_header, $1, $2);
           free($1);
           free($2);
+        }
+        |
+        string LL_ARROW string_or_number
+        {
+          python_http_header_set_option(last_header, $1, $3);
+          free($1);
+          free($3);
         }
         ;
 

--- a/news/feature-3247.md
+++ b/news/feature-3247.md
@@ -1,0 +1,7 @@
+python: added support for arrow syntax for python source, python fetcher, and python http auth header.
+The key value pairs can now be provided in the following format
+options("key1" => "value1", "key2" => "values") in addition to the previous syntax
+option("key1","value1") 
+option("key2","value2")
+
+


### PR DESCRIPTION
fixes: #3105