### PR TITLE
python_persist: fix test with python3

### DIFF
--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -409,12 +409,12 @@ _py_persist_type_set(PyObject *o, PyObject *k, PyObject *v)
       return -1;
     }
 
-  if (_py_is_string(v))
+  if (PyBytes_Check(v))
+    type = ENTRY_TYPE_BYTES;
+  else if (_py_is_string(v))
     type = ENTRY_TYPE_STRING;
   else if (py_object_is_integer(v))
     type = ENTRY_TYPE_LONG;
-  else if (PyBytes_Check(v))
-    type = ENTRY_TYPE_BYTES;
   else
     {
       PyErr_SetString(PyExc_TypeError, "Value must be either string, integer or bytes");

--- a/modules/python/tests/Makefile.am
+++ b/modules/python/tests/Makefile.am
@@ -7,7 +7,8 @@ check_PROGRAMS += \
 modules_python_tests_TESTS = \
   modules/python/tests/test_python_logmsg \
   modules/python/tests/test_python_template \
-  modules/python/tests/test_python_persist_name
+  modules/python/tests/test_python_persist_name \
+  modules/python/tests/test_python_persist
 
 modules_python_tests_test_python_logmsg_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) -I$(top_srcdir)/modules/python
 modules_python_tests_test_python_logmsg_LDADD = $(TEST_LDADD) \

--- a/modules/python/tests/test_python_persist.c
+++ b/modules/python/tests/test_python_persist.c
@@ -180,7 +180,7 @@ persist = Persist('persist_name')\n\
 persist['integer'] = 1\n\
 persist['str'] = 'str'\n\
 persist['bytes'] = b'bytes'\n\
-assert sorted([1, 'str', b'bytes']) == sorted([persist[k] for k in persist])";
+assert set([1, 'str', b'bytes']) == set([persist[k] for k in persist])";
 
 Test(python_persist, test_python_persist_iter_returns_proper_types)
 {


### PR DESCRIPTION
In python3, integer and string cannot be sorted. So the python code throws exception, hence the testcase fails.

I forgot to add the test to `Makefile.am`, so in the end, the job that is responsible for checking unit tests with python3, did not execute this test. That's why we did not find this problem during code review.

Behind this, an actual coding error was hidden. `_py_is_string` returns true both for bytes and strings. So it should be executed last, when detecting the type of the value that is added to persist.

In python2, bytes and strings are the same, so no problem is there.

