### PR TITLE
fix compile error on solaris

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -27,17 +27,22 @@
 #
 SUBMODULES="lib/ivykis lib/jsonc"
 GIT=`which git`
+# bootstrap syslog-ng itself
+case `uname -s` in
+	"SunOS") SED="gsed" ;;
+	*) SED="sed" ;;
+esac
 
 include_automake_from_dir_if_exists()
 {
-  local dir=$1
+  dir=$1
   if [ -f "$1/Makefile.am" ];
   then
     grep "include $dir/Makefile.am" Makefile.am
     if [ "$?" -eq "1" ];
     then
       last_include=$(grep ^include Makefile.am|grep Makefile.am|tail -n 1)
-      sed -i s@"$last_include"@"$last_include\ninclude $dir/Makefile.am"@g Makefile.am
+      $SED -i s@"$last_include"@"$last_include\ninclude $dir/Makefile.am"@g Makefile.am
     fi
   fi
 }
@@ -73,7 +78,7 @@ autogen_submodules()
 
 		CONFIGURE_OPTS="--disable-shared --enable-static --with-pic"
 
-		sed -e "s/@__CONFIGURE_OPTS__@/${CONFIGURE_OPTS}/g" ${origdir}/sub-configure.sh >configure.gnu
+		$SED -e "s/@__CONFIGURE_OPTS__@/${CONFIGURE_OPTS}/g" ${origdir}/sub-configure.sh >configure.gnu
 		cd "$origdir"
 	done
 }
@@ -90,7 +95,7 @@ esac
 
 $LIBTOOLIZE --force --copy
 aclocal -I m4 --install
-sed -i -e 's/PKG_PROG_PKG_CONFIG(\[0\.16\])/PKG_PROG_PKG_CONFIG([0.14])/g' aclocal.m4
+$SED -i -e 's/PKG_PROG_PKG_CONFIG(\[0\.16\])/PKG_PROG_PKG_CONFIG([0.14])/g' aclocal.m4
 
 include_automake_from_dir_if_exists debian
 include_automake_from_dir_if_exists tgz2build

--- a/lib/template/macros.c
+++ b/lib/template/macros.c
@@ -206,7 +206,7 @@ LogMacroDef macros[] =
   { "SOURCEIP", M_SOURCE_IP },
   { "DESTIP", M_DEST_IP },
   { "DESTPORT", M_DEST_PORT },
-  { "PROTO", M_PROTO },
+  { "PROTO", M_PROTOCOL },
   { "SEQNUM", M_SEQNUM },
   { "CONTEXT_ID", M_CONTEXT_ID },
   { "_", M_CONTEXT_ID },
@@ -616,7 +616,7 @@ log_macro_expand(GString *result, gint id, gboolean escape, const LogTemplateOpt
       format_uint32_padded(result, 0, 0, 10, port);
       break;
     }
-    case M_PROTO:
+    case M_PROTOCOL:
     {
       format_uint32_padded(result, 0, 0, 10, msg->proto);
       break;

--- a/lib/template/macros.h
+++ b/lib/template/macros.h
@@ -50,7 +50,7 @@ enum
   M_SOURCE_IP,
   M_DEST_IP,
   M_DEST_PORT,
-  M_PROTO,
+  M_PROTOCOL,
   M_SEQNUM,
   M_CONTEXT_ID,
 

--- a/lib/transport/transport-udp-socket.c
+++ b/lib/transport/transport-udp-socket.c
@@ -130,7 +130,7 @@ _feed_aux_from_cmsg(LogTransportUDP *self, LogTransportAuxData *aux, struct msgh
 }
 
 #else
-#define _feed_aux_from_cmsg(aux, msg)
+#define _feed_aux_from_cmsg(self, aux, msg)
 #endif
 
 


### PR DESCRIPTION
This patchset fixes some compile problems on solaris. With these changes, I could build and run syslog-ng with afsnmp disabled.

If someone wants to test or further experiment: here are my notes of the environment: https://github.com/furiel/notes/blob/master/syslog-ng/platforms/solaris/Vagrantfile
Thanks for @alltilla for the input and guide about solaris build.