### PR TITLE
fix GError handling

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -887,17 +887,17 @@ template_content_inner
         {
           GError *error = NULL;
 
-          CHECK_ERROR(log_template_compile(last_template, $1, &error), @1, "Error compiling template (%s)", error->message);
+          CHECK_ERROR_GERROR(log_template_compile(last_template, $1, &error), @1, error, "Error compiling template");
           free($1);
         }
         | LL_IDENTIFIER '(' string ')'
         {
           GError *error = NULL;
 
-          CHECK_ERROR(log_template_compile(last_template, $3, &error), @3, "Error compiling template (%s)", error->message);
+          CHECK_ERROR_GERROR(log_template_compile(last_template, $3, &error), @3, error, "Error compiling template");
           free($3);
 
-          CHECK_ERROR(log_template_set_type_hint(last_template, $1, &error), @1, "Error setting the template type-hint (%s)", error->message);
+          CHECK_ERROR_GERROR(log_template_set_type_hint(last_template, $1, &error), @1, error, "Error setting the template type-hint");
           free($1);
         }
         ;

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -396,6 +396,7 @@ cfg_lexer_include_file_simple(CfgLexer *self, const gchar *filename)
           msg_error("Error opening directory for reading",
                     evt_tag_str("filename", filename),
                     evt_tag_str("error", error->message));
+          g_error_free(error);
           goto drop_level;
         }
       while ((entry = g_dir_read_name(dir)))

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -1191,5 +1191,6 @@ error:
   if (parse_ctx)
     g_markup_parse_context_free(parse_ctx);
   g_hash_table_unref(state.ruleset_patterns);
+  g_error_free(error);
   return success;
 }

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -216,6 +216,8 @@ error:
   if (parse_ctx)
     g_markup_parse_context_free(parse_ctx);
 
+  g_error_free(error);
+
   return success;
 }
 
@@ -288,6 +290,7 @@ pdbtool_merge(int argc, char *argv[])
     {
       fprintf(stderr, "Error storing patterndb; filename='%s', errror='%s'\n", patterndb_file,
               error ? error->message : "Unknown error");
+      g_error_free(error);
       ok = FALSE;
     }
 

--- a/modules/graphite/graphite-output.c
+++ b/modules/graphite/graphite-output.c
@@ -75,6 +75,7 @@ tf_graphite_parse_command_line_arguments(TFGraphiteState *self, gint *argc, gcha
 
   success = g_option_context_parse (ctx, argc, argv, &error);
   g_option_context_free (ctx);
+  g_error_free(error);
 
   return success;
 }

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -147,6 +147,7 @@ java_dd_init(LogPipe *s)
       msg_error("Can't compile template",
                 evt_tag_str("template", self->template_string),
                 evt_tag_str("error", error->message));
+      g_error_free(error);
       return FALSE;
     }
 

--- a/modules/java/proxies/java-template-proxy.c
+++ b/modules/java/proxies/java-template-proxy.c
@@ -62,6 +62,7 @@ JNICALL Java_org_syslog_1ng_LogTemplate_compile(JNIEnv *env, jobject obj, jlong 
       msg_error("Can't compile template",
                 evt_tag_str("template", template_cstr),
                 evt_tag_str("error", error->message));
+      g_error_free(error);
     }
   (*env)->ReleaseStringUTFChars(env, template_string, template_cstr);
   return result;

--- a/modules/python/python-helpers.c
+++ b/modules/python/python-helpers.c
@@ -435,6 +435,7 @@ _py_string_from_string(const gchar *str, gssize len)
         }
       else
         {
+          g_error_free(error);
           if (len >= 0)
             return PyBytes_FromStringAndSize(str, len);
           else

--- a/news/bugfix-3265.md
+++ b/news/bugfix-3265.md
@@ -1,0 +1,1 @@
+gerror: Fix minor memory leaks in error scenarios

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -226,6 +226,7 @@ main(int argc, char *argv[])
   if (!g_option_context_parse(ctx, &argc, &argv, &error))
     {
       fprintf(stderr, "Error parsing command line arguments: %s\n", error ? error->message : "Invalid arguments");
+      g_error_free(error);
       g_option_context_free(ctx);
       return 1;
     }


### PR DESCRIPTION
- grammar: there are two different macros for error checking (namely: `CHECK_ERROR` and `CHECK_ERROR_GERROR`), we missed using the GError version at some places
- other: add missing `g_error_free` calls.


### Question for reviewers:
- Should we replace `g_clear_error` functions to `g_error_free` in case of local variables? `g_clear_error` makes an extra `=NULL` assignment, but it seems nitpicking for me to change them.