### PR TITLE
Kafkareadme: Updated the Kafka Destination readme file with the current syntax

### DIFF
--- a/modules/kafka/README.md
+++ b/modules/kafka/README.md
@@ -20,10 +20,10 @@ destination d_kafka {
       set("generic"    value(".eventv1.type")       condition("${.eventv1.type}" eq ""));
     };
     destination {
-      kafka-c(properties(metadata.broker.list("localhost:9092")
+      kafka-c(config(metadata.broker.list("localhost:9092")
                        queue.buffering.max.ms("1000"))
-            topic("syslog-ng")
-            payload("$(format-json --key .eventv1.* --rekey .eventv1.* --shift 9)"));
+            topic("test")
+            message("$(format-json --key .eventv1.* --rekey .eventv1.* --shift 9)"));
     };
   };
 };
@@ -43,19 +43,22 @@ installed, compile with `--with-librdkafka`.
 Running Kafka
 -------------
 
-If you are not too familiar with Kafka, a simple recipe using
-[Docker](http://docker.io) can get you started in a minute:
+If you are not too familiar with Kafka, a simple recipe
+[Kafka](https://kafka.apache.org/quickstart) can get you started in a minute.
 
-```
-git clone https://github.com/spotify/docker-kafka
-docker build -t spotify/kafka docker-kafka/kafka
-docker run -e HELIOS_PORT_kafka=vcap.me:9092 -p 2181:2181 -p 9092:9092 spotify/kafka
-```
+
+Once the Kafka zookeeper, server are running and topic is created, start Syslog-ng with the above settings in the configuration file. The logs sent by Syslog-ng will be seen in kafka consumer. 
+
 
 Another useful tool is
-[kafkacat](https://github.com/edenhill/kafkacat). For example, to look
-at logs sent to Kafka, use:
+[kafkacat](https://github.com/edenhill/kafkacat). For example, to look at logs sent to Kafka, use:
 
 ```
 kafkacat -C -u -b localhost -t syslog-ng
 ```
+
+
+
+
+
+


### PR DESCRIPTION
Updated the changes in syntax such as replacement of 'properties' with 'config', 'payload' with 'message'.
The docker-kafka implementation isn't working right now. Hence, on consultation with @furiel, I've replaced it with installation of kafka from official website which can be done following simple steps.