### PR TITLE
Move include directive before default outputs

### DIFF
--- a/packaging/debian/syslog-ng.conf
+++ b/packaging/debian/syslog-ng.conf
@@ -119,6 +119,11 @@ filter f_ppp { facility(local2) and not filter(f_debug); };
 filter f_console { level(warn .. emerg); };
 
 ########################
+# Include all config files in /etc/syslog-ng/conf.d/
+########################
+@include "/etc/syslog-ng/conf.d/*.conf"
+
+########################
 # Log paths
 ########################
 log { source(s_src); filter(f_auth); destination(d_auth); };
@@ -154,8 +159,3 @@ log { source(s_src); filter(f_crit); destination(d_console); };
 # All messages send to a remote site
 #
 #log { source(s_src); destination(d_net); };
-
-###
-# Include all config files in /etc/syslog-ng/conf.d/
-###
-@include "/etc/syslog-ng/conf.d/*.conf"

--- a/packaging/rhel/syslog-ng.conf
+++ b/packaging/rhel/syslog-ng.conf
@@ -52,6 +52,9 @@ filter f_news       { facility(uucp) or
 filter f_boot   { facility(local7); };
 filter f_cron   { facility(cron); };
 
+# Source additional configuration files (.conf extension only)
+@include "/etc/syslog-ng/conf.d/*.conf"
+
 #log { source(s_sys); filter(f_kernel); destination(d_cons); };
 log { source(s_sys); filter(f_kernel); destination(d_kern); };
 log { source(s_sys); filter(f_default); destination(d_mesg); };
@@ -61,10 +64,5 @@ log { source(s_sys); filter(f_emergency); destination(d_mlal); };
 log { source(s_sys); filter(f_news); destination(d_spol); };
 log { source(s_sys); filter(f_boot); destination(d_boot); };
 log { source(s_sys); filter(f_cron); destination(d_cron); };
-
-
-# Source additional configuration files (.conf extension only)
-@include "/etc/syslog-ng/conf.d/*.conf"
-
 
 # vim:ft=syslog-ng:ai:si:ts=4:sw=4:et:


### PR DESCRIPTION
This makes it possible to override the default outputs with additional
configuration files without modifying the default syslog-ng.conf
provided by the package.