### PR TITLE
timeutils: fix crash in %f conversion when non-numeric character is in usec field

### DIFF
--- a/lib/timeutils/tests/test_wallclocktime.c
+++ b/lib/timeutils/tests/test_wallclocktime.c
@@ -74,6 +74,16 @@ Test(wallclocktime, test_strptime_parses_overflowed_usec)
   cr_expect(wct.wct_usec == 12345);
 }
 
+Test(wallclocktime, test_strptime_usec_parse_finds_character)
+{
+  WallClockTime wct = WALL_CLOCK_TIME_INIT;
+  gchar *end;
+
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S.%f", "Jan 16 2019 18:23:12.boom");
+  cr_assert(end == NULL);
+  cr_expect(wct.wct_usec == 0);
+}
+
 Test(wallclocktime, test_strptime_parses_rfc822_timezone)
 {
   WallClockTime wct = WALL_CLOCK_TIME_INIT;

--- a/lib/timeutils/wallclocktime.c
+++ b/lib/timeutils/wallclocktime.c
@@ -413,6 +413,8 @@ recurse:
         case 'f':
         {
           const unsigned char *end = conv_num(bp, &wct->wct_usec, 0, 999999);
+          if (!end)
+            return NULL;
           int digits = end - bp;
 
           /*

--- a/news/bugfix-3270.md
+++ b/news/bugfix-3270.md
@@ -1,0 +1,1 @@
+timeutils: fix crash in %f conversion when non-numeric character is in usec field (e.g. ".asd123")


### PR DESCRIPTION
e.g. with ".asd123"