### PR TITLE
Fix obs related issues 3.27

### DIFF
--- a/dbld/build.manifest
+++ b/dbld/build.manifest
@@ -33,9 +33,9 @@ debian-testing		python3,nojava
 debian-sid		python3,nojava
 
 # on ubuntu, we fetch java from OBS and start using Python3 at focal onwards.
-ubuntu-xenial		python2,nokafka
-ubuntu-bionic		python2
-ubuntu-eoan		python2
+ubuntu-xenial		python2,nokafka,criterion
+ubuntu-bionic		python2,criterion
+ubuntu-eoan		python2,criterion
 ubuntu-focal		python3
 
 centos-6		python2,nokafka,nomongodb		CFLAGS=-D__be16=guint16,PYTHON_LIBS=-lpython2.6,PYTHON_CFLAGS=-I/usr/include/python2.6

--- a/dbld/builddeps
+++ b/dbld/builddeps
@@ -101,6 +101,10 @@ function add_obs_repo {
     PLATFORM=$1
     echo "deb http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/x${PLATFORM} ./" | tee /etc/apt/sources.list.d/lbudai.list
     cat | tee /etc/apt/preferences.d/lbudai <<EOF
+Package: gradle
+Pin: origin "download.opensuse.org"
+Pin-Priority: 500
+
 Package: *
 Pin: origin "download.opensuse.org"
 Pin-Priority: 1

--- a/dbld/images/debian-buster.dockerfile
+++ b/dbld/images/debian-buster.dockerfile
@@ -20,7 +20,6 @@ RUN /dbld/builddeps install_debian_build_deps
 RUN /dbld/builddeps install_pip_packages
 
 RUN /dbld/builddeps install_criterion
-RUN /dbld/builddeps install_gradle
 RUN /dbld/builddeps install_gosu amd64
 
 VOLUME /source

--- a/dbld/images/debian-stretch.dockerfile
+++ b/dbld/images/debian-stretch.dockerfile
@@ -20,7 +20,6 @@ RUN /dbld/builddeps install_debian_build_deps
 RUN /dbld/builddeps install_pip_packages
 
 RUN /dbld/builddeps install_criterion
-RUN /dbld/builddeps install_gradle
 RUN /dbld/builddeps install_gosu amd64
 
 VOLUME /source

--- a/dbld/images/ubuntu-bionic.dockerfile
+++ b/dbld/images/ubuntu-bionic.dockerfile
@@ -21,7 +21,6 @@ RUN /dbld/builddeps install_debian_build_deps
 RUN /dbld/builddeps install_pip_packages
 
 RUN /dbld/builddeps install_criterion
-RUN /dbld/builddeps install_gradle
 RUN /dbld/builddeps install_gosu amd64
 
 VOLUME /source

--- a/dbld/images/ubuntu-bionic.dockerfile
+++ b/dbld/images/ubuntu-bionic.dockerfile
@@ -20,7 +20,6 @@ RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps
 RUN /dbld/builddeps install_pip_packages
 
-RUN /dbld/builddeps install_criterion
 RUN /dbld/builddeps install_gosu amd64
 
 VOLUME /source

--- a/dbld/images/ubuntu-eoan.dockerfile
+++ b/dbld/images/ubuntu-eoan.dockerfile
@@ -21,7 +21,6 @@ RUN /dbld/builddeps install_debian_build_deps
 RUN /dbld/builddeps install_pip_packages
 
 RUN /dbld/builddeps install_criterion
-RUN /dbld/builddeps install_gradle
 RUN /dbld/builddeps install_gosu amd64
 
 VOLUME /source

--- a/dbld/images/ubuntu-eoan.dockerfile
+++ b/dbld/images/ubuntu-eoan.dockerfile
@@ -20,7 +20,6 @@ RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps
 RUN /dbld/builddeps install_pip_packages
 
-RUN /dbld/builddeps install_criterion
 RUN /dbld/builddeps install_gosu amd64
 
 VOLUME /source

--- a/dbld/images/ubuntu-focal.dockerfile
+++ b/dbld/images/ubuntu-focal.dockerfile
@@ -20,7 +20,6 @@ RUN /dbld/builddeps install_debian_build_deps
 RUN /dbld/builddeps install_pip_packages
 
 RUN /dbld/builddeps install_criterion
-RUN /dbld/builddeps install_gradle
 RUN /dbld/builddeps install_gosu amd64
 
 VOLUME /source

--- a/dbld/images/ubuntu-xenial.dockerfile
+++ b/dbld/images/ubuntu-xenial.dockerfile
@@ -20,7 +20,6 @@ RUN /dbld/builddeps install_debian_build_deps
 RUN /dbld/builddeps install_pip_packages
 
 RUN /dbld/builddeps install_criterion
-RUN /dbld/builddeps install_gradle
 RUN /dbld/builddeps install_gosu amd64
 
 VOLUME /source

--- a/dbld/images/ubuntu-xenial.dockerfile
+++ b/dbld/images/ubuntu-xenial.dockerfile
@@ -20,7 +20,6 @@ RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps
 RUN /dbld/builddeps install_pip_packages
 
-RUN /dbld/builddeps install_criterion
 RUN /dbld/builddeps install_gosu amd64
 
 VOLUME /source

--- a/dbld/images/ubuntu-xenial.dockerfile
+++ b/dbld/images/ubuntu-xenial.dockerfile
@@ -15,6 +15,7 @@ COPY images/entrypoint.sh /
 COPY . /dbld/
 
 RUN /dbld/builddeps install_dbld_dependencies
+RUN /dbld/builddeps add_obs_repo Ubuntu_16.04
 RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps
 RUN /dbld/builddeps install_pip_packages

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -36,7 +36,8 @@ Build-Depends: debhelper (>= 10~),
                libsnappy-dev,
                libsnmp-dev [linux-any hurd-i386],
                librdkafka-dev (>= 1.0.0) <!sng-nokafka>,
-               openjdk-8-jdk <!nojava>
+               openjdk-8-jdk <!nojava>,
+               gradle (>= 3.5.1~) <!nojava>
 Build-Conflicts: autoconf2.13
 Standards-Version: 4.4.1
 Homepage: https://www.syslog-ng.com/

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -37,7 +37,8 @@ Build-Depends: debhelper (>= 10~),
                libsnmp-dev [linux-any hurd-i386],
                librdkafka-dev (>= 1.0.0) <!sng-nokafka>,
                openjdk-8-jdk <!nojava>,
-               gradle (>= 3.5.1~) <!nojava>
+               gradle (>= 3.5.1~) <!nojava>,
+               criterion-dev <sng-criterion>
 Build-Conflicts: autoconf2.13
 Standards-Version: 4.4.1
 Homepage: https://www.syslog-ng.com/
@@ -119,6 +120,31 @@ Description: Enhanced system logging daemon (development files)
  This package contains the headers and tools needed to build
  third-party plugins against syslog-ng, the next generation system
  logging daemon.
+
+Package: syslog-ng-test-dev
+Section: libdevel
+Architecture: any
+Depends: syslog-ng-core (= ${binary:Version}), syslog-ng-dev,
+ ${misc:Depends}, criterion-dev
+Build-Profiles: <sng-criterion>
+Description: Enhanced system logging daemon (test development files)
+ syslog-ng is an enhanced log daemon, supporting a wide range of input
+ and output methods: syslog, unstructured text, message queues,
+ databases (SQL and NoSQL alike) and more.
+ .
+ Key features:
+ .
+  * receive and send RFC3164 and RFC5424 style syslog messages
+  * work with any kind of unstructured data
+  * receive and send JSON formatted messages
+  * classify and structure logs with builtin parsers (csv-parser(),
+    db-parser(), etc.)
+  * normalize, crunch and process logs as they flow through the system
+  * hand on messages for further processing using message queues (like
+    AMQP), files or databases (like PostgreSQL or MongoDB).
+ .
+ This package contains the headers and tools needed to unit tests 
+ for syslog-ng, the next generation system  logging daemon.
 
 Package: syslog-ng-core
 Architecture: any

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -40,6 +40,7 @@ endif
 UMAJOR		   = $(shell dpkg-parsechangelog | sed -n '/^Version:/s/^Version: //p' | cut -d. -f1,2)
 
 export DH_OPTIONS += -O-Bdebian/build-tree --dbg-package=syslog-ng-dbg
+export GRADLE_USER_HOME = /tmp/gradle
 
 CFLAGS		?= $(shell dpkg-buildflags --get CFLAGS)
 LDFLAGS		?= $(shell dpkg-buildflags --get LDFLAGS)

--- a/packaging/debian/syslog-ng-test-dev.install
+++ b/packaging/debian/syslog-ng-test-dev.install
@@ -1,0 +1,2 @@
+usr/lib/syslog-ng/syslog-ng/libtest/libsyslog-ng-test.a
+usr/lib/*/pkgconfig/syslog-ng-test.pc


### PR DESCRIPTION
I tried to move to the new packaging structure in my OBS repos.
Finally, I was able to build packages - but had to fix some issues.

Three categories:

1) support ubuntu xenial (xenial EOL: 2024)
 * `dh_systemd`, `dh_autoreconf` are required
 * `debhelper` version

2) missing packages
There are some packages that are part of the environment where we are building the packages in DBLD - criterion and gradle.
In case of gradle we can extend Build-depends.
Criterion is a different thing as criterion is not available on most of the supported Debian/Ubuntu versions. Without criterion `ENABLE_TEST` is false and `libsyslog-ng-test.a` is not built - so I removed it from the `syslog-ng-dev.install` file.

3) `GRADLE_HOME`
I think setting `GRADLE_HOME` is optional - it is maybe OBS specific, but I'd be happy if we could merge this (and I can remove it from this PR).

