### PR TITLE
Fix UDP dest-IP extraction on FreeBSD

### DIFF
--- a/lib/transport/transport-udp-socket.c
+++ b/lib/transport/transport-udp-socket.c
@@ -47,10 +47,12 @@ _extract_dest_ip4_addr_from_cmsg(struct cmsghdr *cmsg, GSockAddr *bind_addr)
 {
   if (cmsg->cmsg_level == IPPROTO_IP && cmsg->cmsg_type == IP_RECVDSTADDR)
     {
-      gint cmsg_header_len = (gchar *) CMSG_DATA(cmsg) - (gchar *) cmsg;
-      struct sockaddr *sa = (struct sockaddr *) CMSG_DATA(cmsg);
+      struct sockaddr_in sin = *(struct sockaddr_in *) &bind_addr->sa;
 
-      return g_sockaddr_new(sa, cmsg->cmsg_len - cmsg_header_len);
+      struct in_addr *sin_addr = (struct in_addr *) CMSG_DATA(cmsg);
+      sin.sin_addr = *sin_addr;
+
+      return g_sockaddr_new((struct sockaddr *) &sin, sizeof(sin));
     }
   return NULL;
 }


### PR DESCRIPTION
On FreeBSD, `struct in_addr` can be extracted from cmsg, not an entire `struct sockaddr_in`.

FreeBSD ip(4) man:

If the IP_RECVDSTADDR option is enabled on	a SOCK_DGRAM socket, the
recvmsg(2)	call will return the destination IP address for	a UDP data-
gram.  The	msg_control field in the msghdr	structure points to a buffer
that contains a cmsghdr structure followed	by the IP address.  The
cmsghdr fields have the following values:

```
  cmsg_len =	sizeof(struct in_addr)
  cmsg_level	= IPPROTO_IP
  cmsg_type = IP_RECVDSTADDR
```

Fixes #3275