### PR TITLE
dbld: fix dockerhub automated builds

### DIFF
--- a/dbld/hooks/build
+++ b/dbld/hooks/build
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-set +x
-set +e
-
-OS_PLATFORM=$(basename $DOCKERFILE_PATH .dockerfile)
-
-./dbld/prepare-image-build $OS_PLATFORM
-docker build --build-arg=COMMIT=$(git rev-parse --short HEAD) --build-arg=OS_PLATFORM=${OS_PLATFORM} -t $IMAGE_NAME -f $DOCKERFILE_PATH .

--- a/dbld/images/hooks/build
+++ b/dbld/images/hooks/build
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set +x
+set +e
+
+
+# we are running in dbld/images as current directory and we need dbld
+cd ../..
+DBLD_DIR="./${BUILD_PATH}"
+
+OS_PLATFORM=$(basename $DOCKERFILE_PATH .dockerfile)
+${DBLD_DIR}/prepare-image-build $OS_PLATFORM
+docker build --build-arg=COMMIT=$(git rev-parse --short HEAD) --build-arg=OS_PLATFORM=${OS_PLATFORM} -t $IMAGE_NAME -f ${DBLD_DIR}/$DOCKERFILE_PATH ${DBLD_DIR}


### PR DESCRIPTION
I mistakenly moved the build hooks in a previous PR to "./dbld", whereas it
should have remained in "./dbld/images/hooks".

Also the cwd is set by dockerhub to dbld/images which is not what we want,
so change the script to the root of the source tree and invoke docker build
from there.

Signed-off-by: Balazs Scheidler <bazsi77@gmail.com>