### PR TITLE
Logmsg deserialization not always updated handles when changed

### DIFF
--- a/lib/logmsg/logmsg-serialize-fixup.c
+++ b/lib/logmsg/logmsg-serialize-fixup.c
@@ -239,7 +239,8 @@ _fixup_entry(NVHandle old_handle, NVEntry *entry, NVIndexEntry *index_entry, gpo
   if (log_msg_is_handle_sdata(new_handle))
     _fixup_sdata_handle(state, old_handle, new_handle);
 
-  state->handle_changed = (new_handle != old_handle);
+  if (!state->handle_changed)
+    state->handle_changed = (new_handle != old_handle);
 
   if (_is_indirect(entry))
     _fixup_handle_in_indirect_entry(self, entry);

--- a/news/bugfix-3281.md
+++ b/news/bugfix-3281.md
@@ -1,0 +1,1 @@
+logmsg-deserialize: fixes possible crash, or fetching wrong value for logmsg nvpair if the message was deserialized after restart. For example messages stored in disk-buffer.


### PR DESCRIPTION
The handles in the logmsg are generated by the log_msg_registry, that object is not persisted between syslog-ng restarts, the handles are assigned in the order of request (incremented) therefore updating a handle to a new value might be needed at logmsg deserialization.

The current solution had a bug, that it only updated if the last handle was not updated. But the handles must be updated if any handle value changed in the logmsg and the current log_msg_registry.

Note: I wanted to write an UT covering the case when the last handle is not changed, but as the values are checked with a foreach that would rely on the way foreach loops the entries, which imho is not nice and may make the test pass but not really check the issue. So I decided not to. If anybody thinks otherwise let me know.