### PR TITLE
packaging/debian: fix rdkafka packaging

### DIFF
--- a/news/bugfix-3282.md
+++ b/news/bugfix-3282.md
@@ -1,0 +1,1 @@
+packaging/debian: fix mod-rdkafka Debian packaging

--- a/packaging/debian/syslog-ng-mod-rdkafka.install
+++ b/packaging/debian/syslog-ng-mod-rdkafka.install
@@ -1,2 +1,1 @@
 usr/lib/syslog-ng/*/libkafka.so
-usr/share/syslog-ng/include/scl/kafka/*


### PR DESCRIPTION
All SCLs are shipped by syslog-ng-core.
