### PR TITLE
fix snapsot version generation

### DIFF
--- a/dbld/rules
+++ b/dbld/rules
@@ -19,7 +19,8 @@ TARBALL_IMAGE ?= ubuntu-bionic
 DEFAULT_DEB_IMAGE=$(DEFAULT_IMAGE)
 DEFAULT_RPM_IMAGE=centos-7
 DOCKER=docker
-VERSION=$(shell scripts/version.sh)
+MODE ?= snapshot
+VERSION=$(shell MODE=${MODE} scripts/version.sh)
 DOCKER_RUN_ARGS=-e USER_NAME_ON_HOST=$(shell whoami)	\
         --network=host --privileged \
 	--ulimit nofile=1024:1024 \
@@ -29,6 +30,7 @@ DOCKER_RUN_ARGS=-e USER_NAME_ON_HOST=$(shell whoami)	\
 	-v $(DBLD_DIR)/install:/install \
 	-e CONFIGURE_OPTS="$${CONFIGURE_OPTS:-$(CONFIGURE_OPTS)}" \
 	-e CCACHE_DIR=/build/ccache \
+	-e MODE=$(MODE) \
 	-e VERSION=$(VERSION) \
 	-e PATH=/usr/lib/ccache:/usr/lib64/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
 	-e GRADLE_USER_HOME=/build/gradle-home \
@@ -41,7 +43,6 @@ DBLD_DIR=$(ROOT_DIR)/dbld
 BUILD_DIR=$(DBLD_DIR)/build
 RELEASE_DIR=$(DBLD_DIR)/release
 TARBALL=$(BUILD_DIR)/syslog-ng-$(VERSION).tar.gz
-MODE=snapshot
 CONFIGURE_OPTS=--enable-debug --enable-manpages --with-python=2 --prefix=/install $(CONFIGURE_ADD)
 
 DOCKER_SHELL=$(DOCKER) run $(DOCKER_RUN_ARGS) --rm -ti balabit/syslog-ng-$* /dbld/shell

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -27,7 +27,7 @@ unset CDPATH
 
 cd $BASEDIR/../
 
-if [ -d .git ] && [ ! $MODE = "release" ] && GIT_VERSION=$(git describe --tags --dirty --abbrev=7); then
+if [ -d .git ] && [ ! "$MODE" = "release" ] && GIT_VERSION=$(git describe --tags --dirty --abbrev=7); then
   echo $GIT_VERSION | sed 's/^syslog-ng-//' | tr '-' '.' | tr -d '\n'
 else
   cat VERSION | tr -d '\n'


### PR DESCRIPTION
https://github.com/syslog-ng/syslog-ng/pull/3272/commits/bc10b1063dc1276fe4ea818cb471cef501e9fb29 was incomplete, it needs a little more work.

The mode variable needs to be quoted within `version.sh`. Strangely `[ ! = "release" ]` evaluates to 0 (which is true in bash), while for example  `[ ! "" = "release" ]` evaluates to 1 (which is false in bash).

Also, MODE needs to be made available for the version script.

After these changes. `dbld/rules pkg-tarball` will generate snapshot tarball, and `dbld/rules MODE=release pkg-tarball` generates release tarball