### PR TITLE
Fix atomic_gssize_set() warning with new glib versions 

### DIFF
--- a/lib/atomic-gssize.h
+++ b/lib/atomic-gssize.h
@@ -67,7 +67,7 @@ atomic_gssize_get(atomic_gssize *a)
 static inline void
 atomic_gssize_set(atomic_gssize *a, gssize value)
 {
-  g_atomic_pointer_set(&a->value, (void *) value);
+  g_atomic_pointer_set(&a->value, value);
 }
 
 static inline gsize

--- a/lib/atomic-gssize.h
+++ b/lib/atomic-gssize.h
@@ -27,7 +27,7 @@
 
 #include "syslog-ng.h"
 
-G_STATIC_ASSERT(sizeof(gsize) == sizeof(gpointer));
+G_STATIC_ASSERT(sizeof(gssize) == sizeof(gpointer));
 
 typedef struct
 {

--- a/news/developer-note-3286.md
+++ b/news/developer-note-3286.md
@@ -1,0 +1,1 @@
+Fix atomic_gssize_set() warning with new glib versions


### PR DESCRIPTION
```
glib/gatomic.h:119:46: warning: initialization of ‘gssize’ from ‘void *’ makes integer from pointer without a cast [-Wint-conversion]
  119 |     __typeof__(*(atomic)) gaps_temp_newval = (newval);
```

`g_atomic_pointer_set()` is documented with the following signature:
`volatile void *atomic, gpointer newval`

Unfortunately, this is not entirely true, because these atomic methods are implemented as macros.

There are multiple implementations of `g_atomic_pointer_set()`, the best is used based on the available compiler features.

`newval` is usually cast to the appropriate type, but the new (preferred) C11-style atomic implementation is polymorphic, so they use `__typeof__` without forcing a type:

GNOME/glib@3251cce

> `__atomic_load()` and `__atomic_store()` built-ins are polymorphic, and
> use `__typeof__()` to ensure that the atomic pointer macros use the
> caller-provided types internally, and hence any type mismatches are
> entirely the caller’s fault rather than ours.

Related to #3277