### PR TITLE
secret-storage: remove additional rlimit check

### DIFF
--- a/lib/secret-storage/tests/test_secret_storage.c
+++ b/lib/secret-storage/tests/test_secret_storage.c
@@ -274,18 +274,6 @@ Test(secretstorage, test_rlimit)
       cr_assert(secret_storage_store_string(key_fmt, "value"), "offending_key: %s, for_limit: %d", key_fmt, for_limit);
     }
 
-  sprintf(key_fmt, "key%03d", i);
-
-  /* root is not restricted by rlimit */
-  if (geteuid() == 0)
-    {
-      cr_assert(secret_storage_store_string(key_fmt, "value"), "offending_key: %s", key_fmt);
-      cr_assert(secret_storage_subscribe_for_key("key000", secret_checker, "value"));
-    }
-  else
-    {
-      cr_assert_not(secret_storage_store_string(key_fmt, "value"), "offending_key: %s", key_fmt);
-    }
   g_free(key_fmt);
 }
 


### PR DESCRIPTION
These asserts are not precise enough, being root is not enough to
determine if rlimit is restricted or not.

We need to check if we have `CAP_IPC_LOCK` capability. We had a run
with that, but we had to depend on `SYSLOG_NG_ENABLE_LINUX_CAPS`,
which is unfortunate in a test, because if we user does not have libcap
the tests are not run, also we will never notice, if the test stops
running for any reason.

In reality these asserts test a linux functionality, and to make it run
correctly it introduces too much complexity for no real usefulness.

Fixes #3181

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>