### PR TITLE
test_secure_logging: use iterate to generate unique strings

### DIFF
--- a/tests/python_functional/functional_tests/template_functions/slog/test_secure_logging.py
+++ b/tests/python_functional/functional_tests/template_functions/slog/test_secure_logging.py
@@ -26,7 +26,9 @@ import pytest
 
 from src.helpers.secure_logging.conftest import *  # noqa:F403, F401
 
-example_message = "example-message"
+seqnum = "$(iterate $(+ 1 $_) 0)"
+message_base = "example-message"
+example_message = "{}: {}".format(message_base, seqnum)
 num_of_messages = 3
 
 
@@ -41,7 +43,8 @@ def test_secure_logging(config, syslog_ng, slog):
     syslog_ng.start(config)
 
     logs = file_destination.read_logs(num_of_messages)
-    assert not any(map(lambda x: example_message in x, logs))
+    # test for no clear text
+    assert not any(map(lambda x: message_base in x, logs))
 
     decrypted = slog.decrypt(output_file_name)
-    assert all(map(lambda x: example_message in x, decrypted))
+    assert decrypted == ["{}: {}: {}".format(str(i).zfill(16), message_base, i) for i in range(num_of_messages)]


### PR DESCRIPTION
This small patch shows an example how we can use `iterate` and `example-msg-generator` to generate unique messages.

Prior this patch, the same message was sent to secure logging multiple times. Now a sequence number is added.