### PR TITLE
map: new template function

### DIFF
--- a/doc/doc-3301.md
+++ b/doc/doc-3301.md
@@ -1,0 +1,20 @@
+# `map` template function
+
+# Short description
+
+`map` template function applies a template function to all elements of a list. It returns the new list.
+
+# Config snippet
+
+```
+log {
+  source { example-msg-generator(template("0,1,2") num(1)); };
+  destination { file("/dev/stdout" template("$(map $(+ 1 $_) $MSG)\n")); };
+};
+```
+
+# Description
+
+`map` template function has two mandatory parameters. The first parameter is a template, that will be applied to each list elements. The second parameter is a string or template, that represents the list.
+
+You can use `$_` template to refer to the list elements inside the template function. If you are chaining `map` calls, `$_` always refers to the innermost of it's enclosing `map` functions.

--- a/modules/basicfuncs/Makefile.am
+++ b/modules/basicfuncs/Makefile.am
@@ -25,6 +25,7 @@ EXTRA_DIST					+=	\
 	modules/basicfuncs/list-funcs.c			\
 	modules/basicfuncs/tf-template.c		\
 	modules/basicfuncs/tf-iterate.c			\
+	modules/basicfuncs/tf-map.c			\
 	modules/basicfuncs/CMakeLists.txt
 
 modules/basicfuncs modules/basicfuncs/ mod-basicfuncs: modules/basicfuncs/libbasicfuncs.la

--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -65,6 +65,7 @@ _append_args_with_separator(gint argc, GString *argv[], GString *result, gchar s
 #include "context-funcs.c"
 #include "fname-funcs.c"
 #include "tf-iterate.c"
+#include "tf-map.c"
 
 static Plugin basicfuncs_plugins[] =
 {
@@ -134,6 +135,7 @@ static Plugin basicfuncs_plugins[] =
 
   /* functional */
   TEMPLATE_FUNCTION_PLUGIN(tf_iterate, "iterate"),
+  TEMPLATE_FUNCTION_PLUGIN(tf_map, "map"),
 
 };
 

--- a/modules/basicfuncs/tf-map.c
+++ b/modules/basicfuncs/tf-map.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2020 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+typedef struct _MapState
+{
+  TFSimpleFuncState super;
+  LogTemplate *template;
+} MapState;
+
+static gboolean
+tf_map_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, gint argc, gchar *argv[],
+               GError **error)
+{
+  MapState *state = (MapState *)s;
+
+  if (argc != 3)
+    {
+      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
+                  "Wrong number of arguments. Example: $(map template list).\n");
+      return FALSE;
+    }
+
+  state->template = log_template_new(configuration, "map");
+  if (!log_template_compile(state->template, argv[1], error))
+    {
+      log_template_unref(state->template);
+      state->template = NULL;
+      return FALSE;
+    }
+
+  memmove(&argv[1], &argv[2], sizeof(argv[0]) * (argc - 2));
+  if (!tf_simple_func_prepare(self, s, parent, argc - 1, argv, error))
+    return FALSE;
+
+  return TRUE;
+}
+
+static void
+tf_map_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArgs *args, GString *result)
+{
+  ListScanner scanner;
+  gsize initial_len = result->len;
+  MapState *state = (MapState *)s;
+  GString *lst = args->argv[0];
+  LogMessage *msg = args->messages[0];
+
+  list_scanner_init(&scanner);
+  list_scanner_input_string(&scanner, lst->str, lst->len);
+
+  ScratchBuffersMarker mark;
+  scratch_buffers_mark(&mark);
+
+  while (list_scanner_scan_next(&scanner))
+    {
+      const gchar *current_value = list_scanner_get_current_value(&scanner);
+      _append_comma_between_list_elements_if_needed(result, initial_len);
+      GString *buffer = scratch_buffers_alloc();
+      log_template_format(state->template, msg, NULL, LTZ_LOCAL, 0, current_value, buffer);
+      str_repr_encode_append(result, buffer->str, -1, ",");
+    }
+  list_scanner_deinit(&scanner);
+
+  scratch_buffers_reclaim_marked(mark);
+}
+
+static void
+tf_map_free_state(gpointer s)
+{
+  MapState *state = (MapState *)s;
+
+  log_template_unref(state->template);
+  state->template = NULL;
+  tf_simple_func_free_state(&state->super);
+}
+
+TEMPLATE_FUNCTION(MapState, tf_map, tf_map_prepare, tf_simple_func_eval,
+                  tf_map_call, tf_map_free_state, NULL);

--- a/news/feature-3301.md
+++ b/news/feature-3301.md
@@ -1,0 +1,3 @@
+`map`: template function
+
+This template function applies a function to all elements of a list. For example: `$(map $(+ 1 $_) 0,1,2)` => 1,2,3.


### PR DESCRIPTION
`map` template function applies a template function to all elements of a list. It returns the new list.

See documentation fragment for example and details.

CC: @jszigetvari

Referring: https://github.com/syslog-ng/syslog-ng/issues/2926

------------------

Future plans:

Originally, I wanted to add a `filter` template function together with map. However, `filter` turned out a bit more problematic. Unfortunately, the `context` is currently not passed to the filter `eval` functions. For example if you check: https://github.com/syslog-ng/syslog-ng/blob/d7d1149c17d9604d44f68e2ddf54d881a2ad460f/lib/filter/filter-cmp.c#L72
you can see `NULL` is passed, in the place of the context. Also, `context` is currently not part of the eval signature:
https://github.com/syslog-ng/syslog-ng/blob/d7d1149c17d9604d44f68e2ddf54d881a2ad460f/lib/filter/filter-expr.c#L45
This means, we cannot use `$_` in the `if` template function. This significantly limits what we could express with a `filter` template function. To fix this, I need to modify the `eval` signature and make sure context is passed around properly. That is a more intrusive change, so I decided to do it separately from `map`.