### PR TITLE
Rdkafka fix simple

### DIFF
--- a/lib/logthrdest/logthrdestdrv.c
+++ b/lib/logthrdest/logthrdestdrv.c
@@ -248,7 +248,7 @@ _process_result_drop(LogThreadedDestWorker *self)
   msg_error("Message(s) dropped while sending message to destination",
             evt_tag_str("driver", self->owner->super.super.id),
             evt_tag_int("worker_index", self->worker_index),
-            evt_tag_int("time_reopen", self->owner->time_reopen),
+            evt_tag_int("time_reopen", self->time_reopen),
             evt_tag_int("batch_size", self->batch_size));
 
   _drop_batch(self);
@@ -278,7 +278,7 @@ _process_result_error(LogThreadedDestWorker *self)
                 log_expr_node_location_tag(self->owner->super.super.super.expr_node),
                 evt_tag_int("worker_index", self->worker_index),
                 evt_tag_int("retries", self->retries_on_error_counter),
-                evt_tag_int("time_reopen", self->owner->time_reopen),
+                evt_tag_int("time_reopen", self->time_reopen),
                 evt_tag_int("batch_size", self->batch_size));
       _rewind_batch(self);
       _disconnect_and_suspend(self);
@@ -292,7 +292,7 @@ _process_result_not_connected(LogThreadedDestWorker *self)
            evt_tag_str("driver", self->owner->super.super.id),
            log_expr_node_location_tag(self->owner->super.super.super.expr_node),
            evt_tag_int("worker_index", self->worker_index),
-           evt_tag_int("time_reopen", self->owner->time_reopen),
+           evt_tag_int("time_reopen", self->time_reopen),
            evt_tag_int("batch_size", self->batch_size));
   self->retries_counter = 0;
   _rewind_batch(self);
@@ -459,7 +459,7 @@ _schedule_restart_on_suspend_timeout(LogThreadedDestWorker *self)
 {
   iv_validate_now();
   self->timer_reopen.expires  = iv_now;
-  self->timer_reopen.expires.tv_sec += self->owner->time_reopen;
+  self->timer_reopen.expires.tv_sec += self->time_reopen;
   iv_timer_register(&self->timer_reopen);
 }
 
@@ -770,6 +770,9 @@ _acquire_worker_queue(LogThreadedDestWorker *self)
 gboolean
 log_threaded_dest_worker_init_method(LogThreadedDestWorker *self)
 {
+  if (self->time_reopen == -1)
+    self->time_reopen = self->owner->time_reopen;
+
   if (!_acquire_worker_queue(self))
     return FALSE;
 
@@ -799,6 +802,7 @@ log_threaded_dest_worker_init_instance(LogThreadedDestWorker *self, LogThreadedD
   self->thread_deinit = log_threaded_dest_worker_deinit_method;
   self->free_fn = log_threaded_dest_worker_free_method;
   self->owner = owner;
+  self->time_reopen = -1;
   self->started_up = g_cond_new();
   _init_watches(self);
 }

--- a/lib/logthrdest/logthrdestdrv.c
+++ b/lib/logthrdest/logthrdestdrv.c
@@ -581,6 +581,13 @@ _perform_work(gpointer data)
     }
 }
 
+void
+log_threaded_dest_worker_wakeup_when_suspended(LogThreadedDestWorker *self)
+{
+  if (self->suspended)
+    _perform_work(self);
+}
+
 static void
 _flush_timer_cb(gpointer data)
 {

--- a/lib/logthrdest/logthrdestdrv.h
+++ b/lib/logthrdest/logthrdestdrv.h
@@ -87,6 +87,7 @@ struct _LogThreadedDestWorker
   gboolean startup_finished;
   gboolean startup_failure;
   GCond *started_up;
+  time_t time_reopen;
 
   gboolean (*thread_init)(LogThreadedDestWorker *s);
   void (*thread_deinit)(LogThreadedDestWorker *s);

--- a/lib/logthrdest/logthrdestdrv.h
+++ b/lib/logthrdest/logthrdestdrv.h
@@ -217,6 +217,7 @@ log_threaded_dest_driver_flush(LogThreadedDestDriver *self)
 void log_threaded_dest_worker_ack_messages(LogThreadedDestWorker *self, gint batch_size);
 void log_threaded_dest_worker_drop_messages(LogThreadedDestWorker *self, gint batch_size);
 void log_threaded_dest_worker_rewind_messages(LogThreadedDestWorker *self, gint batch_size);
+void log_threaded_dest_worker_wakeup_when_suspended(LogThreadedDestWorker *self);
 gboolean log_threaded_dest_worker_init_method(LogThreadedDestWorker *self);
 void log_threaded_dest_worker_deinit_method(LogThreadedDestWorker *self);
 void log_threaded_dest_worker_init_instance(LogThreadedDestWorker *self,

--- a/lib/logthrdest/tests/test_logthrdestdrv.c
+++ b/lib/logthrdest/tests/test_logthrdestdrv.c
@@ -220,7 +220,7 @@ _insert_single_message_connection_failure(LogThreadedDestDriver *s, LogMessage *
 Test(logthrdestdrv, connection_failure_is_considered_an_error_and_retried_indefinitely)
 {
   dd->super.worker.insert = _insert_single_message_connection_failure;
-  dd->super.time_reopen = 0;
+  dd->super.worker.instance.time_reopen = 0;
 
   start_grabbing_messages();
   _generate_message_and_wait_for_processing(dd, dd->super.written_messages);
@@ -247,7 +247,7 @@ _insert_single_message_error_until_drop(LogThreadedDestDriver *s, LogMessage *ms
 Test(logthrdestdrv, error_result_retries_sending_retry_max_times_and_then_drops)
 {
   dd->super.worker.insert = _insert_single_message_error_until_drop;
-  dd->super.time_reopen = 0;
+  dd->super.worker.instance.time_reopen = 0;
   dd->super.retries_on_error_max = 5;
 
   start_grabbing_messages();
@@ -277,7 +277,7 @@ _insert_single_message_error_until_successful(LogThreadedDestDriver *s, LogMessa
 Test(logthrdestdrv, error_result_retries_sending_retry_max_times_and_then_accepts)
 {
   dd->super.worker.insert = _insert_single_message_error_until_successful;
-  dd->super.time_reopen = 0;
+  dd->super.worker.instance.time_reopen = 0;
   dd->super.retries_on_error_max = 5;
 
   start_grabbing_messages();
@@ -364,7 +364,7 @@ Test(logthrdestdrv, batched_set_of_messages_are_dropped_as_a_whole)
 {
   dd->super.worker.insert = _insert_batched_message_drop;
   dd->super.worker.flush = _flush_batched_message_drop;
-  dd->super.time_reopen = 0;
+  dd->super.worker.instance.time_reopen = 0;
 
   start_grabbing_messages();
   _generate_messages_and_wait_for_processing(dd, 10, dd->super.dropped_messages);
@@ -425,7 +425,7 @@ Test(logthrdestdrv,
 {
   dd->super.worker.insert = _insert_batched_message_error_drop;
   dd->super.worker.flush = _flush_batched_message_error_drop;
-  dd->super.time_reopen = 0;
+  dd->super.worker.instance.time_reopen = 0;
   dd->super.retries_on_error_max = 5;
 
   start_grabbing_messages();
@@ -498,7 +498,7 @@ Test(logthrdestdrv,
 
   dd->super.worker.insert = _insert_batched_message_error_success;
   dd->super.worker.flush = _flush_batched_message_error_success;
-  dd->super.time_reopen = 0;
+  dd->super.worker.instance.time_reopen = 0;
   dd->super.retries_on_error_max = 5;
 
   start_grabbing_messages();
@@ -572,7 +572,7 @@ Test(logthrdestdrv,
 
   dd->super.worker.insert = _insert_batched_message_not_connected;
   dd->super.worker.flush = _flush_batched_message_not_connected;
-  dd->super.time_reopen = 0;
+  dd->super.worker.instance.time_reopen = 0;
   dd->super.retries_on_error_max = 5;
 
   start_grabbing_messages();
@@ -718,7 +718,7 @@ Test(logthrdestdrv, test_connect_failure_kicks_in_suspend_retry_logic_which_keep
 
   dd->super.worker.connect = _connect_failure;
   dd->super.worker.insert = _insert_single_message_success;
-  dd->super.time_reopen = 0;
+  dd->super.worker.instance.time_reopen = 0;
   cr_assert(log_pipe_init(&dd->super.super.super.super));
 
   _generate_message_and_wait_for_processing(dd, dd->super.written_messages);

--- a/modules/kafka/kafka-dest-driver.c
+++ b/modules/kafka/kafka-dest-driver.c
@@ -169,7 +169,6 @@ _kafka_delivery_report_cb(rd_kafka_t *rk,
                 evt_tag_str("driver", self->super.super.super.id),
                 log_pipe_location_tag(&self->super.super.super.super));
       log_queue_push_head(queue, msg, &path_options);
-      return;
     }
   else
     {
@@ -181,6 +180,7 @@ _kafka_delivery_report_cb(rd_kafka_t *rk,
                 log_pipe_location_tag(&self->super.super.super.super));
       log_msg_unref(msg);
     }
+  log_threaded_dest_worker_wakeup_when_suspended((LogThreadedDestWorker *) self->super.workers[0]);
 }
 
 static void

--- a/modules/kafka/kafka-dest-worker.c
+++ b/modules/kafka/kafka-dest-worker.c
@@ -60,10 +60,11 @@ static gboolean
 _publish_message(KafkaDestWorker *self, LogMessage *msg)
 {
   KafkaDestDriver *owner = (KafkaDestDriver *) self->super.owner;
+  int block_flag = _is_poller_thread(self) ? 0 : RD_KAFKA_MSG_F_BLOCK;
 
   if (rd_kafka_produce(owner->topic,
                        RD_KAFKA_PARTITION_UA,
-                       RD_KAFKA_MSG_F_FREE | RD_KAFKA_MSG_F_BLOCK,
+                       RD_KAFKA_MSG_F_FREE | block_flag,
                        self->message->str, self->message->len,
                        self->key->len ? self->key->str : NULL, self->key->len,
                        log_msg_ref(msg)) == -1)

--- a/news/bugfix-3305.md
+++ b/news/bugfix-3305.md
@@ -1,0 +1,4 @@
+kafka destination: destination halts if consumer is down, and kafka's queue is filled
+
+Fixes #3080
+


### PR DESCRIPTION
temporary fixes: #3080 

I think this could work until we have the final solution for the issue.

Basic concept:
Poller thread (`worker_index == 0`) calls `rd_kafka_poll` publish messages in non-blocking way, and calls `rd_kafka_poll`. Other threads calls publish in a blocking way - and they don't call `poll()` method.

When the non-blocking publish returns an error (librdkafka's internal queue is full...), `worker_insert` returns `LTR_RETRY` - and then syslog-ng waits `poll_timeout` (converted to seconds) instead of `time_reopen`. Default value for `poll_timeout` is 1 second.
