### PR TITLE
threaded-fetcher: support float at fetch-no-data-delay

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -472,6 +472,8 @@ LogRewrite *last_rewrite;
 %type   <num> positive_integer64
 %type   <num> nonnegative_integer
 %type   <num> nonnegative_integer64
+%type   <fnum> positive_float
+%type   <fnum> nonnegative_float
 %type	<cptr> path_no_check
 %type	<cptr> path_secret
 %type	<cptr> path_check
@@ -1086,6 +1088,28 @@ positive_integer
         : positive_integer64
           {
             CHECK_ERROR(($1 <= G_MAXINT32), @1, "Must be smaller than 2^31");
+          }
+        ;
+
+nonnegative_float
+        : LL_FLOAT
+          {
+            CHECK_ERROR(($1 >= 0), @1, "It cannot be negative");
+          }
+        | nonnegative_integer
+          {
+            $$ = (double) $1;
+          }
+        ;
+
+positive_float
+        : LL_FLOAT
+          {
+            CHECK_ERROR(($1 > 0), @1, "Must be positive");
+          }
+        | positive_integer
+          {
+            $$ = (double) $1;
           }
         ;
 

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1285,7 +1285,7 @@ threaded_source_driver_option
         ;
 
 threaded_fetcher_driver_option
-        : KW_FETCH_NO_DATA_DELAY '(' nonnegative_integer ')' { log_threaded_fetcher_driver_set_fetch_no_data_delay(last_driver, $3); }
+        : KW_FETCH_NO_DATA_DELAY '(' nonnegative_float ')' { log_threaded_fetcher_driver_set_fetch_no_data_delay(last_driver, $3); }
         ;
 
 threaded_source_driver_option_flags

--- a/lib/logthrsource/logthrfetcherdrv.h
+++ b/lib/logthrsource/logthrfetcherdrv.h
@@ -54,7 +54,7 @@ struct _LogThreadedFetcherDriver
 {
   LogThreadedSourceDriver super;
   time_t time_reopen;
-  time_t no_data_delay;
+  gint64 no_data_delay;
   struct iv_task fetch_task;
   struct iv_event wakeup_event;
   struct iv_event shutdown_event;
@@ -77,6 +77,6 @@ gboolean log_threaded_fetcher_driver_init_method(LogPipe *s);
 gboolean log_threaded_fetcher_driver_deinit_method(LogPipe *s);
 void log_threaded_fetcher_driver_free_method(LogPipe *s);
 
-void log_threaded_fetcher_driver_set_fetch_no_data_delay(LogDriver *self, time_t no_data_delay);
+void log_threaded_fetcher_driver_set_fetch_no_data_delay(LogDriver *self, gdouble no_data_delay);
 
 #endif

--- a/lib/logthrsource/tests/test_logthrfetcherdrv.c
+++ b/lib/logthrsource/tests/test_logthrfetcherdrv.c
@@ -364,7 +364,7 @@ Test(logthrfetcherdrv, test_no_data)
   s->no_data_first_time = TRUE;
 
   s->num_of_messages_to_generate = 1;
-  s->super.no_data_delay = 1;
+  log_threaded_fetcher_driver_set_fetch_no_data_delay(&s->super.super.super.super, 1);
   s->super.fetch = _fetch_for_no_data;
 
   struct timespec start = {0};

--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -176,8 +176,7 @@ source_affile_options
         ;
 
 source_affile_option
-	: KW_FOLLOW_FREQ '(' LL_FLOAT ')'		{ file_reader_options_set_follow_freq(last_file_reader_options, (long) ($3 * 1000)); }
-	| KW_FOLLOW_FREQ '(' nonnegative_integer ')'	{ file_reader_options_set_follow_freq(last_file_reader_options, ($3 * 1000)); }
+	: KW_FOLLOW_FREQ '(' nonnegative_float ')'		{ file_reader_options_set_follow_freq(last_file_reader_options, (long) ($3 * 1000)); }
 	| KW_PAD_SIZE '(' nonnegative_integer ')'	{ last_log_proto_options->pad_size = $3; }
 	| multi_line_option
 	| multi_line_timeout

--- a/news/bugfix-3306.md
+++ b/news/bugfix-3306.md
@@ -1,0 +1,1 @@
+`file-source`: Throw error, when `follow-freq()` is set with a negative float number.

--- a/tests/python_functional/functional_tests/source_drivers/file_source/test_follow_freq_value.py
+++ b/tests/python_functional/functional_tests/source_drivers/file_source/test_follow_freq_value.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2015-2018 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import pytest
+
+
+@pytest.mark.parametrize(
+    "follow_freq,expected", [
+        (1, True),
+        (1.0, True),
+        (0.1, True),
+        (0, True),
+        (0.0, True),
+        (-1, False),
+        (-1.0, False),
+        (-0.1, False),
+    ],
+)
+def test_follow_freq_value(config, syslog_ng, follow_freq, expected):
+    raw_config = '@version: {}\nsource s_file {{ file("input.log" follow-freq({})); }};'.format(config.get_version(), follow_freq)
+    config.set_raw_config(raw_config)
+
+    if expected is True:
+        syslog_ng.start(config)
+    else:
+        with pytest.raises(Exception):
+            syslog_ng.start(config)


### PR DESCRIPTION
Also fixed a bug in `file()` source, where we erroneously accepted negative float numbers at `follow-freq()`.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>