### PR TITLE
Remove obs and java support from old ubuntu releases

### DIFF
--- a/dbld/build.manifest
+++ b/dbld/build.manifest
@@ -33,7 +33,7 @@ debian-testing		python3,nojava
 debian-sid		python3,nojava
 
 # on ubuntu, we fetch java from OBS and start using Python3 at focal onwards.
-ubuntu-xenial		python2,nokafka
+ubuntu-xenial		python2,nokafka,nojava
 ubuntu-bionic		python2
 ubuntu-eoan		python2
 ubuntu-focal		python3

--- a/dbld/images/debian-buster.dockerfile
+++ b/dbld/images/debian-buster.dockerfile
@@ -20,7 +20,6 @@ RUN /dbld/builddeps install_debian_build_deps
 RUN /dbld/builddeps install_pip_packages
 
 RUN /dbld/builddeps install_criterion
-RUN /dbld/builddeps install_gradle
 RUN /dbld/builddeps install_gosu amd64
 
 VOLUME /source

--- a/dbld/images/debian-stretch.dockerfile
+++ b/dbld/images/debian-stretch.dockerfile
@@ -20,7 +20,6 @@ RUN /dbld/builddeps install_debian_build_deps
 RUN /dbld/builddeps install_pip_packages
 
 RUN /dbld/builddeps install_criterion
-RUN /dbld/builddeps install_gradle
 RUN /dbld/builddeps install_gosu amd64
 
 VOLUME /source

--- a/dbld/images/ubuntu-xenial.dockerfile
+++ b/dbld/images/ubuntu-xenial.dockerfile
@@ -20,7 +20,6 @@ RUN /dbld/builddeps install_debian_build_deps
 RUN /dbld/builddeps install_pip_packages
 
 RUN /dbld/builddeps install_criterion
-RUN /dbld/builddeps install_gradle
 RUN /dbld/builddeps install_gosu amd64
 
 VOLUME /source


### PR DESCRIPTION
This branch removes Java support from xenial (not needed as our @kira-syslogng has recently been updated to bionic now).

It also removes gradle from images where we don't have java support. (this is the support we implemented in dockerfiles and not if the package installs gradle via build-depends/buildrequires).