### PR TITLE
Stats freq overflow

### DIFF
--- a/lib/stats/stats.c
+++ b/lib/stats/stats.c
@@ -175,9 +175,8 @@ stats_publish_and_prune_counters(StatsOptions *options)
 static void
 stats_timer_rearm(StatsOptions *options, struct iv_timer *timer)
 {
-  gint freq;
+  gint freq = options->log_freq;
 
-  freq = options->log_freq;
   if (!freq)
     freq = options->lifetime <= 1 ? 1 : options->lifetime / 2;
   if (freq > 0)

--- a/lib/stats/stats.c
+++ b/lib/stats/stats.c
@@ -175,7 +175,7 @@ stats_publish_and_prune_counters(StatsOptions *options)
 static void
 stats_timer_rearm(StatsOptions *options, struct iv_timer *timer)
 {
-  gint freq = options->log_freq;
+  glong freq = options->log_freq;
 
   if (!freq)
     freq = options->lifetime <= 1 ? 1 : options->lifetime / 2;

--- a/news/bugfix-3320.md
+++ b/news/bugfix-3320.md
@@ -1,0 +1,1 @@
+stats-freq: with high stats-freq syslog-ng emits stats immediately causing high memory and CPU usage


### PR DESCRIPTION
The current `stats-freq` option could go as high as `2^31-1` (which of course kinda unrealistic), but the opposite happens, the stats reports start to spawn right away in an infinite loop manner.

When timer is adjusted (`timespec_add_msec(&timer->expires, freq * 1000);`) the `freq * 1000` is used, where the `freq` has the type `gint`, and the function - correctly - waits a `glong`, but the multiplication happens before the parameter assignment and in the domain of `gint` that yields `gint` overflow.