### PR TITLE
logsource: add use-syslogng-pid() option

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -249,6 +249,7 @@ extern struct _LogRewrite *last_rewrite;
 %token KW_PERSIST_NAME                10302
 
 %token KW_READ_OLD_RECORDS            10304
+%token KW_USE_SYSLOGNG_PID            10305
 
 /* log statement options */
 %token KW_FLAGS                       10190
@@ -1307,6 +1308,7 @@ source_option
 	| KW_LOG_PREFIX '(' string ')'	        { gchar *p = strrchr($3, ':'); if (p) *p = 0; last_source_options->program_override = g_strdup($3); free($3); }
 	| KW_KEEP_TIMESTAMP '(' yesno ')'	{ last_source_options->keep_timestamp = $3; }
 	| KW_READ_OLD_RECORDS '(' yesno ')'	{ last_source_options->read_old_records = $3; }
+	| KW_USE_SYSLOGNG_PID '(' yesno ')'	{ last_source_options->use_syslogng_pid = $3; }
         | KW_TAGS '(' string_list ')'		{ log_source_options_set_tags(last_source_options, $3); }
         | { last_host_resolve_options = &last_source_options->host_resolve_options; } host_resolve_option
         ;

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -166,6 +166,7 @@ static CfgLexerKeyword main_keywords[] =
   { "batch_timeout",      KW_BATCH_TIMEOUT },
 
   { "read_old_records",   KW_READ_OLD_RECORDS},
+  { "use_syslogng_pid",   KW_USE_SYSLOGNG_PID },
   { "fetch_no_data_delay", KW_FETCH_NO_DATA_DELAY},
   /* filter items */
   { "type",               KW_TYPE },

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -44,6 +44,7 @@ typedef struct _LogSourceOptions
   gint host_override_len;
   LogTagId source_group_tag;
   gboolean read_old_records;
+  gboolean use_syslogng_pid;
   GArray *tags;
   GList *source_queue_callbacks;
   gint stats_level;

--- a/news/feature-3323.md
+++ b/news/feature-3323.md
@@ -1,0 +1,2 @@
+`use-syslogng-pid()`: New option to all sources.
+If set to `yes`, `syslog-ng` overwrites the message's `${PID}` macro to its own PID.


### PR DESCRIPTION
This sets the `${PID}` macro to the `syslog-ng` process' PID.
If `${PID}` was set before, this option overrides it.

Defaults to `no`.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>