### PR TITLE
RHEL 7 packaging: fix logrotate file conflict with rsyslog

### DIFF
--- a/news/packaging-3324.md
+++ b/news/packaging-3324.md
@@ -1,0 +1,1 @@
+RHEL 7 packaging: fix logrotate file conflict with rsyslog

--- a/packaging/rhel/syslog-ng.logrotate7
+++ b/packaging/rhel/syslog-ng.logrotate7
@@ -7,6 +7,6 @@
     missingok
     sharedscripts
     postrotate
-	/usr/bin/systemctl kill -s HUP syslog-ng.service >/dev/null 2>&1 || true
+	/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
     endscript
 }


### PR DESCRIPTION
Fixes #1384

> I had long discussions with Red Hat about it, but renaming it to syslog-ng does not work.
https://github.com/syslog-ng/syslog-ng/issues/1384#issuecomment-286978553

More info: https://github.com/syslog-ng/syslog-ng/issues/1384#issuecomment-644716350