### PR TITLE
Revert excluding secure logging test for cmake

### DIFF
--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -73,7 +73,6 @@ jobs:
       - name: Light
         working-directory: ./build
         run: |
-          [ ${{ matrix.build-tool }} = 'cmake' ] && export cmake_build=1
           make pytest-self-check
           make pytest-linters
           make pytest-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -164,7 +164,6 @@ matrix:
         - make python-pylint
         - make pytest-linters
         - make VERBOSE=1 func-test
-        - export cmake_build=1
         - make pytest-check
 
     - env: B=cmake

--- a/doc/man/slogkey.1.xml
+++ b/doc/man/slogkey.1.xml
@@ -27,7 +27,7 @@
     </refsection>
     <refsection>
       <title>Arguments</title>
-      <para>The arguments depend on the operating mode.</para>  
+      <para>The arguments depend on the operating mode.</para>
       <variablelist>
         <?dbfo term-width="1.25in"?>
         <varlistentry>
@@ -35,7 +35,7 @@
            <command>Master key generation</command>
           </term>
           <listitem>
-            <para>Call sequence: slogkey --masterḱey &lt;filename&gt;</para>
+            <para>Call sequence: slogkey --master-ḱey &lt;filename&gt;</para>
 	    <para>&lt;filename&gt;: The name of the file to which the master key will be written.</para>
          </listitem>
         </varlistentry>

--- a/tests/python_functional/functional_tests/template_functions/slog/test_secure_logging.py
+++ b/tests/python_functional/functional_tests/template_functions/slog/test_secure_logging.py
@@ -20,10 +20,6 @@
 # COPYING for details.
 #
 #############################################################################
-import os
-
-import pytest
-
 from src.helpers.secure_logging.conftest import *  # noqa:F403, F401
 
 seqnum = "$(iterate $(+ 1 $_) 0)"
@@ -32,7 +28,6 @@ example_message = "{}: {}".format(message_base, seqnum)
 num_of_messages = 3
 
 
-@pytest.mark.skipif("cmake_build" in os.environ, reason="only autotools is supported for now")
 def test_secure_logging(config, syslog_ng, slog):
     output_file_name = "output.log"
     generator_source = config.create_example_msg_generator_source(num=num_of_messages, template=config.stringify(example_message), freq="0")


### PR DESCRIPTION
The failing test was fixed in https://github.com/syslog-ng/syslog-ng/pull/3284. This exclude is not needed anymore.