### PR TITLE
light: fix MessageReader-based tests with Python 2

### DIFF
--- a/tests/python_functional/src/driver_io/file/file_io.py
+++ b/tests/python_functional/src/driver_io/file/file_io.py
@@ -39,6 +39,12 @@ class FileIO(File):
         content = self.__readable_file.read()
         return content
 
+    def readline(self):
+        if not self.__readable_file:
+            self.__readable_file = self.open_file(mode="r")
+
+        return self.__readable_file.readline()
+
     def write(self, content):
         if self.__writeable_file is None:
             self.__writeable_file = self.open_file(mode="a+")

--- a/tests/python_functional/src/message_reader/message_reader.py
+++ b/tests/python_functional/src/message_reader/message_reader.py
@@ -23,7 +23,7 @@
 from src.common.blocking import DEFAULT_TIMEOUT
 from src.common.blocking import wait_until_true_custom
 
-READ_ALL_MESSAGES = 0
+READ_ALL_AVAILABLE_MESSAGES = 0
 
 
 class MessageReader(object):
@@ -33,7 +33,7 @@ class MessageReader(object):
 
     def __buffer_and_parse(self, counter):
         buffered_chunk = self.__read()
-        if counter == READ_ALL_MESSAGES:
+        if counter == READ_ALL_AVAILABLE_MESSAGES:
             if buffered_chunk:
                 self.__parser.parse_buffer(buffered_chunk)
                 return False
@@ -44,7 +44,7 @@ class MessageReader(object):
             return len(self.__parser.msg_list) >= counter
 
     def __map_counter(self, counter):
-        if counter == READ_ALL_MESSAGES:
+        if counter == READ_ALL_AVAILABLE_MESSAGES:
             return len(self.__parser.msg_list)
         return counter
 

--- a/tests/python_functional/src/message_reader/tests/test_message_reader.py
+++ b/tests/python_functional/src/message_reader/tests/test_message_reader.py
@@ -21,6 +21,8 @@
 # COPYING for details.
 #
 #############################################################################
+import os
+
 import pytest
 
 from src.common.operations import open_file
@@ -35,6 +37,7 @@ def prepare_input_file(input_content, temp_file):
 
     writeable_file.write(input_content)
     writeable_file.flush()
+    os.fsync(writeable_file.fileno())
     return writeable_file, readable_file
 
 
@@ -140,7 +143,7 @@ def test_writing_popping_in_sequence(temp_file):
     writeable_file, readable_file = prepare_input_file(test_message, temp_file)
     single_line_parser = SingleLineParser()
 
-    message_reader = MessageReader(readable_file.read, single_line_parser)
+    message_reader = MessageReader(readable_file.readline, single_line_parser)
 
     assert message_reader.pop_messages(counter=1) == test_message.splitlines(True)
 
@@ -158,6 +161,7 @@ def test_writing_popping_in_sequence(temp_file):
     test_message = "test message 6\ntest message 7\ntest message 8\ntest message 9\n"
     writeable_file.write(test_message)
     writeable_file.flush()
+    os.fsync(writeable_file.fileno())
     assert message_reader.pop_messages(counter=READ_ALL_AVAILABLE_MESSAGES) == test_message.splitlines(True)
 
     test_message = "test message 10\n"

--- a/tests/python_functional/src/message_reader/tests/test_message_reader.py
+++ b/tests/python_functional/src/message_reader/tests/test_message_reader.py
@@ -25,7 +25,7 @@ import pytest
 
 from src.common.operations import open_file
 from src.message_reader.message_reader import MessageReader
-from src.message_reader.message_reader import READ_ALL_MESSAGES
+from src.message_reader.message_reader import READ_ALL_AVAILABLE_MESSAGES
 from src.message_reader.single_line_parser import SingleLineParser
 
 
@@ -92,7 +92,7 @@ def test_multiple_buffer_and_parse(test_message, temp_file):
             ["test message 1\n", "test message 2\n"],
             [],
         ),
-        (  # pop all messages from buffer, 0 = READ_ALL_MESSAGES
+        (  # pop all messages from buffer, 0 = READ_ALL_AVAILABLE_MESSAGES
             "test message 1\ntest message 2\n",
             0,
             ["test message 1\n", "test message 2\n"],
@@ -158,7 +158,7 @@ def test_writing_popping_in_sequence(temp_file):
     test_message = "test message 6\ntest message 7\ntest message 8\ntest message 9\n"
     writeable_file.write(test_message)
     writeable_file.flush()
-    assert message_reader.pop_messages(counter=READ_ALL_MESSAGES) == test_message.splitlines(True)
+    assert message_reader.pop_messages(counter=READ_ALL_AVAILABLE_MESSAGES) == test_message.splitlines(True)
 
     test_message = "test message 10\n"
     writeable_file.write(test_message)
@@ -187,5 +187,5 @@ def test_read_all_messages():
     generator = read_generator()
     message_reader = MessageReader(lambda: next(generator), single_line_parser)
 
-    assert len(message_reader.pop_messages(counter=READ_ALL_MESSAGES)) == 0
-    assert len(message_reader.pop_messages(counter=READ_ALL_MESSAGES)) == 2
+    assert len(message_reader.pop_messages(counter=READ_ALL_AVAILABLE_MESSAGES)) == 0
+    assert len(message_reader.pop_messages(counter=READ_ALL_AVAILABLE_MESSAGES)) == 2

--- a/tests/python_functional/src/syslog_ng/console_log_reader.py
+++ b/tests/python_functional/src/syslog_ng/console_log_reader.py
@@ -24,7 +24,7 @@ import logging
 
 from src.driver_io.file.file_io import FileIO
 from src.message_reader.message_reader import MessageReader
-from src.message_reader.message_reader import READ_ALL_MESSAGES
+from src.message_reader.message_reader import READ_ALL_AVAILABLE_MESSAGES
 from src.message_reader.single_line_parser import SingleLineParser
 
 logger = logging.getLogger(__name__)
@@ -55,7 +55,7 @@ class ConsoleLogReader(object):
         if not self.__stderr_io.wait_for_creation():
             raise Exception
 
-        console_log_messages = self.__message_reader.pop_messages(counter=READ_ALL_MESSAGES)
+        console_log_messages = self.__message_reader.pop_messages(counter=READ_ALL_AVAILABLE_MESSAGES)
         console_log_content = "".join(console_log_messages)
 
         result = []
@@ -65,7 +65,7 @@ class ConsoleLogReader(object):
 
     def check_for_unexpected_messages(self, unexpected_messages):
         unexpected_patterns = ["Plugin module not found"]
-        console_log_messages = self.__message_reader.peek_messages(counter=READ_ALL_MESSAGES)
+        console_log_messages = self.__message_reader.peek_messages(counter=READ_ALL_AVAILABLE_MESSAGES)
         if unexpected_messages is not None:
             unexpected_patterns.append(unexpected_messages)
         for unexpected_pattern in unexpected_patterns:
@@ -75,7 +75,7 @@ class ConsoleLogReader(object):
                     raise Exception
 
     def dump_stderr(self, last_n_lines=10):
-        console_log_messages = self.__message_reader.peek_messages(counter=READ_ALL_MESSAGES)
+        console_log_messages = self.__message_reader.peek_messages(counter=READ_ALL_AVAILABLE_MESSAGES)
         logger.error("".join(console_log_messages[-last_n_lines:]))
 
     @staticmethod

--- a/tests/python_functional/src/syslog_ng/console_log_reader.py
+++ b/tests/python_functional/src/syslog_ng/console_log_reader.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 class ConsoleLogReader(object):
     def __init__(self, instance_paths):
         self.__stderr_io = FileIO(instance_paths.get_stderr_path())
-        self.__message_reader = MessageReader(self.__stderr_io.read, SingleLineParser())
+        self.__message_reader = MessageReader(self.__stderr_io.readline, SingleLineParser())
 
     def wait_for_start_message(self):
         syslog_ng_start_message = ["syslog-ng starting up;"]

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/destination_reader.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/destination_reader.py
@@ -23,7 +23,7 @@
 import logging
 
 from src.message_reader.message_reader import MessageReader
-from src.message_reader.message_reader import READ_ALL_MESSAGES
+from src.message_reader.message_reader import READ_ALL_AVAILABLE_MESSAGES
 from src.message_reader.single_line_parser import SingleLineParser
 
 logger = logging.getLogger(__name__)
@@ -48,4 +48,4 @@ class DestinationReader(object):
         return messages
 
     def read_all_logs(self, path):
-        return self.read_logs(path, READ_ALL_MESSAGES)
+        return self.read_logs(path, READ_ALL_AVAILABLE_MESSAGES)


### PR DESCRIPTION
In certain Python 2 versions, the `read()` method of buffered file objects can not be used to follow a file: after reaching EOF, subsequent calls will not read new data.

`fsync` calls have also been added to sync data to disk before reading with `READ_ALL_AVAILABLE_MESSAGES`.

Needed for #3277.