### PR TITLE
github-actions: cleanup ENV variables

### DIFF
--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -7,25 +7,35 @@ jobs:
     runs-on: ubuntu-18.04
     container:
       image: balabit/syslog-ng-devshell:latest
-      env:
-        PYTHONUSERBASE: /github/home/python_packages
-        PATH: /github/home/python_packages/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-        CONFIGURE_FLAGS:
-          --prefix=/github/home/install/syslog-ng
-          --enable-all-modules
-          --with-python=${{ matrix.python }}
-        CMAKE_FLAGS:
-          -DCMAKE_C_FLAGS=-Werror
-          -DCMAKE_INSTALL_PREFIX=/github/home/install/syslog-ng
-          -DPYTHON_VERSION=${{ matrix.python }}
 
     strategy:
       matrix:
-        python: [2, 3]
+        python: [python2, python3]
         build-tool: [autotools, cmake]
       fail-fast: false
 
     steps:
+      - name: Set ENV variables
+        run: |
+          export PYTHONVERSION=`printf ${{ matrix.python }} | tail -c 1`
+          export PYTHONUSERBASE=${HOME}/python_packages
+          export PATH=${PYTHONUSERBASE}:${PATH}
+          export CONFIGURE_FLAGS="
+            --prefix=${HOME}/install/syslog-ng
+            --enable-all-modules
+            --with-python=${PYTHONVERSION}
+          "
+          export CMAKE_FLAGS="
+            -DCMAKE_C_FLAGS=-Werror
+            -DCMAKE_INSTALL_PREFIX=${HOME}/install/syslog-ng
+            -DPYTHON_VERSION=${PYTHONVERSION}
+          "
+
+          echo "::set-env name=PYTHONUSERBASE::`echo ${PYTHONUSERBASE}`"
+          echo "::set-env name=PATH::`echo ${PATH}`"
+          echo "::set-env name=CONFIGURE_FLAGS::`echo ${CONFIGURE_FLAGS}`"
+          echo "::set-env name=CMAKE_FLAGS::`echo ${CMAKE_FLAGS}`"
+
       - name: Checkout syslog-ng source
         uses: actions/checkout@v2
 
@@ -38,14 +48,14 @@ jobs:
         run: |
           mkdir build
           cd build
-          ../configure $CONFIGURE_FLAGS
+          ../configure ${CONFIGURE_FLAGS}
 
       - name: cmake
         if: matrix.build-tool == 'cmake'
         run: |
           mkdir build
           cd build
-          cmake $CMAKE_FLAGS ..
+          cmake ${CMAKE_FLAGS} ..
 
       - name: make
         working-directory: ./build
@@ -81,24 +91,30 @@ jobs:
     runs-on: ubuntu-18.04
     container:
       image: balabit/syslog-ng-devshell:latest
-      env:
-        DISTCHECK_CONFIGURE_FLAGS:
-          CFLAGS=-Werror
-          --prefix=/github/home/install/syslog-ng
-          --with-ivykis=internal
-          --with-jsonc=system
-          --enable-tcp-wrapper
-          --enable-linux-caps
-          --enable-manpages
-          --enable-all-modules
-          --with-python=${{ matrix.python }}
 
     strategy:
       matrix:
-        python: [2, 3]
+        python: [python2, python3]
       fail-fast: false
 
     steps:
+      - name: Set ENV variables
+        run: |
+          export PYTHONVERSION=`printf ${{ matrix.python }} | tail -c 1`
+          export DISTCHECK_CONFIGURE_FLAGS="
+            CFLAGS=-Werror
+            --prefix=${HOME}/install/syslog-ng
+            --with-ivykis=internal
+            --with-jsonc=system
+            --enable-tcp-wrapper
+            --enable-linux-caps
+            --enable-manpages
+            --enable-all-modules
+            --with-python=${PYTHONVERSION}
+          "
+
+          echo "::set-env name=DISTCHECK_CONFIGURE_FLAGS::`echo ${DISTCHECK_CONFIGURE_FLAGS}`"
+
       - name: Checkout syslog-ng source
         uses: actions/checkout@v2
 
@@ -106,7 +122,7 @@ jobs:
         run: ./autogen.sh
 
       - name: configure
-        run: ./configure $DISTCHECK_CONFIGURE_FLAGS
+        run: ./configure ${DISTCHECK_CONFIGURE_FLAGS}
 
       - name: distcheck
         run: |


### PR DESCRIPTION
The motivation behind this change:
 1. The `env:` option in the YAML cannot process embedded variables, so we had things like: `PYTHONUSERBASE: /github/home/python_packages`, which should be `${HOME}/python_packages`.
 2. The `env:` option does not handle commands in variables. We need to set the python version, in configure time, with only the python major version, like 2 or 3, so we had 2 and 3 instead of 'python2' and 'python3' in the strategy matrix. The values of the strategy matrix are shown in the workflow run, and we got jobs like: (2, autotools), where the 2 is not comprehensible for the viewer.

The solution for both problems is a separate step, which sets the environment variables. But we have a problem with that too:

Environment variables set in one step are not available in other steps, even if they are set with `export`.

"Fortunately" GitHub Actions give a solution for this:
https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable

With that we can make it work, as expected.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>