### PR TITLE
Fix signal handling when an external library/plugin sets SIG_IGN

### DIFF
--- a/lib/signal-handler.c
+++ b/lib/signal-handler.c
@@ -71,7 +71,7 @@ signal_handler_exec_external_handler(gint signum)
 {
   const struct sigaction *external_sigaction = _get_external_sigaction(signum);
 
-  if (!external_sigaction->sa_handler)
+  if (external_sigaction->sa_handler == SIG_DFL || external_sigaction->sa_handler == SIG_IGN)
     return;
 
   external_sigaction->sa_handler(signum);

--- a/news/bugfix-2811.md
+++ b/news/bugfix-2811.md
@@ -1,6 +1,0 @@
-network sources: fix TLS connection closure
-
-RFC 5425 specifies that once the transport receiver gets `close_notify` from the
-transport sender, it MUST reply with a `close_notify`.
-
-The `close_notify` alert is now sent back correctly in case of TLS network sources.

--- a/news/developer-note-3338.md
+++ b/news/developer-note-3338.md
@@ -1,0 +1,3 @@
+Fix signal handling when an external library/plugin sets SIG_IGN
+
+Previously, setting SIG_IGN in a plugin/library (for example, in a Python module) resulted in a crash.


### PR DESCRIPTION
Previously, setting `SIG_IGN` in a plugin/library (for example, in a Python module) resulted in a crash.

`SIG_DFL` and `SIG_IGN` are special values for `sa_handler`, they should not be treated as valid memory addresses.