### PR TITLE
plugin_skeleton_creator: fix compiler switch

### DIFF
--- a/dev-utils/plugin_skeleton_creator/plugin_template_parser.c
+++ b/dev-utils/plugin_skeleton_creator/plugin_template_parser.c
@@ -35,7 +35,7 @@ static CfgLexerKeyword @PLUGIN_NAME_US@_keywords[] =
 
 CfgParser @PLUGIN_NAME_US@_parser =
 {
-#if ENABLE_DEBUG
+#if SYSLOG_NG_ENABLE_DEBUG
   .debug_flag = &@PLUGIN_NAME_US@_debug,
 #endif
   .name = "@PLUGIN_NAME@",
@@ -45,4 +45,3 @@ CfgParser @PLUGIN_NAME_US@_parser =
 };
 
 CFG_PARSER_IMPLEMENT_LEXER_BINDING(@PLUGIN_NAME_US@_, LogDriver **)
-

--- a/modules/openbsd/openbsd-parser.c
+++ b/modules/openbsd/openbsd-parser.c
@@ -36,7 +36,7 @@ static CfgLexerKeyword openbsd_keywords[] =
 
 CfgParser openbsd_parser =
 {
-#if ENABLE_DEBUG
+#if SYSLOG_NG_ENABLE_DEBUG
   .debug_flag = &openbsd_debug,
 #endif
   .name = "openbsd",

--- a/news/bugfix-3339.md
+++ b/news/bugfix-3339.md
@@ -1,0 +1,1 @@
+`openbsd`: showing grammar debug info for openbsd too, when `-y` command line option is used

--- a/news/developer-note-3339.md
+++ b/news/developer-note-3339.md
@@ -1,0 +1,3 @@
+`plugin_skeleton_creator`: fixing a compiler switch
+
+Wrong compiler switch used in `plugin_skeleton_creator`. This caused a compiler warning. The grammar debug info did not appear for that module, when `-y` command line option was used.


### PR DESCRIPTION
If syslog-ng is compiled with `--enable-debug`, the `-y` command line option adds grammar related debug information for each module. This functionality does not work for these modules due to wrong compiler switch was used.