### PR TITLE
misc: fix `check_nanoseconds()` for wsl

### DIFF
--- a/lib/timeutils/misc.c
+++ b/lib/timeutils/misc.c
@@ -26,6 +26,7 @@
 #include "timeutils/cache.h"
 #include "messages.h"
 
+#include <errno.h>
 #include <string.h>
 
 /**
@@ -89,7 +90,10 @@ check_nanosleep(void)
       sleep_amount.tv_nsec = 1e5;
 
       while (nanosleep(&sleep_amount, &sleep_amount) < 0)
-        ;
+        {
+          if (errno != EINTR)
+            return FALSE;
+        }
 
       clock_gettime(CLOCK_MONOTONIC, &stop);
       diff = timespec_diff_nsec(&stop, &start);

--- a/news/bugfix-3340.md
+++ b/news/bugfix-3340.md
@@ -1,0 +1,1 @@
+wsl: fix infinite loop during startup


### PR DESCRIPTION
Due to https://github.com/microsoft/WSL/issues/4898,
syslog-ng loops in `check_nanoseconds()` infinitely.
This is a wsl bug, that will be probably fixed.
On the other hand, syslog-ng should not interpret
`EINVAL` as expected failure. So this patch fixes
the error handling of `nanosleep`.
