### PR TITLE
db-parser, pdbtool, graphite-output: fix glib assertion error

### DIFF
--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -1191,6 +1191,7 @@ error:
   if (parse_ctx)
     g_markup_parse_context_free(parse_ctx);
   g_hash_table_unref(state.ruleset_patterns);
-  g_error_free(error);
+  if (error)
+    g_error_free(error);
   return success;
 }

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -216,7 +216,8 @@ error:
   if (parse_ctx)
     g_markup_parse_context_free(parse_ctx);
 
-  g_error_free(error);
+  if (error)
+    g_error_free(error);
 
   return success;
 }
@@ -290,7 +291,8 @@ pdbtool_merge(int argc, char *argv[])
     {
       fprintf(stderr, "Error storing patterndb; filename='%s', errror='%s'\n", patterndb_file,
               error ? error->message : "Unknown error");
-      g_error_free(error);
+      if (error)
+        g_error_free(error);
       ok = FALSE;
     }
 

--- a/modules/graphite/graphite-output.c
+++ b/modules/graphite/graphite-output.c
@@ -75,7 +75,8 @@ tf_graphite_parse_command_line_arguments(TFGraphiteState *self, gint *argc, gcha
 
   success = g_option_context_parse (ctx, argc, argv, &error);
   g_option_context_free (ctx);
-  g_error_free(error);
+  if (error)
+    g_error_free(error);
 
   return success;
 }
@@ -176,4 +177,3 @@ tf_graphite_free_state(gpointer s)
 
 TEMPLATE_FUNCTION(TFGraphiteState, tf_graphite, tf_graphite_prepare, NULL, tf_graphite_call,
                   tf_graphite_free_state, NULL);
-

--- a/news/bugfix-3344.md
+++ b/news/bugfix-3344.md
@@ -1,0 +1,10 @@
+db-parser, pdbtool, graphite-output: fix glib assertion error
+
+The assertion happened in these cases
+* dbparser database load
+* argument parsing in graphite-output
+* pdbtool merge commad
+
+Syslog-ng emitted a glib assertion warning in the cases above, even in successful executions.
+
+If `G_DEBUG=fatal-warnings` environment variable was used, the warning turned into a crash.

--- a/news/developer-note-3344.md
+++ b/news/developer-note-3344.md
@@ -1,0 +1,1 @@
+light: test for assertion errors in glib for each testcases

--- a/tests/python_functional/functional_tests/parsers/db_parser/test_db_parser.py
+++ b/tests/python_functional/functional_tests/parsers/db_parser/test_db_parser.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2020 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from src.syslog_ng_config.statements.parsers.db_parser import DBParserConfig
+
+
+def test_db_parser(config, syslog_ng):
+    generator_source = config.create_example_msg_generator_source(
+        num=1, template=config.stringify("some number: 5"),
+        values="PROGRAM => 'program_name'",
+    )
+
+    patterndb_config = DBParserConfig("program_name", [{"class": "patterndb", "rule": "some number: @NUMBER:foo@"}])
+    db_parser = config.create_db_parser(patterndb_config)
+
+    file_destination = config.create_file_destination(file_name="output.log", template=config.stringify('foo=$foo class=${.classifier.class}\n'))
+    config.create_logpath(statements=[generator_source, db_parser, file_destination])
+
+    syslog_ng.start(config)
+    assert file_destination.read_log().strip() == "foo=5 class=patterndb"

--- a/tests/python_functional/functional_tests/template_functions/graphite-output/test_graphite_output.py
+++ b/tests/python_functional/functional_tests/template_functions/graphite-output/test_graphite_output.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2019 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+
+def test_graphite_output(config, syslog_ng):
+    template = "$(graphite-output --timestamp 'custom_timestamp' --key test.*)\n"
+
+    generator_source = config.create_example_msg_generator_source(num=1, values="test.key1 => value1 test.key2 => value2")
+    file_destination = config.create_file_destination(file_name="output.log", template=config.stringify(template))
+
+    config.create_logpath(statements=[generator_source, file_destination])
+    syslog_ng.start(config)
+    log = file_destination.read_logs(2)
+    assert log == ["test.key1 value1 custom_timestamp\n", "test.key2 value2 custom_timestamp\n"]

--- a/tests/python_functional/src/syslog_ng_config/statements/parsers/db_parser.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/parsers/db_parser.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2015-2019 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from xml.etree.ElementTree import Element
+from xml.etree.ElementTree import SubElement
+from xml.etree.ElementTree import tostring
+
+from pathlib2 import Path
+
+import src.testcase_parameters.testcase_parameters as tc_parameters
+from src.syslog_ng_config.statements.parsers.parser import Parser
+
+
+class DBParserConfig(object):
+    def __init__(self, ruleset_pattern, rules):
+        self.ruleset_pattern = ruleset_pattern
+        self.rules = rules
+
+    def write_to(self, file_name):
+        with file_name.open("wb") as f:
+            node_patterndb = Element("patterndb", version="5")
+            node_ruleset = SubElement(node_patterndb, "ruleset", name="some_name", id="1234")
+            node_ruleset_pattern = SubElement(node_ruleset, "pattern")
+            node_ruleset_pattern.text = self.ruleset_pattern
+            node_rules = SubElement(node_ruleset, "rules")
+
+            rule_id = 0
+            for rule in self.rules:
+                node_rule = SubElement(node_rules, "rule", id=str(rule_id))
+                node_rule.set("class", rule["class"])
+                rule_id += 1
+                node_patterns = SubElement(node_rule, "patterns")
+                node_pattern = SubElement(node_patterns, "pattern")
+                node_pattern.text = rule["rule"]
+
+            f.write(tostring(node_patterndb))
+
+
+class DBParser(Parser):
+    index = 0
+
+    def __init__(self, config, **options):
+        path = Path(tc_parameters.WORKING_DIR, "patterndb-{}.xml".format(self.index))
+        config.write_to(path)
+        self.index += 1
+        super(DBParser, self).__init__("db-parser", file=path.resolve(), **options)

--- a/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
@@ -30,6 +30,7 @@ from src.syslog_ng_config.statements.destinations.file_destination import FileDe
 from src.syslog_ng_config.statements.destinations.snmp_destination import SnmpDestination
 from src.syslog_ng_config.statements.filters.filter import Filter
 from src.syslog_ng_config.statements.logpath.logpath import LogPath
+from src.syslog_ng_config.statements.parsers.db_parser import DBParser
 from src.syslog_ng_config.statements.parsers.parser import Parser
 from src.syslog_ng_config.statements.rewrite.rewrite import SetTag
 from src.syslog_ng_config.statements.sources.example_msg_generator_source import ExampleMsgGeneratorSource
@@ -102,6 +103,9 @@ class SyslogNgConfig(object):
 
     def create_snmp_destination(self, **options):
         return SnmpDestination(**options)
+
+    def create_db_parser(self, config, **options):
+        return DBParser(config, **options)
 
     def create_logpath(self, statements=None, flags=None):
         logpath = self.__create_logpath_with_conversion(statements, flags)


### PR DESCRIPTION
```
void
g_error_free (GError *error)
{
  g_return_if_fail (error != NULL);

  g_free (error->message);

  g_slice_free (GError, error);
}
```

`g_error_free` does not expect it's parameter to be null. If syslog-ng
is started with `G_DEBUG=fatal-warnings`, this causes a
crash. Otherwise there is a warning:

```
[2020-07-01T13:17:46.293581] g_error_free: assertion 'error != NULL' failed
```

Example configuration:
```
@version: 3.27

log {
  parser { db-parser(file("/tmp/patterndb.xml")); };
};
```

/tmp/patterndb.xml:
```
<patterndb version='4' pub_date='2020-03-03'>
  <ruleset name='test' id='x'>
  </ruleset>
</patterndb>

```

-------------------------

```
$ ../bin/pdbtool merge -D tmp --pdb output/merge.xml

(pdbtool:11058): GLib-CRITICAL **: g_error_free: assertion 'error != NULL' failed

(pdbtool:11058): GLib-CRITICAL **: g_error_free: assertion 'error != NULL' failed
$ echo $?
0
$  
```

----------------------------

```
@version: 3.27

log {
  source { example-msg-generator(num(1) values(test.key1 => value1 test.key2 => value2)); };
  destination { file(/dev/stdout template("$(graphite-output --timestamp 'custom_timestamp' --key test.*)")); };
};
```

```
$ ./syslog-ng -Fe -f ../etc/graphite.conf 
syslog-ng: Error setting capabilities, capability management disabled; error='Operation not permitted'
[2020-07-06T08:43:31.659210] g_error_free: assertion 'error != NULL' failed
[2020-07-06T08:43:31.659854] syslog-ng starting up; version='3.28.1.37.g3256a78'
test.key1 value1 custom_timestamp
test.key2 value2 custom_timestamp
^C[2020-07-06T08:43:33.184553] syslog-ng shutting down; version='3.28.1.37.g3256a78'
$ 
```