### PR TITLE
panos-parser() source as SCL

### DIFF
--- a/news/feature-3234.md
+++ b/news/feature-3234.md
@@ -1,0 +1,16 @@
+@include "scl.conf"
+
+log {
+  source { network(transport("udp")); };
+  parser { panos-parser(); };
+  destination {     
+	elasticsearch-http(
+	index("syslog-ng-${YEAR}-${MONTH}-${DAY}")
+	type("")
+	url("http://localhost:9200/_bulk")
+	template("$(format-json
+	--scope rfc5424 
+	--scope dot-nv-pairs --rekey .* --shift 1 --exclude *future_* --exclude *devicegroup_* 
+	--scope nv-pairs --exclude DATE --key ISODATE @timestamp=${ISODATE})")
+    );};
+};

--- a/news/feature-3234.md
+++ b/news/feature-3234.md
@@ -10,7 +10,7 @@ log {
 	url("http://localhost:9200/_bulk")
 	template("$(format-json
 	--scope rfc5424 
-	--scope dot-nv-pairs --rekey .* --shift 1 --exclude *future_* --exclude *devicegroup_* 
+	--scope dot-nv-pairs --rekey .* --shift 1 --exclude *future_* --exclude *dg_hier_level_*
 	--scope nv-pairs --exclude DATE --key ISODATE @timestamp=${ISODATE})")
     );};
 };

--- a/scl/CMakeLists.txt
+++ b/scl/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SCL_DIRS
     nodejs
     osquery
     pacct
+    paloalto
     rewrite
     slack
     snmptrap

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -22,6 +22,7 @@ SCL_SUBDIRS	= \
 	nodejs		\
 	osquery	\
 	pacct		\
+	paloalto 	\
 	rewrite	\
 	slack \
 	snmptrap	\

--- a/scl/paloalto/panos.conf
+++ b/scl/paloalto/panos.conf
@@ -51,13 +51,29 @@ block parser panos-parser (prefix(".panos.") ...) {
       };
     } 
     elif (match('CONFIG', value('`prefix`type'))) {
-      parser {
-        csv-parser(
-          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","host_name","vsys","command","admin","client","result","configuration_path","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
-          # Note if using custom logs insert "before_change_detail","after_change_detail" after "action_flags"
-          prefix("`prefix`")
-          delimiters(',')
-        );
+      if {
+          # non-custom format first
+          parser {
+            csv-parser(
+              columns("host_name", "vsys","command","admin","client","result","configuration_path","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+              prefix("`prefix`")
+              template("${`prefix`tmp}")
+              delimiters(',')
+              flags(drop-invalid)
+            );
+          };
+      } else {
+          # custom log with "before_change_detail" and "after_change_detail"
+          # fields in the format
+          parser {
+            csv-parser(
+              columns("host_name", "vsys","command","admin","client","result","configuration_path","sequence_number","before_change_detail","action_flags","after_change_detail","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+              prefix("`prefix`")
+              template("${`prefix`tmp}")
+              delimiters(',')
+              flags(drop-invalid)
+            );
+          };
       };
     } 
     elif (match('THREAT', value('`prefix`type'))) {

--- a/scl/paloalto/panos.conf
+++ b/scl/paloalto/panos.conf
@@ -146,6 +146,6 @@ block parser panos-parser (prefix(".panos.") ...) {
   };
 };
 application panos[syslog] {
-    filter { message(".*,paloalto.*"); };
+    filter { match("1," value("PROGRAM") type(string) flags(prefix)); };
     parser { panos-parser(); };
 };

--- a/scl/paloalto/panos.conf
+++ b/scl/paloalto/panos.conf
@@ -28,29 +28,29 @@
 
 block parser panos-parser (prefix(".panos.") ...) {
   channel {
-    rewrite {
-      set("${LEGACY_MSGHDR}${MESSAGE}" value("MESSAGE"));
-      set("paloalto_panos" value("PROGRAM"));
-    };
 # Common fields - set dot-nv-pairs
     parser {
       csv-parser(
-        columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time")
+        columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time", "tmp")
         delimiters(',')
         prefix("`prefix`")
+	flags(greedy, drop-invalid)
+        template("${LEGACY_MSGHDR}${MESSAGE}")
       );
     };
 # Parse logs according to "type" field
     if (match('SYSTEM', value('`prefix`type'))) {
       parser {
         csv-parser(
-          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","vsys","event_id","object","future_use3","future_use4","module","severity","description","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          columns("vsys","event_id","object","future_use3","future_use4","module","severity","description","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
           prefix("`prefix`")
+          template("${`prefix`tmp}")
           delimiters(',')
+          flags(drop-invalid)
         );
       };
     } 
-    elif (match('CONFIG', value('`prefix`type'))) {    
+    elif (match('CONFIG', value('`prefix`type'))) {
       parser {
         csv-parser(
           columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","host_name","vsys","command","admin","client","result","configuration_path","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
@@ -63,48 +63,70 @@ block parser panos-parser (prefix(".panos.") ...) {
     elif (match('THREAT', value('`prefix`type'))) {
       parser {
         csv-parser(
-          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","src_ip","dest_ip","src_translated_ip","dest_translated_ip","rule","src_user","dest_user","app","vsys","src_zone","dest_zone","src_interface","dest_interface","log_forwarding_profile","future_use3","session_id","repeat_count","src_port","dest_port","src_translated_port","dest_translated_port","session_flags","transport","action","misc","threat","raw_category","severity","direction","sequence_number","action_flags","src_location","dest_location","future_use4","content_type","pcap_id","file_hash","cloud_address","url_index","user_agent","file_type","xff","referrer","sender","subject","recipient","report_id","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          columns("src_ip","dest_ip","src_translated_ip","dest_translated_ip","rule","src_user","dest_user","app","vsys","src_zone","dest_zone","src_interface","dest_interface","log_forwarding_profile","future_use3","session_id","repeat_count","src_port","dest_port","src_translated_port","dest_translated_port","session_flags","transport","action","misc","threat","raw_category","severity","direction","sequence_number","action_flags","src_location","dest_location","future_use4","content_type","pcap_id","file_hash","cloud_address","url_index","user_agent","file_type","xff","referrer","sender","subject","recipient","report_id","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
           prefix("`prefix`")
+          template("${`prefix`tmp}")
           delimiters(',')
+          flags(drop-invalid)
         );
       };
     } 
     elif (match('TRAFFIC', value('`prefix`type'))) {
       parser {
         csv-parser(
-          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","src_ip","dest_ip","src_translated_ip","dest_translated_ip","rule","src_user","dest_user","app","vsys","src_zone","dest_zone","src_interface","dest_interface","log_forwarding_profile","future_use3","session_id","repeat_count","src_port","dest_port","src_translated_port","dest_translated_port","session_flags","transport","action","bytes","bytes_out","bytes_in","packets","start_time","duration","http_category","future_use4","sequence_number","action_flags","src_location","dest_location","future_use5","packets_out","packets_in","session_end_reason","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          columns("src_ip","dest_ip","src_translated_ip","dest_translated_ip","rule","src_user","dest_user","app","vsys","src_zone","dest_zone","src_interface","dest_interface","log_forwarding_profile","future_use3","session_id","repeat_count","src_port","dest_port","src_translated_port","dest_translated_port","session_flags","transport","action","bytes","bytes_out","bytes_in","packets","start_time","duration","http_category","future_use4","sequence_number","action_flags","src_location","dest_location","future_use5","packets_out","packets_in","session_end_reason","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
           prefix("`prefix`")
+          template("${`prefix`tmp}")
           delimiters(',')
+          flags(drop-invalid)
         );
       };
     } 
     elif (match('HIPWATCH', value('`prefix`type'))) {
       parser {
         csv-parser(
-          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","src_user","vsys","host_name","os","src_ip","hip_name","hip_count","hip_type","future_use3","future_use4","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          columns("src_user","vsys","host_name","os","src_ip","hip_name","hip_count","hip_type","future_use3","future_use4","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
           prefix("`prefix`")
+          template("${`prefix`tmp}")
           delimiters(',')
+          flags(drop-invalid)
         );
       };
     } 
     elif (match('CORRELATION', value('`prefix`type'))) {
       parser {
         csv-parser(
-          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","src_ip","src_user","vsys","category","severity","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name","vsys_id","object","object_id","evidence")
+          columns("src_ip","src_user","vsys","category","severity","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name","vsys_id","object","object_id","evidence")
           prefix("`prefix`")
+          template("${`prefix`tmp}")
           delimiters(',')
+          flags(drop-invalid)
         );
       };
     } 
     elif (match('USERID', value('`prefix`type'))) {
       parser {
         csv-parser(
-          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","vsys","src_ip","source_name","event_id","repeat_count","timeout_threshold","src_port","dest_port","source","source_type","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          columns("vsys","src_ip","source_name","event_id","repeat_count","timeout_threshold","src_port","dest_port","source","source_type","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
           prefix("`prefix`")
+          template("${`prefix`tmp}")
           delimiters(',')
+          flags(drop-invalid)
         );
       };
     };
+
+    # no else branch, so we would drop messages where type does not match
+    # any of the known ones in the branches above
+
+    rewrite {
+
+      # fix the message in case we forward it to a syslog consumer
+      set("${LEGACY_MSGHDR}${MESSAGE}" value("MESSAGE"));
+      set("paloalto_panos" value("PROGRAM"));
+      unset(value("`prefix`tmp"));
+    };
+
   };
 };
 application panos[syslog] {

--- a/scl/paloalto/panos.conf
+++ b/scl/paloalto/panos.conf
@@ -39,7 +39,7 @@ block parser panos-parser (prefix(".panos.") ...) {
       );
     };
 # Parse logs according to "type" field
-    if (match('SYSTEM', value('`prefix`type'))) {
+    if (match('SYSTEM' value('`prefix`type') type(string))) {
       parser {
         csv-parser(
           columns("vsys","event_id","object","future_use3","future_use4","module","severity","description","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
@@ -50,7 +50,7 @@ block parser panos-parser (prefix(".panos.") ...) {
         );
       };
     } 
-    elif (match('CONFIG', value('`prefix`type'))) {
+    elif (match('CONFIG' value('`prefix`type') type(string))) {
       if {
           # non-custom format first
           parser {
@@ -76,7 +76,7 @@ block parser panos-parser (prefix(".panos.") ...) {
           };
       };
     } 
-    elif (match('THREAT', value('`prefix`type'))) {
+    elif (match('THREAT' value('`prefix`type') type(string))) {
       parser {
         csv-parser(
           columns("src_ip","dest_ip","src_translated_ip","dest_translated_ip","rule","src_user","dest_user","app","vsys","src_zone","dest_zone","src_interface","dest_interface","log_forwarding_profile","future_use3","session_id","repeat_count","src_port","dest_port","src_translated_port","dest_translated_port","session_flags","transport","action","misc","threat","raw_category","severity","direction","sequence_number","action_flags","src_location","dest_location","future_use4","content_type","pcap_id","file_hash","cloud_address","url_index","user_agent","file_type","xff","referrer","sender","subject","recipient","report_id","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
@@ -87,7 +87,7 @@ block parser panos-parser (prefix(".panos.") ...) {
         );
       };
     } 
-    elif (match('TRAFFIC', value('`prefix`type'))) {
+    elif (match('TRAFFIC' value('`prefix`type') type(string))) {
       parser {
         csv-parser(
           columns("src_ip","dest_ip","src_translated_ip","dest_translated_ip","rule","src_user","dest_user","app","vsys","src_zone","dest_zone","src_interface","dest_interface","log_forwarding_profile","future_use3","session_id","repeat_count","src_port","dest_port","src_translated_port","dest_translated_port","session_flags","transport","action","bytes","bytes_out","bytes_in","packets","start_time","duration","http_category","future_use4","sequence_number","action_flags","src_location","dest_location","future_use5","packets_out","packets_in","session_end_reason","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
@@ -98,7 +98,7 @@ block parser panos-parser (prefix(".panos.") ...) {
         );
       };
     } 
-    elif (match('HIPWATCH', value('`prefix`type'))) {
+    elif (match('HIPWATCH' value('`prefix`type') type(string))) {
       parser {
         csv-parser(
           columns("src_user","vsys","host_name","os","src_ip","hip_name","hip_count","hip_type","future_use3","future_use4","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
@@ -109,7 +109,7 @@ block parser panos-parser (prefix(".panos.") ...) {
         );
       };
     } 
-    elif (match('CORRELATION', value('`prefix`type'))) {
+    elif (match('CORRELATION' value('`prefix`type') type(string))) {
       parser {
         csv-parser(
           columns("src_ip","src_user","vsys","category","severity","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name","vsys_id","object","object_id","evidence")
@@ -120,7 +120,7 @@ block parser panos-parser (prefix(".panos.") ...) {
         );
       };
     } 
-    elif (match('USERID', value('`prefix`type'))) {
+    elif (match('USERID' value('`prefix`type') type(string))) {
       parser {
         csv-parser(
           columns("vsys","src_ip","source_name","event_id","repeat_count","timeout_threshold","src_port","dest_port","source","source_type","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")

--- a/scl/paloalto/panos.conf
+++ b/scl/paloalto/panos.conf
@@ -31,31 +31,51 @@ block parser panos-parser (prefix(".panos.") ...) {
 # Common fields - set dot-nv-pairs
     parser {
       csv-parser(
-        columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time", "tmp")
+        columns("future_use1","receive_time","serial","type","subtype","future_use2","time_generated", "tmp")
         delimiters(',')
         prefix("`prefix`")
-	flags(greedy, drop-invalid)
+        flags(greedy, drop-invalid)
         template("${LEGACY_MSGHDR}${MESSAGE}")
       );
     };
 # Parse logs according to "type" field
     if (match('SYSTEM' value('`prefix`type') type(string))) {
       parser {
+
+        # FUTURE_USE, Receive Time, Serial Number, Type, Content/Threat
+        # Type, FUTURE_USE, Generated Time, Virtual System, Event ID,
+        # Object, FUTURE_USE, FUTURE_USE, Module, Severity, Description,
+        # Sequence Number, Action Flags, Device Group Hierarchy Level 1,
+        # Device Group Hierarchy Level 2, Device Group Hierarchy Level 3,
+        # Device Group Hierarchy Level 4, Virtual System Name, Device Name
+
         csv-parser(
-          columns("vsys","event_id","object","future_use3","future_use4","module","severity","description","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+
+          columns("vsys","eventid","object","future_use3","future_use4","module","severity","opaque","seqno","actionflags",
+                  "dg_hier_level_1","dg_hier_level_2","dg_hier_level_3","dg_hier_level_4","vsys_name","device_name")
+
           prefix("`prefix`")
           template("${`prefix`tmp}")
           delimiters(',')
-          flags(drop-invalid)
         );
       };
+      filter { "${`prefix`device_name}" ne "" };
     } 
     elif (match('CONFIG' value('`prefix`type') type(string))) {
+
+      # FUTURE_USE, Receive Time, Serial Number, Type, Subtype, FUTURE_USE,
+      # Generated Time, Host, Virtual System, Command, Admin, Client,
+      # Result, Configuration Path, Before Change Detail, After Change
+      # Detail, Sequence Number, Action Flags, Device Group Hierarchy Level
+      # 1, Device Group Hierarchy Level 2, Device Group Hierarchy Level 3,
+      # Device Group Hierarchy Level 4, Virtual System Name, Device Name
+
       if {
           # non-custom format first
           parser {
             csv-parser(
-              columns("host_name", "vsys","command","admin","client","result","configuration_path","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+              columns("host", "vsys","cmd","admin","client","result","path","seqno","actionflags",
+                      "dg_hier_level_1","dg_hier_level_2","dg_hier_level_3","dg_hier_level_4","vsys_name","device_name")
               prefix("`prefix`")
               template("${`prefix`tmp}")
               delimiters(',')
@@ -67,69 +87,171 @@ block parser panos-parser (prefix(".panos.") ...) {
           # fields in the format
           parser {
             csv-parser(
-              columns("host_name", "vsys","command","admin","client","result","configuration_path","sequence_number","before_change_detail","action_flags","after_change_detail","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+              columns("host", "vsys","cmd","admin","client","result","path",
+                      "before_change_detail","after_change_detail","seqno","actionflags",
+                      "dg_hier_level_1","dg_hier_level_2","dg_hier_level_3","dg_hier_level_4","vsys_name","device_name")
               prefix("`prefix`")
               template("${`prefix`tmp}")
               delimiters(',')
-              flags(drop-invalid)
             );
           };
+         filter { "${`prefix`device_name}" ne "" };
       };
     } 
     elif (match('THREAT' value('`prefix`type') type(string))) {
       parser {
         csv-parser(
-          columns("src_ip","dest_ip","src_translated_ip","dest_translated_ip","rule","src_user","dest_user","app","vsys","src_zone","dest_zone","src_interface","dest_interface","log_forwarding_profile","future_use3","session_id","repeat_count","src_port","dest_port","src_translated_port","dest_translated_port","session_flags","transport","action","misc","threat","raw_category","severity","direction","sequence_number","action_flags","src_location","dest_location","future_use4","content_type","pcap_id","file_hash","cloud_address","url_index","user_agent","file_type","xff","referrer","sender","subject","recipient","report_id","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          # FUTURE_USE, Receive Time, Serial Number, Type, Threat/Content
+          # Type, FUTURE_USE, Generated Time, Source Address, Destination
+          # Address, NAT Source IP, NAT Destination IP, Rule Name, Source
+          # User, Destination User, Application, Virtual System, Source
+          # Zone, Destination Zone, Inbound Interface, Outbound Interface,
+          # Log Action, FUTURE_USE, Session ID, Repeat Count, Source Port,
+          # Destination Port, NAT Source Port, NAT Destination Port, Flags,
+          # Protocol, Action, URL/Filename, Threat ID, Category, Severity,
+          # Direction, Sequence Number, Action Flags, Source Location,
+          # Destination Location, FUTURE_USE, Content Type, PCAP_ID, File
+          # Digest, Cloud, URL Index, User Agent, File Type,
+          # X-Forwarded-For, Referer, Sender, Subject, Recipient, Report ID,
+          # Device Group Hierarchy Level 1, Device Group Hierarchy Level 2,
+          # Device Group Hierarchy Level 3, Device Group Hierarchy Level 4,
+          # Virtual System Name, Device Name, FUTURE_USE, Source VM UUID,
+          # Destination VM UUID, HTTP Method, Tunnel ID/IMSI, Monitor
+          # Tag/IMEI, Parent Session ID, Parent Start Time, Tunnel Type,
+          # Threat Category, Content Version, FUTURE_USE, SCTP Association
+          # ID, Payload Protocol ID, HTTP Headers, URL Category List, UUID
+          # for rule, HTTP/2 Connection
+
+          columns("src","dst","natsrc","natdst","rule","srcuser","dstuser","app","vsys","from","to",
+                  "inbound_if","outbound_if","logset","future_use3","sessionid","repeatcnt",
+                  "sport","dport","natsport","natdport","flags","proto","action","misc",
+                  "threatid","category","severity","direction","seqno","actionflags",
+                  "srcloc","dstloc","future_use4","contenttype","pcap_id","filedigest",
+                  "cloud","url_idx","user_agent","filetype","xff","referer","sender","subject","recipient","reportid",
+                  "dg_hier_level_1","dg_hier_level_2","dg_hier_level_3","dg_hier_level_4","vsys_name","device_name","future_use5",
+                  "src_uuid","dst_uuid","http_method","tunnel_id/imsi","monitor_tag/imei",
+                  "parent_session_id","parent_start_time","tunnel","thr_category","contentver",
+                  "future_use6","assoc_id","ppid","http_headers","url_category_list",
+                  "rule_uuid","http2_connection")
           prefix("`prefix`")
           template("${`prefix`tmp}")
           delimiters(',')
-          flags(drop-invalid)
         );
       };
+
+      # we require all columns up to device_name, the rest is optional
+      filter { "${`prefix`device_name}" ne "" };
     } 
     elif (match('TRAFFIC' value('`prefix`type') type(string))) {
       parser {
+
+        # FUTURE_USE, Receive Time, Serial Number, Type, Threat/Content
+        # Type, FUTURE_USE, Generated Time, Source Address, Destination
+        # Address, NAT Source IP, NAT Destination IP, Rule Name, Source
+        # User, Destination User, Application, Virtual System, Source Zone,
+        # Destination Zone, Inbound Interface, Outbound Interface, Log
+        # Action, FUTURE_USE, Session ID, Repeat Count, Source Port,
+        # Destination Port, NAT Source Port, NAT Destination Port, Flags,
+        # Protocol, Action, Bytes, Bytes Sent, Bytes Received, Packets,
+        # Start Time, Elapsed Time, Category, FUTURE_USE, Sequence Number,
+        # Action Flags, Source Location, Destination Location, FUTURE_USE,
+        # Packets Sent, Packets Received, Session End Reason, Device Group
+        # Hierarchy Level 1, Device Group Hierarchy Level 2, Device Group
+        # Hierarchy Level 3, Device Group Hierarchy Level 4, Virtual System
+        # Name, Device Name, Action Source, Source VM UUID, Destination VM
+        # UUID, Tunnel ID/IMSI, Monitor Tag/IMEI, Parent Session ID, Parent
+        # Start Time, Tunnel Type, SCTP Association ID, SCTP Chunks, SCTP
+        # Chunks Sent, SCTP Chunks Received, UUID for rule, HTTP/2
+        # Connection
+
         csv-parser(
-          columns("src_ip","dest_ip","src_translated_ip","dest_translated_ip","rule","src_user","dest_user","app","vsys","src_zone","dest_zone","src_interface","dest_interface","log_forwarding_profile","future_use3","session_id","repeat_count","src_port","dest_port","src_translated_port","dest_translated_port","session_flags","transport","action","bytes","bytes_out","bytes_in","packets","start_time","duration","http_category","future_use4","sequence_number","action_flags","src_location","dest_location","future_use5","packets_out","packets_in","session_end_reason","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          columns("src","dst","natsrc","natdst","rule","srcuser","dstuser","app","vsys","from","to","inbound_if","outbound_if",
+                  "logset","future_use3","sessionid","repeatcnt","sport","dport","natsport","natdport","flags","proto","action",
+                  "bytes","bytes_sent","bytes_received","packets","start","sec","category","future_use4","seqno","actionflags",
+                  "srcloc","dstloc","future_use5","pkts_sent","pkts_received","session_end_reason",
+                  "dg_hier_level_1","dg_hier_level_2","dg_hier_level_3","dg_hier_level_4","vsys_name","device_name",
+                  "action_source","src_uuid","dst_uuid","tunnel_id/imsi","monitortag/imei",
+                  "parent_session_id","parent_start_time","tunnel","assoc_id",
+                  "chunks","chunks_sent","chunks_received","rule_uuid",
+                  "http2_connection","link_change_count",
+                  "policy_id","link_switches",
+                  "sdwan_cluster","sdwan_device_type","sdwan_cluster_type","sdwan_site","dynusergroup_name")
           prefix("`prefix`")
           template("${`prefix`tmp}")
           delimiters(',')
-          flags(drop-invalid)
         );
       };
+      # we require all columns up to device_name, the rest is optional
+      filter { "${`prefix`device_name}" ne "" };
     } 
-    elif (match('HIPWATCH' value('`prefix`type') type(string))) {
+    elif (match('HIP-MATCH' value('`prefix`type') type(string))) {
       parser {
+
+        # FUTURE_USE, Receive Time, Serial Number, Type, Threat/Content
+        # Type, FUTURE_USE, Generated Time, Source User, Virtual System,
+        # Machine name, OS, Source Address, HIP, Repeat Count, HIP Type,
+        # FUTURE_USE, FUTURE_USE, Sequence Number, Action Flags, Device
+        # Group Hierarchy Level 1, Device Group Hierarchy Level 2, Device
+        # Group Hierarchy Level 3, Device Group Hierarchy Level 4, Virtual
+        # System Name, Device Name, Virtual System ID, IPv6 Source Address,
+        # Host ID, User Device Serial Number
+
         csv-parser(
-          columns("src_user","vsys","host_name","os","src_ip","hip_name","hip_count","hip_type","future_use3","future_use4","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          columns("srcuser","vsys","machine_name","os","src","matchname","repeatcnt","matchtype","future_use3","future_use4","seqno","actionflags",
+                  "dg_hier_level_1","dg_hier_level_2","dg_hier_level_3","dg_hier_level_4","vsys_name","device_name",
+                  "vsys_id","srcipv6","hostid","serialnumber")
           prefix("`prefix`")
           template("${`prefix`tmp}")
           delimiters(',')
-          flags(drop-invalid)
         );
       };
+      filter { "${`prefix`device_name}" ne "" };
     } 
     elif (match('CORRELATION' value('`prefix`type') type(string))) {
       parser {
+
+        # FUTURE_USE, Receive Time, Serial Number, Type, Content/Threat
+        # Type, FUTURE_USE, Generated Time, Source Address.  Source User,
+        # Virtual System, Category, Severity, Device Group Hierarchy Level
+        # 1, Device Group Hierarchy Level 2, Device Group Hierarchy Level 3,
+        # Device Group Hierarchy Level 4, Virtual System Name, Device Name,
+        # Virtual System ID, Object Name, Object ID, Evidence
+
         csv-parser(
-          columns("src_ip","src_user","vsys","category","severity","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name","vsys_id","object","object_id","evidence")
+          columns("src","srcuser","vsys","category","severity",
+                  "dg_hier_level_1","dg_hier_level_2","dg_hier_level_3","dg_hier_level_4","vsys_name","device_name",
+                  "vsys_id","objectname","object_id","evidence")
           prefix("`prefix`")
           template("${`prefix`tmp}")
           delimiters(',')
-          flags(drop-invalid)
         );
       };
+      filter { "${`prefix`device_name}" ne "" };
     } 
     elif (match('USERID' value('`prefix`type') type(string))) {
       parser {
         csv-parser(
-          columns("vsys","src_ip","source_name","event_id","repeat_count","timeout_threshold","src_port","dest_port","source","source_type","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+
+          # FUTURE_USE, Receive Time, Serial Number, Type, Threat/Content
+          # Type, FUTURE_USE, Generated Time, Virtual System, Source IP,
+          # User, Data Source Name, Event ID, Repeat Count, Time Out
+          # Threshold, Source Port, Destination Port, Data Source, Data
+          # Source Type, Sequence Number, Action Flags, Device Group
+          # Hierarchy Level 1, Device Group Hierarchy Level 2, Device Group
+          # Hierarchy Level 3, Device Group Hierarchy Level 4, Virtual
+          # System Name, Device Name, Virtual System ID, Factor Type, Factor
+          # Completion Time, Factor Number, FUTURE_USE, FUTURE_USE, User
+          # Group Flags, User by Source
+
+          columns("vsys","ip","user","datasourcename","eventid","repeatcnt","timeout","beginport","endport","datasource","datasourcetype","seqno","actionflags",
+                  "dg_hier_level_1","dg_hier_level_2","dg_hier_level_3","dg_hier_level_4","vsys_name","device_name",
+                  "vsys_id","factortype","factorcompletiontime","factorno","future_use3","future_use4","ugflags","userbysource")
           prefix("`prefix`")
           template("${`prefix`tmp}")
           delimiters(',')
-          flags(drop-invalid)
         );
       };
+      filter { "${`prefix`device_name}" ne "" };
     };
 
     # no else branch, so we would drop messages where type does not match

--- a/scl/paloalto/panos.conf
+++ b/scl/paloalto/panos.conf
@@ -1,0 +1,113 @@
+#############################################################################
+# Copyright (c) 2020 Balabit
+# Copyright (c) 2020 MileK <mileek@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+#
+#scl/paloalto/panos.conf -- Paloalto PAN-OS parser fro syslog-ng
+#
+#<12>Apr 14 16:48:54 paloalto.test.net 1,2020/04/14 16:48:54,unknown,SYSTEM,auth,0,2020/04/14 16:48:54,,auth-fail,,0,0,general,medium,failed authentication for user \'admin\'. Reason: Invalid username/password. From: 10.0.10.55.,1718,0x0,0,0,0,0,,paloalto
+#<14>Apr 14 16:54:18 paloalto.test.net 1,2020/04/14 16:54:18,unknown,CONFIG,0,0,2020/04/14 16:54:18,10.0.10.55,,set,admin,Web,Succeeded, deviceconfig system,127,0x0,0,0,0,0,,paloalto
+
+block parser panos-parser (prefix(".panos.") ...) {
+  channel {
+    rewrite {
+      set("${LEGACY_MSGHDR}${MESSAGE}" value("MESSAGE"));
+      set("paloalto_panos" value("PROGRAM"));
+    };
+# Common fields - set dot-nv-pairs
+    parser {
+      csv-parser(
+        columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time")
+        delimiters(',')
+        prefix("`prefix`")
+      );
+    };
+# Parse logs according to "type" field
+    if (match('SYSTEM', value('`prefix`type'))) {
+      parser {
+        csv-parser(
+          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","vsys","event_id","object","future_use3","future_use4","module","severity","description","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          prefix("`prefix`")
+          delimiters(',')
+        );
+      };
+    } 
+    elif (match('CONFIG', value('`prefix`type'))) {    
+      parser {
+        csv-parser(
+          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","host_name","vsys","command","admin","client","result","configuration_path","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          # Note if using custom logs insert "before_change_detail","after_change_detail" after "action_flags"
+          prefix("`prefix`")
+          delimiters(',')
+        );
+      };
+    } 
+    elif (match('THREAT', value('`prefix`type'))) {
+      parser {
+        csv-parser(
+          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","src_ip","dest_ip","src_translated_ip","dest_translated_ip","rule","src_user","dest_user","app","vsys","src_zone","dest_zone","src_interface","dest_interface","log_forwarding_profile","future_use3","session_id","repeat_count","src_port","dest_port","src_translated_port","dest_translated_port","session_flags","transport","action","misc","threat","raw_category","severity","direction","sequence_number","action_flags","src_location","dest_location","future_use4","content_type","pcap_id","file_hash","cloud_address","url_index","user_agent","file_type","xff","referrer","sender","subject","recipient","report_id","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          prefix("`prefix`")
+          delimiters(',')
+        );
+      };
+    } 
+    elif (match('TRAFFIC', value('`prefix`type'))) {
+      parser {
+        csv-parser(
+          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","src_ip","dest_ip","src_translated_ip","dest_translated_ip","rule","src_user","dest_user","app","vsys","src_zone","dest_zone","src_interface","dest_interface","log_forwarding_profile","future_use3","session_id","repeat_count","src_port","dest_port","src_translated_port","dest_translated_port","session_flags","transport","action","bytes","bytes_out","bytes_in","packets","start_time","duration","http_category","future_use4","sequence_number","action_flags","src_location","dest_location","future_use5","packets_out","packets_in","session_end_reason","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          prefix("`prefix`")
+          delimiters(',')
+        );
+      };
+    } 
+    elif (match('HIPWATCH', value('`prefix`type'))) {
+      parser {
+        csv-parser(
+          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","src_user","vsys","host_name","os","src_ip","hip_name","hip_count","hip_type","future_use3","future_use4","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          prefix("`prefix`")
+          delimiters(',')
+        );
+      };
+    } 
+    elif (match('CORRELATION', value('`prefix`type'))) {
+      parser {
+        csv-parser(
+          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","src_ip","src_user","vsys","category","severity","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name","vsys_id","object","object_id","evidence")
+          prefix("`prefix`")
+          delimiters(',')
+        );
+      };
+    } 
+    elif (match('USERID', value('`prefix`type'))) {
+      parser {
+        csv-parser(
+          columns("future_use1","receive_time","serial_number","type","log_subtype","version","generated_time","vsys","src_ip","source_name","event_id","repeat_count","timeout_threshold","src_port","dest_port","source","source_type","sequence_number","action_flags","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name")
+          prefix("`prefix`")
+          delimiters(',')
+        );
+      };
+    };
+  };
+};
+application panos[syslog] {
+    filter { message(".*,paloalto.*"); };
+    parser { panos-parser(); };
+};

--- a/tests/python_functional/functional_tests/parsers/panos/test_panos_parser.py
+++ b/tests/python_functional/functional_tests/parsers/panos/test_panos_parser.py
@@ -24,9 +24,13 @@ import pytest
 
 test_parameters_raw = [
     # Testing SYSTEM branch
-    (r"""<12>Apr 14 16:48:54 paloalto.test.net 1,2020/04/14 16:48:54,unknown,SYSTEM,auth,0,2020/04/14 16:48:54,,auth-fail,,0,0,general,medium,failed authentication for user 'admin'. Reason: Invalid username/password. From: 10.0.10.55.,1718,0x0,0,0,0,0,,paloalto""", "<${PROGRAM}><${.panos.type}><${.panos.event_id}><${.panos.dvc_name}>", "<paloalto_panos><SYSTEM><auth-fail><paloalto>"),
+    (r"""<12>Apr 14 16:48:54 paloalto.test.net 1,2020/04/14 16:48:54,unknown,SYSTEM,auth,0,2020/04/14 16:48:54,,auth-fail,,0,0,general,medium,failed authentication for user 'admin'. Reason: Invalid username/password. From: 10.0.10.55.,1718,0x0,0,0,0,0,,paloalto""", "<${PROGRAM}><${.panos.type}><${.panos.eventid}><${.panos.device_name}>", "<paloalto_panos><SYSTEM><auth-fail><paloalto>"),
+    # Testing SYSTEM branch with extra additions at the end. Should be accepted.
+    (r"""<12>Apr 14 16:48:54 paloalto.test.net 1,2020/04/14 16:48:54,unknown,SYSTEM,auth,0,2020/04/14 16:48:54,,auth-fail,,0,0,general,medium,failed authentication for user 'admin'. Reason: Invalid username/password. From: 10.0.10.55.,1718,0x0,0,0,0,0,,paloalto,foo,bar""", "<${PROGRAM}><${.panos.type}><${.panos.eventid}><${.panos.device_name}>", "<paloalto_panos><SYSTEM><auth-fail><paloalto>"),
     # Testing CONFIG branch
-    (r"""<14>Apr 14 16:54:18 paloalto.test.net 1,2020/04/14 16:54:18,unknown,CONFIG,0,0,2020/04/14 16:54:18,10.0.10.55,,set,admin,Web,Succeeded, deviceconfig system,127,0x0,0,0,0,0,,paloalto""", "<${PROGRAM}><${.panos.type}><${.panos.configuration_path}><${.panos.dvc_name}>", "<paloalto_panos><CONFIG><deviceconfig system><paloalto>"),
+    (r"""<14>Apr 14 16:54:18 paloalto.test.net 1,2020/04/14 16:54:18,unknown,CONFIG,0,0,2020/04/14 16:54:18,10.0.10.55,,set,admin,Web,Succeeded,deviceconfig system,127,0x0,0,0,0,0,,paloalto""", "<${PROGRAM}><${.panos.type}><${.panos.path}><${.panos.device_name}>", "<paloalto_panos><CONFIG><deviceconfig system><paloalto>"),
+    # Testing CONFIG branch, custom logs
+    (r"""<14>Apr 14 16:54:18 paloalto.test.net 1,2020/04/14 16:54:18,unknown,CONFIG,0,0,2020/04/14 16:54:18,10.0.10.55,,set,admin,Web,Succeeded,deviceconfig system,before,after,127,0x0,0,0,0,0,,paloalto""", "<${PROGRAM}><${.panos.type}><${.panos.path}><${.panos.device_name}>", "<paloalto_panos><CONFIG><deviceconfig system><paloalto>"),
 ]
 
 

--- a/tests/python_functional/functional_tests/parsers/panos/test_panos_parser.py
+++ b/tests/python_functional/functional_tests/parsers/panos/test_panos_parser.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2020 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import pytest
+
+test_parameters_raw = [
+    # Testing SYSTEM branch
+    (r"""<12>Apr 14 16:48:54 paloalto.test.net 1,2020/04/14 16:48:54,unknown,SYSTEM,auth,0,2020/04/14 16:48:54,,auth-fail,,0,0,general,medium,failed authentication for user 'admin'. Reason: Invalid username/password. From: 10.0.10.55.,1718,0x0,0,0,0,0,,paloalto""", "<${PROGRAM}><${.panos.type}><${.panos.event_id}><${.panos.dvc_name}>", "<paloalto_panos><SYSTEM><auth-fail><paloalto>"),
+    # Testing CONFIG branch
+    (r"""<14>Apr 14 16:54:18 paloalto.test.net 1,2020/04/14 16:54:18,unknown,CONFIG,0,0,2020/04/14 16:54:18,10.0.10.55,,set,admin,Web,Succeeded, deviceconfig system,127,0x0,0,0,0,0,,paloalto""", "<${PROGRAM}><${.panos.type}><${.panos.configuration_path}><${.panos.dvc_name}>", "<paloalto_panos><CONFIG><deviceconfig system><paloalto>"),
+]
+
+
+@pytest.mark.parametrize(
+    "input_message, template, expected_value", test_parameters_raw,
+    ids=list(map(str, range(len(test_parameters_raw)))),
+)
+def test_panos_parser(config, syslog_ng, input_message, template, expected_value):
+    config.add_include("scl.conf")
+
+    generator_source = config.create_example_msg_generator_source(num=1, template=config.stringify(input_message))
+    checkpoint_parser = config.create_panos_parser()
+
+    file_destination = config.create_file_destination(file_name="output.log", template=config.stringify(template + "\n"))
+    config.create_logpath(statements=[generator_source, checkpoint_parser, file_destination])
+
+    syslog_ng.start(config)
+    assert file_destination.read_log().strip() == expected_value

--- a/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
@@ -94,6 +94,9 @@ class SyslogNgConfig(object):
     def create_checkpoint_parser(self, **options):
         return Parser("checkpoint-parser", **options)
 
+    def create_panos_parser(self, **options):
+        return Parser("panos-parser", **options)
+
     def create_syslog_parser(self, **options):
         return Parser("syslog-parser", **options)
 


### PR DESCRIPTION
This branch continues the great work in originally in #3234 with a couple of changes/improvements:

* support for custom logs are added (e.g. the CONFIG changes with two extra columns: before_change_detail and after_change_detail columns)
* the panos-parser() now handles non paloalto logs by dropping those that don't appear to be valid. (e.g. not enough CSV columns)
* performance improvement by using fixed string matching instead of regexps
* the naming of the fields is matched against the Paloalto official naming (which is a change compared to the original submission)
* support for fields added in later versions of Paloalto were added.
* the application adapter now classifies logs a bit better.

@spricer sorry for taking so long to go through your patches and I hope the changes above are ok with you. With manual testing this seems to work ok.

