### PR TITLE
add example destination from gitbook

### DIFF
--- a/cmake/add_module.cmake
+++ b/cmake/add_module.cmake
@@ -26,7 +26,7 @@ include(CMakeParseArguments)
 
 function (add_module)
 
-  cmake_parse_arguments(ADD_MODULE "" "TARGET" "GRAMMAR;SOURCES;DEPENDS;INCLUDES" ${ARGN})
+  cmake_parse_arguments(ADD_MODULE "" "TARGET" "GRAMMAR;SOURCES;DEPENDS;INCLUDES;LIBRARY_TYPE" ${ARGN})
 
   if (ADD_MODULE_GRAMMAR)
     module_generate_y_from_ym(${CMAKE_CURRENT_SOURCE_DIR}/${ADD_MODULE_GRAMMAR} ${CMAKE_CURRENT_BINARY_DIR}/${ADD_MODULE_GRAMMAR})
@@ -41,14 +41,20 @@ function (add_module)
       )
   endif()
 
-  add_library(${ADD_MODULE_TARGET} SHARED ${ADD_MODULE_SOURCES})
+  if (NOT ADD_MODULE_LIBRARY_TYPE)
+    set(ADD_MODULE_LIBRARY_TYPE SHARED)
+  endif()
+
+  add_library(${ADD_MODULE_TARGET} ${ADD_MODULE_LIBRARY_TYPE} ${ADD_MODULE_SOURCES})
   target_include_directories(${ADD_MODULE_TARGET} SYSTEM PRIVATE ${ADD_MODULE_INCLUDES})
   target_include_directories(${ADD_MODULE_TARGET}
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
   )
   target_link_libraries(${ADD_MODULE_TARGET} PRIVATE ${ADD_MODULE_DEPENDS} syslog-ng)
-  install(TARGETS ${ADD_MODULE_TARGET} LIBRARY DESTINATION lib/syslog-ng COMPONENT ${ADD_MODULE_TARGET})
+
+  if (ADD_MODULE_LIBRARY_TYPE STREQUAL SHARED)
+    install(TARGETS ${ADD_MODULE_TARGET} LIBRARY DESTINATION lib/syslog-ng COMPONENT ${ADD_MODULE_TARGET})
+  endif()
 
 endfunction ()
-

--- a/modules/examples/CMakeLists.txt
+++ b/modules/examples/CMakeLists.txt
@@ -6,13 +6,15 @@ add_subdirectory(sources/threaded-random-generator)
 add_subdirectory(sources/threaded-diskq-source)
 
 add_subdirectory(inner-destinations/http-test-slots)
+add_subdirectory(destinations/example_destination)
+
 
 target_link_libraries(examples PRIVATE msg-generator)
 target_link_libraries(examples PRIVATE threaded-random-generator)
 target_link_libraries(examples PRIVATE threaded-diskq-source)
 
 target_link_libraries(examples PRIVATE http-test-slots)
-
+target_link_libraries(examples PRIVATE example_destination)
 
 target_link_libraries(examples PRIVATE syslog-ng)
 

--- a/modules/examples/Makefile.am
+++ b/modules/examples/Makefile.am
@@ -2,11 +2,14 @@ include modules/examples/sources/msg-generator/Makefile.am
 include modules/examples/sources/threaded-diskq-source/Makefile.am
 include modules/examples/sources/threaded-random-generator/Makefile.am
 include modules/examples/inner-destinations/http-test-slots/Makefile.am
+include modules/examples/destinations/example_destination/Makefile.am
+
 
 EXAMPLE_PLUGINS = \
   $(top_builddir)/modules/examples/sources/libmsg-generator.la \
   $(top_builddir)/modules/examples/sources/libthreaded-diskq-source.la \
-	$(top_builddir)/modules/examples/inner-destinations/http-test-slots/libhttp-test-slots.la
+  $(top_builddir)/modules/examples/inner-destinations/http-test-slots/libhttp-test-slots.la \
+  $(top_builddir)/modules/examples/destinations/example_destination/libexample_destination.la
 
 if HAVE_GETRANDOM
 EXAMPLE_PLUGINS += $(top_builddir)/modules/examples/sources/libthreaded-random-generator.la

--- a/modules/examples/destinations/example_destination/CMakeLists.txt
+++ b/modules/examples/destinations/example_destination/CMakeLists.txt
@@ -9,6 +9,8 @@ set(example_destination_SOURCES
     "example_destination-parser.c"
     "example_destination.h"
     "example_destination.c"
+    "example_destination_worker.h"
+    "example_destination_worker.c"
 )
 
 add_module(

--- a/modules/examples/destinations/example_destination/CMakeLists.txt
+++ b/modules/examples/destinations/example_destination/CMakeLists.txt
@@ -1,0 +1,19 @@
+module_switch(ENABLE_EXAMPLE_DESTINATION "Enable example_destination")
+if (NOT ENABLE_EXAMPLE_DESTINATION)
+  return()
+endif()
+
+set(example_destination_SOURCES
+    "example_destination-parser.h"
+    "example_destination-plugin.c"
+    "example_destination-parser.c"
+    "example_destination.h"
+    "example_destination.c"
+)
+
+add_module(
+  TARGET example_destination
+  GRAMMAR example_destination-grammar
+  SOURCES ${example_destination_SOURCES}
+  LIBRARY_TYPE STATIC # STATIC: Built as part of a larger libexamples module
+)

--- a/modules/examples/destinations/example_destination/Makefile.am
+++ b/modules/examples/destinations/example_destination/Makefile.am
@@ -1,0 +1,27 @@
+# noinst: Built as part of a larger libexamples module as static library
+noinst_LTLIBRARIES      += modules/examples/destinations/example_destination/libexample_destination.la
+modules_examples_destinations_example_destination_libexample_destination_la_SOURCES = \
+  modules/examples/destinations/example_destination/example_destination-grammar.y       \
+  modules/examples/destinations/example_destination/example_destination-parser.c        \
+  modules/examples/destinations/example_destination/example_destination-parser.h        \
+  modules/examples/destinations/example_destination/example_destination-plugin.c        \
+  modules/examples/destinations/example_destination/example_destination.h               \
+  modules/examples/destinations/example_destination/example_destination.c
+
+BUILT_SOURCES       +=      \
+  modules/examples/destinations/example_destination/example_destination-grammar.y       \
+  modules/examples/destinations/example_destination/example_destination-grammar.c       \
+  modules/examples/destinations/example_destination/example_destination-grammar.h
+
+EXTRA_DIST        +=      \
+  modules/examples/destinations/example_destination/example_destination-grammar.ym \
+  modules/examples/destinations/example_destination/CMakeLists.txt
+
+modules_examples_destinations_example_destination_libexample_destination_la_CPPFLAGS  =     \
+  $(AM_CPPFLAGS)            \
+  -I$(top_srcdir)/modules/examples/destinations/example_destination        \
+  -I$(top_builddir)/modules/examples/destinations/example_destination
+
+modules_examples_destinations_example_destination_libexample_destination_la_LIBADD  = $(MODULE_DEPS_LIBS)
+modules_examples_destinations_example_destination_libexample_destination_la_LDFLAGS = $(MODULE_LDFLAGS)
+modules_examples_destinations_example_destination_libexample_destination_la_DEPENDENCIES= $(MODULE_DEPS_LIBS)

--- a/modules/examples/destinations/example_destination/Makefile.am
+++ b/modules/examples/destinations/example_destination/Makefile.am
@@ -5,6 +5,8 @@ modules_examples_destinations_example_destination_libexample_destination_la_SOUR
   modules/examples/destinations/example_destination/example_destination-parser.c        \
   modules/examples/destinations/example_destination/example_destination-parser.h        \
   modules/examples/destinations/example_destination/example_destination-plugin.c        \
+  modules/examples/destinations/example_destination/example_destination_worker.h        \
+  modules/examples/destinations/example_destination/example_destination_worker.c        \
   modules/examples/destinations/example_destination/example_destination.h               \
   modules/examples/destinations/example_destination/example_destination.c
 

--- a/modules/examples/destinations/example_destination/example_destination-grammar.ym
+++ b/modules/examples/destinations/example_destination/example_destination-grammar.ym
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+%code requires {
+
+#include "example_destination-parser.h"
+
+}
+
+%code {
+
+#include "example_destination.h"
+
+#include "cfg-grammar.h"
+#include "plugin.h"
+}
+
+%name-prefix "example_destination_"
+%lex-param {CfgLexer *lexer}
+%parse-param {CfgLexer *lexer}
+%parse-param {LogDriver **instance}
+%parse-param {gpointer arg}
+
+/* INCLUDE_DECLS */
+
+%token KW_EXAMPLE_DESTINATION
+%token KW_FILENAME
+
+%%
+
+start
+        : LL_CONTEXT_DESTINATION KW_EXAMPLE_DESTINATION
+          {
+            last_driver = *instance = example_destination_dd_new(configuration);
+          }
+          '(' example_destination_option ')' { YYACCEPT; }
+;
+
+example_destination_options
+        : example_destination_option example_destination_options
+        |
+        ;
+
+example_destination_option
+        : KW_FILENAME '(' string ')'
+          {
+            example_destination_dd_set_filename(last_driver, $3);
+            free($3);
+          }
+        | threaded_dest_driver_option
+;
+
+/* INCLUDE_RULES */
+
+%%

--- a/modules/examples/destinations/example_destination/example_destination-parser.c
+++ b/modules/examples/destinations/example_destination/example_destination-parser.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "driver.h"
+#include "cfg-parser.h"
+#include "example_destination-grammar.h"
+
+extern int example_destination_debug;
+
+int example_destination_parse(CfgLexer *lexer, LogDriver **instance, gpointer arg);
+
+static CfgLexerKeyword example_destination_keywords[] =
+{
+  { "example_destination", KW_EXAMPLE_DESTINATION },
+  { "filename", KW_FILENAME },
+  { NULL }
+};
+
+CfgParser example_destination_parser =
+{
+#if SYSLOG_NG_ENABLE_DEBUG
+  .debug_flag = &example_destination_debug,
+#endif
+  .name = "example_destination",
+  .keywords = example_destination_keywords,
+  .parse = (gint (*)(CfgLexer *, gpointer *, gpointer)) example_destination_parse,
+  .cleanup = (void (*)(gpointer)) log_pipe_unref,
+};
+
+CFG_PARSER_IMPLEMENT_LEXER_BINDING(example_destination_, LogDriver **)

--- a/modules/examples/destinations/example_destination/example_destination-parser.h
+++ b/modules/examples/destinations/example_destination/example_destination-parser.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef EXAMPLE_DESTINATION_PARSER_H_INCLUDED
+#define EXAMPLE_DESTINATION_PARSER_H_INCLUDED
+
+#include "cfg-parser.h"
+#include "driver.h"
+
+extern CfgParser example_destination_parser;
+
+CFG_PARSER_DECLARE_LEXER_BINDING(example_destination_, LogDriver **)
+
+#endif

--- a/modules/examples/destinations/example_destination/example_destination-plugin.c
+++ b/modules/examples/destinations/example_destination/example_destination-plugin.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+// Already included in example-plugins.c
+
+
+/* #include "cfg-parser.h" */
+/* #include "plugin.h" */
+/* #include "plugin-types.h" */
+
+/* extern CfgParser example_destination_parser; */
+
+/* static Plugin example_destination_plugins[] = */
+/* { */
+/*   { */
+/*     .type = LL_CONTEXT_DESTINATION, */
+/*     .name = "example_destination", */
+/*     .parser = &example_destination_parser, */
+/*   }, */
+/* }; */
+
+/* gboolean */
+/* example_destination_module_init(PluginContext *context, CfgArgs *args) */
+/* { */
+/*   plugin_register(context, example_destination_plugins, G_N_ELEMENTS(example_destination_plugins)); */
+/*   return TRUE; */
+/* } */
+
+/* const ModuleInfo module_info = */
+/* { */
+/*   .canonical_name = "example_destination", */
+/*   .version = SYSLOG_NG_VERSION, */
+/*   .description = "Please fill this description", */
+/*   .core_revision = SYSLOG_NG_SOURCE_REVISION, */
+/*   .plugins = example_destination_plugins, */
+/*   .plugins_len = G_N_ELEMENTS(example_destination_plugins), */
+/* }; */

--- a/modules/examples/destinations/example_destination/example_destination.c
+++ b/modules/examples/destinations/example_destination/example_destination.c
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2020 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "example_destination.h"
+#include "example_destination-parser.h"
+
+#include "plugin.h"
+#include "messages.h"
+#include "misc.h"
+#include "stats/stats-registry.h"
+#include "logqueue.h"
+#include "driver.h"
+#include "plugin-types.h"
+#include "logthrdest/logthrdestdrv.h"
+
+
+typedef struct
+{
+  LogThreadedDestDriver super;
+  gchar *filename;
+} ExampleDestination;
+
+/*
+ * Configuration
+ */
+
+void
+example_destination_dd_set_filename(LogDriver *d, const gchar *filename)
+{
+  ExampleDestination *self = (ExampleDestination *)d;
+
+  g_free(self->filename);
+  self->filename = g_strdup(filename);
+}
+
+/*
+ * Utilities
+ */
+
+static const gchar *
+_format_stats_instance(LogThreadedDestDriver *d)
+{
+  ExampleDestination *self = (ExampleDestination *)d;
+  static gchar persist_name[1024];
+
+  g_snprintf(persist_name, sizeof(persist_name),
+             "example-destination,%s", self->filename);
+  return persist_name;
+}
+
+static const gchar *
+_format_persist_name(const LogPipe *d)
+{
+  ExampleDestination *self = (ExampleDestination *)d;
+  static gchar persist_name[1024];
+
+  if (d->persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "example-destination.%s", d->persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "example-destination.%s", self->filename);
+
+  return persist_name;
+}
+
+static gboolean
+_connect(LogThreadedDestDriver *s)
+{
+  msg_debug("Connection succeeded",
+            evt_tag_str("driver", s->super.super.id), NULL);
+
+  return TRUE;
+}
+
+static void
+_disconnect(LogThreadedDestDriver *d)
+{
+  ExampleDestination *self = (ExampleDestination *)d;
+
+  msg_debug("Connection closed",
+            evt_tag_str("driver", self->super.super.super.id), NULL);
+}
+
+/*
+ * Worker thread
+ */
+
+static LogThreadedResult
+_insert(LogThreadedDestDriver *d, LogMessage *msg)
+{
+  ExampleDestination *self = (ExampleDestination *)d;
+
+  fprintf(stderr, "Message sent using file name: %s\n", self->filename);
+
+  return LTR_SUCCESS;
+  /*
+   * LTR_DROP,
+   * LTR_ERROR,
+   * LTR_SUCCESS,
+   * LTR_QUEUED,
+   * LTR_NOT_CONNECTED,
+   * LTR_RETRY,
+  */
+}
+
+static void
+_thread_init(LogThreadedDestDriver *d)
+{
+  ExampleDestination *self = (ExampleDestination *)d;
+
+  msg_debug("Worker thread started",
+            evt_tag_str("driver", self->super.super.super.id),
+            NULL);
+}
+
+static void
+_thread_deinit(LogThreadedDestDriver *d)
+{
+  ExampleDestination *self = (ExampleDestination *)d;
+
+  msg_debug("Worker thread stopped",
+            evt_tag_str("driver", self->super.super.super.id),
+            NULL);
+}
+
+/*
+ * Main thread
+ */
+
+static gboolean
+_dd_init(LogPipe *d)
+{
+  ExampleDestination *self = (ExampleDestination *)d;
+
+  if (!log_threaded_dest_driver_init_method(d))
+    return FALSE;
+
+  msg_verbose("Initializing ExampleDestination",
+              evt_tag_str("driver", self->super.super.super.id),
+              evt_tag_str("filename", self->filename),
+              NULL);
+
+  return TRUE;
+}
+
+
+gboolean
+_dd_deinit(LogPipe *s)
+{
+  ExampleDestination *self = (ExampleDestination *)s;
+
+  msg_verbose("Deinitializing ExampleDestination",
+              evt_tag_str("driver", self->super.super.super.id),
+              evt_tag_str("filename", self->filename),
+              NULL);
+
+  return log_threaded_dest_driver_deinit_method(s);
+}
+
+static void
+_dd_free(LogPipe *d)
+{
+  ExampleDestination *self = (ExampleDestination *)d;
+
+  g_free(self->filename);
+
+  log_threaded_dest_driver_free(d);
+}
+
+/*
+ * Plugin glue.
+ */
+
+LogDriver *
+example_destination_dd_new(GlobalConfig *cfg)
+{
+  ExampleDestination *self = g_new0(ExampleDestination, 1);
+
+  log_threaded_dest_driver_init_instance(&self->super, cfg);
+  self->super.super.super.super.init = _dd_init;
+  self->super.super.super.super.deinit = _dd_deinit;
+  self->super.super.super.super.free_fn = _dd_free;
+
+  self->super.worker.thread_init = _thread_init;
+  self->super.worker.thread_deinit = _thread_deinit;
+  self->super.worker.connect = _connect;
+  self->super.worker.disconnect = _disconnect;
+  self->super.worker.insert = _insert;
+
+  self->super.format_stats_instance = _format_stats_instance;
+  self->super.super.super.super.generate_persist_name = _format_persist_name;
+  self->super.stats_source = stats_register_type("example-destination");
+
+  return (LogDriver *)self;
+}

--- a/modules/examples/destinations/example_destination/example_destination.c
+++ b/modules/examples/destinations/example_destination/example_destination.c
@@ -76,15 +76,6 @@ _format_persist_name(const LogPipe *d)
   return persist_name;
 }
 
-/*
- * Worker thread
- */
-
-
-/*
- * Main thread
- */
-
 static gboolean
 _dd_init(LogPipe *d)
 {
@@ -93,24 +84,23 @@ _dd_init(LogPipe *d)
   if (!log_threaded_dest_driver_init_method(d))
     return FALSE;
 
-  msg_verbose("Initializing ExampleDestination",
-              evt_tag_str("driver", self->super.super.super.id),
-              evt_tag_str("filename", self->filename),
-              NULL);
+  if (!self->filename)
+    self->filename = g_strdup("/tmp/example-destination-output.txt");
 
   return TRUE;
 }
 
-
 gboolean
 _dd_deinit(LogPipe *s)
 {
-  ExampleDestinationDriver *self = (ExampleDestinationDriver *)s;
+  /*
+     If you created resources during init,
+     you need to destroy them here.
 
-  msg_verbose("Deinitializing ExampleDestination",
-              evt_tag_str("driver", self->super.super.super.id),
-              evt_tag_str("filename", self->filename),
-              NULL);
+     self->filename is outside of the lifecycle of init-deinit (may be
+     filled during configuration parse), that's why it is deallocated
+     in the free method.
+  */
 
   return log_threaded_dest_driver_deinit_method(s);
 }
@@ -124,10 +114,6 @@ _dd_free(LogPipe *d)
 
   log_threaded_dest_driver_free(d);
 }
-
-/*
- * Plugin glue.
- */
 
 LogDriver *
 example_destination_dd_new(GlobalConfig *cfg)

--- a/modules/examples/destinations/example_destination/example_destination.h
+++ b/modules/examples/destinations/example_destination/example_destination.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef EXAMPLE_DESTINATION_H_INCLUDED
+#define EXAMPLE_DESTINATION_H_INCLUDED
+
+#include "driver.h"
+
+LogDriver *example_destination_dd_new(GlobalConfig *cfg);
+
+void example_destination_dd_set_filename(LogDriver *d, const gchar *filename);
+
+#endif

--- a/modules/examples/destinations/example_destination/example_destination.h
+++ b/modules/examples/destinations/example_destination/example_destination.h
@@ -29,7 +29,7 @@
 typedef struct
 {
   LogThreadedDestDriver super;
-  gchar *filename;
+  GString *filename;
 } ExampleDestinationDriver;
 
 LogDriver *example_destination_dd_new(GlobalConfig *cfg);

--- a/modules/examples/destinations/example_destination/example_destination_worker.c
+++ b/modules/examples/destinations/example_destination/example_destination_worker.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2020 Balabit
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "example_destination_worker.h"
+#include "example_destination.h"
+
+static LogThreadedResult
+_dw_insert(LogThreadedDestWorker *s, LogMessage *msg)
+{
+  ExampleDestinationDriver *owner = (ExampleDestinationDriver *) s->owner;
+  fprintf(stderr, "Message sent using file name: %s\n", owner->filename);
+
+  return LTR_SUCCESS;
+  /*
+   * LTR_DROP,
+   * LTR_ERROR,
+   * LTR_SUCCESS,
+   * LTR_QUEUED,
+   * LTR_NOT_CONNECTED,
+   * LTR_RETRY,
+  */
+}
+
+static gboolean
+_connect(LogThreadedDestWorker *s)
+{
+  msg_debug("Connection succeeded",
+            evt_tag_str("driver", s->owner->super.super.id), NULL);
+
+  return TRUE;
+}
+
+static void
+_disconnect(LogThreadedDestWorker *s)
+{
+  msg_debug("Connection closed",
+            evt_tag_str("driver", s->owner->super.super.id), NULL);
+}
+
+static gboolean
+_thread_init(LogThreadedDestWorker *s)
+{
+  msg_debug("Worker thread started",
+            evt_tag_str("driver", s->owner->super.super.id),
+            NULL);
+
+  return log_threaded_dest_worker_init_method(s);
+}
+
+static void
+_thread_deinit(LogThreadedDestWorker *s)
+{
+  msg_debug("Worker thread stopped",
+            evt_tag_str("driver", s->owner->super.super.id),
+            NULL);
+
+  log_threaded_dest_worker_deinit_method(s);
+}
+
+static void
+_dw_free(LogThreadedDestWorker *s)
+{
+  msg_debug("Worker free method called",
+            evt_tag_str("driver", s->owner->super.super.id),
+            NULL);
+
+  log_threaded_dest_worker_free_method(s);
+}
+
+LogThreadedDestWorker *
+example_destination_dw_new(LogThreadedDestDriver *o, gint worker_index)
+{
+  ExampleDestinationWorker *self = g_new0(ExampleDestinationWorker, 1);
+
+  log_threaded_dest_worker_init_instance(&self->super, o, worker_index);
+  self->super.thread_init = _thread_init;
+  self->super.thread_deinit = _thread_deinit;
+  self->super.insert = _dw_insert;
+  self->super.free_fn = _dw_free;
+  self->super.connect = _connect;
+  self->super.disconnect = _disconnect;
+
+  return &self->super;
+}

--- a/modules/examples/destinations/example_destination/example_destination_worker.c
+++ b/modules/examples/destinations/example_destination/example_destination_worker.c
@@ -66,7 +66,7 @@ _connect(LogThreadedDestWorker *s)
   ExampleDestinationWorker *self = (ExampleDestinationWorker *)s;
   ExampleDestinationDriver *owner = (ExampleDestinationDriver *) s->owner;
 
-  self->file = fopen(owner->filename, "a");
+  self->file = fopen(owner->filename->str, "a");
   if (!self->file)
     {
       msg_error("Could not open file", evt_tag_error("error"));

--- a/modules/examples/destinations/example_destination/example_destination_worker.h
+++ b/modules/examples/destinations/example_destination/example_destination_worker.h
@@ -20,20 +20,16 @@
  *
  */
 
-#ifndef EXAMPLE_DESTINATION_H_INCLUDED
-#define EXAMPLE_DESTINATION_H_INCLUDED
+#ifndef EXAMPLE_DESTINATION_WORKER_H_INCLUDED
+#define EXAMPLE_DESTINATION_WORKER_H_INCLUDED 1
 
-#include "driver.h"
 #include "logthrdest/logthrdestdrv.h"
 
-typedef struct
+typedef struct _ExampleDestinationWorker
 {
-  LogThreadedDestDriver super;
-  gchar *filename;
-} ExampleDestinationDriver;
+  LogThreadedDestWorker super;
+} ExampleDestinationWorker;
 
-LogDriver *example_destination_dd_new(GlobalConfig *cfg);
-
-void example_destination_dd_set_filename(LogDriver *d, const gchar *filename);
+LogThreadedDestWorker *example_destination_dw_new(LogThreadedDestDriver *o, gint worker_index);
 
 #endif

--- a/modules/examples/destinations/example_destination/example_destination_worker.h
+++ b/modules/examples/destinations/example_destination/example_destination_worker.h
@@ -24,10 +24,14 @@
 #define EXAMPLE_DESTINATION_WORKER_H_INCLUDED 1
 
 #include "logthrdest/logthrdestdrv.h"
+#include "thread-utils.h"
+
 
 typedef struct _ExampleDestinationWorker
 {
   LogThreadedDestWorker super;
+  FILE *file;
+  ThreadId thread_id;
 } ExampleDestinationWorker;
 
 LogThreadedDestWorker *example_destination_dw_new(LogThreadedDestDriver *o, gint worker_index);

--- a/modules/examples/example-plugins.c
+++ b/modules/examples/example-plugins.c
@@ -35,6 +35,8 @@ extern CfgParser threaded_diskq_source_parser;
 
 extern CfgParser http_test_slots_parser;
 
+extern CfgParser example_destination_parser;
+
 static Plugin example_plugins[] =
 {
   {
@@ -58,6 +60,11 @@ static Plugin example_plugins[] =
     .type = LL_CONTEXT_INNER_DEST,
     .name = "http_test_slots",
     .parser = &http_test_slots_parser
+  },
+  {
+    .type = LL_CONTEXT_DESTINATION,
+    .name = "example_destination",
+    .parser = &example_destination_parser
   }
 };
 

--- a/tests/python_functional/functional_tests/destination_drivers/example_destination/test_example_destination.py
+++ b/tests/python_functional/functional_tests/destination_drivers/example_destination/test_example_destination.py
@@ -23,9 +23,9 @@
 
 
 def test_example_destination_parser(config, syslog_ng):
-    generator_source = config.create_example_msg_generator_source(num=1)
+    generator_source = config.create_example_msg_generator_source(num=1, template=config.stringify("message text"))
     example_destination = config.create_example_destination(filename="output.txt")
     config.create_logpath(statements=[generator_source, example_destination])
 
     syslog_ng.start(config)
-    assert syslog_ng.wait_for_message_in_console_log("Message sent using file name: output.txt")
+    assert example_destination.wait_file_content("message text")

--- a/tests/python_functional/functional_tests/destination_drivers/example_destination/test_example_destination.py
+++ b/tests/python_functional/functional_tests/destination_drivers/example_destination/test_example_destination.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2020 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+
+def test_example_destination_parser(config, syslog_ng):
+    generator_source = config.create_example_msg_generator_source(num=1)
+    example_destination = config.create_example_destination(filename="output.txt")
+    config.create_logpath(statements=[generator_source, example_destination])
+
+    syslog_ng.start(config)
+    assert syslog_ng.wait_for_message_in_console_log("Message sent using file name: output.txt")

--- a/tests/python_functional/src/syslog_ng/console_log_reader.py
+++ b/tests/python_functional/src/syslog_ng/console_log_reader.py
@@ -38,11 +38,11 @@ class ConsoleLogReader(object):
 
     def wait_for_start_message(self):
         syslog_ng_start_message = ["syslog-ng starting up;"]
-        return self.__wait_for_messages_in_console_log(syslog_ng_start_message)
+        return self.wait_for_messages_in_console_log(syslog_ng_start_message)
 
     def wait_for_stop_message(self):
         syslog_ng_stop_message = ["syslog-ng shutting down"]
-        return self.__wait_for_messages_in_console_log(syslog_ng_stop_message)
+        return self.wait_for_messages_in_console_log(syslog_ng_stop_message)
 
     def wait_for_reload_message(self):
         syslog_ng_reload_messages = [
@@ -50,9 +50,12 @@ class ConsoleLogReader(object):
             "Configuration reload request received, reloading configuration",
             "Configuration reload finished",
         ]
-        return self.__wait_for_messages_in_console_log(syslog_ng_reload_messages)
+        return self.wait_for_messages_in_console_log(syslog_ng_reload_messages)
 
-    def __wait_for_messages_in_console_log(self, expected_messages):
+    def wait_for_message_in_console_log(self, expected_message):
+        return self.wait_for_messages_in_console_log(self, [expected_message])
+
+    def wait_for_messages_in_console_log(self, expected_messages):
         if not self.__stderr_io.wait_for_creation():
             raise Exception
 

--- a/tests/python_functional/src/syslog_ng/syslog_ng.py
+++ b/tests/python_functional/src/syslog_ng/syslog_ng.py
@@ -20,6 +20,7 @@
 # COPYING for details.
 #
 #############################################################################
+from src.syslog_ng.console_log_reader import ConsoleLogReader
 from src.syslog_ng.syslog_ng_cli import SyslogNgCli
 
 
@@ -46,3 +47,11 @@ class SyslogNg(object):
 
     def is_process_running(self):
         return self.__syslog_ng_cli.is_process_running()
+
+    def wait_for_messages_in_console_log(self, expected_messages):
+        assert issubclass(type(expected_messages), list)
+        console_log_reader = ConsoleLogReader(self.instance_paths)
+        return console_log_reader.wait_for_messages_in_console_log(expected_messages)
+
+    def wait_for_message_in_console_log(self, expected_message):
+        return self.wait_for_messages_in_console_log([expected_message])

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/example_destination.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/example_destination.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2015-2018 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from src.syslog_ng_config.statements.destinations.destination_driver import DestinationDriver
+
+
+class ExampleDestination(DestinationDriver):
+    def __init__(self, **options):
+        self.driver_name = "example-destination"
+        super(ExampleDestination, self).__init__(None, options)

--- a/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
@@ -26,6 +26,7 @@ from src.common.operations import cast_to_list
 from src.driver_io.file.file_io import FileIO
 from src.syslog_ng_config.renderer import ConfigRenderer
 from src.syslog_ng_config.statement_group import StatementGroup
+from src.syslog_ng_config.statements.destinations.example_destination import ExampleDestination
 from src.syslog_ng_config.statements.destinations.file_destination import FileDestination
 from src.syslog_ng_config.statements.destinations.snmp_destination import SnmpDestination
 from src.syslog_ng_config.statements.filters.filter import Filter
@@ -103,6 +104,9 @@ class SyslogNgConfig(object):
 
     def create_file_destination(self, **options):
         return FileDestination(**options)
+
+    def create_example_destination(self, **options):
+        return ExampleDestination(**options)
 
     def create_snmp_destination(self, **options):
         return SnmpDestination(**options)


### PR DESCRIPTION
By adding the example destination from gitbook to the repo, we have better chance to keep gitbook updated.

The port is not a blind copy paste, there are some changes comparted to the gitbook version.
- The module is not under `modules/example_destination`, but under `modules/examples/destinations/example_destinations`.
- It is not a module on it's own, but it is part of a larger `libexamples` module.
- It is built as static, instead of dynamic.
- The `ModuleInfo` is missing as it is not a module on it's own. The plugin list is moved to the libexamples.
- The functionality is changed a bit: example destination will actually write to a file: the output contains the thread id of the worker.

Other changes:
- the `add_module` in cmake has a new parameter: which can tell if a module wants to build as static or dynamic library.
- a simple e2e test added for `ExampleDestination`
- You can assert messages in light from now.

After this PR is merged, I will update the gitbook too.