### PR TITLE
Control server thread

### DIFF
--- a/lib/control/control-main.c
+++ b/lib/control/control-main.c
@@ -26,18 +26,29 @@
 #include "control-server.h"
 #include "control-commands.h"
 
-ControlServer *
+struct _ControlServerLoop
+{
+  ControlServer *control_server;
+};
+
+ControlServerLoop *
 control_init(const gchar *control_name)
 {
-  ControlServer *control_server = control_server_new(control_name);
-  control_server_start(control_server);
-  return control_server;
+  ControlServerLoop *self = g_new0(ControlServerLoop, 1);
+  self->control_server = control_server_new(control_name);
+  control_server_start(self->control_server);
+
+  return self;
 }
 
 void
-control_deinit(ControlServer *control_server)
+control_deinit(ControlServerLoop *self)
 {
+  if (!self)
+    return;
+
   reset_control_command_list();
-  if (control_server)
-    control_server_free(control_server);
+  if (self && self->control_server)
+    control_server_free(self->control_server);
+  g_free(self);
 }

--- a/lib/control/control-main.h
+++ b/lib/control/control-main.h
@@ -28,7 +28,9 @@
 #include "mainloop.h"
 #include "control/control-server.h"
 
-ControlServer *control_init(const gchar *control_name);
-void control_deinit(ControlServer *control_server);
+typedef struct _ControlServerLoop ControlServerLoop;
+
+ControlServerLoop *control_init(const gchar *control_name);
+void control_deinit(ControlServerLoop *self);
 
 #endif

--- a/lib/control/control-server.c
+++ b/lib/control/control-server.c
@@ -57,14 +57,20 @@ _thread_command_runner_new(ControlConnection *cc, GString *cmd, gpointer user_da
 }
 
 static void
+_thread_command_runner_free(ThreadedCommandRunner *self)
+{
+  g_string_free(self->command, TRUE);
+  g_free(self);
+}
+
+static void
 _send_response(gpointer user_data)
 {
   ThreadedCommandRunner *self = (ThreadedCommandRunner *) user_data;
   g_thread_join(self->thread);
   control_connection_send_reply(self->connection, self->response);
   iv_event_unregister(&self->response_received);
-  g_string_free(self->command, TRUE);
-  g_free(self);
+  _thread_command_runner_free(self);
 }
 
 static void
@@ -81,8 +87,7 @@ _thread_command_runner_sync_run(ThreadedCommandRunner *self, ControlConnectionCo
   msg_warning("Cannot start a separated thread - ControlServer is not running",
               evt_tag_str("command", self->command->str));
   control_connection_send_reply(self->connection, func(self->connection, self->command, self->user_data));
-  g_string_free(self->command, TRUE);
-  g_free(self);
+  _thread_command_runner_free(self);
 }
 
 static void

--- a/lib/control/control-server.c
+++ b/lib/control/control-server.c
@@ -50,7 +50,7 @@ _thread_command_runner_new(ControlConnection *cc, GString *cmd, gpointer user_da
 {
   ThreadedCommandRunner *self = g_new0(ThreadedCommandRunner, 1);
   self->connection = cc;
-  self->command = cmd;
+  self->command = g_string_new(cmd->str);
   self->user_data = user_data;
 
   return self;
@@ -63,6 +63,7 @@ _send_response(gpointer user_data)
   g_thread_join(self->thread);
   control_connection_send_reply(self->connection, self->response);
   iv_event_unregister(&self->response_received);
+  g_string_free(self->command, TRUE);
   g_free(self);
 }
 

--- a/lib/control/control-server.c
+++ b/lib/control/control-server.c
@@ -324,6 +324,16 @@ _send_async_replies(gpointer user_data)
   g_mutex_unlock(&self->async.lock);
 }
 
+static void
+_control_connection_init_async(ControlConnection *self)
+{
+  g_mutex_init(&self->async.lock);
+  IV_EVENT_INIT(&self->async.reply_received);
+  self->async.replies = NULL;
+  self->async.reply_received.handler = _send_async_replies;
+  self->async.reply_received.cookie = self;
+}
+
 void
 control_connection_init_instance(ControlConnection *self, ControlServer *server)
 {
@@ -332,18 +342,14 @@ control_connection_init_instance(ControlConnection *self, ControlServer *server)
   self->input_buffer = g_string_sized_new(128);
   self->handle_input = control_connection_io_input;
   self->handle_output = control_connection_io_output;
-  g_mutex_init(&self->async.lock);
-  IV_EVENT_INIT(&self->async.reply_received);
-  self->async.replies = NULL;
-  self->async.reply_received.handler = _send_async_replies;
-  self->async.reply_received.cookie = self;
-  iv_event_register(&self->async.reply_received);
+  _control_connection_init_async(self);
 }
 
 
 void
 control_connection_start_watches(ControlConnection *self)
 {
+  iv_event_register(&self->async.reply_received);
   if (self->events.start_watches)
     self->events.start_watches(self);
 }
@@ -358,6 +364,8 @@ control_connection_update_watches(ControlConnection *self)
 void
 control_connection_stop_watches(ControlConnection *self)
 {
+  iv_event_unregister(&self->async.reply_received);
+
   if (self->events.stop_watches)
     self->events.stop_watches(self);
 }

--- a/lib/control/control-server.c
+++ b/lib/control/control-server.c
@@ -26,6 +26,7 @@
 #include "messages.h"
 #include "str-utils.h"
 #include "secret-storage/secret-storage.h"
+#include "thread-utils.h"
 
 #include <string.h>
 #include <errno.h>
@@ -40,6 +41,13 @@ typedef struct _ThreadedCommandRunner
   gpointer user_data;
 
   GThread *thread;
+  struct
+  {
+    GMutex tid_saved_lock;
+    GCond tid_saved_cond;
+    gboolean tid_saved;
+    ThreadId tid;
+  } real_thread;
   ControlConnectionCommand func;
   GString *response;
   struct iv_event response_received;
@@ -52,6 +60,10 @@ _thread_command_runner_new(ControlConnection *cc, GString *cmd, gpointer user_da
   self->connection = cc;
   self->command = g_string_new(cmd->str);
   self->user_data = user_data;
+  g_mutex_init(&self->real_thread.tid_saved_lock);
+  g_cond_init(&self->real_thread.tid_saved_cond);
+  self->real_thread.tid_saved = FALSE;
+  self->real_thread.tid = 0;
 
   return self;
 }
@@ -59,8 +71,29 @@ _thread_command_runner_new(ControlConnection *cc, GString *cmd, gpointer user_da
 static void
 _thread_command_runner_free(ThreadedCommandRunner *self)
 {
+  g_mutex_clear(&self->real_thread.tid_saved_lock);
+  g_cond_clear(&self->real_thread.tid_saved_cond);
   g_string_free(self->command, TRUE);
   g_free(self);
+}
+
+static void
+_thread_command_runner_wait_for_tid_saved(ThreadedCommandRunner *self)
+{
+  g_mutex_lock(&self->real_thread.tid_saved_lock);
+  while (self->real_thread.tid_saved == FALSE)
+    g_cond_wait(&self->real_thread.tid_saved_cond, &self->real_thread.tid_saved_lock);
+  g_mutex_unlock(&self->real_thread.tid_saved_lock);
+}
+
+static void
+_thread_command_runner_save_tid(ThreadedCommandRunner *self)
+{
+  g_mutex_lock(&self->real_thread.tid_saved_lock);
+  self->real_thread.tid = get_thread_id();
+  self->real_thread.tid_saved = TRUE;
+  g_cond_broadcast(&self->real_thread.tid_saved_cond);
+  g_mutex_unlock(&self->real_thread.tid_saved_lock);
 }
 
 static void
@@ -79,6 +112,7 @@ static void
 _thread(gpointer user_data)
 {
   ThreadedCommandRunner *self = (ThreadedCommandRunner *)user_data;
+  _thread_command_runner_save_tid(self);
   self->response = self->func(self->connection, self->command, self->user_data);
   iv_event_post(&self->response_received);
 }
@@ -109,6 +143,7 @@ _thread_command_runner_run(ThreadedCommandRunner *self, ControlConnectionCommand
   iv_event_register(&self->response_received);
 
   self->thread = g_thread_new(self->command->str, (GThreadFunc) _thread, self);
+  _thread_command_runner_wait_for_tid_saved(self);
   ControlServer *server = self->connection->server;
   server->worker_threads = g_list_append(server->worker_threads, self);
 }
@@ -138,6 +173,8 @@ static void
 _delete_thread_command_runner(gpointer data)
 {
   ThreadedCommandRunner *self = (ThreadedCommandRunner *) data;
+  g_assert(self->real_thread.tid_saved == TRUE);
+  thread_cancel(self->real_thread.tid);
   g_thread_join(self->thread);
   _thread_command_runner_free(self);
 }

--- a/lib/control/control-server.h
+++ b/lib/control/control-server.h
@@ -56,13 +56,15 @@ struct _ControlServer
   void (*free_fn)(ControlServer *self);
 };
 
-
 void control_server_connection_closed(ControlServer *self, ControlConnection *cc);
 void control_server_start(ControlServer *self);
 void control_server_free(ControlServer *self);
 void control_server_init_instance(ControlServer *self, const gchar *path);
 ControlServer *control_server_new(const gchar *path);
 
+typedef GString *(*ControlConnectionCommand)(ControlConnection *cc, GString *command, gpointer user_data);
+void control_connection_start_as_thread(ControlConnection *self, ControlConnectionCommand cmd_cb,
+                                        GString *command, gpointer user_data);
 
 void control_connection_send_reply(ControlConnection *self, GString *reply);
 void control_connection_start_watches(ControlConnection *self);

--- a/lib/control/control-server.h
+++ b/lib/control/control-server.h
@@ -60,6 +60,7 @@ struct _ControlConnection
 
 struct _ControlServer
 {
+  GList *worker_threads;
   gchar *control_socket_name;
   void (*free_fn)(ControlServer *self);
 };

--- a/lib/control/control-server.h
+++ b/lib/control/control-server.h
@@ -27,6 +27,8 @@
 #include "control.h"
 #include <stdio.h>
 
+#include <iv_event.h>
+
 #define MAX_CONTROL_LINE_LENGTH 4096
 
 struct _ControlConnection
@@ -48,6 +50,12 @@ struct _ControlConnection
     void (*stop_watches)(ControlConnection *self);
   } events;
 
+  struct
+  {
+    struct iv_event reply_received;
+    GList *replies;
+    GMutex lock;
+  } async;
 };
 
 struct _ControlServer
@@ -67,6 +75,7 @@ void control_connection_start_as_thread(ControlConnection *self, ControlConnecti
                                         GString *command, gpointer user_data);
 
 void control_connection_send_reply(ControlConnection *self, GString *reply);
+void control_connection_send_reply_async(ControlConnection *self, GString *reply);
 void control_connection_start_watches(ControlConnection *self);
 void control_connection_update_watches(ControlConnection *self);
 void control_connection_stop_watches(ControlConnection *self);

--- a/lib/mainloop-control.c
+++ b/lib/mainloop-control.c
@@ -117,7 +117,7 @@ control_connection_config(ControlConnection *cc, GString *command, gpointer user
 
   if (!config)
     {
-      g_string_assign(result, "syslog-ng is being reloaded");
+      g_string_assign(result, "FAIL syslog-ng is being reloaded");
       goto exit;
     }
 
@@ -362,7 +362,7 @@ control_connection_list_files(ControlConnection *cc, GString *command, gpointer 
   GlobalConfig *config = main_loop_lock_current_config(main_loop);
   if (!config)
     {
-      g_string_assign(result, "syslog-ng is being reloaded");
+      g_string_assign(result, "FAIL syslog-ng is being reloaded");
       goto exit;
     }
   for (GList *v = config->file_list; v; v = v->next)
@@ -504,7 +504,7 @@ export_config_graph(ControlConnection *cc, GString *command, gpointer user_data)
   if (!cfg)
     {
       main_loop_unlock_current_config(main_loop);
-      control_connection_send_reply(cc, g_string_new("syslog-ng is being reloaded"));
+      control_connection_send_reply(cc, g_string_new("FAIL {\"fail\" : \"syslog-ng is being reloaded\"}"));
       return;
     }
   cfg_walker_get_graph(cfg->tree.initialized_pipes, &nodes, &arcs);

--- a/lib/mainloop-control.c
+++ b/lib/mainloop-control.c
@@ -409,7 +409,7 @@ export_config_graph(ControlConnection *cc, GString *command, gpointer user_data)
   control_connection_send_reply(cc, result);
 }
 
-ControlCommand default_commands[] =
+ControlCommand default_commands_sync[] =
 {
   { "LOG", control_connection_message_log },
   { "STOP", control_connection_stop_process },
@@ -423,15 +423,20 @@ ControlCommand default_commands[] =
   { NULL, NULL },
 };
 
+static void
+_register_sync_commands(MainLoop *main_loop)
+{
+  ControlCommand *cmd;
+
+  for (gint i = 0; default_commands_sync[i].command_name != NULL; i++)
+    {
+      cmd = &default_commands_sync[i];
+      control_register_command(cmd->command_name, cmd->func, main_loop);
+    }
+}
+
 void
 main_loop_register_control_commands(MainLoop *main_loop)
 {
-  int i;
-  ControlCommand *cmd;
-
-  for (i = 0; default_commands[i].command_name != NULL; i++)
-    {
-      cmd = &default_commands[i];
-      control_register_command(cmd->command_name, cmd->func, main_loop);
-    }
+  _register_sync_commands(main_loop);
 }

--- a/lib/mainloop-control.c
+++ b/lib/mainloop-control.c
@@ -97,6 +97,11 @@ control_connection_stop_process(ControlConnection *cc, GString *command, gpointe
   GString *result = g_string_new("OK Shutdown initiated");
   MainLoop *main_loop = (MainLoop *) user_data;
 
+  // We are at ControlLoop which handles the command list, so it is safe
+  // to reset. After reset, all incoming ctl requests will be rejected.
+  // It could be useful when testing with valgrind and sending commands
+  // in an infinite loop.
+  reset_control_command_list();
   main_loop_exit(main_loop);
 
   control_connection_send_reply(cc, result);

--- a/lib/mainloop-control.c
+++ b/lib/mainloop-control.c
@@ -157,9 +157,11 @@ _respond_config_reload_status(gint type, gpointer user_data)
 }
 
 static void
-control_connection_reload(ControlConnection *cc, GString *command, gpointer user_data)
+_control_connection_reload(gpointer user_data)
 {
-  MainLoop *main_loop = (MainLoop *) user_data;
+  ControlCommandAsync *cmd = (ControlCommandAsync *) user_data;
+  MainLoop *main_loop = cmd->main_loop;
+  ControlConnection *cc = cmd->cc;
   static gpointer args[2];
   GError *error = NULL;
 
@@ -177,6 +179,15 @@ control_connection_reload(ControlConnection *cc, GString *command, gpointer user
   args[1] = cc;
   register_application_hook(AH_CONFIG_CHANGED, _respond_config_reload_status, args);
   main_loop_reload_config_commence(main_loop);
+}
+
+static void
+control_connection_reload(ControlConnection *cc, GString *command, gpointer user_data)
+{
+  ControlCommandAsync *cmd = (ControlCommandAsync *) user_data;
+  cmd->cc = cc;
+  cmd->command = command;
+  iv_event_post(&cmd->command_requested);
 }
 
 static void
@@ -425,7 +436,6 @@ ControlCommand default_commands_sync[] =
 {
   { "LOG", control_connection_message_log },
   { "STOP", control_connection_stop_process },
-  { "RELOAD", control_connection_reload },
   { "REOPEN", control_connection_reopen },
   { "CONFIG", control_connection_config },
   { "LICENSE", show_ose_license_info },
@@ -435,9 +445,11 @@ ControlCommand default_commands_sync[] =
   { NULL, NULL },
 };
 
+
 ControlCommandAsync default_commands_async[] =
 {
-  { {NULL, NULL }, NULL },
+  { { "RELOAD", control_connection_reload }, _control_connection_reload },
+  { { NULL, NULL }, NULL },
 };
 
 static void

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -678,6 +678,12 @@ main_loop_thread_resource_deinit(void)
   g_cond_free(thread_halt_cond);
 }
 
+gboolean
+main_loop_is_control_server_running(MainLoop *self)
+{
+  return self->control_server_loop != NULL;
+}
+
 GQuark
 main_loop_error_quark(void)
 {

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -160,7 +160,7 @@ struct _MainLoop
   GlobalConfig *new_config;
 
   MainLoopOptions *options;
-  ControlServer *control_server;
+  ControlServerLoop *control_server_loop;
 };
 
 static MainLoop main_loop;
@@ -611,7 +611,7 @@ main_loop_read_and_init_config(MainLoop *self)
     {
       return 2;
     }
-  self->control_server = control_init(resolvedConfigurablePaths.ctlfilename);
+  self->control_server_loop = control_init(resolvedConfigurablePaths.ctlfilename);
   main_loop_register_control_commands(self);
   stats_register_control_commands();
   return 0;
@@ -629,7 +629,7 @@ main_loop_deinit(MainLoop *self)
 {
   main_loop_free_config(self);
 
-  control_deinit(self->control_server);
+  control_deinit(self->control_server_loop);
 
   iv_event_unregister(&self->exit_requested);
   main_loop_call_deinit();

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -84,6 +84,8 @@ gboolean main_loop_initialize_state(GlobalConfig *cfg, const gchar *persist_file
 void main_loop_thread_resource_init(void);
 void main_loop_thread_resource_deinit(void);
 
+gboolean main_loop_is_control_server_running(MainLoop *self);
+
 #define MAIN_LOOP_ERROR main_loop_error_quark()
 
 GQuark main_loop_error_quark(void);

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -72,6 +72,8 @@ void main_loop_run(MainLoop *self);
 
 MainLoop *main_loop_get_instance(void);
 GlobalConfig *main_loop_get_current_config(MainLoop *self);
+GlobalConfig *main_loop_lock_current_config(MainLoop *self);
+void main_loop_unlock_current_config(MainLoop *self);
 void main_loop_init(MainLoop *self, MainLoopOptions *options);
 void main_loop_deinit(MainLoop *self);
 

--- a/lib/stats/stats-control.c
+++ b/lib/stats/stats-control.c
@@ -30,6 +30,63 @@
 #include "control/control-commands.h"
 #include "control/control-server.h"
 
+#include <iv.h>
+#include <iv_event.h>
+
+typedef GString *(*ControlConnectionCommand)(ControlConnection *cc, GString *command, gpointer user_data);
+
+typedef struct _ThreadedCommandRunner
+{
+  ControlConnection *connection;
+  GString *command;
+  gpointer user_data;
+
+  GThread *thread;
+  ControlConnectionCommand func;
+  GString *response;
+  struct iv_event response_received;
+} ThreadedCommandRunner;
+
+static ThreadedCommandRunner *
+_thread_command_runner_new(ControlConnection *cc, GString *cmd, gpointer user_data)
+{
+  ThreadedCommandRunner *self = g_new0(ThreadedCommandRunner, 1);
+  self->connection = cc;
+  self->command = cmd;
+  self->user_data = user_data;
+
+  return self;
+}
+
+static void
+_send_response(gpointer user_data)
+{
+  ThreadedCommandRunner *self = (ThreadedCommandRunner *) user_data;
+  g_thread_join(self->thread);
+  control_connection_send_reply(self->connection, self->response);
+  iv_event_unregister(&self->response_received);
+  g_free(self);
+}
+
+static void
+_thread(gpointer user_data)
+{
+  ThreadedCommandRunner *self = (ThreadedCommandRunner *)user_data;
+  self->response = self->func(self->connection, self->command, self->user_data);
+  iv_event_post(&self->response_received);
+}
+
+static void
+_thread_command_runner_run(ThreadedCommandRunner *self, ControlConnectionCommand func)
+{
+  IV_EVENT_INIT(&self->response_received);
+  self->response_received.handler = _send_response;
+  self->response_received.cookie = self;
+  iv_event_register(&self->response_received);
+  self->func = func;
+  self->thread = g_thread_new(self->command->str, (GThreadFunc) _thread, self);
+}
+
 static void
 _reset_counter(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data)
 {

--- a/lib/stats/stats-control.c
+++ b/lib/stats/stats-control.c
@@ -117,13 +117,21 @@ _reset_counters(void)
   stats_unlock();
 }
 
+static GString *
+_send_stats_get_result(ControlConnection *cc, GString *command, gpointer user_data)
+{
+  gchar *stats = stats_generate_csv();
+  GString *response = g_string_new(stats);
+  g_free(stats);
+
+  return response;
+}
+
 static void
 control_connection_send_stats(ControlConnection *cc, GString *command, gpointer user_data)
 {
-  gchar *stats = stats_generate_csv();
-  GString *result = g_string_new(stats);
-  g_free(stats);
-  control_connection_send_reply(cc, result);
+  ThreadedCommandRunner *runner = _thread_command_runner_new(cc, command, user_data);
+  _thread_command_runner_run(runner, _send_stats_get_result);
 }
 
 static void

--- a/lib/stats/stats-control.c
+++ b/lib/stats/stats-control.c
@@ -30,63 +30,6 @@
 #include "control/control-commands.h"
 #include "control/control-server.h"
 
-#include <iv.h>
-#include <iv_event.h>
-
-typedef GString *(*ControlConnectionCommand)(ControlConnection *cc, GString *command, gpointer user_data);
-
-typedef struct _ThreadedCommandRunner
-{
-  ControlConnection *connection;
-  GString *command;
-  gpointer user_data;
-
-  GThread *thread;
-  ControlConnectionCommand func;
-  GString *response;
-  struct iv_event response_received;
-} ThreadedCommandRunner;
-
-static ThreadedCommandRunner *
-_thread_command_runner_new(ControlConnection *cc, GString *cmd, gpointer user_data)
-{
-  ThreadedCommandRunner *self = g_new0(ThreadedCommandRunner, 1);
-  self->connection = cc;
-  self->command = cmd;
-  self->user_data = user_data;
-
-  return self;
-}
-
-static void
-_send_response(gpointer user_data)
-{
-  ThreadedCommandRunner *self = (ThreadedCommandRunner *) user_data;
-  g_thread_join(self->thread);
-  control_connection_send_reply(self->connection, self->response);
-  iv_event_unregister(&self->response_received);
-  g_free(self);
-}
-
-static void
-_thread(gpointer user_data)
-{
-  ThreadedCommandRunner *self = (ThreadedCommandRunner *)user_data;
-  self->response = self->func(self->connection, self->command, self->user_data);
-  iv_event_post(&self->response_received);
-}
-
-static void
-_thread_command_runner_run(ThreadedCommandRunner *self, ControlConnectionCommand func)
-{
-  IV_EVENT_INIT(&self->response_received);
-  self->response_received.handler = _send_response;
-  self->response_received.cookie = self;
-  iv_event_register(&self->response_received);
-  self->func = func;
-  self->thread = g_thread_new(self->command->str, (GThreadFunc) _thread, self);
-}
-
 static void
 _reset_counter(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data)
 {
@@ -130,8 +73,7 @@ _send_stats_get_result(ControlConnection *cc, GString *command, gpointer user_da
 static void
 control_connection_send_stats(ControlConnection *cc, GString *command, gpointer user_data)
 {
-  ThreadedCommandRunner *runner = _thread_command_runner_new(cc, command, user_data);
-  _thread_command_runner_run(runner, _send_stats_get_result);
+  control_connection_start_as_thread(cc, _send_stats_get_result, command, user_data);
 }
 
 static void

--- a/lib/stats/stats-query-commands.c
+++ b/lib/stats/stats-query-commands.c
@@ -182,8 +182,8 @@ _dispatch_query(gint cmd_id, const gchar *filter_expr, GString *result)
   return QUERY_CMDS[cmd_id](filter_expr, result);
 }
 
-void
-process_query_command(ControlConnection *cc, GString *command, gpointer user_data)
+static GString *
+_process_query_command(ControlConnection *cc, GString *command, gpointer user_data)
 {
   GString *result = g_string_new("");
   gchar **cmds = g_strsplit(command->str, " ", 3);
@@ -197,5 +197,11 @@ process_query_command(ControlConnection *cc, GString *command, gpointer user_dat
   if (result->len == 0)
     g_string_assign(result, "\n");
 
-  control_connection_send_reply(cc, result);
+  return result;
+}
+
+void
+process_query_command(ControlConnection *cc, GString *command, gpointer user_data)
+{
+  control_connection_start_as_thread(cc, _process_query_command, command, user_data);
 }

--- a/lib/thread-utils.h
+++ b/lib/thread-utils.h
@@ -51,4 +51,14 @@ threads_equal(ThreadId thread_a, ThreadId thread_b)
 #endif
 }
 
+static inline void
+thread_cancel(ThreadId tid)
+{
+#ifndef _WIN32
+  pthread_cancel(tid);
+#else
+  TerminateThread(tid, 0);
+#endif
+}
+
 #endif

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -584,6 +584,25 @@ _finalize_init_async(gpointer arg)
 }
 
 static gboolean
+_transport_mapper_async_init(AFSocketDestDriver *self)
+{
+  TransportMapperAsyncResult res = transport_mapper_async_init(self->transport_mapper, _finalize_init_async, self);
+  switch (res)
+    {
+    case TR_MAP_ASYNC_NOT_SUPPORTED:
+      _finalize_init_async(self);
+      return TRUE;
+    case TR_MAP_ASYNC_REGISTERED_SUCCESS:
+      return TRUE;
+    case TR_MAP_ASYNC_REGISTERED_FAILED:
+      return FALSE;
+    default:
+      g_assert_not_reached();
+    }
+  return FALSE;
+}
+
+static gboolean
 _dd_init_stream(AFSocketDestDriver *self)
 {
   if (!afsocket_dd_setup_writer(self))
@@ -591,7 +610,7 @@ _dd_init_stream(AFSocketDestDriver *self)
 
   iv_event_register(&self->finalize_init_event);
 
-  return transport_mapper_async_init(self->transport_mapper, _finalize_init_async, self);
+  return _transport_mapper_async_init(self);
 }
 
 static gboolean

--- a/modules/afsocket/afsocket-dest.h
+++ b/modules/afsocket/afsocket-dest.h
@@ -31,6 +31,7 @@
 #include "logwriter.h"
 
 #include <iv.h>
+#include <iv_event.h>
 
 typedef struct _AFSocketDestDriver AFSocketDestDriver;
 
@@ -52,6 +53,7 @@ struct _AFSocketDestDriver
   gboolean connection_initialized;
   struct iv_fd connect_fd;
   struct iv_timer reconnect_timer;
+  struct iv_event finalize_init_event;
   SocketOptions *socket_options;
   TransportMapper *transport_mapper;
 

--- a/modules/afsocket/afsocket-source.h
+++ b/modules/afsocket/afsocket-source.h
@@ -33,6 +33,7 @@
 #include "atomic-gssize.h"
 
 #include <iv.h>
+#include <iv_event.h>
 
 typedef struct _AFSocketSourceDriver AFSocketSourceDriver;
 
@@ -43,6 +44,7 @@ struct _AFSocketSourceDriver
           window_size_initialized:1;
   struct iv_fd listen_fd;
   struct iv_timer dynamic_window_timer;
+  struct iv_event finalize_init_event;
   gsize dynamic_window_size;
   gsize dynamic_window_timer_tick;
   gfloat dynamic_window_stats_freq;

--- a/modules/afsocket/transport-mapper-inet.c
+++ b/modules/afsocket/transport-mapper-inet.c
@@ -222,13 +222,13 @@ _call_finalize_init(Secret *secret, gpointer user_data)
     }
 }
 
-static gboolean
+static TransportMapperAsyncResult
 transport_mapper_inet_async_init(TransportMapper *s, TransportMapperAsyncInitCB func, gpointer func_args)
 {
   TransportMapperInet *self = (TransportMapperInet *)s;
 
   if (!self->tls_context)
-    return func(func_args);
+    return TR_MAP_ASYNC_NOT_SUPPORTED;
 
   TLSContextSetupResult tls_ctx_setup_res = tls_context_setup_context(self->tls_context);
 
@@ -238,7 +238,7 @@ transport_mapper_inet_async_init(TransportMapper *s, TransportMapperAsyncInitCB 
     {
       if (key && secret_storage_contains_key(key))
         secret_storage_update_status(key, SECRET_STORAGE_SUCCESS);
-      return func(func_args);
+      return TR_MAP_ASYNC_NOT_SUPPORTED;
     }
 
   if (tls_ctx_setup_res == TLS_CONTEXT_SETUP_BAD_PASSWORD)
@@ -257,10 +257,11 @@ transport_mapper_inet_async_init(TransportMapper *s, TransportMapperAsyncInitCB 
       else
         msg_error("Failed to subscribe for key",
                   evt_tag_str("keyfile", key));
-      return subscribe_res;
+
+      return subscribe_res ? TR_MAP_ASYNC_REGISTERED_SUCCESS : TR_MAP_ASYNC_REGISTERED_FAILED;
     }
 
-  return FALSE;
+  return TR_MAP_ASYNC_REGISTERED_FAILED;
 }
 
 void

--- a/modules/afsocket/transport-mapper.h
+++ b/modules/afsocket/transport-mapper.h
@@ -31,6 +31,13 @@
 typedef struct _TransportMapper TransportMapper;
 typedef gboolean (*TransportMapperAsyncInitCB)(gpointer arg);
 
+typedef enum
+{
+  TR_MAP_ASYNC_NOT_SUPPORTED,
+  TR_MAP_ASYNC_REGISTERED_SUCCESS,
+  TR_MAP_ASYNC_REGISTERED_FAILED
+} TransportMapperAsyncResult;
+
 struct _TransportMapper
 {
   /* the transport() option as specified by the user */
@@ -51,7 +58,7 @@ struct _TransportMapper
   gboolean (*apply_transport)(TransportMapper *self, GlobalConfig *cfg);
   LogTransport *(*construct_log_transport)(TransportMapper *self, gint fd);
   gboolean (*init)(TransportMapper *self);
-  gboolean (*async_init)(TransportMapper *self, TransportMapperAsyncInitCB func, gpointer arg);
+  TransportMapperAsyncResult (*async_init)(TransportMapper *self, TransportMapperAsyncInitCB func, gpointer arg);
   void (*free_fn)(TransportMapper *self);
 };
 
@@ -92,7 +99,7 @@ transport_mapper_init(TransportMapper *self)
   return TRUE;
 }
 
-static inline gboolean
+static inline TransportMapperAsyncResult
 transport_mapper_async_init(TransportMapper *self, TransportMapperAsyncInitCB func, gpointer arg)
 {
   if (self->async_init)
@@ -100,6 +107,6 @@ transport_mapper_async_init(TransportMapper *self, TransportMapperAsyncInitCB fu
       return self->async_init(self, func, arg);
     }
 
-  return func(arg);
+  return TR_MAP_ASYNC_NOT_SUPPORTED;
 }
 #endif

--- a/news/bugfix-3349.md
+++ b/news/bugfix-3349.md
@@ -1,0 +1,8 @@
+syslog-ng-ctl: when syslog-ng gets stuck on executing a heavy stats-ctl command, should be
+able to do a graceful shutdown when it is requested
+
+The solution has two parts:
+ 1) move control loop to a separated thread
+ 2) run stats and query ctl commands in a separated thread
+
+


### PR DESCRIPTION
The aim of this PR is to help users when syslog-ng stuck on 'syslog-ng-ctl stats' (or on any other control command...).

There are two parts of the PR:
 * run ControlServer in a separate thread (it runs its own `iv_main()`)
 * run stats/query commands in a separate thread
 

After this PR is merged, it is possible to stop syslog-ng with 'syslog-ng-ctl stop'
even if 'syslog-ng-ctl stats' is still in progress and 'syslog-ng-ctl stats' won't 
'suspend' main thread anymore.
