### PR TITLE
requirements.txt: use isort==4.3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 nose==1.3.7
 ply==3.10
 pep8==1.7.1
+isort==4.3.4
 pylint==1.8.2
 astroid==1.6.1
 logilab-common<=0.63.0


### PR DESCRIPTION
Due to a temporary incompatibility between the latest version of isort and Pylint (details: https://github.com/PyCQA/pylint/issues/3722), we freeze isort to version 4.3.4
Once the problem got fixed, we can remove this line and use the latest version from all library.