### PR TITLE
scratch-buffers: fix 'global.scratch_buffers_count.queued' bug

### DIFF
--- a/lib/scratch-buffers.c
+++ b/lib/scratch-buffers.c
@@ -207,8 +207,8 @@ scratch_buffers_allocator_deinit(void)
     }
 
   /* remove our values from stats */
-  stats_counter_add(stats_scratch_buffers_count, -scratch_buffers->len);
-  stats_counter_add(stats_scratch_buffers_bytes, -scratch_buffers_bytes_reported);
+  stats_counter_sub(stats_scratch_buffers_count, scratch_buffers->len);
+  stats_counter_sub(stats_scratch_buffers_bytes, scratch_buffers_bytes_reported);
 
   /* free thread local scratch buffers */
   for (int i = 0; i < scratch_buffers->len; i++)

--- a/lib/tests/test_scratch_buffers.c
+++ b/lib/tests/test_scratch_buffers.c
@@ -139,18 +139,18 @@ Test(scratch_buffers_stats, stats_counters_are_updated)
       allocated_counter++;
 
       /* check through accessor functions */
-      cr_assert(scratch_buffers_get_local_usage_count() == allocated_counter,
-                "get_local_usage_count() not returning proper value, value=%d, expected=%d",
-                scratch_buffers_get_local_usage_count(), allocated_counter);
+      cr_assert_eq(scratch_buffers_get_local_usage_count(), allocated_counter,
+                   "get_local_usage_count() not returning proper value, value=%d, expected=%d",
+                   scratch_buffers_get_local_usage_count(), allocated_counter);
 
-      cr_assert(scratch_buffers_get_local_allocation_bytes() == allocated_counter * DEFAULT_ALLOC_SIZE,
-                "get_local_allocation_bytes() not returning proper value, value=%ld, expected=%ld",
-                scratch_buffers_get_local_allocation_bytes(), allocated_counter * DEFAULT_ALLOC_SIZE);
+      cr_assert_eq(scratch_buffers_get_local_allocation_bytes(), allocated_counter * DEFAULT_ALLOC_SIZE,
+                   "get_local_allocation_bytes() not returning proper value, value=%ld, expected=%ld",
+                   scratch_buffers_get_local_allocation_bytes(), allocated_counter * DEFAULT_ALLOC_SIZE);
 
       /* check through metrics */
-      cr_assert(stats_counter_get(stats_scratch_buffers_count) == allocated_counter,
-                "Statistic scratch_buffers_count is not updated properly, value=%d, expected=%d",
-                (gint) stats_counter_get(stats_scratch_buffers_count), allocated_counter);
+      cr_assert_eq(stats_counter_get(stats_scratch_buffers_count), allocated_counter,
+                   "Statistic scratch_buffers_count is not updated properly, value=%d, expected=%d",
+                   (gint) stats_counter_get(stats_scratch_buffers_count), allocated_counter);
 
       /* check if byte counter is updated */
       scratch_buffers_update_stats();

--- a/news/bugfix-3355.md
+++ b/news/bugfix-3355.md
@@ -1,0 +1,2 @@
+scratch-buffers: fix `global.scratch_buffers_bytes.queued` counter bug
+This bug only affected the stats_counter value, not the actual memory usage (i.e. memory usage was fine before)


### PR DESCRIPTION
Due to some bug, the `global.scratch_buffers_count.queued` could shown an invalid value (e.g. 2^32 value, while the actual usage was just decreased to 0).

This bug only affected the stats_counter value, not the actual memory usage (i.e. memory usage was fine before).