### PR TITLE
tlscontext: apply ecdh-curve-list for client, too

### DIFF
--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -572,10 +572,6 @@ _load_dh_fallback(TLSContext *self)
 static gboolean
 tls_context_setup_ecdh(TLSContext *self)
 {
-  /* server only */
-  if (self->mode != TM_SERVER)
-    return TRUE;
-
   if (!_set_optional_ecdh_curve_list(self->ssl_ctx, self->ecdh_curve_list))
     return FALSE;
 

--- a/news/bugfix-3356.md
+++ b/news/bugfix-3356.md
@@ -1,0 +1,1 @@
+`tls`: Fixed a bug, where `ecdh-curve-list()` were not applied at client side.


### PR DESCRIPTION
https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set1_curves_list.html
> SSL_CTX_set1_groups() sets the supported groups for ctx to glistlen
> groups in the array glist. The array consist of all NIDs of groups in
> preference order. For a TLS client the groups are used directly in the
> supported groups extension. For a TLS server the groups are used to
> determine the set of shared groups.
> ...
> The curve functions are synonyms for the equivalently named group
> functions and are identical in every respect.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>