### PR TITLE
github-actions: fix commits-check

### DIFF
--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -190,10 +190,12 @@ jobs:
     steps:
       - name: Checkout syslog-ng source
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Commits check (Pull request)
         if: github.event_name == 'pull_request'
-        run: tests/commits/check.sh ${{ github.base_ref }}..${{ github.head_ref }}
+        run: tests/commits/check.sh origin/${{ github.base_ref }}..HEAD
 
       - name: Commits check (Push)
         if: github.event_name == 'push'

--- a/tests/commits/check.sh
+++ b/tests/commits/check.sh
@@ -27,7 +27,7 @@ if [ $# -gt 0 ]; then
   commit_range=$1
 fi
 
-git log --no-merges --pretty="%H" $commit_range -- | (
+(git log --no-merges --pretty="%H" $commit_range -- || echo "git log failed with $?" 1>&2) | (
   ret=0
   while read commit; do
     commit_has_valid_subject=1


### PR DESCRIPTION
Fetch mechanism changed when switched from actions/checkout@v1 to v2.
This PR tweaks the invokation of `tests/commits/check.sh` to match the new behavior, also makes it fail if bad revisions are given.

Thanks @Kokan for the heads-up :)

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>