### PR TITLE
stats-counter: do not crash when set an external/read-only counter

### DIFF
--- a/lib/stats/stats-counter.h
+++ b/lib/stats/stats-counter.h
@@ -90,9 +90,8 @@ stats_counter_dec(StatsCounterItem *counter)
 static inline void
 stats_counter_set(StatsCounterItem *counter, gsize value)
 {
-  if (counter)
+  if (counter && !stats_counter_read_only(counter))
     {
-      g_assert(!stats_counter_read_only(counter));
       atomic_gssize_racy_set(&counter->value, value);
     }
 }

--- a/lib/stats/tests/test_external_ctr_reg.c
+++ b/lib/stats/tests/test_external_ctr_reg.c
@@ -79,11 +79,12 @@ _register_external_stats_counter(atomic_gssize *ctr, gssize initial_value)
   return counter;
 }
 
-Test(stats_external_counter, external_ctr_is_read_only_for_stats_set, .signal=SIGABRT)
+Test(stats_external_counter, external_ctr_is_read_only_for_stats_set)
 {
   atomic_gssize test_ctr;
   StatsCounterItem *stats_ctr = _register_external_stats_counter(&test_ctr, 11);
   stats_counter_set(stats_ctr, 1);
+  cr_expect_eq(stats_counter_get(stats_ctr), 11);
 };
 
 Test(stats_external_counter, external_ctr_is_read_only_for_stats_inc, .signal=SIGABRT)

--- a/news/bugfix-3361.md
+++ b/news/bugfix-3361.md
@@ -1,0 +1,2 @@
+stats: fix stats-ctl query crash when trying to reset all the counters
+`syslog-ng-ctl query get '*' --reset`


### PR DESCRIPTION
When trying to reset a read-only stats counter with
`syslog-ng-ctl query get '*' --reset`
syslog-ng crashed before this patch.

As this situation can be triggered by users, it does not
count as a programming error, so using assert is not reasonable.

Reported-by: Peter Kokai <peter.kokai@balabit.com>
Signed-off-by: Laszlo Budai <laszlo.budai@outlook.com>