### PR TITLE
program destination wrapper for signal-cli

### DIFF
--- a/news/feature-3362.md
+++ b/news/feature-3362.md
@@ -1,0 +1,39 @@
+signal: use signal-cli via a program destination
+
+Adding Signal (https://signal.org) destintaion to Syslog-ng,
+relying on the work of https://github.com/AsamK/signal-cli
+
+# The destination requires manual setup before use!
+Please refer to official signal-cli documentation for
+further information about registering it as a client:
+https://github.com/AsamK/signal-cli#usage
+
+
+# Example usage:
+
+```
+destination d_signal_cli{
+  signal-cli-dest(
+    signal-cli-executable("/usr/local/bin/signal-cli")
+    own-number("+36001111111")
+    partner-number("+36002222222")
+  );
+};
+```
+
+
+# WARNING! Performance measurements
+Syslog-ng program destination assumes that the consumer has a
+"daemon" like behaviour. The program will be started by Syslog-ng
+at initialization time, and it will receive new messages on it's
+standard input, separated by new line characters.
+
+This aproach is very intentional from Syslog-ng. Since starting
+and freeing up a process is a very resource intensive work,
+doing it on per message basis can put a system on it's kneels.
+
+In order to make signal-cli feasible we have to write a small
+"wrapper" script, which achieves this "daemon like" behaviour.
+Thus, this implementation is only intended to use for "alerts"
+and "notifcations". Not for implementing heavy duty message
+delivery pipelines.

--- a/scl/CMakeLists.txt
+++ b/scl/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SCL_DIRS
     pacct
     paloalto
     rewrite
+    signal
     slack
     snmptrap
     solaris

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -24,6 +24,7 @@ SCL_SUBDIRS	= \
 	pacct		\
 	paloalto 	\
 	rewrite	\
+	signal \
 	slack \
 	snmptrap	\
 	solaris	\

--- a/scl/signal/signal-cli-dest.conf
+++ b/scl/signal/signal-cli-dest.conf
@@ -1,0 +1,37 @@
+#############################################################################
+# Copyright (c) 2020 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+block destination signal-cli-dest(
+  signal-cli-executable()
+  own-number()
+  partner-number()
+  message-template('${MSG}')
+  ...)
+
+{
+  program("`scl-root`/signal/signal-cli-wrapper.sh \
+    SIGNAL_CLI_EXECUTABLE=\"`signal-cli-executable`\" \
+    OWN_NUMBER=\"`own-number`\" \
+    PARTNER_NUMBER=\"`partner-number`\""
+    `__VARARGS__`
+  );
+};

--- a/scl/signal/signal-cli-wrapper.sh
+++ b/scl/signal/signal-cli-wrapper.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#############################################################################
+# Copyright (c) 2020 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+
+for ARGUMENT in "$@"
+do
+
+  KEY=$(echo $ARGUMENT | cut -f1 -d=)
+  VALUE=$(echo $ARGUMENT | cut -f2 -d=)
+
+  case "$KEY" in
+    SIGNAL_CLI_EXECUTABLE)    SIGNAL_CLI_EXECUTABLE=${VALUE} ;;
+    OWN_NUMBER)               OWN_NUMBER=${VALUE} ;;
+    PARTNER_NUMBER)           PARTNER_NUMBER=${VALUE} ;;
+    *)
+  esac
+
+done
+
+
+
+while read line ; do
+  $SIGNAL_CLI_EXECUTABLE -u $OWN_NUMBER send $PARTNER_NUMBER -m "$line"
+done


### PR DESCRIPTION
Wrapping the https://github.com/AsamK/signal-cli binary into a program destination of syslog-ng.
resolves: #3345

# The destination requires manual setup before use!
Please refer to the official signal-cli documentation for
further information about registering it as a client:
https://github.com/AsamK/signal-cli#usage


# Example usage:

```
destination d_signal_cli{
  signal-cli-dest(
    signal-cli-executable("/usr/local/bin/signal-cli")
    own-number("+36001111111")
    partner-number("+36002222222")
  );
};
```


# WARNING! Performance measurements
Syslog-ng program destination assumes that the consumer has a
"daemon" like behaviour. The program will be started by Syslog-ng
at initialization time, and it will receive new messages on it's
standard input, separated by new line characters.

This aproach is very intentional from Syslog-ng. Since starting
and freeing up a process is a very resource intensive work,
doing it on per message basis can put a system on it's kneels.

In order to make signal-cli feasible we have to write a small
"wrapper" script, which achieves this "daemon like" behaviour.
Thus, this implementation is only intended to use for "alerts"
and "notifcations". Not for implementing heavy duty message
delivery pipelines.
