### PR TITLE
snmptrap: improve error message when missing dependency

### DIFF
--- a/news/feature-3363.md
+++ b/news/feature-3363.md
@@ -1,0 +1,1 @@
+snmptrap: improve error message when missing dependency

--- a/scl/snmptrap/snmptrapd-source.conf
+++ b/scl/snmptrap/snmptrapd-source.conf
@@ -20,8 +20,6 @@
 #
 #############################################################################
 
-@requires afsnmp
-
 block source snmptrap(
   filename()
   prefix(".snmp.")
@@ -29,6 +27,9 @@ block source snmptrap(
   ...
 )
 {
+
+@requires afsnmp "The snmptrap() driver depends on the syslog-ng afsnmp module, please install the syslog-ng-mod-snmptrapd-parser (Debian & derivatives) or the syslog-ng-afsnmp (RHEL & co) package"
+
   channel {
     source {
       file("`filename`"


### PR DESCRIPTION
Inspired by mail list question: https://lists.balabit.hu/pipermail/syslog-ng/2020-July/025972.html