### PR TITLE
Cfg version current

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -434,6 +434,13 @@ cfg_set_version(GlobalConfig *self, gint version)
 }
 
 gboolean
+cfg_set_current_version(GlobalConfig *self)
+{
+  msg_info("Setting current version as config version", evt_tag_str("version", VERSION_STR_CURRENT));
+  return cfg_set_version(self, VERSION_VALUE_CURRENT);
+}
+
+gboolean
 cfg_allow_config_dups(GlobalConfig *self)
 {
   const gchar *s;

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -142,6 +142,7 @@ gint cfg_ts_format_value(gchar *format);
 
 void cfg_set_version_without_validation(GlobalConfig *self, gint version);
 gboolean cfg_set_version(GlobalConfig *self, gint version);
+gboolean cfg_set_current_version(GlobalConfig *self);
 
 void cfg_set_global_paths(GlobalConfig *self);
 

--- a/lib/pragma-grammar.ym
+++ b/lib/pragma-grammar.ym
@@ -44,6 +44,7 @@
 /* INCLUDE_DECLS */
 
 %token KW_VERSION
+%token KW_VERSION_CURRENT
 %token KW_DEFINE
 %token KW_MODULE
 %token KW_REQUIRES
@@ -88,7 +89,12 @@ stmt_with_eol
         ;
 
 version_stmt
-        : KW_VERSION ':' string_or_number
+        : KW_VERSION ':' KW_VERSION_CURRENT
+        {
+          if (!cfg_set_current_version(configuration))
+            PRAGMA_ERROR();
+        }
+        | KW_VERSION ':' string_or_number
           {
             guint parsed_version = process_version_string($3);
             free($3);

--- a/lib/pragma-parser.c
+++ b/lib/pragma-parser.c
@@ -67,6 +67,7 @@ process_version_string(gchar *value)
 static CfgLexerKeyword pragma_keywords[] =
 {
   { "version",            KW_VERSION, },
+  { "current",            KW_VERSION_CURRENT },
   { "include",            KW_INCLUDE, },
   { "module",             KW_MODULE, },
   { "define",             KW_DEFINE, },

--- a/news/feature-3368.md
+++ b/news/feature-3368.md
@@ -1,0 +1,1 @@
+config: support `@version: current`


### PR DESCRIPTION
From release to release we `sed` previous version values to the current version value...
I think it could be useful if we would have a `@version: current` syntax in the config file.
This PR implements this.