### PR TITLE
Implement template syntax in the topic parameter for kafka destination

### DIFF
--- a/modules/kafka/CMakeLists.txt
+++ b/modules/kafka/CMakeLists.txt
@@ -22,6 +22,7 @@ set(KAFKA_SOURCES
   kafka-dest-worker.c
   kafka-plugin.c
   kafka-props.c
+  kafka-internal.h
 )
 
 add_module(

--- a/modules/kafka/Makefile.am
+++ b/modules/kafka/Makefile.am
@@ -15,6 +15,7 @@ modules_kafka_libkafka_la_SOURCES = \
   modules/kafka/kafka-dest-driver.c \
   modules/kafka/kafka-dest-worker.h \
   modules/kafka/kafka-dest-worker.c \
+  modules/kafka/kafka-internal.h \
   modules/kafka/kafka-plugin.c
 
 modules_kafka_libkafka_la_CPPFLAGS  = \

--- a/modules/kafka/kafka-dest-driver.c
+++ b/modules/kafka/kafka-dest-driver.c
@@ -340,6 +340,11 @@ kafka_dd_init(LogPipe *s)
                 log_pipe_location_tag(&self->super.super.super.super));
       return FALSE;
     }
+  if (strchr(self->topic_name, '$') != NULL)
+    {
+      self->topicname_is_a_template = TRUE;
+      self->topic_hash = g_hash_table_new(g_str_hash, g_str_equal);
+    }
 
   self->kafka = _construct_client(self);
   if (self->kafka == NULL)

--- a/modules/kafka/kafka-dest-driver.h
+++ b/modules/kafka/kafka-dest-driver.h
@@ -37,18 +37,29 @@ typedef struct
   LogTemplate *message;
   LogTemplate *topic_name;
   GHashTable *topics;
-  GMutex topics_lock;
+  GMutex *topics_lock;
 
   GList *config;
   gchar *bootstrap_servers;
   gchar *fallback_topic_name;
   rd_kafka_topic_t *topic;
-  rd_kafka_topic_t *fallback_topic;
   rd_kafka_t *kafka;
   gint flush_timeout_on_shutdown;
   gint flush_timeout_on_reload;
   gint poll_timeout;
 } KafkaDestDriver;
+
+#define TOPIC_NAME_ERROR topic_name_error_quark()
+
+GQuark topic_name_error_quark(void);
+
+enum KafkaTopicError
+{
+  TOPIC_LENGTH_ZERO,
+  TOPIC_DOT_TWO_DOTS,
+  TOPIC_EXCEEDS_MAX_LENGTH,
+  TOPIC_INVALID_PATTERN,
+};
 
 void kafka_dd_set_topic(LogDriver *d, LogTemplate *topic);
 void kafka_dd_set_fallback_topic(LogDriver *d, const gchar *fallback_topic);
@@ -59,6 +70,8 @@ void kafka_dd_set_message_ref(LogDriver *d, LogTemplate *message);
 void kafka_dd_set_flush_timeout_on_shutdown(LogDriver *d, gint shutdown_timeout);
 void kafka_dd_set_flush_timeout_on_reload(LogDriver *d, gint reload_timeout);
 void kafka_dd_set_poll_timeout(LogDriver *d, gint poll_timeout);
+
+gboolean kafka_dd_validate_topic_name(const gchar *name, GError **error);
 gboolean kafka_dd_is_topic_name_a_template(KafkaDestDriver *self);
 rd_kafka_topic_t *kafka_dd_query_insert_topic(KafkaDestDriver *self, const gchar *name);
 LogTemplateOptions *kafka_dd_get_template_options(LogDriver *d);

--- a/modules/kafka/kafka-dest-driver.h
+++ b/modules/kafka/kafka-dest-driver.h
@@ -35,31 +35,32 @@ typedef struct
   LogTemplateOptions template_options;
   LogTemplate *key;
   LogTemplate *message;
-  LogTemplate *temp_topic_name;
-  GHashTable *topic_hash;
-  GMutex lock;
+  LogTemplate *topic_name;
+  GHashTable *topics;
+  GMutex topics_lock;
 
-  gchar *topic_name;
   GList *config;
   gchar *bootstrap_servers;
+  gchar *fallback_topic_name;
   rd_kafka_topic_t *topic;
+  rd_kafka_topic_t *fallback_topic;
   rd_kafka_t *kafka;
   gint flush_timeout_on_shutdown;
   gint flush_timeout_on_reload;
   gint poll_timeout;
-  gboolean topicname_is_a_template;
 } KafkaDestDriver;
 
-void kafka_dd_set_topic(LogDriver *d, const gchar *topic);
+void kafka_dd_set_topic(LogDriver *d, LogTemplate *topic);
+void kafka_dd_set_fallback_topic(LogDriver *d, const gchar *fallback_topic);
 void kafka_dd_merge_config(LogDriver *d, GList *props);
 void kafka_dd_set_bootstrap_servers(LogDriver *d, const gchar *bootstrap_servers);
-
 void kafka_dd_set_key_ref(LogDriver *d, LogTemplate *key);
 void kafka_dd_set_message_ref(LogDriver *d, LogTemplate *message);
 void kafka_dd_set_flush_timeout_on_shutdown(LogDriver *d, gint shutdown_timeout);
 void kafka_dd_set_flush_timeout_on_reload(LogDriver *d, gint reload_timeout);
 void kafka_dd_set_poll_timeout(LogDriver *d, gint poll_timeout);
-
+gboolean kafka_dd_is_topic_name_a_template(KafkaDestDriver *self);
+rd_kafka_topic_t *kafka_dd_query_insert_topic(KafkaDestDriver *self, const gchar *name);
 LogTemplateOptions *kafka_dd_get_template_options(LogDriver *d);
 
 LogDriver *kafka_dd_new(GlobalConfig *cfg);

--- a/modules/kafka/kafka-dest-driver.h
+++ b/modules/kafka/kafka-dest-driver.h
@@ -35,8 +35,9 @@ typedef struct
   LogTemplateOptions template_options;
   LogTemplate *key;
   LogTemplate *message;
+  LogTemplate *temp_topic_name;
   GHashTable *topic_hash;
-  GStaticMutex lock;
+  GMutex lock;
 
   gchar *topic_name;
   GList *config;

--- a/modules/kafka/kafka-dest-driver.h
+++ b/modules/kafka/kafka-dest-driver.h
@@ -35,6 +35,8 @@ typedef struct
   LogTemplateOptions template_options;
   LogTemplate *key;
   LogTemplate *message;
+  GHashTable *topic_hash;
+  GStaticMutex lock;
 
   gchar *topic_name;
   GList *config;
@@ -44,6 +46,7 @@ typedef struct
   gint flush_timeout_on_shutdown;
   gint flush_timeout_on_reload;
   gint poll_timeout;
+  gboolean topicname_is_a_template;
 } KafkaDestDriver;
 
 void kafka_dd_set_topic(LogDriver *d, const gchar *topic);

--- a/modules/kafka/kafka-dest-worker.c
+++ b/modules/kafka/kafka-dest-worker.c
@@ -35,6 +35,7 @@ typedef struct _KafkaDestWorker
   struct iv_timer poll_timer;
   GString *key;
   GString *message;
+  GString *topic_name_buffer;
 } KafkaDestWorker;
 
 static gboolean
@@ -56,33 +57,51 @@ _format_message_and_key(KafkaDestWorker *self, LogMessage *msg)
                         self->super.seq_num, NULL, self->key);
 }
 
+static rd_kafka_topic_t *
+_calculate_topic_from_template(KafkaDestWorker *self, LogMessage *msg)
+{
+  KafkaDestDriver *owner = (KafkaDestDriver *) self->super.owner;
+  log_template_format(owner->topic_name, msg, &owner->template_options, LTZ_SEND, self->super.seq_num, NULL,
+                      self->topic_name_buffer);
+  rd_kafka_topic_t *topic = kafka_dd_query_insert_topic(owner, self->topic_name_buffer->str);
+
+  if (!topic)
+    {
+      g_assert(owner->fallback_topic != NULL);
+      topic = owner->fallback_topic;
+    }
+
+  return topic;
+}
+
+static rd_kafka_topic_t *
+_get_literal_topic(KafkaDestWorker *self)
+{
+  KafkaDestDriver *owner = (KafkaDestDriver *) self->super.owner;
+
+  return owner->topic;
+}
+
+static rd_kafka_topic_t *
+_calculate_topic(KafkaDestWorker *self, LogMessage *msg)
+{
+  KafkaDestDriver *owner = (KafkaDestDriver *) self->super.owner;
+
+  if (kafka_dd_is_topic_name_a_template(owner))
+    {
+      return _calculate_topic_from_template(self, msg);
+    }
+
+  return _get_literal_topic(self);
+}
+
 static gboolean
 _publish_message(KafkaDestWorker *self, LogMessage *msg)
 {
   KafkaDestDriver *owner = (KafkaDestDriver *) self->super.owner;
   int block_flag = _is_poller_thread(self) ? 0 : RD_KAFKA_MSG_F_BLOCK;
-  rd_kafka_topic_t *topic;
-  GString *topic_name_new = g_string_sized_new(128);
-  if (owner->topicname_is_a_template)
-    {
-      log_template_format(owner->temp_topic_name, msg, &owner->template_options, LTZ_SEND, self->super.seq_num, NULL,
-                          topic_name_new);
-      g_mutex_lock(&owner->lock);
-      topic = g_hash_table_lookup(owner->topic_hash, topic_name_new->str);
-      g_mutex_unlock(&owner->lock);
-      if(!topic)
-        {
-          topic = rd_kafka_topic_new(owner->kafka, topic_name_new->str, NULL);
-          g_mutex_lock(&owner->lock);
-          g_hash_table_insert(owner->topic_hash, g_strdup(topic_name_new->str), topic);
-          g_mutex_unlock(&owner->lock);
-        }
-    }
-  else
-    {
-      topic = owner->topic;
-      g_string_assign(topic_name_new, owner->topic_name);
-    }
+  rd_kafka_topic_t *topic = _calculate_topic(self, msg);
+
   if (rd_kafka_produce(topic,
                        RD_KAFKA_PARTITION_UA,
                        RD_KAFKA_MSG_F_FREE | block_flag,
@@ -91,23 +110,21 @@ _publish_message(KafkaDestWorker *self, LogMessage *msg)
                        log_msg_ref(msg)) == -1)
     {
       msg_error("kafka: failed to publish message",
-                owner->topicname_is_a_template ? evt_tag_str("topic", topic_name_new->str) :
-                evt_tag_str("topic", owner->topic_name),
+                evt_tag_str("topic", rd_kafka_topic_name(topic)),
                 evt_tag_str("error", rd_kafka_err2str(rd_kafka_last_error())),
                 evt_tag_str("driver", owner->super.super.super.id),
                 log_pipe_location_tag(&owner->super.super.super.super));
-      g_string_free(topic_name_new, TRUE);
+
       return FALSE;
     }
 
   msg_debug("kafka: message published",
-            owner->topicname_is_a_template ? evt_tag_str("topic", topic_name_new->str) :
-            evt_tag_str("topic", owner->topic_name),
+            evt_tag_str("topic", rd_kafka_topic_name(topic)),
             evt_tag_str("key", self->key->len ? self->key->str : "NULL"),
             evt_tag_str("message", self->message->str),
             evt_tag_str("driver", owner->super.super.super.id),
             log_pipe_location_tag(&owner->super.super.super.super));
-  g_string_free(topic_name_new, TRUE);
+
   /* we passed the allocated buffers to rdkafka, which will eventually free them */
   g_string_steal(self->message);
   return TRUE;
@@ -144,8 +161,9 @@ _drain_responses(KafkaDestWorker *self)
   if (count != 0)
     {
       msg_trace("kafka: destination side rd_kafka_poll() processed some responses",
-                owner->topicname_is_a_template ? evt_tag_str("template", owner->topic_name):
-                evt_tag_str("topic", owner->topic_name),
+                kafka_dd_is_topic_name_a_template(owner) ? evt_tag_str("template", owner->topic_name->template):
+                evt_tag_str("topic", owner->topic_name->template),
+                evt_tag_str("fallback_topic", owner->fallback_topic_name),
                 evt_tag_int("count", count),
                 evt_tag_str("driver", owner->super.super.super.id),
                 log_pipe_location_tag(&owner->super.super.super.super));
@@ -178,6 +196,7 @@ kafka_dest_worker_free(LogThreadedDestWorker *s)
   KafkaDestWorker *self = (KafkaDestWorker *)s;
   g_string_free(self->key, TRUE);
   g_string_free(self->message, TRUE);
+  g_string_free(self->topic_name_buffer, TRUE);
   log_threaded_dest_worker_free_method(s);
 }
 
@@ -210,5 +229,7 @@ kafka_dest_worker_new(LogThreadedDestDriver *o, gint worker_index)
 
   self->key = g_string_sized_new(0);
   self->message = g_string_sized_new(1024);
+  self->topic_name_buffer = g_string_sized_new(256);
+
   return &self->super;
 }

--- a/modules/kafka/kafka-dest-worker.c
+++ b/modules/kafka/kafka-dest-worker.c
@@ -61,8 +61,10 @@ _publish_message(KafkaDestWorker *self, LogMessage *msg)
 {
   KafkaDestDriver *owner = (KafkaDestDriver *) self->super.owner;
   int block_flag = _is_poller_thread(self) ? 0 : RD_KAFKA_MSG_F_BLOCK;
-
-  if (rd_kafka_produce(owner->topic,
+  gchar *topicname = g_strdup_printf("worker%d",self->super.worker_index);
+  msg_error("DEBUG STATEMENT TO CHECK INDEX", evt_tag_str("tn", topicname));
+  rd_kafka_topic_t *topic1 = rd_kafka_topic_new(owner->kafka, topicname, NULL);
+  if (rd_kafka_produce(topic1,
                        RD_KAFKA_PARTITION_UA,
                        RD_KAFKA_MSG_F_FREE | block_flag,
                        self->message->str, self->message->len,
@@ -74,17 +76,20 @@ _publish_message(KafkaDestWorker *self, LogMessage *msg)
                 evt_tag_str("error", rd_kafka_err2str(rd_kafka_last_error())),
                 evt_tag_str("driver", owner->super.super.super.id),
                 log_pipe_location_tag(&owner->super.super.super.super));
-
+                g_free(topicname);
+                if (topic1)
+                  rd_kafka_topic_destroy(topic1);
       return FALSE;
     }
-
   msg_debug("kafka: message published",
             evt_tag_str("topic", owner->topic_name),
             evt_tag_str("key", self->key->len ? self->key->str : "NULL"),
             evt_tag_str("message", self->message->str),
             evt_tag_str("driver", owner->super.super.super.id),
             log_pipe_location_tag(&owner->super.super.super.super));
-
+  g_free(topicname);
+  if (topic1)
+    rd_kafka_topic_destroy(topic1);
   /* we passed the allocated buffers to rdkafka, which will eventually free them */
   g_string_steal(self->message);
   return TRUE;
@@ -137,15 +142,48 @@ static LogThreadedResult
 kafka_dest_worker_insert(LogThreadedDestWorker *s, LogMessage *msg)
 {
   KafkaDestWorker *self = (KafkaDestWorker *)s;
+  KafkaDestDriver *owner = (KafkaDestDriver *) self->super.owner;
+  if (owner->topicname_is_a_template)
+    {
+      msg_error("Is a template");
+      GString *topic_name_new = g_string_sized_new(128);
+      LogTemplate *temp_topic_name = log_template_new(configuration, NULL);
+      log_template_compile(temp_topic_name, owner->topic_name, NULL);
+      log_template_format(temp_topic_name, msg, &owner->template_options, LTZ_SEND, self->super.seq_num, NULL, topic_name_new);
+      log_template_unref(temp_topic_name);
+      msg_error("PRINT TOPIC NAME", evt_tag_str("topicname", topic_name_new->str));
+      rd_kafka_topic_t *topic;
+      g_static_mutex_lock(&owner->lock);
+      topic = g_hash_table_lookup(owner->topic_hash, topic_name_new->str);
+      g_static_mutex_unlock(&owner->lock);
+      if(topic)
+       {
+         msg_error("TOPIC ALREADY EXISTS");
+       }
+      else
+      {
+        msg_error("CREATED NEW TOPIC");
+        topic = rd_kafka_topic_new(owner->kafka, topic_name_new->str, NULL);
+        g_static_mutex_lock(&owner->lock);
+        g_hash_table_insert(owner->topic_hash, g_strdup(topic_name_new->str), topic);
+        g_static_mutex_unlock(&owner->lock);
+      }
 
-  _drain_responses(self);
+      g_string_free(topic_name_new, TRUE);
+      return LTR_SUCCESS;
+    }
+  else
+    {
+      msg_error("Not a template");
+      _drain_responses(self);
+      _format_message_and_key(self, msg);
+      if (!_publish_message(self, msg))
+        return LTR_RETRY;
+      _drain_responses(self);
+      return LTR_SUCCESS;
+    }
 
-  _format_message_and_key(self, msg);
-  if (!_publish_message(self, msg))
-    return LTR_RETRY;
-
-  _drain_responses(self);
-  return LTR_SUCCESS;
+  
 }
 
 static void

--- a/modules/kafka/kafka-grammar.ym
+++ b/modules/kafka/kafka-grammar.ym
@@ -56,6 +56,7 @@
 
 %token KW_KAFKA
 %token KW_TOPIC
+%token KW_FALLBACK_TOPIC
 %token KW_CONFIG
 %token KW_WORKERS
 %token KW_FLUSH_TIMEOUT_ON_SHUTDOWN
@@ -82,11 +83,15 @@ kafka_options
         ;
 
 kafka_option
-        : KW_TOPIC '(' string ')'
+        : KW_TOPIC '(' template_content ')'
         {
             kafka_dd_set_topic(last_driver, $3);
-            free($3);
         }
+        | KW_FALLBACK_TOPIC '(' string ')'
+        {
+            kafka_dd_set_fallback_topic(last_driver, $3);
+            free($3);
+        } 
         | KW_CONFIG '(' kafka_properties ')'
         {
             kafka_dd_merge_config(last_driver, $3);

--- a/modules/kafka/kafka-internal.h
+++ b/modules/kafka/kafka-internal.h
@@ -1,8 +1,7 @@
 /*
- * Copyright (c) 2013 Tihamer Petrovics <tihameri@gmail.com>
- * Copyright (c) 2014 Pierre-Yves Ritschard <pyr@spootnik.org>
- * Copyright (c) 2019 Balabit
- * Copyright (c) 2019 Balazs Scheidler
+ * Copyright (c) 2020 Balabit
+ * Copyright (c) 2020 Balazs Scheidler
+ * Copyright (c) 2020 Vivin Peris
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -22,20 +21,19 @@
  * COPYING for details.
  *
  */
-#ifndef KAFKA_DEST_WORKER_H_INCLUDED
-#define KAFKA_DEST_WORKER_H_INCLUDED
+
+#ifndef KAFKA_INTERNAL_H_INCLUDED
+#define KAFKA_INTERNAL_H_INCLUDED
 
 #include "logthrdest/logthrdestdrv.h"
+#include <librdkafka/rdkafka.h>
+#include "kafka-dest-worker.h"
 
-typedef struct _KafkaDestWorker
-{
-  LogThreadedDestWorker super;
-  struct iv_timer poll_timer;
-  GString *key;
-  GString *message;
-  GString *topic_name_buffer;
-} KafkaDestWorker;
-
-LogThreadedDestWorker *kafka_dest_worker_new(LogThreadedDestDriver *owner, gint worker_index);
+gchar *kafka_dest_worker_resolve_template_topic_name(KafkaDestWorker *self, LogMessage *msg);
+rd_kafka_topic_t *kafka_dest_worker_calculate_topic_from_template(KafkaDestWorker *self, LogMessage *msg);
+rd_kafka_topic_t *kafka_dest_worker_get_literal_topic(KafkaDestWorker *self);
+rd_kafka_topic_t *kafka_dest_worker_calculate_topic(KafkaDestWorker *self, LogMessage *msg);
+gboolean kafka_dd_init(LogPipe *s);
 
 #endif
+

--- a/modules/kafka/kafka-parser.c
+++ b/modules/kafka/kafka-parser.c
@@ -32,6 +32,7 @@ int kafka_parse(CfgLexer *lexer, LogDriver **instance, gpointer arg);
 static CfgLexerKeyword kafka_keywords[] =
 {
   { "topic",          KW_TOPIC },
+  { "fallback_topic", KW_FALLBACK_TOPIC},
 
   /* https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md */
   { "config",         KW_CONFIG },

--- a/modules/kafka/tests/CMakeLists.txt
+++ b/modules/kafka/tests/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_unit_test(CRITERION LIBTEST TARGET test_kafka-props DEPENDS kafka)
+add_unit_test(CRITERION LIBTEST TARGET test_kafka_topic DEPENDS kafka rdkafka)

--- a/modules/kafka/tests/Makefile.am
+++ b/modules/kafka/tests/Makefile.am
@@ -1,17 +1,36 @@
 if ENABLE_KAFKA
 
 modules_kafka_tests_TESTS			= \
-	modules/kafka/tests/test_kafka_props
+	modules/kafka/tests/test_kafka_props \
+	modules/kafka/tests/test_kafka_topic
 
 check_PROGRAMS					+= ${modules_kafka_tests_TESTS}
 
 modules_kafka_tests_test_kafka_props_SOURCES = 	\
 	modules/kafka/tests/test_kafka-props.c
+
+modules_kafka_tests_test_kafka_topic_SOURCES = \
+	modules/kafka/tests/test_kafka_topic.c
+
 modules_kafka_tests_test_kafka_props_DEPENDENCIES =      \
         $(top_builddir)/modules/kafka/libkafka.la
+
+modules_kafka_tests_test_kafka_topic_DEPENDENCIES =      \
+        $(top_builddir)/modules/kafka/libkafka.la  
+
 modules_kafka_tests_test_kafka_props_CFLAGS	= $(TEST_CFLAGS) -I$(top_srcdir)/modules/kafka
-modules_kafka_tests_test_kafka_props_LDADD	= $(TEST_LDADD)
+
+modules_kafka_tests_test_kafka_topic_CFLAGS	= $(TEST_CFLAGS) -I$(top_srcdir)/modules/kafka
+
+modules_kafka_tests_test_kafka_props_LDADD	= $(TEST_LDADD) 
+
+modules_kafka_tests_test_kafka_topic_LDADD	= $(TEST_LDADD) $(LIBRDKAFKA_LIBS)
+
 modules_kafka_tests_test_kafka_props_LDFLAGS	= \
+	-dlpreopen $(top_builddir)/modules/kafka/libkafka.la
+
+
+modules_kafka_tests_test_kafka_topic_LDFLAGS	= \
 	-dlpreopen $(top_builddir)/modules/kafka/libkafka.la
 
 

--- a/modules/kafka/tests/test_kafka_topic.c
+++ b/modules/kafka/tests/test_kafka_topic.c
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2020 Balabit
+ * Copyright (c) 2020 Balazs Scheidler
+ * Copyright (c) 2020 Vivin Peris
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include <syslog-ng.h>
+#include <apphook.h>
+#include "logthrdest/logthrdestdrv.h"
+#include "kafka-dest-driver.h"
+#include <librdkafka/rdkafka.h>
+#include "kafka-dest-worker.h"
+#include "kafka-dest-driver.h"
+#include "kafka-internal.h"
+
+#include <criterion/criterion.h>
+#include <criterion/parameterized.h>
+
+#define STRING_250_LEN "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+                       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+                       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+                       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+                       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+#define STRING_249_LEN "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+                       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+                       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+                       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
+                       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+struct valid_topic_test_params
+{
+  gchar *topic_name;
+};
+
+struct invalid_topic_test_params
+{
+  gchar *topic_name;
+  enum KafkaTopicError type;
+};
+
+static void
+setup(void)
+{
+  app_startup();
+}
+
+static void
+teardown(void)
+{
+  app_shutdown();
+}
+
+static void
+_init_topic_names(LogDriver *driver, const gchar *topic, const gchar *fallback_topic)
+{
+  LogTemplate *topic_name = log_template_new(configuration, NULL);
+
+  log_template_compile(topic_name, topic, NULL);
+  kafka_dd_set_topic(driver, topic_name);
+  kafka_dd_set_fallback_topic(driver, fallback_topic);
+}
+
+TestSuite(kafka_topic, .init = setup, .fini = teardown);
+
+ParameterizedTestParameters(kafka_topic, valid_topic_tests)
+{
+  static struct valid_topic_test_params params[] =
+  {
+    {"validname123"},
+    {"valid.name123"},
+    {"valid-name123"},
+    {"valid_name123"},
+    {"valid.name-123"},
+    {"valid_name-123"},
+    {"This.is.a.valid.name"},
+    {"This.is-a_valid-name"},
+    {STRING_249_LEN},
+  };
+
+  return cr_make_param_array(struct valid_topic_test_params, params, G_N_ELEMENTS(params));
+}
+
+ParameterizedTest(struct valid_topic_test_params *param, kafka_topic, valid_topic_tests)
+{
+  GError *error = NULL;
+  cr_assert_eq(kafka_dd_validate_topic_name(param->topic_name, &error), TRUE);
+  cr_assert_null(error);
+}
+
+ParameterizedTestParameters(kafka_topic, invalid_topic_tests)
+{
+  static struct invalid_topic_test_params params[] =
+  {
+    {"test 1", TOPIC_INVALID_PATTERN},
+    {"", TOPIC_LENGTH_ZERO},
+    {"..", TOPIC_DOT_TWO_DOTS},
+    {".", TOPIC_DOT_TWO_DOTS},
+    {" invalidname", TOPIC_INVALID_PATTERN},
+    {"a*123", TOPIC_INVALID_PATTERN},
+    {"topic@123", TOPIC_INVALID_PATTERN},
+    {"aba#2", TOPIC_INVALID_PATTERN},
+    {"dontuse&", TOPIC_INVALID_PATTERN},
+    {"illegal%", TOPIC_INVALID_PATTERN},
+    {"name!", TOPIC_INVALID_PATTERN},
+    {"topics^", TOPIC_INVALID_PATTERN},
+    {"round()", TOPIC_INVALID_PATTERN},
+    {"sum+", TOPIC_INVALID_PATTERN},
+    {"topic=name", TOPIC_INVALID_PATTERN},
+    {"topic``~invalid", TOPIC_INVALID_PATTERN},
+    {STRING_250_LEN, TOPIC_EXCEEDS_MAX_LENGTH},
+  };
+
+  return cr_make_param_array(struct invalid_topic_test_params, params, G_N_ELEMENTS(params));
+}
+
+ParameterizedTest(struct invalid_topic_test_params *param, kafka_topic, invalid_topic_tests)
+{
+  GError *error = NULL;
+  cr_assert_eq(kafka_dd_validate_topic_name(param->topic_name, &error), FALSE);
+  cr_assert_eq(error->domain, TOPIC_NAME_ERROR);
+  cr_assert_eq(error->code, param->type);
+  cr_assert_not_null(error);
+  g_error_free(error);
+}
+
+Test(kafka_topic, test_resolve_template_topic_name)
+{
+  configuration = cfg_new_snippet();
+  LogDriver *driver = kafka_dd_new(configuration);
+
+  _init_topic_names(driver, "$kafka_topic", "fallbacktopicname");
+
+  cr_assert(kafka_dd_init((LogPipe *) driver));
+
+  KafkaDestDriver *kafka_driver = (KafkaDestDriver *) driver;
+
+  KafkaDestWorker *worker = (KafkaDestWorker *) kafka_dest_worker_new(&kafka_driver->super, 0);
+
+  LogMessage *msg = log_msg_new_empty();
+  log_msg_set_value_by_name(msg, "kafka_topic", "valid_template_topic", -1);
+  cr_assert_str_eq(kafka_dest_worker_resolve_template_topic_name(worker, msg), "valid_template_topic");
+
+  log_msg_set_value_by_name(msg, "kafka_topic", "invalid name", -1);
+
+  cr_assert_str_eq(kafka_dest_worker_resolve_template_topic_name(worker, msg), "fallbacktopicname");
+
+  log_msg_unref(msg);
+
+  log_threaded_dest_worker_free(&worker->super);
+  log_pipe_deinit(&driver->super);
+  log_pipe_unref(&driver->super);
+  cfg_free(configuration);
+}
+
+Test(kafka_topic, test_calculate_topic_from_template)
+{
+  configuration = cfg_new_snippet();
+  LogDriver *driver = kafka_dd_new(configuration);
+
+  _init_topic_names(driver, "$kafka_topic", "fallbackhere");
+
+  cr_assert(kafka_dd_init((LogPipe *) driver));
+
+  KafkaDestDriver *kafka_driver = (KafkaDestDriver *) driver;
+
+  KafkaDestWorker *worker = (KafkaDestWorker *) kafka_dest_worker_new(&kafka_driver->super, 0);
+
+  LogMessage *msg = log_msg_new_empty();
+
+  cr_assert(kafka_dd_is_topic_name_a_template(kafka_driver));
+
+  log_msg_set_value_by_name(msg, "kafka_topic", "validtopic", -1);
+  cr_assert_str_eq(rd_kafka_topic_name(kafka_dest_worker_calculate_topic_from_template(worker, msg)), "validtopic");
+
+  log_msg_set_value_by_name(msg, "kafka_topic", "invalid name", -1);
+
+  cr_assert_str_eq(rd_kafka_topic_name(kafka_dest_worker_calculate_topic_from_template(worker, msg)), "fallbackhere");
+
+  log_msg_unref(msg);
+
+  log_threaded_dest_worker_free(&worker->super);
+  log_pipe_deinit(&driver->super);
+  log_pipe_unref(&driver->super);
+  cfg_free(configuration);
+}
+
+Test(kafka_topic, test_get_literal_topic)
+{
+  configuration = cfg_new_snippet();
+  LogDriver *driver = kafka_dd_new(configuration);
+
+  _init_topic_names(driver, "topicname", "fallback");
+  cr_assert(kafka_dd_init((LogPipe *) driver));
+
+  KafkaDestDriver *kafka_driver = (KafkaDestDriver *) driver;
+
+  KafkaDestWorker *worker = (KafkaDestWorker *) kafka_dest_worker_new(&kafka_driver->super, 0);
+
+  cr_assert_not(kafka_dd_is_topic_name_a_template(kafka_driver));
+
+  LogMessage *msg = log_msg_new_empty();
+  cr_assert_str_eq(rd_kafka_topic_name(kafka_dest_worker_get_literal_topic(worker)), "topicname");
+
+  log_msg_unref(msg);
+  log_threaded_dest_worker_free(&worker->super);
+  log_pipe_deinit(&driver->super);
+  log_pipe_unref(&driver->super);
+  cfg_free(configuration);
+}
+
+Test(kafka_topic, test_calculate_topic)
+{
+  configuration = cfg_new_snippet();
+  LogDriver *driver = kafka_dd_new(configuration);
+
+  _init_topic_names(driver, "$kafka_topic", "fallbackhere");
+
+  cr_assert(kafka_dd_init((LogPipe *) driver));
+
+  KafkaDestDriver *kafka_driver = (KafkaDestDriver *) driver;
+
+  KafkaDestWorker *worker = (KafkaDestWorker *) kafka_dest_worker_new(&kafka_driver->super, 0);
+
+  LogMessage *msg = log_msg_new_empty();
+
+  cr_assert(kafka_dd_is_topic_name_a_template(kafka_driver));
+
+  log_msg_set_value_by_name(msg, "kafka_topic", "validtopic", -1);
+  cr_assert_str_eq(rd_kafka_topic_name(kafka_dest_worker_calculate_topic(worker, msg)), "validtopic");
+
+  log_msg_set_value_by_name(msg, "kafka_topic", "invalid name", -1);
+
+  cr_assert_str_eq(rd_kafka_topic_name(kafka_dest_worker_calculate_topic(worker, msg)), "fallbackhere");
+
+  log_msg_unref(msg);
+
+  log_threaded_dest_worker_free(&worker->super);
+  log_pipe_deinit(&driver->super);
+  log_pipe_unref(&driver->super);
+  cfg_free(configuration);
+}


### PR DESCRIPTION
The librdkafka based Kafka implementation doesn't support template syntax in the topic parameter. This patch implements the same.
The flow is as follows
Case 1 - Topic name isn't a template.
Here, we check if the topic name is valid. If the topic name isn't valid, we return a run time error. Here, we don't need fallback topic even though the grammar allows for the same since its not possible for a message publish failure due to a VALID topic name to be fixed by another valid topic name.

Case 2 - Topic name is a template.
Here, we first check if the topic name is in hashmap. If it isn't present, we check  If it is valid, then we insert the valid topic name into hash map. In case topic name isn't valid, we use the fallback topic which has to be defined(as the driver would generate run time error)

The validation for topic is based on the logic provided in the official Apache Kafka repository.