### PR TITLE
stats-query: speedup

### DIFF
--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -167,7 +167,7 @@ _query_counter_hash(const gchar *key_str)
       if (_is_pattern_matches_key(pattern, key))
         {
           StatsCounterItem *counter = (StatsCounterItem *) value;
-          counters = g_list_append(counters, counter);
+          counters = g_list_prepend(counters, counter);
 
           if (single_match)
             break;
@@ -176,7 +176,7 @@ _query_counter_hash(const gchar *key_str)
   g_static_mutex_unlock(&stats_query_mutex);
 
   g_pattern_spec_free(pattern);
-  return counters;
+  return g_list_reverse(counters);
 }
 
 static GList *
@@ -210,10 +210,10 @@ _get_aggregated_counters_from_views(GList *views)
         continue;
 
       view->aggregate(counters, &view->counter);
-      aggregated_counters = g_list_append(aggregated_counters, view->counter);
+      aggregated_counters = g_list_prepend(aggregated_counters, view->counter);
       g_list_free(counters);
     }
-  return aggregated_counters;
+  return g_list_reverse(aggregated_counters);
 }
 
 static GList *
@@ -234,7 +234,7 @@ _get_views(const gchar *filter)
       if (_is_pattern_matches_key(pattern, key))
         {
           ViewRecord *view = (ViewRecord *) value;
-          views = g_list_append(views, view);
+          views = g_list_prepend(views, view);
 
           if (single_match)
             break;
@@ -243,7 +243,7 @@ _get_views(const gchar *filter)
   g_static_mutex_unlock(&stats_query_mutex);
 
   g_pattern_spec_free(pattern);
-  return views;
+  return g_list_reverse(views);
 }
 
 static GList *

--- a/news/bugfix-3376.md
+++ b/news/bugfix-3376.md
@@ -1,0 +1,3 @@
+`stats-query`: speedup `syslog-ng-ctl query get "*"` command.
+
+An algorithmic error view made `syslog-ng-ctl query get "*"` very slow with large number of counters.


### PR DESCRIPTION
This  patchset speeds up `syslog-ng-ctl query get "*"` command. When the stats counters were collected into a list, they were appended instead of prepend and reverse in the end. The former is quadratic in complexity, the latter is linear. This made `query` impractical to be used with large number of counters.

PS: I experimented with `stats` too, but me seemed changing `num` changes the execution time linearly. So I believe there is no such problem with stats.

```
@version: 3.29

options {
 stats-level(3);
};

log {
  source { example-msg-generator(freq(0) num(50000)
                                 values("HOST" => "host$(iterate $(+ 1 $_) 0)") keep-hostname(yes)); };
  destination { file(/dev/null); };
};
```

Before:
```
$ time ./syslog-ng-ctl query get "*" | wc -l
194637

real	0m59.636s
user	0m0.003s
sys	0m0.019s
```
After:

```
$ time ./syslog-ng-ctl query get "*" | wc -l
200057

real	0m0.160s
user	0m0.011s
sys	0m0.014s
```

In the same scenario, stats is a bit slower, but not significantly.

```
$ time ./syslog-ng-ctl stats | wc -l
200058

real	0m0.356s
user	0m0.015s
sys	0m0.008s
```