### PR TITLE
DBLD: Fix docker build for centos6 and debian sid

### DIFF
--- a/dbld/builddeps
+++ b/dbld/builddeps
@@ -187,9 +187,18 @@ function install_pip_packages {
             ;;
     esac
     for python_executable in ${python_executables}; do
-        $python_executable -m pip install --upgrade pip
-        $python_executable -m pip install --upgrade setuptools
-        filter_packages_by_platform $DBLD_DIR/pip_packages.manifest | xargs $python_executable -m pip install --ignore-installed -U
+        case "${OS_PLATFORM}" in
+            centos-6)
+                pip install --upgrade pip==9.0.3
+                pip install --upgrade setuptools
+                filter_packages_by_platform $DBLD_DIR/pip_packages.manifest | xargs pip install --ignore-installed -U
+                ;;
+            *)
+                $python_executable -m pip install --upgrade pip
+                $python_executable -m pip install --upgrade setuptools
+                filter_packages_by_platform $DBLD_DIR/pip_packages.manifest | xargs $python_executable -m pip install --ignore-installed -U
+                ;;
+        esac
     done
 }
 

--- a/dbld/packages.manifest
+++ b/dbld/packages.manifest
@@ -84,7 +84,8 @@ automake                    [centos, fedora]
 #
 # We are now using the same version for both.
 
-python-dev                  [debian, ubuntu-xenial, ubuntu-bionic]
+python-dev                  [debian-stretch, debian-buster, ubuntu-xenial, ubuntu-bionic]
+python2-dev                 [debian-sid]
 python-devel                [centos, fedora]
 python3-devel               [fedora]
 python3-dev                 [ubuntu-focal]


### PR DESCRIPTION

- This PR fixes python related docker builds for CentOS-6 and Debian-Sid