### PR TITLE
Fixed location reporting and long lines in config errors

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -903,7 +903,7 @@ template_content_inner
           CHECK_ERROR_GERROR(log_template_compile(last_template, $3, &error), @3, error, "Error compiling template");
           free($3);
 
-          CHECK_ERROR_GERROR(log_template_set_type_hint(last_template, $1, &error), @1, error, "Error setting the template type-hint");
+          CHECK_ERROR_GERROR(log_template_set_type_hint(last_template, $1, &error), @1, error, "Error setting the template type-hint \"%s\"", $1);
           free($1);
         }
         ;
@@ -985,7 +985,7 @@ options_item
         | KW_MARK_MODE '(' KW_INTERNAL ')'         { cfg_set_mark_mode(configuration, "internal"); }
         | KW_MARK_MODE '(' string ')'
           {
-            CHECK_ERROR(cfg_lookup_mark_mode($3) > 0 && cfg_lookup_mark_mode($3) != MM_GLOBAL, @3, "illegal global mark-mode");
+            CHECK_ERROR(cfg_lookup_mark_mode($3) > 0 && cfg_lookup_mark_mode($3) != MM_GLOBAL, @3, "illegal global mark-mode \"%s\"", $3);
             cfg_set_mark_mode(configuration, $3);
             free($3);
           }
@@ -1295,7 +1295,7 @@ threaded_fetcher_driver_option
 threaded_source_driver_option_flags
 	: string threaded_source_driver_option_flags
         {
-          CHECK_ERROR(msg_format_options_process_flag(log_threaded_source_driver_get_parse_options(last_driver), $1), @1, "Unknown flag %s", $1);
+          CHECK_ERROR(msg_format_options_process_flag(log_threaded_source_driver_get_parse_options(last_driver), $1), @1, "Unknown flag \"%s\"", $1);
           free($1);
         }
         |
@@ -1331,7 +1331,7 @@ source_reader_option
 	;
 
 source_reader_option_flags
-        : string source_reader_option_flags     { CHECK_ERROR(log_reader_options_process_flag(last_reader_options, $1), @1, "Unknown flag %s", $1); free($1); }
+        : string source_reader_option_flags     { CHECK_ERROR(log_reader_options_process_flag(last_reader_options, $1), @1, "Unknown flag \"%s\"", $1); free($1); }
         | KW_CHECK_HOSTNAME source_reader_option_flags     { log_reader_options_process_flag(last_reader_options, "check-hostname"); }
 	|
 	;
@@ -1342,7 +1342,7 @@ source_proto_option
           {
             CHECK_ERROR(log_proto_server_options_set_encoding(last_proto_server_options, $3),
                         @3,
-                        "unknown encoding %s", $3);
+                        "unknown encoding \"%s\"", $3);
             free($3);
           }
         | KW_LOG_MSG_SIZE '(' positive_integer ')'      { last_proto_server_options->max_msg_size = $3; }
@@ -1397,7 +1397,7 @@ dest_writer_option
         | KW_MARK_MODE '(' KW_INTERNAL ')'      { log_writer_options_set_mark_mode(last_writer_options, "internal"); }
 	| KW_MARK_MODE '(' string ')'
 	  {
-	    CHECK_ERROR(cfg_lookup_mark_mode($3) != -1, @3, "illegal mark mode: %s", $3);
+	    CHECK_ERROR(cfg_lookup_mark_mode($3) != -1, @3, "illegal mark mode \"%s\"", $3);
             log_writer_options_set_mark_mode(last_writer_options, $3);
             free($3);
           }
@@ -1434,7 +1434,7 @@ template_option
         {
           gint on_error;
 
-          CHECK_ERROR(log_template_on_error_parse($3, &on_error), @3, "Invalid on-error() setting");
+          CHECK_ERROR(log_template_on_error_parse($3, &on_error), @3, "Invalid on-error() setting \"%s\"", $3);
           free($3);
 
           log_template_options_set_on_error(last_template_options, on_error);
@@ -1442,12 +1442,12 @@ template_option
 	;
 
 matcher_option
-        : KW_TYPE '(' string ')'		{ CHECK_ERROR(log_matcher_options_set_type(last_matcher_options, $3), @3, "unknown matcher type"); free($3); }
+        : KW_TYPE '(' string ')'		{ CHECK_ERROR(log_matcher_options_set_type(last_matcher_options, $3), @3, "unknown matcher type \"%s\"", $3); free($3); }
         | KW_FLAGS '(' matcher_flags ')'
         ;
 
 matcher_flags
-        : string matcher_flags			{ CHECK_ERROR(log_matcher_options_process_flag(last_matcher_options, $1), @1, "unknown matcher flag"); free($1); }
+        : string matcher_flags			{ CHECK_ERROR(log_matcher_options_process_flag(last_matcher_options, $1), @1, "unknown matcher flag \"%s\"", $1); free($1); }
         |
         ;
 

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -332,32 +332,42 @@ report_syntax_error(CfgLexer *lexer, YYLTYPE *yylloc, const char *what, const ch
 
   for (from = level; from >= lexer->include_stack; from--)
     {
+      YYLTYPE *from_lloc;
+
       if (from == level)
         {
+          /* the location on the initial level is the one we get as
+           * argument, instead of what we have in the lexer's state.  This
+           * is because the lexer might be one token in advance (because of
+           * LALR) and the grammar is kind enough to pass us the original
+           * location.  */
+
+          from_lloc = yylloc;
           fprintf(stderr, "Error parsing %s, %s in %s:%d:%d-%d:%d:\n",
                   what,
                   msg,
-                  from->lloc.level->name,
-                  from->lloc.first_line,
-                  from->lloc.first_column,
-                  from->lloc.last_line,
-                  from->lloc.last_column);
+                  from_lloc->level->name,
+                  from_lloc->first_line,
+                  from_lloc->first_column,
+                  from_lloc->last_line,
+                  from_lloc->last_column);
         }
       else
         {
+          from_lloc = &from->lloc;
           fprintf(stderr, "Included from %s:%d:%d-%d:%d:\n", from->name,
-                  from->lloc.first_line,
-                  from->lloc.first_column,
-                  from->lloc.last_line,
-                  from->lloc.last_column);
+                  from_lloc->first_line,
+                  from_lloc->first_column,
+                  from_lloc->last_line,
+                  from_lloc->last_column);
         }
       if (from->include_type == CFGI_FILE)
         {
-          _report_file_location(from->name, &from->lloc);
+          _report_file_location(from->name, from_lloc);
         }
       else if (from->include_type == CFGI_BUFFER)
         {
-          _report_buffer_location(from->buffer.original_content, &from->lloc);
+          _report_buffer_location(from->buffer.original_content, from_lloc);
         }
       fprintf(stderr, "\n");
     }

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -270,14 +270,15 @@ _report_file_location(const gchar *filename, YYLTYPE *yylloc)
 {
   FILE *f;
   gint lineno = 0;
-  gchar buf[1024];
+  gsize buflen = 65520;
+  gchar *buf = g_malloc(buflen);
   GPtrArray *context = g_ptr_array_new();
   gint error_index = 0;
 
   f = fopen(filename, "r");
   if (f)
     {
-      while (fgets(buf, sizeof(buf), f))
+      while (fgets(buf, buflen, f))
         {
           lineno++;
           if (lineno > (gint) yylloc->first_line + CONTEXT)
@@ -297,6 +298,7 @@ _report_file_location(const gchar *filename, YYLTYPE *yylloc)
   _print_underlined_source_block(yylloc, (gchar **) context->pdata, error_index);
 
 exit:
+  g_free(buf);
   g_ptr_array_foreach(context, (GFunc) g_free, NULL);
   g_ptr_array_free(context, TRUE);
 }

--- a/news/bugfix-3383.md
+++ b/news/bugfix-3383.md
@@ -1,0 +1,4 @@
+config: fix error reporting
+
+- Error reporting was fixed for lines longer than 1024 characters.
+- The location of the error was incorrectly reported in some cases.


### PR DESCRIPTION
This branch fixes a couple of issues in configuration error reporting:

1) when the configuration file has lines longer than 1024 bytes, the report could become confusing
2) the location of the error was incorrectly reported in some cases

+1 I've added the parsed value to the main grammar error message for cases where the value is a string.

All this together would probably have avoided the bug report in #3382 