### PR TITLE
Unit tests for kafka topic name

### DIFF
--- a/modules/kafka/kafka-dest-driver.c
+++ b/modules/kafka/kafka-dest-driver.c
@@ -36,12 +36,21 @@
  */
 
 void
-kafka_dd_set_topic(LogDriver *d, const gchar *topic)
+kafka_dd_set_topic(LogDriver *d, LogTemplate *topic)
 {
   KafkaDestDriver *self = (KafkaDestDriver *)d;
 
-  g_free(self->topic_name);
-  self->topic_name = g_strdup(topic);
+  log_template_unref(self->topic_name);
+  self->topic_name = topic;
+}
+
+void
+kafka_dd_set_fallback_topic(LogDriver *d, const gchar *fallback_topic)
+{
+  KafkaDestDriver *self = (KafkaDestDriver *)d;
+
+  g_free(self->fallback_topic_name);
+  self->fallback_topic_name = g_strdup(fallback_topic);
 }
 
 void
@@ -111,6 +120,12 @@ kafka_dd_get_template_options(LogDriver *d)
   return &self->template_options;
 }
 
+gboolean
+kafka_dd_is_topic_name_a_template(KafkaDestDriver *self)
+{
+  return self->topic == NULL;
+}
+
 /* methods */
 
 static const gchar *
@@ -119,7 +134,7 @@ _format_stats_instance(LogThreadedDestDriver *d)
   KafkaDestDriver *self = (KafkaDestDriver *)d;
   static gchar stats_name[1024];
 
-  g_snprintf(stats_name, sizeof(stats_name), "kafka,%s", self->topic_name);
+  g_snprintf(stats_name, sizeof(stats_name), "kafka,%s", self->topic_name->template);
   return stats_name;
 }
 
@@ -132,7 +147,7 @@ _format_persist_name(const LogPipe *d)
   if (d->persist_name)
     g_snprintf(persist_name, sizeof(persist_name), "kafka.%s", d->persist_name);
   else
-    g_snprintf(persist_name, sizeof(persist_name), "kafka(%s)", self->topic_name);
+    g_snprintf(persist_name, sizeof(persist_name), "kafka(%s)", self->topic_name->template);
   return persist_name;
 }
 
@@ -142,6 +157,98 @@ _kafka_log_callback(const rd_kafka_t *rkt, int level, const char *fac, const cha
   gchar *buf = g_strdup_printf("librdkafka: %s(%d): %s", fac, level, msg);
   msg_event_send(msg_event_create(level, buf, NULL));
   g_free(buf);
+}
+
+
+static gboolean
+_contains_valid_pattern(const gchar *name)
+{
+  const gchar *p;
+  for (p = name; *p; p++)
+    {
+      if (!((*p >= 'a' && *p <= 'z') ||
+            (*p >= 'A' && *p <= 'Z') ||
+            (*p >= '0' && *p <= '9') ||
+            (*p == '_') || (*p == '-') || (*p == '.')))
+        {
+          return FALSE;
+        }
+    }
+  return TRUE;
+}
+
+static gboolean
+_validate_topic_name(KafkaDestDriver *self, const gchar *name)
+{
+  gint len = strlen(name);
+  if (len == 0)
+    {
+      msg_error("kafka: topic name is illegal, it can't be empty",
+                evt_tag_str("driver", self->super.super.super.id),
+                log_pipe_location_tag(&self->super.super.super.super));
+      return FALSE;
+    }
+
+  if ((!g_strcmp0(name, ".")) || !g_strcmp0(name, ".."))
+    {
+      msg_error("kafka: topic name cannot be . or ..", evt_tag_str("topic", name),
+                evt_tag_str("driver", self->super.super.super.id),
+                log_pipe_location_tag(&self->super.super.super.super));
+      return FALSE;
+    }
+
+  if (len > 249)
+    {
+      msg_error("kafka: topic name cannot be longer than 249 characters", evt_tag_str("topic", name),
+                evt_tag_int("length", len),
+                evt_tag_str("driver", self->super.super.super.id),
+                log_pipe_location_tag(&self->super.super.super.super));
+      return FALSE;
+    }
+
+  if (!_contains_valid_pattern(name))
+    {
+      msg_error("kafka: topic name is illegal as it contains characters other than pattern [\\-\\._a-zA-Z0-9]+",
+                evt_tag_str("topic", name),
+                evt_tag_str("driver", self->super.super.super.id),
+                log_pipe_location_tag(&self->super.super.super.super));
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+rd_kafka_topic_t *
+_construct_topic(KafkaDestDriver *self, const gchar *name)
+{
+  g_assert(self->kafka != NULL);
+  if (_validate_topic_name(self, name))
+    {
+      return rd_kafka_topic_new(self->kafka, name, NULL);
+    }
+  return NULL;
+}
+
+rd_kafka_topic_t *
+kafka_dd_query_insert_topic(KafkaDestDriver *self, const gchar *name)
+{
+  g_mutex_lock(&self->topics_lock);
+  rd_kafka_topic_t *topic = g_hash_table_lookup(self->topics, name);
+
+  if (topic)
+    {
+      g_mutex_unlock(&self->topics_lock);
+      return topic;
+    }
+
+  topic = _construct_topic(self, name);
+  if (topic)
+    {
+      g_hash_table_insert(self->topics, g_strdup(name), topic);
+    }
+
+  g_mutex_unlock(&self->topics_lock);
+  return topic;
 }
 
 static void
@@ -163,8 +270,8 @@ _kafka_delivery_report_cb(rd_kafka_t *rk,
       LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
 
       msg_debug("kafka: delivery report for message came back with an error, putting it back to our queue",
-                self->topicname_is_a_template ? evt_tag_str("template", self->topic_name):
-                evt_tag_str("topic", self->topic_name),
+                evt_tag_str("topic", self->topic_name->template),
+                evt_tag_str("fallback_topic", self->fallback_topic_name ? self->fallback_topic_name : "NULL"),
                 evt_tag_printf("message", "%.*s", (int) MIN(len, 128), (char *) payload),
                 evt_tag_str("error", rd_kafka_err2str(err)),
                 evt_tag_str("driver", self->super.super.super.id),
@@ -174,8 +281,8 @@ _kafka_delivery_report_cb(rd_kafka_t *rk,
   else
     {
       msg_debug("kafka: delivery report successful",
-                self->topicname_is_a_template ? evt_tag_str("template", self->topic_name):
-                evt_tag_str("topic", self->topic_name),
+                evt_tag_str("topic", self->topic_name->template),
+                evt_tag_str("fallback_topic", self->fallback_topic_name ? self->fallback_topic_name : "NULL"),
                 evt_tag_printf("message", "%.*s", (int) MIN(len, 128), (char *) payload),
                 evt_tag_str("error", rd_kafka_err2str(err)),
                 evt_tag_str("driver", self->super.super.super.id),
@@ -238,21 +345,12 @@ _construct_client(KafkaDestDriver *self)
   if (!client)
     {
       msg_error("kafka: error constructing the kafka connection object",
-                self->topicname_is_a_template ? evt_tag_str("template", self->topic_name):
-                evt_tag_str("topic", self->topic_name),
+                evt_tag_str("topic", self->topic_name->template),
                 evt_tag_str("error", errbuf),
                 evt_tag_str("driver", self->super.super.super.id),
                 log_pipe_location_tag(&self->super.super.super.super));
     }
   return client;
-}
-
-rd_kafka_topic_t *
-_construct_topic(KafkaDestDriver *self)
-{
-  g_assert(self->kafka != NULL);
-
-  return rd_kafka_topic_new(self->kafka, self->topic_name, NULL);
 }
 
 static LogThreadedDestWorker *
@@ -280,8 +378,9 @@ _flush_inflight_messages(KafkaDestDriver *self)
   if (outq_len > 0)
     {
       msg_notice("kafka: shutting down kafka producer, while messages are still in-flight, waiting for messages to flush",
-                 self->topicname_is_a_template ? evt_tag_str("template", self->topic_name):
-                 evt_tag_str("topic", self->topic_name),
+
+                 evt_tag_str("topic", self->topic_name->template),
+                 evt_tag_str("fallback_topic", self->fallback_topic_name ? self->fallback_topic_name : "NULL"),
                  evt_tag_int("outq_len", outq_len),
                  evt_tag_int("timeout", timeout),
                  evt_tag_str("driver", self->super.super.super.id),
@@ -291,8 +390,8 @@ _flush_inflight_messages(KafkaDestDriver *self)
   if (err != RD_KAFKA_RESP_ERR_NO_ERROR)
     {
       msg_error("kafka: error flushing accumulated messages during shutdown, rd_kafka_flush() returned failure, this might indicate that some in-flight messages are lost",
-                self->topicname_is_a_template ? evt_tag_str("template", self->topic_name):
-                evt_tag_str("topic", self->topic_name),
+                evt_tag_str("topic", self->topic_name->template),
+                evt_tag_str("fallback_topic", self->fallback_topic_name ? self->fallback_topic_name : "NULL"),
                 evt_tag_int("outq_len", rd_kafka_outq_len(self->kafka)),
                 evt_tag_str("error", rd_kafka_err2str(err)),
                 evt_tag_str("driver", self->super.super.super.id),
@@ -330,6 +429,43 @@ _purge_remaining_messages(KafkaDestDriver *self)
 }
 
 static gboolean
+_init_template_topic_name(KafkaDestDriver *self)
+{
+  msg_debug("kafka: The topic name is a template",
+            evt_tag_str("topic", self->topic_name->template),
+            evt_tag_str("driver", self->super.super.super.id),
+            log_pipe_location_tag(&self->super.super.super.super));
+
+  if (!self->fallback_topic_name)
+    {
+      msg_error("kafka: fallback_topic() required when the topic name is a template",
+                evt_tag_str("driver", self->super.super.super.id),
+                log_pipe_location_tag(&self->super.super.super.super));
+      return FALSE;
+    }
+
+  self->fallback_topic = _construct_topic(self, self->fallback_topic_name);
+
+  if (self->fallback_topic == NULL)
+    {
+      msg_error("kafka: error constructing the fallback topic object",
+                evt_tag_str("fallback_topic", self->fallback_topic_name),
+                evt_tag_str("driver", self->super.super.super.id),
+                log_pipe_location_tag(&self->super.super.super.super));
+      return FALSE;
+    }
+
+  self->topics = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, (GDestroyNotify) rd_kafka_topic_destroy);
+  return TRUE;
+}
+
+static gboolean
+_topic_name_is_a_template(KafkaDestDriver *self)
+{
+  return (strchr(self->topic_name->template, '$') != NULL);
+}
+
+static gboolean
 kafka_dd_init(LogPipe *s)
 {
   KafkaDestDriver *self = (KafkaDestDriver *)s;
@@ -345,41 +481,39 @@ kafka_dd_init(LogPipe *s)
                 log_pipe_location_tag(&self->super.super.super.super));
       return FALSE;
     }
-  if (strchr(self->topic_name, '$') != NULL)
-    {
-      self->topicname_is_a_template = TRUE;
-      self->topic_hash = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, (GDestroyNotify) rd_kafka_topic_destroy);
-      self->temp_topic_name = log_template_new(configuration, NULL);
-      log_template_compile(self->temp_topic_name, self->topic_name, NULL);
-    }
 
   self->kafka = _construct_client(self);
   if (self->kafka == NULL)
     {
       msg_error("kafka: error constructing kafka connection object, perhaps metadata.broker.list property is missing?",
-                self->topicname_is_a_template ? evt_tag_str("template", self->topic_name):
-                evt_tag_str("topic", self->topic_name),
+                evt_tag_str("topic", self->topic_name->template),
                 evt_tag_str("driver", self->super.super.super.id),
                 log_pipe_location_tag(&self->super.super.super.super));
       return FALSE;
     }
-  if(!self->topicname_is_a_template)
+
+  if (_topic_name_is_a_template(self))
     {
-      self->topic = _construct_topic(self);
+      if (!_init_template_topic_name(self))
+        {
+          return FALSE;
+        }
+    }
+
+  else
+    {
+      self->topic = _construct_topic(self, self->topic_name->template);
+
       if (self->topic == NULL)
         {
           msg_error("kafka: error constructing the kafka topic object",
-                    self->topicname_is_a_template ? evt_tag_str("template", self->topic_name):
-                    evt_tag_str("topic", self->topic_name),
+                    evt_tag_str("topic", self->topic_name->template),
                     evt_tag_str("driver", self->super.super.super.id),
                     log_pipe_location_tag(&self->super.super.super.super));
           return FALSE;
         }
     }
-  else
-    {
-      g_assert(self->kafka != NULL);
-    }
+
   if (self->message == NULL)
     {
       self->message = log_template_new(cfg, NULL);
@@ -388,8 +522,8 @@ kafka_dd_init(LogPipe *s)
 
   log_template_options_init(&self->template_options, cfg);
   msg_verbose("kafka: Kafka destination initialized",
-              self->topicname_is_a_template ? evt_tag_str("template", self->topic_name):
-              evt_tag_str("topic", self->topic_name),
+              evt_tag_str("topic", self->topic_name->template),
+              evt_tag_str("fallback_topic", self->fallback_topic_name ? self->fallback_topic_name : "NULL"),
               evt_tag_str("key", self->key ? self->key->template : "NULL"),
               evt_tag_str("message", self->message->template),
               evt_tag_str("driver", self->super.super.super.id),
@@ -414,18 +548,20 @@ kafka_dd_free(LogPipe *d)
   KafkaDestDriver *self = (KafkaDestDriver *)d;
 
   log_template_options_destroy(&self->template_options);
-  if(self->topic_hash)
-    g_hash_table_unref(self->topic_hash);
+  if (self->topics)
+    g_hash_table_unref(self->topics);
   log_template_unref(self->key);
   log_template_unref(self->message);
-  log_template_unref(self->temp_topic_name);
   if (self->topic)
     rd_kafka_topic_destroy(self->topic);
+  if (self->fallback_topic)
+    rd_kafka_topic_destroy(self->fallback_topic);
+  if (self->fallback_topic_name)
+    g_free(self->fallback_topic_name);
   if (self->kafka)
     rd_kafka_destroy(self->kafka);
-  if (self->topic_name)
-    g_free(self->topic_name);
-  g_mutex_free(&self->lock);
+  log_template_unref(self->topic_name);
+  g_mutex_free(&self->topics_lock);
   g_free(self->bootstrap_servers);
   kafka_property_list_free(self->config);
   log_threaded_dest_driver_free(d);

--- a/modules/kafka/kafka-dest-driver.c
+++ b/modules/kafka/kafka-dest-driver.c
@@ -340,6 +340,11 @@ kafka_dd_init(LogPipe *s)
                 log_pipe_location_tag(&self->super.super.super.super));
       return FALSE;
     }
+  if (strchr(self->topic_name, '$') != NULL)
+    {
+      self->topicname_is_a_template = TRUE;
+      self->topic_hash = g_hash_table_new(g_str_hash, g_str_equal);
+    }
 
   self->kafka = _construct_client(self);
   if (self->kafka == NULL)

--- a/modules/kafka/kafka-dest-driver.h
+++ b/modules/kafka/kafka-dest-driver.h
@@ -35,31 +35,32 @@ typedef struct
   LogTemplateOptions template_options;
   LogTemplate *key;
   LogTemplate *message;
-  LogTemplate *temp_topic_name;
-  GHashTable *topic_hash;
-  GMutex lock;
+  LogTemplate *topic_name;
+  GHashTable *topics;
+  GMutex topics_lock;
 
-  gchar *topic_name;
   GList *config;
   gchar *bootstrap_servers;
+  gchar *fallback_topic_name;
   rd_kafka_topic_t *topic;
+  rd_kafka_topic_t *fallback_topic;
   rd_kafka_t *kafka;
   gint flush_timeout_on_shutdown;
   gint flush_timeout_on_reload;
   gint poll_timeout;
-  gboolean topicname_is_a_template;
 } KafkaDestDriver;
 
-void kafka_dd_set_topic(LogDriver *d, const gchar *topic);
+void kafka_dd_set_topic(LogDriver *d, LogTemplate *topic);
+void kafka_dd_set_fallback_topic(LogDriver *d, const gchar *fallback_topic);
 void kafka_dd_merge_config(LogDriver *d, GList *props);
 void kafka_dd_set_bootstrap_servers(LogDriver *d, const gchar *bootstrap_servers);
-
 void kafka_dd_set_key_ref(LogDriver *d, LogTemplate *key);
 void kafka_dd_set_message_ref(LogDriver *d, LogTemplate *message);
 void kafka_dd_set_flush_timeout_on_shutdown(LogDriver *d, gint shutdown_timeout);
 void kafka_dd_set_flush_timeout_on_reload(LogDriver *d, gint reload_timeout);
 void kafka_dd_set_poll_timeout(LogDriver *d, gint poll_timeout);
-
+gboolean kafka_dd_is_topic_name_a_template(KafkaDestDriver *self);
+rd_kafka_topic_t *kafka_dd_query_insert_topic(KafkaDestDriver *self, const gchar *name);
 LogTemplateOptions *kafka_dd_get_template_options(LogDriver *d);
 
 LogDriver *kafka_dd_new(GlobalConfig *cfg);

--- a/modules/kafka/kafka-dest-driver.h
+++ b/modules/kafka/kafka-dest-driver.h
@@ -35,8 +35,9 @@ typedef struct
   LogTemplateOptions template_options;
   LogTemplate *key;
   LogTemplate *message;
+  LogTemplate *temp_topic_name;
   GHashTable *topic_hash;
-  GStaticMutex lock;
+  GMutex lock;
 
   gchar *topic_name;
   GList *config;

--- a/modules/kafka/kafka-dest-driver.h
+++ b/modules/kafka/kafka-dest-driver.h
@@ -35,6 +35,8 @@ typedef struct
   LogTemplateOptions template_options;
   LogTemplate *key;
   LogTemplate *message;
+  GHashTable *topic_hash;
+  GStaticMutex lock;
 
   gchar *topic_name;
   GList *config;
@@ -44,6 +46,7 @@ typedef struct
   gint flush_timeout_on_shutdown;
   gint flush_timeout_on_reload;
   gint poll_timeout;
+  gboolean topicname_is_a_template;
 } KafkaDestDriver;
 
 void kafka_dd_set_topic(LogDriver *d, const gchar *topic);

--- a/modules/kafka/kafka-dest-worker.c
+++ b/modules/kafka/kafka-dest-worker.c
@@ -61,8 +61,10 @@ _publish_message(KafkaDestWorker *self, LogMessage *msg)
 {
   KafkaDestDriver *owner = (KafkaDestDriver *) self->super.owner;
   int block_flag = _is_poller_thread(self) ? 0 : RD_KAFKA_MSG_F_BLOCK;
-
-  if (rd_kafka_produce(owner->topic,
+  gchar *topicname = g_strdup_printf("worker%d",self->super.worker_index);
+  msg_error("DEBUG STATEMENT TO CHECK INDEX", evt_tag_str("tn", topicname));
+  rd_kafka_topic_t *topic1 = rd_kafka_topic_new(owner->kafka, topicname, NULL);
+  if (rd_kafka_produce(topic1,
                        RD_KAFKA_PARTITION_UA,
                        RD_KAFKA_MSG_F_FREE | block_flag,
                        self->message->str, self->message->len,
@@ -74,17 +76,20 @@ _publish_message(KafkaDestWorker *self, LogMessage *msg)
                 evt_tag_str("error", rd_kafka_err2str(rd_kafka_last_error())),
                 evt_tag_str("driver", owner->super.super.super.id),
                 log_pipe_location_tag(&owner->super.super.super.super));
-
+                g_free(topicname);
+                if (topic1)
+                  rd_kafka_topic_destroy(topic1);
       return FALSE;
     }
-
   msg_debug("kafka: message published",
             evt_tag_str("topic", owner->topic_name),
             evt_tag_str("key", self->key->len ? self->key->str : "NULL"),
             evt_tag_str("message", self->message->str),
             evt_tag_str("driver", owner->super.super.super.id),
             log_pipe_location_tag(&owner->super.super.super.super));
-
+  g_free(topicname);
+  if (topic1)
+    rd_kafka_topic_destroy(topic1);
   /* we passed the allocated buffers to rdkafka, which will eventually free them */
   g_string_steal(self->message);
   return TRUE;
@@ -137,15 +142,48 @@ static LogThreadedResult
 kafka_dest_worker_insert(LogThreadedDestWorker *s, LogMessage *msg)
 {
   KafkaDestWorker *self = (KafkaDestWorker *)s;
+  KafkaDestDriver *owner = (KafkaDestDriver *) self->super.owner;
+  if (owner->topicname_is_a_template)
+    {
+      msg_error("Is a template");
+      GString *topic_name_new = g_string_sized_new(128);
+      LogTemplate *temp_topic_name = log_template_new(configuration, NULL);
+      log_template_compile(temp_topic_name, owner->topic_name, NULL);
+      log_template_format(temp_topic_name, msg, &owner->template_options, LTZ_SEND, self->super.seq_num, NULL, topic_name_new);
+      log_template_unref(temp_topic_name);
+      msg_error("PRINT TOPIC NAME", evt_tag_str("topicname", topic_name_new->str));
+      rd_kafka_topic_t *topic;
+      g_static_mutex_lock(&owner->lock);
+      topic = g_hash_table_lookup(owner->topic_hash, topic_name_new->str);
+      g_static_mutex_unlock(&owner->lock);
+      if(topic)
+       {
+         msg_error("TOPIC ALREADY EXISTS");
+       }
+      else
+      {
+        msg_error("CREATED NEW TOPIC");
+        topic = rd_kafka_topic_new(owner->kafka, topic_name_new->str, NULL);
+        g_static_mutex_lock(&owner->lock);
+        g_hash_table_insert(owner->topic_hash, g_strdup(topic_name_new->str), topic);
+        g_static_mutex_unlock(&owner->lock);
+      }
 
-  _drain_responses(self);
+      g_string_free(topic_name_new, TRUE);
+      return LTR_SUCCESS;
+    }
+  else
+    {
+      msg_error("Not a template");
+      _drain_responses(self);
+      _format_message_and_key(self, msg);
+      if (!_publish_message(self, msg))
+        return LTR_RETRY;
+      _drain_responses(self);
+      return LTR_SUCCESS;
+    }
 
-  _format_message_and_key(self, msg);
-  if (!_publish_message(self, msg))
-    return LTR_RETRY;
-
-  _drain_responses(self);
-  return LTR_SUCCESS;
+  
 }
 
 static void

--- a/modules/kafka/kafka-grammar.ym
+++ b/modules/kafka/kafka-grammar.ym
@@ -56,6 +56,7 @@
 
 %token KW_KAFKA
 %token KW_TOPIC
+%token KW_FALLBACK_TOPIC
 %token KW_CONFIG
 %token KW_WORKERS
 %token KW_FLUSH_TIMEOUT_ON_SHUTDOWN
@@ -82,11 +83,15 @@ kafka_options
         ;
 
 kafka_option
-        : KW_TOPIC '(' string ')'
+        : KW_TOPIC '(' template_content ')'
         {
             kafka_dd_set_topic(last_driver, $3);
-            free($3);
         }
+        | KW_FALLBACK_TOPIC '(' string ')'
+        {
+            kafka_dd_set_fallback_topic(last_driver, $3);
+            free($3);
+        } 
         | KW_CONFIG '(' kafka_properties ')'
         {
             kafka_dd_merge_config(last_driver, $3);

--- a/modules/kafka/kafka-parser.c
+++ b/modules/kafka/kafka-parser.c
@@ -32,6 +32,7 @@ int kafka_parse(CfgLexer *lexer, LogDriver **instance, gpointer arg);
 static CfgLexerKeyword kafka_keywords[] =
 {
   { "topic",          KW_TOPIC },
+  { "fallback_topic", KW_FALLBACK_TOPIC},
 
   /* https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md */
   { "config",         KW_CONFIG },

--- a/modules/kafka/tests/CMakeLists.txt
+++ b/modules/kafka/tests/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_unit_test(CRITERION LIBTEST TARGET test_kafka-props DEPENDS kafka)
+add_unit_test(CRITERION LIBTEST TARGET test_kafka_topic DEPENDS kafka rdkafka)

--- a/modules/kafka/tests/Makefile.am
+++ b/modules/kafka/tests/Makefile.am
@@ -1,17 +1,36 @@
 if ENABLE_KAFKA
 
 modules_kafka_tests_TESTS			= \
-	modules/kafka/tests/test_kafka_props
+	modules/kafka/tests/test_kafka_props \
+	modules/kafka/tests/test_kafka_topic
 
 check_PROGRAMS					+= ${modules_kafka_tests_TESTS}
 
 modules_kafka_tests_test_kafka_props_SOURCES = 	\
 	modules/kafka/tests/test_kafka-props.c
+
+modules_kafka_tests_test_kafka_topic_SOURCES = \
+	modules/kafka/tests/test_kafka_topic.c
+
 modules_kafka_tests_test_kafka_props_DEPENDENCIES =      \
         $(top_builddir)/modules/kafka/libkafka.la
+
+modules_kafka_tests_test_kafka_topic_DEPENDENCIES =      \
+        $(top_builddir)/modules/kafka/libkafka.la  
+
 modules_kafka_tests_test_kafka_props_CFLAGS	= $(TEST_CFLAGS) -I$(top_srcdir)/modules/kafka
-modules_kafka_tests_test_kafka_props_LDADD	= $(TEST_LDADD)
+
+modules_kafka_tests_test_kafka_topic_CFLAGS	= $(TEST_CFLAGS) -I$(top_srcdir)/modules/kafka
+
+modules_kafka_tests_test_kafka_props_LDADD	= $(TEST_LDADD) 
+
+modules_kafka_tests_test_kafka_topic_LDADD	= $(TEST_LDADD) $(LIBRDKAFKA_LIBS)
+
 modules_kafka_tests_test_kafka_props_LDFLAGS	= \
+	-dlpreopen $(top_builddir)/modules/kafka/libkafka.la
+
+
+modules_kafka_tests_test_kafka_topic_LDFLAGS	= \
 	-dlpreopen $(top_builddir)/modules/kafka/libkafka.la
 
 

--- a/modules/kafka/tests/test_kafka_topic.c
+++ b/modules/kafka/tests/test_kafka_topic.c
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2020 Balabit
+ * Copyright (c) 2020 Balazs Scheidler
+ * Copyright (c) 2020 Vivin Peris
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include <syslog-ng.h>
+#include <logmsg/logmsg.h>
+#include <apphook.h>
+#include "logthrdest/logthrdestdrv.h"
+#include "kafka-dest-driver.h"
+#include "kafka-dest-driver.c"
+#include "kafka-dest-worker.h"
+#include "kafka-dest-worker.c"
+#include "debugger/debugger.h"
+#include <librdkafka/rdkafka.h>
+
+#include <criterion/criterion.h>
+#include <criterion/parameterized.h>
+
+MainLoop *main_loop;
+LogDriver *driver;
+KafkaDestWorker *worker;
+MainLoopOptions main_loop_options;
+LogTemplate *topic_name;
+KafkaDestDriver *kafka_driver;
+
+static void
+_init_topic_names(void)
+{
+  topic_name = log_template_new(configuration, NULL);
+  log_template_compile(topic_name, "topicname", NULL);
+  kafka_dd_set_topic(driver, topic_name);
+  kafka_dd_set_fallback_topic(driver, "fallbacktopicname");
+}
+
+static void
+_init_valid_template_topic_names(void)
+{
+  topic_name = log_template_new(configuration, NULL);
+  log_template_compile(topic_name, "$MSG", NULL);
+  kafka_dd_set_topic(driver, topic_name);
+  kafka_dd_set_fallback_topic(driver, "fallbacktopicname");
+}
+
+static void
+_init_topics(void)
+{
+  kafka_driver->kafka = _construct_client(kafka_driver);
+  kafka_driver->topic = _construct_topic(kafka_driver, kafka_driver->topic_name->template);
+  kafka_driver->fallback_topic = _construct_topic(kafka_driver, kafka_driver->fallback_topic_name);
+}
+
+static void
+setup(void)
+{
+  debug_flag = TRUE;
+  log_stderr = TRUE;
+  app_startup();
+
+  main_loop = main_loop_get_instance();
+  main_loop_init(main_loop, &main_loop_options);
+
+  driver = kafka_dd_new(main_loop_get_current_config(main_loop));
+  _init_topic_names();
+  kafka_driver = (KafkaDestDriver *) driver;
+}
+
+static void
+teardown(void)
+{
+  main_loop_sync_worker_startup_and_teardown();
+  log_pipe_deinit((LogPipe *)driver);
+  log_pipe_unref((LogPipe *)driver);
+
+  main_loop_deinit(main_loop);
+  log_template_unref(topic_name);
+  app_shutdown();
+}
+
+TestSuite(kafka_topic, .init = setup, .fini = teardown);
+
+Test(kafka_topic, test_topic_names)
+{
+  cr_assert_str_eq(kafka_driver->topic_name->template, "topicname");
+  cr_assert_str_eq(kafka_driver->fallback_topic_name, "fallbacktopicname");
+}
+
+Test(kafka_topic, test_topics)
+{
+  _init_topics();
+  cr_assert_str_eq(rd_kafka_topic_name(kafka_driver->topic), kafka_driver->topic_name->template);
+  cr_assert_str_eq(rd_kafka_topic_name(kafka_driver->fallback_topic), kafka_driver->fallback_topic_name);
+}
+
+Test(kafka_topic, test_topic_name_validity)
+{
+  cr_assert(_validate_topic_name(kafka_driver, "test 1") == FALSE);
+  cr_assert(_validate_topic_name(kafka_driver, "") == FALSE);
+  cr_assert(_validate_topic_name(kafka_driver, "..") == FALSE);
+  cr_assert(_validate_topic_name(kafka_driver, ".") == FALSE);
+  cr_assert(_validate_topic_name(kafka_driver, " invalidname") == FALSE);
+  cr_assert(_validate_topic_name(kafka_driver, "aba#2") == FALSE);
+  cr_assert(_validate_topic_name(kafka_driver, g_strnfill(250, 'a')) == FALSE);
+
+  cr_assert(_validate_topic_name(kafka_driver, "validname123") == TRUE);
+  cr_assert(_validate_topic_name(kafka_driver, "valid.name123") == TRUE);
+  cr_assert(_validate_topic_name(kafka_driver, "valid_name123") == TRUE);
+  cr_assert(_validate_topic_name(kafka_driver, "valid-name123") == TRUE);
+  cr_assert(_validate_topic_name(kafka_driver, g_strnfill(249, 'a')) == TRUE);
+}
+
+
+Test(kafka_topic, test_valid_non_template_calculate_topic)
+{
+  _init_topics();
+  worker = (KafkaDestWorker *) kafka_dest_worker_new(&kafka_driver->super, 0);
+  LogMessage *msg = log_msg_new_empty();
+  cr_assert_str_eq(rd_kafka_topic_name(_calculate_topic(worker, msg)), "topicname");
+  log_threaded_dest_worker_free(&worker->super);
+}
+
+Test(kafka_topic, test_valid_template_calculate_topic)
+{
+  _init_valid_template_topic_names();
+  _init_topics();
+
+  cr_assert_str_eq(kafka_driver->topic_name->template, "$MSG");
+  worker = (KafkaDestWorker *) kafka_dest_worker_new(&kafka_driver->super, 0);
+  LogMessage *msg = log_msg_new_empty();
+
+  log_msg_set_value_by_name(msg, "MSG", "valid_template_topic", -1);
+  cr_assert_str_eq(rd_kafka_topic_name(_calculate_topic(worker, msg)), "valid_template_topic");
+  log_msg_set_value_by_name(msg, "MSG", "valid.template.topic", -1);
+  cr_assert_str_eq(rd_kafka_topic_name(_calculate_topic(worker, msg)), "valid.template.topic");
+  log_msg_set_value_by_name(msg, "MSG", "valid-template-topic", -1);
+  cr_assert_str_eq(rd_kafka_topic_name(_calculate_topic(worker, msg)), "valid-template-topic");
+
+  log_threaded_dest_worker_free(&worker->super);
+}
+
+Test(kafka_topic, test_invalid_template_calculate_topic)
+{
+  _init_valid_template_topic_names();
+  _init_topics();
+
+  cr_assert_str_eq(kafka_driver->topic_name->template, "$MSG");
+  worker = (KafkaDestWorker *) kafka_dest_worker_new(&kafka_driver->super, 0);
+  LogMessage *msg = log_msg_new_empty();
+
+  log_msg_set_value_by_name(msg, "MSG", "invalid topic", -1);
+  cr_assert_str_eq(rd_kafka_topic_name(_calculate_topic(worker, msg)), "fallbacktopicname");
+  log_msg_set_value_by_name(msg, "MSG", "..", -1);
+  cr_assert_str_eq(rd_kafka_topic_name(_calculate_topic(worker, msg)), "fallbacktopicname");
+  log_msg_set_value_by_name(msg, "MSG", "", -1);
+  cr_assert_str_eq(rd_kafka_topic_name(_calculate_topic(worker, msg)), "fallbacktopicname");
+
+  log_threaded_dest_worker_free(&worker->super);
+}


### PR DESCRIPTION
Test the _calculate_topic_name to handle valid and invalid topic names as and when they arise by use of fallback topic. Also, test the _validate_topic_name method to check for validity of topic name as per the conventions.