### PR TITLE
Python source acknowledgement

### DIFF
--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -48,6 +48,8 @@ set(PYTHON_SOURCES
     python-source.c
     python-fetcher.h
     python-fetcher.c
+    python-bookmark.h
+    python-bookmark.c
     compat/compat-python.c
 )
 

--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -50,6 +50,8 @@ set(PYTHON_SOURCES
     python-fetcher.c
     python-bookmark.h
     python-bookmark.c
+    python-ack-tracker.h
+    python-ack-tracker.c
     compat/compat-python.c
 )
 

--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -63,7 +63,9 @@ modules_python_libmod_python_la_SOURCES		= \
 	modules/python/python-fetcher.h	  \
 	modules/python/python-fetcher.c   \
 	modules/python/python-http-header.h   \
-	modules/python/python-http-header.c
+	modules/python/python-http-header.c \
+	modules/python/python-bookmark.h \
+	modules/python/python-bookmark.c
 
 
 modules_python_libmod_python_la_LDFLAGS		 = \

--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -65,7 +65,9 @@ modules_python_libmod_python_la_SOURCES		= \
 	modules/python/python-http-header.h   \
 	modules/python/python-http-header.c \
 	modules/python/python-bookmark.h \
-	modules/python/python-bookmark.c
+	modules/python/python-bookmark.c \
+	modules/python/python-ack-tracker.h \
+	modules/python/python-ack-tracker.c
 
 
 modules_python_libmod_python_la_LDFLAGS		 = \

--- a/modules/python/pylib/syslogng/__init__.py
+++ b/modules/python/pylib/syslogng/__init__.py
@@ -28,6 +28,7 @@ try:
     from _syslogng import LogTemplate, LogTemplateException, LTZ_LOCAL, LTZ_SEND
     from _syslogng import Logger
     from _syslogng import Persist as SlngPersist
+    from _syslogng import InstantAckTracker
 
     class Persist(SlngPersist):
         def __init__(self, persist_name, defaults=None):

--- a/modules/python/pylib/syslogng/__init__.py
+++ b/modules/python/pylib/syslogng/__init__.py
@@ -28,7 +28,7 @@ try:
     from _syslogng import LogTemplate, LogTemplateException, LTZ_LOCAL, LTZ_SEND
     from _syslogng import Logger
     from _syslogng import Persist as SlngPersist
-    from _syslogng import InstantAckTracker
+    from _syslogng import InstantAckTracker, ConsecutiveAckTracker
 
     class Persist(SlngPersist):
         def __init__(self, persist_name, defaults=None):

--- a/modules/python/pylib/syslogng/__init__.py
+++ b/modules/python/pylib/syslogng/__init__.py
@@ -28,7 +28,7 @@ try:
     from _syslogng import LogTemplate, LogTemplateException, LTZ_LOCAL, LTZ_SEND
     from _syslogng import Logger
     from _syslogng import Persist as SlngPersist
-    from _syslogng import InstantAckTracker, ConsecutiveAckTracker
+    from _syslogng import InstantAckTracker, ConsecutiveAckTracker, BatchedAckTracker
 
     class Persist(SlngPersist):
         def __init__(self, persist_name, defaults=None):

--- a/modules/python/python-ack-tracker.c
+++ b/modules/python/python-ack-tracker.c
@@ -29,6 +29,7 @@
 
 #include "ack-tracker/bookmark.h"
 
+
 static void
 py_ack_tracker_factory_free(PyAckTrackerFactory *self)
 {
@@ -92,6 +93,61 @@ py_consecutive_ack_tracker_factory_new(PyTypeObject *subtype, PyObject *args, Py
   return (PyObject *) self;
 }
 
+static void
+_invoke_batched_ack_callback(GList *ack_records, gpointer user_data)
+{
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  PyAckTrackerFactory *py_batched_ack_tracker_factory = (PyAckTrackerFactory *) user_data;
+  PyObject *py_ack_records = PyList_New(0);
+
+  for (GList *l = ack_records; l != NULL; l = l->next)
+    {
+      AckRecord *ack_record = l->data;
+      Bookmark *bookmark = &ack_record->bookmark;
+
+      PyBookmark *py_bookmark = bookmark_to_py_bookmark(bookmark);
+
+      if (py_bookmark)
+        PyList_Append(py_ack_records, py_bookmark->data);
+
+      Py_XDECREF(py_bookmark);
+    }
+
+  _py_invoke_void_function(py_batched_ack_tracker_factory->ack_callback, py_ack_records,
+                           "BatchedAckTracker", NULL);
+
+  Py_XDECREF(py_ack_records);
+  PyGILState_Release(gstate);
+}
+
+static PyObject *
+py_batched_ack_tracker_factory_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
+{
+  guint timeout, batch_size;
+  PyObject *batched_ack_callback;
+
+  static const gchar *kwlist[] = {"timeout", "batch_size", "batched_ack_callback", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "IIO", (gchar **) kwlist, &timeout, &batch_size, &batched_ack_callback))
+    return NULL;
+
+  if (!PyCallable_Check(batched_ack_callback))
+    {
+      PyErr_Format(PyExc_TypeError, "A callable object is expected (batched_ack_callback)");
+      return NULL;
+    }
+
+  PyAckTrackerFactory *self = (PyAckTrackerFactory *) subtype->tp_alloc(subtype, 0);
+  if (!self)
+    return NULL;
+
+  Py_XINCREF(batched_ack_callback);
+  self->ack_callback = batched_ack_callback;
+
+  self->ack_tracker_factory = batched_ack_tracker_factory_new(timeout, batch_size, _invoke_batched_ack_callback, self);
+
+  return (PyObject *) self;
+}
+
 int
 py_is_ack_tracker_factory(PyObject *obj)
 {
@@ -134,6 +190,18 @@ PyTypeObject py_consecutive_ack_tracker_factory_type =
   0,
 };
 
+PyTypeObject py_batched_ack_tracker_factory_type =
+{
+  PyVarObject_HEAD_INIT(&PyType_Type, 0)
+  .tp_name = "BatchedAckTrackerFactory",
+  .tp_basicsize = sizeof(PyAckTrackerFactory),
+  .tp_dealloc = (destructor) py_ack_tracker_factory_free,
+  .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+  .tp_doc = "BatchedAckTrackerFactory",
+  .tp_new = py_batched_ack_tracker_factory_new,
+  0,
+};
+
 void
 py_ack_tracker_init(void)
 {
@@ -148,4 +216,9 @@ py_ack_tracker_init(void)
   PyType_Ready(&py_consecutive_ack_tracker_factory_type);
   PyModule_AddObject(PyImport_AddModule("_syslogng"), "ConsecutiveAckTracker",
                      (PyObject *) &py_consecutive_ack_tracker_factory_type);
+
+  py_batched_ack_tracker_factory_type.tp_base = &py_ack_tracker_factory_type;
+  PyType_Ready(&py_batched_ack_tracker_factory_type);
+  PyModule_AddObject(PyImport_AddModule("_syslogng"), "BatchedAckTracker", (PyObject *)
+                     &py_batched_ack_tracker_factory_type);
 }

--- a/modules/python/python-ack-tracker.c
+++ b/modules/python/python-ack-tracker.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020 One Identity
+ * Copyright (c) 2020 László Várady
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "python-ack-tracker.h"
+#include "python-bookmark.h"
+#include "compat/compat-python.h"
+#include "python-helpers.h"
+
+#include "ack-tracker/bookmark.h"
+
+void
+py_ack_tracker_init(void)
+{
+
+}

--- a/modules/python/python-ack-tracker.c
+++ b/modules/python/python-ack-tracker.c
@@ -29,8 +29,80 @@
 
 #include "ack-tracker/bookmark.h"
 
+static void
+py_ack_tracker_factory_free(PyAckTrackerFactory *self)
+{
+  ack_tracker_factory_unref(self->ack_tracker_factory);
+  self->ack_tracker_factory = NULL;
+
+  Py_CLEAR(self->ack_callback);
+
+  Py_TYPE(self)->tp_free((PyObject *) self);
+}
+
+static PyObject *
+py_instant_ack_tracker_factory_new(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
+{
+  PyObject *ack_callback;
+  static const gchar *kwlist[] = {"ack_callback", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "O", (gchar **) kwlist, &ack_callback))
+    return NULL;
+
+  if (!PyCallable_Check(ack_callback))
+    {
+      PyErr_Format(PyExc_TypeError, "A callable object is expected (ack_callback)");
+      return NULL;
+    }
+
+  PyAckTrackerFactory *self = (PyAckTrackerFactory *) subtype->tp_alloc(subtype, 0);
+  if (!self)
+    return NULL;
+
+  Py_XINCREF(ack_callback);
+  self->ack_callback = ack_callback;
+
+  self->ack_tracker_factory = instant_ack_tracker_factory_new();
+
+  return (PyObject *) self;
+}
+
+int
+py_is_ack_tracker_factory(PyObject *obj)
+{
+  return PyType_IsSubtype(Py_TYPE(obj), &py_ack_tracker_factory_type);
+}
+
+PyTypeObject py_ack_tracker_factory_type =
+{
+  PyVarObject_HEAD_INIT(&PyType_Type, 0)
+  .tp_name = "AckTrackerFactory",
+  .tp_basicsize = sizeof(PyAckTrackerFactory),
+  .tp_dealloc = (destructor) py_ack_tracker_factory_free,
+  .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+  .tp_doc = "AckTrackerFactory",
+  .tp_new = PyType_GenericNew,
+  0,
+};
+
+PyTypeObject py_instant_ack_tracker_factory_type =
+{
+  PyVarObject_HEAD_INIT(&PyType_Type, 0)
+  .tp_name = "InstantAckTrackerFactory",
+  .tp_basicsize = sizeof(PyAckTrackerFactory),
+  .tp_dealloc = (destructor) py_ack_tracker_factory_free,
+  .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+  .tp_doc = "InstantAckTrackerFactory",
+  .tp_new = py_instant_ack_tracker_factory_new,
+  0,
+};
+
 void
 py_ack_tracker_init(void)
 {
+  PyType_Ready(&py_ack_tracker_factory_type);
 
+  py_instant_ack_tracker_factory_type.tp_base = &py_ack_tracker_factory_type;
+  PyType_Ready(&py_instant_ack_tracker_factory_type);
+  PyModule_AddObject(PyImport_AddModule("_syslogng"), "InstantAckTracker",
+                     (PyObject *) &py_instant_ack_tracker_factory_type);
 }

--- a/modules/python/python-ack-tracker.h
+++ b/modules/python/python-ack-tracker.h
@@ -26,8 +26,19 @@
 #define _SNG_PYTHON_ACK_TRACKER_H
 
 #include "python-module.h"
-#include "ack-tracker/ack_tracker.h"
+#include "ack-tracker/ack_tracker_factory.h"
+
+typedef struct _PyAckTrackerFactory
+{
+  PyObject_HEAD
+  AckTrackerFactory *ack_tracker_factory;
+  PyObject *ack_callback;
+} PyAckTrackerFactory;
+
+extern PyTypeObject py_ack_tracker_factory_type;
+extern PyTypeObject py_instant_ack_tracker_factory_type;
 
 void py_ack_tracker_init(void);
+int py_is_ack_tracker_factory(PyObject *obj);
 
 #endif

--- a/modules/python/python-ack-tracker.h
+++ b/modules/python/python-ack-tracker.h
@@ -38,6 +38,7 @@ typedef struct _PyAckTrackerFactory
 extern PyTypeObject py_ack_tracker_factory_type;
 extern PyTypeObject py_instant_ack_tracker_factory_type;
 extern PyTypeObject py_consecutive_ack_tracker_factory_type;
+extern PyTypeObject py_batched_ack_tracker_factory_type;
 
 void py_ack_tracker_init(void);
 int py_is_ack_tracker_factory(PyObject *obj);

--- a/modules/python/python-ack-tracker.h
+++ b/modules/python/python-ack-tracker.h
@@ -37,6 +37,7 @@ typedef struct _PyAckTrackerFactory
 
 extern PyTypeObject py_ack_tracker_factory_type;
 extern PyTypeObject py_instant_ack_tracker_factory_type;
+extern PyTypeObject py_consecutive_ack_tracker_factory_type;
 
 void py_ack_tracker_init(void);
 int py_is_ack_tracker_factory(PyObject *obj);

--- a/modules/python/python-ack-tracker.h
+++ b/modules/python/python-ack-tracker.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020 One Identity
+ * Copyright (c) 2020 László Várady
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef _SNG_PYTHON_ACK_TRACKER_H
+#define _SNG_PYTHON_ACK_TRACKER_H
+
+#include "python-module.h"
+#include "ack-tracker/ack_tracker.h"
+
+void py_ack_tracker_init(void);
+
+#endif

--- a/modules/python/python-bookmark.c
+++ b/modules/python/python-bookmark.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2020 One Identity
+ * Copyright (c) 2020 László Várady
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "python-bookmark.h"
+#include "compat/compat-python.h"
+#include "python-helpers.h"
+
+#include <structmember.h>
+
+
+typedef struct _PyBookmarkData
+{
+  PyBookmark *py_bookmark;
+} PyBookmarkData;
+
+int
+py_is_bookmark(PyObject *obj)
+{
+  return PyType_IsSubtype(Py_TYPE(obj), &py_bookmark_type);
+}
+
+static void
+py_bookmark_free(PyBookmark *self)
+{
+  Py_CLEAR(self->data);
+  Py_CLEAR(self->save);
+  Py_TYPE(self)->tp_free((PyObject *) self);
+}
+
+PyBookmark *
+py_bookmark_new(PyObject *data, PyObject *save)
+{
+  PyBookmark *self = PyObject_New(PyBookmark, &py_bookmark_type);
+  if (!self)
+    return NULL;
+
+  Py_XINCREF(data);
+  self->data = data;
+
+  Py_XINCREF(save);
+  self->save = save;
+
+  return self;
+}
+
+PyBookmark *
+bookmark_to_py_bookmark(Bookmark *bookmark)
+{
+  PyBookmarkData *data = (PyBookmarkData *) &bookmark->container;
+  return data->py_bookmark;
+}
+
+static void
+py_bookmark_save(Bookmark *bookmark)
+{
+  PyBookmark *self = bookmark_to_py_bookmark(bookmark);
+
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  if (self->save)
+    _py_invoke_void_function(self->save, self->data, "Bookmark", NULL);
+
+  Py_XDECREF(self);
+  PyGILState_Release(gstate);
+}
+
+void
+py_bookmark_fill(Bookmark *bookmark, PyBookmark *py_bookmark)
+{
+  bookmark->save = py_bookmark_save;
+
+  PyBookmarkData *data = (PyBookmarkData *) &bookmark->container;
+  Py_XINCREF(py_bookmark);
+  data->py_bookmark = py_bookmark;
+}
+
+static PyMemberDef
+py_bookmark_members[] =
+{
+  { "data", T_OBJECT, offsetof(PyBookmark, data), 0 },
+  { "save", T_OBJECT, offsetof(PyBookmark, save), 0 },
+  {NULL}
+};
+
+PyTypeObject py_bookmark_type =
+{
+  PyVarObject_HEAD_INIT(&PyType_Type, 0)
+  .tp_name = "Bookmark",
+  .tp_basicsize = sizeof(PyBookmark),
+  .tp_dealloc = (destructor) py_bookmark_free,
+  .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+  .tp_doc = "Bookmark class encapsulating a syslog-ng bookmark",
+  .tp_new = PyType_GenericNew,
+  .tp_members = py_bookmark_members,
+  0,
+};
+
+void
+py_bookmark_init(void)
+{
+  PyType_Ready(&py_bookmark_type);
+}

--- a/modules/python/python-bookmark.h
+++ b/modules/python/python-bookmark.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020 One Identity
+ * Copyright (c) 2020 László Várady
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef _SNG_PYTHON_BOOKMARK_H
+#define _SNG_PYTHON_BOOKMARK_H
+
+#include "python-module.h"
+#include "ack-tracker/bookmark.h"
+
+typedef struct _PyBookmark
+{
+  PyObject_HEAD
+  PyObject *data;
+  PyObject *save;
+} PyBookmark;
+
+extern PyTypeObject py_bookmark_type;
+
+PyBookmark *py_bookmark_new(PyObject *data, PyObject *save);
+void py_bookmark_fill(Bookmark *bookmark, PyBookmark *py_bookmark);
+
+void py_bookmark_init(void);
+
+int py_is_bookmark(PyObject *obj);
+PyBookmark *bookmark_to_py_bookmark(Bookmark *bookmark);
+
+#endif

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -179,6 +179,12 @@ _ulong_to_fetch_result(unsigned long ulong, ThreadedFetchResult *result)
     }
 }
 
+static inline AckTracker *
+_py_fetcher_get_ack_tracker(PythonFetcherDriver *self)
+{
+  return ((LogSource *) self->super.super.worker)->ack_tracker;;
+}
+
 static gboolean
 _py_fetcher_fill_bookmark(PythonFetcherDriver *self, PyLogMessage *pymsg)
 {
@@ -190,7 +196,7 @@ _py_fetcher_fill_bookmark(PythonFetcherDriver *self, PyLogMessage *pymsg)
       return FALSE;
     }
 
-  AckTracker *ack_tracker = ((LogSource *)self->super.super.worker)->ack_tracker;
+  AckTracker *ack_tracker = _py_fetcher_get_ack_tracker(self);
   Bookmark *bookmark = ack_tracker_request_bookmark(ack_tracker);
 
   PyBookmark *py_bookmark = py_bookmark_new(pymsg->bookmark_data, self->py.ack_tracker_factory->ack_callback);

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -611,6 +611,9 @@ python_fetcher_deinit(LogPipe *s)
 {
   PythonFetcherDriver *self = (PythonFetcherDriver *) s;
 
+  AckTracker *ack_tracker = _py_fetcher_get_ack_tracker(self);
+  ack_tracker_deinit(ack_tracker);
+
   PyGILState_STATE gstate = PyGILState_Ensure();
   _py_invoke_deinit(self);
   PyGILState_Release(gstate);

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -169,11 +169,12 @@ py_log_message_new(LogMessage *msg)
 static PyObject *
 py_log_message_new_empty(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
 {
+  PyObject *bookmark_data = NULL;
   const gchar *message = NULL;
   gint message_length = 0;
 
-  static const gchar *kwlist[] = {"message", NULL};
-  if (!PyArg_ParseTupleAndKeywords(args, kwds, "|z#", (gchar **) kwlist, &message, &message_length))
+  static const gchar *kwlist[] = {"message", "bookmark", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "|z#O", (gchar **) kwlist, &message, &message_length, &bookmark_data))
     return NULL;
 
   PyLogMessage *self = (PyLogMessage *) subtype->tp_alloc(subtype, 0);
@@ -186,6 +187,9 @@ py_log_message_new_empty(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
 
   if (message)
     log_msg_set_value(self->msg, LM_V_MESSAGE, message, message_length);
+
+  Py_XINCREF(bookmark_data);
+  self->bookmark_data = bookmark_data;
 
   return (PyObject *) self;
 }

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -148,6 +148,7 @@ static void
 py_log_message_free(PyLogMessage *self)
 {
   log_msg_unref(self->msg);
+  Py_CLEAR(self->bookmark_data);
   Py_TYPE(self)->tp_free((PyObject *) self);
 }
 
@@ -161,6 +162,7 @@ py_log_message_new(LogMessage *msg)
     return NULL;
 
   self->msg = log_msg_ref(msg);
+  self->bookmark_data = NULL;
   return (PyObject *) self;
 }
 
@@ -179,6 +181,7 @@ py_log_message_new_empty(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
     return NULL;
 
   self->msg = log_msg_new_empty();
+  self->bookmark_data = NULL;
   invalidate_cached_time();
 
   if (message)
@@ -372,6 +375,23 @@ py_log_message_set_timestamp(PyLogMessage *self, PyObject *args, PyObject *kwrds
 }
 
 static PyObject *
+py_log_message_set_bookmark(PyLogMessage *self, PyObject *args, PyObject *kwrds)
+{
+  PyObject *bookmark_data;
+
+  static const gchar *kwlist[] = {"bookmark", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwrds, "O", (gchar **) kwlist, &bookmark_data))
+    return NULL;
+
+  Py_CLEAR(self->bookmark_data);
+
+  Py_XINCREF(bookmark_data);
+  self->bookmark_data = bookmark_data;
+
+  Py_RETURN_NONE;
+}
+
+static PyObject *
 py_log_message_parse(PyObject *_none, PyObject *args, PyObject *kwrds)
 {
   const gchar *raw_msg;
@@ -405,6 +425,7 @@ py_log_message_parse(PyObject *_none, PyObject *args, PyObject *kwrds)
     }
 
   py_msg->msg = log_msg_new(raw_msg, raw_msg_length, parse_options);
+  py_msg->bookmark_data = NULL;
 
   return (PyObject *) py_msg;
 }
@@ -414,6 +435,7 @@ static PyMethodDef py_log_message_methods[] =
   { "keys", (PyCFunction)_logmessage_get_keys_method, METH_NOARGS, "Return keys." },
   { "set_pri", (PyCFunction)py_log_message_set_pri, METH_VARARGS | METH_KEYWORDS, "Set priority" },
   { "set_timestamp", (PyCFunction)py_log_message_set_timestamp, METH_VARARGS | METH_KEYWORDS, "Set timestamp" },
+  { "set_bookmark", (PyCFunction)py_log_message_set_bookmark, METH_VARARGS | METH_KEYWORDS, "Set bookmark" },
   { "parse", (PyCFunction)py_log_message_parse, METH_STATIC|METH_VARARGS|METH_KEYWORDS, "Parse and create LogMessage" },
   {NULL}
 };

--- a/modules/python/python-logmsg.h
+++ b/modules/python/python-logmsg.h
@@ -31,6 +31,7 @@ typedef struct _PyLogMessage
 {
   PyObject_HEAD
   LogMessage *msg;
+  PyObject *bookmark_data;
 } PyLogMessage;
 
 extern PyTypeObject py_log_message_type;

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -37,6 +37,7 @@
 #include "python-http-header.h"
 #include "python-persist.h"
 #include "python-bookmark.h"
+#include "python-ack-tracker.h"
 
 #include "plugin.h"
 #include "plugin-types.h"
@@ -118,6 +119,7 @@ _py_init_interpreter(void)
       py_log_fetcher_init();
       py_persist_init();
       py_bookmark_init();
+      py_ack_tracker_init();
       py_global_code_loader_init();
       py_logger_init();
       PyEval_SaveThread();

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -36,6 +36,7 @@
 #include "python-debugger.h"
 #include "python-http-header.h"
 #include "python-persist.h"
+#include "python-bookmark.h"
 
 #include "plugin.h"
 #include "plugin-types.h"
@@ -116,6 +117,7 @@ _py_init_interpreter(void)
       py_log_source_init();
       py_log_fetcher_init();
       py_persist_init();
+      py_bookmark_init();
       py_global_code_loader_init();
       py_logger_init();
       PyEval_SaveThread();

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -644,6 +644,9 @@ python_sd_deinit(LogPipe *s)
 {
   PythonSourceDriver *self = (PythonSourceDriver *) s;
 
+  AckTracker *ack_tracker = _py_sd_get_ack_tracker(self);
+  ack_tracker_deinit(ack_tracker);
+
   PyGILState_STATE gstate = PyGILState_Ensure();
   _py_invoke_deinit(self);
   PyGILState_Release(gstate);

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -54,6 +54,7 @@ struct _PythonSourceDriver
     PyObject *suspend_method;
     PyObject *wakeup_method;
     PyObject *generate_persist_name;
+    PyAckTrackerFactory *ack_tracker_factory;
   } py;
 };
 
@@ -185,6 +186,7 @@ _py_free_bindings(PythonSourceDriver *self)
   Py_CLEAR(self->py.suspend_method);
   Py_CLEAR(self->py.wakeup_method);
   Py_CLEAR(self->py.generate_persist_name);
+  Py_CLEAR(self->py.ack_tracker_factory);
 }
 
 static gboolean
@@ -371,6 +373,30 @@ _py_parse_options_new(PythonSourceDriver *self, MsgFormatOptions *parse_options)
 }
 
 static gboolean
+_py_init_ack_tracker_factory(PythonSourceDriver *self)
+{
+  PyObject *py_ack_tracker_factory = _py_get_attr_or_null(self->py.instance, "ack_tracker");
+
+  if (!py_ack_tracker_factory)
+    return TRUE;
+
+  if (!py_is_ack_tracker_factory(py_ack_tracker_factory))
+    {
+      msg_error("Python source attribute ack_tracker needs to be an AckTracker subtype",
+                evt_tag_str("driver", self->super.super.super.id),
+                evt_tag_str("class", self->class));
+      return FALSE;
+    }
+
+  self->py.ack_tracker_factory = (PyAckTrackerFactory *) py_ack_tracker_factory;
+
+  AckTrackerFactory *ack_tracker_factory = self->py.ack_tracker_factory->ack_tracker_factory;
+  self->super.worker_options.ack_tracker_factory = ack_tracker_factory_ref(ack_tracker_factory);
+
+  return TRUE;
+}
+
+static gboolean
 _py_set_parse_options(PythonSourceDriver *self)
 {
   MsgFormatOptions *parse_options = log_threaded_source_driver_get_parse_options(&self->super.super.super);
@@ -445,6 +471,9 @@ _py_sd_init(PythonSourceDriver *self)
     goto error;
 
   if (!_py_init_object(self))
+    goto error;
+
+  if (!_py_init_ack_tracker_factory(self))
     goto error;
 
   if (!_py_set_parse_options(self))

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -489,6 +489,12 @@ error:
   return FALSE;
 }
 
+static inline AckTracker *
+_py_sd_get_ack_tracker(PythonSourceDriver *self)
+{
+  return ((LogSource *) self->super.worker)->ack_tracker;
+}
+
 static gboolean
 _py_sd_fill_bookmark(PythonSourceDriver *self, PyLogMessage *pymsg)
 {
@@ -499,7 +505,7 @@ _py_sd_fill_bookmark(PythonSourceDriver *self, PyLogMessage *pymsg)
       return FALSE;
     }
 
-  AckTracker *ack_tracker = ((LogSource *)self->super.worker)->ack_tracker;
+  AckTracker *ack_tracker = _py_sd_get_ack_tracker(self);
   Bookmark *bookmark = ack_tracker_request_bookmark(ack_tracker);
 
   PyBookmark *py_bookmark = py_bookmark_new(pymsg->bookmark_data, self->py.ack_tracker_factory->ack_callback);

--- a/modules/python/tests/CMakeLists.txt
+++ b/modules/python/tests/CMakeLists.txt
@@ -32,3 +32,10 @@ add_unit_test(LIBTEST CRITERION
   DEPENDS mod-python "${PYTHON_LIBRARIES}")
 
 set_property(TEST test_python_bookmark APPEND PROPERTY ENVIRONMENT "PYTHONMALLOC=malloc_debug")
+
+add_unit_test(LIBTEST CRITERION
+  TARGET test_python_ack_tracker
+  INCLUDES "${PYTHON_INCLUDE_DIR}" "${PYTHON_INCLUDE_DIRS}"
+  DEPENDS syslogformat mod-python "${PYTHON_LIBRARIES}")
+
+set_property(TEST test_python_ack_tracker APPEND PROPERTY ENVIRONMENT "PYTHONMALLOC=malloc_debug")

--- a/modules/python/tests/CMakeLists.txt
+++ b/modules/python/tests/CMakeLists.txt
@@ -25,3 +25,10 @@ add_unit_test(LIBTEST CRITERION
   DEPENDS syslogformat mod-python "${PYTHON_LIBRARIES}")
 
 set_property(TEST test_python_persist APPEND PROPERTY ENVIRONMENT "PYTHONMALLOC=malloc_debug")
+
+add_unit_test(LIBTEST CRITERION
+  TARGET test_python_bookmark
+  INCLUDES "${PYTHON_INCLUDE_DIR}" "${PYTHON_INCLUDE_DIRS}"
+  DEPENDS mod-python "${PYTHON_LIBRARIES}")
+
+set_property(TEST test_python_bookmark APPEND PROPERTY ENVIRONMENT "PYTHONMALLOC=malloc_debug")

--- a/modules/python/tests/Makefile.am
+++ b/modules/python/tests/Makefile.am
@@ -9,7 +9,8 @@ modules_python_tests_TESTS = \
   modules/python/tests/test_python_template \
   modules/python/tests/test_python_persist_name \
   modules/python/tests/test_python_persist \
-  modules/python/tests/test_python_bookmark
+  modules/python/tests/test_python_bookmark \
+  modules/python/tests/test_python_ack_tracker
 
 modules_python_tests_test_python_logmsg_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) -I$(top_srcdir)/modules/python
 modules_python_tests_test_python_logmsg_LDADD = $(TEST_LDADD) \
@@ -40,5 +41,11 @@ modules_python_tests_test_python_bookmark_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAG
 modules_python_tests_test_python_bookmark_LDADD = $(TEST_LDADD) \
 	-dlpreopen $(top_builddir)/modules/python/libmod-python.la \
 	$(PYTHON_LIBS)
+
+modules_python_tests_test_python_ack_tracker_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) \
+	-I$(top_srcdir)/modules/python -I$(top_srcdir)/modules/syslogformat
+modules_python_tests_test_python_ack_tracker_LDADD = $(TEST_LDADD) \
+	-dlpreopen $(top_builddir)/modules/python/libmod-python.la \
+	$(PYTHON_LIBS) $(PREOPEN_SYSLOGFORMAT)
 
 EXTRA_DIST += modules/python/tests/CMakeLists.txt

--- a/modules/python/tests/Makefile.am
+++ b/modules/python/tests/Makefile.am
@@ -8,7 +8,8 @@ modules_python_tests_TESTS = \
   modules/python/tests/test_python_logmsg \
   modules/python/tests/test_python_template \
   modules/python/tests/test_python_persist_name \
-  modules/python/tests/test_python_persist
+  modules/python/tests/test_python_persist \
+  modules/python/tests/test_python_bookmark
 
 modules_python_tests_test_python_logmsg_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) -I$(top_srcdir)/modules/python
 modules_python_tests_test_python_logmsg_LDADD = $(TEST_LDADD) \
@@ -33,5 +34,11 @@ modules_python_tests_test_python_persist_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS
 modules_python_tests_test_python_persist_LDADD = $(TEST_LDADD) \
 	-dlpreopen $(top_builddir)/modules/python/libmod-python.la \
 	$(PYTHON_LIBS) $(PREOPEN_SYSLOGFORMAT)
+
+modules_python_tests_test_python_bookmark_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) \
+	-I$(top_srcdir)/modules/python -I$(top_srcdir)/modules/syslogformat
+modules_python_tests_test_python_bookmark_LDADD = $(TEST_LDADD) \
+	-dlpreopen $(top_builddir)/modules/python/libmod-python.la \
+	$(PYTHON_LIBS)
 
 EXTRA_DIST += modules/python/tests/CMakeLists.txt

--- a/modules/python/tests/test_python_ack_tracker.c
+++ b/modules/python/tests/test_python_ack_tracker.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2020 Balabit
+ * Copyright (c) 2020 László Várady
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#include "python-helpers.h"
+#include "python-ack-tracker.h"
+#include "python-bookmark.h"
+#include "apphook.h"
+#include "cfg.h"
+#include "ack-tracker/instant_ack_tracker.h"
+
+#include "msg_parse_lib.h"
+
+#include <criterion/criterion.h>
+
+static PyObject *_python_main;
+static PyObject *_python_main_dict;
+
+MsgFormatOptions parse_options;
+
+
+static void
+_py_init_interpreter(void)
+{
+  py_setup_python_home();
+  Py_Initialize();
+  py_init_argv();
+
+  PyEval_InitThreads();
+  py_ack_tracker_init();
+  py_bookmark_init();
+  PyEval_SaveThread();
+}
+
+static void
+_init_python_main(void)
+{
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  {
+    _python_main = PyImport_AddModule("__main__");
+    _python_main_dict = PyModule_GetDict(_python_main);
+  }
+  PyGILState_Release(gstate);
+}
+
+void setup(void)
+{
+  app_startup();
+
+  init_parse_options_and_load_syslogformat(&parse_options);
+
+  _py_init_interpreter();
+  _init_python_main();
+}
+
+void teardown(void)
+{
+  deinit_syslogformat_module();
+  app_shutdown();
+}
+
+TestSuite(python_ack_tracker, .init = setup, .fini = teardown);
+
+{
+}

--- a/modules/python/tests/test_python_bookmark.c
+++ b/modules/python/tests/test_python_bookmark.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2020 Balabit
+ * Copyright (c) 2020 László Várady
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#include "python-helpers.h"
+#include "python-bookmark.h"
+#include "apphook.h"
+#include "ack-tracker/bookmark.h"
+
+#include <criterion/criterion.h>
+
+static PyObject *_python_main;
+static PyObject *_python_main_dict;
+
+const gchar *test_bookmark_data = "test-bookmark-data";
+const gchar *bookmark_saved_marker = "bookmark-saved";
+
+static void
+_py_init_interpreter(void)
+{
+  py_setup_python_home();
+  Py_Initialize();
+  py_init_argv();
+
+  PyEval_InitThreads();
+  py_bookmark_init();
+  PyEval_SaveThread();
+}
+
+static void
+_init_python_main(void)
+{
+  PyGILState_STATE gstate = PyGILState_Ensure();
+  {
+    _python_main = PyImport_AddModule("__main__");
+    _python_main_dict = PyModule_GetDict(_python_main);
+  }
+  PyGILState_Release(gstate);
+}
+
+void setup(void)
+{
+  app_startup();
+
+  _py_init_interpreter();
+  _init_python_main();
+}
+
+void teardown(void)
+{
+  app_shutdown();
+}
+
+TestSuite(python_bookmark, .init = setup, .fini = teardown);
+
+static PyObject *
+test_save_bookmark(PyObject *self, PyObject *args)
+{
+  PyObject *bookmark_data;
+  cr_assert(PyArg_ParseTuple(args, "O", &bookmark_data));
+  cr_assert(PyBytes_Check(bookmark_data));
+  cr_assert_str_eq(PyBytes_AsString(bookmark_data), test_bookmark_data);
+
+  PyList_Append(self, bookmark_data);
+
+  Py_RETURN_NONE;
+}
+
+static PyMethodDef test_save_method =
+{
+  "test_save_bookmark", test_save_bookmark, METH_VARARGS, "Test Bookmark::save()"
+};
+
+
+Test(python_bookmark, test_bookmark_saving)
+{
+  Bookmark bookmark = {0};
+  PyBookmark *py_bookmark;
+  PyObject *saved_bookmarks;
+
+  {
+    PyGILState_STATE gstate = PyGILState_Ensure();
+    saved_bookmarks = PyList_New(0);
+
+    PyObject *data = PyBytes_FromString(test_bookmark_data);
+    PyObject *save = PyCFunction_New(&test_save_method, saved_bookmarks);
+
+    py_bookmark = py_bookmark_new(data, save);
+    cr_assert(py_is_bookmark((PyObject *) py_bookmark));
+
+    py_bookmark_fill(&bookmark, py_bookmark);
+
+    Py_CLEAR(data);
+    Py_CLEAR(save);
+    PyGILState_Release(gstate);
+  }
+
+  bookmark_save(&bookmark);
+
+  {
+    PyGILState_STATE gstate = PyGILState_Ensure();
+
+    cr_assert_eq(PyList_Size(saved_bookmarks), 1);
+
+    Py_CLEAR(saved_bookmarks);
+    PyGILState_Release(gstate);
+  }
+}

--- a/modules/python/tests/test_python_persist_name.c
+++ b/modules/python/tests/test_python_persist_name.c
@@ -25,6 +25,8 @@
 #include "python-main.h"
 #include "python-fetcher.h"
 #include "python-source.h"
+#include "python-bookmark.h"
+#include "python-ack-tracker.h"
 #include "mainloop-worker.h"
 #include "mainloop.h"
 #include "python-persist.h"
@@ -50,6 +52,8 @@ _py_init_interpreter(void)
   PyEval_InitThreads();
   py_log_fetcher_init();
   py_log_source_init();
+  py_bookmark_init();
+  py_ack_tracker_init();
   PyEval_SaveThread();
 }
 


### PR DESCRIPTION
This PR adds acknowledgment support for Python sources.

Example:
```Python
from syslogng import LogSource
from syslogng import LogMessage
from syslogng import Logger
from syslogng import InstantAckTracker, ConsecutiveAckTracker, BatchedAckTracker

import signal
signal.signal(signal.SIGINT, signal.SIG_IGN)

import threading
import time

class TestSource(LogSource):
    def init(self, options):
        self.stop_event = threading.Event()

        self.ack_tracker = InstantAckTracker(ack_callback=self.save_bookmark)
        self.ack_tracker = ConsecutiveAckTracker(ack_callback=self.save_bookmark)
        self.ack_tracker = BatchedAckTracker(timeout=5000, batch_size=100,
                                             batched_ack_callback=self.save_bookmarks)
        return True

    def deinit(self):
        pass

    def save_bookmark(self, bookmark):
        print(bookmark)

    def save_bookmarks(self, bookmarks):
        for b in bookmarks:
            print(b)

    def run(self):
        while not self.stop_event.is_set():
            time.sleep(1)

            msg = LogMessage("test", bookmark="bookmark-data")
            # msg.set_bookmark("bookmark-data")
            self.post_message(msg)

    def request_exit(self):
        self.stop_event.set()
``` 