### PR TITLE
Filter regex missing named matches

### DIFF
--- a/lib/filter/tests/test_filters_common.c
+++ b/lib/filter/tests/test_filters_common.c
@@ -213,7 +213,9 @@ testcase_with_backref_chk(const gchar *msg,
     }
   else
     {
-      cr_assert_eq(strncmp(value_msg, value, length), 0,
+      const gint value_len = strlen(value);
+      cr_assert_eq(length, value_len);
+      cr_assert_eq(strncmp(value_msg, value, value_len), 0,
                    "Filter test failed (value chk); msg='%s', expected_value='%s', value_in_msg='%s'",
                    msg, value, value_msg);
     }

--- a/lib/filter/tests/test_filters_regexp.c
+++ b/lib/filter/tests/test_filters_regexp.c
@@ -73,6 +73,7 @@ ParameterizedTestParameters(filter, test_filter_regexp_backref_chk)
     {.msg = "<15>Oct 15 16:17:02 host openvpn[2499]: alma fa", .field = LM_V_MESSAGE, .regexp = "(?P<a>a)(?P<l>l)(?P<MM>m)(?P<aa>a) (?P<fa>fa)", .flags = LMF_STORE_MATCHES, .expected_result = TRUE, .name = "aaaa", .value = NULL},
     {.msg = "<15>Oct 15 16:17:03 host openvpn[2499]: alma fa", .field = LM_V_MESSAGE, .regexp = "(?P<a>a)(?P<l>l)(?P<MM>m)(?P<aa>a) (?P<fa_name>fa)", .flags = LMF_STORE_MATCHES, .expected_result = TRUE, .name = "fa_name", .value = "fa"},
     {.msg = "<15>Oct 15 16:17:04 host openvpn[2499]: al fa", .field = LM_V_MESSAGE, .regexp = "(a)(l) (fa)", .flags = LMF_STORE_MATCHES, .expected_result = TRUE, .name = "2", .value = "l"},
+    {.msg = "<15>Oct 15 16:17:04 host openvpn[2499]: al fa", .field = LM_V_MESSAGE, .regexp = "(a)(l) (fa)", .flags = LMF_STORE_MATCHES, .expected_result = TRUE, .name = "3", .value = "fa"},
     {.msg = "<15>Oct 15 16:17:05 host openvpn[2499]: al fa", .field = LM_V_MESSAGE, .regexp = "(a)(l) (fa)", .flags = LMF_STORE_MATCHES, .expected_result = TRUE, .name = "0", .value = "al fa"},
     {.msg = "<15>Oct 15 16:17:06 host openvpn[2499]: al fa", .field = LM_V_MESSAGE, .regexp = "(a)(l) (fa)", .flags = LMF_STORE_MATCHES, .expected_result = TRUE, .name = "233", .value = NULL}
   };

--- a/lib/filter/tests/test_filters_regexp.c
+++ b/lib/filter/tests/test_filters_regexp.c
@@ -75,7 +75,10 @@ ParameterizedTestParameters(filter, test_filter_regexp_backref_chk)
     {.msg = "<15>Oct 15 16:17:04 host openvpn[2499]: al fa", .field = LM_V_MESSAGE, .regexp = "(a)(l) (fa)", .flags = LMF_STORE_MATCHES, .expected_result = TRUE, .name = "2", .value = "l"},
     {.msg = "<15>Oct 15 16:17:04 host openvpn[2499]: al fa", .field = LM_V_MESSAGE, .regexp = "(a)(l) (fa)", .flags = LMF_STORE_MATCHES, .expected_result = TRUE, .name = "3", .value = "fa"},
     {.msg = "<15>Oct 15 16:17:05 host openvpn[2499]: al fa", .field = LM_V_MESSAGE, .regexp = "(a)(l) (fa)", .flags = LMF_STORE_MATCHES, .expected_result = TRUE, .name = "0", .value = "al fa"},
-    {.msg = "<15>Oct 15 16:17:06 host openvpn[2499]: al fa", .field = LM_V_MESSAGE, .regexp = "(a)(l) (fa)", .flags = LMF_STORE_MATCHES, .expected_result = TRUE, .name = "233", .value = NULL}
+    {.msg = "<15>Oct 15 16:17:06 host openvpn[2499]: al fa", .field = LM_V_MESSAGE, .regexp = "(a)(l) (fa)", .flags = LMF_STORE_MATCHES, .expected_result = TRUE, .name = "233", .value = NULL},
+    {.msg = "<15>Oct 15 16:17:06 host openvpn[2499]: foobar bar", .field = LM_V_MESSAGE, .regexp = "(?<foobar>foobar) (?<foo>foo)?(?<bar>bar)", .flags = LMF_STORE_MATCHES, .expected_result = TRUE, .name = "bar", .value = "bar"},
+    {.msg = "<15>Oct 15 16:17:06 host openvpn[2499]: foobar bar", .field = LM_V_MESSAGE, .regexp = "(?<foobar>foobar) (?<foo>foo)?(?<bar>bar)", .flags = LMF_STORE_MATCHES, .expected_result = TRUE, .name = "foobar", .value = "foobar"},
+    {.msg = "<15>Oct 15 16:17:06 host openvpn[2499]: foobar bar", .field = LM_V_MESSAGE, .regexp = "(?<foobar>foobar) (?<foo>foo)?(?<bar>bar)", .flags = LMF_STORE_MATCHES, .expected_result = TRUE, .name = "foo", .value = NULL},
   };
 
   return cr_make_param_array(FilterParamRegexp, test_data_list, G_N_ELEMENTS(test_data_list));

--- a/lib/logmatcher.c
+++ b/lib/logmatcher.c
@@ -430,7 +430,7 @@ log_matcher_pcre_re_feed_named_substrings(LogMatcher *s, LogMessage *msg, int *m
          and the substring itself.
        */
       tabptr = name_table;
-      for (i = 0; i < namecount; i++)
+      for (i = 0; i < namecount; i++, tabptr += name_entry_size)
         {
           int n = (tabptr[0] << 8) | tabptr[1];
           gint begin_index = matches[2 * n];
@@ -440,7 +440,6 @@ log_matcher_pcre_re_feed_named_substrings(LogMatcher *s, LogMessage *msg, int *m
             continue;
 
           log_msg_set_value_by_name(msg, tabptr + 2, value + begin_index, end_index - begin_index);
-          tabptr += name_entry_size;
         }
     }
 }

--- a/news/bugfix-3393.md
+++ b/news/bugfix-3393.md
@@ -1,0 +1,1 @@
+filter/regex: if there was a named match (?<named>..)? that is optional to match, the previose or the next named matches might not be saved as named match.


### PR DESCRIPTION
When the regex filters used the `store-matches` flag and it was possible to not to set all of the named matches.
The current known case for not setting is when there were an optional named match: `(?<foobar>foobar) (?<foo>foo)?(?<bar>bar)` such as `foo` here, and if the provided string did not contain the `foo` string itself. In that case either `foobar` or `bar` were not saved into the `LogMessage`.

Additionally there was a test case error, that could lead to false positive asserts.