### PR TITLE
scl/cisco: fix clobbered timestamp in case the triplet contains 3 dashes

### DIFF
--- a/scl/cisco/plugin.conf
+++ b/scl/cisco/plugin.conf
@@ -67,10 +67,10 @@ block parser cisco-triplet-parser(template() prefix()) {
         } else {
 	    parser {
                 csv-parser(delimiters(chars('-')) template(`template`)
-                           columns('`prefix`facility', '1', '`prefix`severity', '`prefix`mnemonic')
+                           columns('`prefix`facility', '4', '`prefix`severity', '`prefix`mnemonic')
                            flags(drop-invalid));
             };
-            rewrite { set("${`prefix`facility}-$1" value('`prefix`facility')); };
+            rewrite { set("${`prefix`facility}-$4" value('`prefix`facility')); };
         };
     };
 };


### PR DESCRIPTION
Signed-off-by: Balazs Scheidler <bazsi77@gmail.com>