### PR TITLE
version.sh: version number must be without newline

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -28,7 +28,7 @@ unset CDPATH
 cd $BASEDIR/../
 
 if [ "$VERSION" != "" ]; then
-  echo $VERSION
+  echo $VERSION | tr -d '\n'
 elif [ -d .git ] && GIT_VERSION=$(git describe --tags --dirty --abbrev=7); then
   echo $GIT_VERSION | sed 's/^syslog-ng-//' | tr '-' '.' | tr -d '\n'
 else


### PR DESCRIPTION
News file is not needed as the change it fixes not released and not visible to any user.
Fixes dbld devshell with cmake + ninja