### PR TITLE
python: fixing printing None instead of the actual exception

### DIFF
--- a/modules/python/python-debugger.c
+++ b/modules/python/python-debugger.c
@@ -117,10 +117,11 @@ python_fetch_debugger_command(void)
   if (!ret)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error calling debugger fetch_command",
                 evt_tag_str("function", DEBUGGER_FETCH_COMMAND),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
       goto exit;
     }

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -230,8 +230,10 @@ _as_int(PyObject *obj)
   if (result == -1 && PyErr_Occurred())
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
+
       msg_error("Error converting PyObject to int. Retrying message later",
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
       return LTR_ERROR;
     }
@@ -346,11 +348,12 @@ _py_init_bindings(PythonDestDriver *self)
   if (!self->py.class)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error looking Python driver class",
                 evt_tag_str("driver", self->super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
       return FALSE;
     }
@@ -368,11 +371,12 @@ _py_init_bindings(PythonDestDriver *self)
   if (!self->py.instance)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error instantiating Python driver class",
                 evt_tag_str("driver", self->super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
       return FALSE;
     }

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -287,11 +287,12 @@ _py_resolve_class(PythonFetcherDriver *self)
   if (!self->py.class)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error looking Python driver class",
                 evt_tag_str("driver", self->super.super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
       return FALSE;
     }
@@ -307,11 +308,12 @@ _py_init_instance(PythonFetcherDriver *self)
   if (!self->py.instance)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error instantiating Python driver class",
                 evt_tag_str("driver", self->super.super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
       return FALSE;
     }
@@ -412,11 +414,12 @@ _py_parse_options_new(PythonFetcherDriver *self, MsgFormatOptions *parse_options
   if (!py_parse_options)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error creating capsule for message parse options",
                 evt_tag_str("driver", self->super.super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
       return NULL;
     }
@@ -460,11 +463,12 @@ _py_set_parse_options(PythonFetcherDriver *self)
   if (PyObject_SetAttrString(self->py.instance, "parse_options", py_parse_options) == -1)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error setting attribute message parse options",
                 evt_tag_str("driver", self->super.super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
 
       Py_DECREF(py_parse_options);

--- a/modules/python/python-helpers.c
+++ b/modules/python/python-helpers.c
@@ -26,7 +26,7 @@
 #include "str-utils.h"
 #include "messages.h"
 
-const gchar *
+void
 _py_get_callable_name(PyObject *callable, gchar *buf, gsize buf_len)
 {
   PyObject *name = PyObject_GetAttrString(callable, "__name__");
@@ -41,7 +41,7 @@ _py_get_callable_name(PyObject *callable, gchar *buf, gsize buf_len)
       g_strlcpy(buf, "<unknown>", buf_len);
     }
   Py_XDECREF(name);
-  return buf;
+  return;
 }
 
 void
@@ -81,7 +81,7 @@ exit:
   PyErr_Restore(exc, value, tb);
 }
 
-const gchar *
+void
 _py_format_exception_text(gchar *buf, gsize buf_len)
 {
   PyObject *exc, *value, *tb, *str;
@@ -90,7 +90,7 @@ _py_format_exception_text(gchar *buf, gsize buf_len)
   if (!exc)
     {
       g_strlcpy(buf, "None", buf_len);
-      return buf;
+      return;
     }
   PyErr_NormalizeException(&exc, &value, &tb);
 
@@ -108,7 +108,7 @@ _py_format_exception_text(gchar *buf, gsize buf_len)
     }
   Py_XDECREF(str);
   PyErr_Restore(exc, value, tb);
-  return buf;
+  return;
 }
 
 void
@@ -153,10 +153,11 @@ _py_do_import(const gchar *modname)
   if (!modobj)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error loading Python module",
                 evt_tag_str("module", modname),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
       return NULL;
     }
@@ -230,12 +231,14 @@ _py_invoke_function(PyObject *func, PyObject *arg, const gchar *class, const gch
   if (!ret)
     {
       gchar buf1[256], buf2[256];
+      _py_format_exception_text(buf2, sizeof(buf2));
+      _py_get_callable_name(func, buf1, sizeof(buf1));
 
       msg_error("Exception while calling a Python function",
                 evt_tag_str("caller", caller_context),
                 evt_tag_str("class", class),
-                evt_tag_str("function", _py_get_callable_name(func, buf1, sizeof(buf1))),
-                evt_tag_str("exception", _py_format_exception_text(buf2, sizeof(buf2))));
+                evt_tag_str("function", buf1),
+                evt_tag_str("exception", buf2));
       _py_finish_exception_handling();
       return NULL;
     }
@@ -251,12 +254,14 @@ _py_invoke_function_with_args(PyObject *func, PyObject *args, const gchar *class
   if (!ret)
     {
       gchar buf1[256], buf2[256];
+      _py_format_exception_text(buf2, sizeof(buf2));
+      _py_get_callable_name(func, buf1, sizeof(buf1));
 
       msg_error("Exception while calling a Python function",
                 evt_tag_str("caller", caller_context),
                 evt_tag_str("class", class),
-                evt_tag_str("function", _py_get_callable_name(func, buf1, sizeof(buf1))),
-                evt_tag_str("exception", _py_format_exception_text(buf2, sizeof(buf2))));
+                evt_tag_str("function", buf1),
+                evt_tag_str("exception", buf2));
       _py_finish_exception_handling();
       return NULL;
     }

--- a/modules/python/python-helpers.h
+++ b/modules/python/python-helpers.h
@@ -26,8 +26,8 @@
 
 #include "python-module.h"
 
-const gchar *_py_get_callable_name(PyObject *callable, gchar *buf, gsize buf_len);
-const gchar *_py_format_exception_text(gchar *buf, gsize buf_len);
+void _py_get_callable_name(PyObject *callable, gchar *buf, gsize buf_len);
+void _py_format_exception_text(gchar *buf, gsize buf_len);
 void _py_finish_exception_handling(void);
 PyObject *_py_get_attr_or_null(PyObject *o, const gchar *attr);
 PyObject *_py_do_import(const gchar *modname);

--- a/modules/python/python-http-header.c
+++ b/modules/python/python-http-header.c
@@ -102,9 +102,10 @@ _py_append_str_to_pylist(gconstpointer data, gpointer user_data)
   if (!py_str)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error creating Python String object from C string",
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
 
       goto exit;
@@ -114,9 +115,10 @@ _py_append_str_to_pylist(gconstpointer data, gpointer user_data)
   if (PyList_Append(py_list, py_str) != 0)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error adding new item to Python List",
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
     }
 
@@ -143,10 +145,11 @@ _py_attach_class(PythonHttpHeaderPlugin *self)
   if (!self->py.class)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error looking up Python class",
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
 
       return FALSE;
@@ -162,10 +165,11 @@ _create_arg_dict_from_options(PythonHttpHeaderPlugin *self)
   if (!py_args)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error creating argument dictionary",
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
 
       return NULL;
@@ -186,10 +190,11 @@ _py_instantiate_class(PythonHttpHeaderPlugin *self)
   if (!self->py.instance)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error instantiating Python class",
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
 
       goto exit;
@@ -282,10 +287,11 @@ _append_headers(PythonHttpHeaderPlugin *self, HttpHeaderRequestSignalData *data)
   if (!py_args)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error creating Python arguments",
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
 
       goto cleanup;
@@ -295,11 +301,12 @@ _append_headers(PythonHttpHeaderPlugin *self, HttpHeaderRequestSignalData *data)
   if (!py_ret_list)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Invalid response returned by Python call",
                 evt_tag_str("class", self->class),
                 evt_tag_str("method", "get_headers"),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
 
       goto cleanup;
@@ -313,11 +320,12 @@ _append_headers(PythonHttpHeaderPlugin *self, HttpHeaderRequestSignalData *data)
   if (!_py_append_pylist_to_list(py_ret_list, &headers))
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Converting Python List failed",
                 evt_tag_str("class", self->class),
                 evt_tag_str("method", "get_headers"),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
       goto cleanup;
     }
@@ -351,10 +359,11 @@ _on_http_response_received(PythonHttpHeaderPlugin *self, HttpResponseReceivedSig
     if (!py_arg)
       {
         gchar buf[256];
+        _py_format_exception_text(buf, sizeof(buf));
 
         msg_error("Error creating Python argument",
                   evt_tag_str("class", self->class),
-                  evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                  evt_tag_str("exception", buf));
         _py_finish_exception_handling();
         return;
       }

--- a/modules/python/python-logparser.c
+++ b/modules/python/python-logparser.c
@@ -116,11 +116,12 @@ _py_init_bindings(PythonParser *self)
   if (!self->py.class)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error looking Python parser class",
                 evt_tag_str("parser", self->super.name),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
       return FALSE;
     }
@@ -129,11 +130,12 @@ _py_init_bindings(PythonParser *self)
   if (!self->py.instance)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error instantiating Python parser class",
                 evt_tag_str("parser", self->super.name),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
       return FALSE;
     }

--- a/modules/python/python-main.c
+++ b/modules/python/python-main.c
@@ -64,9 +64,10 @@ _py_construct_main_module(void)
   if (!module)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error creating syslog-ng main module",
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
       return NULL;
     }
@@ -133,7 +134,6 @@ _py_evaluate_global_code(PythonConfig *pc, const gchar *filename, const gchar *c
   PyObject *module;
   PyObject *dict;
   PyObject *code_object;
-  gchar buf[256];
 
   module = _py_get_main_module(pc);
   if (!module)
@@ -160,8 +160,11 @@ _py_evaluate_global_code(PythonConfig *pc, const gchar *filename, const gchar *c
   code_object = Py_CompileString((char *) code, filename, Py_file_input);
   if (!code_object)
     {
+      gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
+
       msg_error("Error compiling Python global code block",
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
       return FALSE;
     }
@@ -170,8 +173,11 @@ _py_evaluate_global_code(PythonConfig *pc, const gchar *filename, const gchar *c
 
   if (!module)
     {
+      gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
+
       msg_error("Error evaluating global Python block",
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
       return FALSE;
     }

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -227,8 +227,10 @@ _persist_type_init(PyObject *s, PyObject *args, PyObject *kwds)
   if (!self->persist_state)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
+
       msg_error("Error importing persist_state",
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
 
       g_assert_not_reached();

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -199,11 +199,12 @@ _py_resolve_class(PythonSourceDriver *self)
   if (!self->py.class)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error looking Python driver class",
                 evt_tag_str("driver", self->super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
       return FALSE;
     }
@@ -219,11 +220,12 @@ _py_init_instance(PythonSourceDriver *self)
   if (!self->py.instance)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error instantiating Python driver class",
                 evt_tag_str("driver", self->super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
       return FALSE;
     }
@@ -362,11 +364,12 @@ _py_parse_options_new(PythonSourceDriver *self, MsgFormatOptions *parse_options)
   if (!py_parse_options)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error creating capsule for message parse options",
                 evt_tag_str("driver", self->super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
       return NULL;
     }
@@ -410,11 +413,12 @@ _py_set_parse_options(PythonSourceDriver *self)
   if (PyObject_SetAttrString(self->py.instance, "parse_options", py_parse_options) == -1)
     {
       gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error setting attribute message parse options",
                 evt_tag_str("driver", self->super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
 
       Py_DECREF(py_parse_options);

--- a/modules/python/python-tf.c
+++ b/modules/python/python-tf.c
@@ -48,14 +48,16 @@ static PyObject *
 _py_invoke_template_function(const gchar *function_name, LogMessage *msg, gint argc, GString *argv[])
 {
   PyObject *callable, *ret, *args;
-  gchar buf[256];
 
   callable = _py_resolve_qualified_name(function_name);
   if (!callable)
     {
+      gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
+
       msg_error("$(python): Error looking up Python function",
                 evt_tag_str("function", function_name),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
       return NULL;
     }
@@ -71,9 +73,12 @@ _py_invoke_template_function(const gchar *function_name, LogMessage *msg, gint a
 
   if (!ret)
     {
+      gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
+
       msg_error("$(python): Error invoking Python function",
                 evt_tag_str("function", function_name),
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
       return NULL;
     }

--- a/modules/python/python-value-pairs.c
+++ b/modules/python/python-value-pairs.c
@@ -31,13 +31,15 @@
 static void
 add_long_to_dict(PyObject *dict, const gchar *name, long num)
 {
-  gchar buf[256];
 
   PyObject *pyobject_to_add = PyLong_FromLong(num);
   if (!pyobject_to_add)
     {
+      gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
+
       msg_error("Error while constructing python object",
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
       return;
     }
@@ -49,13 +51,14 @@ add_long_to_dict(PyObject *dict, const gchar *name, long num)
 static void
 add_string_to_dict(PyObject *dict, const gchar *name, const char *value, gsize value_len)
 {
-  gchar buf[256];
-
   PyObject *pyobject_to_add = PyBytes_FromStringAndSize(value, value_len);
   if (!pyobject_to_add)
     {
+      gchar buf[256];
+      _py_format_exception_text(buf, sizeof(buf));
+
       msg_error("Error while constructing python object",
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+                evt_tag_str("exception", buf));
       _py_finish_exception_handling();
       return;
     }

--- a/news/bugfix-3405.md
+++ b/news/bugfix-3405.md
@@ -1,0 +1,1 @@
+python: printing the exception instead of None (if compiled with clang)


### PR DESCRIPTION
Kudos for @alltilla finding the ordering issue.

If an exception is triggered in python code, such as with the following
configuration[1], normally a message reports in which function what kind of
exception happened. If syslog-ng was compiled with recent clang (10.0) instead of
showing the exception the default None was displayed.

I did not dig into deep enough why this only happens with clang and not with gcc,
it is a good idea - just like in case of ERRNO - to save the exception before
anything else, this patch does exactly that.

Note: also unit test fails due to this issue with clang

[1] configuration that could trigger this issue
```
python {

from syslogng import LogSource

class S(LogSource):
  def init(self, options):
    raise ValueError('exception')

  def run(self):
    pass

  def request_exit(self):
    pass

};

log {
  source {
    python(
        class(S)
    );
  };
```

Signed-off-by: Kokan <kokaipeter@gmail.com>