### PR TITLE
Add namespace to the systemd-journal persist name

### DIFF
--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -615,6 +615,12 @@ _journal_open(JournalReader *self)
           journal_namespace = self->options->namespace;
         }
     }
+
+  if (journal_namespace)
+    {
+      g_free(self->persist_name);
+      self->persist_name = g_strdup_printf("systemd_journal(%s)", self->options->namespace);
+    }
   gint res = journald_open_namespace(self->journal, journal_namespace, journal_flags);
 #else
   gint res = journald_open(self->journal, SD_JOURNAL_LOCAL_ONLY);

--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -585,47 +585,61 @@ _add_poll_events(JournalReader *self)
   return TRUE;
 }
 
-static gint
-_journal_open(JournalReader *self)
-{
 #if SYSLOG_NG_HAVE_JOURNAL_NAMESPACES
-  gint journal_flags = SD_JOURNAL_LOCAL_ONLY;
-  gchar *journal_namespace = NULL;
-
-  if (strcmp(self->options->namespace, "*") == 0)
+static void
+_journal_process_namespace(gchar *namespace_option, gchar **journal_namespace, gint *journal_flags)
+{
+  if (strcmp(namespace_option, "*") == 0)
     {
-      journal_flags |= SD_JOURNAL_ALL_NAMESPACES;
-      if (strlen(self->options->namespace) > 1)
+      *journal_flags |= SD_JOURNAL_ALL_NAMESPACES;
+      if (strlen(namespace_option) > 1)
         {
           msg_warning("namespace('*'): discarding everything after the asterisk");
         }
     }
-  else if (strncmp(self->options->namespace, "+", 1) == 0)
+  else if (strncmp(namespace_option, "+", 1) == 0)
     {
-      journal_flags |= SD_JOURNAL_INCLUDE_DEFAULT_NAMESPACE;
-      if (strlen(self->options->namespace) > 1)
+      *journal_flags |= SD_JOURNAL_INCLUDE_DEFAULT_NAMESPACE;
+      if (strlen(namespace_option) > 1)
         {
-          journal_namespace = self->options->namespace + 1;
+          *journal_namespace = namespace_option + 1;
         }
     }
   else
     {
-      if (strlen(self->options->namespace) > 0)
+      if (strlen(namespace_option) > 0)
         {
-          journal_namespace = self->options->namespace;
+          *journal_namespace = namespace_option;
         }
     }
-
-  if (journal_namespace)
-    {
-      g_free(self->persist_name);
-      self->persist_name = g_strdup_printf("systemd_journal(%s)", self->options->namespace);
-    }
-  gint res = journald_open_namespace(self->journal, journal_namespace, journal_flags);
-#else
-  gint res = journald_open(self->journal, SD_JOURNAL_LOCAL_ONLY);
+}
 #endif
-  return res;
+
+static gint
+_journal_open(JournalReader *self)
+{
+  gint journal_flags = SD_JOURNAL_LOCAL_ONLY;
+
+#if SYSLOG_NG_HAVE_JOURNAL_NAMESPACES
+  gchar *journal_namespace = NULL;
+  _journal_process_namespace(self->options->namespace, &journal_namespace, &journal_flags);
+  return journald_open_namespace(self->journal, journal_namespace, journal_flags);
+#else
+  return journald_open(self->journal, journal_flags);
+#endif
+}
+
+static void
+_init_persist_name(JournalReader *self)
+{
+#if SYSLOG_NG_HAVE_JOURNAL_NAMESPACES
+  if (strcmp(self->options->namespace, "*") != 0)
+    {
+      self->persist_name = g_strdup_printf("systemd_journal(%s)", self->options->namespace);
+      return;
+    }
+#endif
+  self->persist_name = g_strdup("systemd-journal");
 }
 
 static gboolean
@@ -638,6 +652,8 @@ _init(LogPipe *s)
       msg_error("The configuration must not contain more than one systemd-journal() source");
       return FALSE;
     }
+
+  _init_persist_name(self);
 
   if (!log_source_init(s))
     return FALSE;
@@ -734,7 +750,7 @@ journal_reader_new(GlobalConfig *cfg, Journald *journal)
   self->super.super.init = _init;
   self->super.super.deinit = _deinit;
   self->super.super.free_fn = _free;
-  self->persist_name = g_strdup("systemd-journal");
+  self->persist_name = NULL;
   self->journal = journal;
   _init_watches(self);
   return self;

--- a/modules/systemd-journal/journal-reader.h
+++ b/modules/systemd-journal/journal-reader.h
@@ -44,7 +44,6 @@ typedef struct _JournalReaderOptions
 } JournalReaderOptions;
 
 JournalReader *journal_reader_new(GlobalConfig *cfg, Journald *journal);
-void journal_reader_set_persist_name(JournalReader *self, gchar *persist_name);
 void journal_reader_set_options(LogPipe *s, LogPipe *control, JournalReaderOptions *options, const gchar *stats_id,
                                 const gchar *stats_instance);
 

--- a/news/bugfix-3407.md
+++ b/news/bugfix-3407.md
@@ -1,0 +1,1 @@
+systemd-journal: add namespace to the persist name


### PR DESCRIPTION
WIP: This PR is a modification on top of #3358 (it should be merged first), however I was unable to open a pull request on: https://github.com/bjoe2k4/syslog-ng

This PR helps to resolve _CURSOR issues in the persist file in case the namespace option changes.
(According to the systemd documentation the _CURSOR identifies an entry. However we got seeking errors in case the namespace parameters changes, even if syslog-ng should seek to the same log entry again.)

This PR also prepares the code to allow multiple systemd-journal sources at the same time. Before systemd v2.45 it was illogical to add multiple journal sources (they could even conflict with each other) so it is prohibited now. However if two journal sources are configured to read from two different namespaces they can work side by side.

I would like to thank for @bjoe2k4 for all the work to introduce the namespace option to the systemd-journal source.