### PR TITLE
systemd-journal: match g_free with g_strdup

### DIFF
--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -780,6 +780,58 @@ journal_reader_options_init(JournalReaderOptions *options, GlobalConfig *cfg, co
 }
 
 void
+journal_reader_options_set_default_severity(JournalReaderOptions *self, gint severity)
+{
+  if (self->default_pri == 0xFFFF)
+    self->default_pri = LOG_USER;
+  self->default_pri = (self->default_pri & ~7) | severity;
+}
+
+void
+journal_reader_options_set_default_facility(JournalReaderOptions *self, gint facility)
+{
+  if (self->default_pri == 0xFFFF)
+    self->default_pri = LOG_NOTICE;
+  self->default_pri = (self->default_pri & 7) | facility;
+}
+
+void
+journal_reader_options_set_time_zone(JournalReaderOptions *self, gchar *time_zone)
+{
+  if (self->recv_time_zone)
+    g_free(self->recv_time_zone);
+  self->recv_time_zone = g_strdup(time_zone);
+}
+
+void
+journal_reader_options_set_prefix(JournalReaderOptions *self, gchar *prefix)
+{
+  if (self->prefix)
+    g_free(self->prefix);
+  self->prefix = g_strdup(prefix);
+}
+
+void
+journal_reader_options_set_max_field_size(JournalReaderOptions *self, gint max_field_size)
+{
+  self->max_field_size = max_field_size;
+}
+
+void
+journal_reader_options_set_namespace(JournalReaderOptions *self, gchar *namespace)
+{
+  if (self->namespace)
+    g_free(self->namespace);
+  self->namespace = g_strdup(namespace);
+}
+
+void
+journal_reader_options_set_log_fetch_limit(JournalReaderOptions *self, gint log_fetch_limit)
+{
+  self->fetch_limit = log_fetch_limit;
+}
+
+void
 journal_reader_options_defaults(JournalReaderOptions *options)
 {
   log_source_options_defaults(&options->super);

--- a/modules/systemd-journal/journal-reader.h
+++ b/modules/systemd-journal/journal-reader.h
@@ -49,6 +49,13 @@ void journal_reader_set_options(LogPipe *s, LogPipe *control, JournalReaderOptio
                                 const gchar *stats_instance);
 
 void journal_reader_options_init(JournalReaderOptions *options, GlobalConfig *cfg, const gchar *group_name);
+void journal_reader_options_set_default_severity(JournalReaderOptions *self, gint severity);
+void journal_reader_options_set_default_facility(JournalReaderOptions *self, gint facility);
+void journal_reader_options_set_time_zone(JournalReaderOptions *self, gchar *time_zone);
+void journal_reader_options_set_prefix(JournalReaderOptions *self, gchar *prefix);
+void journal_reader_options_set_max_field_size(JournalReaderOptions *self, gint max_field_size);
+void journal_reader_options_set_namespace(JournalReaderOptions *self, gchar *namespace);
+void journal_reader_options_set_log_fetch_limit(JournalReaderOptions *self, gint log_fetch_limit);
 void journal_reader_options_defaults(JournalReaderOptions *options);
 void journal_reader_options_destroy(JournalReaderOptions *options);
 

--- a/modules/systemd-journal/systemd-journal-grammar.ym
+++ b/modules/systemd-journal/systemd-journal-grammar.ym
@@ -103,16 +103,16 @@ source_systemd_journal_option
         | KW_TIME_ZONE '(' string ')'
           {
             if (last_journal_reader_options->recv_time_zone)
-              free(last_journal_reader_options->recv_time_zone);
-            last_journal_reader_options->recv_time_zone = strdup($3);
+              g_free(last_journal_reader_options->recv_time_zone);
+            last_journal_reader_options->recv_time_zone = g_strdup($3);
             free($3);
           }
 
         | KW_PREFIX '(' string ')'
           {
             if (last_journal_reader_options->prefix)
-              free(last_journal_reader_options->prefix);
-            last_journal_reader_options->prefix = strdup($3);
+              g_free(last_journal_reader_options->prefix);
+            last_journal_reader_options->prefix = g_strdup($3);
             free($3);
           }
         | KW_MAX_FIELD_SIZE '(' positive_integer ')'
@@ -122,8 +122,8 @@ source_systemd_journal_option
         | KW_NAMESPACE '(' string ')'
           {
             if (last_journal_reader_options->namespace)
-              free(last_journal_reader_options->namespace);
-            last_journal_reader_options->namespace = strdup($3);
+              g_free(last_journal_reader_options->namespace);
+            last_journal_reader_options->namespace = g_strdup($3);
             free($3);
           }
         | KW_LOG_FETCH_LIMIT '(' positive_integer ')'

--- a/modules/systemd-journal/systemd-journal-grammar.ym
+++ b/modules/systemd-journal/systemd-journal-grammar.ym
@@ -90,45 +90,35 @@ source_systemd_journal_options
 source_systemd_journal_option
         : KW_DEFAULT_SEVERITY '(' severity_string ')'
           {
-            if (last_journal_reader_options->default_pri == 0xFFFF)
-              last_journal_reader_options->default_pri = LOG_USER;
-            last_journal_reader_options->default_pri = (last_journal_reader_options->default_pri & ~7) | $3;
+            journal_reader_options_set_default_severity(last_journal_reader_options, $3);
           }
         | KW_DEFAULT_FACILITY '(' facility_string ')'
           {
-            if (last_journal_reader_options->default_pri == 0xFFFF)
-              last_journal_reader_options->default_pri = LOG_NOTICE;
-            last_journal_reader_options->default_pri = (last_journal_reader_options->default_pri & 7) | $3;
+            journal_reader_options_set_default_facility(last_journal_reader_options, $3);
           }
         | KW_TIME_ZONE '(' string ')'
           {
-            if (last_journal_reader_options->recv_time_zone)
-              g_free(last_journal_reader_options->recv_time_zone);
-            last_journal_reader_options->recv_time_zone = g_strdup($3);
+            journal_reader_options_set_time_zone(last_journal_reader_options, $3);
             free($3);
           }
 
         | KW_PREFIX '(' string ')'
           {
-            if (last_journal_reader_options->prefix)
-              g_free(last_journal_reader_options->prefix);
-            last_journal_reader_options->prefix = g_strdup($3);
+            journal_reader_options_set_prefix(last_journal_reader_options, $3);
             free($3);
           }
         | KW_MAX_FIELD_SIZE '(' positive_integer ')'
           {
-            last_journal_reader_options->max_field_size = $3;
+            journal_reader_options_set_max_field_size(last_journal_reader_options, $3);
           }
         | KW_NAMESPACE '(' string ')'
           {
-            if (last_journal_reader_options->namespace)
-              g_free(last_journal_reader_options->namespace);
-            last_journal_reader_options->namespace = g_strdup($3);
+            journal_reader_options_set_namespace(last_journal_reader_options, $3);
             free($3);
           }
         | KW_LOG_FETCH_LIMIT '(' positive_integer ')'
           {
-            last_journal_reader_options->fetch_limit = $3;
+            journal_reader_options_set_log_fetch_limit(last_journal_reader_options, $3);
           }
         | source_option
 	| source_driver_option


### PR DESCRIPTION
A libc allocation must be deallocated with libc deallocaton (example: strdup -> free),
and the same with glib (example: g_strdup -> g_free).

News file not needed.