### PR TITLE
afprog: manual cloexec

### DIFF
--- a/news/bugfix-3416.md
+++ b/news/bugfix-3416.md
@@ -1,0 +1,5 @@
+afsocket: syslog-ng fails to bind() after config revert
+
+When having a program source or destination and a network destination in the
+config, if we reload with an invalid config, syslog-ng crashes, as it cannot init
+the old network source, because its address is in use.


### PR DESCRIPTION
Parent waits for child to close all *fd* before `exec`.

Fixes #3409.