### PR TITLE
Fix typos found by spellintian

### DIFF
--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -42,7 +42,7 @@ static StatsCounterItem *internal_queue_dropped;
 /* the expiration timer of the next MARK message */
 static struct timespec next_mark_target = { -1, 0 };
 /* as different sources from different threads can call afinter_postpone_mark,
-   and we use the value in the init thread, we need to syncronize the value references
+   and we use the value in the init thread, we need to synchronize the value references
 */
 static GStaticMutex internal_mark_target_lock = G_STATIC_MUTEX_INIT;
 

--- a/lib/logmatcher.c
+++ b/lib/logmatcher.c
@@ -340,7 +340,7 @@ _compile_pcre_regexp(LogMatcherPcreRe *self, const gchar *re, GError **error)
       flags |= PCRE_DUPNAMES;
     }
 
-  /* complile the regexp */
+  /* compile the regexp */
   self->pattern = pcre_compile2(re, flags, &rc, &errptr, &erroffset, NULL);
   if (!self->pattern)
     {

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -447,7 +447,7 @@ log_msg_init_queue_node(LogMessage *msg, LogMessageQueueNode *node, const LogPat
  * Allocates a new LogMessageQueueNode instance to be enqueued in a
  * LogQueue.
  *
- * NOTE: Assumed to be runnning in the source thread, and that the same
+ * NOTE: Assumed to be running in the source thread, and that the same
  * LogMessage instance is only put into queue from the same thread (e.g.
  * the related fields are _NOT_ locked).
  */

--- a/lib/logmsg/tests/test_log_message.c
+++ b/lib/logmsg/tests/test_log_message.c
@@ -507,7 +507,7 @@ Test(log_message, test_message_size)
   cr_assert_eq(msg_size, log_msg_get_size(msg)); // Tag is not increased until tag id 65
 
   char *tag_name = strdup("00tagname");
-  // (*8 to convert ot bits) + no need plus 1 bcause we already added one tag: test_tag_storage
+  // (*8 to convert to bits) + no need plus 1 bcause we already added one tag: test_tag_storage
   for (int i = 0; i < GLIB_SIZEOF_LONG*8; i++)
     {
       sprintf(tag_name, "%dtagname", i);

--- a/lib/logproto/logproto-framed-server.c
+++ b/lib/logproto/logproto-framed-server.c
@@ -187,7 +187,7 @@ _is_trimmed_part_completely_fetched(LogProtoFramedServer *self)
   return self->buffer_end >= self->frame_len;
 }
 
-/* Returns TRUE if successfully finished consuming the data. Othwerwise it is not finished, but
+/* Returns TRUE if successfully finished consuming the data. Otherwise it is not finished, but
  * there is nothing left to read (or there was a read error) and expects to be called again. */
 static gboolean
 _consume_trimmed_part(LogProtoFramedServer *self, gboolean *may_read,

--- a/lib/logproto/logproto-regexp-multiline-server.c
+++ b/lib/logproto/logproto-regexp-multiline-server.c
@@ -44,7 +44,7 @@ multi_line_regexp_compile(const gchar *regexp, GError **error)
 
   g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-  /* complile the regexp */
+  /* compile the regexp */
   self->pattern = pcre_compile2(regexp, 0, &rc, &errptr, &erroffset, NULL);
   if (!self->pattern)
     {

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -114,7 +114,7 @@ struct _LogWriter
  * success. This is more complex when disk buffering is used, in which case
  * messages are put to the "disk buffer" first and acknowledged immediately.
  * (this way the reader never stops when the disk buffer area is not yet
- * full). When disk buffer reaches its limit, messages are added to the the
+ * full). When disk buffer reaches its limit, messages are added to the
  * usual GQueue and messages get acknowledged when they are moved to the
  * disk buffer.
  *

--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -347,7 +347,7 @@ _worker_thread_func(gpointer st)
   /* NOTE: this assert aims to validate that the worker thread in fact
    * invokes main_loop_worker_invoke_batch_callbacks() during its operation.
    * Please do so every once a couple of messages, hopefully you have a
-   * natural barrier that let's you decide when, the easiest would be
+   * natural barrier that lets you decide when, the easiest would be
    * log-fetch-limit(), but other limits may also be applicable.
    */
   g_assert(iv_list_empty(&batch_callbacks));

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -413,7 +413,7 @@ main_loop_verify_config(GString *result, MainLoop *self)
 }
 
 /************************************************************************************
- * syncronized exit
+ * synchronized exit
  ************************************************************************************/
 
 static void

--- a/lib/rcptid.c
+++ b/lib/rcptid.c
@@ -155,7 +155,7 @@ rcptid_generate_id(void)
 }
 
 /*restore RCTPID from persist file, if possible, else
-  create new enrty point with "next.rcptid" name*/
+  create new entry point with "next.rcptid" name*/
 gboolean
 rcptid_init(PersistState *state, gboolean use_rcptid)
 {

--- a/lib/stats/tests/test_external_ctr_reg.c
+++ b/lib/stats/tests/test_external_ctr_reg.c
@@ -179,7 +179,7 @@ Test(stats_external_counter, register_same_ctr_as_external_after_internal_unregi
     stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &counter);
     // assert, SIGABRT:
     stats_register_external_counter(0, &sc_key, SC_TYPE_PROCESSED, &test_ctr);
-    // this is beacuse we are not unset the live mask even when the use_ctr is 0...
+    // this is because we are not unset the live mask even when the use_ctr is 0...
     // I'm not sure if it is correct, but we have other unit tests, where we expect the same behaviour
     /*  counter = stats_get_counter(&sc_key, SC_TYPE_PROCESSED);
         cr_expect_eq(counter->value_ref, &test_ctr);

--- a/lib/template/macros.h
+++ b/lib/template/macros.h
@@ -103,7 +103,7 @@ enum
 
 /* macros (not NV pairs!) that syslog-ng knows about. This was the
  * earliest mechanism for inserting message-specific information into
- * texts. It is now superseeded by name-value pairs where the value is
+ * texts. It is now superseded by name-value pairs where the value is
  * text, but remains to be used for time and other metadata.
  */
 typedef struct _LogMacroDef

--- a/lib/tests/test_reloc.c
+++ b/lib/tests/test_reloc.c
@@ -37,7 +37,7 @@ ParameterizedTestParameters(reloc, test_path)
 {
   static LookupParameter test_data_list[] =
   {
-    {"/opt/syslog-ng", "/opt/syslog-ng"}, /* absoulte path remains unchanged */
+    {"/opt/syslog-ng", "/opt/syslog-ng"}, /* absolute path remains unchanged */
     {"${prefix}/bin", "/test/bin"}, /* variables are resolved */
     {"/foo/${prefix}/bar", "/foo//test/bar"}, /* variables are resolved in the middle */
     {"${foo}/bin", "/foo/bin"}, /* variables are resolved recursively */

--- a/lib/timeutils/tests/test_unixtime.c
+++ b/lib/timeutils/tests/test_unixtime.c
@@ -122,7 +122,7 @@ Test(unixtime, unix_time_fix_timezone_with_tzinfo_to_a_zone_backwards_during_spr
 
   _fix_timezone_with_tzinfo(&base_ut, &ut, 0, "EST5EDT");
 
-  /* we are at exactly the the DST start time */
+  /* we are at exactly the DST start time */
   cr_assert(ut.ut_sec == 1552201200);
   /* thus the resulting timezone is EDT and not EST */
   cr_assert(ut.ut_gmtoff == -4*3600);
@@ -181,7 +181,7 @@ Test(unixtime, unix_time_fix_timezone_with_tzinfo_to_a_zone_forwards_during_spri
    * Mar 31 2019 03:00:00 CEST */
   _fix_timezone_with_tzinfo(&base_ut, &ut, 0, "CET");
 
-  /* we are at exactly the the DST start time */
+  /* we are at exactly the DST start time */
   cr_assert(ut.ut_sec == 1553994000);
   /* thus the resulting timezone is EDT and not EST */
   cr_assert(ut.ut_gmtoff == 2*3600);

--- a/lib/timeutils/zoneinfo.c
+++ b/lib/timeutils/zoneinfo.c
@@ -422,7 +422,7 @@ zone_info_parser(unsigned char **input, gboolean is64bitData, gint *version)
     }
 
   /* http://osdir.com/ml/time.tz/2006-02/msg00041.html */
-  /* We dont nead this flags to compute the wall time of the timezone*/
+  /* We don't need this flags to compute the wall time of the timezone*/
 
   /* Ignore isstd flags */
   for (i=0; i<isstdcnt; i++)

--- a/modules/affile/logproto-file-writer.c
+++ b/modules/affile/logproto-file-writer.c
@@ -108,9 +108,9 @@ log_proto_file_writer_flush(LogProtoClient *s)
       /* add the lengths of the following messages */
       while (i < self->buf_count)
         self->partial_len += self->buffer[i++].iov_len;
-      /* allocate and copy the remaning data */
+      /* allocate and copy the remaining data */
       self->partial = (guchar *)g_malloc(self->partial_len);
-      ofs = sum - rc; /* the length of the remaning (not processed) chunk in the first message */
+      ofs = sum - rc; /* the length of the remaining (not processed) chunk in the first message */
       pos = self->buffer[i0].iov_len - ofs;
       memcpy(self->partial, (guchar *) self->buffer[i0].iov_base + pos, ofs);
       i = i0 + 1;
@@ -128,7 +128,7 @@ log_proto_file_writer_flush(LogProtoClient *s)
       log_proto_client_msg_ack(&self->super, self->buf_count);
     }
 
-  /* free the previous message strings (the remaning part has been copied to the partial buffer) */
+  /* free the previous message strings (the remaining part has been copied to the partial buffer) */
   for (i = 0; i < self->buf_count; ++i)
     g_free(self->buffer[i].iov_base);
   self->buf_count = 0;

--- a/modules/afsnmp/afsnmpdest.c
+++ b/modules/afsnmp/afsnmpdest.c
@@ -565,7 +565,7 @@ snmpdest_dd_session_init(SNMPDestDriver *self)
 
       /*
        * setup the engineID based on IP addr.  Need a different
-       * algorthim here.  This will cause problems with agents on the
+       * algorithm here.  This will cause problems with agents on the
        * same machine sending traps.
        */
       setup_engineID(NULL, NULL);

--- a/modules/dbparser/patternize.h
+++ b/modules/dbparser/patternize.h
@@ -48,7 +48,7 @@ typedef struct _Patternizer
   gdouble support_treshold;
   const gchar *delimiters;
 
-  // NOTE: for now, we store all logs read in in the memory.
+  // NOTE: for now, we store all logs read in the memory.
   // This brings in some obvious constraints and should be solved
   // in a more optimized way later.
   GPtrArray *logs;

--- a/modules/dbparser/pdb-rule.h
+++ b/modules/dbparser/pdb-rule.h
@@ -28,7 +28,7 @@
 
 /* this class encapsulates a the verdict of a rule in the pattern
  * database and is stored as the "value" member in the RADIX tree
- * node. It contains a reference the the original rule in the rule
+ * node. It contains a reference to the original rule in the rule
  * database. */
 typedef struct _PDBRule PDBRule;
 struct _PDBRule

--- a/modules/http/http-loadbalancer.h
+++ b/modules/http/http-loadbalancer.h
@@ -37,7 +37,7 @@ typedef struct _HTTPLoadBalancerClient HTTPLoadBalancerClient;
 typedef struct _HTTPLoadBalancer HTTPLoadBalancer;
 
 
-/* NOTE: this struct represents an actual HTTP target URL.  The existance of
+/* NOTE: this struct represents an actual HTTP target URL.  The existence of
  * this structure is ensured even in multi-threaded environments.  Some of
  * the members of the struct are read-only and are _always_ available
  * without locking.  Others are protected by the LoadBalancer's lock and

--- a/modules/python/python-main.c
+++ b/modules/python/python-main.c
@@ -32,7 +32,7 @@
  * Some information about how we embed the Python interpreter:
  *  - instead of using the __main__ module, we use a separate _syslogng_main
  *    module as we want to replace it every time syslog-ng is reloaded
- *  - hanlding of our separate main module is implemented by this module
+ *  - handling of our separate main module is implemented by this module
  *  - this separate __main__ module requires some magic though (most of it
  *    is in _py_construct_main_module(), see below.
  *  - the PyObject reference to the current main module is stored in the


### PR DESCRIPTION
This was ~~inpsired~~ -> inspired by #3394.
I've ran spellintian (from the lintian package) on dbld devshell image (ubuntu-focal).

Every fix is in comments.
Some seems to be invalid (duplicate word findings sometimes false reports), e.g. `./modules/dbparser/tests/test_timer_wheel.c: latest latest (duplicate word) -> latest`

```
./libtest/mock-transport.c: count count (duplicate word) -> count
./modules/dbparser/tests/test_patternize.c: korte korte (duplicate word) -> korte
./modules/dbparser/tests/test_timer_wheel.c: latest latest (duplicate word) -> latest
./modules/dbparser/pdb-rule.h: the the (duplicate word) -> the
./modules/dbparser/patternize.h: in in (duplicate word) -> in
./modules/python/python-main.c: hanlding -> handling
./modules/http/http-loadbalancer.h: existance -> existence
./modules/afsnmp/afsnmpdest.c: algorthim -> algorithm
./modules/affile/logproto-file-writer.c: sum sum (duplicate word) -> sum
./modules/affile/logproto-file-writer.c: remaning -> remaining
./lib/tests/test_reloc.c: absoulte -> absolute
./lib/stats/tests/test_external_ctr_reg.c: beacuse -> because
./lib/mainloop.c: syncronized -> synchronized
./lib/afinter.c: syncronize -> synchronize
./lib/logmatcher.c: complile -> compile
./lib/template/macros.h: superseeded -> superseded
./lib/logwriter.c: the the (duplicate word) -> the
./lib/logmsg/tests/test_log_message.c: ot -> to
./lib/logmsg/logmsg.c: runnning -> running
./lib/timeutils/tests/test_unixtime.c: the the (duplicate word) -> the
./lib/timeutils/zoneinfo.c: dont -> don't
./lib/timeutils/zoneinfo.c: nead -> need
./lib/logproto/logproto-framed-server.c: Othwerwise -> Otherwise
./lib/logproto/logproto-regexp-multiline-server.c: complile -> compile
./lib/gsockaddr.c: port port (duplicate word) -> port
./lib/eventlog/src/evttags.c: long long (duplicate word) -> long
./lib/eventlog/src/evtlog.h: long long (duplicate word) -> long
./lib/eventlog/src/evtrec.c: freee -> free
./lib/mainloop-worker.c: "let's you" -> "lets you"
./lib/cfg-lexer.h: YYLTYPE YYLTYPE (duplicate word) -> YYLTYPE
./lib/rcptid.c: enrty -> entry
```

Fixes #3394 