### PR TITLE
Editline debugger cli

### DIFF
--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -9,6 +9,7 @@ EXTRA_DIST += \
 	modules/python/pylib/syslogng/debuggercli/completerlang.py		\
 	modules/python/pylib/syslogng/debuggercli/debuglang.py			\
 	modules/python/pylib/syslogng/debuggercli/debuggercli.py		\
+	modules/python/pylib/syslogng/debuggercli/editline.py \
 	modules/python/pylib/syslogng/debuggercli/getoptlexer.py		\
 	modules/python/pylib/syslogng/debuggercli/langcompleter.py		\
 	modules/python/pylib/syslogng/debuggercli/lexer.py			\

--- a/modules/python/pylib/syslogng/debuggercli/__init__.py
+++ b/modules/python/pylib/syslogng/debuggercli/__init__.py
@@ -21,11 +21,31 @@
 #############################################################################
 
 from __future__ import absolute_import
-from syslogng.debuggercli.readline import setup_readline
 
+def is_readline_available():
+    try:
+        import readline
+    except ImportError:
+        return False
+    return True
+
+def is_editline_available():
+    try:
+        import editline
+    except ImportError:
+        return False
+    return True
+
+def setup_read_or_editline():
+    if is_readline_available():
+        from syslogng.debuggercli.readline import setup_readline
+        setup_readline()
+    elif is_editline_available():
+        from syslogng.debuggercli.editline import setup_editline
+        setup_editline()
 
 def fetch_command():
-    setup_readline()
+    setup_read_or_editline()
     try:
         input_function = raw_input
     except NameError:

--- a/modules/python/pylib/syslogng/debuggercli/editline.py
+++ b/modules/python/pylib/syslogng/debuggercli/editline.py
@@ -1,0 +1,88 @@
+#############################################################################
+# Copyright (c) 2020 One Identity
+# Copyright (c) 2020 Laszlo Budai <laszlo.budai@outlook.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+from __future__ import absolute_import, print_function
+from .debuggercli import DebuggerCLI
+
+from editline import _editline
+from editline.editline import EditLine
+from editline import lineeditor
+
+import sys
+
+class EditlineCompleteHook(object):
+    def __init__(self, completer, editl):
+        self._completer = completer
+        self._last_contents = (None, None)
+        self._last_completions = []
+        self.editl = editl
+
+    def complete(self, text):
+        return self._get_completions(self.editl.get_line_buffer(), text)
+
+    def _get_completions(self, entire_text, text):
+        if self._last_contents == (entire_text, text):
+            return self._last_completions
+        self._last_completions = self._completer.complete(entire_text, text)
+        self._last_contents = (entire_text, text)
+        return self._last_completions
+
+class MyEditLineCompleter(lineeditor.Completer):
+    def __init__(self, subeditor, completer, namespace: dict = None):
+        super().__init__(subeditor, namespace)
+        self._default_display_matches = self.subeditor.display_matches
+        self.subeditor.display_matches = self.display_matches
+        self.completer = completer 
+        self.subeditor.completer = self.complete
+
+    def complete(self, text:str) -> list:
+        self.matches = self.completer.complete(text)
+        return self.matches
+
+    def display_matches(self, matches: list):
+        self.subeditor._display_matches(self.matches)
+
+
+
+__setup_performed__ = False
+
+
+def setup_editline():
+    # pylint: disable=global-statement
+    global __setup_performed__
+
+    if __setup_performed__:
+        return
+
+    debuggercli = DebuggerCLI()
+
+    editline_system = _editline.get_global_instance()
+    if editline_system is None:
+      sys_el = EditLine("DebuggerCLI", sys.stdin, sys.stdout, sys.stderr)
+      _editline.set_global_instance(sys_el)
+      completer = EditlineCompleteHook(debuggercli.get_root_completer(), sys_el)
+      sys_line_ed = MyEditLineCompleter(sys_el, completer=completer)
+      lineeditor.global_line_editor(sys_line_ed)
+      sys_el.completer = sys_line_ed.complete
+
+    __setup_performed__ = True


### PR DESCRIPTION
support BSD licensed `editline` when using debuggercli

motivation: when you have a python without the GPL licensed readline, then you can install [pyeditline](https://pypi.org/project/pyeditline/) for enabling command-completion support. This patch is for enabling completion support also for the built-in debuggercli.

The default is readline - when your python have readline module, then using editline in debuggercli is pointless.

I've tested it my environments and worked as expected.
