### PR TITLE
internal() source running in dedicated thread

### DIFF
--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -187,8 +187,6 @@ afinter_source_mark(gpointer s)
   AFInterSource *self = (AFInterSource *) s;
   struct timespec nmt;
 
-  main_loop_assert_main_thread();
-
   g_static_mutex_lock(&internal_mark_target_lock);
   nmt = next_mark_target;
   g_static_mutex_unlock(&internal_mark_target_lock);

--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -125,6 +125,38 @@ afinter_source_post(gpointer s)
 }
 
 static void
+afinter_source_run(gpointer s)
+{
+  AFInterSource *self = (AFInterSource *) s;
+
+  iv_init();
+
+  iv_main();
+
+  iv_deinit();
+}
+
+static void
+afinter_source_request_exit(gpointer s)
+{
+  AFInterSource *self = (AFInterSource *) s;
+
+}
+
+static gboolean
+afinter_sd_start_thread(LogPipe *s)
+{
+  AFInterSourceDriver *self = (AFInterSourceDriver *) s;
+
+  main_loop_create_worker_thread((WorkerThreadFunc) afinter_source_run,
+                                 (WorkerExitNotificationFunc) afinter_source_request_exit,
+                                 self->source, NULL);
+
+  return TRUE;
+}
+
+
+static void
 afinter_source_mark(gpointer s)
 {
   AFInterSource *self = (AFInterSource *) s;
@@ -412,6 +444,7 @@ afinter_sd_new(GlobalConfig *cfg)
   self->super.super.super.init = afinter_sd_init;
   self->super.super.super.deinit = afinter_sd_deinit;
   self->super.super.super.free_fn = afinter_sd_free;
+  self->super.super.super.on_config_inited = afinter_sd_start_thread;
 
   afinter_source_options_defaults(&self->source_options);
 

--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -353,7 +353,7 @@ afinter_source_deinit(LogPipe *s)
   iv_event_unregister(&self->schedule_wakeup);
 
   afinter_source_stop_watches(self);
-  return log_source_deinit(s);
+  return log_source_deinit(&self->super.super);
 }
 
 static LogSource *

--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -146,6 +146,7 @@ afinter_source_run(gpointer s)
   g_static_mutex_unlock(&internal_msg_lock);
 
   afinter_source_start_watches(self);
+  afinter_source_update_watches(self);
 
   iv_main();
 

--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -150,6 +150,10 @@ afinter_source_run(gpointer s)
 
   iv_main();
 
+  g_static_mutex_lock(&internal_msg_lock);
+  current_internal_source = NULL;
+  g_static_mutex_unlock(&internal_msg_lock);
+
   iv_event_unregister(&self->exit);
   iv_event_unregister(&self->post);
   iv_event_unregister(&self->schedule_wakeup);

--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -134,6 +134,10 @@ afinter_source_run(gpointer s)
 
   iv_event_register(&self->exit);
 
+  g_static_mutex_lock(&internal_msg_lock);
+  self->free_to_send = TRUE;
+  g_static_mutex_unlock(&internal_msg_lock);
+
   iv_main();
 
   iv_event_unregister(&self->exit);
@@ -327,7 +331,7 @@ afinter_source_init(LogPipe *s)
 
   g_static_mutex_lock(&internal_msg_lock);
   current_internal_source = self;
-  self->free_to_send = TRUE;
+
   g_static_mutex_unlock(&internal_msg_lock);
 
   return TRUE;

--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -123,7 +123,6 @@ afinter_source_post(gpointer s)
       log_source_post(&self->super, msg);
     }
   afinter_source_update_watches(self);
-  main_loop_worker_invoke_batch_callbacks();
 }
 
 static void afinter_source_start_watches(AFInterSource *self);
@@ -173,9 +172,11 @@ afinter_sd_start_thread(LogPipe *s)
 {
   AFInterSourceDriver *self = (AFInterSourceDriver *) s;
 
+  self->worker_options.is_external_input = TRUE;
+
   main_loop_create_worker_thread((WorkerThreadFunc) afinter_source_run,
                                  (WorkerExitNotificationFunc) afinter_source_request_exit,
-                                 self->source, NULL);
+                                 self->source, &self->worker_options);
 
   return TRUE;
 }

--- a/lib/afinter.h
+++ b/lib/afinter.h
@@ -27,6 +27,7 @@
 
 #include "driver.h"
 #include "logsource.h"
+#include "mainloop-worker.h"
 
 typedef struct AFInterSourceOptions
 {
@@ -42,6 +43,7 @@ typedef struct _AFInterSourceDriver
   LogSrcDriver super;
   LogSource *source;
   AFInterSourceOptions source_options;
+  WorkerOptions worker_options;
 } AFInterSourceDriver;
 
 void afinter_postpone_mark(gint mark_freq);

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -368,6 +368,13 @@ cfg_init(GlobalConfig *cfg)
   if (!cfg_tree_start(&cfg->tree))
     return FALSE;
 
+  /*
+   * TLDR: A half-initialized pipeline turned out to be really hard to deinitialize
+   * correctly when dedicated source/destination threads are spawned (because we
+   * would have to wait for workers to stop and guarantee some internal
+   * task/timer/fdwatch ordering in ivykis during this action).
+   * See: https://github.com/syslog-ng/syslog-ng/pull/3176#issuecomment-638849597
+   */
   g_assert(cfg_tree_on_inited(&cfg->tree));
   return TRUE;
 }


### PR DESCRIPTION
The `internal()` source currently runs in the main thread, while the main thread main goal is to orchestrate the work and not doing it.