### PR TITLE
nvtable: use atomic refcount

### DIFF
--- a/lib/logmsg/nvtable-serialize-legacy.c
+++ b/lib/logmsg/nvtable-serialize-legacy.c
@@ -316,7 +316,7 @@ nv_table_deserialize_22(SerializeArchive *sa)
   if(!res)
     return NULL;
 
-  res->ref_cnt = 1;
+  g_atomic_counter_set(&res->ref_cnt, 1);
   res->borrowed = FALSE;
 
   if (!_deserialize_struct_22(sa, res))
@@ -453,7 +453,7 @@ nv_table_deserialize_legacy(SerializeArchive *sa)
     return NULL;
 
   res->borrowed = FALSE;
-  res->ref_cnt = 1;
+  g_atomic_counter_set(&res->ref_cnt, 1);
 
   if (!_deserialize_blob_v22(sa, res, nv_table_get_top(res), swap_bytes))
     {

--- a/lib/logmsg/nvtable-serialize.c
+++ b/lib/logmsg/nvtable-serialize.c
@@ -150,7 +150,7 @@ _read_header(SerializeArchive *sa, NVTable **nvtable)
     goto error;
 
   res->borrowed = FALSE;
-  res->ref_cnt = 1;
+  g_atomic_counter_set(&res->ref_cnt, 1);
   *nvtable = res;
   return TRUE;
 

--- a/lib/logmsg/nvtable.h
+++ b/lib/logmsg/nvtable.h
@@ -27,6 +27,7 @@
 
 #include "syslog-ng.h"
 #include "nvhandle-descriptors.h"
+#include "atomic.h"
 
 typedef struct _NVTable NVTable;
 typedef struct _NVRegistry NVRegistry;
@@ -237,8 +238,8 @@ struct _NVTable
    * versions, but index_size is a more descriptive name */
   guint16 index_size;
   guint8 num_static_entries;
-  guint8 ref_cnt:7,
-         borrowed:1; /* specifies if the memory used by NVTable was borrowed from the container struct */
+  GAtomicCounter ref_cnt;
+  gboolean borrowed;
 
   /* variable data, see memory layout in the comment above */
   union


### PR DESCRIPTION
nv_table_serialize can be called from destinations, for example in
LogStore. In destination (logwriter) context, this means these
counters are changed from multiple threads, so they need to be
protected. This patch turns ref_cnt to an atomic counter.

As there are no destinations that serialize messages in ose,
no changenote is necessary.