### PR TITLE
Fix journald namespaces detection on centos-7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1407,7 +1407,7 @@ dnl ***************************************************************************
 PKG_CHECK_MODULES(libsystemd, libsystemd >= ${LIBSYSTEMD_MIN_VERSION},
                   have_libsystemd="yes", have_libsystemd="no")
 
-PKG_CHECK_MODULES(libsystemd, libsystemd >= ${LIBSYSTEMD_WITH_JOURNAL_NAMESPACES_MIN_VERSION},
+PKG_CHECK_MODULES(libsystemd_namespaces, libsystemd >= ${LIBSYSTEMD_WITH_JOURNAL_NAMESPACES_MIN_VERSION},
                   journal_namespaces="yes", journal_namespaces="no")
 
 dnl ***************************************************************************

--- a/dbld/packages.manifest
+++ b/dbld/packages.manifest
@@ -91,7 +91,7 @@ python-devel                [centos, fedora]
 python3-devel               [fedora]
 python3-dev                 [ubuntu-focal]
 python-pip                      [centos, fedora, debian-stretch, debian-buster, ubuntu-trusty, ubuntu-xenial, ubuntu-bionic]
-python3-pip                     [centos, debian, ubuntu]
+python3-pip                     [debian, ubuntu]
 
 # libmongoc and libbson packages on various platforms
 # Because we are using fixed version of libmongoc on Bionic, we need to

--- a/modules/python/pylib/syslogng/debuggercli/editline.py
+++ b/modules/python/pylib/syslogng/debuggercli/editline.py
@@ -48,18 +48,18 @@ class EditlineCompleteHook(object):
         return self._last_completions
 
 class MyEditLineCompleter(lineeditor.Completer):
-    def __init__(self, subeditor, completer, namespace: dict = None):
+    def __init__(self, subeditor, completer, namespace = None):
         super().__init__(subeditor, namespace)
         self._default_display_matches = self.subeditor.display_matches
         self.subeditor.display_matches = self.display_matches
         self.completer = completer 
         self.subeditor.completer = self.complete
 
-    def complete(self, text:str) -> list:
+    def complete(self, text):
         self.matches = self.completer.complete(text)
         return self.matches
 
-    def display_matches(self, matches: list):
+    def display_matches(self, matches):
         self.subeditor._display_matches(self.matches)
 
 


### PR DESCRIPTION
With older pkg-config versions (0.27.1 on centos-7) PKG_CONFIG_CHECK_MODULES() macro doesn't check the library's version on multiple calls (if they have the same prefix).
It seems to be that the macro is idempotent.

With version 0.29.1 it is allowed to call the macro multiple times with the same prefix.

See config.log on centos-7 with pkg-config  version 0.27.1, on the second call it simply returns true.
```
configure:18300: checking for libsystemd
configure:18307: $PKG_CONFIG --exists --print-errors "libsystemd >= ${LIBSYSTEMD_MIN_VERSION}"
configure:18310: $? = 0
configure:18324: $PKG_CONFIG --exists --print-errors "libsystemd >= ${LIBSYSTEMD_MIN_VERSION}"
configure:18327: $? = 0
configure:18365: result: yes
configure:18372: checking for libsystemd
configure:18437: result: yes
```

Alternatively, this could be solved without additional PKG_CHECK_MODULES() calls on libsystemd,
with calling $PKG_CONFIG --modversion directly if we detected libsystemd in the first place.

Fixes: #3418 