### PR TITLE
nv_table_serialize: do not nv_table_ref

### DIFF
--- a/lib/logmsg/nvtable-serialize-legacy.c
+++ b/lib/logmsg/nvtable-serialize-legacy.c
@@ -316,7 +316,7 @@ nv_table_deserialize_22(SerializeArchive *sa)
   if(!res)
     return NULL;
 
-  g_atomic_counter_set(&res->ref_cnt, 1);
+  res->ref_cnt = 1;
   res->borrowed = FALSE;
 
   if (!_deserialize_struct_22(sa, res))
@@ -453,7 +453,7 @@ nv_table_deserialize_legacy(SerializeArchive *sa)
     return NULL;
 
   res->borrowed = FALSE;
-  g_atomic_counter_set(&res->ref_cnt, 1);
+  res->ref_cnt = 1;
 
   if (!_deserialize_blob_v22(sa, res, nv_table_get_top(res), swap_bytes))
     {

--- a/lib/logmsg/nvtable-serialize.c
+++ b/lib/logmsg/nvtable-serialize.c
@@ -150,7 +150,7 @@ _read_header(SerializeArchive *sa, NVTable **nvtable)
     goto error;
 
   res->borrowed = FALSE;
-  g_atomic_counter_set(&res->ref_cnt, 1);
+  res->ref_cnt = 1;
   *nvtable = res;
   return TRUE;
 

--- a/lib/logmsg/nvtable.c
+++ b/lib/logmsg/nvtable.c
@@ -674,7 +674,7 @@ nv_table_init(NVTable *self, gsize alloc_length, gint num_static_entries)
   self->used = 0;
   self->index_size = 0;
   self->num_static_entries = num_static_entries;
-  g_atomic_counter_set(&self->ref_cnt, 1);
+  self->ref_cnt = 1;
   self->borrowed = FALSE;
   memset(&self->static_entries[0], 0, self->num_static_entries * sizeof(self->static_entries[0]));
 }
@@ -718,7 +718,7 @@ nv_table_realloc(NVTable *self, NVTable **new)
   if (new_size == old_size)
     return FALSE;
 
-  if (g_atomic_counter_get(&self->ref_cnt) == 1 && !self->borrowed)
+  if (self->ref_cnt == 1 && !self->borrowed)
     {
       *new = self = g_realloc(self, new_size);
 
@@ -735,7 +735,7 @@ nv_table_realloc(NVTable *self, NVTable **new)
       /* we only copy the header first */
       memcpy(*new, self, sizeof(NVTable) + self->num_static_entries * sizeof(self->static_entries[0]) + self->index_size *
              sizeof(NVIndexEntry));
-      g_atomic_counter_set(&((*new)->ref_cnt), 1);
+      (*new)->ref_cnt = 1;
       (*new)->borrowed = FALSE;
       (*new)->size = new_size;
 
@@ -751,14 +751,14 @@ nv_table_realloc(NVTable *self, NVTable **new)
 NVTable *
 nv_table_ref(NVTable *self)
 {
-  g_atomic_counter_inc(&self->ref_cnt);
+  self->ref_cnt++;
   return self;
 }
 
 void
 nv_table_unref(NVTable *self)
 {
-  if (g_atomic_counter_dec_and_test(&self->ref_cnt) && !self->borrowed)
+  if ((--self->ref_cnt == 0) && !self->borrowed)
     {
       g_free(self);
     }
@@ -789,7 +789,7 @@ nv_table_clone(NVTable *self, gint additional_space)
   memcpy(new, self, sizeof(NVTable) + self->num_static_entries * sizeof(self->static_entries[0]) + self->index_size *
          sizeof(NVIndexEntry));
   new->size = new_size;
-  g_atomic_counter_set(&new->ref_cnt, 1);
+  new->ref_cnt = 1;
   new->borrowed = FALSE;
 
   memcpy(NV_TABLE_ADDR(new, new->size - new->used),

--- a/lib/logmsg/nvtable.h
+++ b/lib/logmsg/nvtable.h
@@ -27,7 +27,6 @@
 
 #include "syslog-ng.h"
 #include "nvhandle-descriptors.h"
-#include "atomic.h"
 
 typedef struct _NVTable NVTable;
 typedef struct _NVRegistry NVRegistry;
@@ -238,8 +237,8 @@ struct _NVTable
    * versions, but index_size is a more descriptive name */
   guint16 index_size;
   guint8 num_static_entries;
-  GAtomicCounter ref_cnt;
-  gboolean borrowed;
+  guint8 ref_cnt:7,
+         borrowed:1; /* specifies if the memory used by NVTable was borrowed from the container struct */
 
   /* variable data, see memory layout in the comment above */
   union


### PR DESCRIPTION
This patch reverts: https://github.com/syslog-ng/syslog-ng/pull/3434.

As it turns out `nv_table_ref` is not necessary during `nv_table_serialize`: we have a better resolution of the problem in #3434 

Changenote is not needed. This is just a fixup for #3434