### PR TITLE
afsocket: added support SO_REUSEPORT_LB

### DIFF
--- a/modules/afsocket/socket-options.c
+++ b/modules/afsocket/socket-options.c
@@ -86,7 +86,16 @@ _setup_keepalive(gint fd)
 static gboolean
 _setup_reuseport(gint fd)
 {
-#ifdef SO_REUSEPORT
+#if defined(SO_REUSEPORT_LB)
+  gint on = 1;
+  if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT_LB, &on, sizeof(on)) < 0)
+    {
+      msg_error("The kernel refused our SO_REUSEPORT_LB setting, which should be supported by FreeBSD 12.0+",
+                evt_tag_error("error"));
+      return FALSE;
+    }
+  return TRUE;
+#elif defined(SO_REUSEPORT)
   gint on = 1;
   if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &on, sizeof(on)) < 0)
     {


### PR DESCRIPTION
Added support of *SO_REUSEPORT_LB* socket option, allowing multiple programs or threads to bind to the same port, and incoming connections load balanced using a hash function. The option has been included in [FreeBSD 12.0](https://www.freebsd.org/releases/12.0R/relnotes.html) (https://github.com/freebsd/freebsd/commit/bbf7d4dd035a71710ac94fe1ada4d99244102159).

As continuation for #2379.