### PR TITLE
autotools: support sanitizers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,8 @@ DIST_SUBDIRS		=
 AM_MAKEFLAGS		= --no-print-directory
 AM_YFLAGS		= -Wno-yacc -Wno-other -Werror=conflicts-sr -Werror=conflicts-rr
 
-AM_TESTS_ENVIRONMENT	= top_srcdir="$(top_srcdir)" CRITERION_TEST_PATTERN='!(*/*performance*)'
+AM_TESTS_ENVIRONMENT	= top_srcdir="$(top_srcdir)" CRITERION_TEST_PATTERN='!(*/*performance*)' ASAN_OPTIONS="detect_odr_violation=0"
+LOG_COMPILER            = $(top_srcdir)/scripts/test-grep.sh
 
 ACLOCAL_AMFLAGS		= -I m4 --install
 

--- a/configure.ac
+++ b/configure.ac
@@ -206,6 +206,11 @@ AC_ARG_ENABLE(gprof,
 AC_ARG_ENABLE(memtrace,
               [  --enable-memtrace   Enable alternative leak debugging code.])
 
+AC_ARG_WITH(sanitizer,
+              [  --with-sanitizer=[address/undefined/etc...]
+                                         Enables compiler sanitizer supports (default: no)]
+              ,,with_sanitizer="no")
+
 AC_ARG_ENABLE(dynamic-linking,
               [  --enable-dynamic-linking        Link everything dynamically.],,enable_dynamic_linking="auto")
 
@@ -1694,6 +1699,14 @@ dnl ***************************************************************************
 dnl check fmemopen
 dnl ***************************************************************************
 AC_CHECK_FUNCS([fmemopen])
+
+dnl ***************************************************************************
+dnl sanitizer
+dnl ***************************************************************************
+
+if  test "x$with_sanitizer" != "xno"; then
+   CFLAGS="$CFLAGS -O1 -fsanitize=$with_sanitizer -fno-omit-frame-pointer"
+fi
 
 dnl ***************************************************************************
 dnl default modules to be loaded

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -5,6 +5,7 @@ EXTRA_DIST	+= scripts/update-patterndb.in \
 	scripts/make-and-check.sh	\
 	scripts/rm-extra-msg-sentinel.sh	\
 	scripts/version.sh	\
+	scripts/test-grep.sh	\
 	scripts/style-checker.sh
 
 install-exec-local:

--- a/scripts/test-grep.sh
+++ b/scripts/test-grep.sh
@@ -29,3 +29,6 @@ if egrep -q 'ERROR: (LeakSanitizer|AddressSanitizer)' $1.result; then
    exit 1
 fi
 
+# keep only result file if test failed
+rm -f -- $1.result
+

--- a/scripts/test-grep.sh
+++ b/scripts/test-grep.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+#############################################################################
+# Copyright (c) 2020 Balabit
+# Copyright (c) 2020 Kokan <kokaipeter@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+$1 2>&1 | tee $1.result
+
+if egrep -q 'ERROR: (LeakSanitizer|AddressSanitizer)' $1.result; then
+   echo "SAN report detected"
+   exit 1
+fi
+


### PR DESCRIPTION
This is an attempt to popularise sanitiser as default option for development.
As of now only cmake supported sanitiser, as a developper using autotools might had harder time to configure and so set as a "default" configure option for themself.

The option is `--with-sanitizer=address/thread/etc`.

This option not a drop in replacement for valgrind, both valgrind and sanitizer cover leaks and memory violations but they won't cover almost the same subset of issues  (but neither of them a subset of the other).

The benefit of using sanitiser opposed to valgrind that sanitizer built into the binary and such it is always on. No need for extra step to check for leaks as well as it is done every time syslog-ng & tests are started.
 
The current downside is that current syslog-ng violates the odr(one definition rulel) defining the same global `module_info` in the modules (which is not likely to change) as the option should be disabled with setting the following environment varialbe `ASAN_OPTIONS="detect_odr_violation=0"` (Note: this is "documented" in the makefile as assigned to tests).

The `LOG_COMPILER` option is needed to overcome a Criterion bug, that it won't report a test failed based on the executed testcase exit status. The same solution already exists in CMake with a difference that CMake by defualt supports regex pattern to fail a test. In the long run it should be removed once the Criterion bug is fixed.