### PR TITLE
Light: add basic NetworkSource without IO layer

### DIFF
--- a/tests/python_functional/src/syslog_ng_config/statements/sources/network_source.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/sources/network_source.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2015-2020 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from src.syslog_ng_config.statements.sources.source_driver import SourceDriver
+
+
+class NetworkSource(SourceDriver):
+    def __init__(self, **options):
+        self.driver_name = "network"
+        super(NetworkSource, self).__init__(options=options)
+        self.source_writer = None  # Will be added later, using Loggen

--- a/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
@@ -36,6 +36,7 @@ from src.syslog_ng_config.statements.parsers.parser import Parser
 from src.syslog_ng_config.statements.rewrite.rewrite import SetTag
 from src.syslog_ng_config.statements.sources.example_msg_generator_source import ExampleMsgGeneratorSource
 from src.syslog_ng_config.statements.sources.file_source import FileSource
+from src.syslog_ng_config.statements.sources.network_source import NetworkSource
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +84,9 @@ class SyslogNgConfig(object):
 
     def create_example_msg_generator_source(self, **options):
         return ExampleMsgGeneratorSource(**options)
+
+    def create_network_source(self, **options):
+        return NetworkSource(**options)
 
     def create_rewrite_set_tag(self, tag, **options):
         return SetTag(tag, **options)


### PR DESCRIPTION
The IO layer will be done with Loggen later.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>