### PR TITLE
logwriter: destination timeout to verbose from notice

### DIFF
--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1314,8 +1314,8 @@ log_writer_idle_timeout(void *cookie)
   LogWriter *self = (LogWriter *) cookie;
 
   g_assert(!self->io_job.working);
-  msg_notice("Destination timeout has elapsed, closing connection",
-             evt_tag_int("fd", log_proto_client_get_fd(self->proto)));
+  msg_verbose("Destination timeout has elapsed, closing connection",
+              evt_tag_int("fd", log_proto_client_get_fd(self->proto)));
 
   log_pipe_notify(self->control, NC_CLOSE, self);
 }


### PR DESCRIPTION
After this change, these two logs will occur together:

```
Destination timeout has elapsed, closing connection; fd='12'
Destination timed out, reaping; template='/dev/stdout', filename='/dev/stdout'
```

Originally, only the first one was visibe (without verbose
flag). Withouth the context of the second, this can cause confusion.