### PR TITLE
fix leaking stats counter_names per creation

### DIFF
--- a/lib/stats/stats-cluster-logpipe.c
+++ b/lib/stats/stats-cluster-logpipe.c
@@ -50,7 +50,7 @@ _counter_group_logpipe_init(StatsCounterGroupInit *self, StatsCounterGroup *coun
 {
   counter_group->counters = g_new0(StatsCounterItem, SC_TYPE_MAX);
   counter_group->capacity = SC_TYPE_MAX;
-  counter_group->counter_names = self->counter_names;
+  counter_group->counter_names = self->counter.names;
   counter_group->free_fn = _counter_group_logpipe_free;
 }
 
@@ -59,6 +59,6 @@ stats_cluster_logpipe_key_set(StatsClusterKey *key, guint16 component, const gch
 {
   stats_cluster_key_set(key, component, id, instance, (StatsCounterGroupInit)
   {
-    .counter_names = tag_names, .init = _counter_group_logpipe_init, .equals = NULL
+    .counter.names = tag_names, .init = _counter_group_logpipe_init, .equals = NULL
   });
 }

--- a/lib/stats/stats-cluster-logpipe.c
+++ b/lib/stats/stats-cluster-logpipe.c
@@ -59,6 +59,6 @@ stats_cluster_logpipe_key_set(StatsClusterKey *key, guint16 component, const gch
 {
   stats_cluster_key_set(key, component, id, instance, (StatsCounterGroupInit)
   {
-    tag_names, _counter_group_logpipe_init
+    .counter_names = tag_names, .init = _counter_group_logpipe_init, .equals = NULL
   });
 }

--- a/lib/stats/stats-cluster-single.c
+++ b/lib/stats/stats-cluster-single.c
@@ -41,7 +41,7 @@ _counter_group_init(StatsCounterGroupInit *self, StatsCounterGroup *counter_grou
 {
   counter_group->counters = g_new0(StatsCounterItem, SC_TYPE_SINGLE_MAX);
   counter_group->capacity = SC_TYPE_SINGLE_MAX;
-  counter_group->counter_names = self->counter_names;
+  counter_group->counter_names = self->counter.names;
   counter_group->free_fn = _counter_group_free;
 }
 
@@ -50,7 +50,7 @@ stats_cluster_single_key_set(StatsClusterKey *key, guint16 component, const gcha
 {
   stats_cluster_key_set(key, component, id, instance, (StatsCounterGroupInit)
   {
-    .counter_names = tag_names, .init = _counter_group_init, .equals = NULL
+    .counter.names = tag_names, .init = _counter_group_init, .equals = NULL
   });
 }
 
@@ -66,15 +66,15 @@ _counter_group_init_with_name(StatsCounterGroupInit *self, StatsCounterGroup *co
 {
   counter_group->counters = g_new0(StatsCounterItem, SC_TYPE_SINGLE_MAX);
   counter_group->capacity = SC_TYPE_SINGLE_MAX;
-  counter_group->counter_names = self->counter_names;
+  counter_group->counter_names = self->counter.names;
   counter_group->free_fn = _counter_group_with_name_free;
 }
 
 static gboolean
 _group_init_equals(const StatsCounterGroupInit *self, const StatsCounterGroupInit *other)
 {
-  g_assert(self != NULL && other != NULL && self->counter_names != NULL && other->counter_names != NULL);
-  return (self->init == other->init) && (g_strcmp0(self->counter_names[0], other->counter_names[0]) == 0);
+  g_assert(self != NULL && other != NULL && self->counter.names != NULL && other->counter.names != NULL);
+  return (self->init == other->init) && (g_strcmp0(self->counter.names[0], other->counter.names[0]) == 0);
 }
 
 void
@@ -83,9 +83,9 @@ stats_cluster_single_key_set_with_name(StatsClusterKey *key, guint16 component, 
 {
   stats_cluster_key_set(key, component, id, instance, (StatsCounterGroupInit)
   {
-    .counter_names = tag_names, .init = _counter_group_init_with_name, .equals = _group_init_equals
+    .counter.names = tag_names, .init = _counter_group_init_with_name, .equals = _group_init_equals
   });
-  key->counter_group_init.counter_names = g_new0(const char *, 1);
-  key->counter_group_init.counter_names[0] = name;
+  key->counter_group_init.counter.names = g_new0(const char *, 1);
+  key->counter_group_init.counter.names[0] = name;
 }
 

--- a/lib/stats/stats-cluster-single.c
+++ b/lib/stats/stats-cluster-single.c
@@ -50,7 +50,7 @@ stats_cluster_single_key_set(StatsClusterKey *key, guint16 component, const gcha
 {
   stats_cluster_key_set(key, component, id, instance, (StatsCounterGroupInit)
   {
-    tag_names, _counter_group_init
+    .counter_names = tag_names, .init = _counter_group_init, .equals = NULL
   });
 }
 
@@ -83,7 +83,7 @@ stats_cluster_single_key_set_with_name(StatsClusterKey *key, guint16 component, 
 {
   stats_cluster_key_set(key, component, id, instance, (StatsCounterGroupInit)
   {
-    tag_names, _counter_group_init_with_name, _group_init_equals
+    .counter_names = tag_names, .init = _counter_group_init_with_name, .equals = _group_init_equals
   });
   key->counter_group_init.counter_names = g_new0(const char *, 1);
   key->counter_group_init.counter_names[0] = name;

--- a/lib/stats/stats-cluster-single.c
+++ b/lib/stats/stats-cluster-single.c
@@ -66,15 +66,19 @@ _counter_group_init_with_name(StatsCounterGroupInit *self, StatsCounterGroup *co
 {
   counter_group->counters = g_new0(StatsCounterItem, SC_TYPE_SINGLE_MAX);
   counter_group->capacity = SC_TYPE_SINGLE_MAX;
-  counter_group->counter_names = self->counter.names;
+
+  const gchar **counter_names = g_new0(const char *, 1);
+  counter_names[0] = self->counter.name;
+  counter_group->counter_names = counter_names;
+
   counter_group->free_fn = _counter_group_with_name_free;
 }
 
 static gboolean
 _group_init_equals(const StatsCounterGroupInit *self, const StatsCounterGroupInit *other)
 {
-  g_assert(self != NULL && other != NULL && self->counter.names != NULL && other->counter.names != NULL);
-  return (self->init == other->init) && (g_strcmp0(self->counter.names[0], other->counter.names[0]) == 0);
+  g_assert(self != NULL && other != NULL && self->counter.name != NULL && other->counter.name != NULL);
+  return (self->init == other->init) && (g_strcmp0(self->counter.name, other->counter.name) == 0);
 }
 
 void
@@ -83,9 +87,7 @@ stats_cluster_single_key_set_with_name(StatsClusterKey *key, guint16 component, 
 {
   stats_cluster_key_set(key, component, id, instance, (StatsCounterGroupInit)
   {
-    .counter.names = tag_names, .init = _counter_group_init_with_name, .equals = _group_init_equals
+    .counter.name = name, .init = _counter_group_init_with_name, .equals = _group_init_equals
   });
-  key->counter_group_init.counter.names = g_new0(const char *, 1);
-  key->counter_group_init.counter.names[0] = name;
 }
 

--- a/lib/stats/stats-cluster-single.c
+++ b/lib/stats/stats-cluster-single.c
@@ -67,7 +67,7 @@ _counter_group_init_with_name(StatsCounterGroupInit *self, StatsCounterGroup *co
   counter_group->counters = g_new0(StatsCounterItem, SC_TYPE_SINGLE_MAX);
   counter_group->capacity = SC_TYPE_SINGLE_MAX;
 
-  const gchar **counter_names = g_new0(const char *, 1);
+  const gchar **counter_names = g_new0(const gchar *, 1);
   counter_names[0] = self->counter.name;
   counter_group->counter_names = counter_names;
 

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -179,7 +179,7 @@ stats_counter_group_init_equals(const StatsCounterGroupInit *self, const StatsCo
   if (self->equals)
     return self->equals(self, other);
 
-  return (self->init == other->init) && (self->counter_names == other->counter_names);
+  return (self->init == other->init) && (self->counter.names == other->counter.names);
 }
 
 gboolean

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -59,7 +59,11 @@ struct _StatsCounterGroup
 
 struct _StatsCounterGroupInit
 {
-  const gchar **counter_names;
+  union
+  {
+    const gchar **names;
+    const gchar *name;
+  } counter;
   void (*init)(StatsCounterGroupInit *self, StatsCounterGroup *counter_group);
   gboolean (*equals)(const StatsCounterGroupInit *self, const StatsCounterGroupInit *other);
 };


### PR DESCRIPTION

Reproduction:
1. syslog-ng configuration with at least one network source
2. start syslog-ng with a leak detector
(2.1 optional do restart (in order to have the exact leak as above))
3. stop syslog-ng

```
=================================================================
==2095056==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x55a4f86db781 in calloc (/tmp/install/sbin/syslog-ng+0xc5781)
    #1 0x7f343f03a941 in g_malloc0 (/usr/lib/libglib-2.0.so.0+0x50941)
    #2 0x7f343acb37c7 in _make_connection_conter_stats_queryable /home/user/src/syslog-ng/build/../modules/afsocket/afsocket-source.c:1007:9
    #3 0x7f343acb30f3 in afsocket_sd_init_method /home/user/src/syslog-ng/build/../modules/afsocket/afsocket-source.c:1060:5
    #4 0x7f343acbc358 in afinet_sd_init /home/user/src/syslog-ng/build/../modules/afsocket/afinet-source.c:103:8
    #5 0x7f343f248e1a in log_pipe_init /home/user/src/syslog-ng/build/../lib/logpipe.h:301:23
    #6 0x7f343f248c88 in cfg_tree_start /home/user/src/syslog-ng/build/../lib/cfg-tree.c:1419:12
    #7 0x7f343f23af71 in cfg_init /home/user/src/syslog-ng/build/../lib/cfg.c:368:8
    #8 0x7f343f270b3c in main_loop_reload_config_apply /home/user/src/syslog-ng/build/../lib/mainloop.c:276:41
    #9 0x7f343f273162 in _consume_action /home/user/src/syslog-ng/build/../lib/mainloop-worker.c:240:3
    #10 0x7f343f27321f in _invoke_sync_call_actions /home/user/src/syslog-ng/build/../lib/mainloop-worker.c:250:7
    #11 0x7f343f2736ba in main_loop_worker_sync_call /home/user/src/syslog-ng/build/../lib/mainloop-worker.c:396:7
    #12 0x7f343f2709d1 in main_loop_reload_config_commence /home/user/src/syslog-ng/build/../lib/mainloop.c:340:3
    #13 0x7f343f275852 in control_connection_reload /home/user/src/syslog-ng/build/../lib/mainloop-control.c:167:3
    #14 0x7f343f290c80 in control_connection_io_input /home/user/src/syslog-ng/build/../lib/control/control-server.c:378:3
    #15 0x7f343efd4b2c  (/usr/lib/libivykis.so.0+0x6b2c)
    #16 0x7f343f239c50 in run_application_hook /home/user/src/syslog-ng/build/../lib/apphook.c:125:11

Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x55a4f86db781 in calloc (/tmp/install/sbin/syslog-ng+0xc5781)
    #1 0x7f343f03a941 in g_malloc0 (/usr/lib/libglib-2.0.so.0+0x50941)
    #2 0x7f343acb3e27 in _stop_connection_counter_stats_queryable /home/user/src/syslog-ng/build/../modules/afsocket/afsocket-source.c:1027:9
    #3 0x7f343acb38bd in afsocket_sd_deinit_method /home/user/src/syslog-ng/build/../modules/afsocket/afsocket-source.c:1073:3
    #4 0x7f343f2491d4 in log_pipe_deinit /home/user/src/syslog-ng/build/../lib/logpipe.h:316:25
    #5 0x7f343f2490e5 in cfg_tree_stop /home/user/src/syslog-ng/build/../lib/cfg-tree.c:1439:12
    #6 0x7f343f23b2d1 in cfg_deinit /home/user/src/syslog-ng/build/../lib/cfg.c:387:10
    #7 0x7f343f271ec2 in main_loop_exit_finish /home/user/src/syslog-ng/build/../lib/mainloop.c:427:3
    #8 0x7f343f273162 in _consume_action /home/user/src/syslog-ng/build/../lib/mainloop-worker.c:240:3
    #9 0x7f343f27321f in _invoke_sync_call_actions /home/user/src/syslog-ng/build/../lib/mainloop-worker.c:250:7
    #9 0x7f343f27321f in _invoke_sync_call_actions /home/user/src/syslog-ng/build/../lib/mainloop-worker.c:250:7
    #10 0x7f343f2736ba in main_loop_worker_sync_call /home/user/src/syslog-ng/build/../lib/mainloop-worker.c:396:7
    #11 0x7f343f2709d1 in main_loop_reload_config_commence /home/user/src/syslog-ng/build/../lib/mainloop.c:340:3
    #12 0x7f343f275852 in control_connection_reload /home/user/src/syslog-ng/build/../lib/mainloop-control.c:167:3
    #13 0x7f343f290c80 in control_connection_io_input /home/user/src/syslog-ng/build/../lib/control/control-server.c:378:3
    #14 0x7f343efd4b2c  (/usr/lib/libivykis.so.0+0x6b2c)
    #15 0x7f343f239c50 in run_application_hook /home/user/src/syslog-ng/build/../lib/apphook.c:125:11
```