### PR TITLE
Fix TLS certificate hostname verification when using failover() servers

### DIFF
--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -231,11 +231,22 @@ afinet_dd_add_failovers(LogDriver *s, GList *failovers)
 }
 
 void
+afinet_dd_fail_back_to_primary(gpointer s, gint fd, GSockAddr *saddr)
+{
+  AFInetDestDriver *self = (AFInetDestDriver *) s;
+
+  if (_is_tls_used(self))
+    afinet_dd_setup_tls_verifier(self);
+
+  afsocket_dd_connected_with_fd(s, fd, saddr);
+}
+
+void
 afinet_dd_enable_failback(LogDriver *s)
 {
   AFInetDestDriver *self = (AFInetDestDriver *) s;
   g_assert(self->failover != NULL);
-  afinet_dd_failover_enable_failback(self->failover, &self->super, afsocket_dd_connected_with_fd);
+  afinet_dd_failover_enable_failback(self->failover, &self->super, afinet_dd_fail_back_to_primary);
 }
 
 void

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -172,6 +172,14 @@ afinet_dd_tls_verify_data_free(gpointer s)
 }
 
 static gboolean
+_is_tls_used(const AFInetDestDriver *self)
+{
+  TransportMapperInet *transport_mapper_inet = (TransportMapperInet *) self->super.transport_mapper;
+
+  return transport_mapper_inet->tls_context != NULL;
+}
+
+static gboolean
 _is_failover_used(const AFInetDestDriver *self)
 {
   return self->failover != NULL;

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -195,7 +195,8 @@ afinet_dd_set_tls_context(LogDriver *s, TLSContext *tls_context)
 
   verify_data = afinet_dd_tls_verify_data_new(tls_context, _afinet_dd_get_hostname(self));
   verifier = tls_verifier_new(afinet_dd_verify_callback, verify_data, afinet_dd_tls_verify_data_free);
-  transport_mapper_inet_set_tls_context((TransportMapperInet *) self->super.transport_mapper, tls_context, verifier);
+  transport_mapper_inet_set_tls_context((TransportMapperInet *) self->super.transport_mapper, tls_context);
+  transport_mapper_inet_set_tls_verifier((TransportMapperInet *) self->super.transport_mapper, verifier);
 }
 
 void

--- a/modules/afsocket/afinet-source.c
+++ b/modules/afsocket/afinet-source.c
@@ -59,7 +59,7 @@ afinet_sd_set_tls_context(LogDriver *s, TLSContext *tls_context)
 {
   AFInetSourceDriver *self = (AFInetSourceDriver *) s;
 
-  transport_mapper_inet_set_tls_context((TransportMapperInet *) self->super.transport_mapper, tls_context, NULL);
+  transport_mapper_inet_set_tls_context((TransportMapperInet *) self->super.transport_mapper, tls_context);
 }
 
 static gboolean

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -729,7 +729,7 @@ afsocket_dd_init_instance(AFSocketDestDriver *self,
   self->super.super.super.free_fn = afsocket_dd_free;
   self->super.super.super.notify = afsocket_dd_notify;
   self->super.super.super.generate_persist_name = afsocket_dd_format_name;
-  self->setup_addresses = afsocket_dd_setup_addresses;
+  self->setup_addresses = afsocket_dd_setup_addresses_method;
   self->construct_writer = afsocket_dd_construct_writer_method;
   self->transport_mapper = transport_mapper;
   self->socket_options = socket_options;

--- a/modules/afsocket/tests/test-transport-mapper-inet.c
+++ b/modules/afsocket/tests/test-transport-mapper-inet.c
@@ -178,7 +178,7 @@ Test(transport_mapper_inet, test_udp_apply_transport_sets_defaults)
 Test(transport_mapper_inet, test_udp_apply_fails_when_tls_context_is_set)
 {
   transport_mapper = transport_mapper_udp_new();
-  transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context(), NULL);
+  transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context());
   assert_transport_mapper_apply_fails(transport_mapper, "udp");
 }
 
@@ -209,7 +209,7 @@ Test(transport_mapper_inet, test_network_transport_udp_apply_transport_sets_defa
 Test(transport_mapper_inet, test_network_transport_udp_apply_fails_when_tls_context_is_set)
 {
   transport_mapper = transport_mapper_network_new();
-  transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context(), NULL);
+  transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context());
   assert_transport_mapper_apply_fails(transport_mapper, "udp");
 }
 
@@ -234,7 +234,7 @@ Test(transport_mapper_inet, test_network_transport_tls_apply_fails_without_tls_c
 Test(transport_mapper_inet, test_network_transport_tls_apply_transport_sets_defaults)
 {
   transport_mapper = transport_mapper_network_new();
-  transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context(), NULL);
+  transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context());
   assert_transport_mapper_apply(transport_mapper, "tls");
   assert_transport_mapper_tcp_socket(transport_mapper);
 
@@ -271,7 +271,7 @@ Test(transport_mapper_inet, test_syslog_transport_udp_apply_transport_sets_defau
 Test(transport_mapper_inet, test_syslog_transport_udp_apply_fails_when_tls_context_is_set)
 {
   transport_mapper = transport_mapper_syslog_new();
-  transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context(), NULL);
+  transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context());
   assert_transport_mapper_apply_fails(transport_mapper, "udp");
 }
 
@@ -296,7 +296,7 @@ Test(transport_mapper_inet, test_syslog_transport_tls_apply_fails_without_tls_co
 Test(transport_mapper_inet, test_syslog_transport_tls_apply_transport_sets_defaults)
 {
   transport_mapper = transport_mapper_syslog_new();
-  transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context(), NULL);
+  transport_mapper_inet_set_tls_context((TransportMapperInet *) transport_mapper, create_dummy_tls_context());
   assert_transport_mapper_apply(transport_mapper, "tls");
   assert_transport_mapper_tcp_socket(transport_mapper);
 

--- a/modules/afsocket/transport-mapper-inet.h
+++ b/modules/afsocket/transport-mapper-inet.h
@@ -72,9 +72,15 @@ transport_mapper_inet_get_port_change_warning(TransportMapper *s)
 }
 
 static inline void
-transport_mapper_inet_set_tls_context(TransportMapperInet *self, TLSContext *tls_context, TLSVerifier *tls_verifier)
+transport_mapper_inet_set_tls_context(TransportMapperInet *self, TLSContext *tls_context)
 {
   self->tls_context = tls_context;
+}
+
+static inline void
+transport_mapper_inet_set_tls_verifier(TransportMapperInet *self, TLSVerifier *tls_verifier)
+{
+  tls_verifier_unref(self->tls_verifier);
   self->tls_verifier = tls_verifier;
 }
 

--- a/news/bugfix-3447.md
+++ b/news/bugfix-3447.md
@@ -1,0 +1,4 @@
+network: fix TLS certificate hostname verification when using `failover()` servers
+
+For TLS certificate hostname verification, the certificate's hostname needs to be compared to the configured hostname
+of the primary and each failover server. syslog-ng used always the primary server's name incorrectly.


### PR DESCRIPTION
For TLS certificate hostname verification, the certificate's hostname needs to be compared to the configured hostname
of the primary and each failover server.

TLSVerifier needs the configured hostname of the server to verify the hostname in the certificate.
Previously, the verifier used only the primary host, failover server names were not updated.