### PR TITLE
date-parser: extend %z to support time zones other then local and gmt

### DIFF
--- a/lib/timeutils/wallclocktime.c
+++ b/lib/timeutils/wallclocktime.c
@@ -245,7 +245,6 @@ static int first_wday_of(int yr);
 #define HAVE_HOUR(s)    (s & S_HOUR)
 #define HAVE_USEC(s)    (s & S_USEC)
 
-static char gmt[] = { "GMT" };
 static char utc[] = { "UTC" };
 /* RFC-822/RFC-2822 */
 static const char *const nast[5] =
@@ -273,9 +272,9 @@ gchar *
 wall_clock_time_strptime(WallClockTime *wct, const gchar *format, const gchar *input)
 {
   unsigned char c;
-  const unsigned char *bp, *ep;
+  const unsigned char *bp, *ep, *zname;
   int alt_format, i, split_year = 0, neg = 0, state = 0,
-                     day_offset = -1, week_offset = 0, offs;
+                     day_offset = -1, week_offset = 0, offs, mandatory;
   const char *new_fmt;
 
   bp = (const unsigned char *)input;
@@ -607,30 +606,8 @@ recurse:
           continue;
 
         case 'Z':
-          if (strncmp((const char *)bp, gmt, 3) == 0 ||
-              strncmp((const char *)bp, utc, 3) == 0)
-            {
-              wct->tm.tm_isdst = 0;
-              wct->wct_gmtoff = 0;
-              wct->wct_zone = gmt;
-              bp += 3;
-            }
-          else
-            {
-              ep = find_string(bp, &i, (const char *const *)tzname, NULL, 2);
-              if (ep != NULL)
-                {
-                  wct->tm.tm_isdst = i;
-#ifdef SYSLOG_NG_HAVE_TIMEZONE
-                  wct->wct_gmtoff = -(timezone);
-#endif
-                  wct->wct_zone = tzname[i];
-                }
-              bp = ep;
-            }
-          continue;
-
         case 'z':
+          mandatory = c == 'z';
           /*
            * We recognize all ISO 8601 formats:
            * Z  = Zulu time/UTC
@@ -648,9 +625,11 @@ recurse:
            * [A-IL-M] = -1 ... -9 (J not used)
            * [N-Y]  = +1 ... +12
            */
-          while (isspace(*bp))
-            bp++;
+          if (mandatory)
+            while (isspace(*bp))
+              bp++;
 
+          zname = bp;
           switch (*bp++)
             {
             case 'G':
@@ -740,22 +719,27 @@ recurse:
           switch (i)
             {
             case 2:
-              offs *= 100;
+              offs *= 60;
               break;
             case 4:
               i = offs % 100;
+              offs /= 100;
               if (i >= 60)
-                return NULL;
+                goto out;
               /* Convert minutes into decimal */
-              offs = (offs / 100) * 100 + (i * 50) / 30;
+              offs = offs * 3600 + i * 60;
               break;
             default:
-              return NULL;
+out:
+              if (mandatory)
+                return NULL;
+              bp = zname;
+              continue;
             }
           if (neg)
             offs = -offs;
           wct->tm.tm_isdst = 0; /* XXX */
-          wct->wct_gmtoff = (offs * 3600) / 100;
+          wct->wct_gmtoff = offs;
           wct->wct_zone = utc; /* XXX */
           continue;
 

--- a/lib/timeutils/wallclocktime.c
+++ b/lib/timeutils/wallclocktime.c
@@ -691,6 +691,18 @@ recurse:
                   bp = ep;
                   continue;
                 }
+              ep = find_string(bp, &i, (const char *const *)tzname, NULL, 2);
+              if (ep != NULL)
+                {
+                  wct->tm.tm_isdst = i;
+#ifdef SYSLOG_NG_HAVE_TIMEZONE
+                  wct->wct_gmtoff = -(timezone);
+#endif
+                  wct->wct_zone = tzname[i];
+                  bp = ep;
+                  continue;
+                }
+
 
               if ((*bp >= 'A' && *bp <= 'I') ||
                   (*bp >= 'L' && *bp <= 'Y'))

--- a/modules/timestamp/tests/test_date.c
+++ b/modules/timestamp/tests/test_date.c
@@ -147,6 +147,29 @@ ParameterizedTestParameters(date, test_date_parser)
     { "2015-01-26 00:40:07 EDT", NULL, "%Y-%m-%d %H:%M:%S %z", LM_TS_STAMP, "2015-01-26T00:40:07-04:00" },
     { "2015-01-26 00:40:07 CET", NULL, "%Y-%m-%d %H:%M:%S %z", LM_TS_STAMP, "2015-01-26T00:40:07+01:00" },
 
+    //The same test as above but using %Z instead of %z
+    /* RFC 2822 */
+    { "Tue, 27 Jan 2015 11:48:46 +0200", NULL, "%a, %d %b %Y %T %Z", LM_TS_STAMP, "2015-01-27T11:48:46+02:00" },
+
+    /* Apache-like */
+    { "21/Jan/2015:14:40:07 +0500", NULL, "%d/%b/%Y:%T %Z", LM_TS_STAMP, "2015-01-21T14:40:07+05:00" },
+
+    /* Try without the year. */
+    { "01/Jan:00:40:07 +0500", NULL, "%d/%b:%T %Z", LM_TS_STAMP, "2016-01-01T00:40:07+05:00" },
+    { "01/Aug:00:40:07 +0500", NULL, "%d/%b:%T %Z", LM_TS_STAMP, "2015-08-01T00:40:07+05:00" },
+    { "01/Sep:00:40:07 +0500", NULL, "%d/%b:%T %Z", LM_TS_STAMP, "2015-09-01T00:40:07+05:00" },
+    { "01/Oct:00:40:07 +0500", NULL, "%d/%b:%T %Z", LM_TS_STAMP, "2015-10-01T00:40:07+05:00" },
+    { "01/Nov:00:40:07 +0500", NULL, "%d/%b:%T %Z", LM_TS_STAMP, "2015-11-01T00:40:07+05:00" },
+
+
+    { "1446128356 +01:00", NULL, "%s %z", LM_TS_STAMP, "2015-10-29T15:19:16+01:00" },
+    { "1446128356", "Europe/Budapest", "%s", LM_TS_STAMP, "2015-10-29T15:19:16+01:00" },
+
+    /* %Y-%m-%d %H:%M:%S %Z */
+    { "2015-01-26 00:40:07 PDT", NULL, "%Y-%m-%d %H:%M:%S %Z", LM_TS_STAMP, "2015-01-26T00:40:07-07:00" },
+    { "2015-01-26 00:40:07 EDT", NULL, "%Y-%m-%d %H:%M:%S %Z", LM_TS_STAMP, "2015-01-26T00:40:07-04:00" },
+    { "2015-01-26 00:40:07 CET", NULL, "%Y-%m-%d %H:%M:%S %Z", LM_TS_STAMP, "2015-01-26T00:40:07+01:00" },
+
   };
 
   return cr_make_param_array(struct date_params, params, sizeof(params) / sizeof(struct date_params));

--- a/modules/timestamp/tests/test_date.c
+++ b/modules/timestamp/tests/test_date.c
@@ -141,6 +141,12 @@ ParameterizedTestParameters(date, test_date_parser)
 
     { "1446128356 +01:00", NULL, "%s %z", LM_TS_STAMP, "2015-10-29T15:19:16+01:00" },
     { "1446128356", "Europe/Budapest", "%s", LM_TS_STAMP, "2015-10-29T15:19:16+01:00" },
+
+    /* %Y-%m-%d %H:%M:%S %z */
+    { "2015-01-26 00:40:07 PDT", NULL, "%Y-%m-%d %H:%M:%S %z", LM_TS_STAMP, "2015-01-26T00:40:07-07:00" },
+    { "2015-01-26 00:40:07 EDT", NULL, "%Y-%m-%d %H:%M:%S %z", LM_TS_STAMP, "2015-01-26T00:40:07-04:00" },
+    { "2015-01-26 00:40:07 CET", NULL, "%Y-%m-%d %H:%M:%S %z", LM_TS_STAMP, "2015-01-26T00:40:07+01:00" },
+
   };
 
   return cr_make_param_array(struct date_params, params, sizeof(params) / sizeof(struct date_params));

--- a/news/bugfix-3453.md
+++ b/news/bugfix-3453.md
@@ -1,0 +1,1 @@
+date-parse: %Z should parse the same timezones as %z not just local and gmt

--- a/news/feature-3453.md
+++ b/news/feature-3453.md
@@ -1,0 +1,1 @@
+date-parser: %z accepts local timezone std format as well


### PR DESCRIPTION
Our date parser is based on the NetBSD `strptime` implementation, that differs from the linux implementation.
The version of `strptime` used from NetBSD supported local and GMT timezone with `%z` and the `%Z` supported the other timezones. This was changed in linux and also in later version of NetBSD.

In our documentation the newer NetBSD behaviour was written, this patch updates to code accordingly.