### PR TITLE
Light framework small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ debian/build-tree/
 debian/*.log
 debian/autoreconf.*
 build/
+tests/python_functional/reports
 tags
 TAGS
 GPATH

--- a/tests/python_functional/Makefile.am
+++ b/tests/python_functional/Makefile.am
@@ -10,7 +10,7 @@ pytest-self-check:
 	@${PYTHON} -m pytest $(top_srcdir)/tests/python_functional/src --showlocals --verbosity=3
 
 pytest-check:
-	@${PYTHON} -m pytest -o log_cli=$(PYTEST_VERBOSE) $(top_srcdir)/tests/python_functional/functional_tests/$(PYTEST_SUBDIR) --installdir=${prefix} --showlocals --verbosity=3
+	@${PYTHON} -m pytest -o log_cli=$(PYTEST_VERBOSE) $(top_srcdir)/tests/python_functional/functional_tests/$(PYTEST_SUBDIR) --installdir=${prefix} --showlocals --verbosity=3 --show-capture=no
 
 pytest-linters:
 	@find $(top_srcdir)/tests/python_functional/ -name "*.py" \

--- a/tests/python_functional/conftest.py
+++ b/tests/python_functional/conftest.py
@@ -29,6 +29,7 @@ import pytest
 from pathlib2 import Path
 
 import src.testcase_parameters.testcase_parameters as tc_parameters
+from src.helpers.loggen.loggen import Loggen
 from src.message_builder.bsd_format import BSDFormat
 from src.message_builder.log_message import LogMessage
 from src.syslog_ng.syslog_ng import SyslogNg
@@ -136,6 +137,8 @@ def version(request):
     return version_output.splitlines()[1].split()[2]
 
 
-pytest_plugins = (
-    "src.helpers.loggen.loggen",
-)
+@pytest.fixture
+def loggen(testcase_parameters):
+    server = Loggen()
+    yield server
+    server.stop()

--- a/tests/python_functional/functional_tests/conftest.py
+++ b/tests/python_functional/functional_tests/conftest.py
@@ -21,6 +21,7 @@
 #
 #############################################################################
 import logging
+import os
 
 import pytest
 from pathlib2 import Path
@@ -62,11 +63,19 @@ def pytest_runtest_setup(item):
         item.user_properties.append(("relative_working_dir", working_dir))
 
 
+def light_extra_files(target_dir):
+    if "LIGHT_EXTRA_FILES" in os.environ:
+        for f in os.environ["LIGHT_EXTRA_FILES"].split(":"):
+            if Path(f).exists():
+                copy_file(f, target_dir)
+
+
 @pytest.fixture(autouse=True)
 def setup(request):
     testcase_parameters = request.getfixturevalue("testcase_parameters")
 
     copy_file(testcase_parameters.get_testcase_file(), testcase_parameters.get_working_dir())
+    light_extra_files(testcase_parameters.get_working_dir())
     request.addfinalizer(lambda: logger.info("Report file path\n{}\n".format(calculate_report_file_path(testcase_parameters.get_working_dir()))))
 
 

--- a/tests/python_functional/pytest.ini
+++ b/tests/python_functional/pytest.ini
@@ -1,5 +1,4 @@
 [pytest]
-log_print=false
 log_cli=false
 log_level=INFO
 log_cli_format= %(asctime)s:%(msecs)d - %(filename)s:%(lineno)d->%(funcName)s - %(levelname)s - %(message)s

--- a/tests/python_functional/src/helpers/loggen/loggen.py
+++ b/tests/python_functional/src/helpers/loggen/loggen.py
@@ -20,7 +20,6 @@
 # COPYING for details.
 #
 #############################################################################
-import pytest
 from pathlib2 import Path
 from psutil import TimeoutExpired
 
@@ -181,10 +180,3 @@ class Loggen(object):
         index_end = content.find(end_pattern, index_start)
 
         return int(content[index_start:index_end])
-
-
-@pytest.fixture
-def loggen(testcase_parameters):
-    server = Loggen()
-    yield server
-    server.stop()


### PR DESCRIPTION
This PR contains some smaller fixes for the light framework:
 - updating the .gitignore fil, so git status will not include the reports folder
 - eliminate the pytest_plugins variable (Continuation of #3448)
 - KUDO for @mitzkia , updating the log_print statement
 - add the possibility to insert extra (static) files into the test case folder.