### PR TITLE
Loggen: command line parameters for proxy protocol header

### DIFF
--- a/news/developer-note-3462.md
+++ b/news/developer-note-3462.md
@@ -1,0 +1,8 @@
+Proxy protocol support added to loggen.
+
+Four new options added to loggen to suppport the proxy protocol:
+* --proxied : Generate PROXY protocol v1 header
+* --proxy-src-ip : Set the source IP for the PROXY protocol v1 header. If not specified a random IP address generated (192.168.1.X).
+* --proxy-dst-ip : Set the destination IP for the PROXY protocol v1 header. If not specified a random IP address generated (192.168.1.X).
+* --proxy-src-port : Set the source port for the PROXY protocol v1 header. If not specified a random port generated in the range 5000-10000.
+* --proxy-dst-port : Set the destination port for the PROXY protocol v1 header. If not specified the port number 514 will be used.

--- a/tests/loggen/loggen_helper.c
+++ b/tests/loggen/loggen_helper.c
@@ -34,6 +34,8 @@
 #include <openssl/err.h>
 
 #define HEADER_BUF_SIZE 128
+#define IP_ADDRESS_MAX_LENGTH 15
+#define IP_PORT_MAX_LENGTH 5
 
 static int debug = 0;
 
@@ -299,16 +301,38 @@ close_ssl_connection(SSL *ssl)
 }
 
 int
-generate_proxy_header(char *buffer, int buffer_size, int thread_id)
+generate_proxy_header(char *buffer, int buffer_size, int thread_id, const char *proxy_src_ip, const char *proxy_dst_ip,
+                      const char *proxy_src_port, const char *proxy_dst_port)
 {
   gchar header[HEADER_BUF_SIZE];
 
-  gint oct1 = g_random_int_range(1, 100);
-  gint oct2 = g_random_int_range(101, 200);
-  gint port = g_random_int_range(5000, 10000);
+  gchar ip_src_random[IP_ADDRESS_MAX_LENGTH + 1];
+  gchar ip_dst_random[IP_ADDRESS_MAX_LENGTH + 1];
+  gchar port_random[IP_PORT_MAX_LENGTH + 1];
 
-  gint header_len = g_snprintf(header, HEADER_BUF_SIZE, "PROXY TCP4 192.168.1.%d 192.168.1.%d %d 514\n",
-                               oct1, oct2, port);
+  if (proxy_src_ip == NULL)
+    {
+      gint oct1 = g_random_int_range(1, 100);
+      g_snprintf(ip_src_random, IP_ADDRESS_MAX_LENGTH + 1, "192.168.1.%d", oct1);
+    }
+
+  if (proxy_dst_ip == NULL)
+    {
+      gint oct2 = g_random_int_range(1, 100);
+      g_snprintf(ip_dst_random, IP_ADDRESS_MAX_LENGTH + 1, "192.168.1.%d", oct2);
+    }
+
+  if (proxy_src_port == NULL)
+    {
+      gint port = g_random_int_range(5000, 10000);
+      g_snprintf(port_random, IP_PORT_MAX_LENGTH + 1, "%d", port);
+    }
+
+  gint header_len = g_snprintf(header, HEADER_BUF_SIZE, "PROXY TCP4 %s %s %s %s\n",
+                               proxy_src_ip == NULL ? ip_src_random : proxy_src_ip,
+                               proxy_dst_ip == NULL ? ip_dst_random : proxy_dst_ip,
+                               proxy_src_port == NULL ? port_random : proxy_src_port,
+                               proxy_dst_port == NULL ? "514" : proxy_dst_port);
 
   if (header_len > buffer_size)
     ERROR("PROXY protocol header is longer than the provided buffer; buf=%p\n", buffer);

--- a/tests/loggen/loggen_helper.h
+++ b/tests/loggen/loggen_helper.h
@@ -52,7 +52,8 @@ int connect_ip_socket(int sock_type, const char *target, const char *port, int u
 int connect_unix_domain_socket(int sock_type, const char *path);
 SSL *open_ssl_connection(int sock_fd);
 void close_ssl_connection(SSL *ssl);
-int generate_proxy_header(char *buffer, int buffer_size, int thread_id);
+int generate_proxy_header(char *buffer, int buffer_size, int thread_id, const char *proxy_src_ip,
+                          const char *proxy_dst_ip, const char *proxy_src_port, const char *proxy_dst_port);
 
 #define ERROR(format,...) do {\
   gchar *base = g_path_get_basename(__FILE__);\

--- a/tests/loggen/loggen_plugin.h
+++ b/tests/loggen/loggen_plugin.h
@@ -42,7 +42,6 @@ typedef struct _plugin_option
   const char *target; /* command line argument */
   const char *port;
   int  rate;
-  gboolean proxied;
 } PluginOption;
 
 typedef struct _thread_data
@@ -59,7 +58,7 @@ typedef struct _thread_data
 typedef GOptionEntry *(*get_option_func)(void);
 typedef gboolean (*start_plugin_func)(PluginOption *option);
 typedef void (*stop_plugin_func)(PluginOption *option);
-typedef int (*generate_message_func)(char *buffer, int buffer_size, int thread_id, unsigned long seq);
+typedef int (*generate_message_func)(char *buffer, int buffer_size, ThreadData *thread_context, unsigned long seq);
 typedef void (*set_generate_message_func)(generate_message_func gen_message);
 typedef int (*get_thread_count_func)(void);
 typedef gboolean (*is_plugin_activated_func)(void);

--- a/tests/loggen/socket_plugin/socket_plugin.c
+++ b/tests/loggen/socket_plugin/socket_plugin.c
@@ -380,30 +380,18 @@ active_thread_func(gpointer user_data)
           break;
         }
 
-      int str_len;
-      if (thread_context->option->proxied && !thread_context->proxy_header_sent)
+      int str_len = generate_message(message, MAX_MESSAGE_LENGTH, thread_context, count++);
+
+      if (str_len < 0)
         {
-          str_len = generate_proxy_header(message, MAX_MESSAGE_LENGTH, thread_context->index);
-          thread_context->proxy_header_sent = TRUE;
-          DEBUG("Generated PROXY protocol v1 header; len=%d\n", str_len);
-
-          connection_error = send_msg(fd, message, str_len);
+          ERROR("can't generate more log lines. end of input file?\n");
+          break;
         }
-      else
-        {
-          str_len = generate_message(message, MAX_MESSAGE_LENGTH, thread_context->index, count++);
 
-          if (str_len < 0)
-            {
-              ERROR("can't generate more log lines. end of input file?\n");
-              break;
-            }
+      connection_error = send_msg(fd, message, str_len);
 
-          connection_error = send_msg(fd, message, str_len);
-
-          thread_context->sent_messages++;
-          thread_context->buckets--;
-        }
+      thread_context->sent_messages++;
+      thread_context->buckets--;
     }
   DEBUG("thread (%s,%p) finished\n", loggen_plugin_info.name, g_thread_self());
 

--- a/tests/loggen/ssl_plugin/ssl_plugin.c
+++ b/tests/loggen/ssl_plugin/ssl_plugin.c
@@ -358,7 +358,7 @@ active_thread_func(gpointer user_data)
           break;
         }
 
-      int str_len = generate_message(message, MAX_MESSAGE_LENGTH, thread_context->index, count++);
+      int str_len = generate_message(message, MAX_MESSAGE_LENGTH, thread_context, count++);
 
       if (str_len < 0)
         {


### PR DESCRIPTION
This PR adds three new command-line option to the loggen to allow the users to define the
source IP, destination IP, and port parameters used in the proxy protocol header.