### PR TITLE
usertty: error message on open error

### DIFF
--- a/modules/afuser/afuser.c
+++ b/modules/afuser/afuser.c
@@ -93,6 +93,16 @@ _utmp_entry_matches(UtmpEntry *ut, GString *username)
   return FALSE;
 }
 
+static gchar *
+_get_utmp_username(UtmpEntry *ut)
+{
+#ifdef SYSLOG_NG_HAVE_MODERN_UTMP
+  return ut->ut_user;
+#else
+  return ut->ut_name;
+#endif
+}
+
 G_LOCK_DEFINE_STATIC(utmp_lock);
 
 static void
@@ -134,11 +144,7 @@ afuser_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
             line[0] = 0;
           strncpy(p, ut->ut_line, sizeof(line) - (p - line));
           msg_debug("Posting message to user terminal",
-#ifdef SYSLOG_NG_HAVE_MODERN_UTMP
-                    evt_tag_str("user", ut->ut_user),
-#else
-                    evt_tag_str("user", ut->ut_name),
-#endif
+                    evt_tag_str("user", _get_utmp_username(ut)),
                     evt_tag_str("line", line));
           fd = open(line, O_NOCTTY | O_APPEND | O_WRONLY | O_NONBLOCK);
           if (fd != -1)

--- a/news/bugfix-3473.md
+++ b/news/bugfix-3473.md
@@ -1,0 +1,2 @@
+usertty(): on each tty open error an error mesage and a 10 minutes long disabling of the usertty() destination has been added.
+Until now, the usertty() destination were only disabled for blocking write() calls.


### PR DESCRIPTION
With this PR, on 1 message there could be multiple error messages (as many as logged in users are for the configured username), this could fill the internal log pretty much.
Nevertheless, I think usertty() destination is mainly intended for alarms and critical log messages, thus logging this much internal  messages is okay.

I don't think a news entry is needed (not a bugfix, and not really something that should be announced).