### PR TITLE
option truncating logwriter based destination msg payload size

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -236,6 +236,9 @@
 %token KW_LOCAL_TIME_ZONE             10204
 %token KW_FORMAT                      10205
 
+/* destination writer options */
+%token KW_TRUNCATE_SIZE               10206
+
 /* timers */
 %token KW_TIME_REOPEN                 10210
 %token KW_TIME_REAP                   10211
@@ -1312,6 +1315,7 @@ dest_writer_option
 	                                        }
 	| KW_TEMPLATE_ESCAPE '(' yesno ')'	{ log_writer_options_set_template_escape(last_writer_options, $3); }
 	| KW_PAD_SIZE '(' nonnegative_integer ')'         { last_writer_options->padding = $3; }
+	| KW_TRUNCATE_SIZE '(' nonnegative_integer ')'         { last_writer_options->truncate_size = $3; }
 	| KW_MARK_FREQ '(' nonnegative_integer ')'        { last_writer_options->mark_freq = $3; }
         | KW_MARK_MODE '(' KW_INTERNAL ')'      { log_writer_options_set_mark_mode(last_writer_options, "internal"); }
 	| KW_MARK_MODE '(' string ')'

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -83,6 +83,7 @@ static CfgLexerKeyword main_keywords[] =
   /* option items */
   { "flags",              KW_FLAGS },
   { "pad_size",           KW_PAD_SIZE },
+  { "truncate_size",      KW_TRUNCATE_SIZE },
   { "mark_freq",          KW_MARK_FREQ },
   { "mark",               KW_MARK_FREQ, KWS_OBSOLETE, "mark_freq" },
   { "mark_mode",          KW_MARK_MODE },

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -25,6 +25,7 @@
 #include "logwriter.h"
 #include "messages.h"
 #include "stats/stats-registry.h"
+#include "stats/stats-cluster-single.h"
 #include "hostname.h"
 #include "host-resolve.h"
 #include "seqnum.h"
@@ -69,6 +70,11 @@ struct _LogWriter
   StatsCounterItem *suppressed_messages;
   StatsCounterItem *processed_messages;
   StatsCounterItem *written_messages;
+  struct
+  {
+    StatsCounterItem *count;
+    StatsCounterItem *bytes;
+  } truncated;
   LogPipe *control;
   LogWriterOptions *options;
   LogMessage *last_msg;
@@ -1096,7 +1102,12 @@ log_writer_format_log(LogWriter *self, LogMessage *lm, GString *result)
 
   if (self->options->truncate_size != -1 && result->len > self->options->truncate_size)
     {
+      const gint truncated_bytes = result->len - self->options->truncate_size;
+
       g_string_truncate(result, self->options->truncate_size);
+
+      stats_counter_inc(self->truncated.count);
+      stats_counter_add(self->truncated.bytes, truncated_bytes);
     }
 }
 
@@ -1393,6 +1404,19 @@ _register_counters(LogWriter *self)
     stats_register_counter(self->options->stats_level, &sc_key, SC_TYPE_PROCESSED, &self->processed_messages);
     stats_register_counter(self->options->stats_level, &sc_key, SC_TYPE_WRITTEN, &self->written_messages);
     log_queue_register_stats_counters(self->queue, self->options->stats_level, &sc_key);
+
+    StatsClusterKey sc_key_truncated_count;
+    stats_cluster_single_key_set_with_name(&sc_key_truncated_count, self->options->stats_source | SCS_DESTINATION,
+                                           self->stats_id, self->stats_instance, "truncated_count");
+    stats_register_counter(self->options->stats_level, &sc_key_truncated_count, SC_TYPE_SINGLE_VALUE,
+                           &self->truncated.count);
+
+    StatsClusterKey sc_key_truncated_bytes;
+    stats_cluster_single_key_set_with_name(&sc_key_truncated_bytes, self->options->stats_source | SCS_DESTINATION,
+                                           self->stats_id, self->stats_instance, "truncated_bytes");
+    stats_register_counter(self->options->stats_level, &sc_key_truncated_bytes, SC_TYPE_SINGLE_VALUE,
+                           &self->truncated.bytes);
+
   }
   stats_unlock();
 }
@@ -1446,6 +1470,17 @@ _unregister_counters(LogWriter *self)
     stats_unregister_counter(&sc_key, SC_TYPE_SUPPRESSED, &self->suppressed_messages);
     stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->processed_messages);
     stats_unregister_counter(&sc_key, SC_TYPE_WRITTEN, &self->written_messages);
+
+    StatsClusterKey sc_key_truncated_count;
+    stats_cluster_single_key_set_with_name(&sc_key_truncated_count, self->options->stats_source | SCS_DESTINATION,
+                                           self->stats_id, self->stats_instance, "truncated_count");
+    stats_unregister_counter(&sc_key_truncated_count, SC_TYPE_SINGLE_VALUE, &self->truncated.count);
+
+    StatsClusterKey sc_key_truncated_bytes;
+    stats_cluster_single_key_set_with_name(&sc_key_truncated_bytes, self->options->stats_source | SCS_DESTINATION,
+                                           self->stats_id, self->stats_instance, "truncated_bytes");
+    stats_unregister_counter(&sc_key_truncated_bytes, SC_TYPE_SINGLE_VALUE, &self->truncated.bytes);
+
     log_queue_unregister_stats_counters(self->queue, &sc_key);
   }
   stats_unlock();

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1093,6 +1093,11 @@ log_writer_format_log(LogWriter *self, LogMessage *lm, GString *result)
         }
 
     }
+
+  if (self->options->truncate_size != -1 && result->len > self->options->truncate_size)
+    {
+      g_string_truncate(result, self->options->truncate_size);
+    }
 }
 
 static void
@@ -1690,6 +1695,7 @@ log_writer_options_defaults(LogWriterOptions *options)
   options->padding = 0;
   options->mark_mode = MM_GLOBAL;
   options->mark_freq = -1;
+  options->truncate_size = -1;
   host_resolve_options_defaults(&options->host_resolve_options);
 }
 

--- a/lib/logwriter.h
+++ b/lib/logwriter.h
@@ -71,6 +71,7 @@ typedef struct _LogWriterOptions
   gint mark_freq;
   gint stats_level;
   gint stats_source;
+  gint truncate_size;
 } LogWriterOptions;
 
 typedef struct _LogWriter LogWriter;

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -50,6 +50,8 @@
 #  define _GNU_SOURCE 1
 #endif
 
+static const gint MAX_UDP_PAYLOAD_SIZE = 65507;
+
 typedef struct _AFInetDestDriverTLSVerifyData
 {
   TLSContext *tls_context;
@@ -432,6 +434,14 @@ afinet_dd_init(LogPipe *s)
         }
     }
 #endif
+
+  if (self->super.transport_mapper->sock_type == SOCK_DGRAM)
+    {
+      if (self->super.writer_options.truncate_size == -1)
+        {
+          self->super.writer_options.truncate_size = MAX_UDP_PAYLOAD_SIZE;
+        }
+    }
 
   if (_is_failover_used(self))
     {

--- a/news/bugfix-3474.md
+++ b/news/bugfix-3474.md
@@ -1,0 +1,1 @@
+network/udp: message was lost (not sent) if it was too large, and a time reopen amount of time needed to expire to send the next message lowering the thoughtput. now it is truncated at 65507.

--- a/news/feature-3474.md
+++ b/news/feature-3474.md
@@ -1,0 +1,11 @@
+file, network, program destinations: : new truncate_size option introduced to truncate an output message to a specified max size. default value is -1 (disabled).
+
+```
+network("127.0.0.1" truncate_size(100));
+```
+
+new stats counters:
+```
+dst.network;d_local#0;udp,127.0.0.1:1111;a;truncated_count;1
+dst.network;d_local#0;udp,127.0.0.1:1111;a;truncated_bytes;1
+```

--- a/tests/unit/test_logwriter.c
+++ b/tests/unit/test_logwriter.c
@@ -157,8 +157,8 @@ _assert_logwriter_output(LogWriterTestCase c)
     {
       templ = log_template_new(configuration, "dummy");
       log_template_compile(templ, c.template, &error);
+      opt.template = templ;
     }
-  opt.template = templ;
   msg = init_msg(c.msg, c.is_rfc5424);
   queue = log_queue_fifo_new(1000, NULL);
   writer = log_writer_new(c.writer_flags, configuration);

--- a/tests/unit/test_logwriter.c
+++ b/tests/unit/test_logwriter.c
@@ -146,10 +146,8 @@ _assert_logwriter_output(LogWriterTestCase c)
   LogWriterOptions opt = {0};
   LogQueue *queue;
 
-  static TimeZoneInfo *tzinfo = NULL;
+  TimeZoneInfo *tzinfo = time_zone_info_new(NULL);
 
-  if (!tzinfo)
-    tzinfo = time_zone_info_new(NULL);
   opt.options = LWO_NO_MULTI_LINE | LWO_NO_STATS | LWO_SHARE_STATS;
   opt.template_options.time_zone_info[LTZ_SEND]=tzinfo;
 


### PR DESCRIPTION
The PR contains the following changes:
* A new option for `LogWriter` based destinations for truncating formatted message length `tuncate_size`, with default not truncating any messages.
* Change the default truncate_size only for udp network destination to 65507.
* New counters indicating truncation:
  ```
   dst.network;d_local#0;udp,127.0.0.1:1111;a;truncated_count;1
   dst.network;d_local#0;udp,127.0.0.1:1111;a;truncated_bytes;1
  ```
* Fix logwriter unit test (`LogWriterOptions` was "hand" initialized)