### PR TITLE
Fix distcheck on devshell image (ubuntu-focal)

### DIFF
--- a/dbld/packages.manifest
+++ b/dbld/packages.manifest
@@ -44,10 +44,10 @@ rpm-build                       [centos, fedora]
 # Tarball related tools
 #############################################################################
 # needed to create a tarball from libjson-c
-doxygen                         [tarball]
+doxygen                         [tarball, devshell]
 
 # docbook to generate man pages
-docbook-xsl                     [tarball]
+docbook-xsl                     [tarball, devshell]
 docbook-style-xsl               [fedora]
 
 #############################################################################


### PR DESCRIPTION
when `tarball` image was created (#3455), some dependencies (doxygen, docbook-xsl) for distcheck had removed from ubuntu images, therefore from devshell too (which is based on ubuntu focal).

This PR is a quick solution before devshell can be based onto debian testing (#3476).

github actions distcheck job going to be failed for this PR, as docker images are pulled from docker hub and not re-built.
I've tested this on my fork, with locally built docker image pushed to dockerhub under my namespace: https://github.com/gaborznagy/syslog-ng/runs/1395335808
