### PR TITLE
Fix stringop overflow warnings

### DIFF
--- a/lib/logmsg/nvtable.h
+++ b/lib/logmsg/nvtable.h
@@ -148,7 +148,7 @@ struct _NVEntry
     {
       guint32 value_len;
       /* variable data, first the name of this entry, then the value, both are NUL terminated */
-      gchar data[0];
+      gchar data[];
     } vdirect;
 
     NVReferencedSlice vindirect;

--- a/modules/afuser/afuser.c
+++ b/modules/afuser/afuser.c
@@ -142,7 +142,7 @@ afuser_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
             }
           else
             line[0] = 0;
-          strncpy(p, ut->ut_line, sizeof(line) - (p - line));
+          strncpy(p, ut->ut_line, MIN(sizeof(ut->ut_line), sizeof(line) - (p - line)));
           msg_debug("Posting message to user terminal",
                     evt_tag_str("user", _get_utmp_username(ut)),
                     evt_tag_str("line", line));


### PR DESCRIPTION
With image-tarball now pointing to debian testing, we are getting extra warnings (and compile failures due to -Werror) because of 
-Wstringop-overflow.

This PR fixes those.