### PR TITLE
github/workflows/draft-release: upload the correct tar.gz

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -51,6 +51,7 @@ jobs:
         run: |
           RELEASE_NAME=syslog-ng-`cat VERSION`
           sed "1 i${RELEASE_NAME}\n" NEWS.md > /tmp/message
+          mv dbld/build/${RELEASE_NAME}.orig.tar.gz dbld/build/${RELEASE_NAME}.tar.gz
 
           hub release create \
             --draft \


### PR DESCRIPTION
note: name should be the same as in case of previous releases
(-> support scripts polling our repository for new releases)
