### PR TITLE
github-actions: use new env API

### DIFF
--- a/.github/workflows/comment-on-version-bump-pr.yml
+++ b/.github/workflows/comment-on-version-bump-pr.yml
@@ -29,7 +29,7 @@ jobs:
 
           if [ -n ${PR_NUMBER} ]
           then
-            echo "::set-env name=PR_NUMBER::${PR_NUMBER}"
+            echo "PR_NUMBER=${PR_NUMBER}" >> $GITHUB_ENV
           else
             echo "No version bump PR is open. Skipping."
           fi

--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -16,16 +16,12 @@ jobs:
       fail-fast: false
 
     steps:
+      - name: Checkout syslog-ng source
+        uses: actions/checkout@v2
+
       - name: Set ENV variables
         run: |
-          gh_export() {
-            while [ "x$1" != "x" ]; do
-              echo "$1<<__EOF__" >> $GITHUB_ENV
-              eval echo \$$1     >> $GITHUB_ENV
-              echo "__EOF__"     >> $GITHUB_ENV
-              shift;
-            done
-          }
+          . .github/workflows/gh_export.sh
 
           PYTHONVERSION="`printf ${{ matrix.python }} | tail -c 1`"
           PYTHONUSERBASE="${HOME}/python_packages"
@@ -44,9 +40,6 @@ jobs:
           gh_export PYTHONVERSION PYTHONUSERBASE CC CONFIGURE_FLAGS CMAKE_FLAGS
 
           echo "${HOME}/python_packages" >> $GITHUB_PATH
-
-      - name: Checkout syslog-ng source
-        uses: actions/checkout@v2
 
       - name: autogen.sh
         if: matrix.build-tool == 'autotools'
@@ -125,16 +118,13 @@ jobs:
       fail-fast: false
 
     steps:
+      - name: Checkout syslog-ng source
+        uses: actions/checkout@v2
+
       - name: Set ENV variables
         run: |
-          gh_export() {
-            while [ "x$1" != "x" ]; do
-              echo "$1<<__EOF__" >> $GITHUB_ENV
-              eval echo \$$1     >> $GITHUB_ENV
-              echo "__EOF__"     >> $GITHUB_ENV
-              shift;
-            done
-          }
+          . .github/workflows/gh_export.sh
+
           PYTHONVERSION=`printf ${{ matrix.python }} | tail -c 1`
           DISTCHECK_CONFIGURE_FLAGS="
             CFLAGS=-Werror
@@ -149,9 +139,6 @@ jobs:
           "
 
           gh_export DISTCHECK_CONFIGURE_FLAGS
-
-      - name: Checkout syslog-ng source
-        uses: actions/checkout@v2
 
       - name: autogen.sh
         run: ./autogen.sh

--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -18,27 +18,32 @@ jobs:
     steps:
       - name: Set ENV variables
         run: |
-          export PYTHONVERSION=`printf ${{ matrix.python }} | tail -c 1`
-          export PYTHONUSERBASE=${HOME}/python_packages
-          export PATH=${PYTHONUSERBASE}:${PATH}
-          export CC=${{ matrix.cc }}
-          export CONFIGURE_FLAGS="
+          gh_export() {
+            while [ "x$1" != "x" ]; do
+              echo "$1<<__EOF__" >> $GITHUB_ENV
+              eval echo \$$1     >> $GITHUB_ENV
+              echo "__EOF__"     >> $GITHUB_ENV
+              shift;
+            done
+          }
+
+          PYTHONVERSION="`printf ${{ matrix.python }} | tail -c 1`"
+          PYTHONUSERBASE="${HOME}/python_packages"
+          CC="${{ matrix.cc }}"
+          CONFIGURE_FLAGS="
             --prefix=${HOME}/install/syslog-ng
             --enable-all-modules
             --with-python=${PYTHONVERSION}
-            `[ $CC = clang ] && echo '--enable-force-gnu99'`
+            `[ $CC = clang ] && echo '--enable-force-gnu99' || true`
           "
-          export CMAKE_FLAGS="
+          CMAKE_FLAGS="
             -DCMAKE_C_FLAGS=-Werror
             -DCMAKE_INSTALL_PREFIX=${HOME}/install/syslog-ng
             -DPYTHON_VERSION=${PYTHONVERSION}
           "
+          gh_export PYTHONVERSION PYTHONUSERBASE CC CONFIGURE_FLAGS CMAKE_FLAGS
 
-          echo "::set-env name=PYTHONUSERBASE::`echo ${PYTHONUSERBASE}`"
-          echo "::set-env name=PATH::`echo ${PATH}`"
-          echo "::set-env name=CONFIGURE_FLAGS::`echo ${CONFIGURE_FLAGS}`"
-          echo "::set-env name=CMAKE_FLAGS::`echo ${CMAKE_FLAGS}`"
-          echo "::set-env name=CC::`echo ${CC}`"
+          echo "${HOME}/python_packages" >> $GITHUB_PATH
 
       - name: Checkout syslog-ng source
         uses: actions/checkout@v2
@@ -122,8 +127,16 @@ jobs:
     steps:
       - name: Set ENV variables
         run: |
-          export PYTHONVERSION=`printf ${{ matrix.python }} | tail -c 1`
-          export DISTCHECK_CONFIGURE_FLAGS="
+          gh_export() {
+            while [ "x$1" != "x" ]; do
+              echo "$1<<__EOF__" >> $GITHUB_ENV
+              eval echo \$$1     >> $GITHUB_ENV
+              echo "__EOF__"     >> $GITHUB_ENV
+              shift;
+            done
+          }
+          PYTHONVERSION=`printf ${{ matrix.python }} | tail -c 1`
+          DISTCHECK_CONFIGURE_FLAGS="
             CFLAGS=-Werror
             --prefix=${HOME}/install/syslog-ng
             --with-ivykis=internal
@@ -135,7 +148,7 @@ jobs:
             --with-python=${PYTHONVERSION}
           "
 
-          echo "::set-env name=DISTCHECK_CONFIGURE_FLAGS::`echo ${DISTCHECK_CONFIGURE_FLAGS}`"
+          gh_export DISTCHECK_CONFIGURE_FLAGS
 
       - name: Checkout syslog-ng source
         uses: actions/checkout@v2

--- a/.github/workflows/gh_export.sh
+++ b/.github/workflows/gh_export.sh
@@ -1,0 +1,9 @@
+gh_export()
+{
+    while [ "x$1" != "x" ]; do
+        echo "$1<<__EOF__" >> $GITHUB_ENV
+        eval echo \$$1     >> $GITHUB_ENV
+        echo "__EOF__"     >> $GITHUB_ENV
+        shift;
+    done
+}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,14 +17,8 @@ jobs:
 
       - name: Set ENV variables
         run: |
-          gh_export() {
-            while [ "x$1" != "x" ]; do
-              echo "$1<<__EOF__" >> $GITHUB_ENV
-              eval echo \$$1     >> $GITHUB_ENV
-              echo "__EOF__"     >> $GITHUB_ENV
-              shift;
-            done
-          }
+          . .github/workflows/gh_export.sh
+
           PYTHONUSERBASE="${HOME}/python_packages"
           PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig:$PKG_CONFIG_PATH"
           THREADS="$(sysctl -n hw.physicalcpu)"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,11 +17,18 @@ jobs:
 
       - name: Set ENV variables
         run: |
-          export PYTHONUSERBASE=${HOME}/python_packages
-          export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig:$PKG_CONFIG_PATH
-          export PATH=/usr/local/opt/bison/bin:/usr/local/opt/libnet/bin:${PYTHONUSERBASE}/bin:$PATH
-          export THREADS=$(sysctl -n hw.physicalcpu)
-          export CONFIGURE_FLAGS="
+          gh_export() {
+            while [ "x$1" != "x" ]; do
+              echo "$1<<__EOF__" >> $GITHUB_ENV
+              eval echo \$$1     >> $GITHUB_ENV
+              echo "__EOF__"     >> $GITHUB_ENV
+              shift;
+            done
+          }
+          PYTHONUSERBASE="${HOME}/python_packages"
+          PKG_CONFIG_PATH="/usr/local/opt/openssl/lib/pkgconfig:$PKG_CONFIG_PATH"
+          THREADS="$(sysctl -n hw.physicalcpu)"
+          CONFIGURE_FLAGS="
             --with-ivykis=system
             --disable-sun-streams
             --disable-systemd
@@ -30,11 +37,8 @@ jobs:
             --enable-all-modules
           "
 
-          echo "::set-env name=PYTHONUSERBASE::`echo ${PYTHONUSERBASE}`"
-          echo "::set-env name=PKG_CONFIG_PATH::`echo ${PKG_CONFIG_PATH}`"
-          echo "::set-env name=PATH::`echo ${PATH}`"
-          echo "::set-env name=THREADS::`echo ${THREADS}`"
-          echo "::set-env name=CONFIGURE_FLAGS::`echo ${CONFIGURE_FLAGS}`"
+          gh_export PYTHONUSERBASE PKG_CONFIG_PATH THREADS CONFIGURE_FLAGS
+          echo "/usr/local/opt/bison/bin:/usr/local/opt/libnet/bin:${PYTHONUSERBASE}/bin" >> $GITHUB_PATH
 
       - name: autogen.sh
         run: |

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -51,6 +51,7 @@ cmake/.*$
 tests/python_functional/pytest.ini
 tests/python_functional/tox.ini
 tests/python_functional/.pre-commit-config.yaml
+.github/workflows/.*$
  LGPLv2.1+_SSL,non-balabit
 lib/timeutils/zonecache.[ch]$
 modules/secure-logging


### PR DESCRIPTION
Based upon #3484. I have opened a new PR, because this problem just become critical, as `set-env` is removed, and nearly all of our CI jobs fail.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>