### PR TITLE
dbld: bump versioning.h in prepare-release

### DIFF
--- a/dbld/prepare-release
+++ b/dbld/prepare-release
@@ -6,8 +6,12 @@ cd /source
 VERSION=$1
 
 OLD_VERSION=`cat VERSION`
-OLD_MAJOR=$(echo $OLD_VERSION | cut -d. -f1-2)
-NEW_MAJOR=$(echo $VERSION | cut -d. -f1-2)
+OLD_MAJOR=$(echo $OLD_VERSION | cut -d. -f1)
+OLD_MINOR=$(echo $OLD_VERSION | cut -d. -f2)
+OLD_PATCH=$(echo $OLD_VERSION | cut -d. -f3)
+NEW_MAJOR=$(echo $VERSION | cut -d. -f1)
+NEW_MINOR=$(echo $VERSION | cut -d. -f2)
+NEW_PATCH=$(echo $VERSION | cut -d. -f3)
 USER_EMAIL=$(git config --get user.email || echo "noemail@set.any.where")
 USER_NAME=$(git config --get user.name || echo "unknown user")
 VERSION_FILE_LIST="README.md doc/man/*.xml
@@ -34,9 +38,33 @@ function update_packaging_rhel() {
 
 function update_version_refs_in_source() {
 	echo Updating version references in source files
-	ESCAPED_OLD_MAJOR=$(echo $OLD_MAJOR | sed -e 's/[]\/$*.^[]/\\&/g') &&
-	ESCAPED_NEW_MAJOR=$(echo $NEW_MAJOR | sed -e 's/[\/&]/\\&/g') &&
-	git ls-files $VERSION_FILE_LIST | xargs sed -i "s/$ESCAPED_OLD_MAJOR/$ESCAPED_NEW_MAJOR/g"
+	ESCAPED_OLD_MAJOR_AND_MINOR=$(echo $OLD_MAJOR.$OLD_MINOR | sed -e 's/[]\/$*.^[]/\\&/g') &&
+	ESCAPED_NEW_MAJOR_AND_MINOR=$(echo $NEW_MAJOR.$NEW_MINOR | sed -e 's/[\/&]/\\&/g') &&
+	git ls-files $VERSION_FILE_LIST | xargs sed -i "s/$ESCAPED_OLD_MAJOR_AND_MINOR/$ESCAPED_NEW_MAJOR_AND_MINOR/g"
+}
+
+function update_versioning_h() {
+	echo Updating versioning.h
+	VERSIONING_H="lib/versioning.h"
+
+	if grep "^#define VERSION_${NEW_MAJOR}_${NEW_MINOR} \"syslog-ng ${NEW_MAJOR}.${NEW_MINOR}\"$" ${VERSIONING_H}; then
+		echo "VERSION_${NEW_MAJOR}_${NEW_MINOR} is already defined."
+	else
+		sed -i "/^#define VERSION_${OLD_MAJOR}_${OLD_MINOR} \"syslog-ng ${OLD_MAJOR}.${OLD_MINOR}\"$/a#define VERSION_${NEW_MAJOR}_${NEW_MINOR} \"syslog-ng ${NEW_MAJOR}.${NEW_MINOR}\"" ${VERSIONING_H}
+	fi
+
+	OLD_HEX=$(grep "#define VERSION_VALUE_${OLD_MAJOR}_${OLD_MINOR}" ${VERSIONING_H} | grep -o "0x.*$")
+	NEW_HEX=$(printf "0x%04X" $((${OLD_HEX} + 0x0001)) | tr "[:upper:]" "[:lower:]")
+
+	if grep "^#define VERSION_VALUE_${NEW_MAJOR}_${NEW_MINOR} ${NEW_HEX}$" ${VERSIONING_H}; then
+		echo "VERSION_VALUE_${NEW_MAJOR}_${NEW_MINOR} is already defined."
+	else
+		sed -i "/^#define VERSION_VALUE_${OLD_MAJOR}_${OLD_MINOR} ${OLD_HEX}$/a#define VERSION_VALUE_${NEW_MAJOR}_${NEW_MINOR} ${NEW_HEX}" ${VERSIONING_H}
+	fi
+
+	sed -i "s/^#define VERSION_VALUE_CURRENT   VERSION_VALUE_${OLD_MAJOR}_${OLD_MINOR}$/#define VERSION_VALUE_CURRENT   VERSION_VALUE_${NEW_MAJOR}_${NEW_MINOR}/g" ${VERSIONING_H}
+	sed -i "s/^#define VERSION_STR_CURRENT     \"${OLD_MAJOR}.${OLD_MINOR}\"$/#define VERSION_STR_CURRENT     \"${NEW_MAJOR}.${NEW_MINOR}\"/g" ${VERSIONING_H}
+	sed -i "s/^#define VERSION_PRODUCT_CURRENT VERSION_${OLD_MAJOR}_${OLD_MINOR}$/#define VERSION_PRODUCT_CURRENT VERSION_${NEW_MAJOR}_${NEW_MINOR}/g" ${VERSIONING_H}
 }
 
 function perform_updates()
@@ -44,7 +72,8 @@ function perform_updates()
 	update_version && \
 		update_packaging_debian && \
 		update_packaging_rhel && \
-		update_version_refs_in_source
+		update_version_refs_in_source && \
+		update_versioning_h
 }
 
 if [ "$VERSION" = "" ]; then

--- a/dbld/rules
+++ b/dbld/rules
@@ -158,20 +158,18 @@ validate-tree-clean:
 		exit 1; \
 	fi
 
-validate-version-for-release:
+validate-version-format:
 	@if [ "$$(echo $(VERSION) | sed -e 's/^[0-9]\+\.[0-9]\+.[0-9]\+//')" != "" ]; then \
 		echo "The version number you specified $(VERSION) is not a valid version for a RELEASE. Please supply one using VERSION= via the command line"; \
 		exit 1; \
 	fi
 
-prepare-release: setup validate-tree-clean validate-version-for-release
+prepare-release: setup validate-tree-clean validate-version-format
 	$(DOCKER) run $(DOCKER_RUN_ARGS) --rm -i  balabit/syslog-ng-$(TARBALL_IMAGE) /dbld/prepare-release $(VERSION)
 
-validate-release: validate-tree-clean validate-version-for-release
-	@if [ "`cat VERSION`" != "$(VERSION)" ]; then \
-		echo "The VERSION file in the root of the source tree does not have the version number to be released $(VERSION). Please commit a version bump change first (or use prepare-release)."; \
-		exit 1; \
-	fi;
+validate-release: validate-tree-clean validate-version-format
+	$(DOCKER) run $(DOCKER_RUN_ARGS) --rm -i  balabit/syslog-ng-$(TARBALL_IMAGE) /dbld/validate-release-version $(VERSION)
+
 	@if $(GIT) rev-parse --verify -q "$(GIT_RELEASE_TAG)" > /dev/null; then \
 		echo "Your git tree already has $(GIT_RELEASE_TAG), this might indicate a duplicate release, please remove that first."; \
 		exit 1; \

--- a/dbld/validate-release-version
+++ b/dbld/validate-release-version
@@ -2,9 +2,36 @@
 
 set -e
 
-VERSION=$1
+cd /source
 
-if [ "`cat VERSION`" != "${VERSION}" ]; then
-	echo "The VERSION file in the root of the source tree does not have the version number to be released ${VERSION}. Please commit a version bump change first (or use prepare-release)."
-	exit 1
-fi
+VERSION=$1
+MAJOR=$(echo ${VERSION} | cut -d. -f1)
+MINOR=$(echo ${VERSION} | cut -d. -f2)
+
+function validate_VERSION_file() {
+	if [ "`cat VERSION`" != "${VERSION}" ]; then
+		echo "The VERSION file in the root of the source tree does not have the version number to be released ${VERSION}. Please commit a version bump change first (or use prepare-release)."
+		exit 1
+	fi
+}
+
+function grep_pattern_in_versioning_h() {
+	VERSIONING_H="lib/versioning.h"
+	PATTERN=$1
+
+	if ! grep --perl-regexp "${PATTERN}" ${VERSIONING_H} > /dev/null; then
+		echo "${PATTERN} was not found in ${VERSIONING_H}"
+		exit 1
+	fi
+}
+
+function validate_versioning_h_file() {
+	grep_pattern_in_versioning_h "^#define VERSION_${MAJOR}_${MINOR} \"syslog-ng ${MAJOR}.${MINOR}\"$"
+	grep_pattern_in_versioning_h "^#define VERSION_VALUE_${MAJOR}_${MINOR} 0x[a-f0-9]{4}$"
+	grep_pattern_in_versioning_h "^#define VERSION_VALUE_CURRENT +VERSION_VALUE_${MAJOR}_${MINOR}$"
+	grep_pattern_in_versioning_h "^#define VERSION_STR_CURRENT +\"${MAJOR}.${MINOR}\"$"
+	grep_pattern_in_versioning_h "^#define VERSION_PRODUCT_CURRENT VERSION_${MAJOR}_${MINOR}$"
+}
+
+validate_VERSION_file
+validate_versioning_h_file

--- a/dbld/validate-release-version
+++ b/dbld/validate-release-version
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+VERSION=$1
+
+if [ "`cat VERSION`" != "${VERSION}" ]; then
+	echo "The VERSION file in the root of the source tree does not have the version number to be released ${VERSION}. Please commit a version bump change first (or use prepare-release)."
+	exit 1
+fi


### PR DESCRIPTION
Note: it is enough to merge this PR after releasing 3.30.1, if we manually do these bumps this time for 3.30.1.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>