### PR TITLE
github-actions: run jobs nightly

### DIFF
--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -1,6 +1,10 @@
 name: CI @ devshell
 
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '00 21 * * *'
 
 jobs:
   general:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,10 @@
 name: macOS
 
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '00 21 * * *'
 
 jobs:
   general:


### PR DESCRIPTION
A test run on my fork:
https://github.com/gaborznagy/syslog-ng/actions/runs/387375769/workflow