### PR TITLE
docs: fix simple typo, inperfect -> imperfect

### DIFF
--- a/modules/python/pylib/syslogng/debuggercli/commandlinelexer.py
+++ b/modules/python/pylib/syslogng/debuggercli/commandlinelexer.py
@@ -30,7 +30,7 @@ CLL_QUOTED_CHAR = 2
 
 
 class CommandLineLexer(Lexer):
-    """This an inperfect lexer for both the debug language and template functions"""
+    """This an imperfect lexer for both the debug language and template functions"""
     def __init__(self):
         self._tokens = []
         self._input = ''


### PR DESCRIPTION
There is a small typo in modules/python/pylib/syslogng/debuggercli/commandlinelexer.py.

Should read `imperfect` rather than `inperfect`.

