### PR TITLE
dbld/rules: remove deb/rpm build from the "release" target

### DIFF
--- a/dbld/rules
+++ b/dbld/rules
@@ -165,8 +165,6 @@ release: validate-release
 	ARTIFACT_DIR=$(RELEASE_DIR)/$(VERSION) && \
 	rm -rf "$$ARTIFACT_DIR" && mkdir -p "$$ARTIFACT_DIR" && rm -rf $(TARBALL) && \
 	$(DBLD_RULES) MODE=release VERSION=$(VERSION) pkg-tarball && \
-	$(DBLD_RULES) MODE=release VERSION=$(VERSION) deb && \
-	$(DBLD_RULES) MODE=release VERSION=$(VERSION) rpm && \
 	echo "Building the release was successful, artifacts stored in $$ARTIFACT_DIR" && \
 	$(DBLD_RULES) MODE=release VERSION=$(VERSION) tag-release
 


### PR DESCRIPTION
We don't publish .deb/.rpm as a part of release (only a tarball), so
remove them to make builds faster.
