### PR TITLE
github-actions: build packages nightly

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,6 +1,10 @@
 name: Binary packages
 
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '00 21 * * *'
 
 
 jobs:


### PR DESCRIPTION
Since #3464 and #3498 is merged, we could build packages in the nightly job.