### PR TITLE
glib-compat: fix g_cond_wait_until() with older glib versions (< 2.32) 

### DIFF
--- a/lib/compat/glib.c
+++ b/lib/compat/glib.c
@@ -344,8 +344,12 @@ g_thread_new(const gchar *name, GThreadFunc func, gpointer data)
 gboolean
 g_cond_wait_until (GCond *cond, GMutex *mutex, gint64 end_time)
 {
-  glong diff_in_sec = (end_time - g_get_monotonic_time())/G_TIME_SPAN_SECOND;
-  GTimeVal tv = {.tv_sec = g_get_monotonic_time() + diff_in_sec, .tv_usec = 0};
+  gint64 diff_in_millisec = (end_time - g_get_monotonic_time()) / G_TIME_SPAN_MILLISECOND;
+
+  GTimeVal tv;
+  g_get_current_time(&tv);
+  g_time_val_add(&tv, diff_in_millisec * 1000);
+
   return g_cond_timed_wait(cond, mutex, &tv);
 }
 #endif

--- a/news/bugfix-3504.md
+++ b/news/bugfix-3504.md
@@ -1,0 +1,4 @@
+`loggen`: fix undefined timeout while connecting to network sources (`glib < 2.32`)
+
+When compiling syslog-ng with old glib versions (< 2.32), `loggen` could fail due a timeout bug.
+This has been fixed.

--- a/tests/functional/test_performance.py
+++ b/tests/functional/test_performance.py
@@ -45,7 +45,7 @@ def test_performance():
     print_user("Starting loggen for 10 seconds")
     out = os.popen("../loggen/loggen -r 1000000 -Q -i -S -s 160 -I 10 127.0.0.1 %d 2>&1 |tail -n +1" % port_number, 'r').read()
 
-    print_user("performane: %s" % out)
+    print_user("performance: %s" % out)
     rate = float(re.sub('^.*rate = ([0-9.]+).*$', '\\1', out))
 
     hostname = os.uname()[1]

--- a/tests/functional/test_performance.py
+++ b/tests/functional/test_performance.py
@@ -43,7 +43,7 @@ def test_performance():
       'bzorp': 10000
     }
     print_user("Starting loggen for 10 seconds")
-    out = os.popen("../loggen/loggen -r 1000000 -Q -i -S -s 160 -I 10 127.0.0.1 %d 2>&1 |tail -n +1" % port_number, 'r').read()
+    out = os.popen("../loggen/loggen --quiet --stream --inet --rate 1000000 --size 160 --interval 10 --active-connections 1 127.0.0.1 %d 2>&1 |tail -n +1" % port_number, 'r').read()
 
     print_user("performance: %s" % out)
     rate = float(re.sub('^.*rate = ([0-9.]+).*$', '\\1', out))


### PR DESCRIPTION
When compiling syslog-ng with old glib versions (< 2.32), our compactibility implementation of `g_cond_wait_until()` is used.
The implementation of the compat call had a bug, which could cause indefinite waiting when `loggen` tries to connect to a TCP/TLS host.
https://github.com/syslog-ng/syslog-ng/blob/f7812c4a1d2fd9e4402f25e85f0cf5940500d50f/tests/loggen/socket_plugin/socket_plugin.c#L199

----

The deprecated `g_cond_timed_wait()` call operates with system wall-clock time, passing `GTimeVal` based on system monotonic time is not valid.

We've found this issue with `tests/functional/test_performance.py`. This test failed due to undefined, but very short timeouts.

A code snippet to reproduce the problem:
https://gist.github.com/MrAnno/6b4ec783a91975177a1028bd357fddbc

Docs:
- https://developer.gnome.org/glib/stable/glib-Threads.html#g-cond-wait-until
- https://developer.gnome.org/glib/stable/glib-Threads.html#g-cond-timed-wait