### PR TITLE
affile/wildcard: fix crash when reader replaced

### DIFF
--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -81,8 +81,7 @@ log_reader_set_options(LogReader *s, LogPipe *control, LogReaderOptions *options
   log_source_set_ack_tracker_factory(&self->super, ack_tracker_factory_ref(factory));
 
   log_pipe_unref(self->control);
-  log_pipe_ref(control);
-  self->control = control;
+  self->control = log_pipe_ref(control);
 
   self->options = options;
   log_proto_server_set_options(self->proto, &self->options->proto_options.super);

--- a/modules/affile/file-list.h
+++ b/modules/affile/file-list.h
@@ -35,4 +35,10 @@ gchar *pending_file_list_pop(PendingFileList *self);
 
 gboolean pending_file_list_remove(PendingFileList *self, const gchar *value);
 
+void pending_file_list_steal(PendingFileList *self, GList *entry);
+
+GList *pending_file_list_begin(PendingFileList *self);
+GList *pending_file_list_end(PendingFileList *self);
+GList *pending_file_list_next(GList *it);
+
 #endif /* MODULES_AFFILE_HASHED_QUEUE_H_ */

--- a/modules/affile/tests/test_file_list.c
+++ b/modules/affile/tests/test_file_list.c
@@ -147,3 +147,104 @@ Test(hashed_queue, no_duplication)
   g_free(f3);
   pending_file_list_free(queue);
 }
+
+Test(hashed_queue, reverse_iterator_in_empty)
+{
+  PendingFileList *queue = pending_file_list_new();
+
+  GList *f1 = pending_file_list_begin(queue);
+  cr_assert_null(f1);
+
+  pending_file_list_free(queue);
+}
+
+Test(hashed_queue, reverse_iterator_one_entry)
+{
+  PendingFileList *queue = pending_file_list_new();
+  pending_file_list_add(queue, "file1");
+
+  GList *f1 = pending_file_list_begin(queue);
+
+  cr_assert_not_null(f1);
+  cr_assert_str_eq(f1->data, "file1");
+
+  pending_file_list_free(queue);
+}
+
+Test(hashed_queue, reverse_iterator_two_entry)
+{
+  PendingFileList *queue = pending_file_list_new();
+  pending_file_list_add(queue, "file3");
+  pending_file_list_add(queue, "file1");
+
+  GList *f1 = pending_file_list_begin(queue);
+
+  cr_assert_not_null(f1);
+  cr_assert_str_eq(f1->data, "file3");
+
+  pending_file_list_free(queue);
+}
+
+Test(hashed_queue, reverse_iterator_second_entry)
+{
+  PendingFileList *queue = pending_file_list_new();
+  pending_file_list_add(queue, "file1");
+  pending_file_list_add(queue, "file2");
+  pending_file_list_add(queue, "file3");
+
+  GList *it = pending_file_list_begin(queue);
+  it = pending_file_list_next(it);
+
+  cr_assert_not_null(it);
+  cr_assert_str_eq(it->data, "file2");
+
+  pending_file_list_free(queue);
+}
+
+Test(hashed_queue, reverse_iterator_count_entries)
+{
+  PendingFileList *queue = pending_file_list_new();
+  pending_file_list_add(queue, "file1");
+  pending_file_list_add(queue, "file2");
+  pending_file_list_add(queue, "file3");
+
+  gint length = 0;
+  for (GList *it = pending_file_list_begin(queue); it != pending_file_list_end(queue);
+       it = pending_file_list_next(it))
+    ++length;
+
+  cr_assert_eq(length, 3);
+
+  pending_file_list_free(queue);
+}
+
+Test(hashed_queue, steal_from_empty)
+{
+  PendingFileList *queue = pending_file_list_new();
+
+  GList *it = pending_file_list_begin(queue);
+  pending_file_list_steal(queue, it);
+
+  cr_assert_null(it);
+
+  pending_file_list_free(queue);
+}
+
+Test(hashed_queue, steal_from_one_entry)
+{
+  PendingFileList *queue = pending_file_list_new();
+  pending_file_list_add(queue, "file1");
+
+  GList *it = pending_file_list_begin(queue);
+  pending_file_list_steal(queue, it);
+
+  cr_assert_not_null(it);
+  cr_assert_str_eq(it->data, "file1");
+
+  cr_assert_null(pending_file_list_begin(queue));
+
+  g_free(it->data);
+  g_list_free_1(it);
+
+  pending_file_list_free(queue);
+}


### PR DESCRIPTION
reproduction of the crash:

config:
```
@version: 7.0

log {

source {
  wildcard_file(
    base-dir("/tmp/input/")
    filename-pattern("*")
  );
};

destination {
  file("/tmp/output.txt");
};

flags(flow-control);

};
```
create a non empty file in /tmp/input/

1. start syslog-ng with the above configuration
2. start an infinite loop with renaming the file created in /tmp/input/
   (for example while true ; mv /tmp/input/2 /tmp/input1 && mv
/tmp/input/1 /tmp/input2 ; end)
The crash might occure right away, or after a few minutes.

Signed-off-by: Kokan <kokaipeter@gmail.com>