### PR TITLE
grouping-by: fix deadlock when context expires

### DIFF
--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -58,6 +58,69 @@ typedef struct
 
 static NVHandle context_id_handle = 0;
 
+
+#define EXPECTED_NUMBER_OF_MESSAGES_EMITTED 32
+typedef struct _GPMessageEmitter
+{
+  gpointer emitted_messages[EXPECTED_NUMBER_OF_MESSAGES_EMITTED];
+  GPtrArray *emitted_messages_overflow;
+  gint num_emitted_messages;
+} GPMessageEmitter;
+
+
+/* This function is called to populate the emitted_messages array in
+ * msg_emitter.  It only manipulates per-thread data structure so it does
+ * not require locks but does not mind them being locked either.  */
+static void
+_emit_message(GPMessageEmitter *msg_emitter, LogMessage *msg)
+{
+  if (msg_emitter->num_emitted_messages < EXPECTED_NUMBER_OF_MESSAGES_EMITTED)
+    {
+      msg_emitter->emitted_messages[msg_emitter->num_emitted_messages++] = log_msg_ref(msg);
+      return;
+    }
+
+  if (!msg_emitter->emitted_messages_overflow)
+    msg_emitter->emitted_messages_overflow = g_ptr_array_new();
+
+  g_ptr_array_add(msg_emitter->emitted_messages_overflow, log_msg_ref(msg));
+}
+
+static void
+_send_emitted_message_array(GroupingBy *self, gpointer *values, gsize len)
+{
+  for (gint i = 0; i < len; i++)
+    {
+      LogMessage *msg = values[i];
+      stateful_parser_emit_synthetic(&self->super, msg);
+      log_msg_unref(msg);
+    }
+}
+
+/* This function is called to flush the accumulated list of messages that
+ * are generated during processing.  We must not hold any locks within
+ * GroupingBy when doing this, as it will cause log_pipe_queue() calls to
+ * subsequent elements in the message pipeline, which in turn may recurse
+ * into PatternDB.  This works as msg_emitter itself is per-thread
+ * (actually an auto variable on the stack), and this is called without
+ * locks held at the end of a process() invocation. */
+static void
+_flush_emitted_messages(GroupingBy *self, GPMessageEmitter *msg_emitter)
+{
+  _send_emitted_message_array(self, msg_emitter->emitted_messages, msg_emitter->num_emitted_messages);
+  msg_emitter->num_emitted_messages = 0;
+
+  if (!msg_emitter->emitted_messages_overflow)
+    return;
+
+  _send_emitted_message_array(self, msg_emitter->emitted_messages_overflow->pdata,
+                              msg_emitter->emitted_messages_overflow->len);
+
+  g_ptr_array_free(msg_emitter->emitted_messages_overflow, TRUE);
+  msg_emitter->emitted_messages_overflow = NULL;
+
+}
+
 static void
 _free_persist_data(GroupingByPersistData *self)
 {
@@ -136,7 +199,7 @@ grouping_by_set_synthetic_message(LogParser *s, SyntheticMessage *message)
 
 /* NOTE: lock should be acquired for writing before calling this function. */
 void
-grouping_by_set_time(GroupingBy *self, const UnixTime *ls)
+grouping_by_set_time(GroupingBy *self, const UnixTime *ls, GPMessageEmitter *msg_emitter)
 {
   GTimeVal now;
 
@@ -151,7 +214,7 @@ grouping_by_set_time(GroupingBy *self, const UnixTime *ls)
   if (ls->ut_sec < now.tv_sec)
     now.tv_sec = ls->ut_sec;
 
-  timer_wheel_set_time(self->timer_wheel, now.tv_sec, NULL);
+  timer_wheel_set_time(self->timer_wheel, now.tv_sec, msg_emitter);
   msg_debug("Advancing grouping-by() current time because of an incoming message",
             evt_tag_long("utc", timer_wheel_get_time(self->timer_wheel)),
             log_pipe_location_tag(&self->super.super.super));
@@ -171,6 +234,8 @@ _grouping_by_timer_tick(GroupingBy *self)
   GTimeVal now;
   glong diff;
 
+  GPMessageEmitter msg_emitter = {0};
+
   g_static_mutex_lock(&self->lock);
   cached_g_current_time(&now);
   diff = g_time_val_diff(&now, &self->last_tick);
@@ -179,7 +244,7 @@ _grouping_by_timer_tick(GroupingBy *self)
     {
       glong diff_sec = (glong)(diff / 1e6);
 
-      timer_wheel_set_time(self->timer_wheel, timer_wheel_get_time(self->timer_wheel) + diff_sec, NULL);
+      timer_wheel_set_time(self->timer_wheel, timer_wheel_get_time(self->timer_wheel) + diff_sec, &msg_emitter);
       msg_debug("Advancing grouping-by() current time because of timer tick",
                 evt_tag_long("utc", timer_wheel_get_time(self->timer_wheel)),
                 log_pipe_location_tag(&self->super.super.super));
@@ -197,6 +262,7 @@ _grouping_by_timer_tick(GroupingBy *self)
       self->last_tick = now;
     }
   g_static_mutex_unlock(&self->lock);
+  _flush_emitted_messages(self, &msg_emitter);
 }
 
 static void
@@ -276,6 +342,7 @@ static void
 grouping_by_expire_entry(TimerWheel *wheel, guint64 now, gpointer user_data, gpointer caller_context)
 {
   CorrelationContext *context = user_data;
+  GPMessageEmitter *msg_emitter = caller_context;
   GroupingBy *self = (GroupingBy *) timer_wheel_get_associated_data(wheel);
 
   msg_debug("Expiring grouping-by() correlation context",
@@ -286,7 +353,7 @@ grouping_by_expire_entry(TimerWheel *wheel, guint64 now, gpointer user_data, gpo
   LogMessage *msg = grouping_by_update_context_and_generate_msg(self, context);
   if (msg)
     {
-      stateful_parser_emit_synthetic(&self->super, msg);
+      _emit_message(msg_emitter, msg);
       log_msg_unref(msg);
     }
 }
@@ -342,9 +409,10 @@ _lookup_or_create_context(GroupingBy *self, LogMessage *msg)
 static gboolean
 _perform_groupby(GroupingBy *self, LogMessage *msg)
 {
+  GPMessageEmitter msg_emitter = {0};
 
   g_static_mutex_lock(&self->lock);
-  grouping_by_set_time(self, &msg->timestamps[LM_TS_STAMP]);
+  grouping_by_set_time(self, &msg->timestamps[LM_TS_STAMP], &msg_emitter);
 
   CorrelationContext *context = _lookup_or_create_context(self, msg);
   g_ptr_array_add(context->messages, log_msg_ref(msg));
@@ -364,6 +432,7 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
       LogMessage *genmsg = grouping_by_update_context_and_generate_msg(self, context);
 
       g_static_mutex_unlock(&self->lock);
+      _flush_emitted_messages(self, &msg_emitter);
 
       if (genmsg)
         {
@@ -392,6 +461,7 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
   log_msg_write_protect(msg);
 
   g_static_mutex_unlock(&self->lock);
+  _flush_emitted_messages(self, &msg_emitter);
 
   return TRUE;
 }

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -151,7 +151,7 @@ grouping_by_set_time(GroupingBy *self, const UnixTime *ls)
   if (ls->ut_sec < now.tv_sec)
     now.tv_sec = ls->ut_sec;
 
-  timer_wheel_set_time(self->timer_wheel, now.tv_sec);
+  timer_wheel_set_time(self->timer_wheel, now.tv_sec, NULL);
   msg_debug("Advancing grouping-by() current time because of an incoming message",
             evt_tag_long("utc", timer_wheel_get_time(self->timer_wheel)),
             log_pipe_location_tag(&self->super.super.super));
@@ -179,7 +179,7 @@ _grouping_by_timer_tick(GroupingBy *self)
     {
       glong diff_sec = (glong)(diff / 1e6);
 
-      timer_wheel_set_time(self->timer_wheel, timer_wheel_get_time(self->timer_wheel) + diff_sec);
+      timer_wheel_set_time(self->timer_wheel, timer_wheel_get_time(self->timer_wheel) + diff_sec, NULL);
       msg_debug("Advancing grouping-by() current time because of timer tick",
                 evt_tag_long("utc", timer_wheel_get_time(self->timer_wheel)),
                 log_pipe_location_tag(&self->super.super.super));
@@ -273,7 +273,7 @@ grouping_by_update_context_and_generate_msg(GroupingBy *self, CorrelationContext
 }
 
 static void
-grouping_by_expire_entry(TimerWheel *wheel, guint64 now, gpointer user_data)
+grouping_by_expire_entry(TimerWheel *wheel, guint64 now, gpointer user_data, gpointer caller_context)
 {
   CorrelationContext *context = user_data;
   GroupingBy *self = (GroupingBy *) timer_wheel_get_associated_data(wheel);

--- a/modules/dbparser/tests/test_timer_wheel.c
+++ b/modules/dbparser/tests/test_timer_wheel.c
@@ -37,7 +37,7 @@ gint num_callbacks;
 guint64 prev_now;
 
 void
-timer_callback(TimerWheel *self, guint64 now, gpointer user_data)
+timer_callback(TimerWheel *self, guint64 now, gpointer user_data, gpointer caller_context)
 {
   guint64 expires = *(guint64 *) user_data;
 
@@ -78,7 +78,7 @@ test_wheel(gint seed)
   srand(seed);
   wheel = timer_wheel_new();
   _test_assoc_data(wheel);
-  timer_wheel_set_time(wheel, 1);
+  timer_wheel_set_time(wheel, 1, NULL);
   for (i = 0; i < NUM_TIMERS; i++)
     {
       guint64 expires;
@@ -119,7 +119,7 @@ test_wheel(gint seed)
           expected_callbacks--;
         }
     }
-  timer_wheel_set_time(wheel, latest + 1);
+  timer_wheel_set_time(wheel, latest + 1, NULL);
   cr_assert_eq(num_callbacks, expected_callbacks, "Error: not enough callbacks received, "
                "num_callbacks=%d, expected=%d\n",
                num_callbacks, expected_callbacks);

--- a/modules/dbparser/timerwheel.c
+++ b/modules/dbparser/timerwheel.c
@@ -289,7 +289,7 @@ timer_wheel_cascade(TimerWheel *self)
  * Main time adjustment function
  */
 void
-timer_wheel_set_time(TimerWheel *self, guint64 new_now)
+timer_wheel_set_time(TimerWheel *self, guint64 new_now, gpointer caller_context)
 {
   /* time is not allowed to go backwards */
   if (self->now >= new_now)
@@ -320,7 +320,7 @@ timer_wheel_set_time(TimerWheel *self, guint64 new_now)
         entry = iv_list_entry(lh, TWEntry, list);
 
         tw_entry_unlink(entry);
-        entry->callback(self, self->now, entry->user_data);
+        entry->callback(self, self->now, entry->user_data, caller_context);
         tw_entry_free(entry);
         self->num_timers--;
       }
@@ -344,12 +344,12 @@ timer_wheel_get_time(TimerWheel *self)
 }
 
 void
-timer_wheel_expire_all(TimerWheel *self)
+timer_wheel_expire_all(TimerWheel *self, gpointer caller_context)
 {
   guint64 now;
 
   now = self->now;
-  timer_wheel_set_time(self, (guint64) -1);
+  timer_wheel_set_time(self, (guint64) -1, caller_context);
   self->now = now;
 }
 

--- a/modules/dbparser/timerwheel.h
+++ b/modules/dbparser/timerwheel.h
@@ -28,7 +28,7 @@
 
 typedef struct _TWEntry TWEntry;
 typedef struct _TimerWheel TimerWheel;
-typedef void (*TWCallbackFunc)(TimerWheel *tw, guint64 now, gpointer user_data);
+typedef void (*TWCallbackFunc)(TimerWheel *tw, guint64 now, gpointer user_data, gpointer caller_context);
 
 TWEntry *timer_wheel_add_timer(TimerWheel *self, gint timeout, TWCallbackFunc cb, gpointer user_data,
                                GDestroyNotify user_data_free);
@@ -36,9 +36,9 @@ void timer_wheel_del_timer(TimerWheel *self, TWEntry *entry);
 void timer_wheel_mod_timer(TimerWheel *self, TWEntry *entry, gint new_timeout);
 guint64 timer_wheel_get_timer_expiration(TimerWheel *self, TWEntry *entry);
 
-void timer_wheel_set_time(TimerWheel *self, guint64 new_now);
+void timer_wheel_set_time(TimerWheel *self, guint64 new_now, gpointer caller_context);
 guint64 timer_wheel_get_time(TimerWheel *self);
-void timer_wheel_expire_all(TimerWheel *self);
+void timer_wheel_expire_all(TimerWheel *self, gpointer caller_context);
 void timer_wheel_set_associated_data(TimerWheel *self, gpointer assoc_data, GDestroyNotify assoc_data_free);
 gpointer timer_wheel_get_associated_data(TimerWheel *self);
 TimerWheel *timer_wheel_new(void);

--- a/news/bugfix-3515.md
+++ b/news/bugfix-3515.md
@@ -1,0 +1,6 @@
+`grouping-by()`: fix deadlock when context expires
+
+In certain cases, the `grouping-by()` parser could get stuck when a message
+context expired, causing a deadlock in syslog-ng.
+
+This has been fixed.


### PR DESCRIPTION
This PR accumulates synthetic messages in an array, and forwards them
after releasing the GroupingBy parser's lock.

It is NOT allowed to call `log_pipe_forward_msg()` when locks are held,
because it would slow down the entire pipeline, and it could also result
in deadlock, for example:

1. A new message is produced in syslog-ng's worker pool, which goes
   through the parser, so it acquires `GroupingBy::lock`, and starts
   processing the message (continues in step 3).

2. The main thread schedules `grouping_by_timer_tick()`, which needs to
   hold `GroupingBy::lock`, so it blocks and waits for the other thread.

3. A new synthetic message is emitted in the worker thread (step 1).
   `stateful_parser_emit_synthetic()` is called in
   `grouping_by_expire_entry()`, which is protected by `GroupingBy::lock`,
   The message goes through the pipeline with this lock held, reaches a
   destination, where `main_loop_call(wait=TRUE)` is called.

Worker waits for the main loop call to be scheduled and finished,
main thread waits for `GroupingBy::lock`, which will never be released.

A deadlock situation requires at least 2 locks:
- one was `GroupingBy::lock`;
- the other was `main_task_lock` and its `GCond` in `main_loop_call()`.

Main thread:
```
#0  syscall ()
#1  g_mutex_lock_slowpath ()
#2  _grouping_by_timer_tick ()
#3  grouping_by_timer_tick ()
#4  iv_run_timers ()
#5  iv_main ()
#6  main_loop_run ()
#7  main ()
```

Worker thread:
```
#0  syscall ()
#1  g_cond_wait ()
#2  main_loop_call ()
#3  ml_batched_timer_postpone ()
#4  log_writer_queue ()
#5  log_dest_driver_queue_method ()
#6  log_multiplexer_queue ()
#7  log_multiplexer_queue ()
#8  log_filter_pipe_queue ()
#9  stateful_parser_emit_synthetic ()
#10 grouping_by_expire_entry ()
#11 timer_wheel_set_time ()
#12 grouping_by_set_time ()
#13 grouping_by_process ()
...
```

Important note:
The unlock trick wouldn't have worked in the timer expire callback case,
as we would be iterating through a non-locked data structure (`TimerWheel`)
that could be modified by other threads.

This commit is based on a00164c04d608502e2136c1667fb40d6ddfc1709, which is
a similar deadlock fix for PatternDB.

Fixes #3451