### PR TITLE
github-actions: build macOS with --with-python=3

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,6 +33,7 @@ jobs:
             --disable-pacct
             --disable-smtp
             --enable-all-modules
+            --with-python=3
           "
 
           gh_export PYTHONUSERBASE PKG_CONFIG_PATH THREADS CONFIGURE_FLAGS

--- a/contrib/Brewfile
+++ b/contrib/Brewfile
@@ -16,7 +16,6 @@ brew "openssl"
 # brew "pcre"
 
 brew "gradle"
-brew "python", link: false
 brew "python@3", link: true, force: true
 brew "hiredis"
 brew "libdbi"


### PR DESCRIPTION
Sometimes python2 fails to install in the macOS runner:
```
Using python
Error: Could not symlink bin/2to3
Target /usr/local/bin/2to3
already exists. You may want to remove it:
  rm '/usr/local/bin/2to3'

To force the link and overwrite all conflicting files:
  brew link --overwrite python@3.9

To list all files that would be deleted:
  brew link --overwrite --dry-run python@3.9
Linking /usr/local/Cellar/python@3.9/3.9.1... 
```

There is no point of testing the support for python2 on the latest macOS.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>