### PR TITLE
gprocess: fix macOS compatibility

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,11 +13,18 @@ jobs:
       - name: Checkout syslog-ng source
         uses: actions/checkout@v2
 
+      - name: Unlinking preinstalled Python 2 (workaround)
+        # The python@3 brew package has to be installed and linked system-wide (it's a dependency of glib and syslog-ng)
+        # The macos-latest GitHub runner has Python 2.7 preinstalled as a pkg, this prevents linking the python@3
+        # brew package, even when linking is forced.
+        run : |
+          find /usr/local/bin/ -lname "*Python.framework*" -delete
+
       - name: Install dependencies
         run: |
           brew update --preinstall
           brew bundle --file=contrib/Brewfile
-          pip install --user -r requirements.txt
+          pip3 install --user -r requirements.txt
 
       - name: Set ENV variables
         run: |

--- a/lib/gprocess.c
+++ b/lib/gprocess.c
@@ -683,7 +683,13 @@ g_process_change_limits(void)
   struct rlimit limit;
 
   getrlimit(RLIMIT_NOFILE, &limit);
+
+#if defined(__APPLE__) && defined(__MACH__)
+  limit.rlim_cur = MIN(OPEN_MAX, limit.rlim_max);
+#else
   limit.rlim_cur = limit.rlim_max;
+#endif
+
   if (process_opts.fd_limit_min)
     {
       limit.rlim_cur = limit.rlim_max = process_opts.fd_limit_min;

--- a/news/bugfix-3522.md
+++ b/news/bugfix-3522.md
@@ -1,0 +1,3 @@
+Fix abort on macOS Big Sur
+
+A basic subset of syslog-ng's functionality now works on the latest macOS version.


### PR DESCRIPTION
man `setrlimit()`:
> It no longer accepts "rlim_cur = RLIM_INFINITY" for RLIM_NOFILE.
> Use "rlim_cur = min(OPEN_MAX, rlim_max)".

Note:
I could have used `sysconf()` to get `OPEN_MAX` in a portable manner, like this:
https://github.com/syslog-ng/syslog-ng/blob/013df12e397eb3bfc40d00f0c1b7cb228d28483f/modules/affile/directory-monitor.c#L57

but I think it's not necessary in this case, as `rlim_cur` can be set to `rlim_max` on all platforms except for macOS.

Fixes #3385.