### PR TITLE
 afinet: don't disable checksum calculation with spoof-source'd UDP6

### DIFF
--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -429,7 +429,7 @@ afinet_dd_init(LogPipe *s)
           if (!self->lnet_ctx)
             {
               msg_error("Error initializing raw socket, spoof-source support disabled",
-                        evt_tag_str("error", NULL));
+                        evt_tag_str("error", error));
             }
         }
     }

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -549,11 +549,6 @@ afinet_dd_construct_ipv6_packet(AFInetDestDriver *self, LogMessage *msg, GString
   if (udp == -1)
     return FALSE;
 
-  /* There seems to be a bug in libnet 1.1.2 that is triggered when
-   * checksumming UDP6 packets. This is a workaround below. */
-
-  libnet_toggle_checksum(self->lnet_ctx, udp, LIBNET_OFF);
-
   memcpy(&ln_src, &src.sin6_addr, sizeof(ln_src));
   memcpy(&ln_dst, &dst->sin6_addr, sizeof(ln_dst));
   ip = libnet_build_ipv6(0, 0,

--- a/news/bugfix-3528.md
+++ b/news/bugfix-3528.md
@@ -1,0 +1,2 @@
+`udp destination`: Fixed a bug, where the packet's checksum was not calculated,
+when `spoof-source(yes)` and `ip-protocol(6)` were set.

--- a/news/packaging-3528.md
+++ b/news/packaging-3528.md
@@ -1,0 +1,1 @@
+`libnet`: Minimal libnet version is now 1.1.6.


### PR DESCRIPTION
The problem, we worked around, has been fixed in libnet 1.1.6, which is out in every major distro. The workaround can be safely removed.

Fixes #3525.
~NOTE: Internal testing is still in progress!~

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>