### PR TITLE
dbld: improve cache-image rule

### DIFF
--- a/dbld/rules
+++ b/dbld/rules
@@ -222,6 +222,7 @@ pull-image-%:
 cache-image-%:
 	@IMAGE=balabit/syslog-ng-$*:latest;										\
 	IMAGE_ID=$$(docker images -q $$IMAGE | head -1);								\
+	WATCHED_FILES="dbld packaging/rhel/syslog-ng.spec packaging/debian/control";					\
 	if [ "$$IMAGE_ID" = "" ]; then 											\
 		$(DBLD_RULES) pull-image-$*;										\
 	fi;														\
@@ -230,7 +231,7 @@ cache-image-%:
 		image_commit=$$(docker inspect  --format '{{ index .Config.Labels "COMMIT"}}' $$IMAGE_ID);		\
 		dbld_changes=$$( 											\
 			($(GIT) cat-file -e $${image_commit:-NO_COMMIT_LABEL_IN_DBLD_IMAGE}^{commit} 			\
-				&& $(GIT) diff $${image_commit} -- dbld | wc -l						\
+				&& $(GIT) diff $${image_commit} -- $${WATCHED_FILES} | wc -l				\
 				|| echo 1)										\
 		);													\
 	else														\


### PR DESCRIPTION
Dependencies of dbld docker images come from:
  - manifest files, e.g. dbld/packages.manifest
  - packaging files (see dbld/builddeps install_debian_build_deps() and install_rpm_build_deps())

We should check if a dependency is changed in the packaging files.
However rpm spec file and debian control file contain other packaging instructions besides build dependencies.
This means that e.g. when we are releasing, the PR that is opened by "version bump" github actions will re-build the docker images just because of the version bump itself.

@bazsi What do you think of this change?