### PR TITLE
add "no-header" flag to syslog-parser()

### DIFF
--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -153,6 +153,7 @@ CfgFlagHandler msg_format_flag_handlers[] =
   { "expect-hostname",            CFH_SET, offsetof(MsgFormatOptions, flags), LP_EXPECT_HOSTNAME },
   { "no-hostname",              CFH_CLEAR, offsetof(MsgFormatOptions, flags), LP_EXPECT_HOSTNAME },
   { "guess-timezone",             CFH_SET, offsetof(MsgFormatOptions, flags), LP_GUESS_TIMEZONE },
+  { "no-header",                  CFH_SET, offsetof(MsgFormatOptions, flags), LP_NO_HEADER },
 
   { NULL },
 };

--- a/lib/msg-format.h
+++ b/lib/msg-format.h
@@ -57,6 +57,7 @@ enum
   LP_NO_PARSE_DATE = 0x0400,
   LP_STORE_RAW_MESSAGE = 0x0800,
   LP_GUESS_TIMEZONE = 0x1000,
+  LP_NO_HEADER = 0x2000,
 };
 
 typedef struct _MsgFormatHandler MsgFormatHandler;

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -722,33 +722,12 @@ error:
   return ret;
 }
 
-
-/**
- * log_msg_parse_legacy:
- * @self: LogMessage instance to store parsed information into
- * @data: message
- * @length: length of the message pointed to by @data
- * @flags: value affecting how the message is parsed (bits from LP_*)
- *
- * Parse an RFC3164 formatted log message and store the parsed information
- * in @self. Parsing is affected by the bits set @flags argument.
- **/
 static gboolean
-log_msg_parse_legacy(const MsgFormatOptions *parse_options,
-                     const guchar *data, gint length,
-                     LogMessage *self, gint *position)
+log_msg_parse_legacy_header(LogMessage *self, const guchar **data, gint *length, const MsgFormatOptions *parse_options)
 {
-  const guchar *src;
-  gint left;
+  const guchar *src = *data;
+  gint left = *length;
   GTimeVal now;
-
-  src = (const guchar *) data;
-  left = length;
-
-  if (!log_msg_parse_pri(self, &src, &left, parse_options->flags, parse_options->default_pri))
-    {
-      goto error;
-    }
 
   log_msg_parse_cisco_sequence_id(self, &src, &left);
   log_msg_parse_skip_chars(self, &src, &left, " ", -1);
@@ -823,6 +802,38 @@ log_msg_parse_legacy(const MsgFormatOptions *parse_options,
           log_msg_parse_legacy_program_name(self, &src, &left, parse_options->flags);
         }
     }
+  *data = src;
+  *length = left;
+  return TRUE;
+}
+
+/**
+ * log_msg_parse_legacy:
+ * @self: LogMessage instance to store parsed information into
+ * @data: message
+ * @length: length of the message pointed to by @data
+ * @flags: value affecting how the message is parsed (bits from LP_*)
+ *
+ * Parse an RFC3164 formatted log message and store the parsed information
+ * in @self. Parsing is affected by the bits set @flags argument.
+ **/
+static gboolean
+log_msg_parse_legacy(const MsgFormatOptions *parse_options,
+                     const guchar *data, gint length,
+                     LogMessage *self, gint *position)
+{
+  const guchar *src;
+  gint left;
+
+  src = (const guchar *) data;
+  left = length;
+
+  if (!log_msg_parse_pri(self, &src, &left, parse_options->flags, parse_options->default_pri))
+    {
+      goto error;
+    }
+
+  log_msg_parse_legacy_header(self, &src, &left, parse_options);
 
   if (parse_options->flags & LP_SANITIZE_UTF8 && !g_utf8_validate((gchar *) src, left, NULL))
     {

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -833,7 +833,8 @@ log_msg_parse_legacy(const MsgFormatOptions *parse_options,
       goto error;
     }
 
-  log_msg_parse_legacy_header(self, &src, &left, parse_options);
+  if ((parse_options->flags & LP_NO_HEADER) == 0)
+    log_msg_parse_legacy_header(self, &src, &left, parse_options);
 
   if (parse_options->flags & LP_SANITIZE_UTF8 && !g_utf8_validate((gchar *) src, left, NULL))
     {

--- a/news/feature-3538.md
+++ b/news/feature-3538.md
@@ -1,0 +1,2 @@
+`syslog-parser()`: add no-header flag to tell syslog-ng to parse only the
+PRI field of an incoming message, everything else is just put into $MSG.

--- a/tests/unit/test_msgparse.c
+++ b/tests/unit/test_msgparse.c
@@ -1175,3 +1175,20 @@ Test(msgparse, test_simple_message)
   };
   run_parameterized_test(params);
 }
+
+Test(msgparse, test_no_header_flag)
+{
+  struct msgparse_params params[] =
+  {
+    {
+      .msg = "<189>some message",
+      .parse_flags = LP_NO_HEADER,
+      .expected_pri = 189,
+      .expected_program = "",
+      .expected_host = "",
+      .expected_msg = "some message",
+    },
+    {NULL}
+  };
+  run_parameterized_test(params);
+}


### PR DESCRIPTION
This patch was originally part of #3536 but is split off to a separate PR, as it is a feature of its own right. #3536 would depend on this.

The new header can be used either at a source:

```
source s_udp { 
    udp(flags(no-header)); 
};
```

Or with syslog-parser()
```
parser p_syslog {
    syslog-parser(flags(no-header));
};
```

The no-header flag means that the syslog header is not present (or does not adhere to the conventions/RFCs), so the entire message (except from the PRI field) is shoved into $MSG.

It is somewhat similar to flags(no-parse), except that no-parse would skip the PRI field too.
