### PR TITLE
add set-pri() as a rewrite operation

### DIFF
--- a/lib/rewrite/CMakeLists.txt
+++ b/lib/rewrite/CMakeLists.txt
@@ -6,6 +6,7 @@ set(REWRITE_HEADERS
     rewrite/rewrite-expr-parser.h
     rewrite/rewrite-groupset.h
     rewrite/rewrite-unset.h
+    rewrite/rewrite-set-pri.h
     rewrite/rewrite-set-severity.h
     rewrite/rewrite-set-facility.h
     PARENT_SCOPE
@@ -19,6 +20,7 @@ set(REWRITE_SOURCES
     rewrite/rewrite-expr-parser.c
     rewrite/rewrite-groupset.c
     rewrite/rewrite-unset.c
+    rewrite/rewrite-set-pri.c
     rewrite/rewrite-set-severity.c
     rewrite/rewrite-set-facility.c
     PARENT_SCOPE

--- a/lib/rewrite/Makefile.am
+++ b/lib/rewrite/Makefile.am
@@ -10,6 +10,7 @@ rewriteinclude_HEADERS = 			\
 	lib/rewrite/rewrite-subst.h		\
 	lib/rewrite/rewrite-expr-parser.h	\
 	lib/rewrite/rewrite-groupset.h		\
+	lib/rewrite/rewrite-set-pri.h		\
 	lib/rewrite/rewrite-set-severity.h	\
 	lib/rewrite/rewrite-set-facility.h
 
@@ -23,6 +24,7 @@ rewrite_sources = 				\
 	lib/rewrite/rewrite-expr-parser.c	\
 	lib/rewrite/rewrite-expr-grammar.y	\
 	lib/rewrite/rewrite-groupset.c		\
+	lib/rewrite/rewrite-set-pri.c		\
 	lib/rewrite/rewrite-set-severity.c	\
 	lib/rewrite/rewrite-set-facility.c
 

--- a/lib/rewrite/rewrite-expr-grammar.ym
+++ b/lib/rewrite/rewrite-expr-grammar.ym
@@ -35,6 +35,7 @@
 #include "rewrite/rewrite-unset.h"
 #include "rewrite/rewrite-subst.h"
 #include "rewrite/rewrite-groupset.h"
+#include "rewrite/rewrite-set-pri.h"
 #include "rewrite/rewrite-set-severity.h"
 #include "rewrite/rewrite-set-facility.h"
 #include "filter/filter-expr.h"
@@ -78,6 +79,7 @@
 %token KW_VALUES
 %token KW_SET_SEVERITY
 %token KW_SET_FACILITY
+%token KW_SET_PRI
 
 %%
 
@@ -139,6 +141,11 @@ rewrite_expr
             last_rewrite = log_rewrite_groupunset_new(configuration);
           }
           rewrite_groupset_opts ')'             { $$ = last_rewrite; }
+        | KW_SET_PRI '(' template_content
+          {
+            last_rewrite = log_rewrite_set_pri_new($3, configuration);
+            log_template_unref($3);
+          } rewrite_set_pri_opts ')'		{ $$ = last_rewrite; };
         | KW_SET_SEVERITY '(' template_content
           {
             last_rewrite = log_rewrite_set_severity_new($3, configuration);
@@ -212,6 +219,15 @@ rewrite_set_opt
 rewrite_expr_opts
         : rewrite_expr_opt rewrite_expr_opts
         |
+        ;
+
+rewrite_set_pri_opts
+        : rewrite_set_pri_opt rewrite_set_pri_opts
+        |
+        ;
+
+rewrite_set_pri_opt
+        : rewrite_condition_opt
         ;
 
 rewrite_set_severity_opts

--- a/lib/rewrite/rewrite-expr-parser.c
+++ b/lib/rewrite/rewrite-expr-parser.c
@@ -36,6 +36,7 @@ static CfgLexerKeyword rewrite_expr_keywords[] =
   { "subst",              KW_SUBST },
   { "set_tag",            KW_SET_TAG },
   { "clear_tag",          KW_CLEAR_TAG },
+  { "set_pri",            KW_SET_PRI },
   { "set_severity",       KW_SET_SEVERITY },
   { "set_facility",       KW_SET_FACILITY },
 

--- a/lib/rewrite/rewrite-set-pri.c
+++ b/lib/rewrite/rewrite-set-pri.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2021 Balazs Scheidler <bazsi77@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "rewrite-set-pri.h"
+#include "template/templates.h"
+#include "syslog-names.h"
+#include "scratch-buffers.h"
+
+#include <stdlib.h>
+
+typedef struct _LogRewriteSetPri LogRewriteSetPri;
+
+struct _LogRewriteSetPri
+{
+  LogRewrite super;
+  LogTemplate *pri;
+};
+
+static gint
+_convert_pri(GString *pri_text)
+{
+  char *endptr;
+  long int pri = strtol(pri_text->str, &endptr, 10);
+  if (!endptr)
+    return -1;
+
+  if (endptr[0] != '\0' || pri_text->str == endptr)
+    return -1;
+
+  /* the maximum facility code is 127 in set-facility() */
+  if (pri > 127*8 + 7)
+    return -1;
+
+  return pri;
+}
+
+static void
+log_rewrite_set_pri_process(LogRewrite *s, LogMessage **pmsg, const LogPathOptions *path_options)
+{
+  LogRewriteSetPri *self = (LogRewriteSetPri *) s;
+  GString *result = scratch_buffers_alloc();
+
+  log_msg_make_writable(pmsg, path_options);
+
+  log_template_format(self->pri, *pmsg, &DEFAULT_TEMPLATE_EVAL_OPTIONS, result);
+
+  const gint pri = _convert_pri(result);
+  if (pri < 0)
+    {
+      msg_debug("Warning: invalid value passed to set-pri()",
+                evt_tag_str("pri", result->str),
+                log_pipe_location_tag(&s->super));
+      return;
+    }
+
+  msg_trace("Setting syslog pri",
+            evt_tag_int("old_pri", (*pmsg)->pri),
+            evt_tag_int("new_pri", pri),
+            evt_tag_printf("msg", "%p", *pmsg));
+  (*pmsg)->pri = pri;
+}
+
+static LogPipe *
+log_rewrite_set_pri_clone(LogPipe *s)
+{
+  LogRewriteSetPri *self = (LogRewriteSetPri *) s;
+  LogRewriteSetPri *cloned = (LogRewriteSetPri *) log_rewrite_set_pri_new(log_template_ref(self->pri),
+                             s->cfg);
+
+  if (self->super.condition)
+    cloned->super.condition = filter_expr_ref(self->super.condition);
+
+  return &cloned->super.super;
+}
+
+void
+log_rewrite_set_pri_free(LogPipe *s)
+{
+  LogRewriteSetPri *self = (LogRewriteSetPri *) s;
+  log_template_unref(self->pri);
+  log_rewrite_free_method(s);
+}
+
+LogRewrite *
+log_rewrite_set_pri_new(LogTemplate *pri, GlobalConfig *cfg)
+{
+  LogRewriteSetPri *self = g_new0(LogRewriteSetPri, 1);
+
+  log_rewrite_init_instance(&self->super, cfg);
+  self->super.super.free_fn = log_rewrite_set_pri_free;
+  self->super.super.clone = log_rewrite_set_pri_clone;
+  self->super.process = log_rewrite_set_pri_process;
+  self->pri = log_template_ref(pri);
+  return &self->super;
+}

--- a/lib/rewrite/rewrite-set-pri.h
+++ b/lib/rewrite/rewrite-set-pri.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021 Balazs Scheidler <bazsi77@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef REWRITE_SET_PRI_H_INCLUDED
+#define REWRITE_SET_PRI_H_INCLUDED
+
+#include "rewrite-expr.h"
+
+LogRewrite *log_rewrite_set_pri_new(LogTemplate *severity, GlobalConfig *cfg);
+
+#endif

--- a/lib/rewrite/tests/CMakeLists.txt
+++ b/lib/rewrite/tests/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_unit_test(LIBTEST CRITERION TARGET test_rewrite)
+add_unit_test(LIBTEST CRITERION TARGET test_set_pri)
 add_unit_test(LIBTEST CRITERION TARGET test_set_severity)
 add_unit_test(LIBTEST CRITERION TARGET test_set_facility)

--- a/lib/rewrite/tests/Makefile.am
+++ b/lib/rewrite/tests/Makefile.am
@@ -1,5 +1,6 @@
 lib_rewrite_tests_TESTS = \
     lib/rewrite/tests/test_rewrite \
+    lib/rewrite/tests/test_set_pri \
     lib/rewrite/tests/test_set_severity \
     lib/rewrite/tests/test_set_facility
 
@@ -22,3 +23,8 @@ lib_rewrite_tests_test_set_facility_CFLAGS = $(TEST_CFLAGS)
 lib_rewrite_tests_test_set_facility_LDADD = $(TEST_LDADD)
 lib_rewrite_tests_test_set_facility_SOURCES =    \
     lib/rewrite/tests/test_set_facility.c
+
+lib_rewrite_tests_test_set_pri_CFLAGS = $(TEST_CFLAGS)
+lib_rewrite_tests_test_set_pri_LDADD = $(TEST_LDADD)
+lib_rewrite_tests_test_set_pri_SOURCES =    \
+    lib/rewrite/tests/test_set_pri.c

--- a/lib/rewrite/tests/test_set_pri.c
+++ b/lib/rewrite/tests/test_set_pri.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2021 Balazs Scheidler <bazsi77@gmail.com>
+ * Copyright (c) 2019 Balabit
+ * Copyright (c) 2019 Kokan <kokaipeter@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+
+#include "apphook.h"
+#include "rewrite/rewrite-set-pri.h"
+#include "logmsg/logmsg.h"
+#include "scratch-buffers.h"
+#include "grab-logging.h"
+
+GlobalConfig *cfg = NULL;
+LogMessage *msg;
+
+static LogTemplate *
+_create_template(const gchar *str)
+{
+  GError *error = NULL;
+  LogTemplate *template = log_template_new(cfg, NULL);
+  log_template_compile(template, str, &error);
+
+  cr_expect_null(error);
+
+  return template;
+}
+
+static void
+_perform_rewrite(LogRewrite *rewrite, LogMessage *msg_)
+{
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+
+  log_pipe_init(&rewrite->super);
+  log_pipe_queue(&rewrite->super, log_msg_ref(msg_), &path_options);
+  log_pipe_deinit(&rewrite->super);
+  log_pipe_unref(&rewrite->super);
+}
+
+static void
+_perform_set_pri(LogTemplate *template, LogMessage *msg_)
+{
+  LogRewrite *rewrite = log_rewrite_set_pri_new(template, cfg);
+  log_template_unref(template);
+
+  _perform_rewrite(rewrite, msg_);
+}
+
+static gboolean
+_msg_pri_equals(LogMessage *msg_, gint pri)
+{
+  return msg_->pri == pri;
+}
+
+Test(set_pri, numeric)
+{
+  _perform_set_pri(_create_template("7"), msg);
+  cr_assert(_msg_pri_equals(msg, LOG_KERN | LOG_DEBUG));
+
+  _perform_set_pri(_create_template("189"), msg);
+  cr_assert(_msg_pri_equals(msg, LOG_LOCAL7 | LOG_NOTICE));
+
+  log_msg_set_value_by_name(msg, "pri_value", "137", -1);
+  _perform_set_pri(_create_template("$pri_value"), msg);
+  cr_assert(_msg_pri_equals(msg, 137));
+
+  _perform_set_pri(_create_template("1023"), msg);
+  cr_assert(_msg_pri_equals(msg, 127*8+7));
+
+  _perform_set_pri(_create_template(" 123"), msg);
+  cr_assert(_msg_pri_equals(msg, 123));
+
+}
+
+Test(set_pri, test_set_pri_with_various_invalid_values)
+{
+  debug_flag = 1;
+
+  int default_pri = msg->pri;
+  _perform_set_pri(_create_template("${nonexistentvalue}"), msg);
+  assert_grabbed_log_contains("invalid value passed to set-pri()");
+  cr_assert(_msg_pri_equals(msg, default_pri),
+            "empty templates should not change the original pri");
+
+  reset_grabbed_messages();
+  _perform_set_pri(_create_template("1024"), msg);
+  assert_grabbed_log_contains("invalid value passed to set-pri()");
+  cr_assert(_msg_pri_equals(msg, default_pri),
+            "too large numeric values should not change the original pri");
+
+  reset_grabbed_messages();
+  _perform_set_pri(_create_template("-1"), msg);
+  assert_grabbed_log_contains("invalid value passed to set-pri()");
+  cr_assert(_msg_pri_equals(msg, default_pri),
+            "negative values should not change the original pri");
+
+  reset_grabbed_messages();
+  _perform_set_pri(_create_template("random-text"), msg);
+  assert_grabbed_log_contains("invalid value passed to set-pri()");
+  cr_assert(_msg_pri_equals(msg, default_pri),
+            "non-numeric data should not change the original pri");
+
+  reset_grabbed_messages();
+  _perform_set_pri(_create_template("123 "), msg);
+  assert_grabbed_log_contains("invalid value passed to set-pri()");
+  cr_assert(_msg_pri_equals(msg, default_pri),
+            "non-numeric data should not change the original pri");
+
+  reset_grabbed_messages();
+  _perform_set_pri(_create_template("123d"), msg);
+  assert_grabbed_log_contains("invalid value passed to set-pri()");
+  cr_assert(_msg_pri_equals(msg, default_pri),
+            "non-numeric data should not change the original pri");
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  cfg = cfg_new_snippet();
+  start_grabbing_messages();
+  msg = log_msg_new_empty();
+}
+
+static void
+teardown(void)
+{
+  scratch_buffers_explicit_gc();
+  log_msg_unref(msg);
+  stop_grabbing_messages();
+  cfg_free(cfg);
+  app_shutdown();
+}
+
+TestSuite(set_pri, .init = setup, .fini = teardown);

--- a/news/feature-3546.md
+++ b/news/feature-3546.md
@@ -1,0 +1,2 @@
+`set-pri()`: this new rewrite operation allows you to change the PRI value
+of a message based on the string directly parsed out of a syslog header.

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -61,6 +61,8 @@ modules/secure-logging/slogverify
 modules/secure-logging/slogkey
 lib/rewrite/rewrite-set-facility\.h
 lib/rewrite/tests/test_set_facility\.c
+lib/rewrite/rewrite-set-pri\.h
+lib/rewrite/rewrite-set-pri\.c
  LGPLv2.1+_SSL
 autogen\.sh$
 sub-configure\.sh$


### PR DESCRIPTION
This branch adds a new rewrite operation, set-pri() that allows one to set the pri value of the message (e.g. facility * 8 + severity) based on a template string.

The template string needs to expand to a number between in the interval [0, 1023] inclusive, that permits up to 127 facilities.

The format accepted by set-pri() is a simple number, e.g. if you extract this value from a syslog header, the brackets "<" and ">" needs to be removed first.

The format may be extended in the future if use-cases arise, I was thinking of allowing the brackets to be present, or the use of the dot separated, string based format, such as "mail.info".

Fixes #3541