### PR TITLE
Fix crash with dynamic-window-size() when a kept-alive connection is reconfigured

### DIFF
--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -219,7 +219,7 @@ log_source_dynamic_window_update_statistics(LogSource *self)
 static void
 _reclaim_dynamic_window(LogSource *self, gsize window_size)
 {
-  g_assert(self->full_window_size - window_size >= self->options->init_window_size);
+  g_assert(self->full_window_size - window_size >= self->initial_window_size);
   atomic_gssize_set(&self->window_size_to_be_reclaimed, window_size);
 }
 
@@ -228,7 +228,7 @@ _release_dynamic_window(LogSource *self)
 {
   g_assert(self->ack_tracker == NULL);
 
-  gsize dynamic_part = self->full_window_size - self->options->init_window_size;
+  gsize dynamic_part = self->full_window_size - self->initial_window_size;
   msg_trace("Releasing dynamic part of the window", evt_tag_int("dynamic_window_to_be_released", dynamic_part),
             log_pipe_location_tag(&self->super));
 
@@ -334,7 +334,7 @@ _reclaim_window_instead_of_rebalance(LogSource *self)
 static void
 _dynamic_window_rebalance(LogSource *self)
 {
-  gsize current_dynamic_win = self->full_window_size - self->options->init_window_size;
+  gsize current_dynamic_win = self->full_window_size - self->initial_window_size;
   gboolean have_to_increase = current_dynamic_win < self->dynamic_window.pool->balanced_window;
   gboolean have_to_decrease = current_dynamic_win > self->dynamic_window.pool->balanced_window;
 
@@ -343,7 +343,7 @@ _dynamic_window_rebalance(LogSource *self)
             evt_tag_printf("connection", "%p", self),
             evt_tag_int("full_window", self->full_window_size),
             evt_tag_int("dynamic_win", current_dynamic_win),
-            evt_tag_int("static_window", self->options->init_window_size),
+            evt_tag_int("static_window", self->initial_window_size),
             evt_tag_int("balanced_window", self->dynamic_window.pool->balanced_window),
             evt_tag_int("avg_free", dynamic_window_stat_get_avg(&self->dynamic_window.stat)));
 

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -670,6 +670,8 @@ _initialize_window(LogSource *self, gint init_window_size)
 {
   self->window_initialized = TRUE;
   window_size_counter_set(&self->window_size, init_window_size);
+
+  self->initial_window_size = init_window_size;
   self->full_window_size = init_window_size;
 }
 

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -104,7 +104,7 @@ log_source_free_to_send(LogSource *self)
 static inline gint
 log_source_get_init_window_size(LogSource *self)
 {
-  return self->options->init_window_size;
+  return self->initial_window_size;
 }
 
 static inline void

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -72,6 +72,7 @@ struct _LogSource
   WindowSizeCounter window_size;
   DynamicWindow dynamic_window;
   gboolean window_initialized;
+  gsize initial_window_size;
   /* full_window_size = static + dynamic */
   gsize full_window_size;
   atomic_gssize window_size_to_be_reclaimed;


### PR DESCRIPTION
Currently, it is not supported to reconfigure either `log-iw-size()` or the `dynamic-window-size()` option on a kept-alive source. The current behavior is to maintain original window sizes when `keep-alive()` is enabled for a network source. New connections and connections configured with `keep-alive(no)` will, of course, use the recently configured window values.

This commit fixes a crash (underflow) in the dynamic window mechanism by using the static window size that is actually in-use, not `LogSourceOptions::init_window_size`, which may contain a different, recently configured value.

Reproduction steps:
```
log {
  source {
    network(port(4444) log-iw-size(4000) max-connections(10) dynamic-window-size(100000) keep-alive(yes));
  };
};
```

1. Start syslog-ng with the config above
2. Connect to the source (`nc localhost 4444`)
3. Change `log-iw-size()` to a smaller value (`log-iw-size(3000)`) and reload
4. Close the connection that was made in step 2

```
Bail out! ERROR:../lib/dynamic-window-pool.c:78:dynamic_window_pool_release: assertion failed: (self->free_window <= self->pool_size)
“sbin/syslog-ng -Fe” terminated by signal SIGABRT (Abort)

...
#3 in g_assertion_message_expr () from /usr/lib/libglib-2.0.so.0
#4 in dynamic_window_pool_release (self=0x555d01cd2890, release_size=100100) at ../lib/dynamic-window-pool.c:78
#5 in dynamic_window_release (self=0x555d01cd8a40, size=100100) at ../lib/dynamic-window.c:92
#6 in _release_dynamic_window (self=0x555d01cd8970) at ../lib/logsource.c:240
#7 in log_source_free (s=0x555d01cd8970) at ../lib/logsource.c:750
#8 in log_reader_free (s=0x555d01cd8970) at ../lib/logreader.c:659
...
```