### PR TITLE
Fix crash in dateparser %z parsing

### DIFF
--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -43,6 +43,7 @@
 #include "secret-storage/nondumpable-allocator.h"
 #include "secret-storage/secret-storage.h"
 #include "transport/transport-factory-id.h"
+#include "timeutils/timeutils.h"
 #include "msg-stats.h"
 
 #include <iv.h>
@@ -177,6 +178,7 @@ app_startup(void)
   transport_factory_id_global_init();
   scratch_buffers_global_init();
   msg_stats_init();
+  timeutils_global_init();
 }
 
 void

--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -239,10 +239,16 @@ app_shutdown(void)
 }
 
 void
+app_config_stopped(void)
+{
+  run_application_hook(AH_CONFIG_STOPPED);
+  res_init();
+}
+
+void
 app_config_changed(void)
 {
   run_application_hook(AH_CONFIG_CHANGED);
-  res_init();
 }
 
 void

--- a/lib/apphook.h
+++ b/lib/apphook.h
@@ -42,8 +42,9 @@ enum
 
   /* these happen from time to time and don't update the current state of
    * the process */
-  AH_CONFIG_CHANGED,
-  AH_REOPEN_FILES,
+  AH_CONFIG_STOPPED,   /* configuration is deinitialized, threads have stopped */
+  AH_CONFIG_CHANGED,   /* configuration changed, threads are running again */
+  AH_REOPEN_FILES,     /* reopen files signal from syslog-ng-ctl */
 };
 
 /* state-like hook entry points */
@@ -54,6 +55,7 @@ void app_pre_shutdown(void);
 void app_shutdown(void);
 
 /* stateless entry points */
+void app_config_stopped(void);
 void app_config_changed(void);
 void app_reopen_files(void);
 

--- a/lib/timeutils/CMakeLists.txt
+++ b/lib/timeutils/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TIMEUTILS_HEADERS
     timeutils/format.h
     timeutils/misc.h
     timeutils/names.h
+    timeutils/timeutils.h
     timeutils/unixtime.h
     timeutils/zonecache.h
     timeutils/zonedb.h
@@ -19,6 +20,7 @@ set(TIMEUTILS_SOURCES
     timeutils/format.c
     timeutils/misc.c
     timeutils/names.c
+    timeutils/timeutils.c
     timeutils/unixtime.c
     timeutils/zonecache.c
     timeutils/zonedb.c

--- a/lib/timeutils/Makefile.am
+++ b/lib/timeutils/Makefile.am
@@ -9,6 +9,7 @@ timeutilsinclude_HEADERS =	\
   lib/timeutils/format.h	\
   lib/timeutils/misc.h	\
   lib/timeutils/names.h	\
+  lib/timeutils/timeutils.h	\
   lib/timeutils/unixtime.h	\
   lib/timeutils/zonecache.h	\
   lib/timeutils/zonedb.h	\
@@ -22,6 +23,7 @@ timeutils_sources =		\
  lib/timeutils/format.c		\
  lib/timeutils/misc.c		\
  lib/timeutils/names.c		\
+ lib/timeutils/timeutils.c	\
  lib/timeutils/unixtime.c	\
  lib/timeutils/zonecache.c	\
  lib/timeutils/zonedb.c		\

--- a/lib/timeutils/cache.c
+++ b/lib/timeutils/cache.c
@@ -254,18 +254,3 @@ cached_get_time_zone_info(const gchar *tz)
   TimeZoneInfo *result = cache_lookup(cache.tzinfo.zones, tz);
   return result;
 }
-
-void timeutils_setup_timezone_hook(void);
-
-static void
-timeutils_reset_timezone(gint type, gpointer user_data)
-{
-  invalidate_timeutils_cache();
-  timeutils_setup_timezone_hook();
-}
-
-void
-timeutils_setup_timezone_hook(void)
-{
-  register_application_hook(AH_CONFIG_CHANGED, timeutils_reset_timezone, NULL);
-}

--- a/lib/timeutils/cache.h
+++ b/lib/timeutils/cache.h
@@ -28,6 +28,12 @@
 #include "timeutils/wallclocktime.h"
 #include "timeutils/zoneinfo.h"
 
+/* the thread safe variant of the global "timezone" */
+glong cached_get_system_tzofs(void);
+
+/* the thread safe variant of the global "tzname" */
+const gchar *const *cached_get_system_tznames(void);
+
 time_t cached_mktime(struct tm *tm);
 void cached_localtime(time_t *when, struct tm *tm);
 void cached_gmtime(time_t *when, struct tm *tm);

--- a/lib/timeutils/tests/test_wallclocktime.c
+++ b/lib/timeutils/tests/test_wallclocktime.c
@@ -297,7 +297,7 @@ static void
 setup(void)
 {
   setenv("TZ", "CET", TRUE);
-  tzset();
+  invalidate_timeutils_cache();
 }
 
 static void

--- a/lib/timeutils/tests/test_wallclocktime.c
+++ b/lib/timeutils/tests/test_wallclocktime.c
@@ -137,7 +137,7 @@ Test(wallclocktime, test_strptime_percent_z_parses_rfc822_timezone)
   /* local timezone */
   wct.wct_gmtoff = -1;
   end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S %z", "Jan 16 2019 18:23:12 CET");
-  cr_expect(wct.wct_gmtoff == 1*3600, "Unexpected timezone offset: %ld, expected 0", wct.wct_gmtoff);
+  cr_expect(wct.wct_gmtoff == 1*3600, "Unexpected timezone offset: %ld, expected 1*3600", wct.wct_gmtoff);
 
   /* military zones */
   wct.wct_gmtoff = -1;
@@ -208,7 +208,7 @@ Test(wallclocktime, test_strptime_percent_Z_allows_timezone_to_be_optional)
 
   wct.wct_gmtoff = -1;
   end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S %Z", "Jan 16 2019 18:23:12 Y");
-  cr_expect(wct.wct_gmtoff == 12*3600, "Unexpected timezone offset: %ld, expected -1", wct.wct_gmtoff);
+  cr_expect(wct.wct_gmtoff == 12*3600, "Unexpected timezone offset: %ld, expected 12*3600", wct.wct_gmtoff);
 
   /* invalid timezone offset, too short */
   wct.wct_gmtoff = -1;

--- a/lib/timeutils/timeutils.c
+++ b/lib/timeutils/timeutils.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2021 Balazs Scheidler <bazsi77@gmail.com>
  * Copyright (c) 2002-2018 Balabit
  * Copyright (c) 1998-2018 Balázs Scheidler
  *
@@ -21,42 +22,28 @@
  * COPYING for details.
  *
  */
+#include "timeutils/timeutils.h"
+#include "timeutils/cache.h"
+#include "apphook.h"
 
-#ifndef TIMEUTILS_CACHE_H_INCLUDED
-#define TIMEUTILS_CACHE_H_INCLUDED
+static void _setup_timezone_changed_hook(void);
 
-#include "timeutils/wallclocktime.h"
-#include "timeutils/zoneinfo.h"
-
-time_t cached_mktime(struct tm *tm);
-void cached_localtime(time_t *when, struct tm *tm);
-void cached_gmtime(time_t *when, struct tm *tm);
-
-
-static inline void
-cached_localtime_wct(time_t *when, WallClockTime *wct)
+static void
+_reset_timezone_apphook(gint type, gpointer user_data)
 {
-  cached_localtime(when, &wct->tm);
+  invalidate_timeutils_cache();
+  _setup_timezone_changed_hook();
 }
 
-static inline time_t
-cached_mktime_wct(WallClockTime *wct)
+static void
+_setup_timezone_changed_hook(void)
 {
-  return cached_mktime(&wct->tm);
+  register_application_hook(AH_CONFIG_CHANGED, _reset_timezone_apphook, NULL);
 }
 
-static inline void
-cached_gmtime_wct(time_t *when, WallClockTime *wct)
+void
+timeutils_global_init(void)
 {
-  cached_gmtime(when, &wct->tm);
+  invalidate_timeutils_cache();
+  _setup_timezone_changed_hook();
 }
-
-void invalidate_cached_time(void);
-void set_cached_time(GTimeVal *timeval);
-void cached_g_current_time(GTimeVal *result);
-time_t cached_g_current_time_sec(void);
-TimeZoneInfo *cached_get_time_zone_info(const gchar *tz);
-
-void invalidate_timeutils_cache(void);
-
-#endif

--- a/lib/timeutils/timeutils.c
+++ b/lib/timeutils/timeutils.c
@@ -38,7 +38,12 @@ _reset_timezone_apphook(gint type, gpointer user_data)
 static void
 _setup_timezone_changed_hook(void)
 {
-  register_application_hook(AH_CONFIG_CHANGED, _reset_timezone_apphook, NULL);
+  /* We are using the STOPPED hook as the timezone related variables (tzname
+   * and timezone) may be changed without locking by other threads.  At
+   * AH_CONFIG_STOPPED those threads should have stopped already, so nothing
+   * touches the global variables.  Hopefully. */
+
+  register_application_hook(AH_CONFIG_STOPPED, _reset_timezone_apphook, NULL);
 }
 
 void

--- a/lib/timeutils/timeutils.h
+++ b/lib/timeutils/timeutils.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021 Balázs Scheidler <bazsi77@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef TIMEUTILS_TIMEUTILS_H_INCLUDED
+#define TIMEUTILS_TIMEUTILS_H_INCLUDED
+
+#include "syslog-ng.h"
+
+void timeutils_global_init(void);
+
+#endif

--- a/lib/timeutils/wallclocktime.c
+++ b/lib/timeutils/wallclocktime.c
@@ -276,6 +276,7 @@ wall_clock_time_strptime(WallClockTime *wct, const gchar *format, const gchar *i
   int alt_format, i, split_year = 0, neg = 0, state = 0,
                      day_offset = -1, week_offset = 0, offs, mandatory;
   const char *new_fmt;
+  const char *const *system_tznames;
 
   bp = (const unsigned char *)input;
 
@@ -670,14 +671,13 @@ recurse:
                   bp = ep;
                   continue;
                 }
-              ep = find_string(bp, &i, (const char *const *)tzname, NULL, 2);
+              system_tznames = cached_get_system_tznames();
+              ep = find_string(bp, &i, system_tznames, NULL, 2);
               if (ep != NULL)
                 {
                   wct->tm.tm_isdst = i;
-#ifdef SYSLOG_NG_HAVE_TIMEZONE
-                  wct->wct_gmtoff = -(timezone);
-#endif
-                  wct->wct_zone = tzname[i];
+                  wct->wct_gmtoff = -cached_get_system_tzofs();
+                  wct->wct_zone = system_tznames[i];
                   bp = ep;
                   continue;
                 }

--- a/lib/timeutils/wallclocktime.c
+++ b/lib/timeutils/wallclocktime.c
@@ -676,7 +676,7 @@ recurse:
               if (ep != NULL)
                 {
                   wct->tm.tm_isdst = i;
-                  wct->wct_gmtoff = -cached_get_system_tzofs();
+                  wct->wct_gmtoff = -cached_get_system_tzofs() + wct->tm.tm_isdst*3600;
                   wct->wct_zone = system_tznames[i];
                   bp = ep;
                   continue;

--- a/lib/timeutils/wallclocktime.h
+++ b/lib/timeutils/wallclocktime.h
@@ -44,6 +44,13 @@
  * "struct tm" around for conversions, rather we contain one instance and
  * provide wrapper macros so that fields that are present in struct tm are
  * used from there, those that aren't will be part of the wrapper structure.
+ *
+ * NOTE on thread safety: the wct_zone field is a pointer to a dynamically
+ * allocated string, that is managed in a thread-specific location (in
+ * cache.c), the pointer could become stale across a syslog-ng reload.  In
+ * general it is not a good idea to pass WallClockTime instances between
+ * threads, if the wct_zone field was initialized by cached_localtime() and
+ * friends, unless you ensure this field does not become stale.
  */
 typedef struct _WallClockTime WallClockTime;
 struct _WallClockTime

--- a/modules/timestamp/tests/test_date.c
+++ b/modules/timestamp/tests/test_date.c
@@ -71,11 +71,9 @@ _construct_logmsg(const gchar *msg)
 void
 setup(void)
 {
-  app_startup();
-
   setlocale (LC_ALL, "C");
   setenv("TZ", "CET-1", TRUE);
-  tzset();
+  app_startup();
 
   configuration = cfg_new_snippet();
 

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -38,7 +38,6 @@
 #include "plugin.h"
 #include "reloc.h"
 #include "resolved-configurable-paths.h"
-#include "timeutils/cache.h"
 
 #include <sys/types.h>
 #include <stdio.h>
@@ -278,8 +277,6 @@ main(int argc, char *argv[])
    */
   g_process_start();
   app_startup();
-
-  timeutils_setup_timezone_hook();
 
   main_loop_options.server_mode = ((SYSLOG_NG_ENABLE_FORCED_SERVER_MODE) == 1 ? TRUE : FALSE);
   main_loop_init(main_loop, &main_loop_options);

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -63,6 +63,7 @@ lib/rewrite/rewrite-set-facility\.h
 lib/rewrite/tests/test_set_facility\.c
 lib/rewrite/rewrite-set-pri\.h
 lib/rewrite/rewrite-set-pri\.c
+lib/timeutils/timeutils\.h
  LGPLv2.1+_SSL
 autogen\.sh$
 sub-configure\.sh$


### PR DESCRIPTION
@rfaircloth-splunk encountered crashes since 3.30 was released. After looking at the core it turned out that there's a quite severe
race that we triggered with the latest changes in strptime() %z format.

If someone is using "%z" in his config and multiple threads are used (and running due to load), we were crashing every few seconds because of a race on the "tzname" global variable.

I've initially included a number of not-closely related patches within this PR, but I've now split them off to a separate #3561. This now concentrates on the fix and only the fix.
