### PR TITLE
wallclocktime: fix non-mandatory parsing of timezone name

### DIFF
--- a/lib/timeutils/tests/test_wallclocktime.c
+++ b/lib/timeutils/tests/test_wallclocktime.c
@@ -84,10 +84,24 @@ Test(wallclocktime, test_strptime_usec_parse_finds_character)
   cr_expect(wct.wct_usec == 0);
 }
 
-Test(wallclocktime, test_strptime_parses_rfc822_timezone)
+Test(wallclocktime, test_strptime_percent_z_parses_rfc822_timezone)
 {
   WallClockTime wct = WALL_CLOCK_TIME_INIT;
   gchar *end;
+
+  /* quoting RFC822:
+   *
+   * Time zone may be indicated in several ways.  "UT" is Universal Time
+   * (formerly called "Greenwich Mean Time"); "GMT" is permitted as a
+   * reference to Universal Time.  The military standard uses a single
+   * character for each zone.  "Z" is Universal Time.  "A" indicates one
+   * hour earlier, and "M" indicates 12 hours earlier; "N" is one hour
+   * later, and "Y" is 12 hours later.  The letter "J" is not used.  The
+   * other remaining two forms are taken from ANSI standard X3.51-1975.  One
+   * allows explicit indication of the amount of offset from UT; the other
+   * uses common 3-character strings for indicating time zones in North
+   * America.
+   */
 
   end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S %z", "Jan 16 2019 18:23:12 PST");
   cr_assert(*end == 0);
@@ -100,7 +114,112 @@ Test(wallclocktime, test_strptime_parses_rfc822_timezone)
   cr_expect(wct.wct_sec == 12);
   cr_expect(wct.wct_usec == 0);
 
-  cr_expect(wct.wct_gmtoff == -8*3600, "Unexpected timezone offset: %ld", wct.wct_gmtoff);
+  cr_expect(wct.wct_gmtoff == -8*3600, "Unexpected timezone offset: %ld, expected -8*3600", wct.wct_gmtoff);
+
+  /* white space in front of the timezone is skipped with %z */
+  wct.wct_gmtoff = -1;
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S%z", "Jan 16 2019 18:23:12 PST");
+  cr_expect(wct.wct_gmtoff == -8*3600, "Unexpected timezone offset: %ld, expected -8*3600", wct.wct_gmtoff);
+  wct.wct_gmtoff = -1;
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S%z", "Jan 16 2019 18:23:12PST");
+  cr_expect(wct.wct_gmtoff == -8*3600, "Unexpected timezone offset: %ld, expected -8*3600", wct.wct_gmtoff);
+
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S %z", "Jan 16 2019 18:23:12 EDT");
+  cr_expect(wct.wct_gmtoff == -4*3600, "Unexpected timezone offset: %ld, expected -4*3600", wct.wct_gmtoff);
+
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S %z", "Jan 16 2019 18:23:12 GMT");
+  cr_expect(wct.wct_gmtoff == 0, "Unexpected timezone offset: %ld, expected 0", wct.wct_gmtoff);
+
+  wct.wct_gmtoff = -1;
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S %z", "Jan 16 2019 18:23:12 UTC");
+  cr_expect(wct.wct_gmtoff == 0, "Unexpected timezone offset: %ld, expected 0", wct.wct_gmtoff);
+
+  /* local timezone */
+  wct.wct_gmtoff = -1;
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S %z", "Jan 16 2019 18:23:12 CET");
+  cr_expect(wct.wct_gmtoff == 1*3600, "Unexpected timezone offset: %ld, expected 0", wct.wct_gmtoff);
+
+  /* military zones */
+  wct.wct_gmtoff = -1;
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S %z", "Jan 16 2019 18:23:12 Z");
+  cr_expect(wct.wct_gmtoff == 0, "Unexpected timezone offset: %ld, expected 0", wct.wct_gmtoff);
+  wct.wct_gmtoff = -1;
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S %z", "Jan 16 2019 18:23:12 M");
+  cr_expect(wct.wct_gmtoff == -12*3600, "Unexpected timezone offset: %ld, expected -12*3600", wct.wct_gmtoff);
+  wct.wct_gmtoff = -1;
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S %z", "Jan 16 2019 18:23:12 Y");
+  cr_expect(wct.wct_gmtoff == 12*3600, "Unexpected timezone offset: %ld, expected 12*3600", wct.wct_gmtoff);
+
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S %z", "Jan 16 2019 18:23:12 J");
+  cr_expect(end == NULL);
+
+  /* hours only */
+  wct.wct_gmtoff = -1;
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S %z", "Jan 16 2019 18:23:12 +05");
+  cr_expect(wct.wct_gmtoff == 5*3600, "Unexpected timezone offset: %ld, expected 5*3600", wct.wct_gmtoff);
+
+  /* hours & minutes */
+  wct.wct_gmtoff = -1;
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S %z", "Jan 16 2019 18:23:12 +0500");
+  cr_expect(wct.wct_gmtoff == 5*3600, "Unexpected timezone offset: %ld, expected 5*3600", wct.wct_gmtoff);
+  wct.wct_gmtoff = -1;
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S %z", "Jan 16 2019 18:23:12 +05:00");
+  cr_expect(wct.wct_gmtoff == 5*3600, "Unexpected timezone offset: %ld, expected 5*3600", wct.wct_gmtoff);
+
+  /* non-zero minutes */
+  wct.wct_gmtoff = -1;
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S %z", "Jan 16 2019 18:23:12 +05:30");
+  cr_expect(wct.wct_gmtoff == 5*3600+30*60, "Unexpected timezone offset: %ld, expected 5*3600+30*60", wct.wct_gmtoff);
+}
+
+Test(wallclocktime, test_strptime_percent_Z_allows_timezone_to_be_optional)
+{
+  WallClockTime wct = WALL_CLOCK_TIME_INIT;
+  gchar *end;
+
+  /* NOTE: %Z accepts the same formats as %z, except that it allows the timezone to be optional */
+
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S%Z", "Jan 16 2019 18:23:12PST");
+  cr_assert(*end == 0);
+  cr_expect(wct.wct_year == 119);
+  cr_expect(wct.wct_mon == 0);
+  cr_expect(wct.wct_mday == 16);
+
+  cr_expect(wct.wct_hour == 18);
+  cr_expect(wct.wct_min == 23);
+  cr_expect(wct.wct_sec == 12);
+  cr_expect(wct.wct_usec == 0);
+
+  cr_expect(wct.wct_gmtoff == -8*3600, "Unexpected timezone offset: %ld, expected -8*3600", wct.wct_gmtoff);
+
+  /* initial whitespace is not skipped */
+  wct.wct_gmtoff = -1;
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S%Z", "Jan 16 2019 18:23:12 PST");
+  cr_expect(end != NULL);
+  cr_expect_str_eq(end, " PST");
+
+  wct.wct_gmtoff = -1;
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S %Z", "Jan 16 2019 18:23:12 PST");
+  cr_expect(wct.wct_gmtoff == -8*3600, "Unexpected timezone offset: %ld, expected -8*3600", wct.wct_gmtoff);
+
+  wct.wct_gmtoff = -1;
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S %Z", "Jan 16 2019 18:23:12");
+  cr_expect(wct.wct_gmtoff == -1, "Unexpected timezone offset: %ld, expected -1", wct.wct_gmtoff);
+
+  wct.wct_gmtoff = -1;
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S %Z", "Jan 16 2019 18:23:12 Y");
+  cr_expect(wct.wct_gmtoff == 12*3600, "Unexpected timezone offset: %ld, expected -1", wct.wct_gmtoff);
+
+  /* invalid timezone offset, too short */
+  wct.wct_gmtoff = -1;
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S %Z", "Jan 16 2019 18:23:12 +300");
+  cr_expect(end != NULL);
+  cr_expect_str_eq(end, "+300");
+
+  wct.wct_gmtoff = -1;
+  end = wall_clock_time_strptime(&wct, "%b %d %Y %H:%M:%S %Z", "Jan 16 2019 18:23:12 +3");
+  cr_expect(end != NULL);
+  cr_expect_str_eq(end, "+3");
 }
 
 static void

--- a/lib/timeutils/wallclocktime.c
+++ b/lib/timeutils/wallclocktime.c
@@ -698,7 +698,11 @@ recurse:
                   bp++;
                   continue;
                 }
-              return NULL;
+              if (mandatory)
+                return NULL;
+
+              bp = zname;
+              continue;
             }
           offs = 0;
           for (i = 0; i < 4; )

--- a/lib/timeutils/wallclocktime.c
+++ b/lib/timeutils/wallclocktime.c
@@ -719,7 +719,7 @@ recurse:
           switch (i)
             {
             case 2:
-              offs *= 60;
+              offs *= 3600;
               break;
             case 4:
               i = offs % 100;


### PR DESCRIPTION
Since #3453 %Z was converted to allow a missing timezone specifier (porting over https://github.com/NetBSD/src/commit/1ab766532027329c2d69f6c89c0b9b5907553d15)

However, one case was missing: when a non-numeric timezone was specified but we couldn't find a match in nast/nadt/tzname. In that case we errored out, while NetBSD accepted it if the timezone was not mandatory.

I've added unit test coverage for both %z and %Z with this branch and identified another bug (but in this case it is an actual bug in NetBSD too), if the timezone was only using two digits (in the form "+05"), that should be interpreted in HOURs and not minutes. I've fixed that issue too.

@Kokan please let me know if you think this is not right. Thanks
