### PR TITLE
DbldPipInstall: Add Python2 compatible URL for get-pip.py script

### DIFF
--- a/dbld/builddeps
+++ b/dbld/builddeps
@@ -193,6 +193,11 @@ function install_pip_packages {
                 pip install --upgrade setuptools
                 filter_packages_by_platform $DBLD_DIR/pip_packages.manifest | xargs pip install --ignore-installed -U
                 ;;
+            centos-7|ubuntu-xenial)
+                $python_executable -m pip install --upgrade "pip < 21.0"
+                $python_executable -m pip install --upgrade setuptools
+                filter_packages_by_platform $DBLD_DIR/pip_packages.manifest | xargs $python_executable -m pip install --ignore-installed -U
+                ;;
             *)
                 $python_executable -m pip install --upgrade pip
                 $python_executable -m pip install --upgrade setuptools

--- a/dbld/builddeps
+++ b/dbld/builddeps
@@ -86,7 +86,7 @@ function install_gradle {
 }
 
 function install_pip2 {
-    download_target "https://bootstrap.pypa.io/get-pip.py" get-pip.py
+    download_target "https://bootstrap.pypa.io/2.7/get-pip.py" get-pip.py
     python2 get-pip.py
 }
 


### PR DESCRIPTION
- due to latest get-pip.py not supported with Python2

Issues with the latest get-pip.py

```shell
+ python2 get-pip.py
Traceback (most recent call last):
  File "get-pip.py", line 24244, in <module>
    main()
  File "get-pip.py", line 199, in main
    bootstrap(tmpdir=tmpdir)
  File "get-pip.py", line 82, in bootstrap
    from pip._internal.cli.main import main as pip_entry_point
  File "/tmp/tmpksJPUp/pip.zip/pip/_internal/cli/main.py", line 60
    sys.stderr.write(f"ERROR: {exc}")
                                   ^
SyntaxError: invalid syntax
The command '/bin/sh -c /dbld/builddeps install_pip2' returned a non-zero code: 1
```