### PR TITLE
python: fix LogMessage.keys() listing non-existenting keys and duplicates

### DIFF
--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -215,10 +215,8 @@ _collect_nvpair_names_from_logmsg(NVHandle handle, const gchar *name, const gcha
 }
 
 static gboolean
-_is_macro_name_visible_to_user(const gchar *name)
+_is_macro_name_visible_to_user(const gchar *name, NVHandle handle)
 {
-  NVHandle handle = log_msg_get_value_handle(name);
-
   return log_msg_is_handle_macro(handle) && !_is_key_blacklisted(name);
 }
 
@@ -226,9 +224,10 @@ static void
 _collect_macro_names(gpointer key, gpointer value, gpointer user_data)
 {
   const gchar *name = (const gchar *)key;
+  NVHandle handle = GPOINTER_TO_UINT(value);
   PyObject *list = (PyObject *)user_data;
 
-  if (_is_macro_name_visible_to_user(name))
+  if (_is_macro_name_visible_to_user(name, handle))
     {
       PyObject *py_name = PyBytes_FromString(name);
       PyList_Append(list, py_name);

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -215,7 +215,7 @@ _collect_nvpair_names_from_logmsg(NVHandle handle, const gchar *name, const gcha
 }
 
 static gboolean
-_is_macro_name_visible_to_user(LogMessage *logmsg, const gchar *name)
+_is_macro_name_visible_to_user(const gchar *name)
 {
   NVHandle handle = log_msg_get_value_handle(name);
 
@@ -225,12 +225,10 @@ _is_macro_name_visible_to_user(LogMessage *logmsg, const gchar *name)
 static void
 _collect_macro_names(gpointer key, gpointer value, gpointer user_data)
 {
-  gpointer *args = (gpointer *)user_data;
-  LogMessage *logmsg = (LogMessage *)args[0];
-  PyObject *list = (PyObject *)args[1];
   const gchar *name = (const gchar *)key;
+  PyObject *list = (PyObject *)user_data;
 
-  if (_is_macro_name_visible_to_user(logmsg, name))
+  if (_is_macro_name_visible_to_user(name))
     {
       PyObject *py_name = PyBytes_FromString(name);
       PyList_Append(list, py_name);
@@ -245,8 +243,7 @@ _logmessage_get_keys_method(PyLogMessage *self)
   LogMessage *msg = self->msg;
 
   log_msg_values_foreach(msg, _collect_nvpair_names_from_logmsg, (gpointer) keys);
-  gpointer registry_foreach_args[] = { msg, keys };
-  log_msg_registry_foreach(_collect_macro_names, (gpointer) registry_foreach_args);
+  log_msg_registry_foreach(_collect_macro_names, keys);
 
   return keys;
 }

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -215,27 +215,11 @@ _collect_nvpair_names_from_logmsg(NVHandle handle, const gchar *name, const gcha
 }
 
 static gboolean
-_is_key_assigned_to_match_handle(const gchar *s)
-{
-  char *end = NULL;
-  long val = strtol(s, &end, 10);
-
-  if (*end == '\0' && (val >= 0 && val <= 255))
-    return TRUE;
-
-  return FALSE;
-}
-
-static gboolean
 _is_macro_name_visible_to_user(LogMessage *logmsg, const gchar *name)
 {
-  gssize value_len;
+  NVHandle handle = log_msg_get_value_handle(name);
 
-  return (!_is_key_blacklisted(name) &&
-          (!_is_key_assigned_to_match_handle(name) ||
-           (_is_key_assigned_to_match_handle(name) &&
-            log_msg_get_value_by_name(logmsg, name, &value_len) != NULL
-            && value_len > 0)));
+  return log_msg_is_handle_macro(handle) && !_is_key_blacklisted(name);
 }
 
 static void

--- a/news/bugfix-3557.md
+++ b/news/bugfix-3557.md
@@ -1,0 +1,1 @@
+`python`: fix LogMessage.keys() listing non-existenting keys and duplicates


### PR DESCRIPTION
Previously, the `keys()` method of `LogMessage` returned non-existent keys and duplicates that were part of the name-value registry.

The name-value registry contains all the possible names that are referenced in our codebase or in the syslog-ng configuration.

Reproducer code:
```
rewrite r_neverused { set("${neverused}" value("nonexistent")); };

log {
    source { stdin(); };
    parser { python(class(Test)); };
    destination{ file("/dev/stdout"); };
};

python {
class Test(object):
    def parse(self, log_message):
        for akey in log_message.keys():
            print(akey)
        return True
};
```

The above Python snippet prints "neverused" and "nonexistent" as if they were valid name-value pairs of the message, as well as duplicates, because the preceding `log_msg_values_foreach()` call added all keys including regex matches and builtin values.

This commit fixes the issue by filtering the nv-registry and allowing only macros.

Reported by @faxm0dem (thank you)