### PR TITLE
telegram: support silent mode

### DIFF
--- a/news/feature-3558.md
+++ b/news/feature-3558.md
@@ -1,0 +1,7 @@
+telegram: option to send silent message
+
+Example:
+
+```
+destination { telegram(bot-id(...) chat-id(...) disable_notification(true)); };
+```

--- a/scl/telegram/telegram.conf
+++ b/scl/telegram/telegram.conf
@@ -32,6 +32,7 @@ block destination telegram(
       throttle(1)
       disable-web-page-preview("true")
       disable-notification("false")
+      extra-parameters("")
       use-system-cert-store(yes)
       max-size(4096)
       ...)
@@ -42,7 +43,7 @@ block destination telegram(
     http(
         url("https://api.telegram.org/bot`bot-id`/sendMessage")
         method("POST")
-        body("disable_web_page_preview=`disable-web-page-preview`&disable_notification=`disable-notification`&parse_mode=`parse-mode`&chat_id=`chat-id`&text=$(url-encode $(substr \"`template`\" 0 `max-size`))\n")
+        body("disable_web_page_preview=`disable-web-page-preview`&disable_notification=`disable-notification`&parse_mode=`parse-mode`&chat_id=`chat-id`&`extra-parameters`&text=$(url-encode $(substr \"`template`\" 0 `max-size`))\n")
         throttle(`throttle`)
         use-system-cert-store(`use-system-cert-store`)
         `__VARARGS__`

--- a/scl/telegram/telegram.conf
+++ b/scl/telegram/telegram.conf
@@ -31,6 +31,7 @@ block destination telegram(
       parse-mode("none")
       throttle(1)
       disable-web-page-preview("true")
+      disable-notification("false")
       use-system-cert-store(yes)
       max-size(4096)
       ...)
@@ -41,7 +42,7 @@ block destination telegram(
     http(
         url("https://api.telegram.org/bot`bot-id`/sendMessage")
         method("POST")
-        body("disable_web_page_preview=`disable-web-page-preview`&parse_mode=`parse-mode`&chat_id=`chat-id`&text=$(url-encode $(substr \"`template`\" 0 `max-size`))\n")
+        body("disable_web_page_preview=`disable-web-page-preview`&disable_notification=`disable-notification`&parse_mode=`parse-mode`&chat_id=`chat-id`&text=$(url-encode $(substr \"`template`\" 0 `max-size`))\n")
         throttle(`throttle`)
         use-system-cert-store(`use-system-cert-store`)
         `__VARARGS__`


### PR DESCRIPTION
This PR adds support to send telegram notifications in silent mode. 

I have telegram alerting in place for my ssh server. Recently, some enthusiastic hackers tend to wake me up at night with their login attempts. Although fail2ban is in place, a few attempts still generate notifications. Sleep deprivation eventually leads to denial of service, just not for the server, so I thought it would be nice if syslog-ng could send telegram messages without sound.

A new option is introduced: `disable_notification(true/false)`. Default value is "false", same as the original behavior: notification with sound. More on the option(s) here: https://core.telegram.org/bots/api#sendmessage

I also added an `extra-parameters` option, that we can use to quicky add a missing option in the future, without the necessity of opening a pull request. I think `extra-parameters` is not necessary to be documented, though we can do so if you want. That is an optional part of the PR, so I can also drop the patch if you have concerns with the idea.

Examples:
```
  destination { telegram(bot-id(...) chat-id(...)); };
  destination { telegram(bot-id(...) chat-id(...) disable_notification(true)); };
  destination { telegram(bot-id(...) chat-id(...) extra-parameters("reply_to_message_id=1")); };
```

Implementation details:
* if `extra-parameters` is missing, then `&extra-parameters&` "collapses" to an "&&", which is handled gracefully by telegram. So we do not really need to use `if` templates.
* `extra-parameters` does not seem to override values specified previously. Hence I needed to use another missing get parameter in my example.
* I do not plan to add `reply_to_message_id` to the template options, because then I could not show you a working example for `extra-parameters`. Nor I see any reasonable way to use it in deployment.

