### PR TITLE
LogThreadedDestDriver move worker (and queue) construction into the init phase

### DIFF
--- a/lib/logthrdest/logthrdestdrv.c
+++ b/lib/logthrdest/logthrdestdrv.c
@@ -1084,12 +1084,6 @@ log_threaded_dest_driver_start_workers(LogPipe *s)
   return startup_success;
 }
 
-static gboolean
-log_threaded_dest_driver_init(LogPipe *s)
-{
-  return log_threaded_dest_driver_init_method(s);
-}
-
 gboolean
 log_threaded_dest_driver_deinit_method(LogPipe *s)
 {
@@ -1132,7 +1126,7 @@ log_threaded_dest_driver_init_instance(LogThreadedDestDriver *self, GlobalConfig
 
   self->worker_options.is_output_thread = TRUE;
 
-  self->super.super.super.init = log_threaded_dest_driver_init;
+  self->super.super.super.init = log_threaded_dest_driver_init_method;
   self->super.super.super.deinit = log_threaded_dest_driver_deinit_method;
   self->super.super.super.queue = log_threaded_dest_driver_queue;
   self->super.super.super.free_fn = log_threaded_dest_driver_free;

--- a/lib/logthrdest/logthrdestdrv.c
+++ b/lib/logthrdest/logthrdestdrv.c
@@ -1060,6 +1060,12 @@ log_threaded_dest_driver_init_method(LogPipe *s)
   if (cfg && self->time_reopen == -1)
     self->time_reopen = cfg->time_reopen;
 
+  self->shared_seq_num = GPOINTER_TO_INT(cfg_persist_config_fetch(cfg,
+                                         _format_seqnum_persist_name(self)));
+  if (!self->shared_seq_num)
+    init_sequence_number(&self->shared_seq_num);
+
+  _register_stats(self);
   _create_workers(self);
 
   return TRUE;
@@ -1073,14 +1079,6 @@ gboolean
 log_threaded_dest_driver_start_workers(LogPipe *s)
 {
   LogThreadedDestDriver *self = (LogThreadedDestDriver *) s;
-  GlobalConfig *cfg = log_pipe_get_config((LogPipe *) self);
-
-  self->shared_seq_num = GPOINTER_TO_INT(cfg_persist_config_fetch(cfg,
-                                         _format_seqnum_persist_name(self)));
-  if (!self->shared_seq_num)
-    init_sequence_number(&self->shared_seq_num);
-
-  _register_stats(self);
 
   for (gint worker_index = 0; worker_index < self->num_workers; worker_index++)
     {

--- a/lib/logthrdest/logthrdestdrv.h
+++ b/lib/logthrdest/logthrdestdrv.h
@@ -135,7 +135,7 @@ struct _LogThreadedDestDriver
 
   LogThreadedDestWorker **workers;
   gint num_workers;
-  gint workers_started;
+  gint created_workers;
   guint last_worker;
 
   gint stats_source;

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -718,15 +718,15 @@ afamqp_dd_init(LogPipe *s)
   AMQPDestDriver *self = (AMQPDestDriver *) s;
   GlobalConfig *cfg = log_pipe_get_config(s);
 
-  if (!log_threaded_dest_driver_init_method(s))
-    return FALSE;
-
   if (self->auth_method == AMQP_SASL_METHOD_PLAIN && (!self->user || !self->password))
     {
       msg_error("Error initializing AMQP destination: username and password MUST be set!",
                 evt_tag_str("driver", self->super.super.super.id));
       return FALSE;
     }
+
+  if (!log_threaded_dest_driver_init_method(s))
+    return FALSE;
 
   log_template_options_init(&self->template_options, cfg);
 

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -502,14 +502,14 @@ _init(LogPipe *s)
   MongoDBDestDriver *self = (MongoDBDestDriver *)s;
   GlobalConfig *cfg = log_pipe_get_config(s);
 
-  if (!log_threaded_dest_driver_init_method(s))
-    return FALSE;
-
   log_template_options_init(&self->template_options, cfg);
 
   _init_value_pairs_dot_to_underscore_transformation(self);
 
   if (!afmongodb_dd_private_uri_init(&self->super.super.super))
+    return FALSE;
+
+  if (!log_threaded_dest_driver_init_method(s))
     return FALSE;
 
   return TRUE;

--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -600,15 +600,15 @@ afsmtp_dd_init(LogPipe *s)
   AFSMTPDriver *self = (AFSMTPDriver *)s;
   GlobalConfig *cfg = log_pipe_get_config(s);
 
-  if (!log_threaded_dest_driver_init_method(s))
-    return FALSE;
-
   msg_verbose("Initializing SMTP destination",
               evt_tag_str("driver", self->super.super.super.id),
               evt_tag_str("host", self->host),
               evt_tag_int("port", self->port));
 
   if (!__check_required_options(self))
+    return FALSE;
+
+  if (!log_threaded_dest_driver_init_method(s))
     return FALSE;
 
   log_template_options_init(&self->template_options, cfg);

--- a/modules/afsnmp/afsnmpdest.c
+++ b/modules/afsnmp/afsnmpdest.c
@@ -624,9 +624,6 @@ snmpdest_dd_init(LogPipe *s)
   SNMPDestDriver *self = (SNMPDestDriver *)s;
   GlobalConfig *cfg = log_pipe_get_config(s);
 
-  if (!log_threaded_dest_driver_init_method(s))
-    return FALSE;
-
   msg_verbose("Initializing SNMP destination",
               evt_tag_str("driver", self->super.super.super.id),
               evt_tag_str("host", self->host),
@@ -638,6 +635,9 @@ snmpdest_dd_init(LogPipe *s)
       msg_error(err_msg);
       return FALSE;
     }
+
+  if (!log_threaded_dest_driver_init_method(s))
+    return FALSE;
 
   log_template_options_init(&self->template_options, cfg);
   return TRUE;

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1114,8 +1114,6 @@ afsql_dd_init(LogPipe *s)
   AFSqlDestDriver *self = (AFSqlDestDriver *) s;
   GlobalConfig *cfg = log_pipe_get_config(s);
 
-  if (!log_threaded_dest_driver_init_method(s))
-    return FALSE;
   if (!_update_legacy_persist_name_if_exists(self))
     return FALSE;
   if (!_initialize_dbi())
@@ -1135,6 +1133,9 @@ afsql_dd_init(LogPipe *s)
     }
 
   if (!_init_fields_from_columns_and_values(self))
+    return FALSE;
+
+  if (!log_threaded_dest_driver_init_method(s))
     return FALSE;
 
   log_template_options_init(&self->template_options, cfg);

--- a/modules/examples/destinations/example_destination/example_destination.c
+++ b/modules/examples/destinations/example_destination/example_destination.c
@@ -80,11 +80,11 @@ _dd_init(LogPipe *d)
 {
   ExampleDestinationDriver *self = (ExampleDestinationDriver *)d;
 
-  if (!log_threaded_dest_driver_init_method(d))
-    return FALSE;
-
   if (!self->filename->len)
     g_string_assign(self->filename, "/tmp/example-destination-output.txt");
+
+  if (!log_threaded_dest_driver_init_method(d))
+    return FALSE;
 
   return TRUE;
 }

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -137,9 +137,6 @@ java_dd_init(LogPipe *s)
   GlobalConfig *cfg = log_pipe_get_config(s);
   GError *error = NULL;
 
-  if (!log_threaded_dest_driver_init_method(s))
-    return FALSE;
-
   log_template_options_init(&self->template_options, cfg);
 
   if (!log_template_compile(self->template, self->template_string, &error))
@@ -158,6 +155,9 @@ java_dd_init(LogPipe *s)
     return FALSE;
 
   if (!java_destination_proxy_init(self->proxy))
+    return FALSE;
+
+  if (!log_threaded_dest_driver_init_method(s))
     return FALSE;
 
   return TRUE;

--- a/modules/kafka/kafka-dest-driver.c
+++ b/modules/kafka/kafka-dest-driver.c
@@ -515,9 +515,6 @@ kafka_dd_init(LogPipe *s)
   KafkaDestDriver *self = (KafkaDestDriver *)s;
   GlobalConfig *cfg = log_pipe_get_config(s);
 
-  if (!log_threaded_dest_driver_init_method(s))
-    return FALSE;
-
   if (!self->topic_name)
     {
       msg_error("kafka: the topic() argument is required for kafka destinations",
@@ -540,6 +537,9 @@ kafka_dd_init(LogPipe *s)
     }
 
   if (!_init_topic_name(self))
+    return FALSE;
+
+  if (!log_threaded_dest_driver_init_method(s))
     return FALSE;
 
   if (self->message == NULL)

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -562,19 +562,21 @@ python_dd_init(LogPipe *d)
       return FALSE;
     }
 
-  if (!log_threaded_dest_driver_init_method(d))
-    return FALSE;
-
   log_template_options_init(&self->template_options, cfg);
   self->super.time_reopen = 1;
 
   gstate = PyGILState_Ensure();
-
   _py_perform_imports(self->loaders);
-  if (!_py_init_bindings(self) ||
-      !_py_init_object(self))
+  if (!_py_init_bindings(self))
     goto fail;
+  PyGILState_Release(gstate);
 
+  if (!log_threaded_dest_driver_init_method(d))
+    return FALSE;
+
+  gstate = PyGILState_Ensure();
+  if (!_py_init_object(self))
+    goto fail;
   PyGILState_Release(gstate);
 
   msg_verbose("Python destination initialized",

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -390,15 +390,15 @@ redis_dd_init(LogPipe *s)
   RedisDriver *self = (RedisDriver *)s;
   GlobalConfig *cfg = log_pipe_get_config(s);
 
-  if (!log_threaded_dest_driver_init_method(s))
-    return FALSE;
-
   if (g_list_length(self->arguments) == 0)
     {
       msg_error("Error initializing Redis destination, command option MUST be set",
                 log_pipe_location_tag(s));
       return FALSE;
     }
+
+  if (!log_threaded_dest_driver_init_method(s))
+    return FALSE;
 
   log_template_options_init(&self->template_options, cfg);
 

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -256,15 +256,15 @@ riemann_dd_init(LogPipe *s)
   RiemannDestDriver *self = (RiemannDestDriver *)s;
   GlobalConfig *cfg = log_pipe_get_config(s);
 
-  if (!log_threaded_dest_driver_init_method(s))
-    return FALSE;
-
   log_template_options_init(&self->template_options, cfg);
 
   if (!self->server)
     self->server = g_strdup("127.0.0.1");
   if (self->port == -1)
     self->port = 5555;
+
+  if (!log_threaded_dest_driver_init_method(s))
+    return FALSE;
 
   if (!self->fields.host)
     {

--- a/tests/python_functional/functional_tests/source_drivers/internal_source/test_internal_acceptance.py
+++ b/tests/python_functional/functional_tests/source_drivers/internal_source/test_internal_acceptance.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2015-2021 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+
+def test_internal_source_with_threaded_destination(config, syslog_ng):
+    internal_source = config.create_internal_source()
+    example_destination = config.create_example_destination(filename="output.txt")
+    config.create_logpath(statements=[internal_source, example_destination])
+
+    syslog_ng.start(config, stderr=False, debug=True, trace=False, verbose=False)
+    assert example_destination.wait_file_content("syslog-ng starting up")
+
+    for _ in range(0, 5):
+        syslog_ng.reload(config)
+        assert example_destination.wait_file_content("Configuration reload finished")
+
+    syslog_ng.stop()
+    assert example_destination.wait_file_content("syslog-ng shutting down")

--- a/tests/python_functional/src/syslog_ng/syslog_ng.py
+++ b/tests/python_functional/src/syslog_ng/syslog_ng.py
@@ -29,8 +29,8 @@ class SyslogNg(object):
         self.instance_paths = instance_paths
         self.__syslog_ng_cli = SyslogNgCli(instance_paths, testcase_parameters)
 
-    def start(self, config):
-        return self.__syslog_ng_cli.start(config)
+    def start(self, config, stderr=True, debug=True, trace=True, verbose=True, startup_debug=True, no_caps=True, config_path=None, persist_path=None, pid_path=None, control_socket_path=None):
+        return self.__syslog_ng_cli.start(config, stderr, debug, trace, verbose, startup_debug, no_caps, config_path, persist_path, pid_path, control_socket_path)
 
     def stop(self, unexpected_messages=None):
         self.__syslog_ng_cli.stop(unexpected_messages)

--- a/tests/python_functional/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/python_functional/src/syslog_ng/syslog_ng_cli.py
@@ -42,6 +42,16 @@ class SyslogNgCli(object):
         self.__syslog_ng_ctl = SyslogNgCtl(instance_paths)
         self.__external_tool = testcase_parameters.get_external_tool()
         self.__process = None
+        self.__stderr = None
+        self.__debug = None
+        self.__trace = None
+        self.__verbose = None
+        self.__startup_debug = None
+        self.__no_caps = None
+        self.__config_path = None
+        self.__persist_path = None
+        self.__pid_path = None
+        self.__control_socket_path = None
 
     # Application commands
     def get_version(self):
@@ -88,11 +98,13 @@ class SyslogNgCli(object):
         if self.__external_tool:
             self.__process = self.__syslog_ng_executor.run_process_with_external_tool(self.__external_tool)
         else:
-            self.__process = self.__syslog_ng_executor.run_process()
-        self.__wait_for_start()
+            self.__process = self.__syslog_ng_executor.run_process(self.__stderr, self.__debug, self.__trace, self.__verbose, self.__startup_debug, self.__no_caps, self.__config_path, self.__persist_path, self.__pid_path, self.__control_socket_path)
+        if self.__stderr and self.__debug and self.__verbose:
+            self.__wait_for_start()
 
     # Process commands
-    def start(self, config):
+    def start(self, config, stderr, debug, trace, verbose, startup_debug, no_caps, config_path, persist_path, pid_path, control_socket_path):
+        self.set_start_parameters(stderr, debug, trace, verbose, startup_debug, no_caps, config_path, persist_path, pid_path, control_socket_path)
         if self.__process:
             raise Exception("syslog-ng has been already started")
 
@@ -116,8 +128,9 @@ class SyslogNgCli(object):
             self.__error_handling("Control socket fails to reload syslog-ng")
         if not self.__wait_for_control_socket_alive():
             self.__error_handling("Control socket not alive")
-        if not self.__console_log_reader.wait_for_reload_message():
-            self.__error_handling("Reload message not arrived")
+        if self.__stderr and self.__debug and self.__verbose:
+            if not self.__console_log_reader.wait_for_reload_message():
+                self.__error_handling("Reload message not arrived")
         logger.info("syslog-ng process has been reloaded with PID: {}\n".format(self.__process.pid))
 
     def stop(self, unexpected_messages=None):
@@ -131,8 +144,9 @@ class SyslogNgCli(object):
                 self.__error_handling("Control socket fails to stop syslog-ng")
             if not wait_until_false(self.is_process_running):
                 self.__error_handling("syslog-ng did not stop")
-            if not self.__console_log_reader.wait_for_stop_message():
-                self.__error_handling("Stop message not arrived")
+            if self.__stderr and self.__debug and self.__verbose:
+                if not self.__console_log_reader.wait_for_stop_message():
+                    self.__error_handling("Stop message not arrived")
             self.__console_log_reader.check_for_unexpected_messages(unexpected_messages)
             if self.__external_tool == "valgrind":
                 self.__console_log_reader.handle_valgrind_log(self.__instance_paths.get_external_tool_output_path(self.__external_tool))
@@ -155,3 +169,15 @@ class SyslogNgCli(object):
                 core_file.replace(Path(tc_parameters.WORKING_DIR, core_file))
             if core_file_found:
                 raise Exception("syslog-ng core file was found and processed")
+
+    def set_start_parameters(self, stderr, debug, trace, verbose, startup_debug, no_caps, config_path, persist_path, pid_path, control_socket_path):
+        self.__stderr = stderr
+        self.__debug = debug
+        self.__trace = trace
+        self.__verbose = verbose
+        self.__startup_debug = startup_debug
+        self.__no_caps = no_caps
+        self.__config_path = config_path
+        self.__persist_path = persist_path
+        self.__pid_path = pid_path
+        self.__control_socket_path = control_socket_path

--- a/tests/python_functional/src/syslog_ng/syslog_ng_executor.py
+++ b/tests/python_functional/src/syslog_ng/syslog_ng_executor.py
@@ -31,9 +31,9 @@ class SyslogNgExecutor(object):
         self.__process_executor = ProcessExecutor()
         self.__command_executor = CommandExecutor()
 
-    def run_process(self):
+    def run_process(self, stderr, debug, trace, verbose, startup_debug, no_caps, config_path, persist_path, pid_path, control_socket_path):
         return self.__process_executor.start(
-            command=self.__construct_syslog_ng_process(),
+            command=self.__construct_syslog_ng_process(stderr, debug, trace, verbose, startup_debug, no_caps, config_path, persist_path, pid_path, control_socket_path),
             stdout_path=self.__instance_paths.get_stdout_path(),
             stderr_path=self.__instance_paths.get_stderr_path(),
         )
@@ -112,16 +112,16 @@ class SyslogNgExecutor(object):
 
     def __construct_syslog_ng_process(
         self,
-        stderr=True,
-        debug=True,
-        trace=True,
-        verbose=True,
-        startup_debug=True,
-        no_caps=True,
-        config_path=None,
-        persist_path=None,
-        pid_path=None,
-        control_socket_path=None,
+        stderr,
+        debug,
+        trace,
+        verbose,
+        startup_debug,
+        no_caps,
+        config_path,
+        persist_path,
+        pid_path,
+        control_socket_path,
     ):
         syslog_ng_process_args = [self.__instance_paths.get_syslog_ng_bin()]
         syslog_ng_process_args += ["--foreground", "--enable-core"]

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/example_destination.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/example_destination.py
@@ -23,6 +23,7 @@
 from pathlib2 import Path
 
 import src.testcase_parameters.testcase_parameters as tc_parameters
+from src.common.blocking import wait_until_true
 from src.message_reader.message_reader import MessageReader
 from src.message_reader.single_line_parser import SingleLineParser
 from src.syslog_ng_config.statements.destinations.destination_driver import DestinationDriver
@@ -35,6 +36,8 @@ class ExampleDestination(DestinationDriver):
         super(ExampleDestination, self).__init__(None, dict({"filename": self.path.resolve()}, **options))
 
     def wait_file_content(self, content):
+        wait_until_true(self.path.exists)
+
         with self.path.open() as f:
             message_reader = MessageReader(f.readline, SingleLineParser())
 

--- a/tests/python_functional/src/syslog_ng_config/statements/sources/internal_source.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/sources/internal_source.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2015-2021 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from src.syslog_ng_config.statements.sources.source_driver import SourceDriver
+
+
+class InternalSource(SourceDriver):
+    def __init__(self, **options):
+        self.driver_name = "internal"
+        super(InternalSource, self).__init__(None, options)

--- a/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
@@ -36,6 +36,7 @@ from src.syslog_ng_config.statements.parsers.parser import Parser
 from src.syslog_ng_config.statements.rewrite.rewrite import SetTag
 from src.syslog_ng_config.statements.sources.example_msg_generator_source import ExampleMsgGeneratorSource
 from src.syslog_ng_config.statements.sources.file_source import FileSource
+from src.syslog_ng_config.statements.sources.internal_source import InternalSource
 from src.syslog_ng_config.statements.sources.network_source import NetworkSource
 
 logger = logging.getLogger(__name__)
@@ -84,6 +85,9 @@ class SyslogNgConfig(object):
 
     def create_example_msg_generator_source(self, **options):
         return ExampleMsgGeneratorSource(**options)
+
+    def create_internal_source(self, **options):
+        return InternalSource(**options)
 
     def create_network_source(self, **options):
         return NetworkSource(**options)


### PR DESCRIPTION
Solves #3548 

Based on @bazsi 's instructions: moved every construction into the LogThreadedDestDriver init phase, so from now on *on_config_inited* only starts the constructed workers.

KUDO's for @MrAnno for all the help and second opinions.
