### PR TITLE
Apphook add "REPEAT" run mode for hooks

### DIFF
--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -579,7 +579,7 @@ afinter_register_posted_hook(gint hook_type, gpointer user_data)
 void
 afinter_global_init(void)
 {
-  register_application_hook(AH_CONFIG_CHANGED, afinter_register_posted_hook, NULL);
+  register_application_hook(AH_CONFIG_CHANGED, afinter_register_posted_hook, NULL, AHM_RUN_ONCE);
 }
 
 void

--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -48,7 +48,6 @@
 
 #include <iv.h>
 #include <iv_work.h>
-#include <resolv.h>
 
 typedef struct _ApplicationHookEntry
 {
@@ -254,7 +253,6 @@ void
 app_config_stopped(void)
 {
   run_application_hook(AH_CONFIG_STOPPED);
-  res_init();
 }
 
 void

--- a/lib/apphook.h
+++ b/lib/apphook.h
@@ -47,6 +47,12 @@ enum
   AH_REOPEN_FILES,     /* reopen files signal from syslog-ng-ctl */
 };
 
+typedef enum
+{
+  AHM_RUN_ONCE,
+  AHM_RUN_REPEAT,
+} ApplicationHookRunMode;
+
 /* state-like hook entry points */
 void app_startup(void);
 void app_post_daemonized(void);
@@ -64,7 +70,9 @@ typedef void (*ApplicationHookFunc)(gint type, gpointer user_data);
 gboolean app_is_starting_up(void);
 gboolean app_is_shutting_down(void);
 
-void register_application_hook(gint type, ApplicationHookFunc func, gpointer user_data);
+void register_application_hook(gint type,
+                               ApplicationHookFunc func, gpointer user_data,
+                               ApplicationHookRunMode run_mode);
 
 void app_thread_start(void);
 void app_thread_stop(void);

--- a/lib/host-resolve.c
+++ b/lib/host-resolve.c
@@ -27,12 +27,14 @@
 #include "cfg.h"
 #include "tls-support.h"
 #include "compat/socket.h"
+#include "apphook.h"
 
 #include <iv.h>
 
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <string.h>
+#include <resolv.h>
 
 #if !defined(SYSLOG_NG_HAVE_GETADDRINFO) || !defined(SYSLOG_NG_HAVE_GETNAMEINFO)
 G_LOCK_DEFINE_STATIC(resolv_lock);
@@ -469,4 +471,16 @@ host_resolve_options_init(HostResolveOptions *options, HostResolveOptions *globa
 void
 host_resolve_options_destroy(HostResolveOptions *options)
 {
+}
+
+static void
+_reinit_resolver(gint type, gpointer user_data)
+{
+  res_init();
+}
+
+void
+host_resolve_global_init(void)
+{
+  register_application_hook(AH_CONFIG_STOPPED, _reinit_resolver, NULL, AHM_RUN_REPEAT);
 }

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1883,7 +1883,7 @@ log_msg_global_init(void)
   /* NOTE: we always initialize counters as they are on stats-level(0),
    * however we need to defer that as the stats subsystem may not be
    * operational yet */
-  register_application_hook(AH_RUNNING, (ApplicationHookFunc) log_msg_register_stats, NULL);
+  register_application_hook(AH_RUNNING, (ApplicationHookFunc) log_msg_register_stats, NULL, AHM_RUN_ONCE);
 }
 
 

--- a/lib/logmsg/tags.c
+++ b/lib/logmsg/tags.c
@@ -201,7 +201,7 @@ log_tags_global_init(void)
   log_tags_list = g_new0(LogTag, log_tags_list_size);
 
   g_static_mutex_unlock(&log_tags_lock);
-  register_application_hook(AH_CONFIG_CHANGED, (ApplicationHookFunc) log_tags_reinit_stats, NULL, AHM_RUN_ONCE);
+  register_application_hook(AH_CONFIG_CHANGED, (ApplicationHookFunc) log_tags_reinit_stats, NULL, AHM_RUN_REPEAT);
 }
 
 void

--- a/lib/logmsg/tags.c
+++ b/lib/logmsg/tags.c
@@ -201,7 +201,7 @@ log_tags_global_init(void)
   log_tags_list = g_new0(LogTag, log_tags_list_size);
 
   g_static_mutex_unlock(&log_tags_lock);
-  register_application_hook(AH_CONFIG_CHANGED, (ApplicationHookFunc) log_tags_reinit_stats, NULL);
+  register_application_hook(AH_CONFIG_CHANGED, (ApplicationHookFunc) log_tags_reinit_stats, NULL, AHM_RUN_ONCE);
 }
 
 void

--- a/lib/mainloop-control.c
+++ b/lib/mainloop-control.c
@@ -163,7 +163,7 @@ control_connection_reload(ControlConnection *cc, GString *command, gpointer user
 
   args[0] = main_loop;
   args[1] = cc;
-  register_application_hook(AH_CONFIG_CHANGED, _respond_config_reload_status, args);
+  register_application_hook(AH_CONFIG_CHANGED, _respond_config_reload_status, args, AHM_RUN_ONCE);
   main_loop_reload_config_commence(main_loop);
 }
 

--- a/lib/msg-stats.c
+++ b/lib/msg-stats.c
@@ -131,7 +131,7 @@ stats_syslog_reinit(void)
 void
 msg_stats_init(void)
 {
-  register_application_hook(AH_CONFIG_CHANGED, (ApplicationHookFunc) stats_syslog_reinit, NULL, AHM_RUN_ONCE);
+  register_application_hook(AH_CONFIG_CHANGED, (ApplicationHookFunc) stats_syslog_reinit, NULL, AHM_RUN_REPEAT);
 }
 
 void

--- a/lib/msg-stats.c
+++ b/lib/msg-stats.c
@@ -131,7 +131,7 @@ stats_syslog_reinit(void)
 void
 msg_stats_init(void)
 {
-  register_application_hook(AH_CONFIG_CHANGED, (ApplicationHookFunc) stats_syslog_reinit, NULL);
+  register_application_hook(AH_CONFIG_CHANGED, (ApplicationHookFunc) stats_syslog_reinit, NULL, AHM_RUN_ONCE);
 }
 
 void

--- a/lib/scratch-buffers.c
+++ b/lib/scratch-buffers.c
@@ -322,7 +322,7 @@ scratch_buffers_unregister_stats(void)
 void
 scratch_buffers_global_init(void)
 {
-  register_application_hook(AH_RUNNING, (ApplicationHookFunc) scratch_buffers_register_stats, NULL);
+  register_application_hook(AH_RUNNING, (ApplicationHookFunc) scratch_buffers_register_stats, NULL, AHM_RUN_ONCE);
 }
 
 void

--- a/lib/timeutils/timeutils.c
+++ b/lib/timeutils/timeutils.c
@@ -26,29 +26,20 @@
 #include "timeutils/cache.h"
 #include "apphook.h"
 
-static void _setup_timezone_changed_hook(void);
-
 static void
 _reset_timezone_apphook(gint type, gpointer user_data)
 {
   invalidate_timeutils_cache();
-  _setup_timezone_changed_hook();
-}
-
-static void
-_setup_timezone_changed_hook(void)
-{
-  /* We are using the STOPPED hook as the timezone related variables (tzname
-   * and timezone) may be changed without locking by other threads.  At
-   * AH_CONFIG_STOPPED those threads should have stopped already, so nothing
-   * touches the global variables.  Hopefully. */
-
-  register_application_hook(AH_CONFIG_STOPPED, _reset_timezone_apphook, NULL);
 }
 
 void
 timeutils_global_init(void)
 {
   invalidate_timeutils_cache();
-  _setup_timezone_changed_hook();
+
+  /* We are using the STOPPED hook as the timezone related variables (tzname
+   * and timezone) may be changed without locking by other threads.  At
+   * AH_CONFIG_STOPPED those threads should have stopped already, so nothing
+   * touches the global variables.  Hopefully. */
+  register_application_hook(AH_CONFIG_STOPPED, _reset_timezone_apphook, NULL, AHM_RUN_REPEAT);
 }

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -375,7 +375,7 @@ affile_dd_register_reopen_hook(gint hook_type, gpointer user_data)
 {
   g_list_foreach(affile_dest_drivers, affile_dd_reopen_all_writers, NULL);
 
-  register_application_hook(AH_REOPEN_FILES, affile_dd_register_reopen_hook, NULL);
+  register_application_hook(AH_REOPEN_FILES, affile_dd_register_reopen_hook, NULL, AHM_RUN_ONCE);
 }
 
 void
@@ -817,7 +817,7 @@ affile_dd_global_init(void)
 
   if (!initialized)
     {
-      register_application_hook(AH_REOPEN_FILES, affile_dd_register_reopen_hook, NULL);
+      register_application_hook(AH_REOPEN_FILES, affile_dd_register_reopen_hook, NULL, AHM_RUN_ONCE);
       initialized = TRUE;
     }
 }

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -374,8 +374,6 @@ static void
 affile_dd_register_reopen_hook(gint hook_type, gpointer user_data)
 {
   g_list_foreach(affile_dest_drivers, affile_dd_reopen_all_writers, NULL);
-
-  register_application_hook(AH_REOPEN_FILES, affile_dd_register_reopen_hook, NULL, AHM_RUN_ONCE);
 }
 
 void
@@ -817,7 +815,7 @@ affile_dd_global_init(void)
 
   if (!initialized)
     {
-      register_application_hook(AH_REOPEN_FILES, affile_dd_register_reopen_hook, NULL, AHM_RUN_ONCE);
+      register_application_hook(AH_REOPEN_FILES, affile_dd_register_reopen_hook, NULL, AHM_RUN_REPEAT);
       initialized = TRUE;
     }
 }

--- a/modules/afstreams/afstreams.c
+++ b/modules/afstreams/afstreams.c
@@ -201,7 +201,7 @@ afstreams_sd_init(LogPipe *s)
            * not inherited through forks, and syslog-ng forks during
            * startup, but _after_ the configuration was initialized */
 
-          register_application_hook(AH_POST_DAEMONIZED, afstreams_init_door, self);
+          register_application_hook(AH_POST_DAEMONIZED, afstreams_init_door, self, AHM_RUN_ONCE);
         }
       if (!log_pipe_init((LogPipe *) self->reader))
         {

--- a/modules/java/native/java_machine.c
+++ b/modules/java/native/java_machine.c
@@ -81,7 +81,7 @@ java_machine_ref(void)
        * therefore the reference counter must be incremented before that.
        * But we are in the _ref() function, so the counter must be updated as below.  */
       g_atomic_counter_inc(&global_jvm->ref_cnt);
-      register_application_hook(AH_SHUTDOWN, java_machine_unref_callback, global_jvm);
+      register_application_hook(AH_SHUTDOWN, java_machine_unref_callback, global_jvm, AHM_RUN_ONCE);
     }
   return global_jvm;
 }

--- a/news/bugfix-3561.md
+++ b/news/bugfix-3561.md
@@ -1,0 +1,5 @@
+`stats-level()`: fix processing the changes in the stats-level() global
+option: changes in stats-level() were not reflected in syslog
+facility/severity related and message tag related counters after first
+configuration reload. These counters continued to operate according to the
+value of stats-level() at the first reload.

--- a/news/developer-note-3561.md
+++ b/news/developer-note-3561.md
@@ -1,0 +1,3 @@
+`apphook`: the concept of hook run modes were introduced, adding support for
+two modes: AHM_RUN_ONCE (the original behavior) and AHM_RUN_REPEAT (the new
+behavior with the hook repeatedly called after registration).


### PR DESCRIPTION
This PR is split off from #3553 which adds a new run-mode for apphooks, namely the ability to be called any number of times
instead of just once. This simplifies a number of locations where the hook needs to re-register itself.

It also contains fixes to minor bugs, where this re-registration was missing.

Right now it depends on #3553, as it converts that call-site to the new API too. If we drop that patch (ie. the last patch) from the series, this can be merged even prior to that.
