### PR TITLE
Syslog parser drop invalid

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1337,7 +1337,7 @@ log_msg_new(const gchar *msg, gint length,
   LogMessage *self = log_msg_alloc(_determine_payload_size(length, parse_options));
 
   log_msg_init(self);
-  msg_format_parse(parse_options, (guchar *) msg, length, self);
+  msg_format_parse(parse_options, self, (guchar *) msg, length);
   return self;
 }
 

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1337,6 +1337,8 @@ log_msg_new(const gchar *msg, gint length,
   LogMessage *self = log_msg_alloc(_determine_payload_size(length, parse_options));
 
   log_msg_init(self);
+
+  msg_trace("Initial message parsing follows");
   msg_format_parse(parse_options, self, (guchar *) msg, length);
   return self;
 }

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1194,7 +1194,8 @@ log_msg_clear(LogMessage *self)
     g_sockaddr_unref(self->daddr);
   self->daddr = NULL;
 
-  self->flags |= LF_STATE_OWN_MASK;
+  /* clear "local", "utf8", "internal", "mark" and similar flags, we start afresh */
+  self->flags = LF_STATE_OWN_MASK;
 }
 
 static inline LogMessage *

--- a/lib/logmsg/tests/test_log_message.c
+++ b/lib/logmsg/tests/test_log_message.c
@@ -80,6 +80,7 @@ static void
 assert_log_msg_clear_clears_all_properties(LogMessage *message, NVHandle nv_handle,
                                            NVHandle sd_handle, const gchar *tag_name)
 {
+  message->flags |= LF_LOCAL + LF_UTF8 + LF_INTERNAL + LF_MARK;
   log_msg_clear(message);
 
   cr_assert_str_empty(log_msg_get_value(message, nv_handle, NULL),
@@ -91,6 +92,10 @@ assert_log_msg_clear_clears_all_properties(LogMessage *message, NVHandle nv_hand
   cr_assert_null(message->saddr, "Message still contains an saddr after log_msg_clear");
   cr_assert_not(log_msg_is_tag_by_name(message, tag_name),
                 "Message still contains a valid tag after log_msg_clear");
+  cr_assert((message->flags & LF_LOCAL) == 0, "Message still contains the 'local' flag after log_msg_clear");
+  cr_assert((message->flags & LF_UTF8) == 0, "Message still contains the 'utf8' flag after log_msg_clear");
+  cr_assert((message->flags & LF_MARK) == 0, "Message still contains the 'mark' flag after log_msg_clear");
+  cr_assert((message->flags & LF_INTERNAL) == 0, "Message still contains the 'internal' flag after log_msg_clear");
 }
 
 static void

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -50,7 +50,12 @@ msg_format_inject_parse_error(LogMessage *msg, const guchar *data, gsize length,
 }
 
 static void
-msg_format_postprocess_message(MsgFormatOptions *options, LogMessage *msg)
+msg_format_preprocess_message(MsgFormatOptions *options, const guchar *data, gsize length, LogMessage *msg)
+{
+}
+
+static void
+msg_format_postprocess_message(MsgFormatOptions *options, const guchar *data, gsize length, LogMessage *msg)
 {
   if (options->flags & LP_NO_PARSE_DATE)
     {
@@ -88,8 +93,9 @@ msg_format_parse(MsgFormatOptions *options, const guchar *data, gsize length, Lo
     }
 
   msg_trace("Initial message parsing follows");
+  msg_format_preprocess_message(options, data, length, msg);
   options->format_handler->parse(options, data, length, msg);
-  msg_format_postprocess_message(options, msg);
+  msg_format_postprocess_message(options, data, length, msg);
 }
 
 void

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -63,16 +63,19 @@ msg_format_inject_parse_error(LogMessage *msg, const guchar *data, gsize length,
 }
 
 static void
-msg_format_preprocess_message(MsgFormatOptions *options, LogMessage *msg, const guchar *data, gsize length)
+msg_format_preprocess_message(MsgFormatOptions *options, LogMessage *msg,
+                              const guchar *data, gsize length)
 {
   if (options->flags & LP_STORE_RAW_MESSAGE)
     {
-      log_msg_set_value(msg, LOG_MSG_GET_VALUE_HANDLE_STATIC("RAWMSG"), (gchar *) data, _rstripped_message_length(data, length));
+      log_msg_set_value(msg, LOG_MSG_GET_VALUE_HANDLE_STATIC("RAWMSG"),
+                        (gchar *) data, _rstripped_message_length(data, length));
     }
 }
 
 static void
-msg_format_postprocess_message(MsgFormatOptions *options, LogMessage *msg, const guchar *data, gsize length)
+msg_format_postprocess_message(MsgFormatOptions *options, LogMessage *msg,
+                               const guchar *data, gsize length)
 {
   if (options->flags & LP_NO_PARSE_DATE)
     {
@@ -101,7 +104,9 @@ msg_format_postprocess_message(MsgFormatOptions *options, LogMessage *msg, const
 }
 
 static gboolean
-msg_format_process_message(MsgFormatOptions *options, LogMessage *msg, const guchar *data, gsize length, gsize *problem_position)
+msg_format_process_message(MsgFormatOptions *options, LogMessage *msg,
+                           const guchar *data, gsize length,
+                           gsize *problem_position)
 {
   if ((options->flags & LP_NOPARSE) == 0)
     {
@@ -116,7 +121,9 @@ msg_format_process_message(MsgFormatOptions *options, LogMessage *msg, const guc
 }
 
 gboolean
-msg_format_parse_conditional(MsgFormatOptions *options, LogMessage *msg, const guchar *data, gsize length, gsize *problem_position)
+msg_format_parse_conditional(MsgFormatOptions *options, LogMessage *msg,
+                             const guchar *data, gsize length,
+                             gsize *problem_position)
 {
   if (G_UNLIKELY(!options->format_handler))
     {
@@ -137,7 +144,8 @@ msg_format_parse_conditional(MsgFormatOptions *options, LogMessage *msg, const g
 }
 
 void
-msg_format_parse(MsgFormatOptions *options, LogMessage *msg, const guchar *data, gsize length)
+msg_format_parse(MsgFormatOptions *options, LogMessage *msg,
+                 const guchar *data, gsize length)
 {
   gsize problem_position = 0;
 

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -72,6 +72,8 @@ msg_format_postprocess_message(MsgFormatOptions *options, LogMessage *msg)
           p++;
         }
     }
+  if (options->flags & LP_LOCAL)
+    msg->flags |= LF_LOCAL;
 }
 
 void

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -58,6 +58,7 @@ msg_format_inject_parse_error(LogMessage *msg, const guchar *data, gsize length,
   g_string_printf(buf, "%d", (int) getpid());
   log_msg_set_value(msg, LM_V_PID, buf->str, buf->len);
 
+  msg->flags |= LF_LOCAL;
   msg->pri = LOG_SYSLOG | LOG_ERR;
 }
 

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -26,6 +26,7 @@
 #include "cfg.h"
 #include "plugin.h"
 #include "plugin-types.h"
+#include "find-crlf.h"
 
 void
 msg_format_inject_parse_error(LogMessage *msg, const guchar *data, gsize length, gint problem_position)
@@ -57,6 +58,19 @@ msg_format_postprocess_message(MsgFormatOptions *options, LogMessage *msg)
       unix_time_set_timezone(&msg->timestamps[LM_TS_STAMP],
                              time_zone_info_get_offset(options->recv_time_zone_info,
                                                        msg->timestamps[LM_TS_RECVD].ut_sec));
+    }
+  if (G_UNLIKELY(options->flags & LP_NO_MULTI_LINE))
+    {
+      gssize msg_len;
+      gchar *msg_text;
+      gchar *p;
+
+      p = msg_text = (gchar *) log_msg_get_value(msg, LM_V_MESSAGE, &msg_len);
+      while ((p = find_cr_or_lf(p, msg_text + msg_len - p)))
+        {
+          *p = ' ';
+          p++;
+        }
     }
 }
 

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -115,8 +115,11 @@ msg_format_parse(MsgFormatOptions *options, LogMessage *msg, const guchar *data,
 {
   if (G_UNLIKELY(!options->format_handler))
     {
-      log_msg_set_value(msg, LM_V_MESSAGE, "Error parsing message, format module is not loaded", -1);
-      return;
+      gchar buf[256];
+
+      g_snprintf(buf, sizeof(buf), "Error parsing message, format module %s is not loaded", options->format);
+      log_msg_set_value(msg, LM_V_MESSAGE, buf, -1);
+      return FALSE;
     }
 
   msg_format_preprocess_message(options, msg, data, length);

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -60,6 +60,10 @@ msg_format_inject_parse_error(LogMessage *msg, const guchar *data, gsize length,
 static void
 msg_format_preprocess_message(MsgFormatOptions *options, const guchar *data, gsize length, LogMessage *msg)
 {
+  if (options->flags & LP_STORE_RAW_MESSAGE)
+    {
+      log_msg_set_value(msg, LOG_MSG_GET_VALUE_HANDLE_STATIC("RAWMSG"), (gchar *) data, _rstripped_message_length(data, length));
+    }
 }
 
 static void

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -51,21 +51,20 @@ msg_format_inject_parse_error(LogMessage *msg, const guchar *data, gsize length,
 void
 msg_format_parse(MsgFormatOptions *options, const guchar *data, gsize length, LogMessage *msg)
 {
-  if (G_LIKELY(options->format_handler))
-    {
-      msg_trace("Initial message parsing follows");
-      options->format_handler->parse(options, data, length, msg);
-      if (options->flags & LP_NO_PARSE_DATE)
-        {
-          msg->timestamps[LM_TS_STAMP] = msg->timestamps[LM_TS_RECVD];
-          unix_time_set_timezone(&msg->timestamps[LM_TS_STAMP],
-                                 time_zone_info_get_offset(options->recv_time_zone_info,
-                                                           msg->timestamps[LM_TS_RECVD].ut_sec));
-        }
-    }
-  else
+  if (G_UNLIKELY(!options->format_handler))
     {
       log_msg_set_value(msg, LM_V_MESSAGE, "Error parsing message, format module is not loaded", -1);
+      return;
+    }
+
+  msg_trace("Initial message parsing follows");
+  options->format_handler->parse(options, data, length, msg);
+  if (options->flags & LP_NO_PARSE_DATE)
+    {
+      msg->timestamps[LM_TS_STAMP] = msg->timestamps[LM_TS_RECVD];
+      unix_time_set_timezone(&msg->timestamps[LM_TS_STAMP],
+                             time_zone_info_get_offset(options->recv_time_zone_info,
+                                                       msg->timestamps[LM_TS_RECVD].ut_sec));
     }
 }
 

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -58,7 +58,7 @@ msg_format_inject_parse_error(LogMessage *msg, const guchar *data, gsize length,
 }
 
 static void
-msg_format_preprocess_message(MsgFormatOptions *options, const guchar *data, gsize length, LogMessage *msg)
+msg_format_preprocess_message(MsgFormatOptions *options, LogMessage *msg, const guchar *data, gsize length)
 {
   if (options->flags & LP_STORE_RAW_MESSAGE)
     {
@@ -67,7 +67,7 @@ msg_format_preprocess_message(MsgFormatOptions *options, const guchar *data, gsi
 }
 
 static void
-msg_format_postprocess_message(MsgFormatOptions *options, const guchar *data, gsize length, LogMessage *msg)
+msg_format_postprocess_message(MsgFormatOptions *options, LogMessage *msg, const guchar *data, gsize length)
 {
   if (options->flags & LP_NO_PARSE_DATE)
     {
@@ -96,11 +96,11 @@ msg_format_postprocess_message(MsgFormatOptions *options, const guchar *data, gs
 }
 
 static gboolean
-msg_format_process_message(MsgFormatOptions *options, const guchar *data, gsize length, LogMessage *msg, gsize *problem_position)
+msg_format_process_message(MsgFormatOptions *options, LogMessage *msg, const guchar *data, gsize length, gsize *problem_position)
 {
   if ((options->flags & LP_NOPARSE) == 0)
     {
-      return options->format_handler->parse(options, data, length, msg, problem_position);
+      return options->format_handler->parse(options, msg, data, length, problem_position);
     }
   else
     {
@@ -111,7 +111,7 @@ msg_format_process_message(MsgFormatOptions *options, const guchar *data, gsize 
 }
 
 void
-msg_format_parse(MsgFormatOptions *options, const guchar *data, gsize length, LogMessage *msg)
+msg_format_parse(MsgFormatOptions *options, LogMessage *msg, const guchar *data, gsize length)
 {
   if (G_UNLIKELY(!options->format_handler))
     {
@@ -120,14 +120,14 @@ msg_format_parse(MsgFormatOptions *options, const guchar *data, gsize length, Lo
     }
 
   msg_trace("Initial message parsing follows");
-  msg_format_preprocess_message(options, data, length, msg);
+  msg_format_preprocess_message(options, msg, data, length);
 
   gsize problem_position = 0;
 
-  if (!msg_format_process_message(options, data, length, msg, &problem_position))
+  if (!msg_format_process_message(options, msg, data, length, &problem_position))
     msg_format_inject_parse_error(msg, data, _rstripped_message_length(data, length), problem_position);
 
-  msg_format_postprocess_message(options, data, length, msg);
+  msg_format_postprocess_message(options, msg, data, length);
 }
 
 void

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -74,6 +74,8 @@ msg_format_postprocess_message(MsgFormatOptions *options, LogMessage *msg)
     }
   if (options->flags & LP_LOCAL)
     msg->flags |= LF_LOCAL;
+  if (options->flags & LP_ASSUME_UTF8)
+    msg->flags |= LF_UTF8;
 }
 
 void

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -119,7 +119,6 @@ msg_format_parse(MsgFormatOptions *options, LogMessage *msg, const guchar *data,
       return;
     }
 
-  msg_trace("Initial message parsing follows");
   msg_format_preprocess_message(options, msg, data, length);
 
   gsize problem_position = 0;

--- a/lib/msg-format.h
+++ b/lib/msg-format.h
@@ -83,11 +83,16 @@ struct _MsgFormatHandler
    */
   LogProtoServer *(*construct_proto)(const MsgFormatOptions *options, LogTransport *transport,
                                      const LogProtoServerOptions *proto_options);
-  gboolean (*parse)(const MsgFormatOptions *options, LogMessage *msg, const guchar *data, gsize length, gsize *problem_position);
+  gboolean (*parse)(const MsgFormatOptions *options, LogMessage *msg,
+                    const guchar *data, gsize length,
+                    gsize *problem_position);
 };
 
-gboolean msg_format_parse_conditional(MsgFormatOptions *options, LogMessage *msg, const guchar *data, gsize length, gsize *problem_position);
-void msg_format_parse(MsgFormatOptions *options, LogMessage *msg, const guchar *data, gsize length);
+gboolean msg_format_parse_conditional(MsgFormatOptions *options, LogMessage *msg,
+                                      const guchar *data, gsize length,
+                                      gsize *problem_position);
+void msg_format_parse(MsgFormatOptions *options, LogMessage *msg,
+                      const guchar *data, gsize length);
 
 void msg_format_options_defaults(MsgFormatOptions *options);
 void msg_format_options_init(MsgFormatOptions *parse_options, GlobalConfig *cfg);

--- a/lib/msg-format.h
+++ b/lib/msg-format.h
@@ -83,10 +83,10 @@ struct _MsgFormatHandler
    */
   LogProtoServer *(*construct_proto)(const MsgFormatOptions *options, LogTransport *transport,
                                      const LogProtoServerOptions *proto_options);
-  gboolean (*parse)(const MsgFormatOptions *options, const guchar *data, gsize length, LogMessage *msg, gsize *problem_position);
+  gboolean (*parse)(const MsgFormatOptions *options, LogMessage *msg, const guchar *data, gsize length, gsize *problem_position);
 };
 
-void msg_format_parse(MsgFormatOptions *options, const guchar *data, gsize length, LogMessage *msg);
+void msg_format_parse(MsgFormatOptions *options, LogMessage *msg, const guchar *data, gsize length);
 
 void msg_format_options_defaults(MsgFormatOptions *options);
 void msg_format_options_init(MsgFormatOptions *parse_options, GlobalConfig *cfg);

--- a/lib/msg-format.h
+++ b/lib/msg-format.h
@@ -83,7 +83,7 @@ struct _MsgFormatHandler
    */
   LogProtoServer *(*construct_proto)(const MsgFormatOptions *options, LogTransport *transport,
                                      const LogProtoServerOptions *proto_options);
-  void (*parse)(const MsgFormatOptions *options, const guchar *data, gsize length, LogMessage *msg);
+  gboolean (*parse)(const MsgFormatOptions *options, const guchar *data, gsize length, LogMessage *msg, gsize *problem_position);
 };
 
 void msg_format_parse(MsgFormatOptions *options, const guchar *data, gsize length, LogMessage *msg);
@@ -94,7 +94,5 @@ void msg_format_options_destroy(MsgFormatOptions *parse_options);
 void msg_format_options_copy(MsgFormatOptions *options, const MsgFormatOptions *source);
 
 gboolean msg_format_options_process_flag(MsgFormatOptions *options, const gchar *flag);
-
-void msg_format_inject_parse_error(LogMessage *msg, const guchar *data, gsize length, gint problem_position);
 
 #endif

--- a/lib/msg-format.h
+++ b/lib/msg-format.h
@@ -86,6 +86,7 @@ struct _MsgFormatHandler
   gboolean (*parse)(const MsgFormatOptions *options, LogMessage *msg, const guchar *data, gsize length, gsize *problem_position);
 };
 
+gboolean msg_format_parse_conditional(MsgFormatOptions *options, LogMessage *msg, const guchar *data, gsize length, gsize *problem_position);
 void msg_format_parse(MsgFormatOptions *options, LogMessage *msg, const guchar *data, gsize length);
 
 void msg_format_options_defaults(MsgFormatOptions *options);

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -507,7 +507,7 @@ pdbtool_match(int argc, char *argv[])
         {
           log_msg_unref(msg);
           msg = log_msg_new_empty();
-          parse_options.format_handler->parse(&parse_options, buf, buflen, msg);
+          msg_format_parse(&parse_options, buf, buflen, msg);
         }
 
       if (G_UNLIKELY(debug_pattern))

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -507,7 +507,7 @@ pdbtool_match(int argc, char *argv[])
         {
           log_msg_unref(msg);
           msg = log_msg_new_empty();
-          msg_format_parse(&parse_options, buf, buflen, msg);
+          msg_format_parse(&parse_options, msg, buf, buflen);
         }
 
       if (G_UNLIKELY(debug_pattern))

--- a/modules/linux-kmsg-format/linux-kmsg-format.c
+++ b/modules/linux-kmsg-format/linux-kmsg-format.c
@@ -357,17 +357,18 @@ error:
 
 gboolean
 linux_kmsg_format_handler(const MsgFormatOptions *parse_options,
+                          LogMessage *msg,
                           const guchar *data, gsize length,
-                          LogMessage *self, gsize *problem_position)
+                          gsize *problem_position)
 {
   gboolean success;
 
   while (length > 0 && (data[length - 1] == '\n' || data[length - 1] == '\0'))
     length--;
 
-  self->initial_parse = TRUE;
-  success = log_msg_parse_kmsg(self, data, length, problem_position);
-  self->initial_parse = FALSE;
+  msg->initial_parse = TRUE;
+  success = log_msg_parse_kmsg(msg, data, length, problem_position);
+  msg->initial_parse = FALSE;
 
   return success;
 }

--- a/modules/linux-kmsg-format/linux-kmsg-format.c
+++ b/modules/linux-kmsg-format/linux-kmsg-format.c
@@ -315,7 +315,7 @@ kmsg_parse_key_value_pair(const guchar *data, gsize *pos, gsize length,
 }
 
 static gboolean
-log_msg_parse_kmsg(LogMessage *msg, const guchar *data, gsize length, gint *position)
+log_msg_parse_kmsg(LogMessage *msg, const guchar *data, gsize length, gsize *position)
 {
   gsize pos = 0;
 
@@ -355,26 +355,21 @@ error:
   return FALSE;
 }
 
-void
+gboolean
 linux_kmsg_format_handler(const MsgFormatOptions *parse_options,
                           const guchar *data, gsize length,
-                          LogMessage *self)
+                          LogMessage *self, gsize *problem_position)
 {
   gboolean success;
-  gint problem_position = 0;
 
   while (length > 0 && (data[length - 1] == '\n' || data[length - 1] == '\0'))
     length--;
 
   self->initial_parse = TRUE;
-  success = log_msg_parse_kmsg(self, data, length, &problem_position);
+  success = log_msg_parse_kmsg(self, data, length, problem_position);
   self->initial_parse = FALSE;
 
-  if (G_UNLIKELY(!success))
-    {
-      msg_format_inject_parse_error(self, data, length, problem_position);
-      return;
-    }
+  return success;
 }
 
 #ifdef __linux__

--- a/modules/linux-kmsg-format/linux-kmsg-format.c
+++ b/modules/linux-kmsg-format/linux-kmsg-format.c
@@ -373,8 +373,6 @@ linux_kmsg_format_handler(const MsgFormatOptions *parse_options,
       return;
     }
 
-  self->flags |= LF_UTF8;
-
   self->initial_parse = TRUE;
 
   success = log_msg_parse_kmsg(self, data, length, &problem_position);

--- a/modules/linux-kmsg-format/linux-kmsg-format.c
+++ b/modules/linux-kmsg-format/linux-kmsg-format.c
@@ -366,17 +366,8 @@ linux_kmsg_format_handler(const MsgFormatOptions *parse_options,
   while (length > 0 && (data[length - 1] == '\n' || data[length - 1] == '\0'))
     length--;
 
-  if (parse_options->flags & LP_NOPARSE)
-    {
-      log_msg_set_value(self, LM_V_MESSAGE, (gchar *) data, length);
-      self->pri = parse_options->default_pri;
-      return;
-    }
-
   self->initial_parse = TRUE;
-
   success = log_msg_parse_kmsg(self, data, length, &problem_position);
-
   self->initial_parse = FALSE;
 
   if (G_UNLIKELY(!success))

--- a/modules/linux-kmsg-format/linux-kmsg-format.c
+++ b/modules/linux-kmsg-format/linux-kmsg-format.c
@@ -375,9 +375,6 @@ linux_kmsg_format_handler(const MsgFormatOptions *parse_options,
 
   self->flags |= LF_UTF8;
 
-  if (parse_options->flags & LP_LOCAL)
-    self->flags |= LF_LOCAL;
-
   self->initial_parse = TRUE;
 
   success = log_msg_parse_kmsg(self, data, length, &problem_position);

--- a/modules/linux-kmsg-format/linux-kmsg-format.h
+++ b/modules/linux-kmsg-format/linux-kmsg-format.h
@@ -26,9 +26,10 @@
 
 #include "msg-format.h"
 
-void linux_kmsg_format_handler(const MsgFormatOptions *parse_options,
-                               const guchar *data, gsize length,
-                               LogMessage *self);
+gboolean linux_kmsg_format_handler(const MsgFormatOptions *parse_options,
+                                   const guchar *data, gsize length,
+                                   LogMessage *self,
+                                   gsize *problem_position);
 
 void linux_msg_format_init (void);
 

--- a/modules/linux-kmsg-format/linux-kmsg-format.h
+++ b/modules/linux-kmsg-format/linux-kmsg-format.h
@@ -27,8 +27,8 @@
 #include "msg-format.h"
 
 gboolean linux_kmsg_format_handler(const MsgFormatOptions *parse_options,
+                                   LogMessage *msg,
                                    const guchar *data, gsize length,
-                                   LogMessage *self,
                                    gsize *problem_position);
 
 void linux_msg_format_init (void);

--- a/modules/pacctformat/pacct-format.c
+++ b/modules/pacctformat/pacct-format.c
@@ -99,7 +99,9 @@ pacct_register_handles(void)
 }
 
 gboolean
-pacct_format_handler(const MsgFormatOptions *options, LogMessage *msg, const guchar *data, gsize length, gsize *problem_position)
+pacct_format_handler(const MsgFormatOptions *options, LogMessage *msg,
+                     const guchar *data, gsize length,
+                     gsize *problem_position)
 {
   acct_t *rec;
   gsize len;

--- a/modules/pacctformat/pacct-format.c
+++ b/modules/pacctformat/pacct-format.c
@@ -99,7 +99,7 @@ pacct_register_handles(void)
 }
 
 gboolean
-pacct_format_handler(const MsgFormatOptions *options, const guchar *data, gsize length, LogMessage *msg, gsize *problem_position)
+pacct_format_handler(const MsgFormatOptions *options, LogMessage *msg, const guchar *data, gsize length, gsize *problem_position)
 {
   acct_t *rec;
   gsize len;

--- a/modules/pacctformat/pacct-format.c
+++ b/modules/pacctformat/pacct-format.c
@@ -98,12 +98,13 @@ pacct_register_handles(void)
   PACCT_REGISTER(ac_comm);
 }
 
-void
-pacct_format_handler(const MsgFormatOptions *options, const guchar *data, gsize length, LogMessage *msg)
+gboolean
+pacct_format_handler(const MsgFormatOptions *options, const guchar *data, gsize length, LogMessage *msg, gsize *problem_position)
 {
   acct_t *rec;
   gsize len;
 
+  *problem_position = 0;
   if (length < sizeof(*rec))
     {
       gchar *buf;
@@ -112,7 +113,7 @@ pacct_format_handler(const MsgFormatOptions *options, const guchar *data, gsize 
                             (gint) length, (gint) sizeof(*rec));
       log_msg_set_value(msg, LM_V_MESSAGE, buf, -1);
       g_free(buf);
-      return;
+      return TRUE;
     }
   rec = (acct_t *) data;
   if (rec->ac_version != 3)
@@ -123,7 +124,7 @@ pacct_format_handler(const MsgFormatOptions *options, const guchar *data, gsize 
                             rec->ac_version);
       log_msg_set_value(msg, LM_V_MESSAGE, buf, -1);
       g_free(buf);
-      return;
+      return TRUE;
     }
   if (G_UNLIKELY(!handles_registered))
     {
@@ -152,6 +153,7 @@ pacct_format_handler(const MsgFormatOptions *options, const guchar *data, gsize 
   else
     len = ACCT_COMM;
   log_msg_set_value(msg, handle_ac_comm, rec->ac_comm, len);
+  return TRUE;
 }
 
 static LogProtoServer *

--- a/modules/secure-logging/tests/CMakeLists.txt
+++ b/modules/secure-logging/tests/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_unit_test(LIBTEST CRITERION TARGET test_secure_logging DEPENDS secure-logging)
+add_unit_test(LIBTEST CRITERION TARGET test_secure_logging DEPENDS secure-logging syslogformat)

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -994,13 +994,6 @@ syslog_format_handler(const MsgFormatOptions *parse_options,
   if (parse_options->flags & LP_STORE_RAW_MESSAGE)
     log_msg_set_value(self, handles.raw_message, (gchar *) data, length);
 
-  if (parse_options->flags & LP_NOPARSE)
-    {
-      log_msg_set_value(self, LM_V_MESSAGE, (gchar *) data, length);
-      self->pri = parse_options->default_pri;
-      return;
-    }
-
   self->initial_parse = TRUE;
   if (parse_options->flags & LP_SYSLOG_PROTOCOL)
     success = log_msg_parse_syslog_proto(parse_options, data, length, self, &problem_position);

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -790,8 +790,7 @@ log_msg_parse_legacy_header(LogMessage *self, const guchar **data, gint *length,
       /* Different format */
 
       /* A kernel message? Use 'kernel' as the program name. */
-      if ((self->flags & LF_INTERNAL) == 0 && ((self->pri & LOG_FACMASK) == LOG_KERN &&
-                                               (self->flags & LF_LOCAL) != 0))
+      if (((self->pri & LOG_FACMASK) == LOG_KERN && (parse_options->flags & LP_LOCAL) != 0))
         {
           log_msg_set_value(self, LM_V_PROGRAM, "kernel", 6);
         }

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -1004,9 +1004,6 @@ syslog_format_handler(const MsgFormatOptions *parse_options,
   if (parse_options->flags & LP_ASSUME_UTF8)
     self->flags |= LF_UTF8;
 
-  if (parse_options->flags & LP_LOCAL)
-    self->flags |= LF_LOCAL;
-
   self->initial_parse = TRUE;
   if (parse_options->flags & LP_SYSLOG_PROTOCOL)
     success = log_msg_parse_syslog_proto(parse_options, data, length, self, &problem_position);

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -987,7 +987,6 @@ syslog_format_handler(const MsgFormatOptions *parse_options,
 {
   gboolean success;
   gint problem_position = 0;
-  gchar *p;
 
   while (length > 0 && (data[length - 1] == '\n' || data[length - 1] == '\0'))
     length--;
@@ -1021,19 +1020,6 @@ syslog_format_handler(const MsgFormatOptions *parse_options,
       return;
     }
 
-  if (G_UNLIKELY(parse_options->flags & LP_NO_MULTI_LINE))
-    {
-      gssize msglen;
-      gchar *msg;
-
-      p = msg = (gchar *) log_msg_get_value(self, LM_V_MESSAGE, &msglen);
-      while ((p = find_cr_or_lf(p, msg + msglen - p)))
-        {
-          *p = ' ';
-          p++;
-        }
-
-    }
 }
 
 void

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -1001,9 +1001,6 @@ syslog_format_handler(const MsgFormatOptions *parse_options,
       return;
     }
 
-  if (parse_options->flags & LP_ASSUME_UTF8)
-    self->flags |= LF_UTF8;
-
   self->initial_parse = TRUE;
   if (parse_options->flags & LP_SYSLOG_PROTOCOL)
     success = log_msg_parse_syslog_proto(parse_options, data, length, self, &problem_position);

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -991,9 +991,6 @@ syslog_format_handler(const MsgFormatOptions *parse_options,
   while (length > 0 && (data[length - 1] == '\n' || data[length - 1] == '\0'))
     length--;
 
-  if (parse_options->flags & LP_STORE_RAW_MESSAGE)
-    log_msg_set_value(self, handles.raw_message, (gchar *) data, length);
-
   self->initial_parse = TRUE;
   if (parse_options->flags & LP_SYSLOG_PROTOCOL)
     success = log_msg_parse_syslog_proto(parse_options, data, length, self, &problem_position);

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -981,20 +981,21 @@ error:
 
 gboolean
 syslog_format_handler(const MsgFormatOptions *parse_options,
+                      LogMessage *msg,
                       const guchar *data, gsize length,
-                      LogMessage *self, gsize *problem_position)
+                      gsize *problem_position)
 {
   gboolean success;
 
   while (length > 0 && (data[length - 1] == '\n' || data[length - 1] == '\0'))
     length--;
 
-  self->initial_parse = TRUE;
+  msg->initial_parse = TRUE;
   if (parse_options->flags & LP_SYSLOG_PROTOCOL)
-    success = log_msg_parse_syslog_proto(parse_options, data, length, self, problem_position);
+    success = log_msg_parse_syslog_proto(parse_options, data, length, msg, problem_position);
   else
-    success = log_msg_parse_legacy(parse_options, data, length, self, problem_position);
-  self->initial_parse = FALSE;
+    success = log_msg_parse_legacy(parse_options, data, length, msg, problem_position);
+  msg->initial_parse = FALSE;
 
   return success;
 }

--- a/modules/syslogformat/syslog-format.h
+++ b/modules/syslogformat/syslog-format.h
@@ -27,8 +27,8 @@
 #include "msg-format.h"
 
 gboolean syslog_format_handler(const MsgFormatOptions *parse_options,
+                               LogMessage *msg,
                                const guchar *data, gsize length,
-                               LogMessage *self,
                                gsize *problem_position);
 
 void syslog_format_init(void);

--- a/modules/syslogformat/syslog-format.h
+++ b/modules/syslogformat/syslog-format.h
@@ -26,9 +26,10 @@
 
 #include "msg-format.h"
 
-void syslog_format_handler(const MsgFormatOptions *parse_options,
-                           const guchar *data, gsize length,
-                           LogMessage *self);
+gboolean syslog_format_handler(const MsgFormatOptions *parse_options,
+                               const guchar *data, gsize length,
+                               LogMessage *self,
+                               gsize *problem_position);
 
 void syslog_format_init(void);
 

--- a/modules/syslogformat/syslog-parser-grammar.ym
+++ b/modules/syslogformat/syslog-parser-grammar.ym
@@ -48,6 +48,7 @@
 /* INCLUDE_DECLS */
 
 %token KW_SYSLOG_PARSER
+%token KW_DROP_INVALID
 
 %type	<ptr> parser_expr_syslog
 
@@ -77,6 +78,7 @@ parser_syslog_opts
 parser_syslog_opt
 	: parser_opt
 	| KW_FLAGS '(' parser_syslog_opt_flags ')'
+	| KW_DROP_INVALID '(' yesno ')'			{ syslog_parser_set_drop_invalid(last_parser, $3); }
 	| { last_msg_format_options = &((SyslogParser *) last_parser)->parse_options; } msg_format_option
         ;
 

--- a/modules/syslogformat/syslog-parser-parser.c
+++ b/modules/syslogformat/syslog-parser-parser.c
@@ -32,6 +32,7 @@ int syslog_parser_parse(CfgLexer *lexer, LogParser **instance, gpointer arg);
 static CfgLexerKeyword syslog_parser_keywords[] =
 {
   { "syslog_parser",          KW_SYSLOG_PARSER },
+  { "drop_invalid",           KW_DROP_INVALID },
   { NULL }
 };
 

--- a/modules/syslogformat/syslog-parser.c
+++ b/modules/syslogformat/syslog-parser.c
@@ -36,7 +36,7 @@ syslog_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
             evt_tag_str ("input", input),
             evt_tag_printf("msg", "%p", *pmsg));
 
-  msg_format_parse(&self->parse_options, (guchar *) input, input_len, msg);
+  msg_format_parse(&self->parse_options, msg, (guchar *) input, input_len);
   return TRUE;
 }
 

--- a/modules/syslogformat/syslog-parser.c
+++ b/modules/syslogformat/syslog-parser.c
@@ -36,7 +36,7 @@ syslog_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
             evt_tag_str ("input", input),
             evt_tag_printf("msg", "%p", *pmsg));
 
-  syslog_format_handler(&self->parse_options, (guchar *) input, input_len, msg);
+  msg_format_parse(&self->parse_options, (guchar *) input, input_len, msg);
   return TRUE;
 }
 

--- a/modules/syslogformat/syslog-parser.c
+++ b/modules/syslogformat/syslog-parser.c
@@ -24,6 +24,14 @@
 #include "syslog-parser.h"
 #include "syslog-format.h"
 
+void
+syslog_parser_set_drop_invalid(LogParser *s, gboolean drop_invalid)
+{
+  SyslogParser *self = (SyslogParser *) s;
+
+  self->drop_invalid = drop_invalid;
+}
+
 static gboolean
 syslog_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, const gchar *input,
                       gsize input_len)
@@ -36,8 +44,16 @@ syslog_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
             evt_tag_str ("input", input),
             evt_tag_printf("msg", "%p", *pmsg));
 
-  msg_format_parse(&self->parse_options, msg, (guchar *) input, input_len);
-  return TRUE;
+  if (self->drop_invalid)
+    {
+      gsize problem_position = 0;
+      return msg_format_parse_conditional(&self->parse_options, msg, (guchar *) input, input_len, &problem_position);
+    }
+  else
+    {
+      msg_format_parse(&self->parse_options, msg, (guchar *) input, input_len);
+      return TRUE;
+    }
 }
 
 static gboolean

--- a/modules/syslogformat/syslog-parser.h
+++ b/modules/syslogformat/syslog-parser.h
@@ -29,8 +29,10 @@ typedef struct _SyslogParser
 {
   LogParser super;
   MsgFormatOptions parse_options;
+  gboolean drop_invalid;
 } SyslogParser;
 
+void syslog_parser_set_drop_invalid(LogParser *s, gboolean drop_invalid);
 LogParser *syslog_parser_new(GlobalConfig *cfg);
 
 #endif

--- a/news-3565.md
+++ b/news-3565.md
@@ -1,0 +1,3 @@
+`syslog-parser()`: add a new drop-invalid() option that allows the use of
+syslog-parser() in if statements. Normally a syslog-parser() injects an
+error message instead of failing.


### PR DESCRIPTION
This PR contains a combination of a long-needed msg-format related refactor (moving common code out of format modules into the msg-format layer) and the ability for syslog-parser() to drop incorrectly formatted messages (right now it is only RFC5424 that can indicate invalid messages, RFC3164 consumes everything).

The motivation behind this feature is that more and more rfc5424 style messages are actually incorrectly formatted, while still containing the initial "1 " version indicator right after the priority field. Instead of making the parser less strict, the drop-invalid() setting allows the easy identification of these messages, so that an alternative parser can be applied, like this:

```
@version: 3.30

log {
        source { tcp(port(2000) flags(no-parse)); };

        if {
                parser { syslog-parser(drop-invalid(yes) flags(syslog-protocol)); };
        } else {
                # drop RFC5424 indicator as it was not right
                rewrite { subst("^(<[0-9]+>)1 ", "$1"); };
                parser { syslog-parser(drop-invalid(no)); };
        };
        destination { file("log"); };
};
```

This was a long requested feature by the https://github.com/splunk/splunk-connect-for-syslog team @rfaircloth-splunk