### PR TITLE
python: do not double free seqnum and template_options

### DIFF
--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
     container:
       image: balabit/syslog-ng-devshell:latest
+      options: --privileged --ulimit core=-1
 
     strategy:
       matrix:
@@ -23,15 +24,24 @@ jobs:
       - name: Checkout syslog-ng source
         uses: actions/checkout@v2
 
-      - name: Set ENV variables
+      - name: Setup environment
         run: |
           . .github/workflows/gh-tools.sh
 
+          # Setup corefiles
+          ulimit -c unlimited
+          COREFILES_DIR=/tmp/corefiles
+          mkdir ${COREFILES_DIR}
+          echo "${COREFILES_DIR}/core.%h.%e.%t" > /proc/sys/kernel/core_pattern
+
+          # Setup build time environment variables
           PYTHONVERSION="`printf ${{ matrix.python }} | tail -c 1`"
           PYTHONUSERBASE="${HOME}/python_packages"
           CC="${{ matrix.cc }}"
+          SYSLOG_NG_INSTALL_DIR=${HOME}/install/syslog-ng
           CONFIGURE_FLAGS="
-            --prefix=${HOME}/install/syslog-ng
+            --prefix=${SYSLOG_NG_INSTALL_DIR}
+            --enable-debug
             --enable-all-modules
             --disable-java
             --disable-java-modules
@@ -39,11 +49,12 @@ jobs:
             `[ $CC = clang ] && echo '--enable-force-gnu99' || true`
           "
           CMAKE_FLAGS="
+            -DCMAKE_BUILD_TYPE=Debug
             -DCMAKE_C_FLAGS=-Werror
             -DCMAKE_INSTALL_PREFIX=${HOME}/install/syslog-ng
             -DPYTHON_VERSION=${PYTHONVERSION}
           "
-          gh_export PYTHONVERSION PYTHONUSERBASE CC CONFIGURE_FLAGS CMAKE_FLAGS
+          gh_export COREFILES_DIR PYTHONVERSION PYTHONUSERBASE CC SYSLOG_NG_INSTALL_DIR CONFIGURE_FLAGS CMAKE_FLAGS
           gh_path "${PYTHONUSERBASE}"
 
       - name: autogen.sh
@@ -111,6 +122,20 @@ jobs:
         with:
           name: light-reports-${{ matrix.build-tool }}-${{ matrix.cc }}-${{ matrix.python }}
           path: /tmp/light-reports
+
+      - name: Dump corefile backtrace
+        working-directory: ${{ env.COREFILES_DIR }}
+        if: failure()
+        run: |
+          find -name "core.*syslog-ng*" -exec \
+            gdb --ex="thread apply all bt full" --ex="quit" ${SYSLOG_NG_INSTALL_DIR}/sbin/syslog-ng --core {} \;
+
+      - name: "Artifact: corefiles"
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: corefiles-${{ matrix.build-tool }}-${{ matrix.cc }}-${{ matrix.python }}
+          path: ${{ env.COREFILES_DIR }}
 
   distcheck:
     runs-on: ubuntu-18.04

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -55,8 +55,6 @@ typedef struct
     PyObject *open;
     PyObject *send;
     PyObject *flush;
-    PyObject *log_template_options;
-    PyObject *seqnum;
     PyObject *generate_persist_name;
     GPtrArray *_refs_to_clean;
   } py;
@@ -360,12 +358,13 @@ _py_init_bindings(PythonDestDriver *self)
 
   _inject_worker_insert_result_consts(self);
 
-  self->py.log_template_options = py_log_template_options_new(&self->template_options);
-  PyObject_SetAttrString(self->py.class, "template_options", self->py.log_template_options);
-  Py_DECREF(self->py.log_template_options);
-  self->py.seqnum = py_integer_pointer_new(&self->super.worker.instance.seq_num);
-  PyObject_SetAttrString(self->py.class, "seqnum", self->py.seqnum);
-  Py_DECREF(self->py.seqnum);
+  PyObject *py_log_template_options = py_log_template_options_new(&self->template_options);
+  PyObject_SetAttrString(self->py.class, "template_options", py_log_template_options);
+  Py_DECREF(py_log_template_options);
+
+  PyObject *py_seqnum = py_integer_pointer_new(&self->super.worker.instance.seq_num);
+  PyObject_SetAttrString(self->py.class, "seqnum", py_seqnum);
+  Py_DECREF(py_seqnum);
 
   self->py.instance = _py_invoke_function(self->py.class, NULL, self->class, self->super.super.super.id);
   if (!self->py.instance)
@@ -405,8 +404,6 @@ _py_init_bindings(PythonDestDriver *self)
   g_ptr_array_add(self->py._refs_to_clean, self->py.open);
   g_ptr_array_add(self->py._refs_to_clean, self->py.flush);
   g_ptr_array_add(self->py._refs_to_clean, self->py.send);
-  g_ptr_array_add(self->py._refs_to_clean, self->py.log_template_options);
-  g_ptr_array_add(self->py._refs_to_clean, self->py.seqnum);
   g_ptr_array_add(self->py._refs_to_clean, self->py.generate_persist_name);
 
   return TRUE;

--- a/news/bugfix-3568.md
+++ b/news/bugfix-3568.md
@@ -1,0 +1,1 @@
+`python destination`: Fixed a rare crash during reload.


### PR DESCRIPTION
When these two objects are passed to `PyObject_SetAttrString()`, their reference counter is incremented. In the next line, we drop our own reference to them with `Py_DECREF()`, but still keep track of them to free it later in `_py_free_bindings()`.

It is not needed, the python lib will take care of the reference, that was added in `PyObject_SetAttrString().

Because we do not need these objects in our code, it is the easiest, to not store them in our struct.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>