### PR TITLE
Fix improper initialization in affile and LogWriter

### DIFF
--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1452,8 +1452,6 @@ log_writer_init(LogPipe *s)
       log_writer_postpone_mark_timer(self);
     }
 
-  log_pipe_add_info(s, "writer");
-
   return TRUE;
 }
 
@@ -1715,6 +1713,8 @@ log_writer_new(guint32 flags, GlobalConfig *cfg)
   g_static_mutex_init(&self->suppress_lock);
   g_static_mutex_init(&self->pending_proto_lock);
   self->pending_proto_cond = g_cond_new();
+
+  log_pipe_add_info((LogPipe *)self, "writer");
 
   return self;
 }

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1714,7 +1714,7 @@ log_writer_new(guint32 flags, GlobalConfig *cfg)
   g_static_mutex_init(&self->pending_proto_lock);
   self->pending_proto_cond = g_cond_new();
 
-  log_pipe_add_info((LogPipe *)self, "writer");
+  log_pipe_add_info(&self->super, "writer");
 
   return self;
 }

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -813,5 +813,11 @@ affile_dd_new(gchar *filename, GlobalConfig *cfg)
 void
 affile_dd_global_init(void)
 {
-  register_application_hook(AH_REOPEN_FILES, affile_dd_register_reopen_hook, NULL);
+  static gboolean initialized = FALSE;
+
+  if (!initialized)
+    {
+      register_application_hook(AH_REOPEN_FILES, affile_dd_register_reopen_hook, NULL);
+      initialized = TRUE;
+    }
 }

--- a/news/bugfix-3574.md
+++ b/news/bugfix-3574.md
@@ -1,1 +1,1 @@
-`affile`: Fix improper initialization in affile and LogWriter
+`affile`: Fix improper initialization in affile and LogWriter to avoid memory leak when reloading

--- a/news/bugfix-3574.md
+++ b/news/bugfix-3574.md
@@ -1,0 +1,1 @@
+`affile`: Fix improper initialization in affile and LogWriter


### PR DESCRIPTION
When reloading configuration, syslog-ng performs the following operations
1. Load modules
2. Initialize modules (calling `%s_module_init`)
3. ...
4. Create log pipes
5. Initialize log pipes

There are two issues:

---

`affile_module_init` calls `affile_dd_global_init` to register an application hook.

However, it doesn't use any flag to avoid registering hook repeatedly.
Therefore, if we reload configuration 1000 times, there will be 1000 entries in `applications_hooks`.

This can be observed by executing the following commands in gdb
```
set $hook=application_hooks
while ($hook != 0)
  p *((ApplicationHookEntry*)($hook->data))
  set $hook=$hook->next
end
```

---

`affile-dest` creates LogWriter if necessary ([code](https://github.com/syslog-ng/syslog-ng/blob/master/modules/affile/affile-dest.c#L194)), and initialize it every time ([code](https://github.com/syslog-ng/syslog-ng/blob/master/modules/affile/affile-dest.c#L205)).

Currently, `log_writer_init` uses `log_pipe_add_info` to add `writer` to `LogWriter::info`. If we reload 1000 times, `affile_dw_init` will be performed 1000 times, `log_writer_new` and `log_writer_init` will be called 1 time and 1000 times repectively.

---

The memory allocated for hook and LogWriter::info entry will not be freed until syslog-ng exits.
Therefore, massif shows like the following

![image](https://user-images.githubusercontent.com/1191368/108153729-b54eed80-7116-11eb-8015-e49f072474d7.png)

Apply this patchset, massif shows like the following

![image_fixed](https://user-images.githubusercontent.com/1191368/108153759-c992ea80-7116-11eb-9ea4-ba81e53f7abc.png)

---

Fix #3574