### PR TITLE
python: use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/dbld/builddeps
+++ b/dbld/builddeps
@@ -183,14 +183,14 @@ function install_pip_packages {
     for python_executable in ${python_executables}; do
         case "${OS_PLATFORM}" in
             centos-7|ubuntu-xenial)
-                $python_executable -m pip install --upgrade "pip < 21.0"
-                $python_executable -m pip install --upgrade setuptools
-                filter_packages_by_platform $DBLD_DIR/pip_packages.manifest | xargs $python_executable -m pip install --ignore-installed -U
+                $python_executable -m pip install --no-cache-dir --upgrade "pip < 21.0"
+                $python_executable -m pip install --no-cache-dir --upgrade setuptools
+                filter_packages_by_platform $DBLD_DIR/pip_packages.manifest | xargs $python_executable -m pip install --no-cache-dir --ignore-installed -U
                 ;;
             *)
-                $python_executable -m pip install --upgrade pip
-                $python_executable -m pip install --upgrade setuptools
-                filter_packages_by_platform $DBLD_DIR/pip_packages.manifest | xargs $python_executable -m pip install --ignore-installed -U
+                $python_executable -m pip install --no-cache-dir --upgrade pip
+                $python_executable -m pip install --no-cache-dir --upgrade setuptools
+                filter_packages_by_platform $DBLD_DIR/pip_packages.manifest | xargs $python_executable -m pip install --no-cache-dir --ignore-installed -U
                 ;;
         esac
     done


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>