### PR TITLE
kafka-c: fix double ack on re-added messages

### DIFF
--- a/modules/kafka/kafka-dest-driver.c
+++ b/modules/kafka/kafka-dest-driver.c
@@ -282,7 +282,7 @@ _kafka_delivery_report_cb(rd_kafka_t *rk,
     {
       LogThreadedDestWorker *worker = (LogThreadedDestWorker *) self->super.workers[0];
       LogQueue *queue = worker->queue;
-      LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+      LogPathOptions path_options = LOG_PATH_OPTIONS_INIT_NOACK;
 
       msg_debug("kafka: delivery report for message came back with an error, putting it back to our queue",
                 evt_tag_str("topic", self->topic_name->template),

--- a/news/bugfix-3583.md
+++ b/news/bugfix-3583.md
@@ -1,0 +1,1 @@
+`kafka-c`: fix a double LogMessage acknowledgement bug, which can cause crash with segmentation fault or exit with sigabrt. The issue affects both flow-controlled and non-flow-controlled log paths and it's triggered in case previously published messages failed to be delivered to Kafka.


### PR DESCRIPTION
Delivery_report_callback re-adds the message to the head of the queue for resending.
(with more workers, the message is possibly re-added to a different worker thread's queue than the original worker who tried to sent out the message, as we always poll from worker#0 and re-add the message to worker#0's queue).

The problem was, that the message was re-added to the queue with acknowledgement re-enabled.
This can cause trouble in both flow-controlled and non flow-controlled cases, as even with a flow-controlled log path, the message is already acknowledged since kafka-c driver's insert method returned with SUCCESS, and delivery failure only detected in the delivery_report callback.

Acknowledgement in kafka-c has to be revised, so we can acknowledge at the right time. Currently, flow-control doesn't work as it is intended, the messages are ack-ed back before the delivery callback could give us feedback on the message sending.
This will be done in a later step.