### PR TITLE
afuser: support time-reopen() 

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1326,6 +1326,7 @@ dest_writer_option
             log_writer_options_set_mark_mode(last_writer_options, $3);
             free($3);
           }
+	| KW_TIME_REOPEN '(' positive_integer ')' { last_writer_options->time_reopen = $3; }
         | { last_template_options = &last_writer_options->template_options; } template_option
 	;
 

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1212,6 +1212,7 @@ threaded_source_driver_option
 
 threaded_fetcher_driver_option
         : KW_FETCH_NO_DATA_DELAY '(' nonnegative_float ')' { log_threaded_fetcher_driver_set_fetch_no_data_delay(last_driver, $3); }
+        | KW_TIME_REOPEN '(' positive_integer ')' { log_threaded_fetcher_driver_set_time_reopen(last_driver, $3); }
         ;
 
 threaded_source_driver_option_flags

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1198,6 +1198,7 @@ threaded_dest_driver_option
         }
         | KW_BATCH_LINES '(' nonnegative_integer ')' { log_threaded_dest_driver_set_batch_lines(last_driver, $3); }
         | KW_BATCH_TIMEOUT '(' positive_integer ')' { log_threaded_dest_driver_set_batch_timeout(last_driver, $3); }
+        | KW_TIME_REOPEN '(' positive_integer ')' { log_threaded_dest_driver_set_time_reopen(last_driver, $3); }
         | dest_driver_option
         ;
 

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -276,6 +276,7 @@ void log_pipe_detach_expr_node(LogPipe *self);
 static inline GlobalConfig *
 log_pipe_get_config(LogPipe *s)
 {
+  g_assert(s->cfg);
   return s->cfg;
 }
 

--- a/lib/logthrdest/logthrdestdrv.c
+++ b/lib/logthrdest/logthrdestdrv.c
@@ -69,6 +69,14 @@ log_threaded_dest_driver_set_batch_timeout(LogDriver *s, gint batch_timeout)
   self->batch_timeout = batch_timeout;
 }
 
+void
+log_threaded_dest_driver_set_time_reopen(LogDriver *s, time_t time_reopen)
+{
+  LogThreadedDestDriver *self = (LogThreadedDestDriver *) s;
+
+  self->time_reopen = time_reopen;
+}
+
 /* this should be used in combination with LTR_EXPLICIT_ACK_MGMT to actually confirm message delivery. */
 void
 log_threaded_dest_worker_ack_messages(LogThreadedDestWorker *self, gint batch_size)

--- a/lib/logthrdest/logthrdestdrv.c
+++ b/lib/logthrdest/logthrdestdrv.c
@@ -1061,7 +1061,7 @@ log_threaded_dest_driver_init_method(LogPipe *s)
 
   self->under_termination = FALSE;
 
-  if (cfg && self->time_reopen == -1)
+  if (self->time_reopen == -1)
     self->time_reopen = cfg->time_reopen;
 
   self->shared_seq_num = GPOINTER_TO_INT(cfg_persist_config_fetch(cfg,

--- a/lib/logthrdest/logthrdestdrv.h
+++ b/lib/logthrdest/logthrdestdrv.h
@@ -237,5 +237,6 @@ void log_threaded_dest_driver_set_max_retries_on_error(LogDriver *s, gint max_re
 void log_threaded_dest_driver_set_num_workers(LogDriver *s, gint num_workers);
 void log_threaded_dest_driver_set_batch_lines(LogDriver *s, gint batch_lines);
 void log_threaded_dest_driver_set_batch_timeout(LogDriver *s, gint batch_timeout);
+void log_threaded_dest_driver_set_time_reopen(LogDriver *s, time_t time_reopen);
 
 #endif

--- a/lib/logthrsource/logthrfetcherdrv.c
+++ b/lib/logthrsource/logthrfetcherdrv.c
@@ -324,7 +324,7 @@ log_threaded_fetcher_driver_init_method(LogPipe *s)
 
   g_assert(self->fetch);
 
-  if (cfg && self->time_reopen == -1)
+  if (self->time_reopen == -1)
     self->time_reopen = cfg->time_reopen;
 
   if (self->no_data_delay == -1)

--- a/lib/logthrsource/logthrfetcherdrv.c
+++ b/lib/logthrsource/logthrfetcherdrv.c
@@ -35,6 +35,13 @@ log_threaded_fetcher_driver_set_fetch_no_data_delay(LogDriver *s, gdouble no_dat
   self->no_data_delay = (gint64) SEC_TO_MSEC(no_data_delay);
 }
 
+void
+log_threaded_fetcher_driver_set_time_reopen(LogDriver *s, time_t time_reopen)
+{
+  LogThreadedFetcherDriver *self = (LogThreadedFetcherDriver *) s;
+  self->time_reopen = time_reopen;
+}
+
 static EVTTAG *
 _tag_driver(LogThreadedFetcherDriver *f)
 {

--- a/lib/logthrsource/logthrfetcherdrv.h
+++ b/lib/logthrsource/logthrfetcherdrv.h
@@ -78,5 +78,6 @@ gboolean log_threaded_fetcher_driver_deinit_method(LogPipe *s);
 void log_threaded_fetcher_driver_free_method(LogPipe *s);
 
 void log_threaded_fetcher_driver_set_fetch_no_data_delay(LogDriver *self, gdouble no_data_delay);
+void log_threaded_fetcher_driver_set_time_reopen(LogDriver *s, time_t time_reopen);
 
 #endif

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -137,12 +137,10 @@ affile_dw_reopen(AFFileDestWriter *self)
 {
   int fd;
   struct stat st;
-  GlobalConfig *cfg;
+  GlobalConfig *cfg = log_pipe_get_config(&self->super);
   LogProtoClient *proto = NULL;
 
-  cfg = log_pipe_get_config(&self->super);
-  if (cfg)
-    self->time_reopen = cfg->time_reopen;
+  self->time_reopen = cfg->time_reopen;
 
   msg_verbose("Initializing destination file writer",
               evt_tag_str("template", self->owner->filename_template->template),

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -260,8 +260,7 @@ afprogram_sd_init(LogPipe *s)
   if (!log_src_driver_init_method(s))
     return FALSE;
 
-  if (cfg)
-    log_reader_options_init(&self->reader_options, cfg, self->super.super.group);
+  log_reader_options_init(&self->reader_options, cfg, self->super.super.group);
 
   msg_verbose("Starting source program",
               evt_tag_str("cmdline", self->process_info.cmdline->str));

--- a/modules/afuser/afuser-grammar.ym
+++ b/modules/afuser/afuser-grammar.ym
@@ -60,10 +60,21 @@ extern LogDriver *last_driver;
 
 start
 	: LL_CONTEXT_DESTINATION dest_afuser			 { last_driver = *instance = $2; YYACCEPT; }
-        ;
+	;
 
 dest_afuser
-	: KW_USERTTY '(' string ')'		{ $$ = afuser_dd_new($3, configuration); free($3); }
+	: KW_USERTTY '(' string { last_driver = afuser_dd_new($3, configuration); }
+		afuser_opts
+		')' { $$ = last_driver; free($3); }
+	;
+
+afuser_opts
+	: afuser_opt afuser_opts
+	|
+	;
+
+afuser_opt
+	: KW_TIME_REOPEN '(' positive_integer ')' { afuser_dd_set_time_reopen(last_driver, $3); }
 	;
 
 /* INCLUDE_RULES */

--- a/modules/afuser/afuser.c
+++ b/modules/afuser/afuser.c
@@ -36,6 +36,7 @@ typedef struct _AFUserDestDriver
   LogDestDriver super;
   GString *username;
   time_t disable_until;
+  time_t time_reopen;
 } AFUserDestDriver;
 
 #ifdef SYSLOG_NG_HAVE_UTMPX_H
@@ -105,6 +106,14 @@ _get_utmp_username(UtmpEntry *ut)
 
 G_LOCK_DEFINE_STATIC(utmp_lock);
 
+void
+afuser_dd_set_time_reopen(LogDriver *s, time_t time_reopen)
+{
+  AFUserDestDriver *self = (AFUserDestDriver *) s;
+
+  self->time_reopen = time_reopen;
+}
+
 static void
 afuser_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
@@ -149,18 +158,20 @@ afuser_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
           fd = open(line, O_NOCTTY | O_APPEND | O_WRONLY | O_NONBLOCK);
           if (fd == -1)
             {
-              msg_error("Opening tty device failed, disabling usertty() for 10 minutes",
+              msg_error("Opening tty device failed, disabling usertty() for time-reopen seconds",
                         evt_tag_str("user", _get_utmp_username(ut)),
                         evt_tag_str("line", line),
+                        evt_tag_int("time_reopen", self->time_reopen),
                         evt_tag_error("errno"));
-              self->disable_until = now + 600;
+              self->disable_until = now + self->time_reopen;
               continue;
             }
           if (write(fd, buf, strlen(buf)) < 0 && errno == EAGAIN)
             {
-              msg_notice("Writing to the user terminal has blocked for writing, disabling for 10 minutes",
-                         evt_tag_str("user", self->username->str));
-              self->disable_until = now + 600;
+              msg_notice("Writing to the user terminal has blocked for writing, disabling for time-reopen seconds",
+                         evt_tag_str("user", self->username->str),
+                         evt_tag_int("time_reopen", self->time_reopen));
+              self->disable_until = now + self->time_reopen;
             }
           close(fd);
         }
@@ -180,14 +191,29 @@ afuser_dd_free(LogPipe *s)
   log_dest_driver_free(s);
 }
 
+static gboolean
+afuser_dd_init(LogPipe *s)
+{
+  AFUserDestDriver *self = (AFUserDestDriver *) s;
+  GlobalConfig *cfg = log_pipe_get_config(s);
+
+  if (self->time_reopen == -1)
+    self->time_reopen = cfg->time_reopen;
+
+  return log_dest_driver_init_method(s);
+}
+
 LogDriver *
 afuser_dd_new(gchar *user, GlobalConfig *cfg)
 {
   AFUserDestDriver *self = g_new0(AFUserDestDriver, 1);
 
   log_dest_driver_init_instance(&self->super, cfg);
+  self->super.super.super.init = afuser_dd_init;
   self->super.super.super.queue = afuser_dd_queue;
   self->super.super.super.free_fn = afuser_dd_free;
   self->username = g_string_new(user);
+  self->time_reopen = -1;
+
   return &self->super.super;
 }

--- a/modules/afuser/afuser.h
+++ b/modules/afuser/afuser.h
@@ -27,5 +27,6 @@
 #include "driver.h"
 
 LogDriver *afuser_dd_new(gchar *user, GlobalConfig *cfg);
+void afuser_dd_set_time_reopen(LogDriver *s, time_t time_reopen);
 
 #endif

--- a/modules/geoip2/tests/test_geoip_parser.c
+++ b/modules/geoip2/tests/test_geoip_parser.c
@@ -26,13 +26,15 @@
 
 #include <criterion/criterion.h>
 
+GlobalConfig *cfg;
 LogParser *geoip_parser;
 
 void
 setup(void)
 {
   app_startup();
-  geoip_parser = maxminddb_parser_new(configuration);
+  cfg = cfg_new_snippet();
+  geoip_parser = maxminddb_parser_new(cfg);
   /*
    * The origin of the database:
    * https://github.com/maxmind/MaxMind-DB/blob/ea7cd314bb55879b8cb1a059c425d53ff3b9b6cc/test-data/GeoIP2-Precision-Enterprise-Test.mmdb
@@ -48,6 +50,7 @@ teardown(void)
   log_pipe_deinit(&geoip_parser->super);
   log_pipe_unref(&geoip_parser->super);
   scratch_buffers_explicit_gc();
+  cfg_free(cfg);
   app_shutdown();
 }
 

--- a/modules/kvformat/tests/test_kv_parser.c
+++ b/modules/kvformat/tests/test_kv_parser.c
@@ -26,6 +26,7 @@
 
 #include <criterion/criterion.h>
 
+GlobalConfig *cfg;
 LogParser *kv_parser;
 
 static LogMessage *
@@ -62,7 +63,8 @@ void
 setup(void)
 {
   app_startup();
-  kv_parser = kv_parser_new(NULL);
+  cfg = cfg_new_snippet();
+  kv_parser = kv_parser_new(cfg);
   log_pipe_init((LogPipe *)kv_parser);
 }
 
@@ -72,6 +74,7 @@ teardown(void)
   log_pipe_deinit((LogPipe *)kv_parser);
   log_pipe_unref(&kv_parser->super);
   scratch_buffers_explicit_gc();
+  cfg_free(cfg);
   app_shutdown();
 }
 

--- a/modules/pseudofile/pseudofile-grammar.ym
+++ b/modules/pseudofile/pseudofile-grammar.ym
@@ -75,6 +75,7 @@ pseudofile_opts
 
 pseudofile_opt
 	: KW_TEMPLATE '(' template_content ')'			{ pseudofile_dd_set_template(last_driver, $3); }
+	| KW_TIME_REOPEN '(' positive_integer ')'	{ pseudofile_dd_set_time_reopen(last_driver, $3); }
 	| { last_template_options = pseudofile_dd_get_template_options(last_driver); } template_option
 	| dest_driver_option
 	;

--- a/modules/pseudofile/pseudofile.h
+++ b/modules/pseudofile/pseudofile.h
@@ -28,6 +28,7 @@
 
 LogTemplateOptions *pseudofile_dd_get_template_options(LogDriver *s);
 void pseudofile_dd_set_template(LogDriver *self, LogTemplate *template);
+void pseudofile_dd_set_time_reopen(LogDriver *s, time_t time_reopen);
 LogDriver *pseudofile_dd_new(gchar *user, GlobalConfig *cfg);
 
 #endif

--- a/news/feature-3585-2.md
+++ b/news/feature-3585-2.md
@@ -1,0 +1,3 @@
+`usertty() destination`: Support changing the terminal disable timeout with the `time-reopen()` option.
+Default timeout change to 60 from 600. If you wish to use the old 600 timeout, add `time-reopen(600)`
+to your config in the `usertty()` driver.

--- a/news/feature-3585.md
+++ b/news/feature-3585.md
@@ -1,0 +1,5 @@
+`time-reopen`: Support the `time-reopen()` option on the driver level for the following drivers:
+ * sources: `example-diskq-source`, `python-fetcher`
+ * destinations: `amqp`, `example-destination`, `file`, `http`, `mongodb`, `network`, `pipe`,
+                 `program`, `pseudofile`, `python`, `redis`, `riemann`, `smtp`, `sql`, `stomp`,
+                 `syslog`, `tcp`, `tcp6`, `udp`, `udp6`, `unix-dgram`, `unix-stream`, `usertty`


### PR DESCRIPTION
Support `time-reopen()` option. `syslog-ng` will wait `time-reopen()` seconds (instead of the previously hard-coded 600), when it could not connect to the usertty terminal, then try to connect again.

Add per driver `time-reopen()` option, for drivers, which were previously supporting it, but was not able to set it per driver.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>