### PR TITLE
system source: fix FreeBSD kernel messages

### DIFF
--- a/modules/system-source/system-source.c
+++ b/modules/system-source/system-source.c
@@ -164,7 +164,7 @@ system_sysblock_add_freebsd_klog(GString *sysblock, const gchar *release)
       strncmp(release, "9.0", 3) == 0)
     system_sysblock_add_file(sysblock, "/dev/klog", 1, "kernel", "no-parse", NULL, FALSE);
   else
-    system_sysblock_add_file(sysblock, "/dev/klog", 0, "kernel", "no-parse", NULL, FALSE);
+    system_sysblock_add_file(sysblock, "/dev/klog", 0, "kernel", NULL, NULL, FALSE);
 }
 
 static gboolean

--- a/news/bugfix-3586.md
+++ b/news/bugfix-3586.md
@@ -1,0 +1,2 @@
+Remove the no-parse flag in system() source from FreeBSD kernel 
+messages, so the message header is no more part of the message.


### PR DESCRIPTION
Remove the no-parse flag from kernel messages, so the message
header is no more part of the message.

Signed-off-by: Peter Czanik <peter@czanik.hu>