### PR TITLE
packaging: simplify spec file for RHEL/Fedora

### DIFF
--- a/news/packaging-3587.md
+++ b/news/packaging-3587.md
@@ -1,0 +1,4 @@
+Simplify spec file by removing obsolete technologies:
+- remove RHEL 6 support
+- remove Python 2 support
+- keep Java support, but remove Java-based drivers (HDFS, etc.)


### PR DESCRIPTION
Simplify spec file by removing obsolete technologies:
- remove RHEL 6 support
- remove Python 2 support
- keep Java support, but remove Java-based drivers (HDFS,
  Elasticsearch, etc.)
- minor reorganization to make it more readable

Signed-off-by: Peter Czanik <peter@czanik.hu>