### PR TITLE
kafka: fix missing log_msg_unref in case of failure

### DIFF
--- a/modules/kafka/kafka-dest-worker.c
+++ b/modules/kafka/kafka-dest-worker.c
@@ -122,6 +122,7 @@ _publish_message(KafkaDestWorker *self, LogMessage *msg)
                 evt_tag_str("driver", owner->super.super.super.id),
                 log_pipe_location_tag(&owner->super.super.super.super));
 
+      log_msg_unref(msg);
       return FALSE;
     }
 


### PR DESCRIPTION
We increase the ref-count when we publish the message to the kafka broker, and normally decrease it in the delivery callback.
However if the publishing fails, the delivery callback is never called, though the message re-publishing will be re-tried again increasing the ref-count of the same message.

After certain number of retries an integer overflow can happen to the ref-counter, causing an abort on the next call of log_msg_ref.