### PR TITLE
dbld/release: create dbld/{install,release,build} dir before docker does

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,9 +39,6 @@ m4/ax*.m4
 .deps
 /lib/cfg-grammar.h
 /test-driver
-dbld/build/
-dbld/release/
-dbld/install/
 dbld/rules.conf
 dbld/extra-files/
 debian/build-tree/

--- a/dbld/build/.gitignore
+++ b/dbld/build/.gitignore
@@ -1,0 +1,7 @@
+# The directory is kept due to docker creating the directory
+# if not exists with root permission. If the directory exists,
+# docker will not change the permission.
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/dbld/install/.gitignore
+++ b/dbld/install/.gitignore
@@ -1,0 +1,7 @@
+# The directory is kept due to docker creating the directory
+# if not exists with root permission. If the directory exists,
+# docker will not change the permission.
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/dbld/release/.gitignore
+++ b/dbld/release/.gitignore
@@ -1,0 +1,7 @@
+# The directory is kept due to docker creating the directory
+# if not exists with root permission. If the directory exists,
+# docker will not change the permission.
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
dbld/rules in some cases may start docker before calling mkdir for the
above listed directories. This may lead to permission issues, as docker
runs as root and creates those directories with root, but the user
calling dbld/rules may not be root user, thus not able to utilize those
directories.

A possible solution would be to make sure in every execution path the
directories are created before docker run. That is full of trial and
error.

This alternative solution adds those directories to git, and as such
make sures the files exists before even the user able to run dbld/rules.

No news file, neither updating NEWS.md.

Tested in my own fork: https://github.com/Kokan/syslog-ng/runs/2030802765?check_suite_focus=true