### PR TITLE
dbld: upgrade bison to 3.7.6

### DIFF
--- a/dbld/builddeps
+++ b/dbld/builddeps
@@ -80,7 +80,7 @@ function install_gradle {
 }
 
 function install_pip2 {
-    download_target "https://bootstrap.pypa.io/2.7/get-pip.py" get-pip.py
+    download_target "https://bootstrap.pypa.io/pip/2.7/get-pip.py" get-pip.py
     python2 get-pip.py
 }
 

--- a/dbld/builddeps
+++ b/dbld/builddeps
@@ -224,28 +224,11 @@ function install_perf {
 }
 
 function install_bison_from_source {
-    BISON_VERSION=3.7.5
+    BISON_VERSION=3.7.6
     cd /tmp
     wget https://ftp.gnu.org/gnu/bison/bison-${BISON_VERSION}.tar.gz
     tar xvfz bison-${BISON_VERSION}.tar.gz
     cd bison-${BISON_VERSION}
-    cat <<EOF | patch -p1
-diff --git a/src/tables.c b/src/tables.c
-index b04a496e..60e3ec93 100644
---- a/src/tables.c
-+++ b/src/tables.c
-@@ -186,8 +186,8 @@ pos_set_set (int pos)
-       bitset_resize (pos_set, new_size);
-       // Shift all the bits by DELTA.
-       // FIXME: add bitset_assign, and bitset_shift?
--      for (int i = new_size - 1; delta <= i ; --i)
--        if (bitset_test (pos_set, i))
-+      for (int i = old_size - 1; i >= -delta ; --i)
-+        if (i >= 0 && bitset_test (pos_set, i))
-           bitset_set (pos_set, i + delta);
-         else
-           bitset_reset (pos_set, i + delta);
-EOF
     ./configure --prefix=/usr/local --disable-nls
     make && make install
 }


### PR DESCRIPTION
This bison version contains the local patch, previously was applied in 5754d6aaea7380b86ca0bb3c2faabe4f63445324
Tested the new bison via the csvparser change: https://github.com/syslog-ng/syslog-ng/pull/3547 
The pip2 link also updated, due to their instruction. 
> The URL you are using to fetch this script has changed, and this one
will no onger work. Please use get-pip.py from the following URL instead:
>
>     https://bootstrap.pypa.io/pip/2.7/get-pip.py
>
> Sorry if this change causes any inconvenience for you!
