### PR TITLE
GitHub workflow changes to allow maintenance releases

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Generate NEWS.md
         run: |
           ./news/create-newsfile.py
-          git commit -a -s -m "NEWS: generate for ${RELEASE_VERSION}"
+          git diff-index --quiet HEAD NEWS.md || git commit -a -s -m "NEWS: generate for ${RELEASE_VERSION}"
 
       - name: "DBLD: release"
         run: |

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -91,5 +91,6 @@ jobs:
 
           git push --force origin ${VERSION_BUMP_BRANCH}
           hub pull-request \
+            --base ${GITHUB_REF} \
             --file /tmp/message \
             --labels "version-bump"

--- a/dbld/prepare-release
+++ b/dbld/prepare-release
@@ -54,7 +54,7 @@ function update_versioning_h() {
 	fi
 
 	OLD_HEX=$(grep "#define VERSION_VALUE_${OLD_MAJOR}_${OLD_MINOR}" ${VERSIONING_H} | grep -o "0x.*$")
-	NEW_HEX=$(printf "0x%04X" $((${OLD_HEX} + 0x0001)) | tr "[:upper:]" "[:lower:]")
+	NEW_HEX=$(printf "0x%04X" $((${NEW_MAJOR} * 256 + ${NEW_MINOR})) | tr "[:upper:]" "[:lower:]")
 
 	if grep "^#define VERSION_VALUE_${NEW_MAJOR}_${NEW_MINOR} ${NEW_HEX}$" ${VERSIONING_H}; then
 		echo "VERSION_VALUE_${NEW_MAJOR}_${NEW_MINOR} is already defined."


### PR DESCRIPTION
These changes allowed me to prepare a maintenance release for 3.31.x using github actions.

The changes are:
1) I wanted to manually update the NEWS file as I was cherry-picking patches without NEWS entries
2) I wanted the PR to be opened against the "3.31/master" branch instead of "master"
3) I needed to fix the versioning.h update, as it was incrementing the hex value instead of just calculating it from major/minor

With these the 3.31.2 PR was generated properly.