### PR TITLE
WIP: defer template compile

### DIFF
--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -159,6 +159,7 @@ gboolean cfg_is_shutting_down(GlobalConfig *cfg);
 void cfg_free(GlobalConfig *self);
 gboolean cfg_init(GlobalConfig *cfg);
 gboolean cfg_deinit(GlobalConfig *cfg);
+gboolean cfg_compile_templates(GlobalConfig *cfg);
 
 PersistConfig *persist_config_new(void);
 void persist_config_free(PersistConfig *self);

--- a/lib/globals.c
+++ b/lib/globals.c
@@ -26,3 +26,4 @@
 
 GlobalConfig *configuration;
 int cfg_parser_debug;
+int template_seq_num;

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -613,6 +613,11 @@ main_loop_read_and_init_config(MainLoop *self)
       return 1;
     }
 
+  if (!cfg_compile_templates(self->current_configuration))
+    {
+      return 1;
+    }
+
   if (options->syntax_only || options->preprocess_into)
     {
       return 0;

--- a/lib/syslog-ng.h
+++ b/lib/syslog-ng.h
@@ -57,5 +57,6 @@ typedef struct _StatsClusterKey StatsClusterKey;
 
 /* configuration being parsed, used by the bison generated code, NULL whenever parsing is finished. */
 extern GlobalConfig *configuration;
+extern int template_seq_num;
 
 #endif

--- a/lib/template/repr.c
+++ b/lib/template/repr.c
@@ -25,6 +25,36 @@
 #include "template/repr.h"
 
 LogTemplateElem *
+log_template_elem_clone(const LogTemplateElem *from)
+{
+  LogTemplateElem *e;
+  e = g_new0(LogTemplateElem, 1);
+  
+  e->type = from->type;
+  e->text_len = from->text_len;
+  e->text = g_strdup(from->text);
+  e->default_value = g_strdup(from->default_value);
+  e->msg_ref = from->msg_ref;
+  e->type = from->type;
+
+  switch (from->type) 
+  {
+    case LTE_MACRO:
+      e->macro = from->macro;
+    break;
+
+    case LTE_VALUE:
+      e->value_handle = from->value_handle;
+    break;
+
+    case LTE_FUNC:
+      // TODO (We should make a proper deep copy)
+      e->func = from->func;
+    break;
+  }
+}
+
+LogTemplateElem *
 log_template_elem_new_macro(const gchar *text, guint macro, gchar *default_value, gint msg_ref)
 {
   LogTemplateElem *e;

--- a/lib/template/repr.h
+++ b/lib/template/repr.h
@@ -60,6 +60,7 @@ LogTemplateElem *log_template_elem_new_value(const gchar *text, gchar *value_nam
 LogTemplateElem *log_template_elem_new_func(LogTemplate *template,
                                             const gchar *text, gint argc, gchar *argv[], gint msg_ref,
                                             GError **error);
+LogTemplateElem *log_template_elem_clone(const LogTemplateElem *from);
 
 void log_template_elem_free_list(GList *el);
 

--- a/lib/template/templates.c
+++ b/lib/template/templates.c
@@ -119,9 +119,36 @@ log_template_reset_compiled(LogTemplate *self)
   self->trivial = FALSE;
 }
 
+
+void log_template_set_raw_template(LogTemplate *self, const gchar *raw_template)
+{
+  g_free(self->raw_template);
+  self->raw_template = g_strdup(raw_template);
+}
+
+gpointer _copy_func(gconstpointer src, gpointer data)
+{
+  LogTemplateElem *tmp = log_template_elem_clone((LogTemplateElem *)src);
+  return (gpointer)tmp;
+}
+
+void log_template_copy(LogTemplate *from, LogTemplate *to)
+{
+  to->template = g_strdup(from->template);
+  to->compiled_template = g_list_copy_deep(from->compiled_template, _copy_func, NULL);
+  to->cfg = from->cfg;
+  to->escape = from->escape;
+  to->def_inline = from->def_inline;
+  to->trivial = from->trivial;
+  to->type_hint = from->type_hint;
+}
+
 gboolean
 log_template_compile(LogTemplate *self, const gchar *template, GError **error)
 {
+  if (self->compiled_template)
+    return TRUE;
+
   LogTemplateCompiler compiler;
   gboolean result;
 
@@ -212,6 +239,7 @@ log_template_free(LogTemplate *self)
   log_template_reset_compiled(self);
   g_free(self->name);
   g_free(self->template);
+  g_free(self->raw_template);
   g_free(self);
 }
 

--- a/lib/template/templates.h
+++ b/lib/template/templates.h
@@ -56,6 +56,7 @@ struct _LogTemplate
 {
   GAtomicCounter ref_cnt;
   gchar *name;
+  gchar *raw_template;
   gchar *template;
   GList *compiled_template;
   GlobalConfig *cfg;
@@ -86,5 +87,9 @@ void log_template_global_deinit(void);
 
 gboolean log_template_on_error_parse(const gchar *on_error, gint *out);
 void log_template_options_set_on_error(LogTemplateOptions *options, gint on_error);
+
+
+void log_template_set_raw_template(LogTemplate *self, const gchar *raw_template);
+void log_template_copy(LogTemplate *from, LogTemplate *to);
 
 #endif


### PR DESCRIPTION
This is a POC code to continue the discussion, started in #3059 

The problem is that we can not refer to a template block prior its declaration. I started the implementation of the only idea we came up: postpone template compilation after we finished parsing the configuration.

The current code is working with a simple config:

<details>
<summary>example config</summary>
<p>

@version: 3.31

template bar "bar template\n";

source s_example {
  example-msg-generator();
};

destination d_file1 {
  file("/tmp/file1"
    template("Hello $MSG World\n")
  );
};

destination d_file2 {
  file("/tmp/file2"
    template(bar)
  );
};

destination d_file3 {
  file("/tmp/file3"
    template(foo)
  );
};

template foo "foo template\n";

log {
  source(s_example);
  destination(d_file1);
  destination(d_file2);
  destination(d_file3);
};

</p>
</details>

However there are details/TODO I want to discuss:

1. As a quick solution, I implemented a not finished "deep copy" of LogTemplate, because I can not replace a template inside a driver. (I also tried to add an "owner" to templates, but this is far from trivial. i.e.: AFFileDestDriver uses multiple templates.) Maybe a callback function?
2. We can not report the location of template compilation errors properly. Maybe passing yylloc to templates?
3. We use small configuration snippets inside unit tests. I completely ignored that part for now.