### PR TITLE
tlscontext: eliminate TVM_NONE when using peer-verify(none)

### DIFF
--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -424,9 +424,6 @@ tls_context_setup_verify_mode(TLSContext *self)
 
   switch (self->verify_mode)
     {
-    case TVM_NONE:
-      verify_mode = SSL_VERIFY_NONE;
-      break;
     case TVM_OPTIONAL | TVM_UNTRUSTED:
       verify_mode = SSL_VERIFY_NONE;
       break;
@@ -910,11 +907,10 @@ tls_verifier_unref(TLSVerifier *self)
 gboolean
 tls_context_set_verify_mode_by_name(TLSContext *self, const gchar *mode_str)
 {
-  if (strcasecmp(mode_str, "none") == 0)
-    self->verify_mode = TVM_NONE;
-  else if (strcasecmp(mode_str, "optional-trusted") == 0 || strcasecmp(mode_str, "optional_trusted") == 0)
+  if (strcasecmp(mode_str, "optional-trusted") == 0 || strcasecmp(mode_str, "optional_trusted") == 0)
     self->verify_mode = TVM_OPTIONAL | TVM_TRUSTED;
-  else if (strcasecmp(mode_str, "optional-untrusted") == 0 || strcasecmp(mode_str, "optional_untrusted") == 0)
+  else if (strcasecmp(mode_str, "optional-untrusted") == 0 || strcasecmp(mode_str, "optional_untrusted") == 0
+           || strcasecmp(mode_str, "none") == 0)
     self->verify_mode = TVM_OPTIONAL | TVM_UNTRUSTED;
   else if (strcasecmp(mode_str, "required-trusted") == 0 || strcasecmp(mode_str, "required_trusted") == 0)
     self->verify_mode = TVM_REQUIRED | TVM_TRUSTED;


### PR DESCRIPTION
TVM_NONE was only used in one place, and it was used in the same
way as "optional-untrusted". So there were no need for it.
However I left the TVM_NONE as the original 0th element of the enum.
Hopefully it will reveal hidden uninitialised issues.

Note: original intention was to modify the behavior of the `tls_session_verify` function, so it will skip certificate validation in case of `peer-verify(none)`.
https://github.com/syslog-ng/syslog-ng/blob/de4997facb5a66c394f625d8562b4923c15425f3/lib/tlscontext.c#L186