### PR TITLE
Fix issue #3598 date parser incorrect sets seconds

### DIFF
--- a/lib/timeutils/tests/test_wallclocktime.c
+++ b/lib/timeutils/tests/test_wallclocktime.c
@@ -332,6 +332,67 @@ Test(wallclocktime, guess_year_returns_next_year)
     cr_assert(_guessed_year_is_current_year(&wct, mon));
 }
 
+Test(wallclocktime, test_strptime_parses_without_date)
+{
+  WallClockTime wct = WALL_CLOCK_TIME_INIT;
+  gchar *end;
+
+  /* Thu Dec 19 22:25:44 CET 2019 */
+  fake_time(1576790744);
+
+  end = wall_clock_time_strptime(&wct, "%H:%M:%S %Z", "10:30:00 CET");
+  wall_clock_time_guess_missing_fields(&wct);
+  cr_expect(end != NULL);
+  cr_expect(wct.wct_year == 119);
+  cr_expect(wct.wct_mon == 11);
+  cr_expect(wct.wct_mday == 19);
+}
+
+Test(wallclocktime, test_strptime_parses_without_mday)
+{
+  WallClockTime wct = WALL_CLOCK_TIME_INIT;
+  gchar *end;
+
+  /* Thu Dec 19 22:25:44 CET 2019 */
+  fake_time(1576790744);
+
+  end = wall_clock_time_strptime(&wct, "%Y-%m %H:%M:%S %Z", "2015-03 10:30:00 CET");
+  wall_clock_time_guess_missing_fields(&wct);
+  cr_expect(end != NULL);
+  cr_expect(wct.wct_mday == 1);
+}
+
+Test(wallclocktime, test_strptime_parses_without_time)
+{
+  WallClockTime wct = WALL_CLOCK_TIME_INIT;
+  gchar *end;
+
+  /* Thu Dec 19 22:25:44 CET 2019 */
+  fake_time(1576790744);
+
+  end = wall_clock_time_strptime(&wct, "%Y-%m-%d %Z", "2015-03-01 CET");
+  wall_clock_time_guess_missing_fields(&wct);
+  cr_expect(end != NULL);
+  cr_expect(wct.wct_hour == 0);
+  cr_expect(wct.wct_min == 0);
+  cr_expect(wct.wct_sec == 0);
+}
+
+Test(wallclocktime, test_strptime_parses_without_second)
+{
+  WallClockTime wct = WALL_CLOCK_TIME_INIT;
+  gchar *end;
+
+  /* Thu Dec 19 22:25:44 CET 2019 */
+  fake_time(1576790744);
+
+  end = wall_clock_time_strptime(&wct, "%Y-%m-%d %H:%M %Z", "2015-03-01 10:30 CET");
+  wall_clock_time_guess_missing_fields(&wct);
+  cr_expect(end != NULL);
+  cr_expect(wct.wct_min == 30);
+  cr_expect(wct.wct_sec == 0);
+}
+
 static void
 setup(void)
 {

--- a/lib/timeutils/wallclocktime.h
+++ b/lib/timeutils/wallclocktime.h
@@ -135,5 +135,6 @@ wall_clock_time_is_set(WallClockTime *wct)
 void wall_clock_time_unset(WallClockTime *wct);
 gchar *wall_clock_time_strptime(WallClockTime *wct, const gchar *format, const gchar *input);
 void wall_clock_time_guess_missing_year(WallClockTime *self);
+void wall_clock_time_guess_missing_fields(WallClockTime *self);
 
 #endif

--- a/modules/timestamp/date-parser.c
+++ b/modules/timestamp/date-parser.c
@@ -96,11 +96,10 @@ _parse_timestamp_and_deduce_missing_parts(DateParser *self, WallClockTime *wct, 
   if (!remainder || remainder[0])
     return FALSE;
 
-  /* hopefully _parse_timestamp will fill the year information, if
-   * not, we are going to need the received year to find it out
-   * heuristically */
+  /* hopefully _parse_timestamp will fill all necessary information, if
+   * not, we are going to guess the missing_fields heuristically */
 
-  wall_clock_time_guess_missing_year(wct);
+  wall_clock_time_guess_missing_fields(wct);
   return TRUE;
 }
 

--- a/modules/timestamp/tests/test_date.c
+++ b/modules/timestamp/tests/test_date.c
@@ -168,6 +168,15 @@ ParameterizedTestParameters(date, test_date_parser)
     { "2015-01-26 00:40:07 EDT", NULL, "%Y-%m-%d %H:%M:%S %Z", LM_TS_STAMP, "2015-01-26T00:40:07-04:00" },
     { "2015-01-26 00:40:07 CET", NULL, "%Y-%m-%d %H:%M:%S %Z", LM_TS_STAMP, "2015-01-26T00:40:07+01:00" },
 
+    /* Try with different missing fields*/
+    { "10:30:00 PDT", NULL, "%H:%M:%S %Z", LM_TS_STAMP, "2015-12-30T10:30:00-07:00" },
+    { "03-17 10:30:00 PDT", NULL, "%m-%d %H:%M:%S %Z", LM_TS_STAMP, "2015-03-17T10:30:00-07:00" },
+    { "03 10:30:00 PDT", NULL, "%m %H:%M:%S %Z", LM_TS_STAMP, "2015-03-01T10:30:00-07:00" },
+    { "2015-03 10:30:00 EDT", NULL, "%Y-%m %H:%M:%S %Z", LM_TS_STAMP, "2015-03-01T10:30:00-04:00" },
+    { "2015-03-01 EDT", NULL, "%Y-%m-%d %Z", LM_TS_STAMP, "2015-03-01T00:00:00-04:00" },
+    { "2015-03 EDT", NULL, "%Y-%m %Z", LM_TS_STAMP, "2015-03-01T00:00:00-04:00" },
+    { "2015-03-01 10:30 EDT", NULL, "%Y-%m-%d %H:%M %Z", LM_TS_STAMP, "2015-03-01T10:30:00-04:00" },
+
   };
 
   return cr_make_param_array(struct date_params, params, sizeof(params) / sizeof(struct date_params));


### PR DESCRIPTION
## Purpose / Description
Fix #3598 date parser incorrect sets seconds
This is because the default value of the `WallClockTime` is -1. After the `mktime()` function is called, we would get an incorrect for undefined filed. For instance, '%Y-%b-%d %I:%M %p%z', where second is not provided.

## Approach
Adding a new function called `set_default_value_for_undefined` to provided default values for undefined fields. I set the default value as in [strptime](https://docs.python.org/3/library/time.html#time.strptime). In addition, testing coverage is added to the unit test.

## How Has This Been Tested?
Pass unit tests
