### PR TITLE
Fix issue #3623 incorrect debug message for loggen

### DIFF
--- a/tests/loggen/loggen_plugin.h
+++ b/tests/loggen/loggen_plugin.h
@@ -29,6 +29,9 @@
 #include <sys/time.h>
 
 #define LOGGEN_PLUGIN_INFO "loggen_plugin_info"
+#define LOGGEN_PLUGIN_LIB_PREFIX "libloggen_"
+#define LOGGEN_PLUGIN_LIB_SUFFIX "_plugin.so"
+#define LOGGEN_PLUGIN_NAME_MAXSIZE 100
 
 typedef struct _plugin_option
 {

--- a/tests/loggen/socket_plugin/socket_plugin.c
+++ b/tests/loggen/socket_plugin/socket_plugin.c
@@ -76,7 +76,7 @@ static GOptionEntry loggen_options[] =
   { NULL }
 };
 
-PluginInfo loggen_plugin_info =
+PluginInfo socket_loggen_plugin_info =
 {
   .name = "socket-plugin",
   .get_options_list = get_options,
@@ -175,7 +175,7 @@ start(PluginOption *option)
       data->option = option;
       data->index = j;
 
-      GThread *thread_id = g_thread_new(loggen_plugin_info.name, active_thread_func, (gpointer)data);
+      GThread *thread_id = g_thread_new(socket_loggen_plugin_info.name, active_thread_func, (gpointer)data);
       g_ptr_array_add(thread_array, (gpointer) thread_id);
     }
 
@@ -185,7 +185,7 @@ start(PluginOption *option)
       data->option = option;
       data->index = j;
 
-      GThread *thread_id = g_thread_new(loggen_plugin_info.name, idle_thread_func, (gpointer)data);
+      GThread *thread_id = g_thread_new(socket_loggen_plugin_info.name, idle_thread_func, (gpointer)data);
       g_ptr_array_add(thread_array, (gpointer) thread_id);
     }
 
@@ -281,7 +281,7 @@ idle_thread_func(gpointer user_data)
 
   g_mutex_unlock(thread_lock);
 
-  DEBUG("thread (%s,%p) created. wait for start ...\n", loggen_plugin_info.name, g_thread_self());
+  DEBUG("thread (%s,%p) created. wait for start ...\n", socket_loggen_plugin_info.name, g_thread_self());
   g_mutex_lock(thread_lock);
   while (!thread_run)
     {
@@ -289,7 +289,7 @@ idle_thread_func(gpointer user_data)
     }
   g_mutex_unlock(thread_lock);
 
-  DEBUG("thread (%s,%p) started. (r=%d,c=%d)\n", loggen_plugin_info.name, g_thread_self(), option->rate,
+  DEBUG("thread (%s,%p) started. (r=%d,c=%d)\n", socket_loggen_plugin_info.name, g_thread_self(), option->rate,
         option->number_of_messages);
 
   while (fd > 0 && thread_run && active_thread_count > 0)
@@ -347,7 +347,7 @@ active_thread_func(gpointer user_data)
 
   g_mutex_unlock(thread_lock);
 
-  DEBUG("thread (%s,%p) created. wait for start ...\n", loggen_plugin_info.name, g_thread_self());
+  DEBUG("thread (%s,%p) created. wait for start ...\n", socket_loggen_plugin_info.name, g_thread_self());
   g_mutex_lock(thread_lock);
   while (!thread_run)
     {
@@ -355,7 +355,7 @@ active_thread_func(gpointer user_data)
     }
   g_mutex_unlock(thread_lock);
 
-  DEBUG("thread (%s,%p) started. (r=%d,c=%d)\n", loggen_plugin_info.name, g_thread_self(), option->rate,
+  DEBUG("thread (%s,%p) started. (r=%d,c=%d)\n", socket_loggen_plugin_info.name, g_thread_self(), option->rate,
         option->number_of_messages);
 
   unsigned long count = 0;
@@ -393,7 +393,7 @@ active_thread_func(gpointer user_data)
       thread_context->sent_messages++;
       thread_context->buckets--;
     }
-  DEBUG("thread (%s,%p) finished\n", loggen_plugin_info.name, g_thread_self());
+  DEBUG("thread (%s,%p) finished\n", socket_loggen_plugin_info.name, g_thread_self());
 
   g_free((gpointer)message);
   g_mutex_lock(thread_lock);

--- a/tests/loggen/ssl_plugin/ssl_plugin.c
+++ b/tests/loggen/ssl_plugin/ssl_plugin.c
@@ -69,7 +69,7 @@ static GOptionEntry loggen_options[] =
   { NULL }
 };
 
-PluginInfo loggen_plugin_info =
+PluginInfo ssl_loggen_plugin_info =
 {
   .name = "ssl-plugin",
   .get_options_list = get_options,
@@ -161,7 +161,7 @@ start(PluginOption *option)
       data->option = option;
       data->index = j;
 
-      GThread *thread_id = g_thread_new(loggen_plugin_info.name, active_thread_func, (gpointer)data);
+      GThread *thread_id = g_thread_new(ssl_loggen_plugin_info.name, active_thread_func, (gpointer)data);
       g_ptr_array_add(thread_array, (gpointer) thread_id);
     }
 
@@ -171,7 +171,7 @@ start(PluginOption *option)
       data->option = option;
       data->index = j;
 
-      GThread *thread_id = g_thread_new(loggen_plugin_info.name, idle_thread_func, (gpointer)data);
+      GThread *thread_id = g_thread_new(ssl_loggen_plugin_info.name, idle_thread_func, (gpointer)data);
       g_ptr_array_add(thread_array, (gpointer) thread_id);
     }
 
@@ -267,7 +267,7 @@ idle_thread_func(gpointer user_data)
 
   g_mutex_unlock(thread_lock);
 
-  DEBUG("thread (%s,%p) created. wait for start ...\n", loggen_plugin_info.name, g_thread_self());
+  DEBUG("thread (%s,%p) created. wait for start ...\n", ssl_loggen_plugin_info.name, g_thread_self());
   g_mutex_lock(thread_lock);
   while (!thread_run)
     {
@@ -275,7 +275,7 @@ idle_thread_func(gpointer user_data)
     }
   g_mutex_unlock(thread_lock);
 
-  DEBUG("thread (%s,%p) started. (r=%d,c=%d)\n", loggen_plugin_info.name, g_thread_self(), option->rate,
+  DEBUG("thread (%s,%p) started. (r=%d,c=%d)\n", ssl_loggen_plugin_info.name, g_thread_self(), option->rate,
         option->number_of_messages);
 
   while (thread_run && active_thread_count>0)
@@ -325,7 +325,7 @@ active_thread_func(gpointer user_data)
 
   g_mutex_unlock(thread_lock);
 
-  DEBUG("thread (%s,%p) created. wait for start ...\n", loggen_plugin_info.name, g_thread_self());
+  DEBUG("thread (%s,%p) created. wait for start ...\n", ssl_loggen_plugin_info.name, g_thread_self());
   g_mutex_lock(thread_lock);
   while (!thread_run)
     {
@@ -333,7 +333,7 @@ active_thread_func(gpointer user_data)
     }
   g_mutex_unlock(thread_lock);
 
-  DEBUG("thread (%s,%p) started. (r=%d,c=%d)\n", loggen_plugin_info.name, g_thread_self(), option->rate,
+  DEBUG("thread (%s,%p) started. (r=%d,c=%d)\n", ssl_loggen_plugin_info.name, g_thread_self(), option->rate,
         option->number_of_messages);
 
   unsigned long count = 0;
@@ -383,7 +383,7 @@ active_thread_func(gpointer user_data)
       thread_context->sent_messages++;
       thread_context->buckets--;
     }
-  DEBUG("thread (%s,%p) finished\n", loggen_plugin_info.name, g_thread_self());
+  DEBUG("thread (%s,%p) finished\n", ssl_loggen_plugin_info.name, g_thread_self());
 
   g_mutex_lock(thread_lock);
   active_thread_count--;


### PR DESCRIPTION
## Purpose / Description
Fix #3623 incorrect debug message  for loggen
This is because socket-plugin and ssl-plugin is implemented as shared libraries, i.e., libloggen_socket_plugin.so and libloggen_ssl_plugin.so. If these two file have global variables with the same identifier, one of them will become invisible.

## Approach
Use different names for different loggen plugins based on the filename.
First, we rename the loggen_plugin_info in socket_plugin.c and change all `loggen_plugin_info.name` to `socket_loggen_plugin_info.name` (take it for example, same for ssl_plugin.c):

```c++
PluginInfo socket_loggen_plugin_info =
{
  .name = "socket-plugin",
  // ...
};
```

Second, we define three Macro in loggen_plugin.h , which will be used later:

```c++
#define LOGGEN_PLUGIN_LIB_PREFIX "libloggen_"
#define LOGGEN_PLUGIN_LIB_SUFFIX "_plugin.so"
#define LOGGEN_PLUGIN_NAME_MAXSIZE 100
```

Third, change the code in `loggen.c`, which infers the name of PluginInfo variable from the fname (for socket_plugin, the fname will be libloggen_socket_plugin.so):

```c++
gchar *full_lib_path = g_build_filename(plugin_path, fname, NULL);
module = g_module_open(full_lib_path, G_MODULE_BIND_LAZY);
g_free(full_lib_path);

if (!module || !g_str_has_prefix(fname, LOGGEN_PLUGIN_LIB_PREFIX) || !g_str_has_suffix(fname, LOGGEN_PLUGIN_LIB_SUFFIX))
  {
    ERROR("error opening plugin module %s (%s)\n", fname, g_module_error());
    continue;
  }

gchar *extracted_fname = g_strndup(fname + strlen(LOGGEN_PLUGIN_LIB_PREFIX),
                                   strlen(fname) - strlen(LOGGEN_PLUGIN_LIB_PREFIX) - strlen(LOGGEN_PLUGIN_LIB_SUFFIX));
g_snprintf(plugin_name, LOGGEN_PLUGIN_NAME_MAXSIZE, "%s_%s", extracted_fname, LOGGEN_PLUGIN_INFO);
g_free(extracted_fname);

/* get plugin info from lib file */
PluginInfo *plugin;
if (!g_module_symbol(module, plugin_name, (gpointer *) &plugin))
  {
    DEBUG("%s isn't a plugin for loggen. skip it. (%s)\n", fname, g_module_error());
    g_module_close(module);
    continue;
  }
```

## How Has This Been Tested?
Pass unit tests