### PR TITLE
test_filters_regexp: skip a negative test in case of old libpcre

### DIFF
--- a/lib/filter/tests/test_filters_regexp.c
+++ b/lib/filter/tests/test_filters_regexp.c
@@ -34,6 +34,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <pcre.h>
 
 TestSuite(filter, .init = setup, .fini = teardown);
 
@@ -50,6 +51,12 @@ typedef struct _FilterParamRegexp
   const gchar *value;
 } FilterParamRegexp;
 
+static gboolean
+check_pcre_version_is_atleast(const gchar *version)
+{
+  return strncmp(pcre_version(), version, strlen(version)) >= 0;
+}
+
 Test(filter, create_pcre_regexp_filter)
 {
   cr_assert_eq(create_pcre_regexp_filter(LM_V_PROGRAM, "((", 0), NULL);
@@ -61,7 +68,8 @@ Test(filter, create_pcre_regexp_filter)
   cr_assert_eq(create_pcre_regexp_filter(LM_V_HOST, "(?iana", 0), NULL);
   cr_assert_eq(create_pcre_regexp_match("((", 0), NULL);
   cr_assert_eq(create_pcre_regexp_match("(?P<foo_123", 0), NULL);  // Unterminated group identifier
-  cr_assert_eq(create_pcre_regexp_match("(?P<1>a)", 0), NULL);  // Begins with a digit
+  if (check_pcre_version_is_atleast("8.34"))
+    cr_assert_eq(create_pcre_regexp_match("(?P<1>a)", 0), NULL);  // Begins with a digit
   cr_assert_eq(create_pcre_regexp_match("(?P<!>a)", 0), NULL);  // Begins with an illegal char
   cr_assert_eq(create_pcre_regexp_match("(?P<foo!>a)", 0), NULL);  // Ends with an illegal char
   cr_assert_eq(create_pcre_regexp_match("\\1", 0), NULL);  // Backreference


### PR DESCRIPTION
PCRE introduced a constraint in pcre 8.34 to named subpatterns: names must start with a non-digit character. [1]
This means that the following pattern is invalid: `(?P<1name>foo)`.

For the current documentation, see: http://pcre.org/original/doc/html/pcrepattern.html#SEC16

[1] https://vcs.pcre.org/pcre?view=revision&sortby=rev&revision=1394