### PR TITLE
cfg-tree: fix empty config crash

### DIFF
--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -1022,6 +1022,12 @@ cfg_tree_compile_sequence(CfgTree *self, LogExprNode *node,
     }
 
 
+  if (!first_pipe && !last_pipe)
+    {
+      /* this is an empty sequence, insert a do-nothing LogPipe */
+      first_pipe = last_pipe = cfg_tree_new_pipe(self, node);
+    }
+
 
   /* NOTE: if flow control is enabled, then we either need to have an
    * embedded log statement (in which case first_pipe is set, as we're not
@@ -1031,12 +1037,6 @@ cfg_tree_compile_sequence(CfgTree *self, LogExprNode *node,
 
   g_assert(((node->flags & LC_FLOW_CONTROL) && (first_pipe || source_join_pipe)) ||
            !(node->flags & LC_FLOW_CONTROL));
-
-  if (!first_pipe && !last_pipe)
-    {
-      /* this is an empty sequence, insert a do-nothing LogPipe */
-      first_pipe = last_pipe = cfg_tree_new_pipe(self, node);
-    }
 
   if (!node_properties_propagated)
     {


### PR DESCRIPTION
Fixes https://github.com/syslog-ng/syslog-ng/issues/3429
An empty logpath with flow-control enabled caused syslog-ng to stop in an assert.

```
@version: 3.29

log {
  flags(flow-control);
};
```

Th crash:
```
ERROR:/home/furiel/workspace/test-syslogng/syslog-ng/lib/cfg-tree.c:1033:cfg_tree_compile_sequence: assertion failed: (((node->flags & LC_FLOW_CONTROL) && (first_pipe || source_join_pipe)) || !(node->flags & LC_FLOW_CONTROL))
```

News entry: I do not think this worth mentioning in the news file.