### PR TITLE
cfg: stop if there is no source configured

### DIFF
--- a/lib/cfg-tree.h
+++ b/lib/cfg-tree.h
@@ -168,6 +168,7 @@ typedef struct _CfgTree
   GPtrArray *rules;
   GHashTable *templates;
   gboolean compiled;
+  gboolean check_zero_source_count;
 } CfgTree;
 
 gboolean cfg_tree_add_object(CfgTree *self, LogExprNode *rule);

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -531,6 +531,7 @@ cfg_new_snippet(void)
 
   self->use_plugin_discovery = FALSE;
   self->enable_forced_modules = FALSE;
+  self->tree.check_zero_source_count = FALSE;
   return self;
 }
 

--- a/lib/tests/test_cfg_tree.c
+++ b/lib/tests/test_cfg_tree.c
@@ -121,6 +121,7 @@ ParameterizedTest(PipeParameter *test_data, cfg_tree, test_pipe_init)
   AlmightyAlwaysPipe *pipe;
 
   cfg_tree_init_instance(&tree, NULL);
+  tree.check_zero_source_count = FALSE;
 
   pipe = create_and_attach_almighty_pipe(&tree, test_data->always_pipe_value);
 
@@ -142,6 +143,7 @@ Test(cfg_tree, test_pipe_init_multi_success)
   CfgTree tree;
 
   cfg_tree_init_instance (&tree, NULL);
+  tree.check_zero_source_count = FALSE;
 
   create_and_attach_almighty_pipe (&tree, TRUE);
   create_and_attach_almighty_pipe (&tree, TRUE);
@@ -161,6 +163,7 @@ Test(cfg_tree, test_pipe_init_multi_with_bad_node)
   CfgTree tree;
 
   cfg_tree_init_instance (&tree, NULL);
+  tree.check_zero_source_count = FALSE;
 
   pipe1 = create_and_attach_almighty_pipe (&tree, TRUE);
   pipe2 = create_and_attach_almighty_pipe (&tree, FALSE);

--- a/tests/python_functional/functional_tests/config_change/test_backtick_substitution.py
+++ b/tests/python_functional/functional_tests/config_change/test_backtick_substitution.py
@@ -48,7 +48,7 @@ block root invalid()
     config.set_raw_config(raw_config)
 
     if expected is True:
-        syslog_ng.start(config)
+        syslog_ng.syntax_check(config)
     else:
         with pytest.raises(Exception):
-            syslog_ng.start(config)
+            syslog_ng.syntax_check(config)

--- a/tests/python_functional/functional_tests/config_change/test_backtick_substitution.py
+++ b/tests/python_functional/functional_tests/config_change/test_backtick_substitution.py
@@ -24,10 +24,19 @@
 
 def test_backtick_substitution(config, syslog_ng):
     raw_config = """
-@define disable none
-options {
-    mark-mode(`disable`);
+@define config-type valid
+block root valid()
+{
+  log { };
 };
+
+block root invalid()
+{
+  this should fail!!
+};
+
+`config-type`();
+
 """
     raw_config = "@version: {}\n".format(config.get_version()) + raw_config
     config.set_raw_config(raw_config)

--- a/tests/python_functional/functional_tests/config_change/test_backtick_substitution.py
+++ b/tests/python_functional/functional_tests/config_change/test_backtick_substitution.py
@@ -33,7 +33,7 @@ def test_backtick_substitution(config, syslog_ng, config_valid, expected):
     raw_config = """
 block root valid()
 {
-  log { };
+  log { source { example-msg-generator(); }; };
 };
 
 block root invalid()

--- a/tests/python_functional/functional_tests/config_change/test_backtick_substitution.py
+++ b/tests/python_functional/functional_tests/config_change/test_backtick_substitution.py
@@ -20,11 +20,17 @@
 # COPYING for details.
 #
 #############################################################################
+import pytest
 
 
-def test_backtick_substitution(config, syslog_ng):
+@pytest.mark.parametrize(
+    "config_valid,expected", [
+        ("valid", True),
+        ("invalid", False),
+    ],
+)
+def test_backtick_substitution(config, syslog_ng, config_valid, expected):
     raw_config = """
-@define config-type valid
 block root valid()
 {
   log { };
@@ -38,7 +44,11 @@ block root invalid()
 `config-type`();
 
 """
-    raw_config = "@version: {}\n".format(config.get_version()) + raw_config
+    raw_config = "@version: {}\n@define config-type {}\n".format(config.get_version(), config_valid) + raw_config
     config.set_raw_config(raw_config)
 
-    syslog_ng.start(config)
+    if expected is True:
+        syslog_ng.start(config)
+    else:
+        with pytest.raises(Exception):
+            syslog_ng.start(config)

--- a/tests/python_functional/functional_tests/source_drivers/file_source/test_follow_freq_value.py
+++ b/tests/python_functional/functional_tests/source_drivers/file_source/test_follow_freq_value.py
@@ -40,7 +40,7 @@ def test_follow_freq_value(config, syslog_ng, follow_freq, expected):
     config.set_raw_config(raw_config)
 
     if expected is True:
-        syslog_ng.start(config)
+        syslog_ng.syntax_check(config)
     else:
         with pytest.raises(Exception):
-            syslog_ng.start(config)
+            syslog_ng.syntax_check(config)

--- a/tests/python_functional/functional_tests/source_drivers/file_source/test_follow_freq_value.py
+++ b/tests/python_functional/functional_tests/source_drivers/file_source/test_follow_freq_value.py
@@ -36,7 +36,7 @@ import pytest
     ],
 )
 def test_follow_freq_value(config, syslog_ng, follow_freq, expected):
-    raw_config = '@version: {}\nsource s_file {{ file("input.log" follow-freq({})); }};'.format(config.get_version(), follow_freq)
+    raw_config = '@version: {}\nsource s_file {{ file("input.log" follow-freq({})); }}; log {{ source(s_file); }};'.format(config.get_version(), follow_freq)
     config.set_raw_config(raw_config)
 
     if expected is True:

--- a/tests/python_functional/src/syslog_ng/syslog_ng.py
+++ b/tests/python_functional/src/syslog_ng/syslog_ng.py
@@ -32,6 +32,9 @@ class SyslogNg(object):
     def start(self, config, stderr=True, debug=True, trace=True, verbose=True, startup_debug=True, no_caps=True, config_path=None, persist_path=None, pid_path=None, control_socket_path=None):
         return self.__syslog_ng_cli.start(config, stderr, debug, trace, verbose, startup_debug, no_caps, config_path, persist_path, pid_path, control_socket_path)
 
+    def syntax_check(self, config):
+        return self.__syslog_ng_cli.syntax_check(config)
+
     def stop(self, unexpected_messages=None):
         self.__syslog_ng_cli.stop(unexpected_messages)
 

--- a/tests/python_functional/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/python_functional/src/syslog_ng/syslog_ng_cli.py
@@ -110,7 +110,6 @@ class SyslogNgCli(object):
 
         config.write_config(self.__instance_paths.get_config_path())
 
-        self.__syntax_check()
         self.__start_syslog_ng()
 
         logger.info("syslog-ng process has been started with PID: {}\n".format(self.__process.pid))

--- a/tests/python_functional/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/python_functional/src/syslog_ng/syslog_ng_cli.py
@@ -70,7 +70,8 @@ class SyslogNgCli(object):
             command_short_name="syntax_only", command=["--syntax-only", "--cfgfile={}".format(config_path)],
         )
 
-    def __syntax_check(self):
+    def syntax_check(self, config):
+        config.write_config(self.__instance_paths.get_config_path())
         result = self.__syntax_only()
         if result["exit_code"] != 0:
             logger.error(result["stderr"])


### PR DESCRIPTION
If there is no source configured in syslog-ng, there is not much it can do. Instead starting up and doing nothing, syslog-ng should not accept configuration that has no source.

This config has a source `s`, but that is not connected to any logpath, thus nothing is going to really happen.
```
@version: 3.30

source s { file("/tmp/foo"); };

log {
  destination { file("/tmp/bar"); }
};
```

Doing a detection on empty logpath (not nested ones) could be also done, and warning the user in those cases.
A related issue: https://github.com/syslog-ng/syslog-ng/issues/1161 (but this PR does not everything covered by that issue).
News file is missing.