### PR TITLE
Fix issue #3469: add reconnect opt in loggen

### DIFF
--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -57,6 +57,7 @@ static PluginOption global_plugin_option =
   .target = NULL,
   .port = NULL,
   .rate = 1000,
+  .reconnect = 0,
 };
 
 static char *sdata_value = NULL;
@@ -99,6 +100,7 @@ static GOptionEntry loggen_options[] =
   { "number", 'n', 0, G_OPTION_ARG_INT, &global_plugin_option.number_of_messages, "Number of messages to generate", "<number>" },
   { "quiet", 'Q', 0, G_OPTION_ARG_NONE, &quiet, "Don't print the msg/sec data", NULL },
   { "debug", 0, 0, G_OPTION_ARG_NONE, &debug, "Enable loggen debug messages", NULL },
+  { "reconnect", 0, 0, G_OPTION_ARG_NONE, &global_plugin_option.reconnect, "Attempt to reconnect when destination connections are lost", NULL},
   { NULL }
 };
 

--- a/tests/loggen/loggen_plugin.h
+++ b/tests/loggen/loggen_plugin.h
@@ -45,6 +45,7 @@ typedef struct _plugin_option
   const char *target; /* command line argument */
   const char *port;
   int  rate;
+  int reconnect;
 } PluginOption;
 
 typedef struct _thread_data

--- a/tests/loggen/socket_plugin/socket_plugin.c
+++ b/tests/loggen/socket_plugin/socket_plugin.c
@@ -390,10 +390,13 @@ active_thread_func(gpointer user_data)
 
       connection_error = send_msg(fd, message, str_len);
 
-      thread_context->sent_messages++;
-      thread_context->buckets--;
+      if(!connection_error)
+        {
+          thread_context->sent_messages++;
+          thread_context->buckets--;
+        }
 
-      if(connection_error && option->reconnect)
+      if(connection_error && option->reconnect && thread_run)
         {
           shutdown(fd, SHUT_RDWR);
           close(fd);

--- a/tests/loggen/socket_plugin/socket_plugin.c
+++ b/tests/loggen/socket_plugin/socket_plugin.c
@@ -392,6 +392,35 @@ active_thread_func(gpointer user_data)
 
       thread_context->sent_messages++;
       thread_context->buckets--;
+
+      if(connection_error && option->reconnect)
+        {
+          shutdown(fd, SHUT_RDWR);
+          close(fd);
+
+          ERROR("destination connection %s:%s (%p) is lost, try to reconnect\n", option->target, option->port, g_thread_self());
+          if (unix_socket_x)
+            fd = connect_unix_domain_socket(sock_type, option->target);
+          else
+            fd = connect_ip_socket(sock_type, option->target, option->port, option->use_ipv6);
+
+          while(fd < 0 && !thread_check_exit_criteria(thread_context))
+            {
+              ERROR("can not reconnect to %s:%s (%p), try again after %d sec\n", option->target, option->port, g_thread_self(), 1);
+              g_usleep(1e6);
+
+              if (unix_socket_x)
+                fd = connect_unix_domain_socket(sock_type, option->target);
+              else
+                fd = connect_ip_socket(sock_type, option->target, option->port, option->use_ipv6);
+            }
+
+          if(fd > 0)
+            {
+              DEBUG("(%d) reconnected to server on socket %d (%p)\n", thread_context->index, fd, g_thread_self());
+              connection_error = FALSE;
+            }
+        }
     }
   DEBUG("thread (%s,%p) finished\n", socket_loggen_plugin_info.name, g_thread_self());
 

--- a/tests/loggen/ssl_plugin/ssl_plugin.c
+++ b/tests/loggen/ssl_plugin/ssl_plugin.c
@@ -382,6 +382,32 @@ active_thread_func(gpointer user_data)
 
       thread_context->sent_messages++;
       thread_context->buckets--;
+
+      if(connection_error && option->reconnect)
+        {
+          close_ssl_connection(ssl);
+          shutdown(sock_fd, SHUT_RDWR);
+          close(sock_fd);
+
+          ERROR("destination connection %s:%s (%p) is lost, try to reconnect\n", option->target, option->port, g_thread_self());
+          sock_fd = connect_ip_socket(SOCK_STREAM, option->target, option->port, option->use_ipv6);;
+          ssl = open_ssl_connection(sock_fd);
+
+          while(ssl == NULL && !thread_check_exit_criteria(thread_context))
+            {
+              ERROR("can not reconnect to %s:%s (%p), try again after %d sec\n", option->target, option->port, g_thread_self(), 1);
+              g_usleep(1e6);
+
+              sock_fd = connect_ip_socket(SOCK_STREAM, option->target, option->port, option->use_ipv6);;
+              ssl = open_ssl_connection(sock_fd);
+            }
+
+          if(ssl != NULL)
+            {
+              DEBUG("(%d) reconnected to server on socket (%p)\n", thread_context->index, g_thread_self());
+              connection_error = FALSE;
+            }
+        }
     }
   DEBUG("thread (%s,%p) finished\n", ssl_loggen_plugin_info.name, g_thread_self());
 

--- a/tests/loggen/ssl_plugin/ssl_plugin.c
+++ b/tests/loggen/ssl_plugin/ssl_plugin.c
@@ -247,7 +247,7 @@ idle_thread_func(gpointer user_data)
   PluginOption *option = thread_context->option;
   int thread_index = thread_context->index;
 
-  int sock_fd = connect_ip_socket(SOCK_STREAM, option->target, option->port, option->use_ipv6);;
+  int sock_fd = connect_ip_socket(SOCK_STREAM, option->target, option->port, option->use_ipv6);
 
   SSL *ssl = open_ssl_connection(sock_fd);
   if (ssl == NULL)
@@ -304,7 +304,7 @@ active_thread_func(gpointer user_data)
 
   char *message = g_malloc0(MAX_MESSAGE_LENGTH+1);
 
-  int sock_fd = connect_ip_socket(SOCK_STREAM, option->target, option->port, option->use_ipv6);;
+  int sock_fd = connect_ip_socket(SOCK_STREAM, option->target, option->port, option->use_ipv6);
 
   SSL *ssl = open_ssl_connection(sock_fd);
 
@@ -380,8 +380,11 @@ active_thread_func(gpointer user_data)
           sent += rc;
         }
 
-      thread_context->sent_messages++;
-      thread_context->buckets--;
+      if(!connection_error)
+        {
+          thread_context->sent_messages++;
+          thread_context->buckets--;
+        }
 
       if(connection_error && option->reconnect)
         {
@@ -390,7 +393,7 @@ active_thread_func(gpointer user_data)
           close(sock_fd);
 
           ERROR("destination connection %s:%s (%p) is lost, try to reconnect\n", option->target, option->port, g_thread_self());
-          sock_fd = connect_ip_socket(SOCK_STREAM, option->target, option->port, option->use_ipv6);;
+          sock_fd = connect_ip_socket(SOCK_STREAM, option->target, option->port, option->use_ipv6);
           ssl = open_ssl_connection(sock_fd);
 
           while(ssl == NULL && !thread_check_exit_criteria(thread_context))
@@ -398,7 +401,7 @@ active_thread_func(gpointer user_data)
               ERROR("can not reconnect to %s:%s (%p), try again after %d sec\n", option->target, option->port, g_thread_self(), 1);
               g_usleep(1e6);
 
-              sock_fd = connect_ip_socket(SOCK_STREAM, option->target, option->port, option->use_ipv6);;
+              sock_fd = connect_ip_socket(SOCK_STREAM, option->target, option->port, option->use_ipv6);
               ssl = open_ssl_connection(sock_fd);
             }
 

--- a/tests/python_functional/functional_tests/Makefile.am
+++ b/tests/python_functional/functional_tests/Makefile.am
@@ -37,5 +37,6 @@ EXTRA_DIST += \
 	tests/python_functional/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_with_syslog_proto.py \
 	tests/python_functional/functional_tests/source_options/test_use_syslogng_pid.py \
 	tests/python_functional/functional_tests/template_functions/graphite-output/test_graphite_output.py \
-	tests/python_functional/functional_tests/template_functions/slog/test_secure_logging.py
+	tests/python_functional/functional_tests/template_functions/slog/test_secure_logging.py \
+	tests/python_functional/functional_tests/tools/loggen/test_loggen_with_reconnect.py
 

--- a/tests/python_functional/functional_tests/tools/loggen/test_loggen_with_reconnect.py
+++ b/tests/python_functional/functional_tests/tools/loggen/test_loggen_with_reconnect.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2020 One Identity
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+NUMBER_OF_MESSAGES = 3
+
+
+def test_loggen_with_reconnect(config, port_allocator, syslog_ng, loggen):
+    network_source = config.create_network_source(ip="localhost", port=port_allocator())
+    file_destination = config.create_file_destination(file_name="output.log")
+    config.create_logpath(statements=[network_source, file_destination])
+
+    syslog_ng.start(config)
+
+    loggen.start(
+        network_source.options["ip"], network_source.options["port"], inet=True,
+        rate=1, active_connections=1, reconnect=True, interval=30, number=NUMBER_OF_MESSAGES,
+    )
+
+    syslog_ng.stop()
+    syslog_ng.start(config)
+
+    logs = file_destination.read_logs(counter=NUMBER_OF_MESSAGES - 1)
+
+    # the send function of socket only write data to the output buffer, if the remote host is lost
+    # the message in the buffer will be discarded, result in len(logs)=NUMBER_OF_MESSAGES-1
+    assert len(logs) == NUMBER_OF_MESSAGES - 1

--- a/tests/python_functional/src/helpers/loggen/loggen.py
+++ b/tests/python_functional/src/helpers/loggen/loggen.py
@@ -42,7 +42,7 @@ class Loggen(object):
     def __decode_start_parameters(
         self, inet, unix, stream, dgram, use_ssl, dont_parse, read_file, skip_tokens, loop_reading,
         rate, interval, permanent, syslog_proto, proxied, sdata, no_framing, active_connections,
-        idle_connections, ipv6, debug, number, csv, quiet, size,
+        idle_connections, ipv6, debug, number, csv, quiet, size, reconnect,
     ):
 
         start_parameters = []
@@ -119,12 +119,15 @@ class Loggen(object):
         if size is not None:
             start_parameters.append("--size={}".format(size))
 
+        if reconnect is True:
+            start_parameters.append("--reconnect")
+
         return start_parameters
 
     def start(
         self, target, port, inet=None, unix=None, stream=None, dgram=None, use_ssl=None, dont_parse=None, read_file=None, skip_tokens=None, loop_reading=None,
         rate=None, interval=None, permanent=None, syslog_proto=None, proxied=None, sdata=None, no_framing=None, active_connections=None,
-        idle_connections=None, ipv6=None, debug=None, number=None, csv=None, quiet=None, size=None,
+        idle_connections=None, ipv6=None, debug=None, number=None, csv=None, quiet=None, size=None, reconnect=None,
     ):
 
         if self.loggen_proc is not None and self.loggen_proc.is_running():
@@ -137,7 +140,7 @@ class Loggen(object):
         self.parameters = self.__decode_start_parameters(
             inet, unix, stream, dgram, use_ssl, dont_parse, read_file, skip_tokens, loop_reading,
             rate, interval, permanent, syslog_proto, proxied, sdata, no_framing, active_connections,
-            idle_connections, ipv6, debug, number, csv, quiet, size,
+            idle_connections, ipv6, debug, number, csv, quiet, size, reconnect,
         )
 
         self.loggen_proc = ProcessExecutor().start(


### PR DESCRIPTION

## Purpose / Description

Fix [#3469](https://github.com/syslog-ng/syslog-ng/issues/3469) loggen should attempt reconnect when destination connections are lost

When destination connections are lost, loggen just stopped sending and never reconnected.

## Approach

Add a new opt in loggen_options,

```
{ "reconnect", 0, 0, G_OPTION_ARG_NONE, &global_plugin_option.reconnect, "Attempt to reconnect when destination connections are lost", NULL},
```

and if encounter connection_error and option->reconnect is true, try to reconnect.