### PR TITLE
WIP: logthreaded_dest_driver_init_method: add persist_name as a parameter

### DIFF
--- a/lib/logthrdest/logthrdestdrv.h
+++ b/lib/logthrdest/logthrdestdrv.h
@@ -146,6 +146,7 @@ struct _LogThreadedDestDriver
    * increased in parallel by the multiple threads. */
 
   gint32 shared_seq_num;
+  gchar *persist_name_for_assertion;
 
   WorkerOptions worker_options;
   const gchar *(*format_stats_instance)(LogThreadedDestDriver *s);
@@ -227,7 +228,7 @@ void log_threaded_dest_worker_free_method(LogThreadedDestWorker *self);
 void log_threaded_dest_worker_free(LogThreadedDestWorker *self);
 
 gboolean log_threaded_dest_driver_deinit_method(LogPipe *s);
-gboolean log_threaded_dest_driver_init_method(LogPipe *s);
+gboolean log_threaded_dest_driver_init_method(LogPipe *s, const gchar *persist_name);
 gboolean log_threaded_dest_driver_start_workers(LogPipe *s);
 
 void log_threaded_dest_driver_init_instance(LogThreadedDestDriver *self, GlobalConfig *cfg);

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -725,7 +725,7 @@ afamqp_dd_init(LogPipe *s)
       return FALSE;
     }
 
-  if (!log_threaded_dest_driver_init_method(s))
+  if (!log_threaded_dest_driver_init_method(s, afamqp_dd_format_persist_name(s)))
     return FALSE;
 
   log_template_options_init(&self->template_options, cfg);

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -509,7 +509,7 @@ _init(LogPipe *s)
   if (!afmongodb_dd_private_uri_init(&self->super.super.super))
     return FALSE;
 
-  if (!log_threaded_dest_driver_init_method(s))
+  if (!log_threaded_dest_driver_init_method(s, _format_persist_name(s)))
     return FALSE;
 
   return TRUE;

--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -608,7 +608,7 @@ afsmtp_dd_init(LogPipe *s)
   if (!__check_required_options(self))
     return FALSE;
 
-  if (!log_threaded_dest_driver_init_method(s))
+  if (!log_threaded_dest_driver_init_method(s, afsmtp_dd_format_persist_name(s)))
     return FALSE;
 
   log_template_options_init(&self->template_options, cfg);

--- a/modules/afsnmp/afsnmpdest.c
+++ b/modules/afsnmp/afsnmpdest.c
@@ -636,7 +636,7 @@ snmpdest_dd_init(LogPipe *s)
       return FALSE;
     }
 
-  if (!log_threaded_dest_driver_init_method(s))
+  if (!log_threaded_dest_driver_init_method(s, snmpdest_dd_format_persist_name(s)))
     return FALSE;
 
   log_template_options_init(&self->template_options, cfg);

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1135,7 +1135,7 @@ afsql_dd_init(LogPipe *s)
   if (!_init_fields_from_columns_and_values(self))
     return FALSE;
 
-  if (!log_threaded_dest_driver_init_method(s))
+  if (!log_threaded_dest_driver_init_method(s, afsql_dd_format_persist_name(s)))
     return FALSE;
 
   log_template_options_init(&self->template_options, cfg);

--- a/modules/afstomp/afstomp.c
+++ b/modules/afstomp/afstomp.c
@@ -347,7 +347,7 @@ afstomp_dd_init(LogPipe *s)
   STOMPDestDriver *self = (STOMPDestDriver *) s;
   GlobalConfig *cfg = log_pipe_get_config(s);
 
-  if (!log_threaded_dest_driver_init_method(s))
+  if (!log_threaded_dest_driver_init_method(s, afstomp_dd_format_persist_name(s)))
     return FALSE;
 
   log_template_options_init(&self->template_options, cfg);

--- a/modules/examples/destinations/example_destination/example_destination.c
+++ b/modules/examples/destinations/example_destination/example_destination.c
@@ -83,7 +83,7 @@ _dd_init(LogPipe *d)
   if (!self->filename->len)
     g_string_assign(self->filename, "/tmp/example-destination-output.txt");
 
-  if (!log_threaded_dest_driver_init_method(d))
+  if (!log_threaded_dest_driver_init_method(d, _format_persist_name(d)))
     return FALSE;
 
   return TRUE;

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -357,7 +357,7 @@ http_dd_init(LogPipe *s)
   /* we need to set up url before we call the inherited init method, so our stats key is correct */
   self->url = self->load_balancer->targets[0].url;
 
-  if (!log_threaded_dest_driver_init_method(s))
+  if (!log_threaded_dest_driver_init_method(s, _format_persist_name(s)))
     return FALSE;
 
   log_template_options_init(&self->template_options, cfg);

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -130,6 +130,21 @@ java_dd_set_template_string(LogDriver *s, const gchar *template_string)
   self->template_string = g_strdup(template_string);
 }
 
+static const gchar *
+java_dd_format_persist_name(const LogPipe *s)
+{
+  const JavaDestDriver *self = (const JavaDestDriver *)s;
+  static gchar persist_name[1024];
+
+  if (s->persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "java_dst.%s", s->persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "java_dst(%s)",
+               java_destination_proxy_get_name_by_uniq_options(self->proxy));
+
+  return persist_name;
+}
+
 gboolean
 java_dd_init(LogPipe *s)
 {
@@ -157,7 +172,7 @@ java_dd_init(LogPipe *s)
   if (!java_destination_proxy_init(self->proxy))
     return FALSE;
 
-  if (!log_threaded_dest_driver_init_method(s))
+  if (!log_threaded_dest_driver_init_method(s, java_dd_format_persist_name(s)))
     return FALSE;
 
   return TRUE;
@@ -232,21 +247,6 @@ java_worker_thread_deinit(LogThreadedDestDriver *d)
 {
   java_dd_close(d);
   java_machine_detach_thread();
-}
-
-static const gchar *
-java_dd_format_persist_name(const LogPipe *s)
-{
-  const JavaDestDriver *self = (const JavaDestDriver *)s;
-  static gchar persist_name[1024];
-
-  if (s->persist_name)
-    g_snprintf(persist_name, sizeof(persist_name), "java_dst.%s", s->persist_name);
-  else
-    g_snprintf(persist_name, sizeof(persist_name), "java_dst(%s)",
-               java_destination_proxy_get_name_by_uniq_options(self->proxy));
-
-  return persist_name;
 }
 
 static const gchar *

--- a/modules/kafka/kafka-dest-driver.c
+++ b/modules/kafka/kafka-dest-driver.c
@@ -539,7 +539,7 @@ kafka_dd_init(LogPipe *s)
   if (!_init_topic_name(self))
     return FALSE;
 
-  if (!log_threaded_dest_driver_init_method(s))
+  if (!log_threaded_dest_driver_init_method(s, _format_persist_name(s)))
     return FALSE;
 
   if (self->message == NULL)

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -568,7 +568,7 @@ python_dd_init(LogPipe *d)
     goto fail;
   PyGILState_Release(gstate);
 
-  if (!log_threaded_dest_driver_init_method(d))
+  if (!log_threaded_dest_driver_init_method(d, python_dd_format_persist_name(d)))
     return FALSE;
 
   gstate = PyGILState_Ensure();

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -397,7 +397,7 @@ redis_dd_init(LogPipe *s)
       return FALSE;
     }
 
-  if (!log_threaded_dest_driver_init_method(s))
+  if (!log_threaded_dest_driver_init_method(s, redis_dd_format_persist_name(s)))
     return FALSE;
 
   log_template_options_init(&self->template_options, cfg);

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -263,7 +263,7 @@ riemann_dd_init(LogPipe *s)
   if (self->port == -1)
     self->port = 5555;
 
-  if (!log_threaded_dest_driver_init_method(s))
+  if (!log_threaded_dest_driver_init_method(s, riemann_dd_format_persist_name(s)))
     return FALSE;
 
   if (!self->fields.host)


### PR DESCRIPTION
Continuation of #3559.

We moved the log_threaded_dest_driver_init_method in each ancesstor
to a place where it is safe to call the generate_persist_name virtual
function. But the code failed to express the reason behind it.

This PR adds the persist_name as a parameter of the public function
to make that dependency between those methods explicit.

To avoid any mismatch between the provided parameter and the result of
later generate_persist_name function calls, the LogThreadedDestDriver
stores the provided value.

Note: To preserve the LogPipe interface, it is still possible to call
the original init_method function. (This is the case when an ancestor
doesn't override it.) In that case the LogThreadedDestDriver will
generate the name internally using the generate_persist_name function.