### PR TITLE
cfg-lex: lookup already defined arguments in block argument definitions

### DIFF
--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -40,7 +40,7 @@ yy_input_run_backtick_substitution(CfgLexer *self, gchar *buf, gsize buf_size, g
   GError *error = NULL;
   CFG_LTYPE *cur_lloc = &self->include_stack[self->include_depth].lloc;
 
-  res = cfg_lexer_subst_args_in_input(self->cfg->globals, NULL, NULL, buf, -1, len, &error);
+  res = cfg_lexer_subst_args_in_input(self->cfg->globals, last_block_args ?: NULL, NULL, buf, -1, len, &error);
   if (!res)
     {
       msg_error("Error performing backtick substitution in configuration file",


### PR DESCRIPTION
notes:
 *  it might not the best solution  - but short and solves my problem... it's just a proposal that can be discussed
 *  nothing depends on this PR

example:
```
block destination test_http (
  body-parts("host=$HOST severity=$LEVEL")
  body("$(format-json --scope none `body-parts`)")
  ...)
{
          http(
            method("POST")
            url("http://localhost:8888")
            body(`body`)
            `__VARARGS__`
            );
};
```

Motivation:

when we have an existing SCL, like this:

```
block destination test_http (
  body-parts("host=$HOST severity=$LEVEL")
  ...)
{
          http(
            method("POST")
            url("http://localhost:8888")
            body("$(format-json --scope none `body-parts`)")
            `__VARARGS__`
            );
};
```

and `body-parts` cannot express what we really need, we have to create
a new SCL. With resolving already defined block arguments we can avoid unnecessary
copy-pastes and we can also keep backward compatibility...
On the other hand - this works only for already defined arguments. So
it won't work if the order of `body-parts` and `body` are replaced.
