### PR TITLE
scl: fix wrong ownership during installation

### DIFF
--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -51,7 +51,7 @@ scl-install-data-local:
 		fi; \
 	done
 	$(mkinstalldirs) $(DESTDIR)/$(scldir)
-	(cd $(srcdir)/scl; tar cf - $(SCL_SUBDIRS)) | (cd $(DESTDIR)/$(scldir) && tar xf -)
+	(cd $(srcdir)/scl; tar cf - $(SCL_SUBDIRS)) | (cd $(DESTDIR)/$(scldir) && tar xf - --no-same-owner)
 	chmod -R u+rwX $(DESTDIR)/$(scldir)
 
 scl-uninstall-local:


### PR DESCRIPTION
The ownership of build user is preserved for some target files, fixed it by
adding --no-same-owner option to tar when extracting files.

Signed-off-by: Ming Liu <ming.liu@windriver.com>
Signed-off-by: Yi Fan Yu <yifan.yu@windriver.com>