### PR TITLE
configure.ac: add option --enable-thread-tls to manage thread ssl sup…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -210,6 +210,8 @@ AC_ARG_WITH(sanitizer,
               [  --with-sanitizer=[address/undefined/etc...]
                                          Enables compiler sanitizer supports (default: no)]
               ,,with_sanitizer="no")
+AC_ARG_ENABLE(thread-tls,
+              [  --enable-thread-tls        Enable Thread Local Storage support (default: yes)],,enable_thread_tls="yes")
 
 AC_ARG_ENABLE(dynamic-linking,
               [  --enable-dynamic-linking        Link everything dynamically.],,enable_dynamic_linking="auto")
@@ -628,12 +630,14 @@ dnl ***************************************************************************
 dnl Is the __thread keyword available?
 dnl ***************************************************************************
 
-AC_LINK_IFELSE([AC_LANG_PROGRAM(
-[[#include <pthread.h>
-__thread int a;
-]],
-[a=0;])],
-[ac_cv_have_tls=yes; AC_DEFINE_UNQUOTED(HAVE_THREAD_KEYWORD, 1, "Whether Thread Local Storage is supported by the system")])
+if test "x$enable_thread_tls" = "xyes"; then
+    AC_LINK_IFELSE([AC_LANG_PROGRAM(
+    [[#include <pthread.h>
+    __thread int a;
+    ]],
+    [a=0;])],
+    [ac_cv_have_tls=yes; AC_DEFINE_UNQUOTED(HAVE_THREAD_KEYWORD, 1, "Whether Thread Local Storage is supported by the system")])
+fi
 
 dnl ***************************************************************************
 dnl How to do static linking?


### PR DESCRIPTION
…port

The thread local storage caused arm-gcc broken while compiling                          │
syslog-ng with option '-g -O'.                                                          │
...                                                                                     │
dnscache.s: Assembler messages:                                                         │
dnscache.s:100: Error: invalid operands (.text and *UND* sections) for `-'              │
...                                                                                     │
                                                                                        │
Add option --enable-thread-tls to manage the including of thread
local storage, so we could explicitly disable it.

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>

change default to 'yes'

Signed-off-by: Yi Fan Yu <yifan.yu@windriver.com>