### PR TITLE
Postpone backtick substitution for block args

### DIFF
--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -36,6 +36,10 @@
 static gboolean
 yy_input_run_backtick_substitution(CfgLexer *self, gchar *buf, gsize buf_size, gsize *len)
 {
+  if (cfg_lexer_is_backtick_substitution_postponed(self))
+    {
+      return TRUE;
+    }
   gchar *res;
   GError *error = NULL;
   CFG_LTYPE *cur_lloc = &self->include_stack[self->include_depth].lloc;

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -182,6 +182,24 @@ cfg_lexer_format_location_tag(CfgLexer *self, CFG_LTYPE *yylloc)
   return evt_tag_str("location", cfg_lexer_format_location(self, yylloc, buf, sizeof(buf)));
 }
 
+gboolean
+cfg_lexer_is_backtick_substitution_postponed(CfgLexer *self)
+{
+  return self->backtick_subst_postponed;
+}
+
+void
+cfg_lexer_postpone_backtick_substition(CfgLexer *self)
+{
+  self->backtick_subst_postponed = TRUE;
+}
+
+void
+cfg_lexer_enable_immediate_backtick_substition(CfgLexer *self)
+{
+  self->backtick_subst_postponed = FALSE;
+}
+
 int
 cfg_lexer_lookup_keyword(CfgLexer *self, CFG_STYPE *yylval, CFG_LTYPE *yylloc, const char *token)
 {

--- a/lib/cfg-lexer.h
+++ b/lib/cfg-lexer.h
@@ -177,6 +177,7 @@ struct _CfgLexer
   GString *token_text;
   GlobalConfig *cfg;
   gboolean non_pragma_seen:1, ignore_pragma:1;
+  gboolean backtick_subst_postponed:1;
 };
 
 /* pattern buffer */
@@ -200,6 +201,9 @@ gboolean cfg_lexer_include_buffer_without_backtick_substitution(CfgLexer *self,
     const gchar *name, const gchar *buffer, gsize length);
 const gchar *cfg_lexer_format_location(CfgLexer *self, CFG_LTYPE *yylloc, gchar *buf, gsize buf_len);
 EVTTAG *cfg_lexer_format_location_tag(CfgLexer *self, CFG_LTYPE *yylloc);
+gboolean cfg_lexer_is_backtick_substitution_postponed(CfgLexer *self);
+void cfg_lexer_postpone_backtick_substition(CfgLexer *self);
+void cfg_lexer_enable_immediate_backtick_substition(CfgLexer *self);
 
 /* context tracking */
 void cfg_lexer_push_context(CfgLexer *self, gint context, CfgLexerKeyword *keywords, const gchar *desc);


### PR DESCRIPTION
### Motivation:

When we have an existing SCL, like this:
    
```
block destination test_http (
    body-parts("host=$HOST severity=$LEVEL")
      ...)
    {
              http(
                method("POST")
                url("http://localhost:8888")
                body("$(format-json --scope none `body-parts`)")
                `__VARARGS__`
                );
    };

```    
 and `body-parts` cannot express what we really need, we have to add a 
 a new SCL block. With resolving already defined block arguments we can avoid unnecessary
 copy-pastes and we can also keep backward compatibility.

With this patch we can write this:

```
    block destination test_http (
      body-parts("host=$HOST severity=$LEVEL")
      body("$(format-json --scope none `body-parts`)")
      ...)
    {
              http(
                method("POST")
                url("http://localhost:8888")
                body(`body`)
                `__VARARGS__`
                );
    };

```

(I had a previous PR, but that did not work as expected. Finally, I found a different solution - it's still a short patch and hopefully not too ugly... )

### Idea

* postpone backtick substitution for block arg defs
* identify postponed cases and do the final backtick substitution

I used the config below (this is a sligthly modified version of the cfg attached by @Kokan).

```
@version: 3.30

block rewrite test (
  E()
  sub-A("sub-A")
  A("[`sub-A` ``sub-A`` ``sub-X``]")
  ...)
{
  set("`A`" value("A") `__VARARGS__`);
  set("`E`" value("E"));
};

source s { example-msg-generator(num(1)); };
destination d { file("/dev/stdout" template("A=${A} should equal to E=${E}\n")); };

log { source(s); rewrite { test(E("[sub-A ``sub-A`` ``sub-X``]")); }; destination(d); }; # ok
log { source(s); rewrite { test(E("B") A("B")); }; destination(d); }; # ok
log { source(s); rewrite { test(E("[sub-B ``sub-A`` ``sub-X``]") sub-A("sub-B")); }; destination(d); }; # nok
log { source(s); rewrite { test(E("C") sub-A("sub-C") A("C")); }; destination(d); }; # ok
log { source(s); rewrite { test(E("D") A("D") sub-A("sub-D")); }; destination(d); }; # ok

```


