### PR TITLE
Fix config parsing for kafka-c/config

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -143,6 +143,9 @@
 %token LL_CONTEXT_OPTIONS             19
 %token LL_CONTEXT_CONFIG              20
 
+/* this is a placeholder for unit tests, must be the latest & largest */
+%token LL_CONTEXT_MAX                 21
+
 
 /* statements */
 %token KW_SOURCE                      10000

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -141,6 +141,7 @@
 %token LL_CONTEXT_CLIENT_PROTO        17
 %token LL_CONTEXT_SERVER_PROTO        18
 %token LL_CONTEXT_OPTIONS             19
+%token LL_CONTEXT_CONFIG              20
 
 
 /* statements */

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -1194,6 +1194,7 @@ static const gchar *lexer_contexts[] =
   [LL_CONTEXT_CLIENT_PROTO] = "client-proto",
   [LL_CONTEXT_SERVER_PROTO] = "server-proto",
   [LL_CONTEXT_OPTIONS] = "options",
+  [LL_CONTEXT_CONFIG] = "config",
 };
 
 gint

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -1184,6 +1184,7 @@ static const gchar *lexer_contexts[] =
   [LL_CONTEXT_FILTER] = "filter",
   [LL_CONTEXT_LOG] = "log",
   [LL_CONTEXT_BLOCK_DEF] = "block-def",
+  [LL_CONTEXT_BLOCK_ARG] = "block-arg",
   [LL_CONTEXT_BLOCK_REF] = "block-ref",
   [LL_CONTEXT_BLOCK_CONTENT] = "block-content",
   [LL_CONTEXT_PRAGMA] = "pragma",

--- a/lib/tests/test_lexer.c
+++ b/lib/tests/test_lexer.c
@@ -504,6 +504,14 @@ Test(lexer, generator_plugins_are_expanded)
   cfg_lexer_pop_context(lexer);
 }
 
+Test(lexer, context_name_lookup)
+{
+  for (int i=LL_CONTEXT_MAX-1; i >= 1; --i)
+    {
+      cr_assert_eq(i, cfg_lexer_lookup_context_type_by_name(cfg_lexer_lookup_context_name_by_type(i)));
+    }
+}
+
 static void
 setup(void)
 {

--- a/modules/kafka/kafka-grammar.ym
+++ b/modules/kafka/kafka-grammar.ym
@@ -52,6 +52,7 @@
 /* INCLUDE_DECLS */
 
 %type <ptr> kafka_properties
+%type <ptr> kafka_properties_list
 %type <ptr> kafka_property
 
 %token KW_KAFKA
@@ -123,7 +124,20 @@ kafka_option
         ;
 
 kafka_properties
-        : kafka_property kafka_properties			{ $$ = g_list_prepend($2, $1); }
+	:
+	{
+		static CfgLexerKeyword empty_keywords[] = {{ CFG_KEYWORD_STOP }};
+		cfg_lexer_push_context(lexer, LL_CONTEXT_CONFIG, empty_keywords, "kafka_config_block");
+	}
+	kafka_properties_list
+	{
+		cfg_lexer_pop_context(lexer);
+		$$ = $2;
+	}
+	;
+
+kafka_properties_list
+        : kafka_property kafka_properties_list			{ $$ = g_list_prepend($2, $1); }
         |							{ $$ = NULL; }
         ;
 

--- a/news/bugfix-3658.md
+++ b/news/bugfix-3658.md
@@ -1,0 +1,1 @@
+kafka: the config() block couldn't contain option that is already a keyword in syslog-ng (example: retries)


### PR DESCRIPTION
Global keywords could conflict with librdkafka's own configuration keywords. An example of this is the `retries`. This PR fixes that, as in destination/kafka-c/config context temporarly remove the keywords (using mechanism of `CFG_KEYWORD_STOP`).
```
@Version: 3.30

log {
  destination {
    kafka-c(
      topic("test-topic")
      bootstrap-servers("localhost:9092")
      config(
          retries => 1
      )
    );
  };
};
```
