### PR TITLE
Fix compilation issues on OpenBSD

### DIFF
--- a/lib/compat/CMakeLists.txt
+++ b/lib/compat/CMakeLists.txt
@@ -11,6 +11,7 @@ set(COMPAT_HEADERS
     compat/pcre.h
     compat/getent.h
     compat/getent-sun.h
+    compat/getent-openbsd.h
     compat/getent-generic.h
     compat/un.h
     PARENT_SCOPE)
@@ -27,6 +28,7 @@ set(COMPAT_SOURCES
     compat/time.c
     compat/openssl_support.c
     compat/getent-sun.c
+    compat/getent-openbsd.c
     compat/getent-generic.c
     PARENT_SCOPE)
 

--- a/lib/compat/Makefile.am
+++ b/lib/compat/Makefile.am
@@ -17,6 +17,7 @@ compatinclude_HEADERS		= 	\
 	lib/compat/pcre.h		\
 	lib/compat/getent.h		\
 	lib/compat/getent-sun.h		\
+	lib/compat/getent-openbsd.h	\
 	lib/compat/getent-generic.h	\
 	lib/compat/un.h			
 
@@ -32,6 +33,7 @@ compat_sources			= 	\
 	lib/compat/time.c		\
 	lib/compat/openssl_support.c	\
 	lib/compat/getent-sun.c		\
+	lib/compat/getent-openbsd.c	\
 	lib/compat/getent-generic.c
 
 include lib/compat/tests/Makefile.am

--- a/lib/compat/getent-openbsd.c
+++ b/lib/compat/getent-openbsd.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "compat/getent-openbsd.h"
+
+#ifdef __OpenBSD__
+#include <errno.h>
+#include <stddef.h>
+
+int
+_compat_openbsd__getprotobynumber_r(int proto,
+                                    struct protoent *result_buf, char *buf,
+                                    size_t buflen, struct protoent **result)
+{
+  struct protoent_data *data_buf = (struct protoent_data *)buf;
+
+  if (buflen < sizeof(*data_buf))
+    {
+      *result = NULL;
+      return ERANGE;
+    }
+  if (getprotobynumber_r(proto, result_buf, data_buf) == -1)
+    {
+      *result = NULL;
+      return errno;
+    }
+  *result = result_buf;
+  return 0;
+}
+
+int
+_compat_openbsd__getprotobyname_r(const char *name,
+                                  struct protoent *result_buf, char *buf,
+                                  size_t buflen, struct protoent **result)
+{
+  struct protoent_data *data_buf = (struct protoent_data *)buf;
+
+  if (buflen < sizeof(*data_buf))
+    {
+      *result = NULL;
+      return ERANGE;
+    }
+  if (getprotobyname_r(name, result_buf, data_buf) == -1)
+    {
+      *result = NULL;
+      return errno;
+    }
+  *result = result_buf;
+  return 0;
+}
+
+int
+_compat_openbsd__getservbyport_r(int port, const char *proto,
+                                 struct servent *result_buf, char *buf,
+                                 size_t buflen, struct servent **result)
+{
+  struct servent_data *data_buf = (struct servent_data *)buf;
+
+  if (buflen < sizeof(*data_buf))
+    {
+      *result = NULL;
+      return ERANGE;
+    }
+  if (getservbyport_r(port, proto, result_buf, data_buf) == -1)
+    {
+      *result = NULL;
+      return errno;
+    }
+  *result = result_buf;
+  return 0;
+}
+
+int
+_compat_openbsd__getservbyname_r(const char *name, const char *proto,
+                                 struct servent *result_buf, char *buf,
+                                 size_t buflen, struct servent **result)
+{
+  struct servent_data *data_buf = (struct servent_data *)buf;
+
+  if (buflen < sizeof(*data_buf))
+    {
+      *result = NULL;
+      return ERANGE;
+    }
+  if (getservbyname_r(name, proto, result_buf, data_buf) == -1)
+    {
+      *result = NULL;
+      return errno;
+    }
+  *result = result_buf;
+  return 0;
+}
+#endif

--- a/lib/compat/getent-openbsd.h
+++ b/lib/compat/getent-openbsd.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017 Balabit
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef COMPAT_GETENT_OPENBSD_H_INCLUDED
+#define COMPAT_GETENT_OPENBSD_H_INCLUDED
+
+#include "compat/compat.h"
+
+#ifdef __OpenBSD__
+
+#include <sys/types.h>
+#include <grp.h>
+#include <pwd.h>
+#include <netdb.h>
+
+int _compat_openbsd__getprotobynumber_r(int proto,
+                                        struct protoent *result_buf, char *buf,
+                                        size_t buflen, struct protoent **result);
+
+int _compat_openbsd__getprotobyname_r(const char *name,
+                                      struct protoent *result_buf, char *buf,
+                                      size_t buflen, struct protoent **result);
+
+int _compat_openbsd__getservbyport_r(int port, const char *proto,
+                                     struct servent *result_buf, char *buf,
+                                     size_t buflen, struct servent **result);
+
+int _compat_openbsd__getservbyname_r(const char *name, const char *proto,
+                                     struct servent *result_buf, char *buf,
+                                     size_t buflen, struct servent **result);
+
+#endif
+
+#endif

--- a/lib/compat/getent.h
+++ b/lib/compat/getent.h
@@ -35,6 +35,15 @@
 #define getservbyport_r _compat_generic__getservbyport_r
 #define getservbyname_r _compat_generic__getservbyname_r
 
+#elif defined(__OpenBSD__)
+
+#include "getent-openbsd.h"
+
+#define getprotobynumber_r _compat_openbsd__getprotobynumber_r
+#define getprotobyname_r _compat_openbsd__getprotobyname_r
+#define getservbyport_r _compat_openbsd__getservbyport_r
+#define getservbyname_r _compat_openbsd__getservbyname_r
+
 #elif defined(sun) || defined(__sun)
 
 #include "getent-sun.h"

--- a/lib/host-resolve.c
+++ b/lib/host-resolve.c
@@ -36,6 +36,10 @@
 #include <string.h>
 #include <resolv.h>
 
+#ifndef AI_V4MAPPED
+#define AI_V4MAPPED 0
+#endif
+
 #if !defined(SYSLOG_NG_HAVE_GETADDRINFO) || !defined(SYSLOG_NG_HAVE_GETNAMEINFO)
 G_LOCK_DEFINE_STATIC(resolv_lock);
 #endif

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -27,6 +27,7 @@
 #include "compat/openssl_support.h"
 #include "secret-storage/secret-storage.h"
 
+#include <sys/socket.h>
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <stdio.h>

--- a/lib/transport/transport-udp-socket.c
+++ b/lib/transport/transport-udp-socket.c
@@ -40,7 +40,7 @@ struct _LogTransportUDP
 
 #if defined(SYSLOG_NG_HAVE_CTRLBUF_IN_MSGHDR)
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
 
 GSockAddr *
 _extract_dest_ip4_addr_from_cmsg(struct cmsghdr *cmsg, GSockAddr *bind_addr)
@@ -190,7 +190,7 @@ log_transport_udp_setup_fd(LogTransportUDP *self, gint fd)
 
   if (self->super.address_family == AF_INET)
     {
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
       setsockopt(fd, IPPROTO_IP, IP_RECVDSTADDR, &on, sizeof(on));
 #else
       setsockopt(fd, IPPROTO_IP, IP_PKTINFO, &on, sizeof(on));

--- a/modules/getent/tfgetent.c
+++ b/modules/getent/tfgetent.c
@@ -20,7 +20,7 @@
  * COPYING for details.
  */
 
-#if defined(sun) || defined(__sun)
+#if defined(sun) || defined(__sun) || defined(__OpenBSD__)
 #define _POSIX_PTHREAD_SEMANTICS
 #endif
 

--- a/tests/loggen/loggen_helper.c
+++ b/tests/loggen/loggen_helper.c
@@ -37,6 +37,10 @@
 #define IP_ADDRESS_MAX_LENGTH 15
 #define IP_PORT_MAX_LENGTH 5
 
+#ifndef AI_V4MAPPED
+#define AI_V4MAPPED 0
+#endif
+
 static int debug = 0;
 
 int


### PR DESCRIPTION
This PR fixes the following issues that prevent building syslog-ng on OpenBSD:
 * OpenBSD uses a different flavor of reentrant getent functions
 * OpenBSD doesn't support IPv4-mapped IPv6 addresses (they are considered harmful)
 * OpenBSD uses IP_RECVDSTADDR for UDP dest-IP like FreeBSD does
 * tlscontext.c uses AF_INET and AF_INET6 but doesn't include sys/socket.h where they are defined.