### PR TITLE
packaging/rhel: remove python3 path fixup in syslog-ng.spec

### DIFF
--- a/packaging/rhel/syslog-ng.spec
+++ b/packaging/rhel/syslog-ng.spec
@@ -274,10 +274,6 @@ ryslog is not on the system.
 # fix perl path
 %{__sed} -i 's|^#!/usr/local/bin/perl|#!%{__perl}|' contrib/relogger.pl
 
-# fix Python path
-%{__sed} -i 's|^#!/usr/bin/env python|#!%{__python3}|' lib/merge-grammar.py
-touch -r lib/cfg-grammar.y lib/merge-grammar.py
-
 # fix executable perms on contrib files
 %{__chmod} -c a-x contrib/syslog2ng
 


### PR DESCRIPTION
After PR #3647 lib/merge-grammar.py has python3 in it's shebang instead of "python",
there is no need for the sed command anymore in the .spec file (python2 is not supported).

Also, the sed expression currently creates an invalid python reference, see result:
`#!/usr/bin/python33`

Packaging CI jobs doesn't hit this issue, as they are creating packages from tarball
(as intended due to bison v3.7.6 which is not yet available on many platforms).
This bug prevented releasing on rpm platforms where the grammar files are changed.

This PR is not critical from OSE release point of view.