### PR TITLE
Minor fixes for OpenBSD source

### DIFF
--- a/modules/openbsd/openbsd-driver.c
+++ b/modules/openbsd/openbsd-driver.c
@@ -80,7 +80,7 @@ openbsd_create_newsyslog_socket(OpenBSDDriver *self)
     }
 
   close(self->pair[1]);
-  self->pair[1] = NULL;
+  self->pair[1] = -1;
 
   return self->pair[0];
 }
@@ -88,17 +88,17 @@ openbsd_create_newsyslog_socket(OpenBSDDriver *self)
 static void
 openbsd_close_newsyslog_socket(OpenBSDDriver *self)
 {
-  if (self->pair[0])
+  if (self->pair[0] != -1)
     close(self->pair[0]);
-  self->pair[0] = NULL;
+  self->pair[0] = -1;
 
-  if (self->pair[1])
+  if (self->pair[1] != -1)
     close(self->pair[1]);
-  self->pair[1] = NULL;
+  self->pair[1] = -1;
 
-  if (self->klog)
+  if (self->klog != -1)
     close(self->klog);
-  self->klog    = NULL;
+  self->klog    = -1;
 }
 
 static gboolean
@@ -171,6 +171,10 @@ openbsd_sd_new(GlobalConfig *cfg)
   OpenBSDDriver *self = g_new0(OpenBSDDriver, 1);
 
   log_src_driver_init_instance(&self->super, cfg);
+
+  self->klog = -1;
+  self->pair[0] = -1;
+  self->pair[1] = -1;
 
   self->super.super.super.init    = _openbsd_sd_init;
   self->super.super.super.deinit  = _openbsd_sd_deinit;

--- a/modules/openbsd/openbsd-plugin.c
+++ b/modules/openbsd/openbsd-plugin.c
@@ -36,9 +36,9 @@ static Plugin openbsd_plugins[] =
 };
 
 gboolean
-openbsd_module_init(GlobalConfig *cfg, CfgArgs *args)
+openbsd_module_init(PluginContext *context, CfgArgs *args)
 {
-  plugin_register(cfg, openbsd_plugins, G_N_ELEMENTS(openbsd_plugins));
+  plugin_register(context, openbsd_plugins, G_N_ELEMENTS(openbsd_plugins));
   return TRUE;
 }
 


### PR DESCRIPTION
No news file entry needed (these are compiler warnings, they're not user-visible in my opinion).