### PR TITLE
[WIP] Light: Add support for network destination driver

### DIFF
--- a/tests/python_functional/functional_tests/Makefile.am
+++ b/tests/python_functional/functional_tests/Makefile.am
@@ -5,6 +5,7 @@ EXTRA_DIST += \
 	tests/python_functional/functional_tests/config_change/test_manipulating_config_between_reload.py \
 	tests/python_functional/functional_tests/conftest.py \
 	tests/python_functional/functional_tests/destination_drivers/example_destination/test_example_destination.py \
+	tests/python_functional/functional_tests/destination_drivers/network_destination/test_network_destination_transport.py \
 	tests/python_functional/functional_tests/destination_drivers/snmp_destination/general/test_snmp_destination_acceptance.py \
 	tests/python_functional/functional_tests/destination_drivers/snmp_destination/general/test_snmp_destination_missing_snmp_obj.py \
 	tests/python_functional/functional_tests/destination_drivers/snmp_destination/general/test_snmp_destination_missing_trap_obj.py \
@@ -38,4 +39,3 @@ EXTRA_DIST += \
 	tests/python_functional/functional_tests/source_options/test_use_syslogng_pid.py \
 	tests/python_functional/functional_tests/template_functions/graphite-output/test_graphite_output.py \
 	tests/python_functional/functional_tests/template_functions/slog/test_secure_logging.py
-

--- a/tests/python_functional/functional_tests/destination_drivers/network_destination/test_network_destination_transport.py
+++ b/tests/python_functional/functional_tests/destination_drivers/network_destination/test_network_destination_transport.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2021 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import pytest
+
+
+@pytest.mark.netcat
+@pytest.mark.parametrize(
+    "transport", [
+        None,
+        "tcp",
+        "udp",
+    ], ids=["default", "tcp", "udp"],
+)
+def test_network_destination_transport(config, syslog_ng, port_allocator, transport):
+    counter = 100
+    message = "message text"
+
+    generator_source = config.create_example_msg_generator_source(num=counter, freq=0.0001, template=config.stringify(message))
+    if transport is not None:
+        network_destination = config.create_network_destination(ip="localhost", port=port_allocator(), transport=transport)
+    else:
+        network_destination = config.create_network_destination(ip="localhost", port=port_allocator())
+    config.create_logpath(statements=[generator_source, network_destination])
+
+    network_destination.start_listener()
+    syslog_ng.start(config)
+    assert network_destination.read_until_logs([message] * counter)

--- a/tests/python_functional/pytest.ini
+++ b/tests/python_functional/pytest.ini
@@ -5,3 +5,4 @@ log_cli_format= %(asctime)s:%(msecs)d - %(filename)s:%(lineno)d->%(funcName)s - 
 log_file_format= %(asctime)s:%(msecs)d - %(filename)s:%(lineno)d->%(funcName)s - %(levelname)s - %(message)s
 markers =
     snmp: mark test cases which are related to snmp
+    netcat: mark test cases which are related to netcat

--- a/tests/python_functional/src/Makefile.am
+++ b/tests/python_functional/src/Makefile.am
@@ -2,8 +2,8 @@
 #find -name '*.py'|awk '{ print "\ttests/python_functional/src/"substr($0,3); }'|sort
 EXTRA_DIST += \
 	tests/python_functional/src/common/blocking.py \
-	tests/python_functional/src/common/__init__.py \
 	tests/python_functional/src/common/file.py \
+	tests/python_functional/src/common/__init__.py \
 	tests/python_functional/src/common/network_operations.py \
 	tests/python_functional/src/common/operations.py \
 	tests/python_functional/src/common/pytest_operations.py \
@@ -27,6 +27,8 @@ EXTRA_DIST += \
 	tests/python_functional/src/helpers/__init__.py \
 	tests/python_functional/src/helpers/loggen/__init__.py \
 	tests/python_functional/src/helpers/loggen/loggen.py \
+	tests/python_functional/src/helpers/netcat/__init__.py \
+	tests/python_functional/src/helpers/netcat/netcat.py \
 	tests/python_functional/src/helpers/secure_logging/conftest.py \
 	tests/python_functional/src/helpers/secure_logging/__init__.py \
 	tests/python_functional/src/helpers/snmptrapd/conftest.py \
@@ -43,6 +45,7 @@ EXTRA_DIST += \
 	tests/python_functional/src/syslog_ng_config/statements/destinations/example_destination.py \
 	tests/python_functional/src/syslog_ng_config/statements/destinations/file_destination.py \
 	tests/python_functional/src/syslog_ng_config/statements/destinations/__init__.py \
+	tests/python_functional/src/syslog_ng_config/statements/destinations/network_destination.py \
 	tests/python_functional/src/syslog_ng_config/statements/destinations/snmp_destination.py \
 	tests/python_functional/src/syslog_ng_config/statements/filters/filter.py \
 	tests/python_functional/src/syslog_ng_config/statements/filters/__init__.py \

--- a/tests/python_functional/src/driver_io/network/network_io.py
+++ b/tests/python_functional/src/driver_io/network/network_io.py
@@ -20,6 +20,8 @@
 # COPYING for details.
 #
 #############################################################################
+import atexit
+from enum import auto
 from enum import Enum
 
 from pathlib2 import Path
@@ -28,6 +30,7 @@ import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.common.file import File
 from src.common.random_id import get_unique_id
 from src.helpers.loggen.loggen import Loggen
+from src.helpers.netcat.netcat import Netcat
 
 
 class NetworkIO():
@@ -35,6 +38,10 @@ class NetworkIO():
         self.__ip = ip
         self.__port = port
         self.__transport = transport
+        self.__listener = None
+        self.__listener_output_file = None
+
+        atexit.register(self.stop_listener)
 
     def write(self, content, rate=None):
         loggen_input_file_path = Path(tc_parameters.WORKING_DIR, "loggen_input_{}.txt".format(get_unique_id()))
@@ -44,11 +51,44 @@ class NetworkIO():
         loggen_input_file.write(content)
         loggen_input_file.close()
 
-        Loggen().start(self.__ip, self.__port, read_file=str(loggen_input_file_path), dont_parse=True, permanent=True, rate=rate, **self.__transport.value)
+        Loggen().start(self.__ip, self.__port, read_file=str(loggen_input_file_path), dont_parse=True, permanent=True, rate=rate, **self.__transport.to_loggen_params())
+
+    def start_listener(self):
+        self.__listener = Netcat()
+        self.__listener.start(self.__ip, self.__port, l=True, k=True, **self.__transport.to_netcat_params())  # noqa: E741
+        self.__listener_output_file = File(self.__listener.output_path)
+        self.__listener_output_file.open(mode="r")
+
+    def stop_listener(self):
+        if self.__listener is not None:
+            self.__listener.stop()
+
+    def read_number_of_lines(self, counter):
+        return self.__listener_output_file.wait_for_number_of_lines(counter)
+
+    def read_until_lines(self, lines):
+        return self.__listener_output_file.wait_for_lines(lines)
 
     class Transport(Enum):
-        TCP = {"inet": True, "stream": True}
-        UDP = {"dgram": True}
-        TLS = {"use_ssl": True}
-        PROXIED_TCP = {"inet": True, "stream": True}
-        PROXIED_TLS = {"use_ssl": True}
+        TCP = auto()
+        UDP = auto()
+        TLS = auto()
+        PROXIED_TCP = auto()
+        PROXIED_TLS = auto()
+
+        def to_loggen_params(self):
+            loggen_params_mapping = {
+                NetworkIO.Transport.TCP: {"inet": True, "stream": True},
+                NetworkIO.Transport.UDP: {"dgram": True},
+                NetworkIO.Transport.TLS: {"use_ssl": True},
+                NetworkIO.Transport.PROXIED_TCP: {"inet": True, "stream": True},
+                NetworkIO.Transport.PROXIED_TLS: {"use_ssl": True},
+            }
+            return loggen_params_mapping[self]
+
+        def to_netcat_params(self):
+            netcat_params_mapping = {
+                NetworkIO.Transport.TCP: {},
+                NetworkIO.Transport.UDP: {"u": True},
+            }
+            return netcat_params_mapping[self]

--- a/tests/python_functional/src/helpers/netcat/netcat.py
+++ b/tests/python_functional/src/helpers/netcat/netcat.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2021 One Identity
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from pathlib2 import Path
+from psutil import TimeoutExpired
+
+import src.testcase_parameters.testcase_parameters as tc_parameters
+from src.executors.process_executor import ProcessExecutor
+
+
+class Netcat(object):
+
+    instanceIndex = -1
+    @staticmethod
+    def __get_new_instance_index():
+        Netcat.instanceIndex += 1
+        return Netcat.instanceIndex
+
+    def __init__(self):
+        self.netcat_proc = None
+        self.__netcat_stdout_path = None
+
+    @property
+    def output_path(self):
+        return str(self.__netcat_stdout_path.absolute())
+
+    def __decode_start_parameters(self, k, l, u):
+        start_parameters = []
+
+        if k is True:
+            start_parameters.append("-k")
+
+        if l is True:
+            start_parameters.append("-l")
+
+        if u is True:
+            start_parameters.append("-u")
+
+        return start_parameters
+
+    def start(self, destination, port, k=None, l=None, u=None):  # noqa: E741
+        if self.netcat_proc is not None and self.netcat_proc.is_running():
+            raise Exception("Netcat is already running, you shouldn't call start")
+
+        instanceIndex = Netcat.__get_new_instance_index()
+        self.__netcat_stdout_path = Path(tc_parameters.WORKING_DIR, "netcat_stdout_{}".format(instanceIndex))
+        netcat_stderr_path = Path(tc_parameters.WORKING_DIR, "netcat_stderr_{}".format(instanceIndex))
+
+        self.parameters = self.__decode_start_parameters(k, l, u)
+
+        self.netcat_proc = ProcessExecutor().start(
+            ["nc"] + self.parameters + [destination, port],
+            self.__netcat_stdout_path,
+            netcat_stderr_path,
+        )
+
+        return self.netcat_proc
+
+    def stop(self):
+        if self.netcat_proc is None:
+            return
+
+        self.netcat_proc.terminate()
+        try:
+            self.netcat_proc.wait(4)
+        except TimeoutExpired:
+            self.netcat_proc.kill()
+
+        self.netcat_proc = None

--- a/tests/python_functional/src/syslog_ng_config/statements/destinations/network_destination.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/destinations/network_destination.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2021 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from src.driver_io.network.network_io import NetworkIO
+from src.syslog_ng_config.statements.destinations.destination_driver import DestinationDriver
+
+
+def map_transport(transport):
+    mapping = {
+        "tcp": NetworkIO.Transport.TCP,
+        "udp": NetworkIO.Transport.UDP,
+    }
+    transport = transport.replace("_", "-").replace("'", "").replace('"', "").lower()
+
+    return mapping[transport]
+
+
+def create_io(ip, options):
+    transport = options["transport"] if "transport" in options else "tcp"
+
+    return NetworkIO(ip, options["port"], map_transport(transport))
+
+
+class NetworkDestination(DestinationDriver):
+    def __init__(self, ip, **options):
+        self.driver_name = "network"
+        self.ip = ip
+        self.io = create_io(self.ip, options)
+        super(NetworkDestination, self).__init__([self.ip], options)
+
+    def start_listener(self):
+        self.io.start_listener()
+
+    def stop_listener(self):
+        self.io.stop_listener()
+
+    def read_log(self):
+        return self.read_logs(1)[0]
+
+    def read_logs(self, counter):
+        return self.io.read_number_of_lines(counter)
+
+    def read_until_logs(self, logs):
+        return self.io.read_until_lines(logs)

--- a/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
@@ -28,6 +28,7 @@ from src.syslog_ng_config.renderer import ConfigRenderer
 from src.syslog_ng_config.statement_group import StatementGroup
 from src.syslog_ng_config.statements.destinations.example_destination import ExampleDestination
 from src.syslog_ng_config.statements.destinations.file_destination import FileDestination
+from src.syslog_ng_config.statements.destinations.network_destination import NetworkDestination
 from src.syslog_ng_config.statements.destinations.snmp_destination import SnmpDestination
 from src.syslog_ng_config.statements.filters.filter import Filter
 from src.syslog_ng_config.statements.logpath.logpath import LogPath
@@ -121,6 +122,9 @@ class SyslogNgConfig(object):
 
     def create_snmp_destination(self, **options):
         return SnmpDestination(**options)
+
+    def create_network_destination(self, **options):
+        return NetworkDestination(**options)
 
     def create_db_parser(self, config, **options):
         return DBParser(config, **options)


### PR DESCRIPTION
This PR introduces supporting network destination driver.
We have decided to use netcat as a message collector on syslog-ng's output side.
Reasons behind using netcat: 
- almost a standard default package on every Linux systems
- netcat is already installed on our DBLD's devshell image where Light will run in almost all cases

Adding a default parametrized testcase for testing template() option in various cases.