### PR TITLE
Logreader ignore aux data flag

### DIFF
--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -159,7 +159,8 @@ static CfgLexerKeyword main_keywords[] =
   { "dns_cache_size",     KW_DNS_CACHE_SIZE },
   { "dns_cache_expire",   KW_DNS_CACHE_EXPIRE },
   { "dns_cache_expire_failed", KW_DNS_CACHE_EXPIRE_FAILED },
-  { "pass_unix_credentials",   KW_PASS_UNIX_CREDENTIALS, KWS_OBSOLETE,
+  {
+    "pass_unix_credentials",   KW_PASS_UNIX_CREDENTIALS, KWS_OBSOLETE,
     "The use of pass-unix-credentials() has been deprecated in " VERSION_3_35 " in favour of "
     "the 'so-passcred()' source option or the 'ignore-aux-data' source flag"
   },

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -159,7 +159,11 @@ static CfgLexerKeyword main_keywords[] =
   { "dns_cache_size",     KW_DNS_CACHE_SIZE },
   { "dns_cache_expire",   KW_DNS_CACHE_EXPIRE },
   { "dns_cache_expire_failed", KW_DNS_CACHE_EXPIRE_FAILED },
-  { "pass_unix_credentials",   KW_PASS_UNIX_CREDENTIALS },
+  { "pass_unix_credentials",   KW_PASS_UNIX_CREDENTIALS, KWS_OBSOLETE,
+    "The use of pass-unix-credentials() has been deprecated in " VERSION_3_35 " in favour of "
+    "the 'so-passcred()' source option or the 'ignore-aux-data' source flag"
+  },
+
   { "persist_name",            KW_PERSIST_NAME, VERSION_VALUE_3_8 },
 
   { "retries",            KW_RETRIES },

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -497,7 +497,7 @@ cfg_new(gint version)
 
   dns_cache_options_defaults(&self->dns_cache_options);
   self->threaded = TRUE;
-  self->pass_unix_credentials = TRUE;
+  self->pass_unix_credentials = -1;
 
   log_template_options_defaults(&self->template_options);
   self->template_options.ts_format = TS_FMT_BSD;

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -456,9 +456,12 @@ log_reader_handle_line(LogReader *self, const guchar *line, gint length, LogTran
                   &self->options->parse_options);
 
   _log_reader_insert_msg_length_stats(self, length);
-  log_msg_set_saddr(m, aux->peer_addr ? : self->peer_addr);
-  log_msg_set_daddr(m, aux->local_addr ? : self->local_addr);
-  m->proto = aux->proto;
+  if (aux)
+    {
+      log_msg_set_saddr(m, aux->peer_addr ? : self->peer_addr);
+      log_msg_set_daddr(m, aux->local_addr ? : self->local_addr);
+      m->proto = aux->proto;
+    }
   log_msg_refcache_start_producer(m);
 
   log_transport_aux_data_foreach(aux, _add_aux_nvpair, m);
@@ -474,9 +477,12 @@ log_reader_fetch_log(LogReader *self)
 {
   gint msg_count = 0;
   gboolean may_read = TRUE;
-  LogTransportAuxData aux;
+  LogTransportAuxData aux_storage, *aux = &aux_storage;
 
-  log_transport_aux_data_init(&aux);
+  if ((self->options->flags & LR_IGNORE_AUX_DATA))
+    aux = NULL;
+
+  log_transport_aux_data_init(aux);
   if (log_proto_server_handshake_in_progress(self->proto))
     {
       return log_reader_process_handshake(self);
@@ -501,16 +507,16 @@ log_reader_fetch_log(LogReader *self)
        * protocol, it resets may_read to FALSE after the first read was issued.
        */
 
-      log_transport_aux_data_reinit(&aux);
+      log_transport_aux_data_reinit(aux);
       bookmark = ack_tracker_request_bookmark(self->super.ack_tracker);
-      status = log_proto_server_fetch(self->proto, &msg, &msg_len, &may_read, &aux, bookmark);
+      status = log_proto_server_fetch(self->proto, &msg, &msg_len, &may_read, aux, bookmark);
       switch (status)
         {
         case LPS_EOF:
-          log_transport_aux_data_destroy(&aux);
+          log_transport_aux_data_destroy(aux);
           return NC_CLOSE;
         case LPS_ERROR:
-          log_transport_aux_data_destroy(&aux);
+          log_transport_aux_data_destroy(aux);
           return NC_READ_ERROR;
         case LPS_SUCCESS:
           break;
@@ -530,14 +536,14 @@ log_reader_fetch_log(LogReader *self)
         {
           msg_count++;
 
-          if (!log_reader_handle_line(self, msg, msg_len, &aux))
+          if (!log_reader_handle_line(self, msg, msg_len, aux))
             {
               /* window is full, don't generate further messages */
               break;
             }
         }
     }
-  log_transport_aux_data_destroy(&aux);
+  log_transport_aux_data_destroy(aux);
 
   if (msg_count == self->options->fetch_limit)
     self->immediate_check = TRUE;
@@ -832,6 +838,7 @@ CfgFlagHandler log_reader_flag_handlers[] =
   { "kernel",                     CFH_SET, offsetof(LogReaderOptions, flags),               LR_KERNEL },
   { "empty-lines",                CFH_SET, offsetof(LogReaderOptions, flags),               LR_EMPTY_LINES },
   { "threaded",                   CFH_SET, offsetof(LogReaderOptions, flags),               LR_THREADED },
+  { "ignore-aux-data",            CFH_SET, offsetof(LogReaderOptions, flags),               LR_IGNORE_AUX_DATA },
   { NULL },
 };
 

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -507,10 +507,10 @@ log_reader_fetch_log(LogReader *self)
       switch (status)
         {
         case LPS_EOF:
-          g_sockaddr_unref(aux.peer_addr);
+          log_transport_aux_data_destroy(&aux);
           return NC_CLOSE;
         case LPS_ERROR:
-          g_sockaddr_unref(aux.peer_addr);
+          log_transport_aux_data_destroy(&aux);
           return NC_READ_ERROR;
         case LPS_SUCCESS:
           break;

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -36,6 +36,7 @@
 /* flags */
 #define LR_KERNEL          0x0002
 #define LR_EMPTY_LINES     0x0004
+#define LR_IGNORE_AUX_DATA 0x0008
 #define LR_THREADED        0x0040
 
 /* options */

--- a/lib/transport/tests/test_aux_data.c
+++ b/lib/transport/tests/test_aux_data.c
@@ -128,6 +128,26 @@ Test(aux_data, test_aux_data_copy_separates_the_copies)
 Test(aux_data, test_add_nv_pair_to_a_NULL_aux_data_will_do_nothing)
 {
   log_transport_aux_data_add_nv_pair(NULL, "foo", "bar");
+  assert_concatenated_nvpairs(NULL, "");
+}
+
+Test(aux_data, test_aux_data_functions_with_NULL_instance_does_nothing)
+{
+  aux = NULL;
+
+  log_transport_aux_data_init(aux);
+  log_transport_aux_data_reinit(aux);
+  log_transport_aux_data_destroy(aux);
+
+  log_transport_aux_data_init(aux);
+  /* set peer_addr twice to validate that peer_addr is correctly reference counted */
+  log_transport_aux_data_set_peer_addr_ref(aux, g_sockaddr_inet_new("1.2.3.4", 5555));
+  log_transport_aux_data_set_peer_addr_ref(aux, g_sockaddr_inet_new("1.2.3.4", 5555));
+#if 0
+  log_transport_aux_data_add_nv_pair(aux, "foo", "bar");
+  assert_concatenated_nvpairs(aux, "");
+  log_transport_aux_data_destroy(aux);
+#endif
 }
 
 static void

--- a/lib/transport/tests/test_aux_data.c
+++ b/lib/transport/tests/test_aux_data.c
@@ -143,11 +143,6 @@ Test(aux_data, test_aux_data_functions_with_NULL_instance_does_nothing)
   /* set peer_addr twice to validate that peer_addr is correctly reference counted */
   log_transport_aux_data_set_peer_addr_ref(aux, g_sockaddr_inet_new("1.2.3.4", 5555));
   log_transport_aux_data_set_peer_addr_ref(aux, g_sockaddr_inet_new("1.2.3.4", 5555));
-#if 0
-  log_transport_aux_data_add_nv_pair(aux, "foo", "bar");
-  assert_concatenated_nvpairs(aux, "");
-  log_transport_aux_data_destroy(aux);
-#endif
 }
 
 static void

--- a/lib/transport/transport-aux-data.c
+++ b/lib/transport/transport-aux-data.c
@@ -62,6 +62,9 @@ log_transport_aux_data_foreach(LogTransportAuxData *self, void (*func)(const gch
 {
   const gchar *p;
 
+  if (!self)
+    return;
+
   p = self->data;
   while (*p)
     {

--- a/lib/transport/transport-aux-data.h
+++ b/lib/transport/transport-aux-data.h
@@ -38,17 +38,23 @@ typedef struct _LogTransportAuxData
 static inline void
 log_transport_aux_data_init(LogTransportAuxData *self)
 {
-  self->peer_addr = NULL;
-  self->local_addr = NULL;
-  self->end_ptr = 0;
-  self->data[0] = 0;
+  if (self)
+    {
+      self->peer_addr = NULL;
+      self->local_addr = NULL;
+      self->end_ptr = 0;
+      self->data[0] = 0;
+    }
 }
 
 static inline void
 log_transport_aux_data_destroy(LogTransportAuxData *self)
 {
-  g_sockaddr_unref(self->peer_addr);
-  g_sockaddr_unref(self->local_addr);
+  if (self)
+    {
+      g_sockaddr_unref(self->peer_addr);
+      g_sockaddr_unref(self->local_addr);
+    }
 }
 
 static inline void
@@ -63,25 +69,34 @@ log_transport_aux_data_copy(LogTransportAuxData *dst, LogTransportAuxData *src)
 {
   gsize data_to_copy = sizeof(*src) - sizeof(src->data) + src->end_ptr;
 
-  memcpy(dst, src, data_to_copy);
-  g_sockaddr_ref(dst->peer_addr);
-  g_sockaddr_ref(dst->local_addr);
+  if (dst)
+    {
+      memcpy(dst, src, data_to_copy);
+      g_sockaddr_ref(dst->peer_addr);
+      g_sockaddr_ref(dst->local_addr);
+    }
 }
 
 static inline void
 log_transport_aux_data_set_peer_addr_ref(LogTransportAuxData *self, GSockAddr *peer_addr)
 {
-  if (self->peer_addr)
-    g_sockaddr_unref(self->peer_addr);
-  self->peer_addr = peer_addr;
+  if (self)
+    {
+      if (self->peer_addr)
+        g_sockaddr_unref(self->peer_addr);
+      self->peer_addr = peer_addr;
+    }
 }
 
 static inline void
 log_transport_aux_data_set_local_addr_ref(LogTransportAuxData *self, GSockAddr *local_addr)
 {
-  if (self->local_addr)
-    g_sockaddr_unref(self->local_addr);
-  self->local_addr = local_addr;
+  if (self)
+    {
+      if (self->local_addr)
+        g_sockaddr_unref(self->local_addr);
+      self->local_addr = local_addr;
+    }
 }
 
 void log_transport_aux_data_add_nv_pair(LogTransportAuxData *self, const gchar *name, const gchar *value);

--- a/lib/versioning.h
+++ b/lib/versioning.h
@@ -129,6 +129,7 @@
 #define VERSION_3_32 "syslog-ng 3.32"
 #define VERSION_3_33 "syslog-ng 3.33"
 #define VERSION_3_34 "syslog-ng 3.34"
+#define VERSION_3_35 "syslog-ng 3.35"
 
 /* VERSION_VALUE_* references versions as integers to be compared against stuff like cfg->user_version */
 /* VERSION_STR_* references versions as strings to be shown to the user */
@@ -168,18 +169,19 @@
 #define VERSION_VALUE_3_32 0x0320
 #define VERSION_VALUE_3_33 0x0321
 #define VERSION_VALUE_3_34 0x0322
+#define VERSION_VALUE_3_35 0x0323
 
 /* config version code, in the same format as GlobalConfig->version */
-#define VERSION_VALUE_CURRENT   VERSION_VALUE_3_34
-#define VERSION_STR_CURRENT     "3.34"
-#define VERSION_PRODUCT_CURRENT VERSION_3_34
+#define VERSION_VALUE_CURRENT   VERSION_VALUE_3_35
+#define VERSION_STR_CURRENT     "3.35"
+#define VERSION_PRODUCT_CURRENT VERSION_3_35
 
 /* this value points to the last syslog-ng version where we changed the
  * meaning of any setting in the configuration file.  Basically, it is the
  * highest value passed to any cfg_is_config_version_older() call.
  */
-#define VERSION_VALUE_LAST_SEMANTIC_CHANGE  VERSION_VALUE_3_33
-#define VERSION_STR_LAST_SEMANTIC_CHANGE    "3.33"
+#define VERSION_VALUE_LAST_SEMANTIC_CHANGE  VERSION_VALUE_3_35
+#define VERSION_STR_LAST_SEMANTIC_CHANGE    "3.35"
 
 #define version_convert_from_user(v)  (v)
 

--- a/modules/afsocket/CMakeLists.txt
+++ b/modules/afsocket/CMakeLists.txt
@@ -29,8 +29,8 @@ set(AFSOCKET_SOURCES
     transport-mapper-unix.h
     transport-unix-socket.c
     transport-unix-socket.h
-    unix-credentials.c
-    unix-credentials.h
+    compat-unix-creds.c
+    compat-unix-creds.h
     afsocket-grammar.y
     afsocket-parser.c
     afsocket-parser.h

--- a/modules/afsocket/CMakeLists.txt
+++ b/modules/afsocket/CMakeLists.txt
@@ -27,6 +27,8 @@ set(AFSOCKET_SOURCES
     afunix-dest.h
     transport-mapper-unix.c
     transport-mapper-unix.h
+    socket-options-unix.c
+    socket-options-unix.h
     transport-unix-socket.c
     transport-unix-socket.h
     compat-unix-creds.c

--- a/modules/afsocket/Makefile.am
+++ b/modules/afsocket/Makefile.am
@@ -29,8 +29,8 @@ modules_afsocket_libafsocket_la_SOURCES	=	\
 	modules/afsocket/transport-mapper-unix.h 	\
 	modules/afsocket/transport-unix-socket.c	\
 	modules/afsocket/transport-unix-socket.h	\
-	modules/afsocket/unix-credentials.c		\
-	modules/afsocket/unix-credentials.h		\
+	modules/afsocket/compat-unix-creds.c		\
+	modules/afsocket/compat-unix-creds.h		\
 	modules/afsocket/afsocket-grammar.y		\
 	modules/afsocket/afsocket-parser.c		\
 	modules/afsocket/afsocket-parser.h		\

--- a/modules/afsocket/Makefile.am
+++ b/modules/afsocket/Makefile.am
@@ -19,6 +19,8 @@ modules_afsocket_libafsocket_la_SOURCES	=	\
 	modules/afsocket/afinet-dest-failover.h		\
 	modules/afsocket/socket-options-inet.c		\
 	modules/afsocket/socket-options-inet.h   	\
+	modules/afsocket/socket-options-unix.c		\
+	modules/afsocket/socket-options-unix.h   	\
 	modules/afsocket/transport-mapper-inet.c 	\
 	modules/afsocket/transport-mapper-inet.h 	\
 	modules/afsocket/afunix-source.c		\

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -40,6 +40,7 @@
 #include "plugin.h"
 #include "cfg-grammar-internal.h"
 #include "socket-options-inet.h"
+#include "socket-options-unix.h"
 #include "transport-mapper-inet.h"
 #include "service-management.h"
 
@@ -148,6 +149,7 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 %token KW_TCP_KEEPALIVE_TIME
 %token KW_TCP_KEEPALIVE_PROBES
 %token KW_TCP_KEEPALIVE_INTVL
+%token KW_SO_PASSCRED
 %token KW_LISTEN_BACKLOG
 %token KW_SPOOF_SOURCE
 %token KW_SPOOF_SOURCE_MAX_MSGLEN
@@ -286,7 +288,7 @@ source_afunix_option
 	| source_afsocket_stream_params		{}
 	| source_reader_option			{}
 	| source_driver_option
-	| socket_option				{}
+	| unix_socket_option			{}
 	| KW_OPTIONAL '(' yesno ')'		{ last_driver->optional = $3; }
 	| KW_PASS_UNIX_CREDENTIALS '(' yesno ')'
 	  {
@@ -875,6 +877,11 @@ socket_option
 	| KW_SO_KEEPALIVE '(' yesno ')'             { last_sock_options->so_keepalive = $3; }
 	| KW_SO_REUSEPORT '(' yesno ')'             { last_sock_options->so_reuseport = $3; }
 	;
+
+unix_socket_option
+        : socket_option
+        | KW_SO_PASSCRED '(' yesno ')'              { socket_options_unix_set_so_passcred(last_sock_options, $3); }
+        ;
 
 inet_socket_option
 	: socket_option

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -80,6 +80,8 @@ static CfgLexerKeyword afsocket_keywords[] =
   { "tcp_keepalive_time", KW_TCP_KEEPALIVE_TIME },
   { "tcp_keepalive_probes", KW_TCP_KEEPALIVE_PROBES },
   { "tcp_keepalive_intvl", KW_TCP_KEEPALIVE_INTVL },
+  { "so_passcred",        KW_SO_PASSCRED },
+  { "local_creds",        KW_SO_PASSCRED },   /* BSD specific alias */
   { "spoof_source",       KW_SPOOF_SOURCE },
   { "spoof_source_max_msglen", KW_SPOOF_SOURCE_MAX_MSGLEN },
   { "transport",          KW_TRANSPORT },

--- a/modules/afsocket/compat-unix-creds.c
+++ b/modules/afsocket/compat-unix-creds.c
@@ -21,29 +21,16 @@
  *
  */
 
-#ifndef _SYSLOG_NG_UNIX_CREDENTIALS_H
-#define _SYSLOG_NG_UNIX_CREDENTIALS_H
+#include "compat-unix-creds.h"
 
-#include <sys/types.h>
-#include <sys/socket.h>
-
-#include "syslog-ng.h"
-
-#if defined(__linux__)
-# if SYSLOG_NG_HAVE_STRUCT_UCRED && SYSLOG_NG_HAVE_CTRLBUF_IN_MSGHDR
-# define CRED_PASS_SUPPORTED
-# define cred_t struct ucred
-# define cred_get(c,x) (c->x)
-# endif
-#elif defined(__FreeBSD__)
-# if SYSLOG_NG_HAVE_STRUCT_CMSGCRED && SYSLOG_NG_HAVE_CTRLBUF_IN_MSGHDR
-#  define CRED_PASS_SUPPORTED
-#  define SCM_CREDENTIALS SCM_CREDS
-#  define cred_t struct cmsgcred
-#  define cred_get(c,x) (c->cmcred_##x)
-# endif
+void
+setsockopt_so_passcred(gint fd, gint onoff)
+{
+#ifdef LOCAL_CREDS
+  setsockopt(fd, 0, LOCAL_CREDS, &onoff, sizeof(onoff));
+#else
+#ifdef SO_PASSCRED
+  setsockopt(fd, SOL_SOCKET, SO_PASSCRED, &onoff, sizeof(onoff));
 #endif
-
-void socket_set_pass_credentials(gint fd);
-
 #endif
+}

--- a/modules/afsocket/socket-options-unix.h
+++ b/modules/afsocket/socket-options-unix.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2002-2013 Balabit
- * Copyright (c) 1998-2013 Balázs Scheidler
+ * Copyright (c) 2021 Balazs Scheidler <bazsi77@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -20,14 +19,25 @@
  * COPYING for details.
  *
  */
-#ifndef TRANSPORT_MAPPER_UNIX_H_INCLUDED
-#define TRANSPORT_MAPPER_UNIX_H_INCLUDED
+#ifndef SOCKET_OPTIONS_UNIX_H_INCLUDED
+#define SOCKET_OPTIONS_UNIX_H_INCLUDED
 
-#include "transport-mapper.h"
+#include "socket-options.h"
 
-typedef struct _TransportMapperUnix TransportMapperUnix;
+typedef struct _SocketOptionsUnix
+{
+  SocketOptions super;
+  gint so_passcred;
+} SocketOptionsUnix;
 
-TransportMapper *transport_mapper_unix_dgram_new(void);
-TransportMapper *transport_mapper_unix_stream_new(void);
+static inline void
+socket_options_unix_set_so_passcred(SocketOptions *s, gint so_passcred)
+{
+  SocketOptionsUnix *self = (SocketOptionsUnix *) s;
+
+  self->so_passcred = so_passcred;
+}
+
+SocketOptions *socket_options_unix_new(void);
 
 #endif

--- a/modules/afsocket/transport-mapper-unix.c
+++ b/modules/afsocket/transport-mapper-unix.c
@@ -22,7 +22,7 @@
  */
 #include "transport-mapper-unix.h"
 #include "transport-unix-socket.h"
-#include "unix-credentials.h"
+#include "compat-unix-creds.h"
 #include "stats/stats-registry.h"
 
 #include <sys/types.h>
@@ -53,7 +53,7 @@ _construct_log_transport(TransportMapper *s, gint fd)
   LogTransport *transport = _create_log_transport(s, fd);
 
   if (self->pass_unix_credentials)
-    socket_set_pass_credentials(fd);
+    setsockopt_so_passcred(fd, TRUE);
 
   return transport;
 }

--- a/modules/afsocket/transport-mapper-unix.c
+++ b/modules/afsocket/transport-mapper-unix.c
@@ -22,7 +22,6 @@
  */
 #include "transport-mapper-unix.h"
 #include "transport-unix-socket.h"
-#include "compat-unix-creds.h"
 #include "stats/stats-registry.h"
 
 #include <sys/types.h>
@@ -33,29 +32,15 @@
 struct _TransportMapperUnix
 {
   TransportMapper super;
-  gchar *filename;
-  gboolean pass_unix_credentials;
 };
 
 static LogTransport *
-_create_log_transport(TransportMapper *s, gint fd)
+_construct_log_transport(TransportMapper *s, gint fd)
 {
   if (s->sock_type == SOCK_DGRAM)
     return log_transport_unix_dgram_socket_new(fd);
   else
     return log_transport_unix_stream_socket_new(fd);
-}
-
-static LogTransport *
-_construct_log_transport(TransportMapper *s, gint fd)
-{
-  TransportMapperUnix *self = (TransportMapperUnix *) s;
-  LogTransport *transport = _create_log_transport(s, fd);
-
-  if (self->pass_unix_credentials)
-    setsockopt_so_passcred(fd, TRUE);
-
-  return transport;
 }
 
 static TransportMapperUnix *
@@ -68,13 +53,6 @@ transport_mapper_unix_new_instance(const gchar *transport, gint sock_type)
   self->super.address_family = AF_UNIX;
   self->super.sock_type = sock_type;
   return self;
-}
-
-void
-transport_mapper_unix_set_pass_unix_credentials(TransportMapper *s, gboolean pass)
-{
-  TransportMapperUnix *self = (TransportMapperUnix *) s;
-  self->pass_unix_credentials = pass;
 }
 
 TransportMapper *

--- a/modules/afsocket/transport-unix-socket.c
+++ b/modules/afsocket/transport-unix-socket.c
@@ -25,7 +25,7 @@
 #include "transport/transport-socket.h"
 #include "scratch-buffers.h"
 #include "str-format.h"
-#include "unix-credentials.h"
+#include "compat-unix-creds.h"
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/news/feature-3670.md
+++ b/news/feature-3670.md
@@ -1,0 +1,19 @@
+`afsocket`: Socket options, such as ip-ttl() or tcp-keepalive-time(), are
+traditionally named by their identifier defined in socket(7) and unix(7) man
+pages.  This was not the case with the pass-unix-credentials() option, which
+- unlike other similar options - was also possible to set globally.
+
+A new option called so-passcred() is now introduced, which works similarly
+how other socket related options do, which also made possible a nice code
+cleanup in the related code sections.  Of course the old name remains
+supported in compatibility modes.
+
+The PR also implements a new source flag `ignore-aux-data`, which causes
+syslog-ng not to propagate transport-level auxiliary information to log
+messages.  Auxiliary information includes for example the pid/uid of the
+sending process in the case of UNIX based transports, OR the X.509
+certificate information in case of SSL/TLS encrypted data streams.
+
+By setting flags(ignore-aux-data) one can improve performance at the cost of
+making this information unavailable in the log messages received through
+affected sources.

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -87,6 +87,7 @@ modules/timestamp/rewrite-.*$
 modules/add-contextual-data/add-contextual-data-glob-selector\.[ch]$
 modules/add-contextual-data/tests/test_glob_selector\.c$
 modules/affile/tests/test_file_writer\.c$
+modules/afsocket/socket-options-unix\.[ch]$
 scl/fortigate/.*\.conf$
 scl/cee/.*\.conf$
  GPLv2+_SSL


### PR DESCRIPTION
syslog-ng automatically collects information such as PID, UNIX UID/GID and similar process related information on the sender application when local logs are delivered via the unix-dgram() or unix-stream() drivers. This information becomes part of each log message, under the ".unix" prefix.

In extreme logging loads, the auxiliary data processing path might become a bottleneck, causing syslog-ng to consume more CPU than the application generating the logs (it was a Zorp instance at -v8, which is known to produce huge amount of logs).

This branch introduces a new flag, "ignore-aux-data" that allows disabling the collecting of UNIX related aux data.