### PR TITLE
openbsd: targz missing openbsd grammar files

### DIFF
--- a/modules/openbsd/Makefile.am
+++ b/modules/openbsd/Makefile.am
@@ -9,11 +9,6 @@ modules_openbsd_libopenbsd_la_SOURCES = \
   modules/openbsd/openbsd-driver.c 		\
   modules/openbsd/openbsd-driver.h
 
-BUILT_SOURCES       +=      \
-  modules/openbsd/openbsd-grammar.y       \
-  modules/openbsd/openbsd-grammar.c       \
-  modules/openbsd/openbsd-grammar.h
-
 modules_openbsd_libopenbsd_la_CPPFLAGS  =     \
   $(AM_CPPFLAGS)            \
   -I$(top_srcdir)/modules/openbsd        \
@@ -24,6 +19,11 @@ modules_openbsd_libopenbsd_la_DEPENDENCIES= $(MODULE_DEPS_LIBS)
 
 modules/openbsd modules/openbsd/ mod-openbsd: modules/openbsd/libopenbsd.la
 endif
+
+BUILT_SOURCES       +=      \
+  modules/openbsd/openbsd-grammar.y       \
+  modules/openbsd/openbsd-grammar.c       \
+  modules/openbsd/openbsd-grammar.h
 
 EXTRA_DIST        +=      \
   modules/openbsd/openbsd-grammar.ym \


### PR DESCRIPTION
Fixes https://github.com/syslog-ng/syslog-ng/issues/3674