### PR TITLE
mongodb: fix abort with older mongo-c-driver versions

### DIFF
--- a/modules/afmongodb/afmongodb-worker.c
+++ b/modules/afmongodb/afmongodb-worker.c
@@ -34,7 +34,8 @@ _worker_disconnect(LogThreadedDestWorker *s)
   MongoDBDestWorker *self = (MongoDBDestWorker *)s;
   MongoDBDestDriver *owner = (MongoDBDestDriver *) self->super.owner;
 
-  mongoc_collection_destroy(self->coll_obj);
+  if (self->coll_obj)
+    mongoc_collection_destroy(self->coll_obj);
   self->coll_obj = NULL;
 
   if (self->client)
@@ -63,7 +64,9 @@ _switch_collection(MongoDBDestWorker *self, const gchar *collection)
   if (!self->client)
     return FALSE;
 
-  mongoc_collection_destroy(self->coll_obj);
+  if (self->coll_obj)
+    mongoc_collection_destroy(self->coll_obj);
+
   self->coll_obj = mongoc_client_get_collection(self->client, owner->const_db, collection);
 
   if (!self->coll_obj)
@@ -397,7 +400,8 @@ _worker_thread_deinit(LogThreadedDestWorker *s)
 {
   MongoDBDestWorker *self = (MongoDBDestWorker *) s;
 
-  bson_destroy(self->bson);
+  if (self->bson)
+    bson_destroy(self->bson);
   self->bson = NULL;
 
   g_string_free(self->collection, TRUE);

--- a/news/bugfix-3677.md
+++ b/news/bugfix-3677.md
@@ -1,0 +1,4 @@
+`mongodb()`: fix crash with older mongo-c-driver versions
+
+syslog-ng crashed (was aborted) when the `mongodb()` destination was used with
+older mongo-c-driver versions (< v1.11.0).


### PR DESCRIPTION
Prior to v1.11.0, `mongoc_collection_destroy()` and `bson_destroy()` were not NULL-safe.
https://github.com/mongodb/mongo-c-driver/releases/tag/1.11.0

```
mongoc_collection_destroy(): precondition failed: collection
Abort (core dumped)
```

This is a regression, I broke it in #3621, sorry.

Unfortunately, relatively old mongo-c-drivers are used in different distros. For example, Ubuntu Bionic is affected too, they use v1.9.2.
https://repology.org/project/mongo-c-driver/versions