### PR TITLE
java(): fix debug logging of Java-based destinations

### DIFF
--- a/modules/java-modules/common/src/main/java/org/syslog_ng/logging/SyslogNgInternalLogger.java
+++ b/modules/java-modules/common/src/main/java/org/syslog_ng/logging/SyslogNgInternalLogger.java
@@ -38,6 +38,7 @@ public class SyslogNgInternalLogger extends AppenderSkeleton {
         if (logger.getAppender(SyslogNgInternalLogger.NAME) == null) {
             logger.removeAllAppenders();
             logger.addAppender(new SyslogNgInternalLogger());
+            logger.setLevel(SyslogNgInternalLogger.getLevel());
         }
     }
 
@@ -84,4 +85,22 @@ public class SyslogNgInternalLogger extends AppenderSkeleton {
         }
     }
 
+    public static Level getLevel() {
+        switch (InternalMessageSender.getLevel()) {
+        case InternalMessageSender.LevelFatal:
+            return Level.FATAL;
+        case InternalMessageSender.LevelError:
+            return Level.ERROR;
+        case InternalMessageSender.LevelWarning:
+            return Level.WARN;
+        case InternalMessageSender.LevelNotice:
+            return Level.INFO;
+        case InternalMessageSender.LevelInfo:
+            return Level.INFO;
+        case InternalMessageSender.LevelDebug:
+            return Level.DEBUG;
+        }
+
+        return Level.OFF;
+    }
 }

--- a/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestination.java
+++ b/modules/java-modules/kafka/src/main/java/org/syslog_ng/KafkaDestination.java
@@ -46,8 +46,11 @@ public class KafkaDestination extends StructuredLogDestination {
 
   public KafkaDestination(long handle) {
     super(handle);
+
+    Logger.getLogger("org.apache.kafka").setLevel(SyslogNgInternalLogger.getLevel());
     logger = Logger.getRootLogger();
     SyslogNgInternalLogger.register(logger);
+
     options = new KafkaDestinationOptions(this);
     properties = new KafkaDestinationProperties(options);
   }

--- a/modules/java/proxies/internal-message-sender-proxy.c
+++ b/modules/java/proxies/internal-message-sender-proxy.c
@@ -36,3 +36,12 @@ Java_org_syslog_1ng_InternalMessageSender_createInternalMessage(JNIEnv *env, jcl
       (*env)->ReleaseStringUTFChars(env, message, c_str);
     }
 }
+
+JNIEXPORT jint JNICALL
+Java_org_syslog_1ng_InternalMessageSender_getLevel(JNIEnv *env, jclass cls)
+{
+  if (trace_flag || debug_flag)
+    return org_syslog_ng_InternalMessageSender_LevelDebug;
+
+  return org_syslog_ng_InternalMessageSender_LevelInfo;
+}

--- a/modules/java/proxies/internal-message-sender-proxy.c
+++ b/modules/java/proxies/internal-message-sender-proxy.c
@@ -28,7 +28,7 @@
 JNIEXPORT void JNICALL
 Java_org_syslog_1ng_InternalMessageSender_createInternalMessage(JNIEnv *env, jclass cls, jint pri, jstring message)
 {
-  if ((pri != org_syslog_ng_InternalMessageSender_MsgDebug) || debug_flag)
+  if ((pri != org_syslog_ng_InternalMessageSender_LevelDebug) || debug_flag)
     {
       const char *c_str = (*env)->GetStringUTFChars(env, message, 0);
       msg_event_suppress_recursions_and_send(msg_event_create(pri, c_str, NULL));

--- a/modules/java/src/main/java/org/syslog_ng/InternalMessageSender.java
+++ b/modules/java/src/main/java/org/syslog_ng/InternalMessageSender.java
@@ -57,5 +57,7 @@ public class InternalMessageSender {
     createInternalMessage(LevelDebug, message);
   }
 
+  public native static int getLevel();
+
   private native static void createInternalMessage(int level, String message);
 };

--- a/modules/java/src/main/java/org/syslog_ng/InternalMessageSender.java
+++ b/modules/java/src/main/java/org/syslog_ng/InternalMessageSender.java
@@ -26,12 +26,12 @@
 package org.syslog_ng;
 
 public class InternalMessageSender {
-  private static final int LevelFatal = 2;
-  private static final int LevelError = 3;
-  private static final int LevelWarning = 4;
-  private static final int LevelNotice = 5;
-  private static final int LevelInfo = 6;
-  private static final int LevelDebug = 7;
+  public static final int LevelFatal = 2;
+  public static final int LevelError = 3;
+  public static final int LevelWarning = 4;
+  public static final int LevelNotice = 5;
+  public static final int LevelInfo = 6;
+  public static final int LevelDebug = 7;
 
   public static void fatal(String message) {
     createInternalMessage(LevelFatal, message);
@@ -56,5 +56,6 @@ public class InternalMessageSender {
   public static void debug(String message) {
     createInternalMessage(LevelDebug, message);
   }
+
   private native static void createInternalMessage(int level, String message);
 };

--- a/modules/java/src/main/java/org/syslog_ng/InternalMessageSender.java
+++ b/modules/java/src/main/java/org/syslog_ng/InternalMessageSender.java
@@ -26,36 +26,35 @@
 package org.syslog_ng;
 
 public class InternalMessageSender {
-  private static final int MsgFatal = 2;
-  private static final int MsgError = 3;
-  private static final int MsgWarning = 4;
-  private static final int MsgNotice = 5;
-  private static final int MsgInfo = 6;
-  private static final int MsgDebug = 7;
+  private static final int LevelFatal = 2;
+  private static final int LevelError = 3;
+  private static final int LevelWarning = 4;
+  private static final int LevelNotice = 5;
+  private static final int LevelInfo = 6;
+  private static final int LevelDebug = 7;
 
   public static void fatal(String message) {
-    createInternalMessage(MsgFatal, message);
+    createInternalMessage(LevelFatal, message);
   }
 
   public static void error(String message) {
-    createInternalMessage(MsgError, message);
+    createInternalMessage(LevelError, message);
   }
-  
+
   public static void warning(String message) {
-    createInternalMessage(MsgWarning, message);
+    createInternalMessage(LevelWarning, message);
   }
-  
+
   public static void notice(String message) {
-    createInternalMessage(MsgNotice, message);
+    createInternalMessage(LevelNotice, message);
   }
 
   public static void info(String message) {
-    createInternalMessage(MsgInfo, message);
+    createInternalMessage(LevelInfo, message);
   }
-  
+
   public static void debug(String message) {
-    createInternalMessage(MsgDebug, message);
+    createInternalMessage(LevelDebug, message);
   }
-  
   private native static void createInternalMessage(int level, String message);
 };

--- a/news/bugfix-3679.md
+++ b/news/bugfix-3679.md
@@ -1,0 +1,3 @@
+`java()`: fix debug logging of Java-based destinations
+
+Java debug logging was not enabled previously when syslog-ng was started in debug/trace mode. This has been fixed.


### PR DESCRIPTION
This PR fixes Java debug logging.
Previously log4j's log level was left on its default value, even when syslog-ng was started in debug/trace mode.

Now the log4j log level is set to syslog-ng's internal log level, so they'll be in sync.

Note:
Currently, the log level is not updated when debug/trace is enabled or disabled at runtime (using syslog-ng-ctl).

----

The class names and their responsibilities can be confusing here:
- `InternalMessageSender` - this is a native Java "proxy" class that can be used to send messages through the `internal()` source.
- `SyslogNgInternalLogger` - this is a log4j log appender implementation, which uses `InternalMessageSender` - it extends `org.apache.log4j.AppenderSkeleton`.