### PR TITLE
contrib/openbsd-packaging/syslog-ng.conf: sync with OpenBSD ports

### DIFF
--- a/contrib/openbsd-packaging/syslog-ng.conf
+++ b/contrib/openbsd-packaging/syslog-ng.conf
@@ -1,41 +1,37 @@
 # syslog-ng configuration file for OpenBSD.
-# This should provide the same behavior as OpenBSD's syslog.conf(5).
-# 2010-07-18 steven@openbsd.org
+# This should provide behavior similar to OpenBSD's syslog.conf(5).
+# 2021-05-24 millert@openbsd.org
 
 @version: 3.32
+@requires openbsd
 
-options {
+options { 
 	use_dns(no);
+	dns_cache(no);
 	create_dirs(no);
 	keep_hostname(yes);
 };
 
 source s_local {
+	openbsd();
 	unix-dgram ("/dev/log");
-	unix-dgram ("/var/empty/dev/log");
 	internal();
 };
-#source s_local_all {
-#	unix-dgram ("/dev/log");
-#	unix-dgram ("/var/empty/dev/log");
-#	unix-dgram ("/var/www/dev/log");
-#	internal();
-#};
+
 #source s_net {
 #	udp(port(514));
 #};
 
 destination d_console	{ file("/dev/console");		};
-destination d_messages	{ file("/var/log/messages" perm(0644));	};
-destination d_authlog	{ file("/var/log/authlog");	};
-destination d_secure	{ file("/var/log/secure");	};
-destination d_cronlog	{ file("/var/cron/log");	};
-destination d_daemon	{ file("/var/log/daemon");	};
-destination d_xferlog	{ file("/var/log/xferlog");	};
-destination d_lpderrs	{ file("/var/log/lpd-errs");	};
-destination d_maillog	{ file("/var/log/maillog");	};
-destination d_sudolog	{ file("/var/log/sudo");	};
-destination d_chatlog	{ file("/var/log/chat");	};
+destination d_messages	{ file("/var/log/messages" owner(root) group(wheel) perm(0644));	};
+destination d_authlog	{ file("/var/log/authlog" owner(root) group(wheel) perm(0640));	};
+destination d_secure	{ file("/var/log/secure" owner(root) group(wheel) perm(0600));	};
+destination d_cronlog	{ file("/var/cron/log" owner(root) group(wheel) perm(0600));	};
+destination d_daemon	{ file("/var/log/daemon" owner(root) group(wheel) perm(0640));	};
+destination d_xferlog	{ file("/var/log/xferlog" owner(root) group(wheel) perm(0640));	};
+destination d_lpderrs	{ file("/var/log/lpd-errs" owner(root) group(wheel) perm(0640));	};
+destination d_maillog	{ file("/var/log/maillog" owner(root) group(wheel) perm(0600));	};
+destination d_doaslog	{ file("/var/log/doas");	};
 destination d_ttyall	{ usertty("*");			};
 destination d_ttyroot	{ usertty("root");		};
 destination d_loghost	{ udp("loghost" port(514));	};
@@ -91,11 +87,8 @@ filter f_to_loghost {
 	or (level(info .. emerg) and facility(auth,daemon,syslog,user))
 	or (level(debug .. emerg) and facility(authpriv,kern));
 };
-filter f_prog_sudo {
-	program("sudo");
-};
-filter f_prog_chat {
-	program("chat");
+filter f_prog_doas {
+	program("doas");
 };
 
 log { source(s_local); filter(f_notice);	destination(d_messages);};
@@ -117,17 +110,16 @@ log { source(s_local); filter(f_mailinfo);	destination(d_maillog);	};
 # as well as all authentication messages sent to root.
 #log { source(s_local); filter(f_to_root);	destination(d_ttyroot);	};
 
-# Everyone gets emergency messages.
-log { source(s_local); filter(f_emerg);		destination(d_ttyall);	};
+# Uncomment if you want everyone to get emergency messages.
+#log { source(s_local); filter(f_emerg);	destination(d_ttyall);	};
 
 # Uncomment to log to a central host named "loghost".
 #log { source(s_local); filter(f_to_loghost);	destination(d_loghost);	};
 
-# Uncomment to log messages from sudo(8) and chat(8) to their own
-# respective log files.  Matches are done based on the program name.
+# Uncomment to log messages from doas(1) to its own log file.  Matches are done
+# based on the program name.
 # Program-specific logs:
-#log { source(s_local); filter(f_prog_sudo);	destination(d_sudolog);	};
-#log { source(s_local); filter(f_prog_chat);	destination(d_chatlog);	};
+#log { source(s_local); filter(f_prog_doas);	destination(d_doaslog);	};
 
 # Uncomment to log messages from the network.
 # Note: it is recommended to specify a different destination here.


### PR DESCRIPTION
The syslog-ng.conf file in OpenBSD ports has recently been updated to match the current version of the OpenBSD syslog.conf file.