### PR TITLE
kafka: use log_template api in _topic_name_is_a_template()

### DIFF
--- a/modules/kafka/kafka-dest-driver.c
+++ b/modules/kafka/kafka-dest-driver.c
@@ -479,7 +479,7 @@ _init_template_topic_name(KafkaDestDriver *self)
 static gboolean
 _topic_name_is_a_template(KafkaDestDriver *self)
 {
-  return (strchr(self->topic_name->template, '$') != NULL);
+  return !log_template_is_literal_string(self->topic_name);
 }
 
 static gboolean


### PR DESCRIPTION
Motivation: win smallest syslog-ng PR 2021 award. :)  Real motivation came from #3660.

Existing unit tests cover the refactor.
No news file needed.