### PR TITLE
qdisk: don't truncate if it would make a small size difference

### DIFF
--- a/lib/versioning.h
+++ b/lib/versioning.h
@@ -127,6 +127,7 @@
 #define VERSION_3_30 "syslog-ng 3.30"
 #define VERSION_3_31 "syslog-ng 3.31"
 #define VERSION_3_32 "syslog-ng 3.32"
+#define VERSION_3_33 "syslog-ng 3.33"
 
 /* VERSION_VALUE_* references versions as integers to be compared against stuff like cfg->user_version */
 /* VERSION_STR_* references versions as strings to be shown to the user */
@@ -164,6 +165,7 @@
 #define VERSION_VALUE_3_30 0x031e
 #define VERSION_VALUE_3_31 0x031f
 #define VERSION_VALUE_3_32 0x0320
+#define VERSION_VALUE_3_33 0x0321
 
 /* config version code, in the same format as GlobalConfig->version */
 #define VERSION_VALUE_CURRENT   VERSION_VALUE_3_32
@@ -174,8 +176,8 @@
  * meaning of any setting in the configuration file.  Basically, it is the
  * highest value passed to any cfg_is_config_version_older() call.
  */
-#define VERSION_VALUE_LAST_SEMANTIC_CHANGE  VERSION_VALUE_3_29
-#define VERSION_STR_LAST_SEMANTIC_CHANGE    "3.29"
+#define VERSION_VALUE_LAST_SEMANTIC_CHANGE  VERSION_VALUE_3_33
+#define VERSION_STR_LAST_SEMANTIC_CHANGE    "3.33"
 
 #define version_convert_from_user(v)  (v)
 

--- a/modules/diskq/CMakeLists.txt
+++ b/modules/diskq/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(SYSLOG_NG_DISK_BUFFER_SOURCES
     diskq-options.h
     diskq-options.c
+    diskq-config.h
+    diskq-config.c
     logqueue-disk.c
     logqueue-disk.h
     logqueue-disk-non-reliable.c

--- a/modules/diskq/Makefile.am
+++ b/modules/diskq/Makefile.am
@@ -5,6 +5,8 @@ module_LTLIBRARIES += modules/diskq/libdisk-buffer.la
 modules_diskq_libsyslog_ng_disk_buffer_la_SOURCES = \
   modules/diskq/diskq-options.h \
   modules/diskq/diskq-options.c \
+  modules/diskq/diskq-config.h \
+  modules/diskq/diskq-config.c \
   modules/diskq/logqueue-disk.c \
   modules/diskq/logqueue-disk.h \
   modules/diskq/logqueue-disk-non-reliable.c \

--- a/modules/diskq/diskq-config.c
+++ b/modules/diskq/diskq-config.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021 One Identity
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "diskq-config.h"
+#include "cfg.h"
+
+#define MODULE_CONFIG_KEY "disk-buffer"
+
+static void
+disk_queue_config_free(ModuleConfig *s)
+{
+  module_config_free_method(s);
+}
+
+static void
+_set_default_values(DiskQueueConfig *self)
+{
+  self->truncate_size_ratio = 0.01;
+}
+
+DiskQueueConfig *
+disk_queue_config_new(void)
+{
+  DiskQueueConfig *self = g_new0(DiskQueueConfig, 1);
+
+  self->super.free_fn = disk_queue_config_free;
+  _set_default_values(self);
+  return self;
+}
+
+DiskQueueConfig *
+disk_queue_config_get(GlobalConfig *cfg)
+{
+  DiskQueueConfig *dqc = g_hash_table_lookup(cfg->module_config, MODULE_CONFIG_KEY);
+  if (!dqc)
+    {
+      dqc = disk_queue_config_new();
+      g_hash_table_insert(cfg->module_config, g_strdup(MODULE_CONFIG_KEY), dqc);
+    }
+  return dqc;
+}
+
+void
+disk_queue_config_set_truncate_size_ratio(GlobalConfig *cfg, gdouble truncate_size_ratio)
+{
+  DiskQueueConfig *dqc = disk_queue_config_get(cfg);
+  dqc->truncate_size_ratio = truncate_size_ratio;
+}
+
+gdouble
+disk_queue_config_get_truncate_size_ratio(GlobalConfig *cfg)
+{
+  DiskQueueConfig *dqc = disk_queue_config_get(cfg);
+  return dqc->truncate_size_ratio;
+}

--- a/modules/diskq/diskq-config.h
+++ b/modules/diskq/diskq-config.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 One Identity
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef DISKQ_CONFIG_H_INCLUDED
+#define DISKQ_CONFIG_H_INCLUDED
+
+#include "module-config.h"
+
+typedef struct _DiskQueueConfig
+{
+  ModuleConfig super;
+  gdouble truncate_size_ratio;
+} DiskQueueConfig;
+
+DiskQueueConfig *disk_queue_config_get(GlobalConfig *cfg);
+void disk_queue_config_set_truncate_size_ratio(GlobalConfig *cfg, gdouble truncate_size_ratio);
+gdouble disk_queue_config_get_truncate_size_ratio(GlobalConfig *cfg);
+
+#endif
+

--- a/modules/diskq/diskq-grammar.ym
+++ b/modules/diskq/diskq-grammar.ym
@@ -39,6 +39,7 @@
 #include "messages.h"
 #include "diskq.h"
 #include "diskq-options.h"
+#include "diskq-config.h"
 
 #include <string.h>
 
@@ -74,6 +75,7 @@ DiskQueueOptions *last_options;
 
 start
 	: LL_CONTEXT_INNER_DEST dest_diskq { YYACCEPT; }
+	| LL_CONTEXT_OPTIONS KW_DISK_BUFFER '(' diskq_global_options ')' { YYACCEPT; }
 	;
 
 dest_diskq
@@ -100,6 +102,15 @@ dest_diskq_option
         | KW_QOUT_SIZE '(' nonnegative_integer ')'       { disk_queue_options_qout_size_set(last_options, $3); }
         | KW_DIR '(' string ')'                          { disk_queue_options_set_dir(last_options, $3); free($3); }
         | KW_TRUNCATE_SIZE_RATIO '(' float_between_0_and_1 ')' { disk_queue_options_set_truncate_size_ratio(last_options, $3); }
+        ;
+
+diskq_global_options
+        : diskq_global_option diskq_global_options
+        |
+        ;
+
+diskq_global_option
+        : KW_TRUNCATE_SIZE_RATIO '(' float_between_0_and_1 ')' { disk_queue_config_set_truncate_size_ratio(configuration, $3); }
         ;
 
 float_between_0_and_1

--- a/modules/diskq/diskq-grammar.ym
+++ b/modules/diskq/diskq-grammar.ym
@@ -22,6 +22,8 @@
  *
  */
 
+%type <fnum> float_between_0_and_1
+
 %code top {
 #pragma GCC diagnostic ignored "-Wswitch-default"
 
@@ -65,6 +67,7 @@ DiskQueueOptions *last_options;
 %token KW_MEM_BUF_SIZE
 %token KW_QOUT_SIZE
 %token KW_DIR
+%token KW_TRUNCATE_SIZE_RATIO
 
 
 %%
@@ -96,6 +99,11 @@ dest_diskq_option
         | KW_DISK_BUF_SIZE '(' nonnegative_integer64 ')' { disk_queue_options_disk_buf_size_set(last_options, $3); }
         | KW_QOUT_SIZE '(' nonnegative_integer ')'       { disk_queue_options_qout_size_set(last_options, $3); }
         | KW_DIR '(' string ')'                          { disk_queue_options_set_dir(last_options, $3); free($3); }
+        | KW_TRUNCATE_SIZE_RATIO '(' float_between_0_and_1 ')' { disk_queue_options_set_truncate_size_ratio(last_options, $3); }
+        ;
+
+float_between_0_and_1
+        : nonnegative_float { CHECK_ERROR(($1 <= 1), @1, "It cannot be bigger, than 1"); }
         ;
 
 /* INCLUDE_RULES */

--- a/modules/diskq/diskq-options.c
+++ b/modules/diskq/diskq-options.c
@@ -79,6 +79,12 @@ disk_queue_options_mem_buf_length_set(DiskQueueOptions *self, gint mem_buf_lengt
 }
 
 void
+disk_queue_options_set_truncate_size_ratio(DiskQueueOptions *self, gdouble truncate_size_ratio)
+{
+  self->truncate_size_ratio = truncate_size_ratio;
+}
+
+void
 disk_queue_options_check_plugin_settings(DiskQueueOptions *self)
 {
   if (self->reliable)
@@ -128,6 +134,7 @@ disk_queue_options_set_default_options(DiskQueueOptions *self)
   self->mem_buf_size = -1;
   self->qout_size = -1;
   self->dir = g_strdup(get_installation_path_for(SYSLOG_NG_PATH_LOCALSTATEDIR));
+  self->truncate_size_ratio = -1;
 }
 
 void

--- a/modules/diskq/diskq-options.h
+++ b/modules/diskq/diskq-options.h
@@ -39,6 +39,7 @@ typedef struct _DiskQueueOptions
   gint mem_buf_size;
   gint mem_buf_length;
   gchar *dir;
+  gdouble truncate_size_ratio;
 } DiskQueueOptions;
 
 void disk_queue_options_qout_size_set(DiskQueueOptions *self, gint qout_size);
@@ -49,6 +50,7 @@ void disk_queue_options_mem_buf_size_set(DiskQueueOptions *self, gint mem_buf_si
 void disk_queue_options_mem_buf_length_set(DiskQueueOptions *self, gint mem_buf_length);
 void disk_queue_options_check_plugin_settings(DiskQueueOptions *self);
 void disk_queue_options_set_dir(DiskQueueOptions *self, const gchar *dir);
+void disk_queue_options_set_truncate_size_ratio(DiskQueueOptions *self, gdouble truncate_size_ratio);
 void disk_queue_options_set_default_options(DiskQueueOptions *self);
 void disk_queue_options_destroy(DiskQueueOptions *self);
 

--- a/modules/diskq/diskq-parser.c
+++ b/modules/diskq/diskq-parser.c
@@ -38,6 +38,7 @@ static CfgLexerKeyword diskq_keywords[] =
   { "mem_buf_size",      KW_MEM_BUF_SIZE },
   { "qout_size",         KW_QOUT_SIZE },
   { "dir",               KW_DIR },
+  { "truncate_size_ratio", KW_TRUNCATE_SIZE_RATIO },
   { NULL }
 };
 

--- a/modules/diskq/diskq-plugin.c
+++ b/modules/diskq/diskq-plugin.c
@@ -34,6 +34,11 @@ static Plugin diskq_plugins[] =
     .name = "disk_buffer",
     .parser = &diskq_parser,
   },
+  {
+    .type = LL_CONTEXT_OPTIONS,
+    .name = "disk_buffer",
+    .parser = &diskq_parser,
+  },
 };
 
 #ifndef STATIC

--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -22,6 +22,7 @@
  */
 
 #include "diskq.h"
+#include "diskq-config.h"
 
 #include "driver.h"
 #include "messages.h"
@@ -157,7 +158,7 @@ _attach(LogDriverPlugin *s, LogDriver *d)
   if (self->options.qout_size < 0)
     self->options.qout_size = 64;
   if (self->options.truncate_size_ratio < 0)
-    self->options.truncate_size_ratio = 0.01;
+    self->options.truncate_size_ratio = disk_queue_config_get_truncate_size_ratio(cfg);
 
   dd->acquire_queue = _acquire_queue;
   dd->release_queue = _release_queue;

--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -156,6 +156,8 @@ _attach(LogDriverPlugin *s, LogDriver *d)
     self->options.mem_buf_length = cfg->log_fifo_size;
   if (self->options.qout_size < 0)
     self->options.qout_size = 64;
+  if (self->options.truncate_size_ratio < 0)
+    self->options.truncate_size_ratio = 0.01;
 
   dd->acquire_queue = _acquire_queue;
   dd->release_queue = _release_queue;

--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -131,6 +131,22 @@ _release_queue(LogDestDriver *dd, LogQueue *queue)
     }
 }
 
+static void
+_set_default_truncate_size_ratio(DiskQDestPlugin *self, GlobalConfig *cfg)
+{
+  if (cfg_is_config_version_older(cfg, VERSION_VALUE_3_33))
+    {
+      msg_warning_once("WARNING: the truncation of the disk-buffer files is changed starting with "
+                       VERSION_3_33 ". You are using an older config version and your config does not "
+                       "set the truncate-size-ratio() option. We will not use the new truncating logic "
+                       "with this config for compatibility.");
+      self->options.truncate_size_ratio = 0;
+      return;
+    }
+
+  self->options.truncate_size_ratio = disk_queue_config_get_truncate_size_ratio(cfg);
+}
+
 static gboolean
 _attach(LogDriverPlugin *s, LogDriver *d)
 {
@@ -158,7 +174,7 @@ _attach(LogDriverPlugin *s, LogDriver *d)
   if (self->options.qout_size < 0)
     self->options.qout_size = 64;
   if (self->options.truncate_size_ratio < 0)
-    self->options.truncate_size_ratio = disk_queue_config_get_truncate_size_ratio(cfg);
+    _set_default_truncate_size_ratio(self, cfg);
 
   dd->acquire_queue = _acquire_queue;
   dd->release_queue = _release_queue;

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -119,7 +119,7 @@ _ack_backlog(LogQueueDisk *s, guint num_msg_to_ack)
       qdisk_dec_backlog (self->super.qdisk);
     }
 exit_reliable:
-  qdisk_reset_file_if_possible (self->super.qdisk);
+  qdisk_reset_file_if_empty(self->super.qdisk);
 }
 
 static gint

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -47,8 +47,6 @@
 
 #define PATH_QDISK              PATH_LOCALSTATEDIR
 
-#define TRUNCATE_SIZE_RATIO 0.01
-
 typedef union _QDiskFileHeader
 {
   struct
@@ -213,7 +211,7 @@ static gboolean
 _possible_size_reduction_reaches_truncate_threshold(QDisk *self, gint64 expected_size)
 {
   gint64 possible_size_reduction = self->file_size - expected_size;
-  gint64 truncate_threshold = (gint64)(qdisk_get_maximum_size(self) * TRUNCATE_SIZE_RATIO);
+  gint64 truncate_threshold = (gint64)(qdisk_get_maximum_size(self) * self->options->truncate_size_ratio);
   return possible_size_reduction >= truncate_threshold;
 }
 

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -201,9 +201,9 @@ qdisk_is_space_avail(QDisk *self, gint at_least)
 }
 
 static void
-_truncate_file(QDisk *self, off_t expected_size)
+_truncate_file(QDisk *self, gint64 expected_size)
 {
-  if (ftruncate(self->fd, expected_size) == 0)
+  if (ftruncate(self->fd, (off_t) expected_size) == 0)
     {
       self->file_size = expected_size;
       return;
@@ -216,7 +216,7 @@ _truncate_file(QDisk *self, off_t expected_size)
     }
   else
     {
-      self->file_size = st.st_size;
+      self->file_size = (gint64) st.st_size;
     }
 
   msg_error("Error truncating disk-queue file",

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -200,13 +200,13 @@ qdisk_is_space_avail(QDisk *self, gint at_least)
 
 }
 
-static gboolean
+static void
 _truncate_file(QDisk *self, off_t expected_size)
 {
   if (ftruncate(self->fd, expected_size) == 0)
     {
       self->file_size = expected_size;
-      return TRUE;
+      return;
     }
 
   off_t file_size = -1;
@@ -226,8 +226,6 @@ _truncate_file(QDisk *self, off_t expected_size)
             evt_tag_long("expected-size", expected_size),
             evt_tag_long("file-size", file_size),
             evt_tag_int("fd", self->fd));
-
-  return FALSE;
 }
 
 static gint64

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -56,7 +56,7 @@ gboolean qdisk_pop_head(QDisk *self, GString *record);
 gboolean qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow);
 void qdisk_init_instance(QDisk *self, DiskQueueOptions *options, const gchar *file_id);
 void qdisk_stop(QDisk *self);
-void qdisk_reset_file_if_possible(QDisk *self);
+void qdisk_reset_file_if_empty(QDisk *self);
 gboolean qdisk_started(QDisk *self);
 void qdisk_free(QDisk *self);
 

--- a/news/feature-3689.md
+++ b/news/feature-3689.md
@@ -1,0 +1,14 @@
+`disk-buffer`: Now we optimize the file truncating frequency of disk-buffer.
+
+The new behavior saves IO time, but loses some disk space, which is configurable with a new option.
+The new option in the config is settable at 2 places:
+ * `truncate-size-ratio()` in the `disk-buffer()` block, which affects the given disk-buffer.
+ * `disk-buffer(truncate-size-ratio())` in the global `options` block, which affects every disk-buffer
+   which did not set `truncate-size-ratio()` itself.
+The default value is 0.01, which operates well with most disk-buffers.
+
+If the possible size reduction of the truncation does not reach `truncate-size-ratio()` x `disk-buf-size()`,
+we do not truncate the disk-buffer.
+
+To completely turn off truncating (maximal disk space loss, maximal IO time saved) set `truncate-size-ratio(1)`,
+or to mimic the old behavior (minimal disk space loss, minimal IO time saved) set `truncate-size-ratio(0)`.


### PR DESCRIPTION
TODO:
- [x] Run performance test (No noticeable speed-up)
- [x] Check KIRA failure
- [x] Add `disk-buffer()` block to global options
- [x] rename to `truncate-size-ratio()`

---

`ftruncate()` is an expensive call.

In the current form, in case of a reliable disk-buffer when the destination acks the message, the truncate is usually called.

Let's look at the situation, where the destination can keep up with the speed of the source:
   1. Incoming message, it gets written to the disk buffer, the write head moves to `RESERVED_SPACE` + `msg_size`.
   2. We read the message from the disk-buffer, and send it to the destination, the read head moves to `RESERVED_SPACE` + `msg_size`.
   3. The destination acks the message, the backlog_head moves to `RESERVED_SPACE` + `msg_size`.
   4. At the end of the ack, we see, that the disk buffer is "empty", meaning all heads are at the same position, so we truncate the file to `RESERVED_SPACE`, and move all 3 heads there.
   5. A new message arrives, and we go to step 1.

In this scenario we call `ftruncate()` for every incoming message.
I have made a test code (a separate PoC code, **not** in syslog-ng), which measures the `fwrite`, `fread`, `ftruncate` iteration's time taken, and I observed, that more than half of the real word time was taken by `ftruncate()`:
```
Writing, reading 1048576 * 1024 bytes messages, truncating the file to 4096 bytes per message.
   [1/10] DONE in 7.856170541 seconds, from which ftruncate() took 4.734487726 seconds.
   [2/10] DONE in 7.773038602 seconds, from which ftruncate() took 4.678402817 seconds.
   [3/10] DONE in 7.780979727 seconds, from which ftruncate() took 4.664749331 seconds.
   [4/10] DONE in 7.805741840 seconds, from which ftruncate() took 4.675652459 seconds.
   [5/10] DONE in 7.745974862 seconds, from which ftruncate() took 4.642292874 seconds.
   [6/10] DONE in 7.800890915 seconds, from which ftruncate() took 4.690607455 seconds.
   [7/10] DONE in 7.774325797 seconds, from which ftruncate() took 4.693368755 seconds.
   [8/10] DONE in 7.806343633 seconds, from which ftruncate() took 4.683172069 seconds.
   [9/10] DONE in 7.896176455 seconds, from which ftruncate() took 4.757315806 seconds.
   [10/10] DONE in 7.868837540 seconds, from which ftruncate() took 4.715273111 seconds.
```
I've done the measurements on an SSD on my personal Ubuntu Focal machine.

To optimize the calls of `ftruncate()`, in this commit I have introduced a new logic: we calculate the possible size reduction in each `_truncate_file()` call, and we do not call `ftruncate()` if it is less, than 1 percent of the maximal disk-buffer size.

My measurements changed drastically when implementing the same logic in the test code:
```
Writing, reading 1048576 * 1024 bytes messages, truncating the file to 4096 bytes if the size reduction reaches 1% of max size.
   [1/10] DONE in 2.255469215 seconds, from which ftruncate() took 0.107140776 seconds.
   [2/10] DONE in 2.226006879 seconds, from which ftruncate() took 0.109389325 seconds.
   [3/10] DONE in 2.239258063 seconds, from which ftruncate() took 0.110315009 seconds.
   [4/10] DONE in 2.229625672 seconds, from which ftruncate() took 0.110243967 seconds.
   [5/10] DONE in 2.255923025 seconds, from which ftruncate() took 0.108881297 seconds.
   [6/10] DONE in 2.223326513 seconds, from which ftruncate() took 0.107711562 seconds.
   [7/10] DONE in 2.251854651 seconds, from which ftruncate() took 0.134951278 seconds.
   [8/10] DONE in 2.235311433 seconds, from which ftruncate() took 0.126703875 seconds.
   [9/10] DONE in 2.228932757 seconds, from which ftruncate() took 0.109558716 seconds.
   [10/10] DONE in 2.259198891 seconds, from which ftruncate() took 0.109496328 seconds.
```

This logic can cause the disk-buffer file to be maximum 1% in size of the maximal size, with having only already processed messages in it. I believe it is not a big tradeoff, when seeing how much time it can save.

I have done measurements with other thresholds:
   1. 50% of max size: took the same time as for 1% (~0.1 seconds)
   2. 0.1%, 0.01%, 0.001%: took nearly the same time as for 1% (~0.1 seconds)
   3. 0.0001%, 0.00001%: took as much as read and write (~4 seconds)

What I observed is that it gets slow, when truncating nearly per msg. Then we reach a point (approximately at every 500th message), where no matter if we truncate at 1% or 50%, it takes the same time.

Thinking about a general config, where the disk buffer is 1GB, its 1% is 10MB, so if we receive smaller then 20KB sized messages, we have the optimal truncate time. Or for a 100MB disk-buffer it is 2KB.
Max 2KB message size and 100MB disk-buffer are common values, so I think the 1% of the max size threshold works most of the time.

Related issue, but does not get fixed by this PR: #3551

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>
