### PR TITLE
Fix crash when switching between disk-based and memory queues

### DIFF
--- a/lib/driver.c
+++ b/lib/driver.c
@@ -272,6 +272,12 @@ log_dest_driver_acquire_memory_queue(LogDestDriver *self, const gchar *persist_n
   if (persist_name)
     queue = cfg_persist_config_fetch(cfg, persist_name);
 
+  if (queue && !log_queue_has_type(queue, log_queue_fifo_get_type()))
+    {
+      log_queue_unref(queue);
+      queue = NULL;
+    }
+
   if (!queue)
     {
       queue = _create_memory_queue(self, persist_name);

--- a/lib/driver.c
+++ b/lib/driver.c
@@ -242,7 +242,7 @@ log_src_driver_free(LogPipe *s)
 /* LogDestDriver */
 
 static LogQueue *
-_create_log_queue(LogDestDriver *self, const gchar *persist_name)
+_create_memory_queue(LogDestDriver *self, const gchar *persist_name)
 {
   GlobalConfig *cfg = log_pipe_get_config(&self->super.super);
 
@@ -264,7 +264,7 @@ _create_log_queue(LogDestDriver *self, const gchar *persist_name)
 
 /* returns a reference */
 static LogQueue *
-log_dest_driver_acquire_queue_method(LogDestDriver *self, const gchar *persist_name)
+log_dest_driver_acquire_memory_queue(LogDestDriver *self, const gchar *persist_name)
 {
   GlobalConfig *cfg = log_pipe_get_config(&self->super.super);
   LogQueue *queue = NULL;
@@ -274,7 +274,7 @@ log_dest_driver_acquire_queue_method(LogDestDriver *self, const gchar *persist_n
 
   if (!queue)
     {
-      queue = _create_log_queue(self, persist_name);
+      queue = _create_memory_queue(self, persist_name);
       log_queue_set_throttle(queue, self->throttle);
     }
   return queue;
@@ -382,7 +382,7 @@ log_dest_driver_init_instance(LogDestDriver *self, GlobalConfig *cfg)
   self->super.super.init = log_dest_driver_init_method;
   self->super.super.deinit = log_dest_driver_deinit_method;
   self->super.super.queue = log_dest_driver_queue_method;
-  self->acquire_queue = log_dest_driver_acquire_queue_method;
+  self->acquire_queue = log_dest_driver_acquire_memory_queue;
   self->release_queue = log_dest_driver_release_queue_method;
   self->log_fifo_size = -1;
   self->throttle = 0;

--- a/lib/logqueue-fifo.c
+++ b/lib/logqueue-fifo.c
@@ -695,3 +695,9 @@ log_queue_fifo_legacy_new(gint log_fifo_size, const gchar *persist_name)
   self->use_legacy_fifo_size = TRUE;
   return &self->super;
 }
+
+QueueType
+log_queue_fifo_get_type(void)
+{
+  return log_queue_fifo_type;
+}

--- a/lib/logqueue-fifo.h
+++ b/lib/logqueue-fifo.h
@@ -30,4 +30,6 @@
 LogQueue *log_queue_fifo_new(gint log_fifo_size, const gchar *persist_name);
 LogQueue *log_queue_fifo_legacy_new(gint log_fifo_size, const gchar *persist_name);
 
+QueueType log_queue_fifo_get_type(void);
+
 #endif

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -200,6 +200,12 @@ log_queue_set_use_backlog(LogQueue *self, gboolean use_backlog)
     self->use_backlog = use_backlog;
 }
 
+static inline gboolean
+log_queue_has_type(LogQueue *self, QueueType type)
+{
+  return g_strcmp0(self->type, type) == 0;
+}
+
 void log_queue_memory_usage_add(LogQueue *self, gsize value);
 void log_queue_memory_usage_sub(LogQueue *self, gsize value);
 

--- a/news/bugfix-3700.md
+++ b/news/bugfix-3700.md
@@ -1,0 +1,4 @@
+`disk-buffer()`: fix crash when switching between disk-based and memory queues
+
+When a disk-buffer was removed from the configuration and the new config was
+applied by reloading syslog-ng, a crash occurred.


### PR DESCRIPTION
When a disk-buffer is removed from the configuration, and syslog-ng is reloaded, syslog-ng starts acquiring a memory queue instead, but first it fetches and tries to use the previous queue from cfg-persist. The type of the old queue is not validated, so we end up using a different type of queue than what the user configured.

This is not a disaster, this behavior could have been documented, but we also crash when trying to use the old queue, because it was not initialized with the queue's own initialization method (`DiskQ::acquire_queue()`).

This PR fixes the crash by safely closing the disk-buffer queue, and allocating a memory queue instead (exactly what the user wants; and unsent messages remain available in the disk buffer file).


Note: switching from a memory queue to a disk-based queue works the same way, the PR fixes a crash with the diskq-to-memqueue direction.