### PR TITLE
dbld: remove OBS dependencies from the ubuntu-bionic image

### DIFF
--- a/dbld/build.manifest
+++ b/dbld/build.manifest
@@ -32,9 +32,9 @@ debian-buster		python2,nojava,nokafka
 debian-testing		python3,nojava
 debian-sid		python3,nojava
 
-# on ubuntu, we fetch java from OBS and start using Python3 at focal onwards.
+# on ubuntu, we start using Python3 at focal onwards.
 ubuntu-xenial		python2,nokafka,nojava
-ubuntu-bionic		python2
+ubuntu-bionic		python2,nokafka
 ubuntu-focal		python3
 
 centos-7		python2,nokafka

--- a/dbld/builddeps
+++ b/dbld/builddeps
@@ -96,18 +96,6 @@ function filter_packages_by_platform {
     grep -v "#" ${FILENAME} | grep -e "${OS_PLATFORM}" -e "${OS_GROUP}[^-]" | cut -d"[" -f1
 }
 
-function add_obs_repo {
-    PLATFORM=$1
-    echo "deb http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/x${PLATFORM} ./" | tee /etc/apt/sources.list.d/lbudai.list
-    cat | tee /etc/apt/preferences.d/lbudai <<EOF
-Package: *
-Pin: origin "download.opensuse.org"
-Pin-Priority: 1
-EOF
-    wget -qO - http://download.opensuse.org/repositories/home:/laszlo_budai:/syslog-ng/x${PLATFORM}/Release.key | apt-key add -
-    apt-get update
-}
-
 function add_copr_repo {
 
     # NOTE: we are removing dnf/yum plugins after enabling copr as they

--- a/dbld/images/debian-sid.dockerfile
+++ b/dbld/images/debian-sid.dockerfile
@@ -1,6 +1,3 @@
-# this dbld image is special as it will compile syslog-ng against native
-# debian packages instead of pulling our own from OBS.
-
 FROM debian:sid
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
 

--- a/dbld/images/debian-testing.dockerfile
+++ b/dbld/images/debian-testing.dockerfile
@@ -1,6 +1,3 @@
-# this dbld image is special as it will compile syslog-ng against native
-# debian packages instead of pulling our own from OBS.
-
 FROM debian:testing
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
 

--- a/dbld/images/ubuntu-bionic.dockerfile
+++ b/dbld/images/ubuntu-bionic.dockerfile
@@ -15,7 +15,6 @@ COPY images/entrypoint.sh /
 COPY . /dbld/
 
 RUN /dbld/builddeps install_dbld_dependencies
-RUN /dbld/builddeps add_obs_repo Ubuntu_18.04
 RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps
 RUN /dbld/builddeps install_pip_packages

--- a/dbld/packages.manifest
+++ b/dbld/packages.manifest
@@ -112,37 +112,6 @@ libmongoc-dev               [debian, ubuntu-xenial]
 # added as comments.
 #############################################################################
 
-# librdkafka-dev on Ubuntu:
-#
-# We support librdkafka based destination on Ubuntu bionic even though
-# it does not have a recent enough librdkafka, the reason is that as of
-# today, our devshell uses bionic and we want to be able to try stuff that
-# we develop in that module.  Later on this support might be dropped as we
-# migrate to a newer distro.
-#
-# syslog-ng depends on >= 1.0.0, and we install these librdkafka from
-# LBudai's OBS repository.
-#
-# NOTE: even though we Build-Depend on stuff >= 1.0.0, that is not enough,
-# as an apt preferences file prevents installation from OBS without explicit
-# versions. Also, we need to list all recursive dependencies packages as an apt
-# preferences would prevent installation otherwise
-
-librdkafka1=1.0.1-1         [ubuntu-bionic]
-librdkafka++1=1.0.1-1       [ubuntu-bionic]
-librdkafka-dev=1.0.1-1      [ubuntu-bionic]
-
-# libbson* and libmongoc* packages on Ubuntu Bionic:
-#
-# On Bionic there is a cmake building issue with native mongodb packages.
-# To support full featured cmake build on Bionic we need to install newer
-# fixed versioned packages from OBS repository
-
-libbson-1.0=1.15.0-1        [ubuntu-bionic]
-libbson-dev=1.15.0-1        [ubuntu-bionic]
-libmongoc-1.0=1.15.0-1      [ubuntu-bionic]
-libmongoc-dev=1.15.0-1      [ubuntu-bionic]
-
 
 #############################################################################
 # Tools required to run @kira-syslogng, our testbot.


### PR DESCRIPTION
As the unofficial OBS repository is discontinued, I checked what depended on it in our CI and dbld.

- Ubuntu Bionic has librdkafka <1.0.0, so we added librdkafka >1.0 from OBS because that is our min. required version and we wanted a full feature set in our devshell image. The devshell image is now based on Debian Testing, therefore this workaround is not needed anymore. Note: The kafka-c destination is no longer built/packaged on Ubuntu Bionic.

- libmongoc had a CMake-only build issue in v1.9.2, thus we used v1.15.0 instead. The devshell image is now based on Debian Testing, so this is not needed anymore. This has no impact on the MongoDB destination's packaging.

The ubuntu-bionic was the last user of `add_obs_repo()` in dbld, so it has been removed as well.