### PR TITLE
Stats split response

### DIFF
--- a/lib/control/control-server-unix.c
+++ b/lib/control/control-server-unix.c
@@ -75,6 +75,13 @@ control_connection_unix_stop_watches(ControlConnection *s)
   iv_fd_unregister(&self->control_io);
 }
 
+static gboolean
+_pending_output(ControlConnection *s)
+{
+  return (s->output_buffer && s->output_buffer->len > s->pos) ||
+         !g_queue_is_empty(s->response_batches);
+}
+
 static void
 control_connection_unix_update_watches(ControlConnection *s)
 {
@@ -85,7 +92,7 @@ control_connection_unix_update_watches(ControlConnection *s)
       iv_fd_set_handler_out(&self->control_io, NULL);
       iv_fd_set_handler_in(&self->control_io, NULL);
     }
-  else if (s->output_buffer->len > s->pos)
+  else if (_pending_output(s))
     {
       iv_fd_set_handler_out(&self->control_io, s->handle_output);
       iv_fd_set_handler_in(&self->control_io, NULL);

--- a/lib/control/control-server-unix.c
+++ b/lib/control/control-server-unix.c
@@ -78,8 +78,11 @@ control_connection_unix_stop_watches(ControlConnection *s)
 static gboolean
 _pending_output(ControlConnection *s)
 {
-  return (s->output_buffer && s->output_buffer->len > s->pos) ||
-         !g_queue_is_empty(s->response_batches);
+  g_mutex_lock(s->response_batches_lock);
+  gboolean result = (s->output_buffer && s->output_buffer->len > s->pos) ||
+                    !g_queue_is_empty(s->response_batches);
+  g_mutex_unlock(s->response_batches_lock);
+  return result;
 }
 
 static void

--- a/lib/control/control-server.c
+++ b/lib/control/control-server.c
@@ -41,13 +41,8 @@ typedef struct _ThreadedCommandRunner
   gpointer user_data;
 
   GThread *thread;
-  //TODO: remove real_thread
   struct
   {
-    GMutex *tid_saved_lock;
-    GCond *tid_saved_cond;
-    gboolean tid_saved;
-    ThreadId tid;
     GMutex *state_lock;
     gboolean cancelled;
     gboolean finished;
@@ -63,11 +58,7 @@ _thread_command_runner_new(ControlConnection *cc, GString *cmd, gpointer user_da
   self->connection = control_connection_ref(cc);
   self->command = g_string_new(cmd->str);
   self->user_data = user_data;
-  self->real_thread.tid_saved_lock = g_mutex_new();
-  self->real_thread.tid_saved_cond = g_cond_new();
   self->real_thread.state_lock = g_mutex_new();
-  self->real_thread.tid_saved = FALSE;
-  self->real_thread.tid = 0;
 
   return self;
 }
@@ -75,31 +66,10 @@ _thread_command_runner_new(ControlConnection *cc, GString *cmd, gpointer user_da
 static void
 _thread_command_runner_free(ThreadedCommandRunner *self)
 {
-  g_mutex_free(self->real_thread.tid_saved_lock);
-  g_cond_free(self->real_thread.tid_saved_cond);
   g_mutex_free(self->real_thread.state_lock);
   g_string_free(self->command, TRUE);
   control_connection_unref(self->connection);
   g_free(self);
-}
-
-static void
-_thread_command_runner_wait_for_tid_saved(ThreadedCommandRunner *self)
-{
-  g_mutex_lock(self->real_thread.tid_saved_lock);
-  while (self->real_thread.tid_saved == FALSE)
-    g_cond_wait(self->real_thread.tid_saved_cond, self->real_thread.tid_saved_lock);
-  g_mutex_unlock(self->real_thread.tid_saved_lock);
-}
-
-static void
-_thread_command_runner_save_tid(ThreadedCommandRunner *self)
-{
-  g_mutex_lock(self->real_thread.tid_saved_lock);
-  self->real_thread.tid = get_thread_id();
-  self->real_thread.tid_saved = TRUE;
-  g_cond_broadcast(self->real_thread.tid_saved_cond);
-  g_mutex_unlock(self->real_thread.tid_saved_lock);
 }
 
 static void
@@ -117,7 +87,6 @@ static void
 _thread(gpointer user_data)
 {
   ThreadedCommandRunner *self = (ThreadedCommandRunner *)user_data;
-  _thread_command_runner_save_tid(self);
   self->func(self->connection, self->command, self->user_data);
   g_mutex_lock(self->real_thread.state_lock);
   {
@@ -156,7 +125,6 @@ _thread_command_runner_run(ThreadedCommandRunner *self, ControlConnectionCommand
   iv_event_register(&self->thread_finished);
 
   self->thread = g_thread_new(self->command->str, (GThreadFunc) _thread, self);
-  _thread_command_runner_wait_for_tid_saved(self);
   ControlServer *server = self->connection->server;
   server->worker_threads = g_list_append(server->worker_threads, self);
 }
@@ -173,7 +141,6 @@ static void
 _delete_thread_command_runner(gpointer data)
 {
   ThreadedCommandRunner *self = (ThreadedCommandRunner *) data;
-  g_assert(self->real_thread.tid_saved == TRUE);
   gboolean has_to_free = FALSE;
 
   g_mutex_lock(self->real_thread.state_lock);

--- a/lib/control/control-server.c
+++ b/lib/control/control-server.c
@@ -41,6 +41,7 @@ typedef struct _ThreadedCommandRunner
   gpointer user_data;
 
   GThread *thread;
+  //TODO: remove real_thread
   struct
   {
     GMutex *tid_saved_lock;
@@ -59,8 +60,7 @@ static ThreadedCommandRunner *
 _thread_command_runner_new(ControlConnection *cc, GString *cmd, gpointer user_data)
 {
   ThreadedCommandRunner *self = g_new0(ThreadedCommandRunner, 1);
-  // todo: wrapper?-> send_reply_threaded()...
-  self->connection = cc;
+  self->connection = control_connection_ref(cc);
   self->command = g_string_new(cmd->str);
   self->user_data = user_data;
   self->real_thread.tid_saved_lock = g_mutex_new();
@@ -79,6 +79,7 @@ _thread_command_runner_free(ThreadedCommandRunner *self)
   g_cond_free(self->real_thread.tid_saved_cond);
   g_mutex_free(self->real_thread.state_lock);
   g_string_free(self->command, TRUE);
+  control_connection_unref(self->connection);
   g_free(self);
 }
 
@@ -209,7 +210,7 @@ void
 control_server_connection_closed(ControlServer *self, ControlConnection *cc)
 {
   control_connection_stop_watches(cc);
-  control_connection_free(cc);
+  control_connection_unref(cc);
 }
 
 void
@@ -244,8 +245,8 @@ _g_string_destroy(gpointer user_data)
   g_string_free(str, TRUE);
 }
 
-void
-control_connection_free(ControlConnection *self)
+static void
+_control_connection_free(ControlConnection *self)
 {
   if (self->free_fn)
     {
@@ -449,6 +450,7 @@ _on_evt_response_added(gpointer user_data)
 void
 control_connection_init_instance(ControlConnection *self, ControlServer *server)
 {
+  g_atomic_counter_set(&self->ref_cnt, 1);
   self->server = server;
   self->input_buffer = g_string_sized_new(128);
   self->handle_input = control_connection_io_input;
@@ -465,17 +467,42 @@ control_connection_init_instance(ControlConnection *self, ControlServer *server)
   return;
 }
 
+ControlConnection *
+control_connection_ref(ControlConnection *self)
+{
+  g_assert(!self || g_atomic_counter_get(&self->ref_cnt) > 0);
+
+  if (self)
+    g_atomic_counter_inc(&self->ref_cnt);
+
+  return self;
+}
+
+void
+control_connection_unref(ControlConnection *self)
+{
+  g_assert(!self || g_atomic_counter_get(&self->ref_cnt));
+
+  if (self && (g_atomic_counter_dec_and_test(&self->ref_cnt)))
+    _control_connection_free(self);
+}
 
 void
 control_connection_start_watches(ControlConnection *self)
 {
   if (self->events.start_watches)
-    self->events.start_watches(self);
+    {
+      self->watches_are_running = TRUE;
+      self->events.start_watches(self);
+    }
 }
 
 void
 control_connection_update_watches(ControlConnection *self)
 {
+  if (!self->watches_are_running)
+    return;
+
   if (self->events.update_watches)
     self->events.update_watches(self);
 }
@@ -484,5 +511,8 @@ void
 control_connection_stop_watches(ControlConnection *self)
 {
   if (self->events.stop_watches)
-    self->events.stop_watches(self);
+    {
+      self->events.stop_watches(self);
+      self->watches_are_running = FALSE;
+    }
 }

--- a/lib/control/control-server.c
+++ b/lib/control/control-server.c
@@ -180,7 +180,6 @@ _delete_thread_command_runner(gpointer data)
     self->real_thread.cancelled = TRUE;
     if (!self->real_thread.finished)
       {
-        thread_cancel(self->real_thread.tid);
         has_to_free = TRUE;
       }
   }

--- a/lib/control/control-server.c
+++ b/lib/control/control-server.c
@@ -87,7 +87,9 @@ static void
 _thread(gpointer user_data)
 {
   ThreadedCommandRunner *self = (ThreadedCommandRunner *)user_data;
-  self->func(self->connection, self->command, self->user_data);
+  GString *response = self->func(self->connection, self->command, self->user_data);
+  if (response)
+    control_connection_send_reply(self->connection, response);
   g_mutex_lock(self->real_thread.state_lock);
   {
     self->real_thread.finished = TRUE;
@@ -103,7 +105,9 @@ _thread_command_runner_sync_run(ThreadedCommandRunner *self, ControlConnectionCo
   msg_warning("Cannot start a separated thread - ControlServer is not running",
               evt_tag_str("command", self->command->str));
 
-  func(self->connection, self->command, self->user_data);
+  GString *response = func(self->connection, self->command, self->user_data);
+  if (response)
+    control_connection_send_reply(self->connection, response);
 
   _thread_command_runner_free(self);
 }

--- a/lib/control/control-server.c
+++ b/lib/control/control-server.c
@@ -198,6 +198,7 @@ control_server_cancel_workers(ControlServer *self)
 {
   if (self->worker_threads)
     {
+      self->cancelled = TRUE; // racy, but it's okay
       msg_warning("Cancelling control server worker threads");
       g_list_free_full(self->worker_threads, _delete_thread_command_runner);
       msg_warning("Control server worker threads has been cancelled.");
@@ -217,6 +218,7 @@ control_server_init_instance(ControlServer *self, const gchar *path)
 {
   self->control_socket_name = g_strdup(path);
   self->worker_threads = NULL;
+  self->cancelled = FALSE;
 }
 
 void

--- a/lib/control/control-server.h
+++ b/lib/control/control-server.h
@@ -31,6 +31,7 @@
 
 struct _ControlConnection
 {
+  GQueue *response_batches;
   gboolean waiting_for_output;
   GString *input_buffer;
   GString *output_buffer;

--- a/lib/control/control-server.h
+++ b/lib/control/control-server.h
@@ -25,6 +25,7 @@
 
 #include "syslog-ng.h"
 #include "control.h"
+#include <iv_event.h>
 #include <stdio.h>
 
 #define MAX_CONTROL_LINE_LENGTH 4096
@@ -33,6 +34,7 @@ struct _ControlConnection
 {
   GQueue *response_batches;
   GMutex *response_batches_lock;
+  struct iv_event evt_response_added;
   gboolean waiting_for_output;
   GString *input_buffer;
   GString *output_buffer;

--- a/lib/control/control-server.h
+++ b/lib/control/control-server.h
@@ -25,6 +25,7 @@
 
 #include "syslog-ng.h"
 #include "control.h"
+#include "atomic.h"
 #include <iv_event.h>
 #include <stdio.h>
 
@@ -32,10 +33,12 @@
 
 struct _ControlConnection
 {
+  GAtomicCounter ref_cnt;
   GQueue *response_batches;
   GMutex *response_batches_lock;
   struct iv_event evt_response_added;
   gboolean waiting_for_output;
+  gboolean watches_are_running;
   GString *input_buffer;
   GString *output_buffer;
   gsize pos;
@@ -79,7 +82,9 @@ void control_connection_send_close_batch(ControlConnection *self);
 void control_connection_start_watches(ControlConnection *self);
 void control_connection_update_watches(ControlConnection *self);
 void control_connection_stop_watches(ControlConnection *self);
-void control_connection_free(ControlConnection *self);
 void control_connection_init_instance(ControlConnection *self, ControlServer *server);
+
+ControlConnection *control_connection_ref(ControlConnection *self);
+void control_connection_unref(ControlConnection *self);
 
 #endif

--- a/lib/control/control-server.h
+++ b/lib/control/control-server.h
@@ -69,6 +69,8 @@ void control_connection_start_as_thread(ControlConnection *self, ControlConnecti
                                         GString *command, gpointer user_data);
 
 void control_connection_send_reply(ControlConnection *self, GString *reply);
+void control_connection_send_batched_reply(ControlConnection *self, GString *reply);
+void control_connection_send_close_batch(ControlConnection *self);
 void control_connection_start_watches(ControlConnection *self);
 void control_connection_update_watches(ControlConnection *self);
 void control_connection_stop_watches(ControlConnection *self);

--- a/lib/control/control-server.h
+++ b/lib/control/control-server.h
@@ -32,6 +32,7 @@
 struct _ControlConnection
 {
   GQueue *response_batches;
+  GMutex *response_batches_lock;
   gboolean waiting_for_output;
   GString *input_buffer;
   GString *output_buffer;

--- a/lib/control/control-server.h
+++ b/lib/control/control-server.h
@@ -57,6 +57,7 @@ struct _ControlConnection
 struct _ControlServer
 {
   GList *worker_threads;
+  gboolean cancelled;
   gchar *control_socket_name;
   void (*free_fn)(ControlServer *self);
 };

--- a/lib/control/tests/control-server-dummy.c
+++ b/lib/control/tests/control-server-dummy.c
@@ -64,7 +64,7 @@ control_connection_dummy_update_watches(ControlConnection *s)
 {
   if (s->waiting_for_output)
     g_assert_not_reached();
-  else if (s->output_buffer->len > s->pos)
+  else if (!g_queue_is_empty(s->response_batches) || s->output_buffer)
     s->handle_output(s);
 }
 

--- a/lib/stats/stats-control.c
+++ b/lib/stats/stats-control.c
@@ -60,13 +60,18 @@ _reset_counters(void)
   stats_unlock();
 }
 
+static void
+_append_csv_records(const gchar *record, gpointer user_data)
+{
+  GString *response = (GString *) user_data;
+  g_string_append_printf(response, "%s", record);
+}
+
 static GString *
 _send_stats_get_result(ControlConnection *cc, GString *command, gpointer user_data)
 {
-  gchar *stats = stats_generate_csv(NULL, NULL);
-  GString *response = g_string_new(stats);
-  g_free(stats);
-
+  GString *response = g_string_sized_new(1024);
+  stats_generate_csv(_append_csv_records, response);
   return response;
 }
 

--- a/lib/stats/stats-control.c
+++ b/lib/stats/stats-control.c
@@ -61,18 +61,32 @@ _reset_counters(void)
 }
 
 static void
-_append_csv_records(const gchar *record, gpointer user_data)
+_send_batched_response(const gchar *record, gpointer user_data)
 {
-  GString *response = (GString *) user_data;
-  g_string_append_printf(response, "%s", record);
+  //TODO: a) can be set globally; b) len vs counter.
+  static const gsize BATCH_LEN = 1;
+
+  gpointer *args = (gpointer *) user_data;
+  ControlConnection *cc = (ControlConnection *) args[0];
+  GString **batch = (GString **) args[1];
+
+  g_string_append_printf(*batch, "%s", record);
+
+  if ((*batch)->len > BATCH_LEN)
+    {
+      control_connection_send_batched_reply(cc, *batch);
+      *batch = g_string_sized_new(1024);
+    }
 }
 
 static GString *
 _send_stats_get_result(ControlConnection *cc, GString *command, gpointer user_data)
 {
   GString *response = g_string_sized_new(1024);
-  stats_generate_csv(_append_csv_records, response);
-  return response;
+  gpointer args[] = {cc, &response};
+  stats_generate_csv(_send_batched_response, args);
+  control_connection_send_close_batch(cc);
+  return NULL;
 }
 
 static void

--- a/lib/stats/stats-control.c
+++ b/lib/stats/stats-control.c
@@ -63,7 +63,7 @@ _reset_counters(void)
 static GString *
 _send_stats_get_result(ControlConnection *cc, GString *command, gpointer user_data)
 {
-  gchar *stats = stats_generate_csv();
+  gchar *stats = stats_generate_csv(NULL, NULL);
   GString *response = g_string_new(stats);
   g_free(stats);
 

--- a/lib/stats/stats-control.c
+++ b/lib/stats/stats-control.c
@@ -56,7 +56,7 @@ static void
 _reset_counters(void)
 {
   stats_lock();
-  stats_foreach_counter(_reset_counter_if_needed, NULL);
+  stats_foreach_counter(_reset_counter_if_needed, NULL, NULL);
   stats_unlock();
 }
 
@@ -84,7 +84,7 @@ _send_stats_get_result(ControlConnection *cc, GString *command, gpointer user_da
 {
   GString *response = g_string_sized_new(1024);
   gpointer args[] = {cc, &response};
-  stats_generate_csv(_send_batched_response, args);
+  stats_generate_csv(_send_batched_response, args, &cc->server->cancelled);
   control_connection_send_close_batch(cc);
   return NULL;
 }

--- a/lib/stats/stats-csv.c
+++ b/lib/stats/stats-csv.c
@@ -84,9 +84,8 @@ stats_format_csv(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointe
   g_free(s_instance);
 }
 
-
 gchar *
-stats_generate_csv(void)
+stats_generate_csv(csv_record_cb process_record, gpointer user_data)
 {
   GString *csv = g_string_sized_new(1024);
 

--- a/lib/stats/stats-csv.c
+++ b/lib/stats/stats-csv.c
@@ -90,7 +90,7 @@ stats_format_csv(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointe
 }
 
 void
-stats_generate_csv(csv_record_cb process_record, gpointer user_data)
+stats_generate_csv(csv_record_cb process_record, gpointer user_data, gboolean *cancelled)
 {
   GString *csv = g_string_sized_new(512);
 
@@ -100,6 +100,6 @@ stats_generate_csv(csv_record_cb process_record, gpointer user_data)
   g_string_free(csv, TRUE);
   gpointer format_csv_args[] = {process_record, user_data};
   stats_lock();
-  stats_foreach_counter(stats_format_csv, format_csv_args);
+  stats_foreach_counter(stats_format_csv, format_csv_args, cancelled);
   stats_unlock();
 }

--- a/lib/stats/stats-csv.c
+++ b/lib/stats/stats-csv.c
@@ -60,10 +60,13 @@ stats_format_csv_escapevar(const gchar *var)
 static void
 stats_format_csv(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data)
 {
-  GString *csv = (GString *) user_data;
+  gpointer *args = (gpointer *) user_data;
+  csv_record_cb process_record = (csv_record_cb) args[0];
+  gpointer process_record_arg = args[1];
   gchar *s_id, *s_instance, *tag_name;
   gchar buf[32];
   gchar state;
+  GString *csv = g_string_sized_new(512);
 
   s_id = stats_format_csv_escapevar(sc->key.id);
   s_instance = stats_format_csv_escapevar(sc->key.instance);
@@ -76,23 +79,27 @@ stats_format_csv(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointe
     state = 'a';
 
   tag_name = stats_format_csv_escapevar(stats_cluster_get_type_name(sc, type));
-  g_string_append_printf(csv, "%s;%s;%s;%c;%s;%"G_GSIZE_FORMAT"\n",
-                         stats_cluster_get_component_name(sc, buf, sizeof(buf)),
-                         s_id, s_instance, state, tag_name, stats_counter_get(&sc->counter_group.counters[type]));
+  g_string_printf(csv, "%s;%s;%s;%c;%s;%"G_GSIZE_FORMAT"\n",
+                  stats_cluster_get_component_name(sc, buf, sizeof(buf)),
+                  s_id, s_instance, state, tag_name, stats_counter_get(&sc->counter_group.counters[type]));
+  process_record(csv->str, process_record_arg);
+  g_string_free(csv, TRUE);
   g_free(tag_name);
   g_free(s_id);
   g_free(s_instance);
 }
 
-gchar *
+void
 stats_generate_csv(csv_record_cb process_record, gpointer user_data)
 {
-  GString *csv = g_string_sized_new(1024);
+  GString *csv = g_string_sized_new(512);
 
-  g_string_append_printf(csv, "%s;%s;%s;%s;%s;%s\n", "SourceName", "SourceId", "SourceInstance", "State", "Type",
-                         "Number");
+  g_string_printf(csv, "%s;%s;%s;%s;%s;%s\n", "SourceName", "SourceId", "SourceInstance", "State", "Type",
+                  "Number");
+  process_record(csv->str, user_data);
+  g_string_free(csv, TRUE);
+  gpointer format_csv_args[] = {process_record, user_data};
   stats_lock();
-  stats_foreach_counter(stats_format_csv, csv);
+  stats_foreach_counter(stats_format_csv, format_csv_args);
   stats_unlock();
-  return g_string_free(csv, FALSE);
 }

--- a/lib/stats/stats-csv.h
+++ b/lib/stats/stats-csv.h
@@ -28,6 +28,6 @@
 
 typedef void (*csv_record_cb)(const char *record, gpointer user_data);
 
-void stats_generate_csv(csv_record_cb process_record, gpointer user_data);
+void stats_generate_csv(csv_record_cb process_record, gpointer user_data, gboolean *cancelled);
 
 #endif

--- a/lib/stats/stats-csv.h
+++ b/lib/stats/stats-csv.h
@@ -26,6 +26,8 @@
 
 #include "syslog-ng.h"
 
-gchar *stats_generate_csv(void);
+typedef void (*csv_record_cb)(const char *line, gpointer user_data);
+
+gchar *stats_generate_csv(csv_record_cb process_record, gpointer user_data);
 
 #endif

--- a/lib/stats/stats-csv.h
+++ b/lib/stats/stats-csv.h
@@ -26,8 +26,8 @@
 
 #include "syslog-ng.h"
 
-typedef void (*csv_record_cb)(const char *line, gpointer user_data);
+typedef void (*csv_record_cb)(const char *record, gpointer user_data);
 
-gchar *stats_generate_csv(csv_record_cb process_record, gpointer user_data);
+void stats_generate_csv(csv_record_cb process_record, gpointer user_data);
 
 #endif

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -130,7 +130,7 @@ _update_index(void)
 {
   g_static_mutex_lock(&stats_query_mutex);
   stats_lock();
-  stats_foreach_cluster(_update_indexes_of_cluster_if_needed, NULL);
+  stats_foreach_cluster(_update_indexes_of_cluster_if_needed, NULL, NULL);
   stats_unlock();
   g_static_mutex_unlock(&stats_query_mutex);
 }

--- a/lib/stats/stats-registry.h
+++ b/lib/stats/stats-registry.h
@@ -56,8 +56,8 @@ void stats_unregister_dynamic_counter(StatsCluster *handle, gint type, StatsCoun
 gboolean stats_contains_counter(const StatsClusterKey *sc_key, gint type);
 StatsCounterItem *stats_get_counter(const StatsClusterKey *sc_key, gint type);
 
-void stats_foreach_counter(StatsForeachCounterFunc func, gpointer user_data);
-void stats_foreach_cluster(StatsForeachClusterFunc func, gpointer user_data);
+void stats_foreach_counter(StatsForeachCounterFunc func, gpointer user_data, gboolean *cancelled);
+void stats_foreach_cluster(StatsForeachClusterFunc func, gpointer user_data, gboolean *cancelled);
 void stats_foreach_cluster_remove(StatsForeachClusterRemoveFunc func, gpointer user_data);
 
 void stats_registry_init(void);

--- a/syslog-ng-ctl/commands/commands.h
+++ b/syslog-ng-ctl/commands/commands.h
@@ -40,8 +40,10 @@ typedef struct _CommandDescriptor
   struct _CommandDescriptor *subcommands;
 } CommandDescriptor;
 
+typedef gint (*response_handle)(GString *response, gpointer user_data);
+
 gint dispatch_command(const gchar *cmd);
-GString *slng_run_command(const gchar *command);
+gint slng_run_command(const gchar *command, response_handle cb, gpointer user_data);
 gint process_response_status(GString *response);
 gboolean is_syslog_ng_running(void);
 

--- a/syslog-ng-ctl/control-client.h
+++ b/syslog-ng-ctl/control-client.h
@@ -26,13 +26,14 @@
 #define CONTROL_CLIENT_H 1
 
 #include "syslog-ng.h"
+#include "commands/commands.h"
 
 typedef struct _ControlClient ControlClient;
 
 ControlClient *control_client_new(const gchar *path);
 gboolean control_client_connect(ControlClient *self);
 gint control_client_send_command(ControlClient *self, const gchar *cmd);
-GString *control_client_read_reply(ControlClient *self);
+gint control_client_read_reply(ControlClient *self, response_handle cb, gpointer user_data);
 void control_client_free(ControlClient *self);
 
 #endif


### PR DESCRIPTION
## Motivation

When there are a lots of stats counters, getting these counters via `syslog-ng-ctl 
stats` is a challenge.
Before #3387 it was not even possible to stop (gracefully) syslog-ng when such a request was in progress.
Now, we can stop syslog-ng - but at the price of calling a `pthread_cancel` which can sometimes cause problems (-> and in some circumstances syslog-ng still cannot be stopped... when stats-mutex is locked when cancel is received... we could play with setting pthread cancel type to `PTHREAD_CANCEL_DEFERRED` and disable/enable cancel state - but that s*cks).

The aim of this PR is to solve two issues:
  * get rid of `pthread_cancel` by implementing 'cancellable' stats queries
  * decrease the required memory for serving a syslog-ng-ctl request (and send back partial results to the syslog-ng-ctl)

Before this patchset we collected all the responses into one giant GString object -> until all the counters are not visited we didn't send anything back to the `syslog-ng-ctl`.
  
*  notes
     * this work can be continued with improving `syslog-ng-ctl query`.
     * this PR is a kind of PoC - just wanted to share the problem and my code (as a kind of farewell PR :) )
 
 ## What's in the PR?

### batches

 * stats-csv interface changed: instead of returning a GString object that contains all the counters, I've added a callback which is called for all CSV record (->for all counter). 
 * functionality is reimplemented with the new interface (on a CSV record callback basis)
 * new methods are added for supporting batches : one is for adding a batch to the current 'session', other is for closing the batch (session) by adding a '.\n' to the end
 * syslog-ng-ctl also modified to handle response 'streams' (before this PR, response was appended to a GString object until '\n.\n' received, now it prints responses at reception time)
 * as `syslog-ng-ctl stats` handler is run in a separete thread, some synchronization is required:
    * batches are inserted into a thread safe GQueue
    * an iv_event is posted when a batch is sent from the producer thread (-> direct manipulation of ivykis objects from a different thread is not allowed )

### eliminate `pthread_cancel`

 * store cancelled state (could be an atomic variable, but I think it's okay to use a non-atomic variable) at ControlServer object
 * implement cancallable stats queries (-> g_hash_table_foreach replaced with an iterator-loop which can checks the `cancelled` state and break the loop when needed
 * thread id saving also removed (thread id needed by `thread_cancel`)
 
Some parts are implemented at night, so be careful with the review ;)
_Also note that I'm not sure if I'll have the time for fixing review notes - in this case you can close my PR, or if you find it useful, you can freely modify to make it merge-ready._ 