### PR TITLE
logmpx: fix write protecting LogMessage 

### DIFF
--- a/lib/logmpx.c
+++ b/lib/logmpx.c
@@ -62,6 +62,13 @@ log_multiplexer_deinit(LogPipe *self)
   return TRUE;
 }
 
+static gboolean
+_has_multiple_arcs(LogMultiplexer *self)
+{
+  gint num_arcs = self->next_hops->len + (self->super.pipe_next ? 1 : 0);
+  return num_arcs > 1;
+}
+
 static void
 log_multiplexer_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
@@ -73,7 +80,8 @@ log_multiplexer_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_op
   gint fallback;
 
   local_options.matched = &matched;
-  if (self->next_hops->len > 1)
+
+  if (_has_multiple_arcs(self))
     {
       log_msg_write_protect(msg);
     }
@@ -103,10 +111,6 @@ log_multiplexer_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_op
                 break;
             }
         }
-    }
-  if (self->next_hops->len > 1)
-    {
-      log_msg_write_unprotect(msg);
     }
 
   /* NOTE: non of our multiplexed destinations delivered this message, let's

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -218,13 +218,7 @@ static GStaticPrivate priv_macro_value = G_STATIC_PRIVATE_INIT;
 void
 log_msg_write_protect(LogMessage *self)
 {
-  self->protect_cnt++;
-}
-
-void
-log_msg_write_unprotect(LogMessage *self)
-{
-  self->protect_cnt--;
+  self->protected = TRUE;
 }
 
 LogMessage *
@@ -1291,7 +1285,7 @@ log_msg_clone_cow(LogMessage *msg, const LogPathOptions *path_options)
   self->ack_and_ref_and_abort_and_suspended = LOGMSG_REFCACHE_REF_TO_VALUE(1) + LOGMSG_REFCACHE_ACK_TO_VALUE(
                                                 0) + LOGMSG_REFCACHE_ABORT_TO_VALUE(0);
   self->cur_node = 0;
-  self->protect_cnt = 0;
+  self->protected = FALSE;
 
   log_msg_add_ack(self, path_options);
   if (!path_options->ack_needed)

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -220,7 +220,7 @@ struct _LogMessage
 
   guint8 num_nodes;
   guint8 cur_node;
-  guint8 protect_cnt;
+  guint8 protected;
 
 
   /* preallocated LogQueueNodes used to insert this message into a LogQueue */
@@ -237,12 +237,11 @@ extern gint logmsg_node_max;
 LogMessage *log_msg_ref(LogMessage *m);
 void log_msg_unref(LogMessage *m);
 void log_msg_write_protect(LogMessage *m);
-void log_msg_write_unprotect(LogMessage *m);
 
 static inline gboolean
 log_msg_is_write_protected(const LogMessage *self)
 {
-  return self->protect_cnt > 0;
+  return self->protected;
 }
 
 LogMessage *log_msg_clone_cow(LogMessage *msg, const LogPathOptions *path_options);

--- a/news/bugfix-3708.md
+++ b/news/bugfix-3708.md
@@ -1,0 +1,3 @@
+`logpath`: Fixed a message write protection bug, where message modifications (rewrite rules, parsers, etc.)
+leaked through preceding path elements. This may have resulted not only in unwanted/undefined message modification,
+but in certain cases crash as well.


### PR DESCRIPTION
In `LogMultiplexer`, checking the number of `next_hops` is not enough to determine the number of `LogPipes`, that will get the current `LogMessage`, because we need to take account of `pipe_next`, too.

See the following log path, for example:
```
log {
  source(s_network);
  destination(d_http);
  rewrite(r_set)
};
```
Here, the `LogMultiplexer` has one `next_hop` (`d_http`) and one `pipe_next` (`r_set`). In this case we do not set the write protection, so the `r_set` rewrite rule will modify the same `LogMessage` that is queued for `d_http`. If the `LogMessage` gets handled in the threaded destination (`d_http`) after `r_set` has changed it, we get an unexpected behavior, in a bad case even a crash.

---

The other problem is that we remove the write protection before forwarding the `LogMessage` to `pipe_next`.

In the example above we set write protection, queue the message to `d_http`, remove the write protection, then modify the same message in `r_set`. When `d_http` sends the message a bit later, the message is already modified.

We should not remove the write protection in `LogMultiplexer`, so we can delete the write protection removal code from there.

---

The problem is reproducible with the following config:
Note: `disk-buffer` is needed, because `log-fifo` adds write protection to the `LogMessage` for another reason.
```
@version: 3.32

python {
import time
class TestDriver(object):
  def send(self, msg):
    time.sleep(1)
    print("MSG:", msg["MSG"].decode())
    return True
};

destination d_python {
  python(
    class("TestDriver")
    disk-buffer(disk-buf-size(1000000))
  );
};

source s_msg {
  example-msg-generator(num(1));
};

rewrite r_set {
  set("foo", value("MSG"));
};

log {
  source(s_msg);
  destination(d_python);
  rewrite(r_set);
};
```

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>