### PR TITLE
kafka-c: fix blocking rd_kafka_produce() calls hanging syslog-ng reload/shutdown

### DIFF
--- a/modules/kafka/kafka-dest-driver.c
+++ b/modules/kafka/kafka-dest-driver.c
@@ -462,8 +462,6 @@ _purge_remaining_messages(KafkaDestDriver *self)
    * and also those that were sent and not yet acknowledged.  The purged
    * messages will generate failed delivery reports. */
 
-  /* FIXME: Need to check their order!!!! */
-
   rd_kafka_purge(self->kafka, RD_KAFKA_PURGE_F_QUEUE | RD_KAFKA_PURGE_F_INFLIGHT);
   rd_kafka_poll(self->kafka, 0);
 

--- a/modules/kafka/kafka-dest-driver.c
+++ b/modules/kafka/kafka-dest-driver.c
@@ -426,7 +426,7 @@ _flush_inflight_messages(KafkaDestDriver *self)
 {
   rd_kafka_resp_err_t err;
   gint outq_len = rd_kafka_outq_len(self->kafka);
-  gint timeout = _get_flush_timeout(self);
+  gint timeout_ms = _get_flush_timeout(self);
 
   if (outq_len > 0)
     {
@@ -435,11 +435,11 @@ _flush_inflight_messages(KafkaDestDriver *self)
                  evt_tag_str("topic", self->topic_name->template),
                  evt_tag_str("fallback_topic", self->fallback_topic_name),
                  evt_tag_int("outq_len", outq_len),
-                 evt_tag_int("timeout", timeout),
+                 evt_tag_int("timeout_ms", timeout_ms),
                  evt_tag_str("driver", self->super.super.super.id),
                  log_pipe_location_tag(&self->super.super.super.super));
     }
-  err = rd_kafka_flush(self->kafka, timeout);
+  err = rd_kafka_flush(self->kafka, timeout_ms);
   if (err != RD_KAFKA_RESP_ERR_NO_ERROR)
     {
       msg_error("kafka: error flushing accumulated messages during shutdown, rd_kafka_flush() returned failure, this might indicate that some in-flight messages are lost",
@@ -455,7 +455,7 @@ _flush_inflight_messages(KafkaDestDriver *self)
   if (outq_len != 0)
     msg_notice("kafka: timeout while waiting for the librdkafka queue to empty, the "
                "remaining entries will be purged and lost",
-               evt_tag_int("timeout", timeout),
+               evt_tag_int("timeout_ms", timeout_ms),
                evt_tag_int("outq_len", outq_len));
 }
 

--- a/modules/kafka/kafka-dest-driver.h
+++ b/modules/kafka/kafka-dest-driver.h
@@ -70,6 +70,7 @@ void kafka_dd_merge_config(LogDriver *d, GList *props);
 void kafka_dd_set_bootstrap_servers(LogDriver *d, const gchar *bootstrap_servers);
 void kafka_dd_set_key_ref(LogDriver *d, LogTemplate *key);
 void kafka_dd_set_message_ref(LogDriver *d, LogTemplate *message);
+void kafka_dd_shutdown(LogThreadedDestDriver *s);
 void kafka_dd_set_flush_timeout_on_shutdown(LogDriver *d, gint shutdown_timeout);
 void kafka_dd_set_flush_timeout_on_reload(LogDriver *d, gint reload_timeout);
 void kafka_dd_set_poll_timeout(LogDriver *d, gint poll_timeout);

--- a/modules/kafka/kafka-dest-worker.c
+++ b/modules/kafka/kafka-dest-worker.c
@@ -373,6 +373,13 @@ kafka_dest_worker_free(LogThreadedDestWorker *s)
   log_threaded_dest_worker_free_method(s);
 }
 
+static void
+_thread_deinit(LogThreadedDestWorker *s)
+{
+  kafka_dd_shutdown(s->owner);
+  log_threaded_dest_worker_deinit_method(s);
+}
+
 static gboolean
 _thread_init(LogThreadedDestWorker *s)
 {
@@ -413,6 +420,7 @@ _set_methods(KafkaDestWorker *self)
   KafkaDestDriver *owner = (KafkaDestDriver *) self->super.owner;
 
   self->super.thread_init = _thread_init;
+  self->super.thread_deinit = _thread_deinit;
   self->super.free_fn = kafka_dest_worker_free;
 
   if (owner->transaction_commit)

--- a/news/bugfix-3711.md
+++ b/news/bugfix-3711.md
@@ -1,0 +1,2 @@
+kafka-c: fixed a hang during shutdown/reload, when multiple workers is used (workers() option is set to 2 or higher) and the librdkafka internal queue is filled.
+(error message was `kafka: failed to publish message; topic='test-topic', error='Local: Queue full'`)


### PR DESCRIPTION
RD_KAFKA_MSG_F_BLOCK flag caused that rd_kafka_prouce call blocks in case of librdkafka's internal queue filled
(see "queue.buffering.max.messages" or "queue.buffering.max.kbytes").

We set this flag only in worker threads that are not doing rd_kafka_poll (see is_poller_thread), i.e. when we have multiple worker threads e.g. with config workers(4).
This blocking call can cause that a reload or shutdown blocks infinitely if the queue filled when the kafka broker(s) not available.

UPDATE: instead of setting rd_kafka_produce to non-blocking mode, we should trigger a flush and purge when the worker threads are shutting down.
Since, the librdkafka API is thread safe [1] we don't need to lock the flush/purge operations.

[1] https://docs.confluent.io/5.5.1/clients/librdkafka/md_INTRODUCTION.html#threads-and-callbacks
