### PR TITLE
dbld: fix debug_symbol install on devshell

### DIFF
--- a/dbld/builddeps
+++ b/dbld/builddeps
@@ -197,8 +197,8 @@ function enable_dbgsyms {
             apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 428D7C01 C8CAB6595FDFF622
             ;;
         devshell|debian*)
-            echo "deb http://deb.debian.org/debian-debug/ $(lsb_release -rs)-debug main" | tee -a /etc/apt/sources.list
-            echo "deb http://deb.debian.org/debian-debug/ $(lsb_release -rs)-proposed-updates-debug main" | tee -a /etc/apt/sources.list
+            echo "deb http://deb.debian.org/debian-debug/ $(lsb_release -cs)-debug main" | tee -a /etc/apt/sources.list
+            echo "deb http://deb.debian.org/debian-debug/ $(lsb_release -cs)-proposed-updates-debug main" | tee -a /etc/apt/sources.list
             ;;
     esac
 }


### PR DESCRIPTION
When devshell rebased on syslog-ng-tarball image (which is based on debian-testing), the enable_dbgsyms improved to be able to install debug symbols on debian too.
However a recent change On Debian Testing (Release renamed from "testing" to "11", see lsb_release output) broke the devshell image build.

Turns out, using the release number option of lsb_release was a mistake, and codename should be used instead
(this only worked temporarily, and it would have never worked on a stable/old debian release, see).

See available debian-debug repos:
http://debug.mirrors.debian.org/debian-debug/dists/

Some examples of lsb_release:

until now on Debian Testing:
```
root@f881f7fdbe43:/# lsb_release -rs
testing
root@f881f7fdbe43:/# lsb_release -cs
bullseye
```

from now on Debian Testing:
```
root@4afdb701abd1:/# lsb_release -rs
11
root@4afdb701abd1:/# lsb_release -cs
bullseye
```

Debian Buster (stable):
```
root@dd8ffe64114d:/# lsb_release -rs
10
root@dd8ffe64114d:/# lsb_release -cs
buster
```

No news entry needed IMHO.