### PR TITLE
bugfix/python 3.10 not detected FIX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1455,6 +1455,9 @@ if test "x$enable_python" != "xno"; then
       [[0-9]].[[0-9]])
           with_python="python-${with_python}"
           ;;
+      [[0-9]].[[0-9][0-9]])
+          with_python="python-${with_python}"
+          ;;
     esac
 
     PKG_CHECK_MODULES(PYTHON, $with_python-embed, python_found="yes", [

--- a/news/packaging-3713.md
+++ b/news/packaging-3713.md
@@ -1,0 +1,1 @@
+configure: now supporting python with two digit minor version


### PR DESCRIPTION
The problem was the new python 3.10 isn't compatible with previous "python finding script", because it check is only 1 digit or "<digit>.<digit>" and I added a new condition to check "<digit>.<digit><digit>".

This bug can be easily caused. Only need a python 3.10 version and run the configure with this flag: "--with-python=3.10" it will not find the 3.10, but with the bugfix it will found.


Other possible solution:
- using if-else instead of switch-case, because in the if statement can be put regex expression.
- using the configure "if-else", because there can put regex expression also. 

issue: #3709