### PR TITLE
scl: add discord() destination

### DIFF
--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -202,6 +202,10 @@ Test(basicfuncs, test_str_funcs)
   assert_template_format("$(substr $HOST -1)", "p");
   assert_template_format("$(substr $HOST -2 1)", "r");
 
+  assert_template_format("$(substr 'ssstring-shorter-than-the-specified-length' 2 1400)",
+                         "string-shorter-than-the-specified-length");
+
+
   assert_template_format("$(strip ${APP.STRIP1})", "value");
   assert_template_format("$(strip ${APP.STRIP2})", "value");
   assert_template_format("$(strip ${APP.STRIP3})", "value");

--- a/news/feature-3717.md
+++ b/news/feature-3717.md
@@ -1,0 +1,13 @@
+`discord()` destination
+
+syslog-ng now has a webhook-based Discord destination.
+Example usage:
+```
+destination {
+  discord(url("https://discord.com/api/webhooks/x/y"));
+};
+```
+
+The following options can be used to customize the destination further:
+
+`avatar-url()`, `username("$HOST-bot")`, `tts(true)`, `template("${MSG:-[empty message]}")`.

--- a/scl/CMakeLists.txt
+++ b/scl/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SCL_DIRS
     cisco
     collectd
     default-network-drivers
+    discord
     elasticsearch
     ewmm
     fortigate

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -6,6 +6,7 @@ SCL_SUBDIRS	= \
 	collectd \
 	checkpoint	\
 	default-network-drivers	\
+	discord \
 	elasticsearch	\
 	ewmm		\
 	fortigate	\

--- a/scl/discord/discord.conf
+++ b/scl/discord/discord.conf
@@ -1,0 +1,55 @@
+#############################################################################
+# Copyright (c) 2021 One Identity
+# Copyright (c) 2021 László Várady
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+# Rate limits: https://discord.com/developers/docs/topics/rate-limits#global-rate-limit
+# Max message length: https://discord.com/developers/docs/resources/webhook#execute-webhook
+
+@requires http
+@requires json-plugin
+@requires basicfuncs
+
+block destination discord(
+  url()
+  template("${MSG:-[empty message]}")
+  max-msg-length(2000)
+  throttle(5)
+  username("")
+  avatar-url("")
+  tts(false)
+  use-system-cert-store(yes)
+  ...)
+{
+  http(
+    url('`url`')
+    method("POST")
+    headers("Content-type: application/json")
+    body("$(format-json
+      content=$(substr '`template`' 0 `max-msg-length`)
+      username='`username`'
+      avatar_url='`avatar-url`'
+      tts=`tts`)")
+    throttle(`throttle`)
+    use-system-cert-store(`use-system-cert-store`)
+    `__VARARGS__`
+  );
+};


### PR DESCRIPTION
This PR adds a `discord()` SCL destination to syslog-ng.

Based on @czanik's [blog post](https://www.syslog-ng.com/community/b/blog/posts/first-steps-of-sending-alerts-to-discord-and-others-from-syslog-ng-http-and-apprise).

Example usage:

```
destination {
  discord(url("https://discord.com/api/webhooks/x/y"));
};
```

Options:

```
discord(
  url("https://discord.com/api/webhooks/x/y")
  avatar-url("https://example.domain/any_image.png")
  username("$HOST-bot") # Custom bot name, accepts macros
  tts(true) # Text-to-Speech message
  template("${MSG:-[empty message]}") # Message to send, can't be empty
);
```

Setup guide: https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks

![image](https://user-images.githubusercontent.com/3130044/124401379-71f1c600-dd29-11eb-8f5a-37dae5949331.png)

----

API docs:
https://discord.com/developers/docs/resources/webhook#execute-webhook

The default throttle value is set to 5:
https://discord.com/developers/docs/topics/rate-limits#global-rate-limit

We also need a limit for the maximum message length, it's currently 2000 characters.

----

This SCL uses Discord [webhooks](https://discord.com/developers/docs/resources/webhook), instead of the Discord "bot" API.

Webhooks are easier to set up, and they also support embedded hyperlinks in messages, and multiple "embed" objects within a single message:

> Webhooks are a low-effort way to post messages to channels in Discord.
> They do not require a bot user or authentication to use.

Webhook-based bots can not read messages, but we obviously don't need that.

If the regular "bot" API becomes a better choice in the future, we can extend this SCL and add a `token()` option in a backward-compatible manner, but this requires a "preprocessor if" statement in our config language, because the base URL will be different when using this API.
Another option is just to add a new SCL (`discord-bot(token() ...)`), when needed.
