### PR TITLE
get-github-actions-status: filter out PR runs

### DIFF
--- a/contrib/get-github-actions-status.py
+++ b/contrib/get-github-actions-status.py
@@ -29,7 +29,8 @@ def main():
     workflow = sys.argv[1]
     while True:
         runs = get_workflow_runs(workflow)
-        latest_run = max(runs, key=lambda run: run["updated_at"])
+        not_pr_runs = filter(lambda run: run["event"] != "pull_request", runs)
+        latest_run = max(not_pr_runs, key=lambda run: run["updated_at"])
 
         if latest_run["status"] != "completed":
             print("Job is still running. Trying again in 10 minutes.")


### PR DESCRIPTION
There was a problem, where we received the status about a PR, which was opened from fork-of-someone/master.

We want to get the latest syslog-ng/master CI run from the REST API. Unfortunately, it seems that we cannot filter for the repo or the owner as I would expect to (tested with ?owner=syslog-ng and ?repo=syslog-ng).

https://docs.github.com/en/rest/reference/actions#list-workflow-runs

Knowing these, I falled back to filter out PR runs, so hopefully our merge and schedule runs will be queried after this commit.

Example of the problematic PR run:
```
{
  "id": 999485327,
  "name": "CI @ devshell",
  "node_id": "WFR_lAHOAGRToM4A19zFzjuS748",
  "head_branch": "master",
  "head_sha": "73e98ab47fd54404a47d07fa12fd1cb86457bdde",
  "run_number": 1680,
  "event": "pull_request",
  "status": "completed",
  "conclusion": "action_required",
  "workflow_id": 1354784,
  "check_suite_id": 3155994201,
  "check_suite_node_id": "MDEwOkNoZWNrU3VpdGUzMTU1OTk0MjAx",
  "url": "https://api.github.com/repos/syslog-ng/syslog-ng/actions/runs/999485327",
  "html_url": "https://github.com/syslog-ng/syslog-ng/actions/runs/999485327",
  "pull_requests": [

  ],
  "created_at": "2021-07-05T00:46:52Z",
  "updated_at": "2021-07-05T00:46:52Z",
  "jobs_url": "https://api.github.com/repos/syslog-ng/syslog-ng/actions/runs/999485327/jobs",
  "logs_url": "https://api.github.com/repos/syslog-ng/syslog-ng/actions/runs/999485327/logs",
  "check_suite_url": "https://api.github.com/repos/syslog-ng/syslog-ng/check-suites/3155994201",
  "artifacts_url": "https://api.github.com/repos/syslog-ng/syslog-ng/actions/runs/999485327/artifacts",
  "cancel_url": "https://api.github.com/repos/syslog-ng/syslog-ng/actions/runs/999485327/cancel",
  "rerun_url": "https://api.github.com/repos/syslog-ng/syslog-ng/actions/runs/999485327/rerun",
  "workflow_url": "https://api.github.com/repos/syslog-ng/syslog-ng/actions/workflows/1354784",
  "head_commit": {
    "id": "73e98ab47fd54404a47d07fa12fd1cb86457bdde",
    "tree_id": "0e0bca4318fe659f33e3d7a84a4c4695ef3017e8",
    "message": "Merge branch 'syslog-ng:master' into master",
    "timestamp": "2021-07-05T00:46:49Z",
    "author": {
      "name": "Yash Mathne",
      "email": "yash6866@gmail.com"
    },
    "committer": {
      "name": "GitHub",
      "email": "noreply@github.com"
    }
  },
  "repository": {
    "id": 14146757,
    "node_id": "MDEwOlJlcG9zaXRvcnkxNDE0Njc1Nw==",
    "name": "syslog-ng",
    "full_name": "syslog-ng/syslog-ng",
    "private": false,
    "owner": {
      "login": "syslog-ng",
      "id": 6575008,
      "node_id": "MDEyOk9yZ2FuaXphdGlvbjY1NzUwMDg=",
      "avatar_url": "https://avatars.githubusercontent.com/u/6575008?v=4",
      "gravatar_id": "",
      "url": "https://api.github.com/users/syslog-ng",
      "html_url": "https://github.com/syslog-ng",
      "followers_url": "https://api.github.com/users/syslog-ng/followers",
      "following_url": "https://api.github.com/users/syslog-ng/following{/other_user}",
      "gists_url": "https://api.github.com/users/syslog-ng/gists{/gist_id}",
      "starred_url": "https://api.github.com/users/syslog-ng/starred{/owner}{/repo}",
      "subscriptions_url": "https://api.github.com/users/syslog-ng/subscriptions",
      "organizations_url": "https://api.github.com/users/syslog-ng/orgs",
      "repos_url": "https://api.github.com/users/syslog-ng/repos",
      "events_url": "https://api.github.com/users/syslog-ng/events{/privacy}",
      "received_events_url": "https://api.github.com/users/syslog-ng/received_events",
      "type": "Organization",
      "site_admin": false
    },
    "html_url": "https://github.com/syslog-ng/syslog-ng",
    "description": "syslog-ng is an enhanced log daemon, supporting a wide range of input and output methods: syslog, unstructured text, queueing, SQL & NoSQL.",
    "fork": false,
    "url": "https://api.github.com/repos/syslog-ng/syslog-ng",
    "forks_url": "https://api.github.com/repos/syslog-ng/syslog-ng/forks",
    "keys_url": "https://api.github.com/repos/syslog-ng/syslog-ng/keys{/key_id}",
    "collaborators_url": "https://api.github.com/repos/syslog-ng/syslog-ng/collaborators{/collaborator}",
    "teams_url": "https://api.github.com/repos/syslog-ng/syslog-ng/teams",
    "hooks_url": "https://api.github.com/repos/syslog-ng/syslog-ng/hooks",
    "issue_events_url": "https://api.github.com/repos/syslog-ng/syslog-ng/issues/events{/number}",
    "events_url": "https://api.github.com/repos/syslog-ng/syslog-ng/events",
    "assignees_url": "https://api.github.com/repos/syslog-ng/syslog-ng/assignees{/user}",
    "branches_url": "https://api.github.com/repos/syslog-ng/syslog-ng/branches{/branch}",
    "tags_url": "https://api.github.com/repos/syslog-ng/syslog-ng/tags",
    "blobs_url": "https://api.github.com/repos/syslog-ng/syslog-ng/git/blobs{/sha}",
    "git_tags_url": "https://api.github.com/repos/syslog-ng/syslog-ng/git/tags{/sha}",
    "git_refs_url": "https://api.github.com/repos/syslog-ng/syslog-ng/git/refs{/sha}",
    "trees_url": "https://api.github.com/repos/syslog-ng/syslog-ng/git/trees{/sha}",
    "statuses_url": "https://api.github.com/repos/syslog-ng/syslog-ng/statuses/{sha}",
    "languages_url": "https://api.github.com/repos/syslog-ng/syslog-ng/languages",
    "stargazers_url": "https://api.github.com/repos/syslog-ng/syslog-ng/stargazers",
    "contributors_url": "https://api.github.com/repos/syslog-ng/syslog-ng/contributors",
    "subscribers_url": "https://api.github.com/repos/syslog-ng/syslog-ng/subscribers",
    "subscription_url": "https://api.github.com/repos/syslog-ng/syslog-ng/subscription",
    "commits_url": "https://api.github.com/repos/syslog-ng/syslog-ng/commits{/sha}",
    "git_commits_url": "https://api.github.com/repos/syslog-ng/syslog-ng/git/commits{/sha}",
    "comments_url": "https://api.github.com/repos/syslog-ng/syslog-ng/comments{/number}",
    "issue_comment_url": "https://api.github.com/repos/syslog-ng/syslog-ng/issues/comments{/number}",
    "contents_url": "https://api.github.com/repos/syslog-ng/syslog-ng/contents/{+path}",
    "compare_url": "https://api.github.com/repos/syslog-ng/syslog-ng/compare/{base}...{head}",
    "merges_url": "https://api.github.com/repos/syslog-ng/syslog-ng/merges",
    "archive_url": "https://api.github.com/repos/syslog-ng/syslog-ng/{archive_format}{/ref}",
    "downloads_url": "https://api.github.com/repos/syslog-ng/syslog-ng/downloads",
    "issues_url": "https://api.github.com/repos/syslog-ng/syslog-ng/issues{/number}",
    "pulls_url": "https://api.github.com/repos/syslog-ng/syslog-ng/pulls{/number}",
    "milestones_url": "https://api.github.com/repos/syslog-ng/syslog-ng/milestones{/number}",
    "notifications_url": "https://api.github.com/repos/syslog-ng/syslog-ng/notifications{?since,all,participating}",
    "labels_url": "https://api.github.com/repos/syslog-ng/syslog-ng/labels{/name}",
    "releases_url": "https://api.github.com/repos/syslog-ng/syslog-ng/releases{/id}",
    "deployments_url": "https://api.github.com/repos/syslog-ng/syslog-ng/deployments"
  },
  "head_repository": null
}
```

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>