### PR TITLE
mqtt/cmake: follow naming convention

### DIFF
--- a/modules/mqtt/CMakeLists.txt
+++ b/modules/mqtt/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(eclipse-paho-mqtt-c)
 
-module_switch(MQTT_DESTINATION "Enable mqtt_destination" eclipse-paho-mqtt-c_FOUND)
-if (NOT MQTT_DESTINATION)
+module_switch(ENABLE_MQTT "Enable mqtt_destination" eclipse-paho-mqtt-c_FOUND)
+if (NOT ENABLE_MQTT)
   return()
 endif()
 


### PR DESCRIPTION
Every module starts with ENABLE_ prefix, and the configure option was also named only after mqtt. Not mentioning destination part.