### PR TITLE
diskq: fix invalid read after disk_buf_size

### DIFF
--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -238,7 +238,7 @@ _possible_size_reduction_reaches_truncate_threshold(QDisk *self, gint64 expected
 }
 
 static void
-_truncate_file(QDisk *self, gint64 expected_size)
+_maybe_truncate_file(QDisk *self, gint64 expected_size)
 {
   if (_ftruncate_would_reduce_file(self, expected_size) &&
       !_possible_size_reduction_reaches_truncate_threshold(self, expected_size) &&
@@ -293,7 +293,7 @@ _truncate_file_to_minimal(QDisk *self)
 {
   if (qdisk_is_file_empty(self))
     {
-      _truncate_file(self, QDISK_RESERVED_SPACE);
+      _maybe_truncate_file(self, QDISK_RESERVED_SPACE);
       return;
     }
 
@@ -301,7 +301,7 @@ _truncate_file_to_minimal(QDisk *self)
   if (file_end_offset <= QDISK_RESERVED_SPACE)
     return;
 
-  _truncate_file(self, file_end_offset);
+  _maybe_truncate_file(self, file_end_offset);
 }
 
 
@@ -389,7 +389,7 @@ qdisk_push_tail(QDisk *self, GString *record)
         {
           msg_debug("Unused area ahead of write_head, truncate queue file",
                     evt_tag_long("new size",  self->hdr->write_head));
-          _truncate_file(self, self->hdr->write_head);
+          _maybe_truncate_file(self, self->hdr->write_head);
         }
       else
         {
@@ -1114,7 +1114,7 @@ qdisk_reset_file_if_empty(QDisk *self)
   self->hdr->write_head = QDISK_RESERVED_SPACE;
   self->hdr->backlog_head = QDISK_RESERVED_SPACE;
 
-  _truncate_file(self, QDISK_RESERVED_SPACE);
+  _maybe_truncate_file(self, QDISK_RESERVED_SPACE);
 }
 
 DiskQueueOptions *

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -247,6 +247,8 @@ _maybe_truncate_file(QDisk *self, gint64 expected_size)
       return;
     }
 
+  msg_debug("Truncating queue file", evt_tag_str("filename", self->filename), evt_tag_long("new size", expected_size));
+
   if (ftruncate(self->fd, (off_t) expected_size) == 0)
     {
       self->file_size = expected_size;
@@ -387,8 +389,6 @@ qdisk_push_tail(QDisk *self, GString *record)
     {
       if (self->file_size > self->hdr->write_head)
         {
-          msg_debug("Unused area ahead of write_head, truncate queue file",
-                    evt_tag_long("new size",  self->hdr->write_head));
           _maybe_truncate_file(self, self->hdr->write_head);
         }
       else
@@ -1107,8 +1107,6 @@ qdisk_reset_file_if_empty(QDisk *self)
 {
   if (!qdisk_is_file_empty(self))
     return;
-
-  msg_debug("Queue file became empty, truncating file", evt_tag_str("filename", self->filename));
 
   self->hdr->read_head = QDISK_RESERVED_SPACE;
   self->hdr->write_head = QDISK_RESERVED_SPACE;

--- a/modules/diskq/tests/test_diskq_truncate.c
+++ b/modules/diskq/tests/test_diskq_truncate.c
@@ -38,7 +38,7 @@
 
 
 static LogQueue *
-_get_diskqueue(gchar *filename, DiskQueueOptions *options)
+_get_non_reliable_diskqueue(gchar *filename, DiskQueueOptions *options)
 {
   LogQueue *q = log_queue_disk_non_reliable_new(options, NULL);
   log_queue_set_use_backlog(q, FALSE);
@@ -47,14 +47,14 @@ _get_diskqueue(gchar *filename, DiskQueueOptions *options)
 }
 
 static LogQueue *
-_create_diskqueue(gchar *filename, DiskQueueOptions *options)
+_create_non_reliable_diskqueue(gchar *filename, DiskQueueOptions *options)
 {
   LogQueue *q;
   unlink(filename);
 
   _construct_options(options, 1100000, 0, FALSE);
   options->qout_size = 40;
-  q = _get_diskqueue(filename, options);
+  q = _get_non_reliable_diskqueue(filename, options);
   return q;
 }
 
@@ -139,7 +139,7 @@ _test_diskq_truncate(TruncateTestParams params)
   DiskQueueOptions options;
 
   cr_assert(cfg_init(configuration), "cfg_init failed!");
-  q = _create_diskqueue(params.filename, &options);
+  q = _create_non_reliable_diskqueue(params.filename, &options);
   cr_assert_eq(log_queue_get_length(q), 0, "No messages should be in a newly created disk-queue file!");
 
   feed_some_messages(q, params.number_of_msgs_to_push);
@@ -153,7 +153,7 @@ _test_diskq_truncate(TruncateTestParams params)
 
   _save_diskqueue(q);
 
-  q = _get_diskqueue(params.filename, &options);
+  q = _get_non_reliable_diskqueue(params.filename, &options);
   cr_assert_eq(log_queue_get_length(q), params.number_of_msgs_to_push - params.number_of_msgs_to_pop,
                "Invalid number of messages in disk-queue after opened existing one");
   _assert_diskq_actual_file_size_with_stored(q);

--- a/modules/diskq/tests/test_diskq_truncate.c
+++ b/modules/diskq/tests/test_diskq_truncate.c
@@ -36,6 +36,8 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 
+#define TEST_DISKQ_SIZE 1100000
+
 
 static LogQueue *
 _get_non_reliable_diskqueue(gchar *filename, DiskQueueOptions *options)
@@ -52,7 +54,7 @@ _create_non_reliable_diskqueue(gchar *filename, DiskQueueOptions *options)
   LogQueue *q;
   unlink(filename);
 
-  _construct_options(options, 1100000, 0, FALSE);
+  _construct_options(options, TEST_DISKQ_SIZE, 0, FALSE);
   options->qout_size = 40;
   q = _get_non_reliable_diskqueue(filename, options);
   return q;
@@ -199,7 +201,7 @@ _create_reliable_diskqueue(gchar *filename, DiskQueueOptions *options, gboolean 
   LogQueue *q;
   unlink(filename);
 
-  _construct_options(options, 1100000, 0, TRUE);
+  _construct_options(options, TEST_DISKQ_SIZE, 0, TRUE);
 
   if (truncate_size_ratio < 0)
     truncate_size_ratio = disk_queue_config_get_truncate_size_ratio(configuration);
@@ -214,7 +216,7 @@ _create_reliable_diskqueue(gchar *filename, DiskQueueOptions *options, gboolean 
 
 Test(diskq_truncate, test_diskq_truncate_on_push)
 {
-  const gint full_disk_message_number = 8194; // measured for disk_buf_size 1100000
+  const gint full_disk_message_number = 8194; // measured for disk_buf_size TEST_DISKQ_SIZE
   const gint read_is_on_end_message_number  = full_disk_message_number - 200;
   const gint write_wraps_message_number = read_is_on_end_message_number - 200;
   const gint read_wraps_message_number = 300;
@@ -276,7 +278,7 @@ _assert_cursors_are_at_start(LogQueue *q)
 
 Test(diskq_truncate, test_diskq_truncate_size_ratio_default)
 {
-  const gint truncate_threshold = (gint)(1100000 * disk_queue_config_get_truncate_size_ratio(configuration));
+  const gint truncate_threshold = (gint)(TEST_DISKQ_SIZE * disk_queue_config_get_truncate_size_ratio(configuration));
   const gint empty_log_msg_size = 134;
   const gint below_threshold_message_number = truncate_threshold / empty_log_msg_size;
   const gint above_threshold_message_number = below_threshold_message_number + 1;
@@ -351,7 +353,7 @@ Test(diskq_truncate, test_diskq_truncate_size_ratio_0)
 
 Test(diskq_truncate, test_diskq_truncate_size_ratio_1)
 {
-  const gint full_disk_message_number = 8194; // measured for disk_buf_size 1100000
+  const gint full_disk_message_number = 8194; // measured for disk_buf_size TEST_DISKQ_SIZE
   LogQueue *q;
   GString *filename = g_string_new("test_dq_truncate_size_ratio_1.rqf");
 
@@ -397,7 +399,7 @@ _feed_one_large_message(LogQueue *q)
 
 Test(diskq_truncate, test_diskq_no_truncate_wrap)
 {
-  const gint just_under_max_size_message_number = 8239;
+  const gint just_under_max_size_message_number = 8239; // measured for disk_buf_size TEST_DISKQ_SIZE
   const gint some_messages_to_let_write_head_wrap = 500;
   gint unprocessed_messages_in_buffer = 0;
   LogQueue *q;
@@ -423,7 +425,7 @@ Test(diskq_truncate, test_diskq_no_truncate_wrap)
   // 3. feed 1 large msg to make file_size big
   _feed_one_large_message(q);
   cr_assert(qdisk_get_writer_head(qdisk) < qdisk_get_reader_head(qdisk), "write_head should have wrapped");
-  cr_assert(qdisk->file_size > 1100000, "file_size should be bigger than max size");
+  cr_assert(qdisk->file_size > TEST_DISKQ_SIZE, "file_size should be bigger than max size");
   unprocessed_messages_in_buffer += 1;
 
   // 4. send and ack all messages

--- a/news/bugfix-3726.md
+++ b/news/bugfix-3726.md
@@ -1,0 +1,2 @@
+`disk-buffer`: fixed a bug, which was introduced in 3.33.1, where we sometimes corrupted the
+disk-buffer file when it reached full size.


### PR DESCRIPTION
We do not check beforehand, whether we can fit a new message to the disk-buffer, we decide to wrap the `write_head` after we wrote over the `disk-buf-size` limit.

It is possible to be just before the `disk-buf-size` with the `write_head` and write a huge message, then wrap the `write_head` to the beginning. This will change `self->file_size` to be a large value.

Let's say we set `truncate-size-ratio(1)`, so we never truncate and never change the `file_size` from that large value.

Imagine, that we handled every message, then wrote a lot of messages to the disk-buffer again, so we are just before the `disk-buf-size` limit.
We write 2 small messages, one will end just after `disk-buf-size` but still before the huge `self->file_size`, the next one will start at the beginning, and end a bit after that.
This is because we decide to wrap the `write_head` based on the position related to disk-buf-size (see `_is_qdisk_overwritten()`).

When we are reading from the disk-buffer we currently decide to wrap the `read_head` based on whether it is after the `self->file_size`.
We read the small message that ends just after `disk-buf-size`, and we decide not to wrap, and try to read one more message there, which is the middle of an old message.

This PR matches the wrap logic between the write and read head, so they both measure their position relative to `disk-buf-size`.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>