### PR TITLE
Fix http requires in scls

### DIFF
--- a/scl/discord/discord.conf
+++ b/scl/discord/discord.conf
@@ -24,7 +24,6 @@
 # Rate limits: https://discord.com/developers/docs/topics/rate-limits#global-rate-limit
 # Max message length: https://discord.com/developers/docs/resources/webhook#execute-webhook
 
-@requires http
 @requires json-plugin
 @requires basicfuncs
 
@@ -39,6 +38,9 @@ block destination discord(
   use-system-cert-store(yes)
   ...)
 {
+
+@requires http "The discord() driver depends on the syslog-ng http module, please install the syslog-ng-mod-http (Debian & derivatives) or the syslog-ng-http (RHEL & co) package"
+
   http(
     url('`url`')
     method("POST")

--- a/scl/telegram/telegram.conf
+++ b/scl/telegram/telegram.conf
@@ -20,8 +20,6 @@
 #
 #############################################################################
 
-@requires http
-
 # Throttle: https://core.telegram.org/bots/faq#my-bot-is-hitting-limits-how-do-i-avoid-this
 # max-size: message size maximum is 4096. Other fields than message do not count.
 block destination telegram(


### PR DESCRIPTION
Recently, we introduced a way to mark modules as hard-requirements, so in case those modules (packages) are missing, then syslog-ng won't start.

The error message helps to show that a module (package) is probably missing.