### PR TITLE
configure: fix typo for disable mqtt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -286,7 +286,7 @@ AC_ARG_WITH(libesmtp,
                             [use libesmtp library from (prefix) directory DIR]),,)
 
 AC_ARG_ENABLE(mqtt,
-              [  --enable-mqtt          Disable MQTT support (default: auto)]
+              [  --disable-mqtt          Disable MQTT support (default: auto)]
               ,,enable_mqtt="auto")
 
 AC_ARG_WITH(libpaho-mqtt,


### PR DESCRIPTION
All sentences which begins with disable has there option disable instead
of enable, I consider this as typo based on smtp/http/redis and so on.

Fixes: ffd442d431a9b66c49230fc5af61f6bc38d57baa ("MQTT: create files and
create CMakeLists.txt/Makefile")

___

Option `--disable-mqtt` was tested and it works