### PR TITLE
Add workers() option to the Redis destination

### DIFF
--- a/modules/redis/CMakeLists.txt
+++ b/modules/redis/CMakeLists.txt
@@ -8,6 +8,8 @@ endif()
 set(REDIS_SOURCES
     "redis-parser.h"
     "redis.h"
+    "redis-worker.h"
+    "redis-worker.c"
     "redis-parser.c"
     "redis.c"
 )

--- a/modules/redis/Makefile.am
+++ b/modules/redis/Makefile.am
@@ -13,6 +13,8 @@ modules_redis_libredis_la_SOURCES	=	\
 	modules/redis/redis-grammar.y 		\
 	modules/redis/redis.c			\
 	modules/redis/redis.h			\
+	modules/redis/redis-worker.h	\
+	modules/redis/redis-worker.c 	\
 	modules/redis/redis-parser.c		\
 	modules/redis/redis-parser.h
 modules_redis_libredis_la_LIBADD	=	\

--- a/modules/redis/redis-grammar.ym
+++ b/modules/redis/redis-grammar.ym
@@ -86,6 +86,7 @@ redis_option
             redis_dd_set_timeout(last_driver, $3);
           }
         | threaded_dest_driver_general_option
+        | threaded_dest_driver_workers_option
         | { last_template_options = redis_dd_get_template_options(last_driver); } template_option
         ;
 

--- a/modules/redis/redis-worker.c
+++ b/modules/redis/redis-worker.c
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2014 Balabit
+ * Copyright (c) 2013 Tihamer Petrovics <tihameri@gmail.com>
+ * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
+ * Copyright (c) 2021 Szilárd Parrag
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "redis-worker.h"
+#include "redis.h"
+#include "messages.h"
+#include "scratch-buffers.h"
+#include "utf8utils.h"
+
+
+
+static inline void
+_fill_template(RedisDestWorker *self, LogMessage *msg, LogTemplate *template, gchar **str,
+               gsize *size)
+{
+  RedisDriver *owner = (RedisDriver *) self->super.owner;
+
+  if (log_template_is_trivial(template))
+    {
+      gssize unsigned_size;
+      *str = (gchar *)log_template_get_trivial_value(template, msg, &unsigned_size);
+      *size = unsigned_size;
+    }
+  else
+    {
+      GString *buffer = scratch_buffers_alloc();
+      LogTemplateEvalOptions options = {&owner->template_options, LTZ_SEND,
+                                        owner->super.worker.instance.seq_num, NULL
+                                       };
+      log_template_format(template, msg, &options, buffer);
+      *size = buffer->len;
+      *str = buffer->str;
+    }
+}
+
+static void
+_fill_argv_from_template_list(RedisDestWorker *self, LogMessage *msg)
+{
+  RedisDriver *owner = (RedisDriver *) self->super.owner;
+  for (gint i = 1; i < self->argc; i++)
+    {
+      LogTemplate *redis_command = g_list_nth_data(owner->arguments, i-1);
+      _fill_template(self, msg, redis_command, &self->argv[i], &self->argvlen[i]);
+    }
+}
+
+static const gchar *
+_argv_to_string(RedisDestWorker *self)
+{
+  GString *full_command = scratch_buffers_alloc();
+
+  full_command = g_string_append(full_command, self->argv[0]);
+  for (gint i = 1; i < self->argc; i++)
+    {
+      g_string_append(full_command, " \"");
+      append_unsafe_utf8_as_escaped_text(full_command, self->argv[i], self->argvlen[i], "\"");
+      g_string_append(full_command, "\"");
+    }
+  return full_command->str;
+}
+
+
+static LogThreadedResult
+redis_worker_insert(LogThreadedDestWorker *s, LogMessage *msg)
+{
+  RedisDestWorker *self = (RedisDestWorker *)s;
+  RedisDriver *owner = (RedisDriver *) self->super.owner;
+
+  ScratchBuffersMarker marker;
+  scratch_buffers_mark(&marker);
+
+  _fill_argv_from_template_list(self, msg);
+
+  redisReply *reply = redisCommandArgv(self->c, self->argc, (const gchar **)self->argv, self->argvlen);
+
+  if (!reply)
+    {
+      msg_error("REDIS server error, suspending",
+                evt_tag_str("driver", owner->super.super.super.id),
+                evt_tag_str("command", _argv_to_string(self)),
+                evt_tag_str("error", self->c->errstr),
+                evt_tag_int("time_reopen", self->super.time_reopen));
+      scratch_buffers_reclaim_marked(marker);
+      return LTR_ERROR;
+    }
+
+  msg_debug("REDIS command sent",
+            evt_tag_str("driver", owner->super.super.super.id),
+            evt_tag_str("command", _argv_to_string(self)));
+
+  freeReplyObject(reply);
+  scratch_buffers_reclaim_marked(marker);
+  return LTR_SUCCESS;
+}
+
+
+static gboolean
+redis_worker_thread_init(LogThreadedDestWorker *d)
+{
+  RedisDestWorker *self = (RedisDestWorker *) d;
+  RedisDriver *owner = (RedisDriver *) self->super.owner;
+
+  self->argc = g_list_length(owner->arguments) + 1;
+  self->argv = g_malloc(self->argc * sizeof(char *));
+  self->argvlen = g_malloc(self->argc * sizeof(size_t));
+
+  self->argv[0] = owner->command->str;
+  self->argvlen[0] = owner->command->len;
+
+  msg_debug("Worker thread started",
+            evt_tag_str("driver", self->super.owner->super.super.id));
+
+
+  return log_threaded_dest_worker_init_method(d);
+
+}
+
+
+static void
+redis_worker_disconnect(LogThreadedDestWorker *s)
+{
+  RedisDestWorker *self = (RedisDestWorker *)s;
+
+  if (self->c)
+    redisFree(self->c);
+  self->c = NULL;
+}
+
+static void
+redis_worker_thread_deinit(LogThreadedDestWorker *d)
+{
+  RedisDestWorker *self = (RedisDestWorker *)d;
+
+  g_free(self->argv);
+  g_free(self->argvlen);
+  redis_worker_disconnect(d);
+
+  log_threaded_dest_worker_deinit_method(d);
+}
+
+static inline void
+_trace_reply_message(redisReply *r)
+{
+  if (trace_flag)
+    {
+      if (r->elements > 0)
+        {
+          msg_trace(">>>>>> REDIS command reply begin",
+                    evt_tag_long("elements", r->elements));
+
+          for (gsize i = 0; i < r->elements; i++)
+            {
+              _trace_reply_message(r->element[i]);
+            }
+
+          msg_trace("<<<<<< REDIS command reply end");
+        }
+      else if (r->type == REDIS_REPLY_STRING || r->type == REDIS_REPLY_STATUS || r->type == REDIS_REPLY_ERROR)
+        {
+          msg_trace("REDIS command reply",
+                    evt_tag_str("str", r->str));
+        }
+      else
+        {
+          msg_trace("REDIS command unhandled reply",
+                    evt_tag_int("type", r->type));
+        }
+    }
+}
+
+
+
+
+static gboolean
+send_redis_command(RedisDestWorker *self, const char *format, ...)
+{
+  va_list ap;
+  va_start(ap, format);
+  redisReply *reply = redisvCommand(self->c, format, ap);
+  va_end(ap);
+
+  gboolean retval = reply && (reply->type != REDIS_REPLY_ERROR);
+  if (reply)
+    {
+      _trace_reply_message(reply);
+      freeReplyObject(reply);
+    }
+  return retval;
+}
+
+static gboolean
+check_connection_to_redis(RedisDestWorker *self)
+{
+  return send_redis_command(self, "ping");
+}
+
+static gboolean
+authenticate_to_redis(RedisDestWorker *self, const gchar *password)
+{
+  return send_redis_command(self, "AUTH %s", password);
+}
+
+static gboolean
+redis_worker_connect(LogThreadedDestWorker *s)
+{
+  RedisDestWorker *self = (RedisDestWorker *)s;
+  RedisDriver *owner = (RedisDriver *) self->super.owner;
+
+  if (self->c && check_connection_to_redis(self))
+    return TRUE;
+
+  if (self->c)
+    redisFree(self->c);
+
+  self->c = redisConnectWithTimeout(owner->host, owner->port, owner->timeout);
+
+  if (self->c == NULL || self->c->err)
+    {
+      if (self->c)
+        {
+          msg_error("REDIS server error during connection",
+                    evt_tag_str("driver", owner->super.super.super.id),
+                    evt_tag_str("error", self->c->errstr),
+                    evt_tag_int("time_reopen", self->super.time_reopen));
+        }
+      else
+        {
+          msg_error("REDIS server can't allocate redis context");
+        }
+      return FALSE;
+    }
+
+  if (owner->auth)
+    if (!authenticate_to_redis(self, owner->auth))
+      {
+        msg_error("REDIS: failed to authenticate",
+                  evt_tag_str("driver", owner->super.super.super.id));
+        return FALSE;
+      }
+
+  if (!check_connection_to_redis(self))
+    {
+      msg_error("REDIS: failed to connect",
+                evt_tag_str("driver", owner->super.super.super.id));
+      return FALSE;
+    }
+
+  if (self->c->err)
+    return FALSE;
+
+  msg_debug("Connecting to REDIS succeeded",
+            evt_tag_str("driver", owner->super.super.super.id));
+
+  return TRUE;
+}
+
+
+LogThreadedDestWorker *redis_worker_new(LogThreadedDestDriver *owner, gint worker_index)
+{
+  RedisDestWorker *self = g_new0(RedisDestWorker, 1);
+
+  log_threaded_dest_worker_init_instance(&self->super, owner, worker_index);
+
+  self->super.thread_init = redis_worker_thread_init;
+  self->super.thread_deinit = redis_worker_thread_deinit;
+  self->super.connect = redis_worker_connect;
+  self->super.disconnect = redis_worker_disconnect;
+  self->super.insert = redis_worker_insert;
+
+  return &self->super;
+}

--- a/modules/redis/redis-worker.h
+++ b/modules/redis/redis-worker.h
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2014 Balabit
  * Copyright (c) 2013 Tihamer Petrovics <tihameri@gmail.com>
+ * Copyright (c) 2014 Gergely Nagy <algernon@balabit.hu>
+ * Copyright (c) 2021 Szilárd Parrag
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published
@@ -21,37 +23,25 @@
  *
  */
 
-#ifndef REDIS_H_INCLUDED
-#define REDIS_H_INCLUDED
+#ifndef REDIS_WORKER_H_INCLUDED
+#define REDIS_WORKER_H_INCLUDED
 
-#include "driver.h"
+#include <hiredis/hiredis.h>
+
+#include "syslog-ng.h"
 #include "logthrdest/logthrdestdrv.h"
 
 
-typedef struct _RedisDriver
+typedef struct _RedisDestWorker
 {
-  LogThreadedDestDriver super;
+  LogThreadedDestWorker super;
+  redisContext *c;
+  gint argc;
+  gchar **argv;
+  size_t *argvlen;
 
-  gchar *host;
-  gint   port;
-  gchar *auth;
-  struct timeval timeout;
+} RedisDestWorker;
 
-  LogTemplateOptions template_options;
-
-  GString *command;
-  GList *arguments;
-} RedisDriver;
-
-
-LogDriver *redis_dd_new(GlobalConfig *cfg);
-
-void redis_dd_set_timeout(LogDriver *d, const glong timeout);
-void redis_dd_set_host(LogDriver *d, const gchar *host);
-void redis_dd_set_port(LogDriver *d, gint port);
-void redis_dd_set_auth(LogDriver *d, const gchar *auth);
-void redis_dd_set_command_ref(LogDriver *d, const gchar *command,
-                              GList *arguments);
-LogTemplateOptions *redis_dd_get_template_options(LogDriver *d);
+LogThreadedDestWorker *redis_worker_new(LogThreadedDestDriver *owner, gint worker_index);
 
 #endif

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -27,35 +27,14 @@
 #include "redis.h"
 #include "redis-parser.h"
 #include "plugin.h"
-#include "messages.h"
 #include "stats/stats-registry.h"
 #include "logqueue.h"
 #include "driver.h"
 #include "plugin-types.h"
 #include "logthrdest/logthrdestdrv.h"
-#include "scratch-buffers.h"
-#include "utf8utils.h"
 
-typedef struct
-{
-  LogThreadedDestDriver super;
+#include "redis-worker.h"
 
-  gchar *host;
-  gint   port;
-  gchar *auth;
-
-  LogTemplateOptions template_options;
-
-  GString *command;
-  GList *arguments;
-
-  /* Worker thread */
-  redisContext *c;
-  gint argc;
-  gchar **argv;
-  size_t *argvlen;
-  struct timeval timeout;
-} RedisDriver;
 
 /*
  * Configuration
@@ -92,6 +71,7 @@ redis_dd_set_timeout(LogDriver *d, const glong timeout)
 {
   RedisDriver *self = (RedisDriver *)d;
   self->timeout.tv_sec = timeout;
+
 }
 
 static void
@@ -152,233 +132,8 @@ redis_dd_format_persist_name(const LogPipe *s)
   return persist_name;
 }
 
-static inline void
-_trace_reply_message(redisReply *r)
-{
-  if (trace_flag)
-    {
-      if (r->elements > 0)
-        {
-          msg_trace(">>>>>> REDIS command reply begin",
-                    evt_tag_long("elements", r->elements));
 
-          for (gsize i = 0; i < r->elements; i++)
-            {
-              _trace_reply_message(r->element[i]);
-            }
 
-          msg_trace("<<<<<< REDIS command reply end");
-        }
-      else if (r->type == REDIS_REPLY_STRING || r->type == REDIS_REPLY_STATUS || r->type == REDIS_REPLY_ERROR)
-        {
-          msg_trace("REDIS command reply",
-                    evt_tag_str("str", r->str));
-        }
-      else
-        {
-          msg_trace("REDIS command unhandled reply",
-                    evt_tag_int("type", r->type));
-        }
-    }
-}
-
-static gboolean
-send_redis_command(RedisDriver *self, const char *format, ...)
-{
-  va_list ap;
-  va_start(ap, format);
-  redisReply *reply = redisvCommand(self->c, format, ap);
-  va_end(ap);
-
-  gboolean retval = reply && (reply->type != REDIS_REPLY_ERROR);
-  if (reply)
-    {
-      _trace_reply_message(reply);
-      freeReplyObject(reply);
-    }
-  return retval;
-}
-
-static gboolean
-check_connection_to_redis(RedisDriver *self)
-{
-  return send_redis_command(self, "ping");
-}
-
-static gboolean
-authenticate_to_redis(RedisDriver *self, const gchar *password)
-{
-  return send_redis_command(self, "AUTH %s", self->auth);
-}
-
-static gboolean
-redis_dd_connect(LogThreadedDestDriver *s)
-{
-  RedisDriver *self = (RedisDriver *)s;
-
-  if (self->c && check_connection_to_redis(self))
-    return TRUE;
-
-  if (self->c)
-    redisFree(self->c);
-
-  self->c = redisConnectWithTimeout(self->host, self->port, self->timeout);
-
-  if (self->c == NULL || self->c->err)
-    {
-      if (self->c)
-        {
-          msg_error("REDIS server error during connection",
-                    evt_tag_str("driver", self->super.super.super.id),
-                    evt_tag_str("error", self->c->errstr),
-                    evt_tag_int("time_reopen", self->super.time_reopen));
-        }
-      else
-        {
-          msg_error("REDIS server can't allocate redis context");
-        }
-      return FALSE;
-    }
-
-  if (self->auth)
-    if (!authenticate_to_redis(self, self->auth))
-      {
-        msg_error("REDIS: failed to authenticate",
-                  evt_tag_str("driver", self->super.super.super.id));
-        return FALSE;
-      }
-
-  if (!check_connection_to_redis(self))
-    {
-      msg_error("REDIS: failed to connect",
-                evt_tag_str("driver", self->super.super.super.id));
-      return FALSE;
-    }
-
-  if (self->c->err)
-    return FALSE;
-
-  msg_debug("Connecting to REDIS succeeded",
-            evt_tag_str("driver", self->super.super.super.id));
-
-  return TRUE;
-}
-
-static void
-redis_dd_disconnect(LogThreadedDestDriver *s)
-{
-  RedisDriver *self = (RedisDriver *)s;
-
-  if (self->c)
-    redisFree(self->c);
-  self->c = NULL;
-}
-
-static inline void _fill_template(RedisDriver *self, LogMessage *msg, LogTemplate *template, gchar **str, gsize *size)
-{
-  if (log_template_is_trivial(template))
-    {
-      gssize unsigned_size;
-      *str = (gchar *)log_template_get_trivial_value(template, msg, &unsigned_size);
-      *size = unsigned_size;
-    }
-  else
-    {
-      GString *buffer = scratch_buffers_alloc();
-      LogTemplateEvalOptions options = {&self->template_options, LTZ_SEND,
-                                        self->super.worker.instance.seq_num, NULL
-                                       };
-      log_template_format(template, msg, &options, buffer);
-      *size = buffer->len;
-      *str = buffer->str;
-    }
-}
-
-static void
-_fill_argv_from_template_list(RedisDriver *self, LogMessage *msg)
-{
-  for (gint i = 1; i < self->argc; i++)
-    {
-      LogTemplate *redis_command = g_list_nth_data(self->arguments, i-1);
-      _fill_template(self, msg, redis_command, &self->argv[i], &self->argvlen[i]);
-    }
-}
-
-static const gchar *
-_argv_to_string(RedisDriver *self)
-{
-  GString *full_command = scratch_buffers_alloc();
-
-  full_command = g_string_append(full_command, self->argv[0]);
-  for (gint i = 1; i < self->argc; i++)
-    {
-      g_string_append(full_command, " \"");
-      append_unsafe_utf8_as_escaped_text(full_command, self->argv[i], self->argvlen[i], "\"");
-      g_string_append(full_command, "\"");
-    }
-  return full_command->str;
-}
-
-/*
- * Worker thread
- */
-
-static LogThreadedResult
-redis_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
-{
-  RedisDriver *self = (RedisDriver *)s;
-
-  ScratchBuffersMarker marker;
-  scratch_buffers_mark(&marker);
-
-  _fill_argv_from_template_list(self, msg);
-
-  redisReply *reply = redisCommandArgv(self->c, self->argc, (const gchar **)self->argv, self->argvlen);
-
-  if (!reply)
-    {
-      msg_error("REDIS server error, suspending",
-                evt_tag_str("driver", self->super.super.super.id),
-                evt_tag_str("command", _argv_to_string(self)),
-                evt_tag_str("error", self->c->errstr),
-                evt_tag_int("time_reopen", self->super.time_reopen));
-      scratch_buffers_reclaim_marked(marker);
-      return LTR_ERROR;
-    }
-
-  msg_debug("REDIS command sent",
-            evt_tag_str("driver", self->super.super.super.id),
-            evt_tag_str("command", _argv_to_string(self)));
-
-  freeReplyObject(reply);
-  scratch_buffers_reclaim_marked(marker);
-  return LTR_SUCCESS;
-}
-
-static void
-redis_worker_thread_init(LogThreadedDestDriver *d)
-{
-  RedisDriver *self = (RedisDriver *)d;
-
-  self->argc = g_list_length(self->arguments) + 1;
-  self->argv = g_malloc(self->argc * sizeof(char *));
-  self->argvlen = g_malloc(self->argc * sizeof(size_t));
-  self->argv[0] = self->command->str;
-  self->argvlen[0] = self->command->len;
-
-  msg_debug("Worker thread started",
-            evt_tag_str("driver", self->super.super.super.id));
-}
-
-static void
-redis_worker_thread_deinit(LogThreadedDestDriver *d)
-{
-  RedisDriver *self = (RedisDriver *)d;
-
-  g_free(self->argv);
-  g_free(self->argvlen);
-  redis_dd_disconnect(d);
-}
 
 /*
  * Main thread
@@ -413,7 +168,7 @@ redis_dd_init(LogPipe *s)
 static void
 redis_dd_free(LogPipe *d)
 {
-  RedisDriver *self = (RedisDriver *)d;
+  RedisDriver *self = (RedisDriver *) d;
 
   log_template_options_destroy(&self->template_options);
 
@@ -421,8 +176,6 @@ redis_dd_free(LogPipe *d)
   g_free(self->auth);
   g_string_free(self->command, TRUE);
   g_list_free_full(self->arguments, _template_unref);
-  if (self->c)
-    redisFree(self->c);
 
   log_threaded_dest_driver_free(d);
 }
@@ -441,11 +194,7 @@ redis_dd_new(GlobalConfig *cfg)
   self->super.super.super.super.free_fn = redis_dd_free;
   self->super.super.super.super.generate_persist_name = redis_dd_format_persist_name;
 
-  self->super.worker.thread_init = redis_worker_thread_init;
-  self->super.worker.thread_deinit = redis_worker_thread_deinit;
-  self->super.worker.connect = redis_dd_connect;
-  self->super.worker.disconnect = redis_dd_disconnect;
-  self->super.worker.insert = redis_worker_insert;
+  self->super.worker.construct = redis_worker_new;
 
   self->super.format_stats_instance = redis_dd_format_stats_instance;
   self->super.stats_source = stats_register_type("redis");

--- a/news/feature-3732.md
+++ b/news/feature-3732.md
@@ -1,0 +1,19 @@
+`redis()`: add `workers()` support
+
+The Redis driver now support the `workers()` opttion, which specifies the
+number of parallel workers to be used.
+
+This increases the throughput of the Redis destination driver.
+
+Example:
+
+```
+destination d_redis {
+  redis(
+      host("localhost")
+      port(6379)
+      command("HINCRBY", "hosts", "$HOST", "1")
+      workers(8)
+      );
+};
+```


### PR DESCRIPTION
This PR adds `workers()` support for the `redis()` destination driver.

This increases the throughput of the Redis destination driver.

