### PR TITLE
log-threaded-dest: add grammar rules to opt-in for workers() and batch-...() options

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1194,14 +1194,17 @@ dest_driver_option
         | driver_option
         ;
 
+threaded_dest_driver_batch_option
+        : KW_BATCH_LINES '(' nonnegative_integer ')' { log_threaded_dest_driver_set_batch_lines(last_driver, $3); }
+        | KW_BATCH_TIMEOUT '(' positive_integer ')' { log_threaded_dest_driver_set_batch_timeout(last_driver, $3); }
+        ;
+
 /* implies dest_driver_option */
 threaded_dest_driver_option
 	: KW_RETRIES '(' positive_integer ')'
         {
           log_threaded_dest_driver_set_max_retries_on_error(last_driver, $3);
         }
-        | KW_BATCH_LINES '(' nonnegative_integer ')' { log_threaded_dest_driver_set_batch_lines(last_driver, $3); }
-        | KW_BATCH_TIMEOUT '(' positive_integer ')' { log_threaded_dest_driver_set_batch_timeout(last_driver, $3); }
         | KW_TIME_REOPEN '(' positive_integer ')' { log_threaded_dest_driver_set_time_reopen(last_driver, $3); }
         | dest_driver_option
         ;

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -182,6 +182,7 @@
 %token KW_TYPE                        10083
 %token KW_STATS_MAX_DYNAMIC           10084
 %token KW_MIN_IW_SIZE_PER_READER      10085
+%token KW_WORKERS                     10086
 %token KW_BATCH_LINES                 10087
 %token KW_BATCH_TIMEOUT               10088
 %token KW_TRIM_LARGE_MESSAGES         10089
@@ -1197,6 +1198,10 @@ dest_driver_option
 threaded_dest_driver_batch_option
         : KW_BATCH_LINES '(' nonnegative_integer ')' { log_threaded_dest_driver_set_batch_lines(last_driver, $3); }
         | KW_BATCH_TIMEOUT '(' positive_integer ')' { log_threaded_dest_driver_set_batch_timeout(last_driver, $3); }
+        ;
+
+threaded_dest_driver_workers_option
+        : KW_WORKERS '(' positive_integer ')'  { log_threaded_dest_driver_set_num_workers(last_driver, $3); }
         ;
 
 /* implies dest_driver_option */

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1200,7 +1200,7 @@ threaded_dest_driver_batch_option
         ;
 
 /* implies dest_driver_option */
-threaded_dest_driver_option
+threaded_dest_driver_general_option
 	: KW_RETRIES '(' positive_integer ')'
         {
           log_threaded_dest_driver_set_max_retries_on_error(last_driver, $3);

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -163,6 +163,7 @@ static CfgLexerKeyword main_keywords[] =
   { "persist_name",            KW_PERSIST_NAME, VERSION_VALUE_3_8 },
 
   { "retries",            KW_RETRIES },
+  { "workers",            KW_WORKERS },
   { "batch_lines",        KW_BATCH_LINES },
   { "batch_timeout",      KW_BATCH_TIMEOUT },
 

--- a/modules/afamqp/afamqp-grammar.ym
+++ b/modules/afamqp/afamqp-grammar.ym
@@ -95,7 +95,7 @@ afamqp_option
 	| KW_FRAME_SIZE '(' positive_integer ')'   { afamqp_dd_set_frame_size(last_driver, $3); }
 	| KW_HEARTBEAT '(' nonnegative_integer ')' { afamqp_dd_set_offered_heartbeat(last_driver, $3); }
 	| value_pair_option                        { afamqp_dd_set_value_pairs(last_driver, $1); }
-	| threaded_dest_driver_option
+	| threaded_dest_driver_general_option
 	| afamqp_tls_option
 	| KW_TLS '(' afamqp_tls_options ')'
 	| { last_template_options = afamqp_dd_get_template_options(last_driver); } template_option

--- a/modules/afmongodb/afmongodb-grammar.ym
+++ b/modules/afmongodb/afmongodb-grammar.ym
@@ -47,7 +47,6 @@
 %token KW_MONGODB
 %token KW_URI
 %token KW_COLLECTION
-%token KW_WORKERS
 
 %%
 
@@ -74,8 +73,8 @@ afmongodb_option
         {
             afmongodb_dd_set_value_pairs(last_driver, $1);
         }
-    | KW_WORKERS '(' positive_integer ')'  { log_threaded_dest_driver_set_num_workers(last_driver, $3); }
     | threaded_dest_driver_general_option
+    | threaded_dest_driver_workers_option
     | { last_template_options = afmongodb_dd_get_template_options(last_driver); } template_option
     ;
 

--- a/modules/afmongodb/afmongodb-grammar.ym
+++ b/modules/afmongodb/afmongodb-grammar.ym
@@ -75,7 +75,7 @@ afmongodb_option
             afmongodb_dd_set_value_pairs(last_driver, $1);
         }
     | KW_WORKERS '(' positive_integer ')'  { log_threaded_dest_driver_set_num_workers(last_driver, $3); }
-    | threaded_dest_driver_option
+    | threaded_dest_driver_general_option
     | { last_template_options = afmongodb_dd_get_template_options(last_driver); } template_option
     ;
 

--- a/modules/afmongodb/afmongodb-parser.c
+++ b/modules/afmongodb/afmongodb-parser.c
@@ -33,7 +33,6 @@ static CfgLexerKeyword afmongodb_keywords[] =
   { "mongodb", KW_MONGODB },
   { "uri", KW_URI },
   { "collection", KW_COLLECTION },
-  { "workers", KW_WORKERS },
   { NULL }
 };
 

--- a/modules/afsmtp/afsmtp-grammar.ym
+++ b/modules/afsmtp/afsmtp-grammar.ym
@@ -160,7 +160,7 @@ afsmtp_option
             log_template_unref($3);
             log_template_unref($4);
           }
-        | threaded_dest_driver_option
+        | threaded_dest_driver_general_option
         | { last_template_options = afsmtp_dd_get_template_options(last_driver); } template_option
         ;
 

--- a/modules/afsql/afsql-grammar.ym
+++ b/modules/afsql/afsql-grammar.ym
@@ -121,6 +121,7 @@ dest_afsql_option
 
 	| { last_template_options = &((AFSqlDestDriver *) last_driver)->template_options; } template_option
 	| threaded_dest_driver_option
+        | threaded_dest_driver_batch_option
         ;
 
 dest_afsql_values

--- a/modules/afsql/afsql-grammar.ym
+++ b/modules/afsql/afsql-grammar.ym
@@ -120,7 +120,7 @@ dest_afsql_option
 	| KW_CREATE_STATEMENT_APPEND '(' string ')' { afsql_dd_set_create_statement_append(last_driver, $3); free($3); }
 
 	| { last_template_options = &((AFSqlDestDriver *) last_driver)->template_options; } template_option
-	| threaded_dest_driver_option
+	| threaded_dest_driver_general_option
         | threaded_dest_driver_batch_option
         ;
 

--- a/modules/afstomp/afstomp-grammar.ym
+++ b/modules/afstomp/afstomp-grammar.ym
@@ -79,7 +79,7 @@ afstomp_option
         | KW_USERNAME '(' string ')'		{ afstomp_dd_set_user(last_driver, $3); free($3); }
         | KW_PASSWORD '(' string ')'		{ afstomp_dd_set_password(last_driver, $3); free($3); }
         | value_pair_option			{ afstomp_dd_set_value_pairs(last_driver, $1); }
-        | threaded_dest_driver_option
+        | threaded_dest_driver_general_option
 	| { last_template_options = afstomp_dd_get_template_options(last_driver); } template_option
         ;
 

--- a/modules/examples/destinations/example_destination/example_destination-grammar.ym
+++ b/modules/examples/destinations/example_destination/example_destination-grammar.ym
@@ -66,7 +66,7 @@ example_destination_option
             example_destination_dd_set_filename(last_driver, $3);
             free($3);
           }
-        | threaded_dest_driver_option
+        | threaded_dest_driver_general_option
 ;
 
 /* INCLUDE_RULES */

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -154,6 +154,7 @@ http_option
     | KW_BATCH_BYTES '(' nonnegative_integer ')' { http_dd_set_batch_bytes(last_driver, $3); }
     | KW_WORKERS '(' positive_integer ')'  { log_threaded_dest_driver_set_num_workers(last_driver, $3); }
     | threaded_dest_driver_option
+    | threaded_dest_driver_batch_option
     | http_tls_option
     | KW_TLS '(' http_tls_options ')'
     | { last_template_options = http_dd_get_template_options(last_driver); } template_option

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -74,7 +74,6 @@ HttpResponseHandler last_response_handler;
 %token KW_BODY_PREFIX
 %token KW_BODY_SUFFIX
 %token KW_DELIMITER
-%token KW_WORKERS
 %token KW_ACCEPT_REDIRECTS
 %token KW_RESPONSE_ACTION
 %token KW_SUCCESS
@@ -152,9 +151,9 @@ http_option
     | KW_ACCEPT_REDIRECTS '(' yesno ')'       { http_dd_set_accept_redirects(last_driver, $3); }
     | KW_TIMEOUT '(' nonnegative_integer ')'  { http_dd_set_timeout(last_driver, $3); }
     | KW_BATCH_BYTES '(' nonnegative_integer ')' { http_dd_set_batch_bytes(last_driver, $3); }
-    | KW_WORKERS '(' positive_integer ')'  { log_threaded_dest_driver_set_num_workers(last_driver, $3); }
     | threaded_dest_driver_general_option
     | threaded_dest_driver_batch_option
+    | threaded_dest_driver_workers_option
     | http_tls_option
     | KW_TLS '(' http_tls_options ')'
     | { last_template_options = http_dd_get_template_options(last_driver); } template_option

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -153,7 +153,7 @@ http_option
     | KW_TIMEOUT '(' nonnegative_integer ')'  { http_dd_set_timeout(last_driver, $3); }
     | KW_BATCH_BYTES '(' nonnegative_integer ')' { http_dd_set_batch_bytes(last_driver, $3); }
     | KW_WORKERS '(' positive_integer ')'  { log_threaded_dest_driver_set_num_workers(last_driver, $3); }
-    | threaded_dest_driver_option
+    | threaded_dest_driver_general_option
     | threaded_dest_driver_batch_option
     | http_tls_option
     | KW_TLS '(' http_tls_options ')'

--- a/modules/http/http-parser.c
+++ b/modules/http/http-parser.c
@@ -62,7 +62,6 @@ static CfgLexerKeyword http_keywords[] =
   { "body_prefix",      KW_BODY_PREFIX },
   { "body_suffix",      KW_BODY_SUFFIX },
   { "delimiter",        KW_DELIMITER },
-  { "workers",          KW_WORKERS },
   { NULL }
 };
 

--- a/modules/java/native/java-grammar.ym
+++ b/modules/java/native/java-grammar.ym
@@ -86,7 +86,7 @@ java_dest_option
             java_dd_set_template_string(last_driver, $3); free($3);
           }
         | KW_OPTIONS '(' java_dest_custom_options ')'
-        | threaded_dest_driver_option
+        | threaded_dest_driver_general_option
         | threaded_dest_driver_batch_option
         | { last_template_options = java_dd_get_template_options(last_driver); } template_option
         ;

--- a/modules/java/native/java-grammar.ym
+++ b/modules/java/native/java-grammar.ym
@@ -87,6 +87,7 @@ java_dest_option
           }
         | KW_OPTIONS '(' java_dest_custom_options ')'
         | threaded_dest_driver_option
+        | threaded_dest_driver_batch_option
         | { last_template_options = java_dd_get_template_options(last_driver); } template_option
         ;
 

--- a/modules/kafka/kafka-grammar.ym
+++ b/modules/kafka/kafka-grammar.ym
@@ -109,7 +109,7 @@ kafka_option
         | KW_POLL_TIMEOUT '(' nonnegative_integer ')'                 { kafka_dd_set_poll_timeout(last_driver, $3); }
 	| KW_BOOTSTRAP_SERVERS '(' string ')'                         { kafka_dd_set_bootstrap_servers(last_driver, $3); free($3); }
 	| KW_SYNC_SEND '(' yesno ')'                                  { kafka_dd_set_transaction_commit(last_driver, $3); }
-        | threaded_dest_driver_option
+        | threaded_dest_driver_general_option
         | threaded_dest_driver_batch_option
         | { last_template_options = kafka_dd_get_template_options(last_driver); } template_option
         ;

--- a/modules/kafka/kafka-grammar.ym
+++ b/modules/kafka/kafka-grammar.ym
@@ -110,6 +110,7 @@ kafka_option
 	| KW_BOOTSTRAP_SERVERS '(' string ')'                         { kafka_dd_set_bootstrap_servers(last_driver, $3); free($3); }
 	| KW_SYNC_SEND '(' yesno ')'                                  { kafka_dd_set_transaction_commit(last_driver, $3); }
         | threaded_dest_driver_option
+        | threaded_dest_driver_batch_option
         | { last_template_options = kafka_dd_get_template_options(last_driver); } template_option
         ;
 

--- a/modules/kafka/kafka-grammar.ym
+++ b/modules/kafka/kafka-grammar.ym
@@ -59,7 +59,6 @@
 %token KW_TOPIC
 %token KW_FALLBACK_TOPIC
 %token KW_CONFIG
-%token KW_WORKERS
 %token KW_FLUSH_TIMEOUT_ON_SHUTDOWN
 %token KW_FLUSH_TIMEOUT_ON_RELOAD
 %token KW_POLL_TIMEOUT
@@ -103,7 +102,6 @@ kafka_option
         {
             kafka_dd_set_message_ref(last_driver, $3);
         }
-        | KW_WORKERS '(' nonnegative_integer ')'                      { log_threaded_dest_driver_set_num_workers(last_driver, $3); }
 	| KW_FLUSH_TIMEOUT_ON_SHUTDOWN '(' nonnegative_integer ')'    { kafka_dd_set_flush_timeout_on_shutdown(last_driver, $3); }
 	| KW_FLUSH_TIMEOUT_ON_RELOAD '(' nonnegative_integer ')'      { kafka_dd_set_flush_timeout_on_reload(last_driver, $3); }
         | KW_POLL_TIMEOUT '(' nonnegative_integer ')'                 { kafka_dd_set_poll_timeout(last_driver, $3); }
@@ -111,6 +109,7 @@ kafka_option
 	| KW_SYNC_SEND '(' yesno ')'                                  { kafka_dd_set_transaction_commit(last_driver, $3); }
         | threaded_dest_driver_general_option
         | threaded_dest_driver_batch_option
+        | threaded_dest_driver_workers_option
         | { last_template_options = kafka_dd_get_template_options(last_driver); } template_option
         ;
 

--- a/modules/kafka/kafka-parser.c
+++ b/modules/kafka/kafka-parser.c
@@ -43,7 +43,6 @@ static CfgLexerKeyword kafka_keywords[] =
   { "message",        KW_MESSAGE },
   { "sync_send",      KW_SYNC_SEND},
   { "bootstrap_servers", KW_BOOTSTRAP_SERVERS },
-  { "workers",        KW_WORKERS },
   { "poll_timeout",   KW_POLL_TIMEOUT },
   { "kafka_c",        KW_KAFKA },   /* compatibility with incubator naming */
   { NULL }

--- a/modules/mqtt/mqtt-grammar.ym
+++ b/modules/mqtt/mqtt-grammar.ym
@@ -82,7 +82,7 @@ mqtt_destination_option
             mqtt_dd_set_qos(last_driver, $3);
           }
         | KW_TEMPLATE '(' template_content ')'   { mqtt_dd_set_message_template_ref(last_driver, $3); }
-        | threaded_dest_driver_option
+        | threaded_dest_driver_general_option
         | { last_template_options = mqtt_dd_get_template_options(last_driver); } template_option
         ;
 

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -119,7 +119,7 @@ python_dd_option
         | KW_LOADERS python_dd_loaders
         | KW_IMPORTS python_dd_loaders
         | KW_OPTIONS '(' python_dd_custom_options ')'
-        | threaded_dest_driver_option
+        | threaded_dest_driver_general_option
         | threaded_dest_driver_batch_option
         | value_pair_option
           {

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -120,6 +120,7 @@ python_dd_option
         | KW_IMPORTS python_dd_loaders
         | KW_OPTIONS '(' python_dd_custom_options ')'
         | threaded_dest_driver_option
+        | threaded_dest_driver_batch_option
         | value_pair_option
           {
             python_dd_set_value_pairs(last_driver, $1);

--- a/modules/redis/redis-grammar.ym
+++ b/modules/redis/redis-grammar.ym
@@ -85,7 +85,7 @@ redis_option
           {
             redis_dd_set_timeout(last_driver, $3);
           }
-        | threaded_dest_driver_option
+        | threaded_dest_driver_general_option
         | { last_template_options = redis_dd_get_template_options(last_driver); } template_option
         ;
 

--- a/modules/riemann/riemann-grammar.ym
+++ b/modules/riemann/riemann-grammar.ym
@@ -143,7 +143,7 @@ riemann_option
           {
             riemann_dd_set_field_attributes(last_driver, last_value_pairs);
           }
-        | threaded_dest_driver_option
+        | threaded_dest_driver_general_option
         | threaded_dest_driver_batch_option
         | KW_TLS '(' riemann_tls_options ')'
         | { last_template_options = riemann_dd_get_template_options(last_driver); } template_option

--- a/modules/riemann/riemann-grammar.ym
+++ b/modules/riemann/riemann-grammar.ym
@@ -144,6 +144,7 @@ riemann_option
             riemann_dd_set_field_attributes(last_driver, last_value_pairs);
           }
         | threaded_dest_driver_option
+        | threaded_dest_driver_batch_option
         | KW_TLS '(' riemann_tls_options ')'
         | { last_template_options = riemann_dd_get_template_options(last_driver); } template_option
         ;

--- a/news/developer-note-3741.md
+++ b/news/developer-note-3741.md
@@ -1,0 +1,7 @@
+`log-threaded-dest`: Descendant drivers from LogThreadedDest no longer inherit
+batch-lines() and batch-timeout() automatically. Each driver have to opt-in for
+these options with `log_threaded_dest_driver_batch_option`.
+
+`log_threaded_dest_driver_option` has been renamed to `log_threaded_dest_driver_general_option`,
+and `log_threaded_dest_driver_workers_option` have been added similarly to the
+batch-related options.


### PR DESCRIPTION
Not every `LogThreadedDest` implementation utilizes `batch-lines()` and `batch-timeout()`.
Similarly not every `LogThreadedDest` implementation utilizes `workers()`.

The batch-related options had the problem, where any descendant driver inherited them, even if they did not use them.
The `workers()` option had the problem, where every descendant driver needed to re-implement it in order to use it.

This PR fixes both.

---

**Note for the reviewers:**

This PR is not a simple refactor, I needed to check which threaded drivers use the batch-related options.

When reviewing, please make sure to check that I have found every driver which uses them, and that I have not put it to drivers, which do not use them.

Thanks!

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>