### PR TITLE
modules/diskq/dqtool.c: fix static build

### DIFF
--- a/modules/diskq/dqtool.c
+++ b/modules/diskq/dqtool.c
@@ -49,8 +49,6 @@ gchar *persist_file_path;
 gchar *assign_persist_name;
 gboolean relocate_all;
 gboolean display_version;
-gboolean debug_flag;
-gboolean verbose_flag;
 gboolean assign_help;
 
 static GOptionEntry cat_options[] =


### PR DESCRIPTION
Fix the following static build failure:

```
/data/buildroot-autobuilder/instance-0/output-1/host/opt/ext-toolchain/bin/../lib/gcc/riscv64-buildroot-linux-musl/10.2.0/../../../../riscv64-buildroot-linux-musl/bin/ld: ./lib/.libs/libsyslog-ng.a(lib_libsyslog_ng_la-messages.o):(.sbss+0x2c): multiple definition of `verbose_flag'; modules/diskq/dqtool.o:(.sbss+0x4): first defined here
/data/buildroot-autobuilder/instance-0/output-1/host/opt/ext-toolchain/bin/../lib/gcc/riscv64-buildroot-linux-musl/10.2.0/../../../../riscv64-buildroot-linux-musl/bin/ld: ./lib/.libs/libsyslog-ng.a(lib_libsyslog_ng_la-messages.o):(.sbss+0x30): multiple definition of `debug_flag'; modules/diskq/dqtool.o:(.sbss+0x8): first defined here
```

Fixes:
 - http://autobuild.buildroot.org/results/ccd0a954f6e0676db67026f8b8c89823f3e5c510

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>