### PR TITLE
disk-buffer: trivial performance-related fixes and refactor

### DIFF
--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -101,7 +101,7 @@ _get_next_message(LogQueueDiskNonReliable *self, LogPathOptions *path_options)
   path_options->ack_needed = TRUE;
   if (qdisk_get_length (self->super.qdisk) > 0)
     {
-      result = self->super.read_message(&self->super, path_options);
+      result = log_queue_disk_read_message(&self->super, path_options);
       if(result)
         {
           log_queue_memory_usage_add(&self->super.super, log_msg_get_size(result));
@@ -162,7 +162,7 @@ _move_messages_from_overflow(LogQueueDiskNonReliable *self)
         }
       else
         {
-          if (self->super.write_message(&self->super, msg))
+          if (log_queue_disk_write_message(&self->super, msg))
             {
               log_queue_memory_usage_sub(&self->super.super, log_msg_get_size(msg));
             }
@@ -263,7 +263,7 @@ _pop_head (LogQueueDisk *s, LogPathOptions *path_options)
     }
   if (msg == NULL)
     {
-      msg = s->read_message(s, path_options);
+      msg = log_queue_disk_read_message(s, path_options);
       if (msg)
         {
           path_options->ack_needed = FALSE;
@@ -321,7 +321,7 @@ _push_tail (LogQueueDisk *s, LogMessage *msg, LogPathOptions *local_options, con
     }
   else
     {
-      if (self->qoverflow->length != 0 || !s->write_message(s, msg))
+      if (self->qoverflow->length != 0 || !log_queue_disk_write_message(s, msg))
         {
           if (HAS_SPACE_IN_QUEUE(self->qoverflow))
             {

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -39,24 +39,10 @@ _start(LogQueueDisk *s, const gchar *filename)
 static gboolean
 _skip_message(LogQueueDisk *self)
 {
-  GString *serialized;
-  SerializeArchive *sa;
-
   if (!qdisk_started(self->qdisk))
     return FALSE;
 
-  serialized = g_string_sized_new(64);
-  if (!qdisk_pop_head(self->qdisk, serialized))
-    {
-      g_string_free(serialized, TRUE);
-      return FALSE;
-    }
-
-  sa = serialize_string_archive_new(serialized);
-  serialize_archive_free(sa);
-
-  g_string_free(serialized, TRUE);
-  return TRUE;
+  return qdisk_remove_head(self->qdisk);
 }
 
 static void

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -217,7 +217,7 @@ _pop_head(LogQueueDisk *s, LogPathOptions *path_options)
 
   if (msg == NULL)
     {
-      msg = s->read_message(s, path_options);
+      msg = log_queue_disk_read_message(s, path_options);
       if (msg)
         {
           path_options->ack_needed = FALSE;
@@ -244,7 +244,7 @@ _push_tail(LogQueueDisk *s, LogMessage *msg, LogPathOptions *local_options, cons
   LogQueueDiskReliable *self = (LogQueueDiskReliable *) s;
 
   gint64 last_wpos = qdisk_get_writer_head (self->super.qdisk);
-  if (!s->write_message(s, msg))
+  if (!log_queue_disk_write_message(s, msg))
     {
       /* we were not able to store the msg, warn */
       msg_error("Destination reliable queue full, dropping message",

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -249,8 +249,8 @@ _pop_disk(LogQueueDisk *self, LogMessage **msg)
   return TRUE;
 }
 
-static LogMessage *
-_read_message(LogQueueDisk *self, LogPathOptions *path_options)
+LogMessage *
+log_queue_disk_read_message(LogQueueDisk *self, LogPathOptions *path_options)
 {
   LogMessage *msg = NULL;
   do
@@ -274,8 +274,8 @@ _read_message(LogQueueDisk *self, LogPathOptions *path_options)
   return msg;
 }
 
-static gboolean
-_write_message(LogQueueDisk *self, LogMessage *msg)
+gboolean
+log_queue_disk_write_message(LogQueueDisk *self, LogMessage *msg)
 {
   GString *serialized;
   SerializeArchive *sa;
@@ -342,7 +342,4 @@ log_queue_disk_init_instance(LogQueueDisk *self, const gchar *persist_name)
   self->super.rewind_backlog = _rewind_backlog;
   self->super.rewind_backlog_all = _backlog_all;
   self->super.free_fn = _free;
-
-  self->read_message = _read_message;
-  self->write_message = _write_message;
 }

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -189,15 +189,6 @@ log_queue_disk_load_queue(LogQueue *s, const gchar *filename)
   return FALSE;
 }
 
-gboolean
-log_queue_disk_is_reliable(LogQueue *s)
-{
-  LogQueueDisk *self = (LogQueueDisk *) s;
-  if (self->is_reliable)
-    return self->is_reliable(self);
-  return FALSE;
-}
-
 const gchar *
 log_queue_disk_get_filename(LogQueue *s)
 {

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -214,7 +214,6 @@ _free(LogQueue *s)
 static gboolean
 _pop_disk(LogQueueDisk *self, LogMessage **msg)
 {
-  GString *serialized;
   SerializeArchive *sa;
 
   *msg = NULL;
@@ -222,21 +221,23 @@ _pop_disk(LogQueueDisk *self, LogMessage **msg)
   if (!qdisk_started(self->qdisk))
     return FALSE;
 
-  serialized = g_string_sized_new(64);
-  if (!qdisk_pop_head(self->qdisk, serialized))
+  ScratchBuffersMarker marker;
+  GString *read_serialized = scratch_buffers_alloc_and_mark(&marker);
+
+  if (!qdisk_pop_head(self->qdisk, read_serialized))
     {
-      g_string_free(serialized, TRUE);
+      scratch_buffers_reclaim_marked(marker);
       return FALSE;
     }
 
-  sa = serialize_string_archive_new(serialized);
+  sa = serialize_string_archive_new(read_serialized);
   *msg = log_msg_new_empty();
 
   if (!log_msg_deserialize(*msg, sa))
     {
-      g_string_free(serialized, TRUE);
       serialize_archive_free(sa);
       log_msg_unref(*msg);
+      scratch_buffers_reclaim_marked(marker);
       *msg = NULL;
       msg_error("Can't read correct message from disk-queue file",
                 evt_tag_str("filename", qdisk_get_filename(self->qdisk)),
@@ -245,8 +246,8 @@ _pop_disk(LogQueueDisk *self, LogMessage **msg)
     }
 
   serialize_archive_free(sa);
+  scratch_buffers_reclaim_marked(marker);
 
-  g_string_free(serialized, TRUE);
   return TRUE;
 }
 

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -46,7 +46,6 @@ struct _LogQueueDisk
   gboolean (*load_queue)(LogQueueDisk *s, const gchar *filename);
   gboolean (*start)(LogQueueDisk *s, const gchar *filename);
   void (*free_fn)(LogQueueDisk *s);
-  gboolean (*is_reliable)(LogQueueDisk *s);
   LogMessage *(*read_message)(LogQueueDisk *self, LogPathOptions *path_options);
   gboolean (*write_message)(LogQueueDisk *self, LogMessage *msg);
   void (*restart)(LogQueueDisk *self, DiskQueueOptions *options);
@@ -54,7 +53,6 @@ struct _LogQueueDisk
 
 extern QueueType log_queue_disk_type;
 
-gboolean log_queue_disk_is_reliable(LogQueue *s);
 const gchar *log_queue_disk_get_filename(LogQueue *self);
 gboolean log_queue_disk_save_queue(LogQueue *self, gboolean *persistent);
 gboolean log_queue_disk_load_queue(LogQueue *self, const gchar *filename);

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -46,8 +46,6 @@ struct _LogQueueDisk
   gboolean (*load_queue)(LogQueueDisk *s, const gchar *filename);
   gboolean (*start)(LogQueueDisk *s, const gchar *filename);
   void (*free_fn)(LogQueueDisk *s);
-  LogMessage *(*read_message)(LogQueueDisk *self, LogPathOptions *path_options);
-  gboolean (*write_message)(LogQueueDisk *self, LogMessage *msg);
   void (*restart)(LogQueueDisk *self, DiskQueueOptions *options);
 };
 
@@ -58,5 +56,9 @@ gboolean log_queue_disk_save_queue(LogQueue *self, gboolean *persistent);
 gboolean log_queue_disk_load_queue(LogQueue *self, const gchar *filename);
 void log_queue_disk_init_instance(LogQueueDisk *self, const gchar *persist_name);
 void log_queue_disk_restart_corrupted(LogQueueDisk *self);
+
+
+LogMessage *log_queue_disk_read_message(LogQueueDisk *self, LogPathOptions *path_options);
+gboolean log_queue_disk_write_message(LogQueueDisk *self, LogMessage *msg);
 
 #endif

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -104,13 +104,13 @@ pwrite_strict(gint fd, const void *buf, size_t count, off_t offset)
 }
 
 
-static gboolean
+static inline gboolean
 _is_position_after_disk_buf_size(QDisk *self, gint64 position)
 {
   return position > self->options->disk_buf_size;
 }
 
-static guint64
+static inline guint64
 _correct_position_if_after_disk_buf_size(QDisk *self, gint64 *position)
 {
   if (G_UNLIKELY(self->hdr->use_v1_wrap_condition))
@@ -223,14 +223,14 @@ qdisk_is_space_avail(QDisk *self, gint at_least)
 
 }
 
-static gboolean
+static inline gboolean
 _ftruncate_would_reduce_file(QDisk *self, gint64 expected_size)
 {
   gint64 expected_size_change = expected_size - self->file_size;
   return expected_size_change < 0;
 }
 
-static gboolean
+static inline gboolean
 _possible_size_reduction_reaches_truncate_threshold(QDisk *self, gint64 expected_size)
 {
   gint64 possible_size_reduction = self->file_size - expected_size;
@@ -274,7 +274,7 @@ _maybe_truncate_file(QDisk *self, gint64 expected_size)
             evt_tag_int("fd", self->fd));
 }
 
-static gint64
+static inline gint64
 qdisk_get_lowest_used_queue_offset(QDisk *self)
 {
   gint64 lowest_offset = G_MAXINT64;
@@ -323,7 +323,7 @@ qdisk_get_empty_space(QDisk *self)
   return bpos - wpos;
 }
 
-static gboolean
+static inline gboolean
 _could_not_wrap_write_head_last_push_but_now_can(QDisk *self)
 {
   return _is_qdisk_overwritten(self) && _is_able_to_reset_write_head_to_beginning_of_qdisk(self);
@@ -420,7 +420,7 @@ qdisk_push_tail(QDisk *self, GString *record)
   return TRUE;
 }
 
-static gssize
+static inline gssize
 _read_record_length_from_disk(QDisk *self, guint32 *record_length)
 {
   gssize bytes_read = pread(self->fd, (gchar *)record_length, sizeof(guint32), self->hdr->read_head);
@@ -436,7 +436,7 @@ _is_record_length_reached_hard_limit(guint32 record_length)
   return record_length > MAX_RECORD_LENGTH;
 }
 
-static gssize
+static inline gssize
 _is_record_length_valid(QDisk *self, gssize bytes_read, guint32 record_length)
 {
   if (bytes_read != sizeof(record_length))
@@ -469,7 +469,7 @@ _is_record_length_valid(QDisk *self, gssize bytes_read, guint32 record_length)
   return TRUE;
 }
 
-static gboolean
+static inline gboolean
 _try_reading_record_length(QDisk *self, guint32 *record_length)
 {
   guint32 read_record_length;
@@ -488,7 +488,7 @@ _try_reading_record_length(QDisk *self, guint32 *record_length)
   return TRUE;
 }
 
-static gboolean
+static inline gboolean
 _read_record_from_disk(QDisk *self, GString *record, guint32 record_length)
 {
   g_string_set_size(record, record_length);
@@ -507,7 +507,7 @@ _read_record_from_disk(QDisk *self, GString *record, guint32 record_length)
   return TRUE;
 }
 
-static gint64
+static inline gint64
 _calculate_new_read_head_position(QDisk *self, guint32 record_length)
 {
   gint64 new_read_head_position = self->hdr->read_head + record_length + sizeof(record_length);
@@ -518,7 +518,7 @@ _calculate_new_read_head_position(QDisk *self, guint32 record_length)
   return new_read_head_position;
 }
 
-static void
+static inline void
 _update_positions_after_read(QDisk *self, guint32 record_length)
 {
   self->hdr->read_head = _calculate_new_read_head_position(self, record_length);
@@ -911,7 +911,7 @@ _create_path(const gchar *filename)
   return file_perm_options_create_containing_directory(&fpermoptions, filename);
 }
 
-static gboolean
+static inline gboolean
 _is_header_version_current(QDisk *self)
 {
   return self->hdr->version == QDISK_HDR_VERSION_CURRENT;

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1138,7 +1138,7 @@ qdisk_stop(QDisk *self)
   self->options = NULL;
 }
 
-gssize
+static gssize
 qdisk_read(QDisk *self, gpointer buffer, gsize bytes_to_read, gint64 position)
 {
   gssize res;

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -461,7 +461,8 @@ qdisk_pop_head(QDisk *self, GString *record)
                   evt_tag_long("offset", self->hdr->read_head));
       return FALSE;
     }
-  else if (record_length == 0)
+
+  if (record_length == 0)
     {
       msg_error("Disk-queue file contains empty record",
                 evt_tag_int("rec_length", record_length),

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -499,15 +499,15 @@ qdisk_pop_head(QDisk *self, GString *record)
     return FALSE;
 
   guint32 record_length;
-  gssize res = _read_record_length_from_disk(self, &record_length);
-  if (res == 0)
+  gssize bytes_read = _read_record_length_from_disk(self, &record_length);
+  if (bytes_read == 0)
     {
       /* hmm, we are either at EOF or at hdr->qout_ofs, we need to wrap */
       self->hdr->read_head = QDISK_RESERVED_SPACE;
-      res = _read_record_length_from_disk(self, &record_length);
+      bytes_read = _read_record_length_from_disk(self, &record_length);
     }
 
-  if (!_is_record_length_valid(self, res, record_length))
+  if (!_is_record_length_valid(self, bytes_read, record_length))
     return FALSE;
 
   if (!_read_record_from_disk(self, record, record_length))

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -502,7 +502,7 @@ qdisk_pop_head(QDisk *self, GString *record)
   if (!_read_record_from_disk(self, record, record_length))
     return FALSE;
 
-  self->hdr->read_head = self->hdr->read_head + record->len + sizeof(record_length);
+  self->hdr->read_head = self->hdr->read_head + record_length + sizeof(record_length);
 
   if (self->hdr->read_head > self->hdr->write_head)
     {

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -435,6 +435,8 @@ qdisk_pop_head(QDisk *self, GString *record)
       self->hdr->read_head = QDISK_RESERVED_SPACE;
       res = pread(self->fd, (gchar *) &record_length, sizeof(record_length), self->hdr->read_head);
     }
+  record_length = GUINT32_FROM_BE(record_length);
+
   if (res != sizeof(record_length))
     {
       msg_error("Error reading disk-queue file, cannot read record-length",
@@ -444,7 +446,6 @@ qdisk_pop_head(QDisk *self, GString *record)
       return FALSE;
     }
 
-  record_length = GUINT32_FROM_BE(record_length);
   if (_is_record_length_reached_hard_limit(record_length))
     {
       msg_warning("Disk-queue file contains possibly invalid record-length",

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -547,6 +547,21 @@ qdisk_pop_head(QDisk *self, GString *record)
   return TRUE;
 }
 
+gboolean
+qdisk_remove_head(QDisk *self)
+{
+  if (self->hdr->read_head == self->hdr->write_head)
+    return FALSE;
+
+  guint32 record_length;
+  if (!_try_reading_record_length(self, &record_length))
+    return FALSE;
+
+  _update_positions_after_read(self, record_length);
+
+  return TRUE;
+}
+
 static FILE *
 _create_stream(QDisk *self, gint64 offset)
 {

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -511,19 +511,9 @@ _calculate_new_read_head_position(QDisk *self, guint32 record_length)
   return new_read_head_position;
 }
 
-gboolean
-qdisk_pop_head(QDisk *self, GString *record)
+static void
+_update_positions_after_read(QDisk *self, guint32 record_length)
 {
-  if (self->hdr->read_head == self->hdr->write_head)
-    return FALSE;
-
-  guint32 record_length;
-  if (!_try_reading_record_length(self, &record_length))
-    return FALSE;
-
-  if (!_read_record_from_disk(self, record, record_length))
-    return FALSE;
-
   self->hdr->read_head = _calculate_new_read_head_position(self, record_length);
   self->hdr->length--;
 
@@ -537,6 +527,23 @@ qdisk_pop_head(QDisk *self, GString *record)
           qdisk_reset_file_if_empty(self);
         }
     }
+}
+
+gboolean
+qdisk_pop_head(QDisk *self, GString *record)
+{
+  if (self->hdr->read_head == self->hdr->write_head)
+    return FALSE;
+
+  guint32 record_length;
+  if (!_try_reading_record_length(self, &record_length))
+    return FALSE;
+
+  if (!_read_record_from_disk(self, record, record_length))
+    return FALSE;
+
+  _update_positions_after_read(self, record_length);
+
   return TRUE;
 }
 

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -53,6 +53,7 @@ gboolean qdisk_is_space_avail(QDisk *self, gint at_least);
 gint64 qdisk_get_empty_space(QDisk *self);
 gboolean qdisk_push_tail(QDisk *self, GString *record);
 gboolean qdisk_pop_head(QDisk *self, GString *record);
+gboolean qdisk_remove_head(QDisk *self);
 gboolean qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow);
 void qdisk_init_instance(QDisk *self, DiskQueueOptions *options, const gchar *file_id);
 void qdisk_stop(QDisk *self);

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -82,6 +82,5 @@ const gchar *qdisk_get_filename(QDisk *self);
 
 gssize qdisk_read(QDisk *self, gpointer buffer, gsize bytes_to_read, gint64 position);
 guint64 qdisk_skip_record(QDisk *self, guint64 position);
-ssize_t pread_all(int fd, char *buf,  size_t count, off_t offset, gint max_block);
 
 #endif /* QDISK_H_ */

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -80,7 +80,6 @@ gint qdisk_get_memory_size(QDisk *self);
 gboolean qdisk_is_read_only(QDisk *self);
 const gchar *qdisk_get_filename(QDisk *self);
 
-gssize qdisk_read(QDisk *self, gpointer buffer, gsize bytes_to_read, gint64 position);
 guint64 qdisk_skip_record(QDisk *self, guint64 position);
 
 #endif /* QDISK_H_ */


### PR DESCRIPTION
We are currently profiling and measuring the performance of the `disk-buffer()` module in different scenarios in order to identify its bottlenecks and to improve its speed.

This PR is the first step in this adventure.
As we got familiar with the code base, we found some trivial performance-related issues, which we've fixed:
- reduced two consecutive `pwrite()` calls to a single one when writing the serialized message and its length
- removed unnecessary read/deserialization logic when skipping messages that are already available in the qreliable memory segment
- replaced heap allocations with scratch_buffers on hot paths

This resulted in a ~20% performance improvement in general.

The PR also contains refactor commits.

For reviewers:
<details>
  <summary>Click to expand!</summary>
  
![image](https://user-images.githubusercontent.com/3130044/126983291-6e59602f-7594-4c8e-a416-d9420199e33d.png)

The reliable disk buffer uses 2 memory queues:
- qreliable:
        - it's just a technicality, it is only used to kick flow-control in when the free space is less than `mem-buf-size()` in the disk-buffer file
        - messages stored in this queue are also written into the disk-buffer file, so these messages will never be lost
- qbacklog: outgoing messages that are not acked yet
  
The non-reliable disk buffer uses 3 memory queue segments:
- qout: a non-reliable segment that increases speed to the detriment of reliability, its size can be configured with `qout-size()`
        - the first `qout-size()` number of messages (64 by default) are stored only in the qout memory queue for performance reasons
        - we only write/read messages to/from disk after the qout queue is full
- qoverflow:
        - this is used for the same reason as qreliable, to kick flow-control in when the disk-buffer file is full
        - it stores `mem-buf-length()` number of messages after the disk-buffer file is fully saturated
- qbacklog: outgoing messages that are not acked yet
</details>