### PR TITLE
Add batch-lines support to Redis destination

### DIFF
--- a/modules/redis/redis-grammar.ym
+++ b/modules/redis/redis-grammar.ym
@@ -87,6 +87,7 @@ redis_option
           }
         | threaded_dest_driver_general_option
         | threaded_dest_driver_workers_option
+        | threaded_dest_driver_batch_option
         | { last_template_options = redis_dd_get_template_options(last_driver); } template_option
         ;
 

--- a/modules/redis/redis-worker.c
+++ b/modules/redis/redis-worker.c
@@ -30,6 +30,37 @@
 #include "utf8utils.h"
 
 
+static LogThreadedResult
+_flush(LogThreadedDestWorker *s, LogThreadedFlushMode mode)
+{
+  RedisDestWorker *self = (RedisDestWorker *) s;
+
+  if(s->batch_size == 0)
+    {
+      return LTR_SUCCESS;
+    }
+
+  if(mode == LTF_FLUSH_EXPEDITE)
+    {
+      return LTR_RETRY;
+    }
+
+  if(self->c == NULL || self->c->err)
+    {
+      return LTR_ERROR;
+    }
+
+  redisReply *reply;
+  for(gint i = s->batch_size; i > 0; i--)
+    {
+      if(redisGetReply(self->c, (void **)&reply) != REDIS_OK)
+        {
+          return LTR_ERROR;
+        }
+      freeReplyObject(reply);
+    }
+  return LTR_SUCCESS;
+}
 
 static inline void
 _fill_template(RedisDestWorker *self, LogMessage *msg, LogTemplate *template, gchar **str,
@@ -81,6 +112,38 @@ _argv_to_string(RedisDestWorker *self)
   return full_command->str;
 }
 
+static LogThreadedResult
+redis_worker_insert_batch(LogThreadedDestWorker *s, LogMessage *msg)
+{
+  RedisDestWorker *self = (RedisDestWorker *)s;
+  RedisDriver *owner = (RedisDriver *) self->super.owner;
+
+  g_assert(owner->super.batch_lines > 0);
+
+  ScratchBuffersMarker marker;
+  scratch_buffers_mark(&marker);
+
+  _fill_argv_from_template_list(self, msg);
+
+  int retval = redisAppendCommandArgv(self->c, self->argc, (const gchar **)self->argv, self->argvlen);
+
+  if(self->c == NULL || self->c->err || retval != REDIS_OK)
+    {
+      msg_error("REDIS server error, suspending",
+                evt_tag_str("driver", owner->super.super.super.id),
+                evt_tag_str("command", _argv_to_string(self)),
+                evt_tag_str("error", self->c->errstr),
+                evt_tag_int("time_reopen", self->super.time_reopen));
+      scratch_buffers_reclaim_marked(marker);
+      return LTR_ERROR;
+    }
+  msg_debug("REDIS command appended",
+            evt_tag_str("driver", owner->super.super.super.id),
+            evt_tag_str("command", _argv_to_string(self)));
+
+  scratch_buffers_reclaim_marked(marker);
+  return LTR_QUEUED;
+}
 
 static LogThreadedResult
 redis_worker_insert(LogThreadedDestWorker *s, LogMessage *msg)
@@ -88,6 +151,8 @@ redis_worker_insert(LogThreadedDestWorker *s, LogMessage *msg)
   RedisDestWorker *self = (RedisDestWorker *)s;
   RedisDriver *owner = (RedisDriver *) self->super.owner;
   LogThreadedResult status = LTR_ERROR;
+
+  g_assert(owner->super.batch_lines == 0);
 
   ScratchBuffersMarker marker;
   scratch_buffers_mark(&marker);
@@ -244,7 +309,6 @@ redis_worker_connect(LogThreadedDestWorker *s)
 
   if (self->c && check_connection_to_redis(self))
     return TRUE;
-
   if (self->c)
     redisFree(self->c);
 
@@ -291,17 +355,19 @@ redis_worker_connect(LogThreadedDestWorker *s)
 }
 
 
-LogThreadedDestWorker *redis_worker_new(LogThreadedDestDriver *owner, gint worker_index)
+LogThreadedDestWorker *redis_worker_new(LogThreadedDestDriver *o, gint worker_index)
 {
   RedisDestWorker *self = g_new0(RedisDestWorker, 1);
 
-  log_threaded_dest_worker_init_instance(&self->super, owner, worker_index);
+  log_threaded_dest_worker_init_instance(&self->super, o, worker_index);
 
   self->super.thread_init = redis_worker_thread_init;
   self->super.thread_deinit = redis_worker_thread_deinit;
   self->super.connect = redis_worker_connect;
   self->super.disconnect = redis_worker_disconnect;
-  self->super.insert = redis_worker_insert;
+  self->super.insert = o->batch_lines > 0 ? redis_worker_insert_batch : redis_worker_insert;
+  if(o->batch_lines > 0)
+    self->super.flush = _flush;
 
   return &self->super;
 }

--- a/modules/redis/redis-worker.c
+++ b/modules/redis/redis-worker.c
@@ -309,10 +309,10 @@ redis_worker_connect(LogThreadedDestWorker *s)
 
   if (self->c && check_connection_to_redis(self))
     return TRUE;
-  if (self->c)
-    redisFree(self->c);
-
-  self->c = redisConnectWithTimeout(owner->host, owner->port, owner->timeout);
+  else if (self->c)
+    redisReconnect(self->c);
+  else
+    self->c = redisConnectWithTimeout(owner->host, owner->port, owner->timeout);
 
   if (self->c == NULL || self->c->err)
     {

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -203,7 +203,6 @@ redis_dd_new(GlobalConfig *cfg)
   redis_dd_set_port((LogDriver *)self, 6379);
   redis_dd_set_auth((LogDriver *)self, NULL);
   redis_dd_set_timeout((LogDriver *)self, 10);
-
   self->command = g_string_sized_new(32);
 
   log_template_options_defaults(&self->template_options);

--- a/news/feature-3745.md
+++ b/news/feature-3745.md
@@ -1,0 +1,18 @@
+`redis`: add batching support 
+
+Performance improvement is significant (at least +200%, but it peaked at almost +500%)
+
+I used the following configuration to enable batching:
+```
+destination d_redis {
+    redis(
+        host("localhost")
+        port(6379)
+        command("HINCRBY", "hosts", "$HOST", "1")
+        workers(8)
+        log-fifo-size(100000)
+        batch-lines(100)
+        batch-timeout(10000)
+    );
+};
+```


### PR DESCRIPTION
This PR adds `batch-lines()` support for the `redis` destination driver which increases performance.
Performance improvement is significant (8665U, 32 GiB RAM): [1]

| 8 workers, no batch-lines() option | 8 workers, batch-lines(100) |
|------------------------------------|-----------------------------|
| ~ 80k/s                            | ~ 240k/s (peak 450k/s)      |

The batching is based on the [pipelining feature of Redis](https://github.com/redis/hiredis#pipelining). We have to count the sent (appended) messages as we must retrieve as many as we sent.

I also tested that when the Redis server goes offline it will reconnect.

[1] I used the following configuration:
```
source s_local {
        network(
        port(4444)
        max-connections(100)
        log-iw-size(100000)
        log-fetch-limit(1000)
        );
};
destination d_redis {
    redis(
        host("localhost")
        port(6379)
        command("HINCRBY", "hosts", "$HOST", "1")
        workers(8)
        log-fifo-size(100000)
        batch-lines(100)
    );
};

log {
        source(s_local);
        destination(d_redis);
        flags(flow-control);
};
```
And sent messages via loggen:
`./loggen --permanent --rate=10000000 --active-connections 10 -i localhost 4444`

Signed-off-by: Parrag Szilárd <szilard.parrag@gmail.com>