### PR TITLE
logqueue-disk: serialize outside of the lock in the source threads

### DIFF
--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -152,7 +152,7 @@ _write_message_to_disk(LogQueueDisk *self, LogMessage *msg)
 {
   gboolean consumed = FALSE;
 
-  if (qdisk_started(self->qdisk) && qdisk_is_space_avail(self->qdisk, 64))
+  if (qdisk_started(self->qdisk))
     {
       ScratchBuffersMarker marker;
       GString *write_serialized = scratch_buffers_alloc_and_mark(&marker);

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -387,15 +387,18 @@ _free_queue (GQueue *q)
 }
 
 static void
-_freefn (LogQueueDisk *s)
+_free(LogQueue *s)
 {
-  LogQueueDiskNonReliable *self = (LogQueueDiskNonReliable *) s;
+  LogQueueDiskNonReliable *self = (LogQueueDiskNonReliable *)s;
+
   _free_queue (self->qoverflow);
   self->qoverflow = NULL;
   _free_queue (self->qout);
   self->qout = NULL;
   _free_queue (self->qbacklog);
   self->qbacklog = NULL;
+
+  log_queue_disk_free_method(&self->super);
 }
 
 static gboolean
@@ -439,7 +442,7 @@ _set_virtual_functions (LogQueueDisk *self)
   self->super.push_head = _push_head;
   self->push_tail = _push_tail;
   self->start = _start;
-  self->free_fn = _freefn;
+  self->super.free_fn = _free;
   self->load_queue = _load_queue;
   self->save_queue = _save_queue;
   self->restart = _restart;

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -462,21 +462,33 @@ _restart(LogQueueDisk *s, DiskQueueOptions *options)
   qdisk_init_instance(self->super.qdisk, options, "SLQF");
 }
 
-static void
-_set_virtual_functions (LogQueueDisk *self)
+static inline void
+_set_logqueue_virtual_functions(LogQueue *s)
 {
-  self->super.get_length = _get_length;
-  self->super.ack_backlog = _ack_backlog;
-  self->super.rewind_backlog = _rewind_backlog;
-  self->super.rewind_backlog_all = _rewind_backlog_all;
-  self->super.pop_head = _pop_head;
-  self->super.push_head = _push_head;
-  self->super.push_tail = _push_tail;
-  self->start = _start;
-  self->super.free_fn = _free;
-  self->load_queue = _load_queue;
-  self->save_queue = _save_queue;
-  self->restart = _restart;
+  s->get_length = _get_length;
+  s->ack_backlog = _ack_backlog;
+  s->rewind_backlog = _rewind_backlog;
+  s->rewind_backlog_all = _rewind_backlog_all;
+  s->pop_head = _pop_head;
+  s->push_head = _push_head;
+  s->push_tail = _push_tail;
+  s->free_fn = _free;
+}
+
+static inline void
+_set_logqueue_disk_virtual_functions(LogQueueDisk *s)
+{
+  s->start = _start;
+  s->load_queue = _load_queue;
+  s->save_queue = _save_queue;
+  s->restart = _restart;
+}
+
+static inline void
+_set_virtual_functions(LogQueueDiskNonReliable *self)
+{
+  _set_logqueue_virtual_functions(&self->super.super);
+  _set_logqueue_disk_virtual_functions(&self->super);
 }
 
 LogQueue *
@@ -491,6 +503,6 @@ log_queue_disk_non_reliable_new(DiskQueueOptions *options, const gchar *persist_
   self->qoverflow = g_queue_new ();
   self->qout_size = options->qout_size;
   self->qoverflow_size = options->mem_buf_length;
-  _set_virtual_functions (&self->super);
+  _set_virtual_functions(self);
   return &self->super.super;
 }

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -496,8 +496,7 @@ log_queue_disk_non_reliable_new(DiskQueueOptions *options, const gchar *persist_
 {
   g_assert(options->reliable == FALSE);
   LogQueueDiskNonReliable *self = g_new0(LogQueueDiskNonReliable, 1);
-  log_queue_disk_init_instance(&self->super, persist_name);
-  qdisk_init_instance(self->super.qdisk, options, "SLQF");
+  log_queue_disk_init_instance(&self->super, options, "SLQF", persist_name);
   self->qbacklog = g_queue_new ();
   self->qout = g_queue_new ();
   self->qoverflow = g_queue_new ();

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -286,6 +286,11 @@ _push_tail(LogQueueDisk *s, LogMessage *msg, LogPathOptions *local_options, cons
 }
 
 static void
+_push_head(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
+{
+}
+
+static void
 _free_queue(LogQueueDisk *s)
 {
   LogQueueDiskReliable *self = (LogQueueDiskReliable *) s;
@@ -329,6 +334,7 @@ _set_virtual_functions(LogQueueDisk *self)
   self->rewind_backlog = _rewind_backlog;
   self->pop_head = _pop_head;
   self->push_tail = _push_tail;
+  self->super.push_head = _push_head;
   self->free_fn = _free_queue;
   self->load_queue = _load_queue;
   self->start = _start;

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -279,7 +279,7 @@ _drop_msg(LogQueueDiskReliable *self, LogMessage *msg, const LogPathOptions *pat
 static gboolean
 _write_message_to_disk(LogQueueDisk *self, GString *serialized_msg)
 {
-  if (!qdisk_started(self->qdisk) || qdisk_is_space_avail(self->qdisk, serialized_msg))
+  if (!qdisk_started(self->qdisk))
     return FALSE;
 
   return qdisk_push_tail(self->qdisk, serialized_msg);

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -302,15 +302,18 @@ _push_head(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
 }
 
 static void
-_free_queue(LogQueueDisk *s)
+_free(LogQueue *s)
 {
-  LogQueueDiskReliable *self = (LogQueueDiskReliable *) s;
+  LogQueueDiskReliable *self = (LogQueueDiskReliable *)s;
+
   _empty_queue(self->qreliable);
   _empty_queue(self->qbacklog);
   g_queue_free(self->qreliable);
   self->qreliable = NULL;
   g_queue_free(self->qbacklog);
   self->qbacklog = NULL;
+
+  log_queue_disk_free_method(&self->super);
 }
 
 static gboolean
@@ -347,7 +350,7 @@ _set_virtual_functions(LogQueueDisk *self)
   self->pop_head = _pop_head;
   self->push_tail = _push_tail;
   self->super.push_head = _push_head;
-  self->free_fn = _free_queue;
+  self->super.free_fn = _free;
   self->load_queue = _load_queue;
   self->start = _start;
   self->save_queue = _save_queue;

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -401,8 +401,7 @@ log_queue_disk_reliable_new(DiskQueueOptions *options, const gchar *persist_name
 {
   g_assert(options->reliable == TRUE);
   LogQueueDiskReliable *self = g_new0(LogQueueDiskReliable, 1);
-  log_queue_disk_init_instance(&self->super, persist_name);
-  qdisk_init_instance(self->super.qdisk, options, "SLRQ");
+  log_queue_disk_init_instance(&self->super, options, "SLRQ", persist_name);
   if (options->mem_buf_size < 0)
     {
       options->mem_buf_size = PESSIMISTIC_MEM_BUF_SIZE;

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -276,15 +276,6 @@ _drop_msg(LogQueueDiskReliable *self, LogMessage *msg, const LogPathOptions *pat
     log_msg_drop(msg, path_options, AT_PROCESSED);
 }
 
-static gboolean
-_write_message_to_disk(LogQueueDisk *self, GString *serialized_msg)
-{
-  if (!qdisk_started(self->qdisk))
-    return FALSE;
-
-  return qdisk_push_tail(self->qdisk, serialized_msg);
-}
-
 static void
 _push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
 {
@@ -307,7 +298,7 @@ _push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
   LogPathOptions local_options = *path_options;
 
   gint64 last_wpos = qdisk_get_writer_head (self->super.qdisk);
-  if (!_write_message_to_disk(&self->super, serialized_msg))
+  if (!qdisk_push_tail(self->super.qdisk, serialized_msg))
     {
       /* we were not able to store the msg, warn */
       msg_error("Destination reliable queue full, dropping message",

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -367,22 +367,33 @@ _restart(LogQueueDisk *s, DiskQueueOptions *options)
   qdisk_init_instance(self->super.qdisk, options, "SLRQ");
 }
 
-
-static void
-_set_virtual_functions(LogQueueDisk *self)
+static inline void
+_set_logqueue_virtual_functions(LogQueue *s)
 {
-  self->super.get_length = _get_length;
-  self->super.ack_backlog = _ack_backlog;
-  self->super.rewind_backlog = _rewind_backlog;
-  self->super.rewind_backlog_all = _rewind_backlog_all;
-  self->super.pop_head = _pop_head;
-  self->super.push_tail = _push_tail;
-  self->super.push_head = _push_head;
-  self->super.free_fn = _free;
-  self->load_queue = _load_queue;
-  self->start = _start;
-  self->save_queue = _save_queue;
-  self->restart = _restart;
+  s->get_length = _get_length;
+  s->ack_backlog = _ack_backlog;
+  s->rewind_backlog = _rewind_backlog;
+  s->rewind_backlog_all = _rewind_backlog_all;
+  s->pop_head = _pop_head;
+  s->push_tail = _push_tail;
+  s->push_head = _push_head;
+  s->free_fn = _free;
+}
+
+static inline void
+_set_logqueue_disk_virtual_functions(LogQueueDisk *s)
+{
+  s->load_queue = _load_queue;
+  s->start = _start;
+  s->save_queue = _save_queue;
+  s->restart = _restart;
+}
+
+static inline void
+_set_virtual_functions(LogQueueDiskReliable *self)
+{
+  _set_logqueue_virtual_functions(&self->super.super);
+  _set_logqueue_disk_virtual_functions(&self->super);
 }
 
 LogQueue *
@@ -398,6 +409,6 @@ log_queue_disk_reliable_new(DiskQueueOptions *options, const gchar *persist_name
     }
   self->qreliable = g_queue_new();
   self->qbacklog = g_queue_new();
-  _set_virtual_functions(&self->super);
+  _set_virtual_functions(self);
   return &self->super.super;
 }

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -71,26 +71,6 @@ _push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
   g_static_mutex_unlock(&self->super.lock);
 }
 
-static LogMessage *
-_pop_head(LogQueue *s, LogPathOptions *path_options)
-{
-  LogQueueDisk *self = (LogQueueDisk *) s;
-  LogMessage *msg = NULL;
-
-  msg = NULL;
-  g_static_mutex_lock(&self->super.lock);
-  if (self->pop_head)
-    {
-      msg = self->pop_head(self, path_options);
-    }
-  if (msg != NULL)
-    {
-      log_queue_queued_messages_dec(&self->super);
-    }
-  g_static_mutex_unlock(&self->super.lock);
-  return msg;
-}
-
 gboolean
 log_queue_disk_save_queue(LogQueue *s, gboolean *persistent)
 {
@@ -265,5 +245,4 @@ log_queue_disk_init_instance(LogQueueDisk *self, const gchar *persist_name)
 
   self->super.type = log_queue_disk_type;
   self->super.push_tail = _push_tail;
-  self->super.pop_head = _pop_head;
 }

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -71,19 +71,6 @@ _push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
   g_static_mutex_unlock(&self->super.lock);
 }
 
-static void
-_push_head(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
-{
-  LogQueueDisk *self = (LogQueueDisk *) s;
-
-  g_static_mutex_lock(&self->super.lock);
-  if (self->push_head)
-    {
-      self->push_head(self, msg, path_options);
-    }
-  g_static_mutex_unlock(&self->super.lock);
-}
-
 static LogMessage *
 _pop_head(LogQueue *s, LogPathOptions *path_options)
 {
@@ -312,7 +299,6 @@ log_queue_disk_init_instance(LogQueueDisk *self, const gchar *persist_name)
 
   self->super.type = log_queue_disk_type;
   self->super.push_tail = _push_tail;
-  self->super.push_head = _push_head;
   self->super.pop_head = _pop_head;
   self->super.rewind_backlog = _rewind_backlog;
   self->super.rewind_backlog_all = _backlog_all;

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -146,30 +146,6 @@ log_queue_disk_read_message(LogQueueDisk *self, LogPathOptions *path_options)
   return msg;
 }
 
-gboolean
-log_queue_disk_write_message(LogQueueDisk *self, LogMessage *msg)
-{
-  gboolean consumed = FALSE;
-
-  if (qdisk_started(self->qdisk) && qdisk_is_space_avail(self->qdisk, 64))
-    {
-      ScratchBuffersMarker marker;
-      GString *write_serialized = scratch_buffers_alloc_and_mark(&marker);
-
-      if (!qdisk_serialize_msg(self->qdisk, msg, write_serialized))
-        {
-          scratch_buffers_reclaim_marked(marker);
-          return FALSE;
-        }
-
-      consumed = qdisk_push_tail(self->qdisk, write_serialized);
-
-      scratch_buffers_reclaim_marked(marker);
-    }
-
-  return consumed;
-}
-
 static void
 _restart_diskq(LogQueueDisk *self)
 {

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -91,35 +91,6 @@ _pop_head(LogQueue *s, LogPathOptions *path_options)
   return msg;
 }
 
-static void
-_rewind_backlog(LogQueue *s, guint rewind_count)
-{
-  LogQueueDisk *self = (LogQueueDisk *) s;
-  g_static_mutex_lock(&self->super.lock);
-
-  if (self->rewind_backlog)
-    {
-      self->rewind_backlog (self, rewind_count);
-    }
-
-  g_static_mutex_unlock(&self->super.lock);
-}
-
-void
-_backlog_all(LogQueue *s)
-{
-  LogQueueDisk *self = (LogQueueDisk *) s;
-
-  g_static_mutex_lock(&self->super.lock);
-
-  if (self->rewind_backlog)
-    {
-      self->rewind_backlog(self, -1);
-    }
-
-  g_static_mutex_unlock(&self->super.lock);
-}
-
 gboolean
 log_queue_disk_save_queue(LogQueue *s, gboolean *persistent)
 {
@@ -300,7 +271,5 @@ log_queue_disk_init_instance(LogQueueDisk *self, const gchar *persist_name)
   self->super.type = log_queue_disk_type;
   self->super.push_tail = _push_tail;
   self->super.pop_head = _pop_head;
-  self->super.rewind_backlog = _rewind_backlog;
-  self->super.rewind_backlog_all = _backlog_all;
   self->super.free_fn = _free;
 }

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -127,18 +127,13 @@ log_queue_disk_get_filename(LogQueue *s)
   return qdisk_get_filename(self->qdisk);
 }
 
-static void
-_free(LogQueue *s)
+void
+log_queue_disk_free_method(LogQueueDisk *self)
 {
-  LogQueueDisk *self = (LogQueueDisk *) s;
-
-  if (self->free_fn)
-    self->free_fn(self);
-
   qdisk_stop(self->qdisk);
   qdisk_free(self->qdisk);
 
-  log_queue_free_method(s);
+  log_queue_free_method(&self->super);
 }
 
 static gboolean
@@ -271,5 +266,4 @@ log_queue_disk_init_instance(LogQueueDisk *self, const gchar *persist_name)
   self->super.type = log_queue_disk_type;
   self->super.push_tail = _push_tail;
   self->super.pop_head = _pop_head;
-  self->super.free_fn = _free;
 }

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -105,21 +105,6 @@ _pop_head(LogQueue *s, LogPathOptions *path_options)
 }
 
 static void
-_ack_backlog(LogQueue *s, gint num_msg_to_ack)
-{
-  LogQueueDisk *self = (LogQueueDisk *) s;
-
-  g_static_mutex_lock(&self->super.lock);
-
-  if (self->ack_backlog)
-    {
-      self->ack_backlog(self, num_msg_to_ack);
-    }
-
-  g_static_mutex_unlock(&self->super.lock);
-}
-
-static void
 _rewind_backlog(LogQueue *s, guint rewind_count)
 {
   LogQueueDisk *self = (LogQueueDisk *) s;
@@ -329,7 +314,6 @@ log_queue_disk_init_instance(LogQueueDisk *self, const gchar *persist_name)
   self->super.push_tail = _push_tail;
   self->super.push_head = _push_head;
   self->super.pop_head = _pop_head;
-  self->super.ack_backlog = _ack_backlog;
   self->super.rewind_backlog = _rewind_backlog;
   self->super.rewind_backlog_all = _backlog_all;
   self->super.free_fn = _free;

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -210,10 +210,11 @@ log_queue_disk_restart_corrupted(LogQueueDisk *self)
 
 
 void
-log_queue_disk_init_instance(LogQueueDisk *self, const gchar *persist_name)
+log_queue_disk_init_instance(LogQueueDisk *self, DiskQueueOptions *options, const gchar *qdisk_file_id,
+                             const gchar *persist_name)
 {
   log_queue_init_instance(&self->super, persist_name);
-  self->qdisk = qdisk_new();
-
   self->super.type = log_queue_disk_type;
+
+  self->qdisk = qdisk_new(options, qdisk_file_id);
 }

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -43,19 +43,6 @@
 
 QueueType log_queue_disk_type = "DISK";
 
-static gint64
-_get_length(LogQueue *s)
-{
-  LogQueueDisk *self = (LogQueueDisk *) s;
-  gint64 qdisk_length = 0;
-
-  if (qdisk_started(self->qdisk) && self->get_length)
-    {
-      qdisk_length = self->get_length(self);
-    }
-  return qdisk_length;
-}
-
 static void
 _push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
 {
@@ -339,7 +326,6 @@ log_queue_disk_init_instance(LogQueueDisk *self, const gchar *persist_name)
   self->qdisk = qdisk_new();
 
   self->super.type = log_queue_disk_type;
-  self->super.get_length = _get_length;
   self->super.push_tail = _push_tail;
   self->super.push_head = _push_head;
   self->super.pop_head = _pop_head;

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -37,7 +37,6 @@ struct _LogQueueDisk
   QDisk *qdisk;         /* disk based queue */
   gboolean (*push_tail)(LogQueueDisk *s, LogMessage *msg, LogPathOptions *local_options,
                         const LogPathOptions *path_options);
-  void (*push_head)(LogQueueDisk *s, LogMessage *msg, const LogPathOptions *path_options);
   LogMessage *(*pop_head)(LogQueueDisk *s, LogPathOptions *path_options);
   void (*rewind_backlog)(LogQueueDisk *s, guint rewind_count);
   gboolean (*save_queue)(LogQueueDisk *s, gboolean *persistent);

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -35,8 +35,6 @@ struct _LogQueueDisk
 {
   LogQueue super;
   QDisk *qdisk;         /* disk based queue */
-  gboolean (*push_tail)(LogQueueDisk *s, LogMessage *msg, LogPathOptions *local_options,
-                        const LogPathOptions *path_options);
   gboolean (*save_queue)(LogQueueDisk *s, gboolean *persistent);
   gboolean (*load_queue)(LogQueueDisk *s, const gchar *filename);
   gboolean (*start)(LogQueueDisk *s, const gchar *filename);

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -35,7 +35,6 @@ struct _LogQueueDisk
 {
   LogQueue super;
   QDisk *qdisk;         /* disk based queue */
-  gint64 (*get_length)(LogQueueDisk *s);
   gboolean (*push_tail)(LogQueueDisk *s, LogMessage *msg, LogPathOptions *local_options,
                         const LogPathOptions *path_options);
   void (*push_head)(LogQueueDisk *s, LogMessage *msg, const LogPathOptions *path_options);

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -37,7 +37,6 @@ struct _LogQueueDisk
   QDisk *qdisk;         /* disk based queue */
   gboolean (*push_tail)(LogQueueDisk *s, LogMessage *msg, LogPathOptions *local_options,
                         const LogPathOptions *path_options);
-  LogMessage *(*pop_head)(LogQueueDisk *s, LogPathOptions *path_options);
   gboolean (*save_queue)(LogQueueDisk *s, gboolean *persistent);
   gboolean (*load_queue)(LogQueueDisk *s, const gchar *filename);
   gboolean (*start)(LogQueueDisk *s, const gchar *filename);

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -41,7 +41,6 @@ struct _LogQueueDisk
   gboolean (*save_queue)(LogQueueDisk *s, gboolean *persistent);
   gboolean (*load_queue)(LogQueueDisk *s, const gchar *filename);
   gboolean (*start)(LogQueueDisk *s, const gchar *filename);
-  void (*free_fn)(LogQueueDisk *s);
   void (*restart)(LogQueueDisk *self, DiskQueueOptions *options);
 };
 
@@ -52,6 +51,7 @@ gboolean log_queue_disk_save_queue(LogQueue *self, gboolean *persistent);
 gboolean log_queue_disk_load_queue(LogQueue *self, const gchar *filename);
 void log_queue_disk_init_instance(LogQueueDisk *self, const gchar *persist_name);
 void log_queue_disk_restart_corrupted(LogQueueDisk *self);
+void log_queue_disk_free_method(LogQueueDisk *self);
 
 
 LogMessage *log_queue_disk_read_message(LogQueueDisk *self, LogPathOptions *path_options);

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -38,7 +38,6 @@ struct _LogQueueDisk
   gboolean (*push_tail)(LogQueueDisk *s, LogMessage *msg, LogPathOptions *local_options,
                         const LogPathOptions *path_options);
   LogMessage *(*pop_head)(LogQueueDisk *s, LogPathOptions *path_options);
-  void (*rewind_backlog)(LogQueueDisk *s, guint rewind_count);
   gboolean (*save_queue)(LogQueueDisk *s, gboolean *persistent);
   gboolean (*load_queue)(LogQueueDisk *s, const gchar *filename);
   gboolean (*start)(LogQueueDisk *s, const gchar *filename);

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -39,7 +39,6 @@ struct _LogQueueDisk
                         const LogPathOptions *path_options);
   void (*push_head)(LogQueueDisk *s, LogMessage *msg, const LogPathOptions *path_options);
   LogMessage *(*pop_head)(LogQueueDisk *s, LogPathOptions *path_options);
-  void (*ack_backlog)(LogQueueDisk *s, guint num_msg_to_ack);
   void (*rewind_backlog)(LogQueueDisk *s, guint rewind_count);
   gboolean (*save_queue)(LogQueueDisk *s, gboolean *persistent);
   gboolean (*load_queue)(LogQueueDisk *s, const gchar *filename);

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -53,6 +53,5 @@ void log_queue_disk_free_method(LogQueueDisk *self);
 
 
 LogMessage *log_queue_disk_read_message(LogQueueDisk *self, LogPathOptions *path_options);
-gboolean log_queue_disk_write_message(LogQueueDisk *self, LogMessage *msg);
 
 #endif

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -46,7 +46,8 @@ extern QueueType log_queue_disk_type;
 const gchar *log_queue_disk_get_filename(LogQueue *self);
 gboolean log_queue_disk_save_queue(LogQueue *self, gboolean *persistent);
 gboolean log_queue_disk_load_queue(LogQueue *self, const gchar *filename);
-void log_queue_disk_init_instance(LogQueueDisk *self, const gchar *persist_name);
+void log_queue_disk_init_instance(LogQueueDisk *self, DiskQueueOptions *options, const gchar *qdisk_file_id,
+                                  const gchar *persist_name);
 void log_queue_disk_restart_corrupted(LogQueueDisk *self);
 void log_queue_disk_free_method(LogQueueDisk *self);
 

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1290,8 +1290,9 @@ qdisk_free(QDisk *self)
 }
 
 QDisk *
-qdisk_new(void)
+qdisk_new(DiskQueueOptions *options, const gchar *file_id)
 {
   QDisk *self = g_new0(QDisk, 1);
+  qdisk_init_instance(self, options, file_id);
   return self;
 }

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -330,6 +330,9 @@ _could_not_wrap_write_head_last_push_but_now_can(QDisk *self)
 gboolean
 qdisk_push_tail(QDisk *self, GString *record)
 {
+  if (!qdisk_started(self))
+    return FALSE;
+
   if (_could_not_wrap_write_head_last_push_but_now_can(self))
     {
       /*

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -82,4 +82,6 @@ const gchar *qdisk_get_filename(QDisk *self);
 
 guint64 qdisk_skip_record(QDisk *self, guint64 position);
 
+gboolean qdisk_serialize_msg(QDisk *self, LogMessage *msg, GString *serialized);
+
 #endif /* QDISK_H_ */

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -83,5 +83,6 @@ const gchar *qdisk_get_filename(QDisk *self);
 guint64 qdisk_skip_record(QDisk *self, guint64 position);
 
 gboolean qdisk_serialize_msg(QDisk *self, LogMessage *msg, GString *serialized);
+gboolean qdisk_deserialize_msg(QDisk *self, GString *serialized, LogMessage **msg);
 
 #endif /* QDISK_H_ */

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -47,7 +47,7 @@ QDiskQueuePosition;
 
 typedef struct _QDisk QDisk;
 
-QDisk *qdisk_new(void);
+QDisk *qdisk_new(DiskQueueOptions *options, const gchar *file_id);
 
 gboolean qdisk_is_space_avail(QDisk *self, gint at_least);
 gint64 qdisk_get_empty_space(QDisk *self);


### PR DESCRIPTION
It is common to have multiple source threads.
When we use disk-buffer, the message's serialization and writing it to the disk happen in the source thread.

Currently, the serialization happens while the source thread is holding the `LogQueue`'s lock. Also it is inbetween two accesses of the `QDisk`.
If we just simply move the serialization outside the lock, we are not guaranteed to have the same `QDisk` state, as we were having beforehand, so it is better to move the whole serialization between `QDisk` is ever accessed and the lock is obtained.

This can yield significant performance improvement, because while the source threads are doing their slow serialization, the destination thread can process messages from the `QDisk`. In my local measurements, this change introduced a 40-50% performance gain compared to syslog-ng-3.32.1.

No news file needed, IMO.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>