### PR TITLE
Handle redis reply error

### DIFF
--- a/modules/redis/redis-worker.c
+++ b/modules/redis/redis-worker.c
@@ -87,6 +87,7 @@ redis_worker_insert(LogThreadedDestWorker *s, LogMessage *msg)
 {
   RedisDestWorker *self = (RedisDestWorker *)s;
   RedisDriver *owner = (RedisDriver *) self->super.owner;
+  LogThreadedResult status = LTR_ERROR;
 
   ScratchBuffersMarker marker;
   scratch_buffers_mark(&marker);
@@ -102,17 +103,19 @@ redis_worker_insert(LogThreadedDestWorker *s, LogMessage *msg)
                 evt_tag_str("command", _argv_to_string(self)),
                 evt_tag_str("error", self->c->errstr),
                 evt_tag_int("time_reopen", self->super.time_reopen));
-      scratch_buffers_reclaim_marked(marker);
-      return LTR_ERROR;
+
+      goto exit;
     }
 
   msg_debug("REDIS command sent",
             evt_tag_str("driver", owner->super.super.super.id),
             evt_tag_str("command", _argv_to_string(self)));
 
+  status = LTR_SUCCESS;
   freeReplyObject(reply);
+exit:
   scratch_buffers_reclaim_marked(marker);
-  return LTR_SUCCESS;
+  return status;
 }
 
 

--- a/modules/redis/redis-worker.c
+++ b/modules/redis/redis-worker.c
@@ -112,8 +112,8 @@ redis_worker_insert(LogThreadedDestWorker *s, LogMessage *msg)
             evt_tag_str("command", _argv_to_string(self)));
 
   status = LTR_SUCCESS;
-  freeReplyObject(reply);
 exit:
+  freeReplyObject(reply);
   scratch_buffers_reclaim_marked(marker);
   return status;
 }

--- a/modules/redis/redis-worker.c
+++ b/modules/redis/redis-worker.c
@@ -107,6 +107,17 @@ redis_worker_insert(LogThreadedDestWorker *s, LogMessage *msg)
       goto exit;
     }
 
+  if (reply->type == REDIS_REPLY_ERROR)
+    {
+      msg_error("REDIS server error, suspending",
+                evt_tag_str("driver", owner->super.super.super.id),
+                evt_tag_str("command", _argv_to_string(self)),
+                evt_tag_str("error", reply->str),
+                evt_tag_int("time_reopen", self->super.time_reopen));
+
+      goto exit;
+    }
+
   msg_debug("REDIS command sent",
             evt_tag_str("driver", owner->super.super.super.id),
             evt_tag_str("command", _argv_to_string(self)));

--- a/news/bugfix-3748.md
+++ b/news/bugfix-3748.md
@@ -1,0 +1,2 @@
+redis: command errors were not detected and marked as successful delivery
+


### PR DESCRIPTION
If redis reply returned with error, we did not detect it. Simple reproduction is to configure a command that does not exists, and syslog-ng reports is as written message.