### PR TITLE
disk-buffer(): fix a rare memory leak

### DIFF
--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -146,6 +146,17 @@ log_queue_disk_read_message(LogQueueDisk *self, LogPathOptions *path_options)
   return msg;
 }
 
+void
+log_queue_disk_drop_message(LogQueueDisk *self, LogMessage *msg, const LogPathOptions *path_options)
+{
+  stats_counter_inc(self->super.dropped_messages);
+
+  if (path_options->flow_control_requested)
+    log_msg_ack(msg, path_options, AT_SUSPENDED);
+  else
+    log_msg_drop(msg, path_options, AT_PROCESSED);
+}
+
 static void
 _restart_diskq(LogQueueDisk *self)
 {

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -152,7 +152,7 @@ log_queue_disk_drop_message(LogQueueDisk *self, LogMessage *msg, const LogPathOp
   stats_counter_inc(self->super.dropped_messages);
 
   if (path_options->flow_control_requested)
-    log_msg_ack(msg, path_options, AT_SUSPENDED);
+    log_msg_drop(msg, path_options, AT_SUSPENDED);
   else
     log_msg_drop(msg, path_options, AT_PROCESSED);
 }

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -53,5 +53,6 @@ void log_queue_disk_free_method(LogQueueDisk *self);
 
 
 LogMessage *log_queue_disk_read_message(LogQueueDisk *self, LogPathOptions *path_options);
+void log_queue_disk_drop_message(LogQueueDisk *self, LogMessage *msg, const LogPathOptions *path_options);
 
 #endif

--- a/news/bugfix-3750.md
+++ b/news/bugfix-3750.md
@@ -1,0 +1,1 @@
+`disk-buffer()`: fix a rare memory leak that occurred when `mem-buf-length()` or `mem-buf-size()` was configured incorrectly


### PR DESCRIPTION
log_queue_disk_drop_message() is responsible for dropping a message
when the disk-buffer reaches its full capacity.

In case flow-control is enabled, the source will stop before the queue
becomes full, so no message loss is possible, but there are special/rare
cases when the user configures mem-buf-length() or mem-buf-size()
incorrectly, and the message has to be dropped.

log_queue_disk_drop_message() must force-suspend the source in the above
case, but we had already lost one single message by then.

log_msg_drop() not only acks the message with the specified ack type,
it also calls log_msg_unref() on the message, which should be done in
both cases to avoid leaking the memory.