### PR TITLE
afsocket: move TCP keepalive options setting after `accept()` call

### DIFF
--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -496,6 +496,8 @@ afsocket_sd_accept(gpointer s)
 
       if (res)
         {
+          socket_options_setup_peer_socket(self->socket_options, new_fd, peer_addr);
+
           if (peer_addr->sa.sa_family != AF_UNIX)
             msg_notice("Syslog connection accepted",
                        evt_tag_int("fd", new_fd),

--- a/modules/afsocket/socket-options-inet.c
+++ b/modules/afsocket/socket-options-inet.c
@@ -136,7 +136,6 @@ socket_options_inet_setup_socket(SocketOptions *s, gint fd, GSockAddr *addr, AFS
   if (!socket_options_setup_socket_method(s, fd, addr, dir))
     return FALSE;
 
-  socket_options_inet_setup_tcp_keepalive_timers(self, fd);
 
   if (self->interface_name)
     {
@@ -233,6 +232,18 @@ socket_options_inet_setup_socket(SocketOptions *s, gint fd, GSockAddr *addr, AFS
   return TRUE;
 }
 
+static gboolean
+socket_options_inet_setup_peer_socket(SocketOptions *s, gint fd, GSockAddr *addr)
+{
+  SocketOptionsInet *self = (SocketOptionsInet *) s;
+
+  if(!socket_options_setup_peer_socket_method(s, fd, addr))
+    return FALSE;
+  socket_options_inet_setup_tcp_keepalive_timers(self, fd);
+  return TRUE;
+
+}
+
 void
 socket_options_inet_set_interface_name(SocketOptionsInet *self, const gchar *interface_name)
 {
@@ -255,6 +266,7 @@ socket_options_inet_new_instance(void)
 
   socket_options_init_instance(&self->super);
   self->super.setup_socket = socket_options_inet_setup_socket;
+  self->super.setup_peer_socket =  socket_options_inet_setup_peer_socket;
   self->super.so_keepalive = TRUE;
   self->tcp_keepalive_time = 60;
   self->tcp_keepalive_intvl = 10;

--- a/modules/afsocket/socket-options.c
+++ b/modules/afsocket/socket-options.c
@@ -134,10 +134,19 @@ socket_options_setup_socket_method(SocketOptions *self, gint fd, GSockAddr *bind
   return TRUE;
 }
 
+gboolean
+socket_options_setup_peer_socket_method(SocketOptions *self, gint fd, GSockAddr *bind_addr)
+{
+  if (self->so_keepalive && !_setup_keepalive(fd))
+    return FALSE;
+  return TRUE;
+}
+
 void
 socket_options_init_instance(SocketOptions *self)
 {
   self->setup_socket = socket_options_setup_socket_method;
+  self->setup_peer_socket = socket_options_setup_peer_socket_method;
   self->free = g_free;
 }
 

--- a/modules/afsocket/socket-options.h
+++ b/modules/afsocket/socket-options.h
@@ -42,10 +42,12 @@ struct _SocketOptions
   gint so_keepalive;
   gboolean so_reuseport;
   gboolean (*setup_socket)(SocketOptions *s, gint sock, GSockAddr *bind_addr, AFSocketDirection dir);
+  gboolean (*setup_peer_socket)(SocketOptions *s, gint sock, GSockAddr *bind_addr);
   void (*free)(gpointer s);
 };
 
 gboolean socket_options_setup_socket_method(SocketOptions *self, gint fd, GSockAddr *bind_addr, AFSocketDirection dir);
+gboolean socket_options_setup_peer_socket_method(SocketOptions *self, gint fd, GSockAddr *bind_addr);
 void socket_options_init_instance(SocketOptions *self);
 SocketOptions *socket_options_new(void);
 
@@ -53,6 +55,12 @@ static inline gboolean
 socket_options_setup_socket(SocketOptions *s, gint sock, GSockAddr *bind_addr, AFSocketDirection dir)
 {
   return s->setup_socket(s, sock, bind_addr, dir);
+}
+
+static inline gboolean
+socket_options_setup_peer_socket(SocketOptions *s, gint sock, GSockAddr *bind_addr)
+{
+  return s->setup_peer_socket(s, sock, bind_addr);
 }
 
 static inline void

--- a/news/bugfix-3751.md
+++ b/news/bugfix-3751.md
@@ -1,0 +1,4 @@
+Fix network sources on NetBSD
+ 
+
+On NetBSD, TCP-based network sources closed their listeners shortly after startup due to a non-portable TCP keepalive setting. This has been fixed.


### PR DESCRIPTION
This should improve POSIX (and by extension NetBSD) compatibility as
the POSIX standard does not guarantee the inheritance of options between listening and peer sockets.
I moved the `socket_options_inet_setup_tcp_keepalive_timers()` function
after `accept()`, and created a new virtual function (`setup_peer_socket()`) in `SocketOptions`
which is redefinied in `SocketOptionsInet`.

Solves #3701

Signed-off-by: Parrag Szilárd <szilard.parrag@gmail.com>