### PR TITLE
qdisk: fix read and write head guessing

### DIFF
--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -97,7 +97,7 @@ _pop_disk(LogQueueDisk *self, LogMessage **msg)
   ScratchBuffersMarker marker;
   GString *read_serialized = scratch_buffers_alloc_and_mark(&marker);
 
-  gint64 read_head = qdisk_get_reader_head(self->qdisk);
+  gint64 read_head = qdisk_get_head_position(self->qdisk);
 
   if (!qdisk_pop_head(self->qdisk, read_serialized))
     {

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -461,12 +461,6 @@ _try_reading_record_length(QDisk *self, guint32 *record_length)
 {
   guint32 read_record_length;
   gssize bytes_read = _read_record_length_from_disk(self, &read_record_length);
-  if (bytes_read == 0)
-    {
-      /* hmm, we are either at EOF or at hdr->qout_ofs, we need to wrap */
-      self->hdr->read_head = QDISK_RESERVED_SPACE;
-      bytes_read = _read_record_length_from_disk(self, &read_record_length);
-    }
 
   if (!_is_record_length_valid(self, bytes_read, read_record_length))
     return FALSE;

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -327,6 +327,15 @@ _could_not_wrap_write_head_last_push_but_now_can(QDisk *self)
   return _is_qdisk_overwritten(self) && _is_able_to_reset_write_head_to_beginning_of_qdisk(self);
 }
 
+gint64
+qdisk_get_next_tail_position(QDisk *self)
+{
+  if (_could_not_wrap_write_head_last_push_but_now_can(self))
+    return QDISK_RESERVED_SPACE;
+
+  return self->hdr->write_head;
+}
+
 gboolean
 qdisk_push_tail(QDisk *self, GString *record)
 {
@@ -515,6 +524,12 @@ _update_positions_after_read(QDisk *self, guint32 record_length)
           qdisk_reset_file_if_empty(self);
         }
     }
+}
+
+gint64
+qdisk_get_head_position(QDisk *self)
+{
+  return self->hdr->read_head;
 }
 
 gboolean

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -54,6 +54,8 @@ gint64 qdisk_get_empty_space(QDisk *self);
 gboolean qdisk_push_tail(QDisk *self, GString *record);
 gboolean qdisk_pop_head(QDisk *self, GString *record);
 gboolean qdisk_remove_head(QDisk *self);
+gint64 qdisk_get_next_tail_position(QDisk *self);
+gint64 qdisk_get_head_position(QDisk *self);
 gboolean qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow);
 void qdisk_init_instance(QDisk *self, DiskQueueOptions *options, const gchar *file_id);
 void qdisk_stop(QDisk *self);

--- a/news/bugfix-3752.md
+++ b/news/bugfix-3752.md
@@ -1,0 +1,2 @@
+`disk-buffer`: fixed a very rare case, where the reliable disk-buffer never resumed
+after triggering `flow-control`.


### PR DESCRIPTION
We need the next tail's position and the head's position info in the reliable disk-buffer, because it is matching its memory queue's messages to the qdisk's messages by their position in the qdisk.

Currently we guess these positions on the caller side, based on the `write_head`'s and `read_head`'s position.
This guess is not always right, because for example `push_tail()` can change the `write_head` before writing to the disk.

I think accessing any of the three QDisk::`..._head`s publicly should not be allowed, because it is an implementation detail, but I did not want to refactor the whole code around that. So I only added the 2 function, which I think would be the correct to have, and used them in the respective parts of the code.

---

In the news entry, I mention that we fixed a rare bug where the reliable disk-buffer did not ever resume after triggering flow-control. I did not observe this behavior anywhere, I just found this bug in the code, and thought about what possible unexpected behavior it can cause.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>