### PR TITLE
Avg and max message size and EPS stats

### DIFF
--- a/lib/atomic-gssize.h
+++ b/lib/atomic-gssize.h
@@ -123,9 +123,9 @@ atomic_gssize_set_and_get(atomic_gssize *a, gssize value)
 {
   gssize oldval = atomic_gssize_get(a);
 
-  while (!g_atomic_pointer_compare_and_exchange(&a->value,
-                                                oldval,
-                                                value))
+  while (!atomic_gssize_compare_and_exchange(a,
+                                             oldval,
+                                             value))
     {
       oldval = atomic_gssize_get(a);
     }

--- a/lib/atomic-gssize.h
+++ b/lib/atomic-gssize.h
@@ -112,6 +112,12 @@ atomic_gssize_and(atomic_gssize *a, gsize value)
   return g_atomic_pointer_and(&a->value, value);
 }
 
+static inline gboolean
+atomic_gssize_compare_and_exchange(atomic_gssize *a, gssize oldval, gssize newval)
+{
+  return g_atomic_pointer_compare_and_exchange(&a->value, oldval, newval);
+}
+
 static inline gssize
 atomic_gssize_set_and_get(atomic_gssize *a, gssize value)
 {

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -575,6 +575,10 @@ log_reader_io_handle_in(gpointer s)
 static void
 _register_aggregated_stats(LogReader *self)
 {
+  StatsClusterKey sc_key_eps_input;
+  stats_cluster_logpipe_key_set(&sc_key_eps_input, self->super.options->stats_source | SCS_SOURCE, self->super.stats_id,
+                                self->super.stats_instance);
+
   stats_aggregator_lock();
   StatsClusterKey sc_key;
 
@@ -588,7 +592,8 @@ _register_aggregated_stats(LogReader *self)
 
   stats_cluster_single_key_set_with_name(&sc_key, self->super.options->stats_source | SCS_SOURCE, self->super.stats_id,
                                          self->super.stats_instance, "eps");
-  stats_register_aggregator_cps(self->super.options->stats_level, &sc_key, self->super.recvd_messages, &self->CPS);
+  stats_register_aggregator_cps(self->super.options->stats_level, &sc_key, &sc_key_eps_input, SC_TYPE_PROCESSED,
+                                &self->CPS);
 
   stats_aggregator_unlock();
 }

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -23,6 +23,7 @@
  */
 
 #include "logreader.h"
+#include "stats/stats-cluster-single.h"
 #include "mainloop-call.h"
 #include "ack-tracker/ack_tracker.h"
 #include "ack-tracker/ack_tracker_factory.h"
@@ -436,6 +437,13 @@ log_reader_process_handshake(LogReader *self)
   return 0;
 }
 
+static void
+_log_reader_insert_msg_length_stats(LogReader *self, gsize len)
+{
+  stats_aggregator_insert_data(self->max_message_size, len);
+  stats_aggregator_insert_data(self->average_messages_size, len);
+}
+
 static gboolean
 log_reader_handle_line(LogReader *self, const guchar *line, gint length, LogTransportAuxData *aux)
 {
@@ -447,6 +455,7 @@ log_reader_handle_line(LogReader *self, const guchar *line, gint length, LogTran
   m = log_msg_new((gchar *) line, length,
                   &self->options->parse_options);
 
+  _log_reader_insert_msg_length_stats(self, length);
   log_msg_set_saddr(m, aux->peer_addr ? : self->peer_addr);
   log_msg_set_daddr(m, aux->local_addr ? : self->local_addr);
   m->proto = aux->proto;
@@ -563,6 +572,39 @@ log_reader_io_handle_in(gpointer s)
     }
 }
 
+static void
+_register_aggregated_stats(LogReader *self)
+{
+  stats_aggregator_lock();
+  StatsClusterKey sc_key;
+
+  stats_cluster_single_key_set_with_name(&sc_key, self->super.options->stats_source | SCS_SOURCE, self->super.stats_id,
+                                         self->super.stats_instance, "msg_size_max");
+  stats_register_aggregator_maximum(self->super.options->stats_level, &sc_key, &self->max_message_size);
+
+  stats_cluster_single_key_set_with_name(&sc_key, self->super.options->stats_source | SCS_SOURCE, self->super.stats_id,
+                                         self->super.stats_instance, "msg_size_avg");
+  stats_register_aggregator_average(self->super.options->stats_level, &sc_key, &self->average_messages_size);
+
+  stats_cluster_single_key_set_with_name(&sc_key, self->super.options->stats_source | SCS_SOURCE, self->super.stats_id,
+                                         self->super.stats_instance, "eps");
+  stats_register_aggregator_cps(self->super.options->stats_level, &sc_key, self->super.recvd_messages, &self->CPS);
+
+  stats_aggregator_unlock();
+}
+
+static void
+_unregister_aggregated_stats(LogReader *self)
+{
+  stats_aggregator_lock();
+
+  stats_unregister_aggregator_maximum(&self->max_message_size);
+  stats_unregister_aggregator_average(&self->average_messages_size);
+  stats_unregister_aggregator_cps(&self->CPS);
+
+  stats_aggregator_unlock();
+}
+
 /*****************************************************************************
  * LogReader->LogPipe interface implementation
  *****************************************************************************/
@@ -592,6 +634,8 @@ log_reader_init(LogPipe *s)
 
   log_reader_start_watches(self);
 
+  _register_aggregated_stats(self);
+
   return TRUE;
 }
 
@@ -608,6 +652,7 @@ log_reader_deinit(LogPipe *s)
 
   log_reader_stop_watches(self);
 
+  _unregister_aggregated_stats(self);
   if (!log_source_deinit(s))
     return FALSE;
 

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -26,6 +26,8 @@
 #define LOGREADER_H_INCLUDED
 
 #include "logsource.h"
+#include "stats/aggregator/stats-aggregator.h"
+#include "stats/aggregator/stats-aggregator-registry.h"
 #include "logproto/logproto-server.h"
 #include "poll-events.h"
 #include "mainloop-io-worker.h"
@@ -62,6 +64,9 @@ struct _LogReader
   PollEvents *poll_events;
   GSockAddr *peer_addr;
   GSockAddr *local_addr;
+  StatsAggregator *max_message_size;
+  StatsAggregator *average_messages_size;
+  StatsAggregator *CPS;
 
   /* NOTE: these used to be LogReaderWatch members, which were merged into
    * LogReader with the multi-thread refactorization */

--- a/lib/logthrdest/logthrdestdrv.c
+++ b/lib/logthrdest/logthrdestdrv.c
@@ -1017,6 +1017,8 @@ log_threaded_dest_driver_insert_batch_length_stats(LogThreadedDestDriver *self, 
 void
 log_threaded_dest_driver_register_aggregated_stats(LogThreadedDestDriver *self)
 {
+  StatsClusterKey sc_key_eps_input;
+  _init_stats_key(self, &sc_key_eps_input);
   stats_aggregator_lock();
   StatsClusterKey sc_key;
 
@@ -1038,7 +1040,7 @@ log_threaded_dest_driver_register_aggregated_stats(LogThreadedDestDriver *self)
 
   stats_cluster_single_key_set_with_name(&sc_key, self->stats_source | SCS_DESTINATION, self->super.super.id,
                                          self->format_stats_instance(self), "eps");
-  stats_register_aggregator_cps(0, &sc_key, self->written_messages, &self->CPS);
+  stats_register_aggregator_cps(0, &sc_key, &sc_key_eps_input, SC_TYPE_WRITTEN, &self->CPS);
 
   stats_aggregator_unlock();
 }

--- a/lib/logthrdest/logthrdestdrv.c
+++ b/lib/logthrdest/logthrdestdrv.c
@@ -23,6 +23,8 @@
  */
 
 #include "stats/stats-cluster-logpipe.h"
+#include "stats/stats-cluster-single.h"
+#include "stats/aggregator/stats-aggregator-registry.h"
 #include "logthrdestdrv.h"
 #include "seqnum.h"
 #include "scratch-buffers.h"
@@ -998,6 +1000,63 @@ _init_stats_key(LogThreadedDestDriver *self, StatsClusterKey *sc_key)
                                 self->format_stats_instance(self));
 }
 
+void
+log_threaded_dest_driver_insert_msg_length_stats(LogThreadedDestDriver *self, gsize len)
+{
+  stats_aggregator_insert_data(self->max_message_size, len);
+  stats_aggregator_insert_data(self->average_messages_size, len);
+}
+
+void
+log_threaded_dest_driver_insert_batch_length_stats(LogThreadedDestDriver *self, gsize len)
+{
+  stats_aggregator_insert_data(self->max_batch_size, len);
+  stats_aggregator_insert_data(self->average_batch_size, len);
+}
+
+void
+log_threaded_dest_driver_register_aggregated_stats(LogThreadedDestDriver *self)
+{
+  stats_aggregator_lock();
+  StatsClusterKey sc_key;
+
+  stats_cluster_single_key_set_with_name(&sc_key, self->stats_source | SCS_DESTINATION, self->super.super.id,
+                                         self->format_stats_instance(self), "msg_size_max");
+  stats_register_aggregator_maximum(0, &sc_key, &self->max_message_size);
+
+  stats_cluster_single_key_set_with_name(&sc_key, self->stats_source | SCS_DESTINATION, self->super.super.id,
+                                         self->format_stats_instance(self), "msg_size_avg");
+  stats_register_aggregator_average(0, &sc_key, &self->average_messages_size);
+
+  stats_cluster_single_key_set_with_name(&sc_key, self->stats_source | SCS_DESTINATION, self->super.super.id,
+                                         self->format_stats_instance(self), "batch_size_max");
+  stats_register_aggregator_maximum(0, &sc_key, &self->max_batch_size);
+
+  stats_cluster_single_key_set_with_name(&sc_key, self->stats_source | SCS_DESTINATION, self->super.super.id,
+                                         self->format_stats_instance(self), "batch_size_avg");
+  stats_register_aggregator_average(0, &sc_key, &self->average_batch_size);
+
+  stats_cluster_single_key_set_with_name(&sc_key, self->stats_source | SCS_DESTINATION, self->super.super.id,
+                                         self->format_stats_instance(self), "eps");
+  stats_register_aggregator_cps(0, &sc_key, self->written_messages, &self->CPS);
+
+  stats_aggregator_unlock();
+}
+
+void
+log_threaded_dest_driver_unregister_aggregated_stats(LogThreadedDestDriver *self)
+{
+  stats_aggregator_lock();
+
+  stats_unregister_aggregator_maximum(&self->max_message_size);
+  stats_unregister_aggregator_average(&self->average_messages_size);
+  stats_unregister_aggregator_maximum(&self->max_batch_size);
+  stats_unregister_aggregator_average(&self->average_batch_size);
+  stats_unregister_aggregator_cps(&self->CPS);
+
+  stats_aggregator_unlock();
+}
+
 static void
 _register_stats(LogThreadedDestDriver *self)
 {
@@ -1009,6 +1068,7 @@ _register_stats(LogThreadedDestDriver *self)
     stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
     stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &self->processed_messages);
     stats_register_counter(0, &sc_key, SC_TYPE_WRITTEN, &self->written_messages);
+
   }
   stats_unlock();
 }
@@ -1024,6 +1084,7 @@ _unregister_stats(LogThreadedDestDriver *self)
     stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
     stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->processed_messages);
     stats_unregister_counter(&sc_key, SC_TYPE_WRITTEN, &self->written_messages);
+
   }
   stats_unlock();
 }

--- a/lib/logthrdest/logthrdestdrv.h
+++ b/lib/logthrdest/logthrdestdrv.h
@@ -28,6 +28,7 @@
 #include "syslog-ng.h"
 #include "driver.h"
 #include "stats/stats-registry.h"
+#include "stats/aggregator/stats-aggregator.h"
 #include "logqueue.h"
 #include "mainloop-worker.h"
 #include "seqnum.h"
@@ -108,6 +109,11 @@ struct _LogThreadedDestDriver
   StatsCounterItem *dropped_messages;
   StatsCounterItem *processed_messages;
   StatsCounterItem *written_messages;
+  StatsAggregator *max_message_size;
+  StatsAggregator *average_messages_size;
+  StatsAggregator *max_batch_size;
+  StatsAggregator *average_batch_size;
+  StatsAggregator *CPS;
 
   gint batch_lines;
   gint batch_timeout;
@@ -225,6 +231,11 @@ void log_threaded_dest_worker_init_instance(LogThreadedDestWorker *self,
                                             gint worker_index);
 void log_threaded_dest_worker_free_method(LogThreadedDestWorker *self);
 void log_threaded_dest_worker_free(LogThreadedDestWorker *self);
+
+void log_threaded_dest_driver_insert_msg_length_stats(LogThreadedDestDriver *self, gsize len);
+void log_threaded_dest_driver_insert_batch_length_stats(LogThreadedDestDriver *self, gsize len);
+void log_threaded_dest_driver_register_aggregated_stats(LogThreadedDestDriver *self);
+void log_threaded_dest_driver_unregister_aggregated_stats(LogThreadedDestDriver *self);
 
 gboolean log_threaded_dest_driver_deinit_method(LogPipe *s);
 gboolean log_threaded_dest_driver_init_method(LogPipe *s);

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -25,7 +25,9 @@
 #include "logwriter.h"
 #include "messages.h"
 #include "stats/stats-registry.h"
+#include "stats/aggregator/stats-aggregator-registry.h"
 #include "stats/stats-cluster-single.h"
+#include "stats/aggregator/stats-aggregator.h"
 #include "hostname.h"
 #include "host-resolve.h"
 #include "seqnum.h"
@@ -70,6 +72,9 @@ struct _LogWriter
   StatsCounterItem *suppressed_messages;
   StatsCounterItem *processed_messages;
   StatsCounterItem *written_messages;
+  StatsAggregator *max_message_size;
+  StatsAggregator *average_messages_size;
+  StatsAggregator *CPS;
   struct
   {
     StatsCounterItem *count;
@@ -1150,6 +1155,13 @@ log_writer_flush_finalize(LogWriter *self)
   return FALSE;
 }
 
+static void
+_log_writer_insert_msg_length_stats(LogWriter *self, gsize msg_len)
+{
+  stats_aggregator_insert_data(self->max_message_size, msg_len);
+  stats_aggregator_insert_data(self->average_messages_size, msg_len);
+}
+
 static gboolean
 log_writer_write_message(LogWriter *self, LogMessage *msg, LogPathOptions *path_options, gboolean *write_error)
 {
@@ -1168,8 +1180,10 @@ log_writer_write_message(LogWriter *self, LogMessage *msg, LogPathOptions *path_
                 evt_tag_printf("message", "%s", self->line_buffer->str));
     }
 
+  gsize msg_len = 0;
   if (self->line_buffer->len)
     {
+      msg_len = self->line_buffer->len;
       LogProtoStatus status = log_proto_client_post(self->proto, msg, (guchar *)self->line_buffer->str,
                                                     self->line_buffer->len,
                                                     &consumed);
@@ -1211,6 +1225,7 @@ log_writer_write_message(LogWriter *self, LogMessage *msg, LogPathOptions *path_
       log_msg_unref(msg);
       msg_set_context(NULL);
       log_msg_refcache_stop();
+      _log_writer_insert_msg_length_stats(self, msg_len);
 
       return TRUE;
     }
@@ -1390,6 +1405,39 @@ log_writer_init_watches(LogWriter *self)
 }
 
 static void
+_register_aggregated_stats(LogWriter *self)
+{
+  stats_aggregator_lock();
+  StatsClusterKey sc_key;
+
+  stats_cluster_single_key_set_with_name(&sc_key, self->options->stats_source | SCS_DESTINATION, self->stats_id,
+                                         self->stats_instance, "msg_size_max");
+  stats_register_aggregator_maximum(self->options->stats_level, &sc_key, &self->max_message_size);
+
+  stats_cluster_single_key_set_with_name(&sc_key, self->options->stats_source | SCS_DESTINATION, self->stats_id,
+                                         self->stats_instance, "msg_size_avg");
+  stats_register_aggregator_average(self->options->stats_level, &sc_key, &self->average_messages_size);
+
+  stats_cluster_single_key_set_with_name(&sc_key, self->options->stats_source | SCS_DESTINATION, self->stats_id,
+                                         self->stats_instance, "eps");
+  stats_register_aggregator_cps(self->options->stats_level, &sc_key, self->written_messages, &self->CPS);
+
+  stats_aggregator_unlock();
+}
+
+static void
+_unregister_aggregated_stats(LogWriter *self)
+{
+  stats_aggregator_lock();
+
+  stats_unregister_aggregator_maximum(&self->max_message_size);
+  stats_unregister_aggregator_average(&self->average_messages_size);
+  stats_unregister_aggregator_cps(&self->CPS);
+
+  stats_aggregator_unlock();
+}
+
+static void
 _register_counters(LogWriter *self)
 {
   stats_lock();
@@ -1419,6 +1467,7 @@ _register_counters(LogWriter *self)
 
   }
   stats_unlock();
+  _register_aggregated_stats(self);
 }
 
 static gboolean
@@ -1480,8 +1529,10 @@ _unregister_counters(LogWriter *self)
     stats_unregister_counter(&sc_key_truncated_bytes, SC_TYPE_SINGLE_VALUE, &self->truncated.bytes);
 
     log_queue_unregister_stats_counters(self->queue, &sc_key);
+
   }
   stats_unlock();
+  _unregister_aggregated_stats(self);
 
 }
 

--- a/lib/stats/CMakeLists.txt
+++ b/lib/stats/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(aggregator)
+
 set(STATS_HEADERS
     stats/stats.h
     stats/stats-control.h
@@ -10,6 +12,7 @@ set(STATS_HEADERS
     stats/stats-query-commands.h
     stats/stats-cluster-logpipe.h
     stats/stats-cluster-single.h
+    ${STATS_AGGREGATOR_HEADERS}
     PARENT_SCOPE)
 
 set(STATS_SOURCES
@@ -23,6 +26,7 @@ set(STATS_SOURCES
     stats/stats-query-commands.c
     stats/stats-cluster-logpipe.c
     stats/stats-cluster-single.c
+    ${STATS_AGGREGATOR_SOURCES}
     PARENT_SCOPE)
 
 add_test_subdirectory(tests)

--- a/lib/stats/Makefile.am
+++ b/lib/stats/Makefile.am
@@ -2,6 +2,8 @@ statsincludedir			= ${pkgincludedir}/stats
 
 EXTRA_DIST += lib/stats/CMakeLists.txt
 
+include lib/stats/aggregator/Makefile.am
+
 statsinclude_HEADERS = \
 	lib/stats/stats.h			\
 	lib/stats/stats-control.h		\
@@ -25,6 +27,7 @@ stats_sources = \
 	lib/stats/stats-query.c			\
 	lib/stats/stats-query-commands.c \
 	lib/stats/stats-cluster-logpipe.c \
-	lib/stats/stats-cluster-single.c
+	lib/stats/stats-cluster-single.c \
+	$(statsaggregator_sources)
 
 include lib/stats/tests/Makefile.am

--- a/lib/stats/aggregator/CMakeLists.txt
+++ b/lib/stats/aggregator/CMakeLists.txt
@@ -4,4 +4,5 @@ set(STATS_AGGREGATOR_HEADERS
 
 set(STATS_AGGREGATOR_SOURCES
     stats/aggregator/stats-aggregator.c
+    stats/aggregator/stats-maximum.c
     PARENT_SCOPE)

--- a/lib/stats/aggregator/CMakeLists.txt
+++ b/lib/stats/aggregator/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(STATS_AGGREGATOR_HEADERS
     stats/aggregator/stats-aggregator.h
+    stats/aggregator/stats-aggregator-registry.h
     PARENT_SCOPE)
 
 set(STATS_AGGREGATOR_SOURCES
@@ -7,4 +8,5 @@ set(STATS_AGGREGATOR_SOURCES
     stats/aggregator/stats-average.c
     stats/aggregator/stats-maximum.c
     stats/aggregator/stats-change-per-second.c
+    stats/aggregator/stats-aggregator-registry.c
     PARENT_SCOPE)

--- a/lib/stats/aggregator/CMakeLists.txt
+++ b/lib/stats/aggregator/CMakeLists.txt
@@ -6,4 +6,5 @@ set(STATS_AGGREGATOR_SOURCES
     stats/aggregator/stats-aggregator.c
     stats/aggregator/stats-average.c
     stats/aggregator/stats-maximum.c
+    stats/aggregator/stats-change-per-second.c
     PARENT_SCOPE)

--- a/lib/stats/aggregator/CMakeLists.txt
+++ b/lib/stats/aggregator/CMakeLists.txt
@@ -4,5 +4,6 @@ set(STATS_AGGREGATOR_HEADERS
 
 set(STATS_AGGREGATOR_SOURCES
     stats/aggregator/stats-aggregator.c
+    stats/aggregator/stats-average.c
     stats/aggregator/stats-maximum.c
     PARENT_SCOPE)

--- a/lib/stats/aggregator/CMakeLists.txt
+++ b/lib/stats/aggregator/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(STATS_AGGREGATOR_HEADERS
+    stats/aggregator/stats-aggregator.h
+    PARENT_SCOPE)
+
+set(STATS_AGGREGATOR_SOURCES
+    stats/aggregator/stats-aggregator.c
+    PARENT_SCOPE)

--- a/lib/stats/aggregator/Makefile.am
+++ b/lib/stats/aggregator/Makefile.am
@@ -7,4 +7,5 @@ statsaggregatorinclude_HEADERS = \
 	lib/stats/aggregator/stats-aggregator.h
 
 statsaggregator_sources = \
-	lib/stats/aggregator/stats-aggregator.c
+	lib/stats/aggregator/stats-aggregator.c	\
+	lib/stats/aggregator/stats-maximum.c

--- a/lib/stats/aggregator/Makefile.am
+++ b/lib/stats/aggregator/Makefile.am
@@ -9,4 +9,5 @@ statsaggregatorinclude_HEADERS = \
 statsaggregator_sources = \
 	lib/stats/aggregator/stats-aggregator.c	\
 	lib/stats/aggregator/stats-average.c		\
-	lib/stats/aggregator/stats-maximum.c
+	lib/stats/aggregator/stats-maximum.c		\
+	lib/stats/aggregator/stats-change-per-second.c 

--- a/lib/stats/aggregator/Makefile.am
+++ b/lib/stats/aggregator/Makefile.am
@@ -4,10 +4,12 @@ EXTRA_DIST += lib/stats/aggregator/CMakeLists.txt
 
 
 statsaggregatorinclude_HEADERS = \
-	lib/stats/aggregator/stats-aggregator.h
+	lib/stats/aggregator/stats-aggregator.h	\
+	lib/stats/aggregator/stats-aggregator-registry.h
 
 statsaggregator_sources = \
 	lib/stats/aggregator/stats-aggregator.c	\
 	lib/stats/aggregator/stats-average.c		\
 	lib/stats/aggregator/stats-maximum.c		\
-	lib/stats/aggregator/stats-change-per-second.c 
+	lib/stats/aggregator/stats-change-per-second.c \
+    lib/stats/aggregator/stats-aggregator-registry.c

--- a/lib/stats/aggregator/Makefile.am
+++ b/lib/stats/aggregator/Makefile.am
@@ -1,0 +1,10 @@
+statsaggregatorincludedir = ${pkgincludedir}/stats/aggregator
+
+EXTRA_DIST += lib/stats/aggregator/CMakeLists.txt
+
+
+statsaggregatorinclude_HEADERS = \
+	lib/stats/aggregator/stats-aggregator.h
+
+statsaggregator_sources = \
+	lib/stats/aggregator/stats-aggregator.c

--- a/lib/stats/aggregator/Makefile.am
+++ b/lib/stats/aggregator/Makefile.am
@@ -8,4 +8,5 @@ statsaggregatorinclude_HEADERS = \
 
 statsaggregator_sources = \
 	lib/stats/aggregator/stats-aggregator.c	\
+	lib/stats/aggregator/stats-average.c		\
 	lib/stats/aggregator/stats-maximum.c

--- a/lib/stats/aggregator/stats-aggregator-registry.c
+++ b/lib/stats/aggregator/stats-aggregator-registry.c
@@ -28,6 +28,7 @@
 #include "iv.h"
 #include "timeutils/cache.h"
 #include "mainloop.h"
+#include "messages.h"
 
 #define FREQUENCY_OF_UPDATE 60
 
@@ -65,6 +66,7 @@ _start_timer(void)
 static void
 _update(void *cookie)
 {
+  msg_trace("stats-aggregator-registry update");
   g_hash_table_foreach(stats_container.aggregators, _update_func, NULL);
 
   if(g_hash_table_size(stats_container.aggregators) > 0

--- a/lib/stats/aggregator/stats-aggregator-registry.c
+++ b/lib/stats/aggregator/stats-aggregator-registry.c
@@ -266,7 +266,8 @@ stats_unregister_aggregator_average(StatsAggregator **s)
 }
 
 void
-stats_register_aggregator_cps(gint level, StatsClusterKey *sc_key, StatsCounterItem *counter, StatsAggregator **s)
+stats_register_aggregator_cps(gint level, StatsClusterKey *sc_key, StatsClusterKey *sc_key_input, gint stats_type,
+                              StatsAggregator **s)
 {
   g_assert(stats_aggregator_locked);
 
@@ -278,7 +279,7 @@ stats_register_aggregator_cps(gint level, StatsClusterKey *sc_key, StatsCounterI
 
   if (!_is_in_table(sc_key))
     {
-      *s = stats_aggregator_cps_new(level, sc_key, counter);
+      *s = stats_aggregator_cps_new(level, sc_key, sc_key_input, stats_type);
       _insert_to_table(*s);
     }
   else

--- a/lib/stats/aggregator/stats-aggregator-registry.c
+++ b/lib/stats/aggregator/stats-aggregator-registry.c
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2021 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "stats/aggregator/stats-aggregator-registry.h"
+#include "stats/stats-registry.h"
+#include "stats/stats-query.h"
+#include "cfg.h"
+
+
+typedef struct
+{
+  GHashTable *aggregators;
+} StatsAggregatorContainer;
+
+static StatsAggregatorContainer stats_container;
+
+static GStaticMutex stats_aggregator_mutex = G_STATIC_MUTEX_INIT;
+static gboolean stats_aggregator_locked;
+
+
+void
+stats_aggregator_lock(void)
+{
+  g_static_mutex_lock(&stats_aggregator_mutex);
+  stats_aggregator_locked = TRUE;
+}
+
+void
+stats_aggregator_unlock(void)
+{
+  stats_aggregator_locked = FALSE;
+  g_static_mutex_unlock(&stats_aggregator_mutex);
+}
+
+static void
+_free_aggregator(StatsAggregator *self)
+{
+  stats_aggregator_free(self);
+}
+
+static gboolean
+_remove_orphaned_helper(gpointer _key, gpointer _value, gpointer _user_data)
+{
+  StatsAggregator *self = (StatsAggregator *) _value;
+  if (stats_aggregator_is_orphaned(self))
+    {
+      _free_aggregator(self);
+      return TRUE;
+    }
+  return FALSE;
+}
+
+void
+stats_aggregator_remove_orphaned_stats(void)
+{
+  g_assert(stats_aggregator_locked);
+
+  g_hash_table_foreach_remove(stats_container.aggregators, _remove_orphaned_helper, NULL);
+}
+
+static gboolean
+_remove_helper(gpointer _key, gpointer _value, gpointer _user_data)
+{
+  StatsAggregator *self = (StatsAggregator *) _value;
+  if (!stats_aggregator_is_orphaned(self))
+    stats_aggregator_unregister(self);
+
+  _free_aggregator(self);
+  return TRUE;
+}
+
+static void
+stats_aggregator_remove_stats(void)
+{
+  g_assert(stats_aggregator_locked);
+
+  g_hash_table_foreach_remove(stats_container.aggregators, _remove_helper, NULL);
+}
+
+static guint
+_stats_cluster_key_hash(const StatsClusterKey *self)
+{
+  return g_str_hash(self->id) + g_str_hash(self->instance) + self->component;
+}
+
+void
+stats_aggregator_registry_init(void)
+{
+  stats_container.aggregators = g_hash_table_new_full((GHashFunc) _stats_cluster_key_hash,
+                                                      (GEqualFunc) stats_cluster_key_equal, NULL, NULL);
+  _init_timer();
+  g_static_mutex_init(&stats_aggregator_mutex);
+}
+
+void
+stats_aggregator_registry_deinit(void)
+{
+  stats_aggregator_lock();
+  stats_aggregator_remove_stats();
+  stats_aggregator_unlock();
+  g_hash_table_destroy(stats_container.aggregators);
+  stats_container.aggregators = NULL;
+  g_static_mutex_free(&stats_aggregator_mutex);
+}
+
+static void
+_insert_to_table(StatsAggregator *value)
+{
+  g_hash_table_insert(stats_container.aggregators, &value->key, value);
+}
+
+static gboolean
+_is_in_table(StatsClusterKey *sc_key)
+{
+  return g_hash_table_lookup(stats_container.aggregators, sc_key) != NULL;
+}
+
+static StatsAggregator *
+_get_from_table(StatsClusterKey *sc_key)
+{
+  return g_hash_table_lookup(stats_container.aggregators, sc_key);
+}
+
+void
+stats_register_aggregator_maximum(gint level, StatsClusterKey *sc_key, StatsAggregator **s)
+{
+  g_assert(stats_aggregator_locked);
+
+  if (!stats_check_level(level))
+    {
+      *s = NULL;
+      return;
+    }
+
+  if (!_is_in_table(sc_key))
+    {
+      *s = stats_aggregator_maximum_new(level, sc_key);
+      _insert_to_table(*s);
+    }
+  else
+    {
+      *s = _get_from_table(sc_key);
+    }
+
+  stats_aggregator_track_counter(*s);
+}
+
+void
+stats_unregister_aggregator_maximum(StatsAggregator **s)
+{
+  g_assert(stats_aggregator_locked);
+  stats_aggregator_untrack_counter(*s);
+  *s = NULL;
+}
+
+void
+stats_register_aggregator_average(gint level, StatsClusterKey *sc_key, StatsAggregator **s)
+{
+  g_assert(stats_aggregator_locked);
+
+  if (!stats_check_level(level))
+    {
+      *s = NULL;
+      return;
+    }
+
+  if (!_is_in_table(sc_key))
+    {
+      *s = stats_aggregator_average_new(level, sc_key);
+      _insert_to_table(*s);
+    }
+  else
+    {
+      *s = _get_from_table(sc_key);
+    }
+
+  stats_aggregator_track_counter(*s);
+}
+
+void
+stats_unregister_aggregator_average(StatsAggregator **s)
+{
+  g_assert(stats_aggregator_locked);
+  stats_aggregator_untrack_counter(*s);
+  *s = NULL;
+}
+
+void
+stats_register_aggregator_cps(gint level, StatsClusterKey *sc_key, StatsCounterItem *counter, StatsAggregator **s)
+{
+  g_assert(stats_aggregator_locked);
+
+  if (!stats_check_level(level))
+    {
+      *s = NULL;
+      return;
+    }
+
+  if (!_is_in_table(sc_key))
+    {
+      *s = stats_aggregator_cps_new(level, sc_key, counter);
+      _insert_to_table(*s);
+    }
+  else
+    {
+      *s = _get_from_table(sc_key);
+    }
+
+  stats_aggregator_track_counter(*s);
+}
+
+void
+stats_unregister_aggregator_cps(StatsAggregator **s)
+{
+  g_assert(stats_aggregator_locked);
+  stats_aggregator_untrack_counter(*s);
+  *s = NULL;
+}
+
+static void
+_reset_func (gpointer _key, gpointer _value, gpointer _user_data)
+{
+  StatsAggregator *self = (StatsAggregator *) _value;
+  stats_aggregator_reset(self);
+}
+
+void
+stats_aggregator_registry_reset(void)
+{
+  g_assert(stats_aggregator_locked);
+
+  g_hash_table_foreach(stats_container.aggregators, _reset_func, NULL);
+}

--- a/lib/stats/aggregator/stats-aggregator-registry.h
+++ b/lib/stats/aggregator/stats-aggregator-registry.h
@@ -44,7 +44,7 @@ void stats_unregister_aggregator_maximum(StatsAggregator **s);
 void stats_register_aggregator_average(gint level, StatsClusterKey *sc_key, StatsAggregator **s);
 void stats_unregister_aggregator_average(StatsAggregator **s);
 
-void stats_register_aggregator_cps(gint level, StatsClusterKey *sc_key, StatsCounterItem *counter,
+void stats_register_aggregator_cps(gint level, StatsClusterKey *sc_key, StatsClusterKey *sc_key_input, gint stats_type,
                                    StatsAggregator **s);
 void stats_unregister_aggregator_cps(StatsAggregator **s);
 

--- a/lib/stats/aggregator/stats-aggregator-registry.h
+++ b/lib/stats/aggregator/stats-aggregator-registry.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef STATS_AGGREGATOR_REGISTRY_H
+#define STATS_AGGREGATOR_REGISTRY_H
+
+#include "stats/aggregator/stats-aggregator.h"
+#include "stats/stats-registry.h"
+#include "syslog-ng.h"
+
+void stats_aggregator_registry_reset(void);
+
+void stats_aggregator_lock(void);
+void stats_aggregator_unlock(void);
+
+void stats_aggregator_registry_init(void);
+void stats_aggregator_registry_deinit(void);
+
+void stats_aggregator_remove_orphaned_stats(void);
+
+void stats_register_aggregator_maximum(gint level, StatsClusterKey *sc_key, StatsAggregator **s);
+void stats_unregister_aggregator_maximum(StatsAggregator **s);
+
+void stats_register_aggregator_average(gint level, StatsClusterKey *sc_key, StatsAggregator **s);
+void stats_unregister_aggregator_average(StatsAggregator **s);
+
+void stats_register_aggregator_cps(gint level, StatsClusterKey *sc_key, StatsCounterItem *counter,
+                                   StatsAggregator **s);
+void stats_unregister_aggregator_cps(StatsAggregator **s);
+
+
+#endif /* STATS_AGGREGATOR_REGISTRY_H */

--- a/lib/stats/aggregator/stats-aggregator.c
+++ b/lib/stats/aggregator/stats-aggregator.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2021 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "stats/aggregator/stats-aggregator.h"
+
+gboolean
+stats_aggregator_is_orphaned(StatsAggregator *self)
+{
+  if (self && self->is_orphaned)
+    return self->is_orphaned(self);
+
+  return TRUE;
+}
+
+void
+stats_aggregator_track_counter(StatsAggregator *self)
+{
+  if (!self)
+    return;
+
+  if (stats_aggregator_is_orphaned(self) && self->register_aggr)
+    self->register_aggr(self);
+
+  ++self->use_count;
+}
+
+void
+stats_aggregator_untrack_counter(StatsAggregator *self)
+{
+  if (!self)
+    return;
+
+  if (self->use_count > 0)
+    --self->use_count;
+
+  if (self->use_count == 0)
+    stats_aggregator_aggregate(self);
+
+  if (stats_aggregator_is_orphaned(self))
+    stats_aggregator_unregister(self);
+}
+
+
+void
+stats_aggregator_insert_data(StatsAggregator *self, gsize value)
+{
+  if (self && self->insert_data)
+    self->insert_data(self, value);
+}
+
+void
+stats_aggregator_aggregate(StatsAggregator *self)
+{
+  if (self && self->aggregate)
+    self->aggregate(self);
+}
+
+void
+stats_aggregator_reset(StatsAggregator *self)
+{
+  if (self && self->reset)
+    self->reset(self);
+}
+
+void
+stats_aggregator_free(StatsAggregator *self)
+{
+  if (self && self->free)
+    self->free(self);
+  stats_cluster_key_cloned_free(&self->key);
+  g_free(self);
+}
+
+static gboolean
+_is_orphaned(StatsAggregator *self)
+{
+  return self->use_count == 0;
+}
+
+static void
+_set_virtual_functions(StatsAggregator *self)
+{
+  self->is_orphaned = _is_orphaned;
+}
+
+void
+stats_aggregator_init_instance(StatsAggregator *self, StatsClusterKey *sc_key, gint stats_level)
+{
+  self->use_count = 0;
+  self->stats_level = stats_level;
+  stats_cluster_key_clone(&self->key, sc_key);
+  _set_virtual_functions(self);
+}
+
+void
+stats_aggregator_unregister(StatsAggregator *self)
+{
+  if (self && self->unregister_aggr)
+    self->unregister_aggr(self);
+}

--- a/lib/stats/aggregator/stats-aggregator.h
+++ b/lib/stats/aggregator/stats-aggregator.h
@@ -63,6 +63,7 @@ StatsAggregator *stats_aggregator_maximum_new(gint level, StatsClusterKey *sc_ke
 
 StatsAggregator *stats_aggregator_average_new(gint level, StatsClusterKey *sc_key);
 
-StatsAggregator *stats_aggregator_cps_new(gint level, StatsClusterKey *sc_key, StatsCounterItem *counter);
+StatsAggregator *stats_aggregator_cps_new(gint level, StatsClusterKey *sc_key, StatsClusterKey *sc_key_input,
+                                          gint stats_type);
 
 #endif /* STATS_AGGREGATOR_H */

--- a/lib/stats/aggregator/stats-aggregator.h
+++ b/lib/stats/aggregator/stats-aggregator.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2021 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef STATS_AGGREGATOR_H
+#define STATS_AGGREGATOR_H
+
+#include "stats/stats-counter.h"
+#include "syslog-ng.h"
+#include "stats/stats-cluster.h"
+
+typedef struct _StatsAggregator StatsAggregator;
+
+struct _StatsAggregator
+{
+  void (*insert_data)(StatsAggregator *self, gsize value);
+  void (*aggregate)(StatsAggregator *self);
+  void (*reset)(StatsAggregator *self);
+  void (*free)(StatsAggregator *self);
+  gboolean (*is_orphaned)(StatsAggregator *self);
+
+  void (*register_aggr)(StatsAggregator *self);
+  void (*unregister_aggr)(StatsAggregator *self);
+
+  gssize use_count;
+  StatsClusterKey key;
+  gint stats_level;
+};
+
+/* public */
+void stats_aggregator_insert_data(StatsAggregator *self, gsize value);
+void stats_aggregator_aggregate(StatsAggregator *self);
+void stats_aggregator_reset(StatsAggregator *self);
+
+/* stats-internals */
+gboolean stats_aggregator_is_orphaned(StatsAggregator *self);
+void stats_aggregator_track_counter(StatsAggregator *self);
+void stats_aggregator_untrack_counter(StatsAggregator *self);
+void stats_aggregator_free(StatsAggregator *self);
+void stats_aggregator_init_instance(StatsAggregator *self, StatsClusterKey *sc_key, gint stats_level);
+void stats_aggregator_unregister(StatsAggregator *self);
+
+
+#endif /* STATS_AGGREGATOR_H */

--- a/lib/stats/aggregator/stats-aggregator.h
+++ b/lib/stats/aggregator/stats-aggregator.h
@@ -63,4 +63,6 @@ StatsAggregator *stats_aggregator_maximum_new(gint level, StatsClusterKey *sc_ke
 
 StatsAggregator *stats_aggregator_average_new(gint level, StatsClusterKey *sc_key);
 
+StatsAggregator *stats_aggregator_cps_new(gint level, StatsClusterKey *sc_key, StatsCounterItem *counter);
+
 #endif /* STATS_AGGREGATOR_H */

--- a/lib/stats/aggregator/stats-aggregator.h
+++ b/lib/stats/aggregator/stats-aggregator.h
@@ -59,5 +59,6 @@ void stats_aggregator_free(StatsAggregator *self);
 void stats_aggregator_init_instance(StatsAggregator *self, StatsClusterKey *sc_key, gint stats_level);
 void stats_aggregator_unregister(StatsAggregator *self);
 
+StatsAggregator *stats_aggregator_maximum_new(gint level, StatsClusterKey *sc_key);
 
 #endif /* STATS_AGGREGATOR_H */

--- a/lib/stats/aggregator/stats-aggregator.h
+++ b/lib/stats/aggregator/stats-aggregator.h
@@ -61,4 +61,6 @@ void stats_aggregator_unregister(StatsAggregator *self);
 
 StatsAggregator *stats_aggregator_maximum_new(gint level, StatsClusterKey *sc_key);
 
+StatsAggregator *stats_aggregator_average_new(gint level, StatsClusterKey *sc_key);
+
 #endif /* STATS_AGGREGATOR_H */

--- a/lib/stats/aggregator/stats-average.c
+++ b/lib/stats/aggregator/stats-average.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2021 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "stats/aggregator/stats-aggregator.h"
+#include "stats/stats-registry.h"
+#include "stats/stats-cluster-single.h"
+
+typedef struct
+{
+  StatsAggregator super;
+  StatsCounterItem *output_counter;
+  atomic_gssize count;
+  atomic_gssize sum;
+} StatsAggregatorAverage;
+
+static inline void
+_inc_count(StatsAggregatorAverage *self)
+{
+  atomic_gssize_inc(&self->count);
+}
+
+static inline void
+_add_sum(StatsAggregatorAverage *self, gsize value)
+{
+  atomic_gssize_add(&self->sum, value);
+}
+
+static inline gsize
+_get_sum(StatsAggregatorAverage *self)
+{
+  return atomic_gssize_get_unsigned(&self->sum);
+}
+
+static inline gsize
+_get_count(StatsAggregatorAverage *self)
+{
+  return atomic_gssize_get_unsigned(&self->count);
+}
+
+static void
+_insert_data(StatsAggregator *s, gsize value)
+{
+  StatsAggregatorAverage *self = (StatsAggregatorAverage *)s;
+  /*
+   * this function isn't truely atomic, reset might set count to zero
+   * and we want to avoid zero division
+   */
+  gsize sum = _get_sum(self) + value;
+  gsize divisor = _get_count(self) + 1;
+
+  stats_counter_set(self->output_counter, sum/divisor);
+
+  _add_sum(self, value);
+  _inc_count(self);
+}
+
+static void
+_reset(StatsAggregator *s)
+{
+  StatsAggregatorAverage *self = (StatsAggregatorAverage *)s;
+  atomic_gssize_set(&self->count, 0);
+  atomic_gssize_set(&self->sum, 0);
+  stats_counter_set(self->output_counter, 0);
+}
+
+static void
+_register(StatsAggregator *s)
+{
+  StatsAggregatorAverage *self = (StatsAggregatorAverage *)s;
+
+  stats_lock();
+  stats_register_counter(self->super.stats_level, &self->super.key, SC_TYPE_SINGLE_VALUE, &self->output_counter);
+  stats_unlock();
+}
+
+static void
+_unregister(StatsAggregator *s)
+{
+  StatsAggregatorAverage *self = (StatsAggregatorAverage *)s;
+
+  if(self->output_counter)
+    {
+      stats_lock();
+      stats_unregister_counter(&self->super.key, SC_TYPE_SINGLE_VALUE, &self->output_counter);
+      self->output_counter = NULL;
+      stats_unlock();
+    }
+}
+
+static void
+_set_virtual_function(StatsAggregatorAverage *self )
+{
+  self->super.insert_data = _insert_data;
+  self->super.reset = _reset;
+  self->super.register_aggr = _register;
+  self->super.unregister_aggr = _unregister;
+}
+
+
+StatsAggregator *
+stats_aggregator_average_new(gint level, StatsClusterKey *sc_key)
+{
+  StatsAggregatorAverage *self = g_new0(StatsAggregatorAverage, 1);
+  stats_aggregator_init_instance(&self->super, sc_key, level);
+  _set_virtual_function(self);
+
+  return &self->super;
+}

--- a/lib/stats/aggregator/stats-change-per-second.c
+++ b/lib/stats/aggregator/stats-change-per-second.c
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) 2021 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "stats/aggregator/stats-aggregator.h"
+#include "timeutils/cache.h"
+#include "stats/stats-registry.h"
+#include "stats/stats-cluster-single.h"
+#include "timeutils/cache.h"
+#include "stats/stats-cluster.h"
+#include <math.h>
+
+#define HOUR_IN_SEC 3600 /* 60*60 */
+#define DAY_IN_SEC 86400 /* 60*60*24 */
+
+typedef struct
+{
+  StatsCounterItem *output_counter;
+  atomic_gssize average;
+  atomic_gssize sum;
+  atomic_gssize last_count;
+
+  gssize duration; /* if the duration equals -1, thats mean, it count since syslog start */
+  gchar *name;
+} CPSLogic;
+/* CPS == Change Per Second */
+
+typedef struct
+{
+  StatsAggregator super;
+  time_t init_time;
+  time_t last_add_time;
+
+  StatsCounterItem *input_counter;
+
+  CPSLogic hour;
+  CPSLogic day;
+  CPSLogic start;
+} StatsAggregatorCPS;
+
+static inline gsize
+_get_count(StatsAggregatorCPS *self)
+{
+  return stats_counter_get(self->input_counter);
+}
+
+static inline void
+_set_sum(CPSLogic *self, gsize set)
+{
+  atomic_gssize_set(&self->sum, set);
+}
+
+static inline void
+_add_to_sum(CPSLogic *self, gsize value)
+{
+  atomic_gssize_add(&self->sum, value);
+}
+
+static inline gsize
+_get_sum(CPSLogic *self)
+{
+  return atomic_gssize_get_unsigned(&self->sum);
+}
+
+static inline void
+_set_average(CPSLogic *self, gsize set)
+{
+  atomic_gssize_set(&self->average, set);
+}
+
+static inline gsize
+_get_average(CPSLogic *self)
+{
+  return atomic_gssize_get_unsigned(&self->average);
+}
+
+static inline void
+_set_last_count(CPSLogic *self, gsize set)
+{
+  atomic_gssize_set(&self->last_count, set);
+}
+
+static inline gsize
+_get_last_count(CPSLogic *self)
+{
+  return atomic_gssize_get_unsigned(&self->last_count);
+}
+
+static void
+_reset_CPS_logic_values(CPSLogic *self)
+{
+  _set_average(self, 0);
+  _set_sum(self, 0);
+  _set_last_count(self, 0);
+  stats_counter_set(self->output_counter, 0);
+}
+
+static void
+_register_CPS(CPSLogic *self, StatsClusterKey *sc_key, gint level, gint type)
+{
+  if(!self->output_counter)
+    stats_register_counter(level, sc_key, type, &self->output_counter);
+}
+
+static void
+_register_CPSs(StatsAggregatorCPS *self)
+{
+  stats_lock();
+  StatsClusterKey sc_key;
+
+  self->hour.name = g_strconcat(self->super.key.counter_group_init.counter.name, "_last_1h", NULL);
+  stats_cluster_single_key_set_with_name(&sc_key, self->super.key.component, self->super.key.id, self->super.key.instance,
+                                         self->hour.name);
+  _register_CPS(&self->hour, &sc_key, self->super.stats_level, SC_TYPE_SINGLE_VALUE);
+
+  self->day.name = g_strconcat(self->super.key.counter_group_init.counter.name, "_last_24h", NULL);
+  stats_cluster_single_key_set_with_name(&sc_key, self->super.key.component, self->super.key.id, self->super.key.instance,
+                                         self->day.name);
+  _register_CPS(&self->day, &sc_key, self->super.stats_level, SC_TYPE_SINGLE_VALUE);
+
+  self->start.name = g_strconcat(self->super.key.counter_group_init.counter.name, "_since_start", NULL);
+  stats_cluster_single_key_set_with_name(&sc_key, self->super.key.component, self->super.key.id, self->super.key.instance,
+                                         self->start.name);
+  _register_CPS(&self->start, &sc_key, self->super.stats_level, SC_TYPE_SINGLE_VALUE);
+
+  stats_unlock();
+}
+
+static void
+_register(StatsAggregator *s)
+{
+  StatsAggregatorCPS *self = (StatsAggregatorCPS *)s;
+  _register_CPSs(self);
+  // track input counter
+}
+
+static void
+_unregister_CPS(CPSLogic *self, StatsClusterKey *sc_key, gint type)
+{
+  stats_unregister_counter(sc_key, type, &self->output_counter);
+  self->output_counter = NULL;
+}
+
+static void
+_unregister_CPSs(StatsAggregatorCPS *self)
+{
+  stats_lock();
+  StatsClusterKey sc_key;
+
+  stats_cluster_single_key_set_with_name(&sc_key, self->super.key.component, self->super.key.id, self->super.key.instance,
+                                         self->hour.name);
+  _unregister_CPS(&self->hour, &sc_key, SC_TYPE_SINGLE_VALUE);
+  g_free(self->hour.name);
+  self->hour.name = NULL;
+
+  stats_cluster_single_key_set_with_name(&sc_key, self->super.key.component, self->super.key.id, self->super.key.instance,
+                                         self->day.name);
+  _unregister_CPS(&self->day, &sc_key, SC_TYPE_SINGLE_VALUE);
+  g_free(self->day.name);
+  self->day.name = NULL;
+
+  stats_cluster_single_key_set_with_name(&sc_key, self->super.key.component, self->super.key.id, self->super.key.instance,
+                                         self->start.name);
+  _unregister_CPS(&self->start, &sc_key, SC_TYPE_SINGLE_VALUE);
+  g_free(self->start.name);
+  self->start.name = NULL;
+
+  stats_unlock();
+}
+
+static void
+_unregister(StatsAggregator *s)
+{
+  StatsAggregatorCPS *self = (StatsAggregatorCPS *)s;
+  _unregister_CPSs(self);
+  // untrack input counter
+}
+
+static inline gdouble
+_calc_sec_between_time(time_t *start, time_t *end)
+{
+  return (difftime(*end, *start));
+}
+
+static gboolean
+_is_less_then_duration(StatsAggregatorCPS *self, CPSLogic *logic, time_t *now)
+{
+  if (logic->duration == -1)
+    return TRUE;
+
+  return _calc_sec_between_time(&self->init_time, now) <= logic->duration;
+}
+
+static void
+_calc_sum(StatsAggregatorCPS *self, CPSLogic *logic, time_t *now)
+{
+  gsize diff = _get_count(self) - _get_last_count(logic);
+  _set_last_count(logic, _get_count(self));
+
+  if (!_is_less_then_duration(self, logic, now))
+    {
+      gsize elapsed_time_since_last = (gsize)_calc_sec_between_time(&self->last_add_time, now);
+      diff -= _get_average(logic) * elapsed_time_since_last;
+    }
+
+  _add_to_sum(logic, diff);
+  self->last_add_time = *now;
+}
+
+static void
+_calc_average(StatsAggregatorCPS *self, CPSLogic *logic, time_t *now)
+{
+  gsize elapsed_time = (gsize)_calc_sec_between_time(&self->init_time, now);
+  gsize to_divide = (_is_less_then_duration(self, logic, now)) ? elapsed_time : logic->duration;
+  if (to_divide <= 0) to_divide = 1;
+
+  _set_average(logic, (_get_sum(logic) / to_divide));
+}
+
+static void
+_aggregate_CPS_logic(StatsAggregatorCPS *self, CPSLogic *logic, time_t *now)
+{
+  _calc_sum(self, logic, now);
+  _calc_average(self, logic, now);
+  stats_counter_set(logic->output_counter, _get_average(logic));
+}
+
+static void
+_aggregate(StatsAggregator *s)
+{
+  StatsAggregatorCPS *self = (StatsAggregatorCPS *)s;
+
+  time_t now = cached_g_current_time_sec();
+  _aggregate_CPS_logic(self, &self->hour, &now);
+  _aggregate_CPS_logic(self, &self->day, &now);
+  _aggregate_CPS_logic(self, &self->start, &now);
+
+  if (stats_aggregator_is_orphaned(self))
+    {
+      _unregister(s);
+    }
+}
+
+static void
+_set_values(StatsAggregatorCPS *self, StatsCounterItem *input_counter)
+{
+  self->init_time = cached_g_current_time_sec();
+  self->last_add_time = 0;
+  self->input_counter = input_counter;
+}
+
+static void
+_reset(StatsAggregator *s)
+{
+  StatsAggregatorCPS *self = (StatsAggregatorCPS *)s;
+  _set_values(self, self->input_counter);
+  _reset_CPS_logic_values(&self->hour);
+  _reset_CPS_logic_values(&self->day);
+  _reset_CPS_logic_values(&self->start);
+}
+
+static gboolean
+_is_orphaned_CPSLogic(CPSLogic *self)
+{
+  return stats_counter_get(self->output_counter) == 0;
+}
+
+static gboolean
+_is_orphaned(StatsAggregator *s)
+{
+  StatsAggregatorCPS *self = (StatsAggregatorCPS *)s;
+  return s->use_count == 0 && _is_orphaned_CPSLogic(&self->day) && _is_orphaned_CPSLogic(&self->hour)
+         && _is_orphaned_CPSLogic(&self->start);
+}
+
+static void
+_set_virtual_function(StatsAggregatorCPS *self )
+{
+  self->super.aggregate = _aggregate;
+  self->super.reset = _reset;
+  self->super.is_orphaned = _is_orphaned;
+  self->super.register_aggr = _register;
+  self->super.unregister_aggr = _unregister;
+}
+
+
+StatsAggregator *
+stats_aggregator_cps_new(gint level, StatsClusterKey *sc_key, StatsCounterItem *input_counter)
+{
+  StatsAggregatorCPS *self = g_new0(StatsAggregatorCPS, 1);
+  stats_aggregator_init_instance(&self->super, sc_key, level);
+  _set_virtual_function(self);
+  _set_values(self, input_counter);
+
+  self->hour.duration = HOUR_IN_SEC;
+  self->day.duration = DAY_IN_SEC;
+  self->start.duration = -1;
+
+  return &self->super;
+}

--- a/lib/stats/aggregator/stats-maximum.c
+++ b/lib/stats/aggregator/stats-maximum.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "stats/aggregator/stats-aggregator.h"
+#include "stats/stats-registry.h"
+#include "stats/stats-cluster-single.h"
+
+typedef struct
+{
+  StatsAggregator super;
+  StatsCounterItem *output_counter;
+} StatsAggregatorMaximum;
+
+static void
+_insert_data(StatsAggregator *s, gsize value)
+{
+  StatsAggregatorMaximum *self = (StatsAggregatorMaximum *)s;
+  gsize current_max = 0;
+
+  do
+    {
+      current_max = stats_counter_get(self->output_counter);
+
+      if (current_max >= value)
+        break;
+
+    }
+  while(!atomic_gssize_compare_and_exchange(&self->output_counter->value, current_max, value));
+}
+
+static void
+_register(StatsAggregator *s)
+{
+  StatsAggregatorMaximum *self = (StatsAggregatorMaximum *)s;
+  stats_lock();
+  stats_register_counter(self->super.stats_level, &self->super.key, SC_TYPE_SINGLE_VALUE, &self->output_counter);
+  stats_unlock();
+}
+
+static void
+_unregister(StatsAggregator *s)
+{
+  StatsAggregatorMaximum *self = (StatsAggregatorMaximum *)s;
+
+  if(self->output_counter)
+    {
+      stats_lock();
+      stats_unregister_counter(&self->super.key, SC_TYPE_SINGLE_VALUE, &self->output_counter);
+      self->output_counter = NULL;
+      stats_unlock();
+    }
+}
+
+static void
+_set_virtual_function(StatsAggregatorMaximum *self)
+{
+  self->super.insert_data = _insert_data;
+  self->super.register_aggr = _register;
+  self->super.unregister_aggr = _unregister;
+}
+
+StatsAggregator *
+stats_aggregator_maximum_new(gint level, StatsClusterKey *sc_key)
+{
+  StatsAggregatorMaximum *self = g_new0(StatsAggregatorMaximum, 1);
+  stats_aggregator_init_instance(&self->super, sc_key, level);
+  _set_virtual_function(self);
+
+  return &self->super;
+}

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -78,8 +78,8 @@ stats_cluster_deinit(void)
   stats_types = NULL;
 }
 
-static StatsClusterKey *
-_clone_stats_cluster_key(StatsClusterKey *dst, const StatsClusterKey *src)
+StatsClusterKey *
+stats_cluster_key_clone(StatsClusterKey *dst, const StatsClusterKey *src)
 {
   dst->component = src->component;
   dst->id = g_strdup(src->id ? : "");
@@ -103,8 +103,8 @@ stats_cluster_key_set(StatsClusterKey *self, guint16 component, const gchar *id,
   self->counter_group_init = counter_group_init;
 }
 
-static void
-_stats_cluster_key_cloned_free(StatsClusterKey *self)
+void
+stats_cluster_key_cloned_free(StatsClusterKey *self)
 {
   g_free((gchar *)(self->id));
   g_free((gchar *)(self->instance));
@@ -295,7 +295,7 @@ stats_cluster_new(const StatsClusterKey *key)
 {
   StatsCluster *self = g_new0(StatsCluster, 1);
 
-  _clone_stats_cluster_key(&self->key, key);
+  stats_cluster_key_clone(&self->key, key);
   self->use_count = 0;
   self->query_key = _stats_build_query_key(self);
   key->counter_group_init.init(&self->key.counter_group_init, &self->counter_group);
@@ -330,7 +330,7 @@ void
 stats_cluster_free(StatsCluster *self)
 {
   stats_cluster_foreach_counter(self, stats_cluster_free_counter, NULL);
-  _stats_cluster_key_cloned_free(&self->key);
+  stats_cluster_key_cloned_free(&self->key);
   g_free(self->query_key);
   stats_counter_group_free(&self->counter_group);
   g_free(self);

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -114,6 +114,8 @@ const gchar *stats_cluster_get_component_name(StatsCluster *self, gchar *buf, gs
 
 void stats_cluster_foreach_counter(StatsCluster *self, StatsForeachCounterFunc func, gpointer user_data);
 
+StatsClusterKey *stats_cluster_key_clone(StatsClusterKey *dst, const StatsClusterKey *src);
+void stats_cluster_key_cloned_free(StatsClusterKey *self);
 gboolean stats_cluster_key_equal(const StatsClusterKey *key1, const StatsClusterKey *key2);
 gboolean stats_cluster_equal(const StatsCluster *sc1, const StatsCluster *sc2);
 guint stats_cluster_hash(const StatsCluster *self);

--- a/lib/stats/stats-control.c
+++ b/lib/stats/stats-control.c
@@ -27,6 +27,7 @@
 #include "stats/stats-counter.h"
 #include "stats/stats-registry.h"
 #include "stats/stats-cluster.h"
+#include "stats/aggregator/stats-aggregator-registry.h"
 #include "stats/stats-query-commands.h"
 #include "control/control-commands.h"
 #include "control/control-server.h"
@@ -59,6 +60,9 @@ _reset_counters(void)
   stats_lock();
   stats_foreach_counter(_reset_counter_if_needed, NULL);
   stats_unlock();
+  stats_aggregator_lock();
+  stats_aggregator_registry_reset();
+  stats_aggregator_unlock();
 }
 
 static GString *
@@ -96,6 +100,9 @@ control_connection_remove_orphans(ControlConnection *cc, GString *command, gpoin
 {
   GString *result = g_string_new("OK Orphaned statistics have been removed.");
 
+  stats_aggregator_lock();
+  stats_aggregator_remove_orphaned_stats();
+  stats_aggregator_unlock();
   stats_lock();
   stats_foreach_cluster_remove(_is_cluster_orphaned, NULL);
   stats_unlock();

--- a/lib/stats/stats-registry.c
+++ b/lib/stats/stats-registry.c
@@ -336,8 +336,8 @@ stats_unregister_dynamic_counter(StatsCluster *sc, gint type, StatsCounterItem *
   stats_cluster_untrack_counter(sc, type, counter);
 }
 
-static StatsCluster *
-_lookup_cluster(const StatsClusterKey *sc_key)
+StatsCluster *
+stats_get_cluster(const StatsClusterKey *sc_key)
 {
   g_assert(stats_locked);
 
@@ -354,7 +354,7 @@ stats_contains_counter(const StatsClusterKey *sc_key, gint type)
 {
   g_assert(stats_locked);
 
-  StatsCluster *sc = _lookup_cluster(sc_key);
+  StatsCluster *sc = stats_get_cluster(sc_key);
   if (!sc)
     {
       return FALSE;
@@ -367,7 +367,7 @@ StatsCounterItem *
 stats_get_counter(const StatsClusterKey *sc_key, gint type)
 {
   g_assert(stats_locked);
-  StatsCluster *sc = _lookup_cluster(sc_key);
+  StatsCluster *sc = stats_get_cluster(sc_key);
 
   if (!sc)
     return NULL;

--- a/lib/stats/stats-registry.h
+++ b/lib/stats/stats-registry.h
@@ -55,6 +55,7 @@ void stats_unregister_dynamic_counter(StatsCluster *handle, gint type, StatsCoun
 
 gboolean stats_contains_counter(const StatsClusterKey *sc_key, gint type);
 StatsCounterItem *stats_get_counter(const StatsClusterKey *sc_key, gint type);
+StatsCluster *stats_get_cluster(const StatsClusterKey *sc_key);
 
 void stats_foreach_counter(StatsForeachCounterFunc func, gpointer user_data);
 void stats_foreach_cluster(StatsForeachClusterFunc func, gpointer user_data);

--- a/lib/stats/stats.c
+++ b/lib/stats/stats.c
@@ -26,6 +26,7 @@
 #include "stats/stats-log.h"
 #include "stats/stats-query.h"
 #include "stats/stats-registry.h"
+#include "stats/aggregator/stats-aggregator-registry.h"
 #include "stats/stats.h"
 #include "timeutils/cache.h"
 #include "timeutils/misc.h"
@@ -238,6 +239,7 @@ stats_init(void)
 {
   stats_cluster_init();
   stats_registry_init();
+  stats_aggregator_registry_init();
   stats_query_init();
 }
 
@@ -245,6 +247,7 @@ void
 stats_destroy(void)
 {
   stats_query_deinit();
+  stats_aggregator_registry_deinit();
   stats_registry_deinit();
   stats_cluster_deinit();
 }

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -672,6 +672,9 @@ _flush(LogThreadedDestWorker *s, LogThreadedFlushMode mode)
       retval = _flush_on_target(self, target);
       if (retval == LTR_SUCCESS)
         {
+          gsize msg_length = self->request_body->len;
+          log_threaded_dest_driver_insert_batch_length_stats(self->super.owner, msg_length);
+
           http_load_balancer_set_target_successful(owner->load_balancer, target);
           break;
         }
@@ -718,7 +721,10 @@ _insert_batched(LogThreadedDestWorker *s, LogMessage *msg)
 {
   HTTPDestinationWorker *self = (HTTPDestinationWorker *) s;
 
+  gsize orig_msg_len = self->request_body->len;
   _add_message_to_batch(self, msg);
+  gsize diff_msg_len = self->request_body->len - orig_msg_len;
+  log_threaded_dest_driver_insert_msg_length_stats(self->super.owner, diff_msg_len);
 
   if (_should_initiate_flush(self))
     {
@@ -732,7 +738,11 @@ _insert_single(LogThreadedDestWorker *s, LogMessage *msg)
 {
   HTTPDestinationWorker *self = (HTTPDestinationWorker *) s;
 
+  gsize orig_msg_len = self->request_body->len;
   _add_message_to_batch(self, msg);
+  gsize diff_msg_len = self->request_body->len - orig_msg_len;
+  log_threaded_dest_driver_insert_msg_length_stats(self->super.owner, diff_msg_len);
+
   _add_msg_specific_headers(self, msg);
 
   return log_threaded_dest_worker_flush(&self->super, LTF_FLUSH_NORMAL);

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -324,6 +324,8 @@ _format_stats_instance(LogThreadedDestDriver *s)
 gboolean
 http_dd_deinit(LogPipe *s)
 {
+  HTTPDestinationDriver *self = (HTTPDestinationDriver *)s;
+  log_threaded_dest_driver_unregister_aggregated_stats(&self->super);
   return log_threaded_dest_driver_deinit_method(s);
 }
 
@@ -364,6 +366,7 @@ http_dd_init(LogPipe *s)
 
   http_load_balancer_set_recovery_timeout(self->load_balancer, self->super.time_reopen);
 
+  log_threaded_dest_driver_register_aggregated_stats(&self->super);
   return TRUE;
 }
 

--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -265,6 +265,7 @@ _handle_message(JournalReader *self)
   gpointer args[] = {msg, self->options};
 
   journald_foreach_data(self->journal, _handle_data, args);
+
   _set_message_timestamp(self, msg);
   _set_program(self->options, msg);
 


### PR DESCRIPTION
Create average/largest message size && EPS stats for 
source (important sources: network, syslog, tcp, udp) and
destination (important destination: network, syslog, tcp, upd, file, logstore, http)

Created new API for stats (can be create new aggregated stats later - for example: minimum message size)

This feature should work for every non threaded source/destination and for http threaded destiantion