### PR TITLE
disk-buffer: add qout-like memory queue to reliable disk-buffer

### DIFF
--- a/modules/diskq/diskq-options.c
+++ b/modules/diskq/diskq-options.c
@@ -29,14 +29,6 @@
 void
 disk_queue_options_qout_size_set(DiskQueueOptions *self, gint qout_size)
 {
-  if (qout_size < 64)
-    {
-      msg_warning("WARNING: The configured qout size is smaller than the minimum allowed",
-                  evt_tag_int("configured_size", qout_size),
-                  evt_tag_int("minimum_allowed_size", 64),
-                  evt_tag_int("new_size", 64));
-      qout_size = 64;
-    }
   self->qout_size = qout_size;
 }
 
@@ -146,5 +138,3 @@ disk_queue_options_destroy(DiskQueueOptions *self)
       self->dir = NULL;
     }
 }
-
-

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -278,10 +278,6 @@ _pop_head(LogQueue *s, LogPathOptions *path_options)
     }
 
   msg = log_queue_disk_read_message(&self->super, path_options);
-  if (msg)
-    {
-      path_options->ack_needed = FALSE;
-    }
 
 exit:
   if (!msg)

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -251,17 +251,17 @@ _pop_head(LogQueue *s, LogPathOptions *path_options)
           log_msg_ref(msg);
           _push_to_memory_queue_tail(self->qbacklog, position, msg, path_options);
         }
+
+      goto exit;
     }
 
-  if (msg == NULL)
+  msg = log_queue_disk_read_message(&self->super, path_options);
+  if (msg)
     {
-      msg = log_queue_disk_read_message(&self->super, path_options);
-      if (msg)
-        {
-          path_options->ack_needed = FALSE;
-        }
+      path_options->ack_needed = FALSE;
     }
 
+exit:
   if (msg != NULL)
     {
       if (s->use_backlog)

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -438,6 +438,7 @@ log_queue_disk_reliable_new(DiskQueueOptions *options, const gchar *persist_name
   self->qreliable = g_queue_new();
   self->qbacklog = g_queue_new();
   self->qout = g_queue_new();
+  self->qout_size = options->qout_size;
   _set_virtual_functions(self);
   return &self->super.super;
 }

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -230,6 +230,15 @@ _is_next_message_in_qreliable(LogQueueDiskReliable *self)
   return _peek_memory_queue_head_position(self->qreliable) == qdisk_get_head_position(self->super.qdisk);
 }
 
+static inline gboolean
+_is_next_message_in_qout(LogQueueDiskReliable *self)
+{
+  if (self->qout->length == 0)
+    return FALSE;
+
+  return _peek_memory_queue_head_position(self->qout) == qdisk_get_head_position(self->super.qdisk);
+}
+
 static LogMessage *
 _pop_head(LogQueue *s, LogPathOptions *path_options)
 {
@@ -358,6 +367,8 @@ _free(LogQueue *s)
   self->qreliable = NULL;
   g_queue_free(self->qbacklog);
   self->qbacklog = NULL;
+  g_queue_free(self->qout);
+  self->qout = NULL;
 
   log_queue_disk_free_method(&self->super);
 }
@@ -426,6 +437,7 @@ log_queue_disk_reliable_new(DiskQueueOptions *options, const gchar *persist_name
     }
   self->qreliable = g_queue_new();
   self->qbacklog = g_queue_new();
+  self->qout = g_queue_new();
   _set_virtual_functions(self);
   return &self->super.super;
 }

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -39,6 +39,14 @@ _push_to_memory_queue_tail(GQueue *queue, gint64 *position, LogMessage *msg, con
   g_queue_push_tail(queue, LOG_PATH_OPTIONS_TO_POINTER(path_options));
 }
 
+static inline void
+_pop_from_memory_queue_head(GQueue *queue, gint64 **position, LogMessage **msg, LogPathOptions *path_options)
+{
+  *position = g_queue_pop_head(queue);
+  *msg = g_queue_pop_head(queue);
+  POINTER_TO_LOG_PATH_OPTIONS(g_queue_pop_head(queue), path_options);
+}
+
 static gboolean
 _start(LogQueueDisk *s, const gchar *filename)
 {
@@ -59,11 +67,10 @@ _empty_queue(GQueue *self)
 {
   while (self && self->length > 0)
     {
+      gint64 *temppos;
+      LogMessage *msg;
       LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
-
-      gint64 *temppos = g_queue_pop_head(self);
-      LogMessage *msg = g_queue_pop_head(self);
-      POINTER_TO_LOG_PATH_OPTIONS(g_queue_pop_head(self), &path_options);
+      _pop_from_memory_queue_head(self, &temppos, &msg, &path_options);
 
       g_free(temppos);
       log_msg_drop(msg, &path_options, AT_PROCESSED);

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -292,7 +292,7 @@ _push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
       /* we were not able to store the msg, warn */
       msg_error("Destination reliable queue full, dropping message",
                 evt_tag_str("filename", qdisk_get_filename(self->super.qdisk)),
-                evt_tag_long("queue_len", _get_length(s)),
+                evt_tag_long("queue_len", log_queue_get_length(s)),
                 evt_tag_int("mem_buf_size", qdisk_get_memory_size(self->super.qdisk)),
                 evt_tag_long("disk_buf_size", qdisk_get_maximum_size(self->super.qdisk)),
                 evt_tag_str("persist_name", s->persist_name));

--- a/modules/diskq/logqueue-disk-reliable.h
+++ b/modules/diskq/logqueue-disk-reliable.h
@@ -31,6 +31,7 @@ typedef struct _LogQueueDiskReliable
   LogQueueDisk super;
   GQueue *qreliable;
   GQueue *qbacklog;
+  GQueue *qout;
 } LogQueueDiskReliable;
 
 LogQueue *log_queue_disk_reliable_new(DiskQueueOptions *options, const gchar *persist_name);

--- a/modules/diskq/logqueue-disk-reliable.h
+++ b/modules/diskq/logqueue-disk-reliable.h
@@ -32,6 +32,7 @@ typedef struct _LogQueueDiskReliable
   GQueue *qreliable;
   GQueue *qbacklog;
   GQueue *qout;
+  gint qout_size;
 } LogQueueDiskReliable;
 
 LogQueue *log_queue_disk_reliable_new(DiskQueueOptions *options, const gchar *persist_name);

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -143,6 +143,10 @@ log_queue_disk_read_message(LogQueueDisk *self, LogPathOptions *path_options)
         }
     }
   while (msg == NULL);
+
+  if (msg)
+    path_options->ack_needed = FALSE;
+
   return msg;
 }
 

--- a/news/feature-3754.md
+++ b/news/feature-3754.md
@@ -1,0 +1,10 @@
+`disk-buffer`: Added a new option to reliable disk-buffer: `qout-size()`.
+
+This option sets the number of messages that are stored in the memory in addition
+to storing them on disk. The default value is 1000.
+
+This serves performance purposes and offers the same no-message-loss guarantees as
+before.
+
+It can be used to maintain a higher throughput when only a small number of messages
+are waiting in the disk-buffer.


### PR DESCRIPTION
This PR adds a fast-path memory queue implementation to the reliable disk-buffer, which can save time, when messages are coming in with a smaller rate, similarly to the qout memory queue in the non-reliable disk-buffer.

This queue still guarantees, that all the received messages are written to the disk as soon as possible.

Also added `qout-size()` option to reliable disk-buffer, which limits the number of messages in the new memory queue.

---

The idea behind this improvement, is that if there is space in qout, additionally to storing the serialized message on the disk, we store the message in memory, too. When we arrive to that message on the disk, we do not read it from the disk, and we do not deserialize it, but use the one, stored in the memory, and skip the one on the disk.

---

**Performance gain:**
On my computer, I tested different input message rates, and checked, which is the highest, that the disk-buffer can follow with the queued counter staying near 0:
 * master: ~60k msg/sec
 * This PR with `qout-size(100000)`: ~80k msg/sec

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>
