### PR TITLE
Perf improvement and refactor for the non-reliable disk buffer

### DIFF
--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -104,10 +104,10 @@ _get_next_message(LogQueueDiskNonReliable *self, LogPathOptions *path_options)
 {
   LogMessage *result = NULL;
   path_options->ack_needed = TRUE;
-  if (qdisk_get_length (self->super.qdisk) > 0)
+  if (qdisk_get_length(self->super.qdisk) > 0)
     {
       result = log_queue_disk_read_message(&self->super, path_options);
-      if(result)
+      if (result)
         {
           log_queue_memory_usage_add(&self->super.super, log_msg_get_size(result));
           path_options->ack_needed = FALSE;
@@ -115,8 +115,8 @@ _get_next_message(LogQueueDiskNonReliable *self, LogPathOptions *path_options)
     }
   else if (self->qoverflow->length > 0)
     {
-      result = g_queue_pop_head (self->qoverflow);
-      POINTER_TO_LOG_PATH_OPTIONS (g_queue_pop_head (self->qoverflow), path_options);
+      result = g_queue_pop_head(self->qoverflow);
+      POINTER_TO_LOG_PATH_OPTIONS(g_queue_pop_head(self->qoverflow), path_options);
     }
   return result;
 }
@@ -134,17 +134,17 @@ _add_message_to_qout(LogQueueDiskNonReliable *self, LogMessage *msg, LogPathOpti
   /* NOTE: we always generate flow-control disabled entries into
    * qout, they only get there via backlog rewind */
 
-  g_queue_push_tail (self->qout, msg);
-  g_queue_push_tail (self->qout, LOG_PATH_OPTIONS_FOR_BACKLOG);
-  log_msg_ack (msg, path_options, AT_PROCESSED);
+  g_queue_push_tail(self->qout, msg);
+  g_queue_push_tail(self->qout, LOG_PATH_OPTIONS_FOR_BACKLOG);
+  log_msg_ack(msg, path_options, AT_PROCESSED);
 }
 
 static inline gboolean
 _has_movable_message(LogQueueDiskNonReliable *self)
 {
   return self->qoverflow->length > 0
-         && ((HAS_SPACE_IN_QUEUE(self->qout) && qdisk_get_length (self->super.qdisk) == 0)
-             || qdisk_is_space_avail (self->super.qdisk, 4096));
+         && ((HAS_SPACE_IN_QUEUE(self->qout) && qdisk_get_length(self->super.qdisk) == 0)
+             || qdisk_is_space_avail(self->super.qdisk, 4096));
 }
 
 static gboolean
@@ -172,15 +172,15 @@ _move_messages_from_overflow(LogQueueDiskNonReliable *self)
   /* move away as much entries from the overflow area as possible */
   while (_has_movable_message(self))
     {
-      msg = g_queue_pop_head (self->qoverflow);
-      POINTER_TO_LOG_PATH_OPTIONS (g_queue_pop_head (self->qoverflow), &path_options);
+      msg = g_queue_pop_head(self->qoverflow);
+      POINTER_TO_LOG_PATH_OPTIONS(g_queue_pop_head(self->qoverflow), &path_options);
 
-      if (qdisk_get_length (self->super.qdisk) == 0 && HAS_SPACE_IN_QUEUE(self->qout))
+      if (qdisk_get_length(self->super.qdisk) == 0 && HAS_SPACE_IN_QUEUE(self->qout))
         {
           /* we can skip qdisk, go straight to qout */
-          g_queue_push_tail (self->qout, msg);
-          g_queue_push_tail (self->qout, LOG_PATH_OPTIONS_FOR_BACKLOG);
-          log_msg_ref (msg);
+          g_queue_push_tail(self->qout, msg);
+          g_queue_push_tail(self->qout, LOG_PATH_OPTIONS_FOR_BACKLOG);
+          log_msg_ref(msg);
         }
       else
         {
@@ -194,24 +194,24 @@ _move_messages_from_overflow(LogQueueDiskNonReliable *self)
                * we failed saving this message, (it might have needed more
                * than 4096 bytes than we ensured), push back and break
                */
-              g_queue_push_head (self->qoverflow, LOG_PATH_OPTIONS_TO_POINTER (&path_options));
-              g_queue_push_head (self->qoverflow, msg);
-              log_msg_ref (msg);
+              g_queue_push_head(self->qoverflow, LOG_PATH_OPTIONS_TO_POINTER(&path_options));
+              g_queue_push_head(self->qoverflow, msg);
+              log_msg_ref(msg);
               break;
             }
         }
-      log_msg_ack (msg, &path_options, AT_PROCESSED);
-      log_msg_unref (msg);
+      log_msg_ack(msg, &path_options, AT_PROCESSED);
+      log_msg_unref(msg);
     }
 }
 
 static void
-_move_disk (LogQueueDiskNonReliable *self)
+_move_disk(LogQueueDiskNonReliable *self)
 {
   LogMessage *msg;
   LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
 
-  if (qdisk_is_read_only (self->super.qdisk))
+  if (qdisk_is_read_only(self->super.qdisk))
     return;
 
   /* stupid message mover between queues */
@@ -246,10 +246,10 @@ _ack_backlog(LogQueue *s, gint num_msg_to_ack)
     {
       if (self->qbacklog->length < ITEM_NUMBER_PER_MESSAGE)
         goto exit;
-      msg = g_queue_pop_head (self->qbacklog);
-      POINTER_TO_LOG_PATH_OPTIONS (g_queue_pop_head (self->qbacklog), &path_options);
-      log_msg_unref (msg);
-      log_msg_ack (msg, &path_options, AT_PROCESSED);
+      msg = g_queue_pop_head(self->qbacklog);
+      POINTER_TO_LOG_PATH_OPTIONS(g_queue_pop_head(self->qbacklog), &path_options);
+      log_msg_unref(msg);
+      log_msg_ack(msg, &path_options, AT_PROCESSED);
     }
 
 exit:
@@ -268,11 +268,11 @@ _rewind_backlog(LogQueue *s, guint rewind_count)
 
   for (i = 0; i < rewind_count; i++)
     {
-      gpointer ptr_opt = g_queue_pop_tail (self->qbacklog);
-      gpointer ptr_msg = g_queue_pop_tail (self->qbacklog);
+      gpointer ptr_opt = g_queue_pop_tail(self->qbacklog);
+      gpointer ptr_msg = g_queue_pop_tail(self->qbacklog);
 
-      g_queue_push_head (self->qout, ptr_opt);
-      g_queue_push_head (self->qout, ptr_msg);
+      g_queue_push_head(self->qout, ptr_opt);
+      g_queue_push_head(self->qout, ptr_msg);
 
       log_queue_queued_messages_inc(s);
       log_queue_memory_usage_add(s, log_msg_get_size((LogMessage *)ptr_msg));
@@ -297,8 +297,8 @@ _pop_head(LogQueue *s, LogPathOptions *path_options)
 
   if (self->qout->length > 0)
     {
-      msg = g_queue_pop_head (self->qout);
-      POINTER_TO_LOG_PATH_OPTIONS (g_queue_pop_head (self->qout), path_options);
+      msg = g_queue_pop_head(self->qout);
+      POINTER_TO_LOG_PATH_OPTIONS(g_queue_pop_head(self->qout), path_options);
       log_queue_memory_usage_sub(s, log_msg_get_size(msg));
     }
   if (msg == NULL)
@@ -311,10 +311,10 @@ _pop_head(LogQueue *s, LogPathOptions *path_options)
     }
   if (msg == NULL)
     {
-      if (self->qoverflow->length > 0 && qdisk_is_read_only (self->super.qdisk))
+      if (self->qoverflow->length > 0 && qdisk_is_read_only(self->super.qdisk))
         {
-          msg = g_queue_pop_head (self->qoverflow);
-          POINTER_TO_LOG_PATH_OPTIONS (g_queue_pop_head (self->qoverflow), path_options);
+          msg = g_queue_pop_head(self->qoverflow);
+          POINTER_TO_LOG_PATH_OPTIONS(g_queue_pop_head(self->qoverflow), path_options);
           log_queue_memory_usage_sub(s, log_msg_get_size(msg));
         }
     }
@@ -323,11 +323,11 @@ _pop_head(LogQueue *s, LogPathOptions *path_options)
     {
       if (s->use_backlog)
         {
-          log_msg_ref (msg);
-          g_queue_push_tail (self->qbacklog, msg);
-          g_queue_push_tail (self->qbacklog, LOG_PATH_OPTIONS_TO_POINTER (path_options));
+          log_msg_ref(msg);
+          g_queue_push_tail(self->qbacklog, msg);
+          g_queue_push_tail(self->qbacklog, LOG_PATH_OPTIONS_TO_POINTER(path_options));
         }
-      _move_disk (self);
+      _move_disk(self);
       log_queue_queued_messages_dec(s);
     }
 
@@ -343,7 +343,7 @@ _push_head(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
 
   g_static_mutex_lock(&s->lock);
 
-  g_queue_push_head(self->qout, LOG_PATH_OPTIONS_TO_POINTER (path_options));
+  g_queue_push_head(self->qout, LOG_PATH_OPTIONS_TO_POINTER(path_options));
   g_queue_push_head(self->qout, msg);
   log_queue_queued_messages_inc(s);
   log_queue_memory_usage_add(s, log_msg_get_size(msg));
@@ -400,7 +400,7 @@ _push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
       if (!qdisk_serialize_msg(self->super.qdisk, msg, serialized_msg))
         {
           msg_error("Failed to serialize message for non-reliable disk-buffer, dropping message",
-                    evt_tag_str("filename", qdisk_get_filename (self->super.qdisk)),
+                    evt_tag_str("filename", qdisk_get_filename(self->super.qdisk)),
                     evt_tag_str("persist_name", s->persist_name));
           log_queue_disk_drop_message(&self->super, msg, path_options);
           scratch_buffers_reclaim_marked(marker);
@@ -412,14 +412,14 @@ _push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
 
   LogPathOptions local_options = *path_options;
 
-  if (HAS_SPACE_IN_QUEUE(self->qout) && qdisk_get_length (self->super.qdisk) == 0)
+  if (HAS_SPACE_IN_QUEUE(self->qout) && qdisk_get_length(self->super.qdisk) == 0)
     {
       /* simple push never generates flow-control enabled entries to qout, they only get there
        * when rewinding the backlog */
 
-      g_queue_push_tail (self->qout, msg);
-      g_queue_push_tail (self->qout, LOG_PATH_OPTIONS_FOR_BACKLOG);
-      log_msg_ref (msg);
+      g_queue_push_tail(self->qout, msg);
+      g_queue_push_tail(self->qout, LOG_PATH_OPTIONS_FOR_BACKLOG);
+      log_msg_ref(msg);
 
       log_queue_memory_usage_add(s, log_msg_get_size(msg));
     }
@@ -429,20 +429,20 @@ _push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
         {
           if (HAS_SPACE_IN_QUEUE(self->qoverflow))
             {
-              g_queue_push_tail (self->qoverflow, msg);
-              g_queue_push_tail (self->qoverflow, LOG_PATH_OPTIONS_TO_POINTER (path_options));
-              log_msg_ref (msg);
+              g_queue_push_tail(self->qoverflow, msg);
+              g_queue_push_tail(self->qoverflow, LOG_PATH_OPTIONS_TO_POINTER(path_options));
+              log_msg_ref(msg);
               local_options.ack_needed = FALSE;
               log_queue_memory_usage_add(s, log_msg_get_size(msg));
             }
           else
             {
-              msg_debug ("Destination queue full, dropping message",
-                         evt_tag_str  ("filename", qdisk_get_filename (self->super.qdisk)),
-                         evt_tag_long ("queue_len", log_queue_get_length(s)),
-                         evt_tag_int  ("mem_buf_length", self->qoverflow_size),
-                         evt_tag_long ("disk_buf_size", qdisk_get_maximum_size (self->super.qdisk)),
-                         evt_tag_str  ("persist_name", s->persist_name));
+              msg_debug("Destination queue full, dropping message",
+                        evt_tag_str("filename", qdisk_get_filename(self->super.qdisk)),
+                        evt_tag_long("queue_len", log_queue_get_length(s)),
+                        evt_tag_int("mem_buf_length", self->qoverflow_size),
+                        evt_tag_long("disk_buf_size", qdisk_get_maximum_size(self->super.qdisk)),
+                        evt_tag_str("persist_name", s->persist_name));
               log_queue_disk_drop_message(&self->super, msg, path_options);
               goto exit;
             }
@@ -461,19 +461,19 @@ exit:
 }
 
 static void
-_free_queue (GQueue *q)
+_free_queue(GQueue *q)
 {
-  while (!g_queue_is_empty (q))
+  while (!g_queue_is_empty(q))
     {
       LogMessage *lm;
       LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
 
-      lm = g_queue_pop_head (q);
-      POINTER_TO_LOG_PATH_OPTIONS (g_queue_pop_head (q), &path_options);
-      log_msg_ack (lm, &path_options, AT_PROCESSED);
-      log_msg_unref (lm);
+      lm = g_queue_pop_head(q);
+      POINTER_TO_LOG_PATH_OPTIONS(g_queue_pop_head(q), &path_options);
+      log_msg_ack(lm, &path_options, AT_PROCESSED);
+      log_msg_unref(lm);
     }
-  g_queue_free (q);
+  g_queue_free(q);
 }
 
 static void
@@ -481,36 +481,36 @@ _free(LogQueue *s)
 {
   LogQueueDiskNonReliable *self = (LogQueueDiskNonReliable *)s;
 
-  _free_queue (self->qoverflow);
+  _free_queue(self->qoverflow);
   self->qoverflow = NULL;
-  _free_queue (self->qout);
+  _free_queue(self->qout);
   self->qout = NULL;
-  _free_queue (self->qbacklog);
+  _free_queue(self->qbacklog);
   self->qbacklog = NULL;
 
   log_queue_disk_free_method(&self->super);
 }
 
 static gboolean
-_load_queue (LogQueueDisk *s, const gchar *filename)
+_load_queue(LogQueueDisk *s, const gchar *filename)
 {
   /* qdisk portion is not yet started when this happens */
-  g_assert(!qdisk_started (s->qdisk));
+  g_assert(!qdisk_started(s->qdisk));
 
   return _start(s, filename);
 }
 
 static gboolean
-_save_queue (LogQueueDisk *s, gboolean *persistent)
+_save_queue(LogQueueDisk *s, gboolean *persistent)
 {
   gboolean success = FALSE;
   LogQueueDiskNonReliable *self = (LogQueueDiskNonReliable *) s;
-  if (qdisk_save_state (s->qdisk, self->qout, self->qbacklog, self->qoverflow))
+  if (qdisk_save_state(s->qdisk, self->qout, self->qbacklog, self->qoverflow))
     {
       *persistent = TRUE;
       success = TRUE;
     }
-  qdisk_stop (s->qdisk);
+  qdisk_stop(s->qdisk);
   return success;
 }
 
@@ -556,9 +556,9 @@ log_queue_disk_non_reliable_new(DiskQueueOptions *options, const gchar *persist_
   g_assert(options->reliable == FALSE);
   LogQueueDiskNonReliable *self = g_new0(LogQueueDiskNonReliable, 1);
   log_queue_disk_init_instance(&self->super, options, "SLQF", persist_name);
-  self->qbacklog = g_queue_new ();
-  self->qout = g_queue_new ();
-  self->qoverflow = g_queue_new ();
+  self->qbacklog = g_queue_new();
+  self->qout = g_queue_new();
+  self->qoverflow = g_queue_new();
   self->qout_size = options->qout_size;
   self->qoverflow_size = options->mem_buf_length;
   _set_virtual_functions(self);

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -84,7 +84,7 @@ _get_message_number_in_queue(GQueue *queue)
   return queue->length / ITEM_NUMBER_PER_MESSAGE;
 }
 
-#define HAS_SPACE_IN_QUEUE(queue) _get_message_number_in_queue(queue) < queue ## _size
+#define HAS_SPACE_IN_QUEUE(queue) (_get_message_number_in_queue(queue) < queue ## _size)
 
 static gint64
 _get_length(LogQueue *s)

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -205,8 +205,8 @@ _move_messages_from_overflow(LogQueueDiskNonReliable *self)
     }
 }
 
-static void
-_move_disk(LogQueueDiskNonReliable *self)
+static inline void
+_maybe_move_messages_among_queue_segments(LogQueueDiskNonReliable *self)
 {
   LogMessage *msg;
   LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
@@ -350,7 +350,7 @@ success:
   if (s->use_backlog)
     _push_tail_qbacklog(self, msg, path_options);
 
-  _move_disk(self);
+  _maybe_move_messages_among_queue_segments(self);
   log_queue_queued_messages_dec(s);
 
   g_static_mutex_unlock(&s->lock);

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -248,8 +248,8 @@ _ack_backlog(LogQueue *s, gint num_msg_to_ack)
         goto exit;
       msg = g_queue_pop_head(self->qbacklog);
       POINTER_TO_LOG_PATH_OPTIONS(g_queue_pop_head(self->qbacklog), &path_options);
-      log_msg_unref(msg);
       log_msg_ack(msg, &path_options, AT_PROCESSED);
+      log_msg_unref(msg);
     }
 
 exit:

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -339,16 +339,7 @@ _pop_head(LogQueue *s, LogPathOptions *path_options)
 static void
 _push_head(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
 {
-  LogQueueDiskNonReliable *self = (LogQueueDiskNonReliable *)s;
-
-  g_static_mutex_lock(&s->lock);
-
-  g_queue_push_head(self->qout, LOG_PATH_OPTIONS_TO_POINTER(path_options));
-  g_queue_push_head(self->qout, msg);
-  log_queue_queued_messages_inc(s);
-  log_queue_memory_usage_add(s, log_msg_get_size(msg));
-
-  g_static_mutex_unlock(&s->lock);
+  g_assert_not_reached();
 }
 
 /* _is_msg_serialization_needed_hint() must be called without holding the queue's lock.

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -152,13 +152,15 @@ _move_messages_from_overflow(LogQueueDiskNonReliable *self)
           /* we can skip qdisk, go straight to qout */
           g_queue_push_tail(self->qout, msg);
           g_queue_push_tail(self->qout, LOG_PATH_OPTIONS_FOR_BACKLOG);
-          log_msg_ref(msg);
+          log_msg_ack(msg, &path_options, AT_PROCESSED);
         }
       else
         {
           if (_serialize_and_write_message_to_disk(self, msg))
             {
               log_queue_memory_usage_sub(&self->super.super, log_msg_get_size(msg));
+              log_msg_ack(msg, &path_options, AT_PROCESSED);
+              log_msg_unref(msg);
             }
           else
             {
@@ -168,12 +170,9 @@ _move_messages_from_overflow(LogQueueDiskNonReliable *self)
                */
               g_queue_push_head(self->qoverflow, LOG_PATH_OPTIONS_TO_POINTER(&path_options));
               g_queue_push_head(self->qoverflow, msg);
-              log_msg_ref(msg);
               break;
             }
         }
-      log_msg_ack(msg, &path_options, AT_PROCESSED);
-      log_msg_unref(msg);
     }
 }
 

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -213,6 +213,7 @@ _maybe_move_messages_among_queue_segments(LogQueueDiskNonReliable *self)
     _move_messages_from_overflow(self);
 }
 
+/* runs only in the output thread */
 static void
 _ack_backlog(LogQueue *s, gint num_msg_to_ack)
 {
@@ -221,20 +222,15 @@ _ack_backlog(LogQueue *s, gint num_msg_to_ack)
   LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
   guint i;
 
-  g_static_mutex_lock(&s->lock);
-
   for (i = 0; i < num_msg_to_ack; i++)
     {
       if (self->qbacklog->length < ITEM_NUMBER_PER_MESSAGE)
-        goto exit;
+        return;
       msg = g_queue_pop_head(self->qbacklog);
       POINTER_TO_LOG_PATH_OPTIONS(g_queue_pop_head(self->qbacklog), &path_options);
       log_msg_ack(msg, &path_options, AT_PROCESSED);
       log_msg_unref(msg);
     }
-
-exit:
-  g_static_mutex_unlock(&s->lock);
 }
 
 static void
@@ -288,6 +284,7 @@ _pop_head_qoverflow(LogQueueDiskNonReliable *self, LogPathOptions *path_options)
   return msg;
 }
 
+/* runs only in the output thread */
 static inline void
 _push_tail_qbacklog(LogQueueDiskNonReliable *self, LogMessage *msg, LogPathOptions *path_options)
 {
@@ -328,13 +325,15 @@ _pop_head(LogQueue *s, LogPathOptions *path_options)
     }
 
 success:
+  _maybe_move_messages_among_queue_segments(self);
+
+  g_static_mutex_unlock(&s->lock);
+
   if (s->use_backlog)
     _push_tail_qbacklog(self, msg, path_options);
 
-  _maybe_move_messages_among_queue_segments(self);
   log_queue_queued_messages_dec(s);
 
-  g_static_mutex_unlock(&s->lock);
   return msg;
 }
 

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -113,7 +113,7 @@ _can_push_to_qout(LogQueueDiskNonReliable *self)
 }
 
 static inline gboolean
-_has_movable_message(LogQueueDiskNonReliable *self)
+_qoverflow_has_movable_message(LogQueueDiskNonReliable *self)
 {
   return self->qoverflow->length > 0
          && (_can_push_to_qout(self) || qdisk_is_space_avail(self->super.qdisk, 4096));
@@ -142,7 +142,7 @@ _move_messages_from_overflow(LogQueueDiskNonReliable *self)
   LogMessage *msg;
   LogPathOptions path_options;
   /* move away as much entries from the overflow area as possible */
-  while (_has_movable_message(self))
+  while (_qoverflow_has_movable_message(self))
     {
       msg = g_queue_pop_head(self->qoverflow);
       POINTER_TO_LOG_PATH_OPTIONS(g_queue_pop_head(self->qoverflow), &path_options);

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -100,13 +100,6 @@ _get_length(LogQueue *s)
 }
 
 static inline gboolean
-_could_move_into_qout(LogQueueDiskNonReliable *self)
-{
-  /* NOTE: we only load half the qout queue at a time */
-  return (_get_message_number_in_queue(self->qout) < (self->qout_size / 2));
-}
-
-static inline gboolean
 _can_push_to_qout(LogQueueDiskNonReliable *self)
 {
   return HAS_SPACE_IN_QUEUE(self->qout) && qdisk_get_length(self->super.qdisk) == 0;
@@ -197,7 +190,7 @@ _move_messages_from_disk_to_qout(LogQueueDiskNonReliable *self)
       g_queue_push_tail(self->qout, LOG_PATH_OPTIONS_FOR_BACKLOG);
       log_queue_memory_usage_add(&self->super.super, log_msg_get_size(msg));
     }
-  while (_could_move_into_qout(self));
+  while (HAS_SPACE_IN_QUEUE(self->qout));
 }
 
 static inline void

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -113,11 +113,6 @@ _get_next_message(LogQueueDiskNonReliable *self, LogPathOptions *path_options)
           path_options->ack_needed = FALSE;
         }
     }
-  else if (self->qoverflow->length > 0)
-    {
-      result = g_queue_pop_head(self->qoverflow);
-      POINTER_TO_LOG_PATH_OPTIONS(g_queue_pop_head(self->qoverflow), path_options);
-    }
   return result;
 }
 

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -332,6 +332,7 @@ _push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
 static void
 _push_head(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
 {
+  g_assert_not_reached();
 }
 
 static void

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -127,17 +127,17 @@ log_queue_disk_read_message(LogQueueDisk *self, LogPathOptions *path_options)
   LogMessage *msg = NULL;
   do
     {
-      if (qdisk_get_length (self->qdisk) == 0)
+      if (qdisk_get_length(self->qdisk) == 0)
         {
           break;
         }
-      if (!_pop_disk (self, &msg))
+      if (!_pop_disk(self, &msg))
         {
           msg_error("Error reading from disk-queue file, dropping disk queue",
                     evt_tag_str("filename", qdisk_get_filename(self->qdisk)));
           log_queue_disk_restart_corrupted(self);
           if (msg)
-            log_msg_unref (msg);
+            log_msg_unref(msg);
           msg = NULL;
           return NULL;
         }

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -905,17 +905,17 @@ _save_queue(QDisk *self, GQueue *q, QDiskQueuePosition *q_pos)
         {
           if (!qdisk_write_serialized_string_to_file(self, serialized, &current_offset))
             goto error;
-          if(!queue_start_position)
+          if (!queue_start_position)
             queue_start_position = current_offset;
           written_bytes += serialized->len;
           g_string_truncate(serialized, 0);
         }
     }
-  if(serialized->len)
+  if (serialized->len)
     {
       if (!qdisk_write_serialized_string_to_file(self, serialized, &current_offset))
         goto error;
-      if(!queue_start_position)
+      if (!queue_start_position)
         queue_start_position = current_offset;
       written_bytes += serialized->len;
     }
@@ -1077,7 +1077,7 @@ qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, 
     {
       self->hdr = g_malloc(sizeof(QDiskFileHeader));
       memcpy(self->hdr, p, sizeof(QDiskFileHeader));
-      munmap(p, sizeof(QDiskFileHeader) );
+      munmap(p, sizeof(QDiskFileHeader));
       p = NULL;
     }
   else
@@ -1230,7 +1230,7 @@ qdisk_skip_record(QDisk *self, guint64 position)
 {
   guint64 new_position = position;
   guint32 record_length;
-  qdisk_read (self, (gchar *) &record_length, sizeof(record_length), position);
+  qdisk_read(self, (gchar *) &record_length, sizeof(record_length), position);
   record_length = GUINT32_FROM_BE(record_length);
   new_position += record_length + sizeof(record_length);
   if (new_position > self->hdr->write_head)

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -131,7 +131,7 @@ Test(diskq, testcase_ack_and_rewind_messages)
   log_queue_set_use_backlog(q, TRUE);
 
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_DESTINATION, "queued messages", NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_DESTINATION, "queued messages", NULL);
   stats_lock();
   stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &q->queued_messages);
   stats_unlock();
@@ -148,7 +148,7 @@ Test(diskq, testcase_ack_and_rewind_messages)
   feed_some_messages(q, 1000);
   cr_assert_eq(stats_counter_get(q->queued_messages), 1000, "queued messages: %d", __LINE__);
 
-  for(i = 0; i < 10; i++)
+  for (i = 0; i < 10; i++)
     {
       send_some_messages(q, 1);
       cr_assert_eq(stats_counter_get(q->queued_messages), 999, "queued messages wrong number %d", __LINE__);
@@ -233,7 +233,7 @@ threaded_consume(gpointer st)
       LogMessage *msg = NULL;
       gint slept = 0;
 
-      while(!msg)
+      while (!msg)
         {
           main_loop_worker_run_gc();
 
@@ -419,9 +419,9 @@ init_statistics(LogQueue *q)
 
   StatsClusterKey sc_key1, sc_key2;
   stats_lock();
-  stats_cluster_logpipe_key_set(&sc_key1, SCS_DESTINATION, "queued messages", NULL );
+  stats_cluster_logpipe_key_set(&sc_key1, SCS_DESTINATION, "queued messages", NULL);
   stats_register_counter(0, &sc_key1, SC_TYPE_QUEUED, &q->queued_messages);
-  stats_cluster_logpipe_key_set(&sc_key2, SCS_DESTINATION, "memory usage", NULL );
+  stats_cluster_logpipe_key_set(&sc_key2, SCS_DESTINATION, "memory usage", NULL);
   stats_register_counter(1, &sc_key2, SC_TYPE_MEMORY_USAGE, &q->memory_usage);
   stats_unlock();
   stats_counter_set(q->queued_messages, 0);

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -70,7 +70,7 @@ test_diskq_become_full(gboolean reliable, const gchar *filename)
 
   stats_lock();
   StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_set(&sc_key, SCS_DESTINATION, q->persist_name, NULL );
+  stats_cluster_logpipe_key_set(&sc_key, SCS_DESTINATION, q->persist_name, NULL);
   stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &q->dropped_messages);
   stats_counter_set(q->dropped_messages, 0);
   stats_unlock();


### PR DESCRIPTION
This PR refactors the non-reliable disk buffer and simplifies how messages are moved among queue segments.
(The trigger behind this refactor was to avoid unnecessarily (de)serialization and disk I/O operations in the move logic, but I had to drop those changes because they would have had unpleasant side effects.)

The last 2 commits improve the performance of the non-reliable disk buffer by using the entire qout when moving messages, and by eliminating a lock during qbacklog operations.

According to my measurements, this could increase the performance up to 20%.

No news file is needed, we'll add a news entry separately about the overall performance improvement we achieved.