### PR TITLE
disk-buffer: change defaults for truncate-size-ratio() and qout-size()

### DIFF
--- a/modules/diskq/diskq-config.c
+++ b/modules/diskq/diskq-config.c
@@ -34,7 +34,7 @@ disk_queue_config_free(ModuleConfig *s)
 static void
 _set_default_values(DiskQueueConfig *self)
 {
-  self->truncate_size_ratio = 0.01;
+  self->truncate_size_ratio = 0.1;
 }
 
 DiskQueueConfig *

--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -172,7 +172,7 @@ _attach(LogDriverPlugin *s, LogDriver *d)
   if (self->options.mem_buf_length < 0)
     self->options.mem_buf_length = cfg->log_fifo_size;
   if (self->options.qout_size < 0)
-    self->options.qout_size = 64;
+    self->options.qout_size = 1000;
   if (self->options.truncate_size_ratio < 0)
     _set_default_truncate_size_ratio(self, cfg);
 

--- a/modules/diskq/dqtool.c
+++ b/modules/diskq/dqtool.c
@@ -131,7 +131,7 @@ open_queue(char *filename, LogQueue **lq, DiskQueueOptions *options)
     {
       options->disk_buf_size = 1;
       options->mem_buf_size = 128;
-      options->qout_size = 128;
+      options->qout_size = 1000;
       *lq = log_queue_disk_non_reliable_new(options, NULL);
     }
 

--- a/modules/examples/sources/threaded-diskq-source/threaded-diskq-source.c
+++ b/modules/examples/sources/threaded-diskq-source/threaded-diskq-source.c
@@ -82,7 +82,7 @@ _load_queue(ThreadedDiskqSourceDriver *self)
     {
       self->diskq_options.disk_buf_size = 1;
       self->diskq_options.mem_buf_size = 128;
-      self->diskq_options.qout_size = 128;
+      self->diskq_options.qout_size = 1000;
       self->queue = log_queue_disk_non_reliable_new(&self->diskq_options, NULL);
     }
 

--- a/news/other-3757.md
+++ b/news/other-3757.md
@@ -1,0 +1,3 @@
+`disk-buffer()`: the default value of the following options has been changed for performance reasons:
+  - truncate-size-ratio(): from 0.01 to 0.1 (from 1% to 10%)
+  - qout-size(): from 64 to 1000 (this affects only the non-reliable disk buffer)


### PR DESCRIPTION
- increase default qout-size() to 1000

  The previous default value (64) has been changed to 1000, which adapts better to the window size and fetch limit of sources (1000 and 100 usually).

  This change does NOT increase the chance of losing messages under normal circumstances, but messages stored in qout may be lost in case syslog-ng crashes.
  This change affects ONLY the non-reliable disk buffer, the reliable disk buffer has no such memory-only queue like qout.

- increase truncate-size-ratio() to 10%

  Truncating and then writing new messages to a truncated disk-buffer file has noticeable performance impact even on ext4, so we decided to increase this ratio to 10% by default, so we truncate less ofter.

  Note: truncate-size-ratio(1) (never truncate) is recommended to avoid performance fluctuations.