### PR TITLE
syslog-ng-ctl: add stats --remove-orphans

### DIFF
--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -122,6 +122,12 @@ void stats_cluster_untrack_counter(StatsCluster *self, gint type, StatsCounterIt
 gboolean stats_cluster_is_alive(StatsCluster *self, gint type);
 gboolean stats_cluster_is_indexed(StatsCluster *self, gint type);
 
+static inline gboolean
+stats_cluster_is_orphaned(StatsCluster *self)
+{
+  return self->use_count == 0;
+}
+
 StatsCluster *stats_cluster_new(const StatsClusterKey *key);
 StatsCluster *stats_cluster_dynamic_new(const StatsClusterKey *key);
 void stats_cluster_free(StatsCluster *self);

--- a/lib/stats/stats-csv.c
+++ b/lib/stats/stats-csv.c
@@ -23,6 +23,7 @@
  */
 #include "stats/stats-csv.h"
 #include "stats/stats-registry.h"
+#include "stats/stats-cluster.h"
 #include "utf8utils.h"
 
 #include <string.h>
@@ -70,7 +71,7 @@ stats_format_csv(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointe
 
   if (sc->dynamic)
     state = 'd';
-  else if (sc->use_count == 0)
+  else if (stats_cluster_is_orphaned(sc))
     state = 'o';
   else
     state = 'a';

--- a/lib/stats/stats-registry.c
+++ b/lib/stats/stats-registry.c
@@ -404,7 +404,12 @@ _foreach_cluster_remove_helper(gpointer key, gpointer value, gpointer user_data)
   gpointer func_data = args[1];
   StatsCluster *sc = (StatsCluster *) value;
 
-  return func(sc, func_data);
+  gboolean should_be_removed = func(sc, func_data);
+
+  if (should_be_removed)
+    stats_query_deindex_cluster(sc);
+
+  return should_be_removed;
 }
 
 void
@@ -456,4 +461,3 @@ stats_registry_deinit(void)
   stats_cluster_container.dynamic_clusters = NULL;
   g_static_mutex_free(&stats_mutex);
 }
-

--- a/lib/stats/stats.c
+++ b/lib/stats/stats.c
@@ -93,7 +93,7 @@ stats_cluster_is_expired(StatsOptions *options, StatsCluster *sc, time_t now)
     return FALSE;
 
   /* this entry is being updated, cannot be too old */
-  if (sc->use_count > 0)
+  if (!stats_cluster_is_orphaned(sc))
     return FALSE;
 
   /* check if timestamp is stored, no timestamp means we can't expire it.

--- a/lib/stats/stats.c
+++ b/lib/stats/stats.c
@@ -126,7 +126,6 @@ stats_prune_cluster(StatsCluster *sc, StatsTimerState *st)
       if ((st->oldest_counter) == 0 || st->oldest_counter > tstamp)
         st->oldest_counter = tstamp;
       st->dropped_counters++;
-      stats_query_deindex_cluster(sc);
     }
   return expired;
 }

--- a/news/feature-3760.md
+++ b/news/feature-3760.md
@@ -1,0 +1,5 @@
+`syslog-ng-ctl`: new flag for pruning statistics
+
+`syslog-ng-ctl stats --remove-orphans` can be used to remove "orphaned" statistic counters.
+It is useful when, for example, a templated file destination (`$YEAR.$MONTH.$DAY`) produces a lot of stats,
+and one wants to remove those abandoned counters occasionally/conditionally.

--- a/syslog-ng-ctl/commands/ctl-stats.c
+++ b/syslog-ng-ctl/commands/ctl-stats.c
@@ -24,17 +24,25 @@
 #include "ctl-stats.h"
 
 static gboolean stats_options_reset_is_set = FALSE;
+static gboolean stats_options_remove_orphans = FALSE;
 
 GOptionEntry stats_options[] =
 {
   { "reset", 'r', 0, G_OPTION_ARG_NONE, &stats_options_reset_is_set, "reset counters", NULL },
+  { "remove-orphans", 'o', 0, G_OPTION_ARG_NONE, &stats_options_remove_orphans, "remove orphaned statistics", NULL},
   { NULL,    0,   0, G_OPTION_ARG_NONE, NULL,                        NULL,             NULL }
 };
 
 static const gchar *
 _stats_command_builder(void)
 {
-  return stats_options_reset_is_set ? "RESET_STATS" : "STATS";
+  if (stats_options_reset_is_set)
+    return "RESET_STATS";
+
+  if (stats_options_remove_orphans)
+    return "REMOVE_ORPHANED_STATS";
+
+  return "STATS";
 }
 
 gint


### PR DESCRIPTION
This PR adds a new command line flag for `syslog-ng-ctl stats`: `--remove-orphans`.

`--remove-orphans` safely removes all counters that are not referenced by any syslog-ng stat producer objects.

The flag can be used to prune dynamic and static counters manually. This is useful, for example, when a templated file destination produces a lot of stats:
```
dst.file;#anon-destination0#0;/tmp/2021-08-16.log;o;processed;253592
dst.file;#anon-destination0#0;/tmp/2021-08-17.log;o;processed;156
dst.file;#anon-destination0#0;/tmp/2021-08-18.log;a;processed;961
...
```

Note: `stats-lifetime()` can be used to do the same automatically and periodically, but currently `stats-lifetime()` removes only dynamic counters that have a timestamp field set.

TODO
- [x] NEWS entry