### PR TITLE
dbld tarball image: remove bison-3.7.6 install from source

### DIFF
--- a/dbld/images/tarball.dockerfile
+++ b/dbld/images/tarball.dockerfile
@@ -7,4 +7,3 @@ LABEL COMMIT=${COMMIT}
 
 RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_pip_packages
-RUN /dbld/builddeps install_bison_from_source


### PR DESCRIPTION
Debian testing has fortunately migrated to using bison 3.7.6 already, so
installing it from source is not needed anymore.
