### PR TITLE
Proxied TLS passthrough

### DIFF
--- a/lib/logproto/logproto-builtins.c
+++ b/lib/logproto/logproto-builtins.c
@@ -39,6 +39,7 @@ DEFINE_LOG_PROTO_SERVER(log_proto_dgram);
 DEFINE_LOG_PROTO_CLIENT(log_proto_text);
 DEFINE_LOG_PROTO_SERVER(log_proto_text);
 DEFINE_LOG_PROTO_SERVER(log_proto_proxied_text);
+DEFINE_LOG_PROTO_SERVER(log_proto_proxied_text_tls_passthrough);
 DEFINE_LOG_PROTO_SERVER(log_proto_indented_multiline);
 DEFINE_LOG_PROTO_CLIENT(log_proto_framed);
 DEFINE_LOG_PROTO_SERVER(log_proto_framed);
@@ -51,6 +52,7 @@ static Plugin framed_server_plugins[] =
   LOG_PROTO_CLIENT_PLUGIN(log_proto_text, "text"),
   LOG_PROTO_SERVER_PLUGIN(log_proto_text, "text"),
   LOG_PROTO_SERVER_PLUGIN(log_proto_proxied_text, "proxied-tcp"),
+  LOG_PROTO_SERVER_PLUGIN(log_proto_proxied_text_tls_passthrough, "proxied-tls-passthrough"),
   LOG_PROTO_SERVER_PLUGIN(log_proto_indented_multiline, "indented-multiline"),
   LOG_PROTO_CLIENT_PLUGIN(log_proto_framed, "framed"),
   LOG_PROTO_SERVER_PLUGIN(log_proto_framed, "framed"),

--- a/lib/logproto/logproto-builtins.c
+++ b/lib/logproto/logproto-builtins.c
@@ -39,7 +39,7 @@ DEFINE_LOG_PROTO_SERVER(log_proto_dgram);
 DEFINE_LOG_PROTO_CLIENT(log_proto_text);
 DEFINE_LOG_PROTO_SERVER(log_proto_text);
 DEFINE_LOG_PROTO_SERVER(log_proto_proxied_text);
-DEFINE_LOG_PROTO_SERVER(log_proto_proxied_text_tls_passthrough);
+DEFINE_LOG_PROTO_SERVER(log_proto_proxied_text_tls_passthrough, .use_multitransport = TRUE);
 DEFINE_LOG_PROTO_SERVER(log_proto_indented_multiline);
 DEFINE_LOG_PROTO_CLIENT(log_proto_framed);
 DEFINE_LOG_PROTO_SERVER(log_proto_framed);

--- a/lib/logproto/logproto-client.h
+++ b/lib/logproto/logproto-client.h
@@ -197,13 +197,14 @@ void log_proto_client_init(LogProtoClient *s, LogTransport *transport, const Log
 void log_proto_client_free(LogProtoClient *s);
 void log_proto_client_free_method(LogProtoClient *s);
 
-#define DEFINE_LOG_PROTO_CLIENT(prefix) \
+#define DEFINE_LOG_PROTO_CLIENT(prefix, options...) \
   static gpointer                                                       \
   prefix ## _client_plugin_construct(Plugin *self)            \
   {                                                                     \
     static LogProtoClientFactory proto = {                              \
       .construct = prefix ## _client_new,                               \
       .stateful  = FALSE,                                               \
+      ##options \
     };                                                                  \
     return &proto;                                                      \
   }

--- a/lib/logproto/logproto-proxied-text-server.c
+++ b/lib/logproto/logproto-proxied-text-server.c
@@ -26,13 +26,13 @@
 #include <stdlib.h>
 #include "messages.h"
 #include "logproto-proxied-text-server.h"
+#include "transport/multitransport.h"
+#include "transport/transport-factory-tls.h"
 #include "str-utils.h"
 
 #define PROXY_HDR_TCP4 "PROXY TCP4 "
 #define PROXY_HDR_TCP6 "PROXY TCP6 "
 #define PROXY_HDR_UNKNOWN "PROXY UNKNOWN"
-#define PROXY_PROTO_HDR_MAX_LEN_RFC 108
-#define PROXY_PROTO_HDR_MAX_LEN (PROXY_PROTO_HDR_MAX_LEN_RFC * 2)
 
 static gboolean
 _check_header_length(const guchar *msg, gsize msg_len)
@@ -189,6 +189,77 @@ _log_proto_proxied_text_server_add_aux_data(LogProtoProxiedTextServer *self, Log
   return;
 }
 
+static LogProtoPrepareAction
+log_proto_proxied_text_server_prepare(LogProtoServer *s, GIOCondition *cond, gint *timeout)
+{
+  LogProtoProxiedTextServer *self = (LogProtoProxiedTextServer *) s;
+
+  *cond = s->transport->cond;
+
+  if(self->handshake_done)
+    return log_proto_text_server_prepare_method(s, cond, timeout);
+
+  /* if there's no pending I/O in the transport layer, then we want to do a read */
+  if (*cond == 0)
+    *cond = G_IO_IN;
+
+  return LPPA_POLL_IO;
+}
+
+static inline LogProtoStatus
+_fetch_into_proxy_buffer(LogProtoProxiedTextServer *self, gsize *hdr_len)
+{
+  while(self->proxy_header_buff_len < PROXY_PROTO_HDR_MAX_LEN)
+    {
+      gssize rc = log_transport_read(self->super.super.super.transport,
+                                     &(self->proxy_header_buff[self->proxy_header_buff_len]),
+                                     sizeof(gchar), NULL);
+      if(rc < 0)
+        {
+          if (errno == EAGAIN)
+            return LPS_AGAIN;
+          else
+            {
+              msg_error("I/O error occurred while reading proxy header", evt_tag_int(EVT_TAG_FD,
+                        self->super.super.super.transport->fd),
+                        evt_tag_error(EVT_TAG_OSERROR));
+              return LPS_ERROR;
+            }
+        }
+
+      /* permissive termination */
+      if(rc == 0)
+        return LPS_SUCCESS;
+
+      self->proxy_header_buff_len++;
+      self->proxy_header_buff[self->proxy_header_buff_len] = '\0';
+      if (self->proxy_header_buff[self->proxy_header_buff_len - 1] == '\n')
+        {
+          *hdr_len = self->proxy_header_buff_len;
+          return LPS_SUCCESS;
+        }
+
+    }
+
+  msg_error("PROXY proto header with invalid header length",
+            evt_tag_int("max_parsable_length", PROXY_PROTO_HDR_MAX_LEN),
+            evt_tag_int("max_length_by_spec", PROXY_PROTO_HDR_MAX_LEN_RFC),
+            evt_tag_long("length", self->proxy_header_buff_len),
+            evt_tag_str("header", (const gchar *)self->proxy_header_buff));
+  return LPS_ERROR;
+}
+
+static void
+_log_proto_proxied_text_server_switch_to_tls(LogProtoProxiedTextServer *self)
+{
+  if (!multitransport_switch((MultiTransport *)self->super.super.super.transport, transport_factory_tls_id()))
+    {
+      msg_error("proxied-tls failed to switch to TLS");
+      return;
+    }
+  msg_debug("proxied-tls switch to TLS: OK");
+}
+
 static LogProtoStatus
 _log_proto_proxied_text_server_handshake(LogProtoServer *s)
 {
@@ -201,8 +272,15 @@ _log_proto_proxied_text_server_handshake(LogProtoServer *s)
   LogProtoProxiedTextServer *self = (LogProtoProxiedTextServer *) s;
 
   // Fetch a line from the transport layer
-  status = log_proto_buffered_server_fetch(&self->super.super.super, &msg, &msg_len, &may_read, NULL, NULL);
-
+  if(self->has_to_switch_to_tls)
+    {
+      status = _fetch_into_proxy_buffer(self, &msg_len);
+      msg = self->proxy_header_buff;
+    }
+  else
+    {
+      status = log_proto_buffered_server_fetch(&self->super.super.super, &msg, &msg_len, &may_read, NULL, NULL);
+    }
   self->handshake_done = (status == LPS_SUCCESS);
   if (status != LPS_SUCCESS)
     return status;
@@ -214,6 +292,11 @@ _log_proto_proxied_text_server_handshake(LogProtoServer *s)
   if (parsable)
     {
       msg_info("PROXY protocol header parsed successfully");
+      if (self->has_to_switch_to_tls)
+        {
+          _log_proto_proxied_text_server_switch_to_tls(self);
+          self->handshake_done = TRUE;
+        }
       return LPS_SUCCESS;
     }
   else
@@ -227,7 +310,6 @@ static gboolean
 _log_proto_proxied_text_server_handshake_in_progress(LogProtoServer *s)
 {
   LogProtoProxiedTextServer *self = (LogProtoProxiedTextServer *) s;
-
   return !self->handshake_done;
 }
 
@@ -274,18 +356,33 @@ _log_proto_proxied_text_server_init(LogProtoProxiedTextServer *self, LogTranspor
   self->super.super.super.free_fn = _log_proto_proxied_text_server_free;
   self->super.super.super.handshake_in_progess = _log_proto_proxied_text_server_handshake_in_progress;
   self->super.super.super.handshake = _log_proto_proxied_text_server_handshake;
+  self->super.super.super.prepare = log_proto_proxied_text_server_prepare;
 
   return;
 }
 
+static LogProtoProxiedTextServer *
+_log_proto_proxied_text_server_new(LogTransport *transport, const LogProtoServerOptions *options)
+{
+  LogProtoProxiedTextServer *self = g_new0(LogProtoProxiedTextServer, 1);
+  self->info = g_new0(struct ProxyProtoInfo, 1);
+  return self;
+}
 
 LogProtoServer *
 log_proto_proxied_text_server_new(LogTransport *transport, const LogProtoServerOptions *options)
 {
-  LogProtoProxiedTextServer *self = g_new0(LogProtoProxiedTextServer, 1);
-  self->info = g_new0(struct ProxyProtoInfo, 1);
-
+  LogProtoProxiedTextServer *self =  _log_proto_proxied_text_server_new(transport, options);
   _log_proto_proxied_text_server_init(self, transport, options);
+  return &self->super.super.super;
+}
 
+
+LogProtoServer *
+log_proto_proxied_text_tls_passthrough_server_new(LogTransport *transport, const LogProtoServerOptions *options)
+{
+  LogProtoProxiedTextServer *self =  _log_proto_proxied_text_server_new(transport, options);
+  _log_proto_proxied_text_server_init(self, transport, options);
+  self->has_to_switch_to_tls = TRUE;
   return &self->super.super.super;
 }

--- a/lib/logproto/logproto-proxied-text-server.c
+++ b/lib/logproto/logproto-proxied-text-server.c
@@ -248,15 +248,17 @@ _fetch_into_proxy_buffer(LogProtoProxiedTextServer *self)
   return LPS_ERROR;
 }
 
-static void
+static gboolean
 _log_proto_proxied_text_server_switch_to_tls(LogProtoProxiedTextServer *self)
 {
   if (!multitransport_switch((MultiTransport *)self->super.super.super.transport, transport_factory_tls_id()))
     {
       msg_error("proxied-tls failed to switch to TLS");
-      return;
+      return FALSE;
     }
+
   msg_debug("proxied-tls switch to TLS: OK");
+  return TRUE;
 }
 
 static LogProtoStatus
@@ -280,8 +282,8 @@ _log_proto_proxied_text_server_handshake(LogProtoServer *s)
     {
       msg_info("PROXY protocol header parsed successfully");
 
-      if (self->has_to_switch_to_tls)
-        _log_proto_proxied_text_server_switch_to_tls(self);
+      if (self->has_to_switch_to_tls && !_log_proto_proxied_text_server_switch_to_tls(self))
+        return LPS_ERROR;
 
       return LPS_SUCCESS;
     }

--- a/lib/logproto/logproto-proxied-text-server.h
+++ b/lib/logproto/logproto-proxied-text-server.h
@@ -27,6 +27,8 @@
 #include "logproto-text-server.h"
 
 #define IP_BUF_SIZE 64
+#define PROXY_PROTO_HDR_MAX_LEN_RFC 108
+#define PROXY_PROTO_HDR_MAX_LEN (PROXY_PROTO_HDR_MAX_LEN_RFC * 2)
 
 struct ProxyProtoInfo
 {
@@ -50,8 +52,14 @@ typedef struct _LogProtoProxiedTextServer
 
   // Flag to only run handshake() once
   gboolean handshake_done;
+  gboolean has_to_switch_to_tls;
+
+  guchar proxy_header_buff[PROXY_PROTO_HDR_MAX_LEN + 1];
+  gsize proxy_header_buff_len;
 } LogProtoProxiedTextServer;
 
 LogProtoServer *log_proto_proxied_text_server_new(LogTransport *transport, const LogProtoServerOptions *options);
+LogProtoServer *log_proto_proxied_text_tls_passthrough_server_new(LogTransport *transport,
+    const LogProtoServerOptions *options);
 
 #endif

--- a/lib/logproto/logproto-server.h
+++ b/lib/logproto/logproto-server.h
@@ -193,12 +193,13 @@ log_proto_server_set_ack_tracker(LogProtoServer *s, AckTracker *ack_tracker)
   s->ack_tracker = ack_tracker;
 }
 
-#define DEFINE_LOG_PROTO_SERVER(prefix) \
+#define DEFINE_LOG_PROTO_SERVER(prefix, options...) \
   static gpointer                                                       \
   prefix ## _server_plugin_construct(Plugin *self)                      \
   {                                                                     \
     static LogProtoServerFactory proto = {                              \
       .construct = prefix ## _server_new,                       \
+      ##options \
     };                                                                  \
     return &proto;                                                      \
   }

--- a/lib/logproto/logproto-text-server.c
+++ b/lib/logproto/logproto-text-server.c
@@ -83,8 +83,8 @@ log_proto_get_char_size_for_fixed_encoding(const gchar *encoding)
 }
 
 
-static LogProtoPrepareAction
-log_proto_text_server_prepare(LogProtoServer *s, GIOCondition *cond, gint *timeout)
+LogProtoPrepareAction
+log_proto_text_server_prepare_method(LogProtoServer *s, GIOCondition *cond, gint *timeout)
 {
   LogProtoTextServer *self = (LogProtoTextServer *) s;
   gboolean avail;
@@ -432,7 +432,7 @@ void
 log_proto_text_server_init(LogProtoTextServer *self, LogTransport *transport, const LogProtoServerOptions *options)
 {
   log_proto_buffered_server_init(&self->super, transport, options);
-  self->super.super.prepare = log_proto_text_server_prepare;
+  self->super.super.prepare = log_proto_text_server_prepare_method;
   self->super.super.free_fn = log_proto_text_server_free;
   self->super.fetch_from_buffer = log_proto_text_server_fetch_from_buffer;
   self->super.flush = log_proto_text_server_flush;

--- a/lib/logproto/logproto-text-server.h
+++ b/lib/logproto/logproto-text-server.h
@@ -65,6 +65,7 @@ LogProtoServer *log_proto_text_server_new(LogTransport *transport, const LogProt
 void log_proto_text_server_free(LogProtoServer *self);
 void log_proto_text_server_init(LogProtoTextServer *self, LogTransport *transport,
                                 const LogProtoServerOptions *options);
+LogProtoPrepareAction log_proto_text_server_prepare_method(LogProtoServer *s, GIOCondition *cond, gint *timeout);
 
 static inline gint
 log_proto_text_server_accumulate_line(LogProtoTextServer *self,

--- a/news/feature-3770.md
+++ b/news/feature-3770.md
@@ -1,0 +1,18 @@
+network: add support for PROXY header before TLS payload
+
+This PR adds a new transport method `proxied-tls-passthrough` which is capable of detecting the [PROXY header](http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) before the TLS payload. Loggen has been updated with the `--proxied-tls-passthrough` option for testing purposes.
+
+
+```
+source s_proxied_tls_passthrough{
+  network(
+    port(1234)
+    transport("proxied-tls-passthrough"),
+    tls(
+      key-file("/path/to/server_key.pem"),
+      cert-file("/path/to/server_cert.pem"),
+      ca-dir("/path/to/ca/")
+    )
+  );
+};
+```

--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -58,6 +58,11 @@ static PluginOption global_plugin_option =
   .port = NULL,
   .rate = 1000,
   .reconnect = 0,
+  .proxied = FALSE,
+  .proxy_src_ip = NULL,
+  .proxy_dst_ip = NULL,
+  .proxy_src_port = NULL,
+  .proxy_dst_port = NULL,
 };
 
 static char *sdata_value = NULL;
@@ -71,11 +76,6 @@ static int read_from_file = 0;
 static gint64 raw_message_length = 0;
 static gint64 *thread_stat_count = NULL;
 static gint64 *thread_stat_count_last = NULL;
-static gboolean proxied = FALSE;
-static char *proxy_src_ip = NULL;
-static char *proxy_dst_ip = NULL;
-static char *proxy_src_port = NULL;
-static char *proxy_dst_port = NULL;
 
 static GMutex message_counter_lock;
 
@@ -86,11 +86,11 @@ static GOptionEntry loggen_options[] =
   { "interval", 'I', 0, G_OPTION_ARG_INT, &global_plugin_option.interval, "Number of seconds to run the test for", "<sec>" },
   { "permanent", 'T', 0, G_OPTION_ARG_NONE, &global_plugin_option.permanent, "Send logs without time limit", NULL},
   { "syslog-proto", 'P', 0, G_OPTION_ARG_NONE, &syslog_proto, "Use the new syslog-protocol message format (see also framing)", NULL },
-  { "proxied", 'H', 0, G_OPTION_ARG_NONE, &proxied, "Generate PROXY protocol v1 header", NULL },
-  { "proxy-src-ip", 0, 0, G_OPTION_ARG_STRING, &proxy_src_ip, "Source IP for the PROXY protocol v1 header", "<ip address>" },
-  { "proxy-dst-ip", 0, 0, G_OPTION_ARG_STRING, &proxy_dst_ip, "Destination IP for the PROXY protocol v1 header", "<ip address>" },
-  { "proxy-src-port", 0, 0, G_OPTION_ARG_STRING, &proxy_src_port, "Source port for the PROXY protocol v1 header", "<port>" },
-  { "proxy-dst-port", 0, 0, G_OPTION_ARG_STRING, &proxy_dst_port, "Destination port for the PROXY protocol v1 header", "<port>" },
+  { "proxied", 'H', 0, G_OPTION_ARG_NONE, &global_plugin_option.proxied, "Generate PROXY protocol v1 header", NULL },
+  { "proxy-src-ip", 0, 0, G_OPTION_ARG_STRING, &global_plugin_option.proxy_src_ip, "Source IP for the PROXY protocol v1 header", "<ip address>" },
+  { "proxy-dst-ip", 0, 0, G_OPTION_ARG_STRING, &global_plugin_option.proxy_dst_ip, "Destination IP for the PROXY protocol v1 header", "<ip address>" },
+  { "proxy-src-port", 0, 0, G_OPTION_ARG_STRING, &global_plugin_option.proxy_src_port, "Source port for the PROXY protocol v1 header", "<port>" },
+  { "proxy-dst-port", 0, 0, G_OPTION_ARG_STRING, &global_plugin_option.proxy_dst_port, "Destination port for the PROXY protocol v1 header", "<port>" },
   { "sdata", 'p', 0, G_OPTION_ARG_STRING, &sdata_value, "Send the given sdata (e.g. \"[test name=\\\"value\\\"]\") in case of syslog-proto", NULL },
   { "no-framing", 'F', G_OPTION_ARG_NONE, G_OPTION_ARG_NONE, &noframing, "Don't use syslog-protocol style framing, even if syslog-proto is set", NULL },
   { "active-connections", 0, 0, G_OPTION_ARG_INT, &global_plugin_option.active_connections, "Number of active connections to the server (default = 1)", "<number>" },
@@ -111,10 +111,11 @@ generate_message(char *buffer, int buffer_size, ThreadData *thread_context, unsi
 {
   int str_len;
 
-  if (proxied && !thread_context->proxy_header_sent)
+  if (global_plugin_option.proxied && !thread_context->proxy_header_sent)
     {
-      str_len = generate_proxy_header(buffer, buffer_size, thread_context->index, proxy_src_ip, proxy_dst_ip, proxy_src_port,
-                                      proxy_dst_port);
+      str_len = generate_proxy_header(buffer, buffer_size, thread_context->index, global_plugin_option.proxy_src_ip,
+                                      global_plugin_option.proxy_dst_ip, global_plugin_option.proxy_src_port,
+                                      global_plugin_option.proxy_dst_port);
       thread_context->proxy_header_sent = TRUE;
       DEBUG("Generated PROXY protocol v1 header; len=%d\n", str_len);
       return str_len;

--- a/tests/loggen/loggen_plugin.h
+++ b/tests/loggen/loggen_plugin.h
@@ -46,6 +46,11 @@ typedef struct _plugin_option
   const char *port;
   int  rate;
   int reconnect;
+  gboolean proxied;
+  char *proxy_src_ip;
+  char *proxy_dst_ip;
+  char *proxy_src_port;
+  char *proxy_dst_port;
 } PluginOption;
 
 typedef struct _thread_data

--- a/tests/python_functional/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_tls_passthrough.py
+++ b/tests/python_functional/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_tls_passthrough.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2020 One Identity
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from pathlib2 import Path
+
+import src.testcase_parameters.testcase_parameters as tc_parameters
+from src.common.blocking import wait_until_true
+from src.common.file import copy_shared_file
+from src.common.file import File
+from src.common.random_id import get_unique_id
+
+TEMPLATE = r'"${PROXIED_SRCIP} ${PROXIED_DSTIP} ${PROXIED_SRCPORT} ${PROXIED_DSTPORT} ${PROXIED_IP_VERSION} ${MESSAGE}\n"'
+INPUT_MESSAGES = "message 0\n\n"
+EXPECTED_MESSAGES = "1.1.1.1 2.2.2.2 3333 4444 4 message 0\n"
+NUMBER_OF_MESSAGES = 1
+
+
+def test_pp_tls_passthrough(config, syslog_ng, port_allocator, loggen, testcase_parameters):
+    server_key_path = copy_shared_file(testcase_parameters, "server.key")
+    server_cert_path = copy_shared_file(testcase_parameters, "server.crt")
+
+    network_source = config.create_network_source(
+        ip="localhost",
+        port=port_allocator(),
+        transport='"proxied-tls-passthrough"',
+        flags="no-parse",
+        tls={
+            "key-file": server_key_path,
+            "cert-file": server_cert_path,
+            "peer-verify": '"optional-untrusted"',
+        },
+    )
+
+    file_destination = config.create_file_destination(file_name="output.log", template=TEMPLATE)
+    config.create_logpath(statements=[network_source, file_destination])
+
+    syslog_ng.start(config)
+
+    loggen_input_file_path = Path(tc_parameters.WORKING_DIR, "loggen_input_{}.txt".format(get_unique_id()))
+    loggen_input_file = File(loggen_input_file_path)
+    loggen_input_file.open(mode="w")
+    loggen_input_file.write(INPUT_MESSAGES)
+    loggen_input_file.close()
+
+    loggen.start(
+        network_source.options["ip"], network_source.options["port"], number=NUMBER_OF_MESSAGES,
+        use_ssl=True, proxied_tls_passthrough=True, read_file=str(loggen_input_file_path),
+        dont_parse=True, proxy_src_ip="1.1.1.1", proxy_dst_ip="2.2.2.2", proxy_src_port="3333",
+        proxy_dst_port="4444",
+    )
+
+    wait_until_true(lambda: loggen.get_sent_message_count() == NUMBER_OF_MESSAGES)
+    assert file_destination.read_log() == EXPECTED_MESSAGES

--- a/tests/python_functional/src/driver_io/network/network_io.py
+++ b/tests/python_functional/src/driver_io/network/network_io.py
@@ -52,3 +52,4 @@ class NetworkIO():
         TLS = {"use_ssl": True}
         PROXIED_TCP = {"inet": True, "stream": True}
         PROXIED_TLS = {"use_ssl": True}
+        PROXIED_TLS_PASSTHROUGH = {"use_ssl": True, "proxied_tls_passthrough": True}

--- a/tests/python_functional/src/helpers/loggen/loggen.py
+++ b/tests/python_functional/src/helpers/loggen/loggen.py
@@ -42,7 +42,7 @@ class Loggen(object):
     def __decode_start_parameters(
         self, inet, unix, stream, dgram, use_ssl, dont_parse, read_file, skip_tokens, loop_reading,
         rate, interval, permanent, syslog_proto, proxied, sdata, no_framing, active_connections,
-        idle_connections, ipv6, debug, number, csv, quiet, size, reconnect,
+        idle_connections, ipv6, debug, number, csv, quiet, size, reconnect, proxied_tls_passthrough,
         proxy_src_ip, proxy_dst_ip, proxy_src_port, proxy_dst_port,
     ):
 
@@ -102,6 +102,9 @@ class Loggen(object):
         if proxy_dst_port is not None:
             start_parameters.append("--proxy-dst-port={}".format(proxy_dst_port))
 
+        if proxied_tls_passthrough is True:
+            start_parameters.append("--proxied-tls-passthrough")
+
         if sdata is True:
             start_parameters.append("--sdata")
 
@@ -140,8 +143,8 @@ class Loggen(object):
     def start(
         self, target, port, inet=None, unix=None, stream=None, dgram=None, use_ssl=None, dont_parse=None, read_file=None, skip_tokens=None, loop_reading=None,
         rate=None, interval=None, permanent=None, syslog_proto=None, proxied=None, sdata=None, no_framing=None, active_connections=None,
-        idle_connections=None, ipv6=None, debug=None, number=None, csv=None, quiet=None, size=None, reconnect=None, proxy_src_ip=None,
-        proxy_dst_ip=None, proxy_src_port=None, proxy_dst_port=None,
+        idle_connections=None, ipv6=None, debug=None, number=None, csv=None, quiet=None, size=None, reconnect=None, proxied_tls_passthrough=None,
+        proxy_src_ip=None, proxy_dst_ip=None, proxy_src_port=None, proxy_dst_port=None,
     ):
 
         if self.loggen_proc is not None and self.loggen_proc.is_running():
@@ -154,8 +157,8 @@ class Loggen(object):
         self.parameters = self.__decode_start_parameters(
             inet, unix, stream, dgram, use_ssl, dont_parse, read_file, skip_tokens, loop_reading,
             rate, interval, permanent, syslog_proto, proxied, sdata, no_framing, active_connections,
-            idle_connections, ipv6, debug, number, csv, quiet, size, reconnect, proxy_src_ip,
-            proxy_dst_ip, proxy_src_port, proxy_dst_port,
+            idle_connections, ipv6, debug, number, csv, quiet, size, reconnect, proxied_tls_passthrough,
+            proxy_src_ip, proxy_dst_ip, proxy_src_port, proxy_dst_port,
         )
 
         self.loggen_proc = ProcessExecutor().start(

--- a/tests/python_functional/src/syslog_ng_config/statements/sources/network_source.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/sources/network_source.py
@@ -31,6 +31,7 @@ def map_transport(transport):
         "tls": NetworkIO.Transport.TLS,
         "proxied-tcp": NetworkIO.Transport.PROXIED_TCP,
         "proxied-tls": NetworkIO.Transport.PROXIED_TLS,
+        "proxied-tls-passthrough": NetworkIO.Transport.PROXIED_TLS_PASSTHROUGH,
     }
     transport = transport.replace("_", "-").replace("'", "").replace('"', "").lower()
 


### PR DESCRIPTION
This PR adds a new transport method `proxied-tls-passthrough` which is capable of detecting the PROXY header before the TLS payload. Loggen has been updated with the ` -proxied-passthrough ` option for testing purposes.

TODO:
~~- [x] add news file~~

Resolves #3758 