### PR TITLE
Dbld/images/Kira: Add gdb tool to kira image

### DIFF
--- a/dbld/packages.manifest
+++ b/dbld/packages.manifest
@@ -117,6 +117,7 @@ libmongoc-dev               [debian, ubuntu-xenial]
 # Tools required to run @kira-syslogng, our testbot.
 #############################################################################
 
+gdb                             [kira]
 faketime                        [kira]
 libdbd-mysql                    [kira]
 lsb-release                     [kira]


### PR DESCRIPTION
- with help of gdb tool testdb can extract a backtrace from core files

Signed-off-by: Andras Mitzki <andras.mitzki@quest.com>