### PR TITLE
draft-release: fix tarball upload

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -60,6 +60,7 @@ jobs:
 
       - name: Store release tarball as artifact
         uses: actions/upload-artifact@v2
+        if-no-files-found: error
         with:
           name: tarball
           path: ${{ env.TARBALL_PATH }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -43,27 +43,35 @@ jobs:
       - name: Checkout syslog-ng source
         uses: actions/checkout@v2
 
+      - name: Setup environment
+        run: |
+          . .github/workflows/gh-tools.sh
+
+          VERSION=`cat VERSION`
+          RELEASE_TAG=syslog-ng-$VERSION
+          RELEASE_NAME=${RELEASE_TAG}
+          TARBALL_PATH=dbld/release/${VERSION}/${RELEASE_NAME}.tar.gz
+
+          gh_export VERSION RELEASE_TAG RELEASE_NAME TARBALL_PATH
+
       - name: "DBLD: release"
         run: |
-          ./dbld/rules release VERSION=`cat VERSION`
+          ./dbld/rules release VERSION=${VERSION}
 
       - name: Store release tarball as artifact
         uses: actions/upload-artifact@v2
         with:
           name: tarball
-          path: dbld/release/${VERSION}/${RELEASE_NAME}.tar.gz
+          path: ${{ env.TARBALL_PATH }}
 
       - name: Create draft release
         run: |
-          VERSION=`cat VERSION`
-          RELEASE_TAG=syslog-ng-$VERSION
-          RELEASE_NAME=${RELEASE_TAG}
           sed "1 i${RELEASE_NAME}\n" NEWS.md > /tmp/message
 
           hub release create \
             --draft \
             --file /tmp/message \
-            --attach dbld/release/${VERSION}/${RELEASE_NAME}.tar.gz \
+            --attach ${TARBALL_PATH} \
             ${RELEASE_TAG}
 
       - name: "Comment: job status"


### PR DESCRIPTION
Example run, where the jobs only failed, because we *correctly* cannot upload the generated packages to the APT repository from a fork: https://github.com/alltilla/syslog-ng/actions/runs/1220228559

![Screenshot from 2021-09-10 08-52-39](https://user-images.githubusercontent.com/45236571/132812414-aa75cda0-c306-4ddf-9ccf-04ff077ec653.png)

NOTE: The draft release job comments on the version bump PR prematurely. I will fix that problem in a separate PR, as it is not essential to the release.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>