### PR TITLE
draft-release: use if-no-files-found in the correct place

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -60,10 +60,10 @@ jobs:
 
       - name: Store release tarball as artifact
         uses: actions/upload-artifact@v2
-        if-no-files-found: error
         with:
           name: tarball
           path: ${{ env.TARBALL_PATH }}
+          if-no-files-found: error
 
       - name: Create draft release
         run: |


### PR DESCRIPTION
See: https://github.com/actions/upload-artifact#customization-if-no-files-are-found

Example run for successful artifact upload: https://github.com/alltilla/syslog-ng/runs/3565129785?check_suite_focus=true

![Screenshot from 2021-09-10 10-25-47](https://user-images.githubusercontent.com/45236571/132824383-b68d47d2-2cca-42e2-8252-c48915bf1521.png)

Example run for unsuccessful artifact upload: https://github.com/alltilla/syslog-ng/runs/3565250330?check_suite_focus=true

![Screenshot from 2021-09-10 10-34-30](https://user-images.githubusercontent.com/45236571/132825441-44514098-43a8-407e-8e33-30506e08ee38.png)


Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>