### PR TITLE
dbld: change default python case to python3

### DIFF
--- a/dbld/builddeps
+++ b/dbld/builddeps
@@ -154,17 +154,17 @@ function install_yum_packages {
 
 function install_pip_packages {
     case "${IMAGE_PLATFORM}" in
-        fedora-*)
-            python_executables="python"
+        ubuntu-xenial|ubuntu-bionic)
+            python_executables="python2"
             ;;
-        ubuntu-focal|tarball)
-            python_executables="python3"
+        debian-stretch|debian-buster)
+            python_executables="python2"
             ;;
         devshell|kira)
             python_executables="python2 python3"
             ;;
         *)
-            python_executables="python2"
+            python_executables="python3"
             ;;
     esac
     for python_executable in ${python_executables}; do

--- a/news/developer-note-3780.md
+++ b/news/developer-note-3780.md
@@ -1,0 +1,2 @@
+dbld: As new distributions use python3 by default it makes sense to explicitly state older platforms which use python2
+instead of the other way around, so it is not necessary to add that new platform to the python3 case.


### PR DESCRIPTION
As new distributions use `python3` by default it makes sense to explicitly state older platforms which use `python2` instead of the other way around, so it is not necessary to add that new platform to the `python3` case.
Signed-off-by: Parrag Szilárd <szilard.parrag@gmail.com>