### PR TITLE
disable package upload on forked repositories

### DIFF
--- a/.github/workflows/nightly-packages.yml
+++ b/.github/workflows/nightly-packages.yml
@@ -72,7 +72,7 @@ jobs:
 
       # Note: azure/CLI docker container mounts the GITHUB_WORKSPACE folder and changes the environment variable.
       - name: Upload the package
-        if: env.UPLOAD == 'true'
+        if: env.UPLOAD == 'true' && github.repository_owner == 'syslog-ng'
         uses: azure/CLI@v1
         env:
           SRC_PATH: ${{ env.MY_WORKSPACE_NAME }}/syslog-ng/dbld/build/${{ env.DISTRIBUTION }}


### PR DESCRIPTION
It is most likely that forked repositories don't want to upload the
binary packages, but this step (in this form) will break their CI.

Negative test: https://github.com/szemere/syslog-ng/commit/b1489797716940bcb119da5ed31d908be9a4156c (commit is deleted from the PR) -> https://github.com/szemere/syslog-ng/actions/runs/1229853496

Positive test: https://github.com/szemere/syslog-ng/actions/runs/1229627448