### PR TITLE
build: support build with bison 3.8

### DIFF
--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -233,7 +233,7 @@ _print_underline(const gchar *line, gint whitespace_before, gint number_of_caret
 }
 
 static void
-_print_underlined_source_block(CFG_LTYPE *yylloc, gchar **lines, gint error_index)
+_print_underlined_source_block(const CFG_LTYPE *yylloc, gchar **lines, gint error_index)
 {
   gint line_ndx;
   gchar line_prefix[12];
@@ -268,7 +268,7 @@ _print_underlined_source_block(CFG_LTYPE *yylloc, gchar **lines, gint error_inde
 }
 
 static void
-_report_file_location(const gchar *filename, CFG_LTYPE *yylloc)
+_report_file_location(const gchar *filename, const CFG_LTYPE *yylloc)
 {
   FILE *f;
   gint lineno = 0;
@@ -306,7 +306,7 @@ exit:
 }
 
 static void
-_report_buffer_location(const gchar *buffer_content, CFG_LTYPE *yylloc)
+_report_buffer_location(const gchar *buffer_content, const CFG_LTYPE *yylloc)
 {
   gchar **lines = g_strsplit(buffer_content, "\n", yylloc->first_line + CONTEXT + 1);
   gint num_lines = g_strv_length(lines);
@@ -328,13 +328,14 @@ exit:
 }
 
 void
-report_syntax_error(CfgLexer *lexer, CFG_LTYPE *yylloc, const char *what, const char *msg, gboolean in_main_grammar)
+report_syntax_error(CfgLexer *lexer, const CFG_LTYPE *yylloc, const char *what, const char *msg,
+                    gboolean in_main_grammar)
 {
   CfgIncludeLevel *level = yylloc->level, *from;
 
   for (from = level; from >= lexer->include_stack; from--)
     {
-      CFG_LTYPE *from_lloc;
+      const CFG_LTYPE *from_lloc;
 
       if (from == level)
         {

--- a/lib/cfg-parser.h
+++ b/lib/cfg-parser.h
@@ -76,7 +76,7 @@ extern CfgParser main_parser;
     parser_prefix ## lex(CFG_STYPE *yylval, CFG_LTYPE *yylloc, CfgLexer *lexer);   \
                                                                                \
     void                                                                       \
-    parser_prefix ## error(CFG_LTYPE *yylloc, CfgLexer *lexer, root_type instance, gpointer arg, const char *msg);
+    parser_prefix ## error(const CFG_LTYPE *yylloc, CfgLexer *lexer, root_type instance, gpointer arg, const char *msg);
 
 
 #define CFG_PARSER_IMPLEMENT_LEXER_BINDING(parser_prefix, PARSER_PREFIX, root_type)          \
@@ -90,14 +90,14 @@ extern CfgParser main_parser;
     }                                                                         \
                                                                               \
     void                                                                      \
-    parser_prefix ## error(CFG_LTYPE *yylloc, CfgLexer *lexer, root_type instance, gpointer arg, const char *msg) \
+    parser_prefix ## error(const CFG_LTYPE *yylloc, CfgLexer *lexer, root_type instance, gpointer arg, const char *msg) \
     {                                                                 \
       gboolean in_main_grammar = __builtin_strcmp( # parser_prefix, "main_") == 0;              \
       report_syntax_error(lexer, yylloc, cfg_lexer_get_context_description(lexer), msg,   \
                           in_main_grammar);                                                     \
     }
 
-void report_syntax_error(CfgLexer *lexer, CFG_LTYPE *yylloc, const char *what, const char *msg,
+void report_syntax_error(CfgLexer *lexer, const CFG_LTYPE *yylloc, const char *what, const char *msg,
                          gboolean in_main_grammar);
 
 CFG_PARSER_DECLARE_LEXER_BINDING(main_, MAIN_, gpointer *)

--- a/news/packaging-3784.md
+++ b/news/packaging-3784.md
@@ -1,0 +1,1 @@
+`bison`: support build with bison 3.8


### PR DESCRIPTION
Starting with bison 3.8, bison generates the function declarations we have already done in `CFG_PARSER_DECLARE_LEXER_BINDING`. https://github.com/akimd/bison/blob/master/NEWS#L19

The only difference between the generated one, and our macro is a `const` qualifier before `CFG_LTYPE *yylloc`.

In order to work with both 3.8 and older bison versions, we should keep our manual function definitions in the code, but it should match with the one, bison generates.

Green macOS CI job should validate this PR: https://formulae.brew.sh/formula/bison

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>