### PR TITLE
dbld: add distro pip package to KIRA

### DIFF
--- a/dbld/pip_packages.manifest
+++ b/dbld/pip_packages.manifest
@@ -3,6 +3,7 @@ ply                     [centos, fedora, debian, ubuntu, devshell, tarball]
 
 # pip packages for kira tests
 # 0.17: Last version that suppports python2
+distro                  [kira]
 hy==0.17                [devshell, kira]
 requests                [kira]
 


### PR DESCRIPTION
We need that in our internal tests.

No news file needed.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>