### PR TITLE
macos: explicitly require OpenSSL 1.1

### DIFF
--- a/contrib/Brewfile
+++ b/contrib/Brewfile
@@ -12,7 +12,7 @@ brew "pkg-config"
 brew "ivykis"
 brew "rabbitmq-c"
 brew "mongo-c-driver"
-brew "openssl"
+brew "openssl@1.1"
 # brew "pcre"
 
 brew "gradle"


### PR DESCRIPTION
This PR aims to fix our macOS build failure.

Signed-off-by: Parrag Szilárd <szilard.parrag@gmail.com>