### PR TITLE
Add TLS keylog capability

### DIFF
--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -118,6 +118,7 @@ gint tls_context_get_verify_mode(const TLSContext *self);
 void tls_context_set_verify_mode(TLSContext *self, gint verify_mode);
 void tls_context_set_key_file(TLSContext *self, const gchar *key_file);
 void tls_context_set_cert_file(TLSContext *self, const gchar *cert_file);
+gboolean tls_context_set_keylog_file(TLSContext *self, gchar *keylog_file_path);
 void tls_context_set_pkcs12_file(TLSContext *self, const gchar *pkcs12_file);
 void tls_context_set_ca_dir(TLSContext *self, const gchar *ca_dir);
 void tls_context_set_crl_dir(TLSContext *self, const gchar *crl_dir);

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -191,6 +191,7 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 %token KW_SSL_OPTIONS
 %token KW_SNI
 %token KW_ALLOW_COMPRESS
+%token KW_KEYLOG_FILE
 
 /* INCLUDE_DECLS */
 
@@ -801,6 +802,11 @@ tls_option
 	| KW_KEY_FILE '(' path_secret ')'
 	  {
 	    tls_context_set_key_file(last_tls_context, $3);
+            free($3);
+          }
+	| KW_KEYLOG_FILE '(' string ')'
+	  {
+		CHECK_ERROR(tls_context_set_keylog_file(last_tls_context, $3), @3, "keylog_file() requires OpenSSL >= v1.1.1");
             free($3);
           }
 	| KW_CERT_FILE '(' path_check ')'

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -47,6 +47,7 @@ static CfgLexerKeyword afsocket_keywords[] =
   { "peer_verify",        KW_PEER_VERIFY },
   { "key_file",           KW_KEY_FILE },
   { "cert_file",          KW_CERT_FILE },
+  { "keylog_file",        KW_KEYLOG_FILE },
   { "dhparam_file",       KW_DHPARAM_FILE },
   { "pkcs12_file",        KW_PKCS12_FILE },
   { "ca_dir",             KW_CA_DIR },

--- a/news/feature-3792.md
+++ b/news/feature-3792.md
@@ -1,0 +1,17 @@
+network drivers: add TLS keylog support
+syslog-ng dumps TLS secrets for a given source/destination, which can be used for debugging purposes to decrypt data with, for example, Wireshark.
+**This should be used for debugging purposes only!**.
+```
+source tls_source{
+  network(
+      port(1234)
+      transport("tls"),
+      tls(
+        key-file("/path/to/server_key.pem"),
+        cert-file("/path/to/server_cert.pem"),
+        ca-dir("/path/to/ca/")
+        keylog-file("/path/to/keylog_file")
+        )
+      );
+};
+```


### PR DESCRIPTION
This PR adds a new TLS block option: `keylog-file()` which will be used to export TLS secrets between clients/servers. This should aid debugging sessions as the specified file can be loaded into Wireshark and then Wireshark is able to decrypt the traffic.

Fixes #3592