### PR TITLE
feat: Add centos-8 with updated python

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -103,6 +103,7 @@ jobs:
         - { distro: 'debian-bullseye', pkg: 'deb', upload: 'true' }
         - { distro: 'ubuntu-focal',    pkg: 'deb', upload: 'true' }
         - { distro: 'centos-7',        pkg: 'rpm', upload: 'false' }
+        - { distro: 'centos-8',        pkg: 'rpm', upload: 'false' }
         - { distro: 'fedora-33',       pkg: 'rpm', upload: 'false' }
       fail-fast: false
     env:

--- a/.github/workflows/nightly-packages.yml
+++ b/.github/workflows/nightly-packages.yml
@@ -42,6 +42,7 @@ jobs:
         - { distro: 'ubuntu-bionic',   pkg: 'deb', upload: 'true' }
         - { distro: 'ubuntu-focal',    pkg: 'deb', upload: 'true' }
         - { distro: 'centos-7',        pkg: 'rpm', upload: 'false' }
+        - { distro: 'centos-8',        pkg: 'rpm', upload: 'false' }
         - { distro: 'fedora-33',       pkg: 'rpm', upload: 'false' }
       fail-fast: false
     env:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         distro: 
-        - centos-7
+        - centos-8
         - debian-bullseye
         - debian-testing
         - fedora-33

--- a/dbld/Makefile.am
+++ b/dbld/Makefile.am
@@ -28,6 +28,7 @@ EXTRA_DIST += \
 	dbld/images/fedora.prepare.sh \
 	dbld/images/devshell.dockerfile \
 	dbld/images/centos-7.dockerfile \
+	dbld/images/centos-8.dockerfile \
 	dbld/images/fedora-33.dockerfile \
 	dbld/images/debian-stretch.dockerfile \
 	dbld/images/debian-buster.dockerfile \

--- a/dbld/build.manifest
+++ b/dbld/build.manifest
@@ -41,4 +41,5 @@ ubuntu-bionic		python2,nocriterion,nokafka,nomqtt
 ubuntu-focal		python3,nocriterion,nomqtt
 
 centos-7		python2
+centos-8        python3,nojava
 fedora			python3

--- a/dbld/builddeps
+++ b/dbld/builddeps
@@ -116,6 +116,11 @@ function add_epel_repo {
     $YUM_INSTALL epel-release
 }
 
+function add_powertools_repo {
+    $YUM_INSTALL dnf-plugins-core
+    dnf config-manager --set-enabled powertools
+}
+
 function install_apt_packages {
     apt-get update -qq -o Acquire::CompressionTypes::Order::=gz
     filter_packages_by_platform $DBLD_DIR/packages.manifest | xargs -t $APT_INSTALL --yes

--- a/dbld/images/centos-8.dockerfile
+++ b/dbld/images/centos-8.dockerfile
@@ -1,0 +1,30 @@
+FROM centos:8
+LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
+ENV OS_DISTRIBUTION=centos
+ENV OS_DISTRIBUTION_CODE_NAME=8
+
+ARG ARG_IMAGE_PLATFORM
+ARG COMMIT
+ENV IMAGE_PLATFORM ${ARG_IMAGE_PLATFORM}
+LABEL COMMIT=${COMMIT}
+
+COPY images/fake-sudo.sh /usr/bin/sudo
+COPY images/entrypoint.sh /
+COPY . /dbld/
+
+RUN /dbld/builddeps install_dbld_dependencies
+RUN /dbld/builddeps add_epel_repo
+RUN /dbld/builddeps add_copr_repo
+RUN /dbld/builddeps add_powertools_repo
+RUN /dbld/builddeps install_yum_packages
+RUN /dbld/builddeps install_rpm_build_deps
+RUN /dbld/builddeps install_pip_packages
+
+RUN /dbld/builddeps install_criterion
+RUN /dbld/builddeps install_gradle
+RUN /dbld/builddeps install_gosu amd64
+
+VOLUME /source
+VOLUME /build
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/dbld/packages.manifest
+++ b/dbld/packages.manifest
@@ -88,12 +88,14 @@ automake                    [centos, fedora]
 
 python-dev                  [debian-stretch, debian-buster, ubuntu-xenial, ubuntu-bionic]
 python2-dev                 [debian-sid]
-python-devel                [centos, fedora]
+python-devel                [centos-7, fedora]
 python3-devel               [fedora]
 python-unversioned-command  [fedora]
 python3-dev                 [ubuntu-focal]
-python-pip                      [centos, fedora, debian-stretch, debian-buster, ubuntu-trusty, ubuntu-xenial, ubuntu-bionic]
+python-pip                      [centos-7, fedora, debian-stretch, debian-buster, ubuntu-trusty, ubuntu-xenial, ubuntu-bionic]
 python3-pip                     [debian, ubuntu]
+python39-devel              [centos-8]
+python39-pip              [centos-8]
 
 # libmongoc and libbson packages on various platforms
 # Because we are using fixed version of libmongoc on Bionic, we need to

--- a/dbld/rules
+++ b/dbld/rules
@@ -2,6 +2,7 @@
 
 BUILDER_IMAGES=		\
 	centos-7 	\
+	centos-8	\
 	fedora-33	\
 	debian-stretch	\
 	debian-buster	\

--- a/packaging/rhel/syslog-ng.spec
+++ b/packaging/rhel/syslog-ng.spec
@@ -27,12 +27,17 @@ Source4: syslog-ng.logrotate7
 %bcond_without mqtt
 
 
+%if 0%{?rhel} == 8
+%global		python_devel python39-devel
+%global         py_ver  3.9
+%else
 %if 0%{?rhel} == 7
 %global		python_devel python36-devel
 %global         py_ver  3.6
 %else
 %global		python_devel python3-devel
 %global         py_ver  %{python3_version}
+%endif
 %endif
 
 %if 0%{?rhel} >= 7 || 0%{?fedora} <= 32


### PR DESCRIPTION
#3795 
This PR adds build rules to dbld for centos-8 to produce rpms with python 3.9 dependencies