### PR TITLE
dbld: enable kafka and mqtt on centos-7

### DIFF
--- a/dbld/build.manifest
+++ b/dbld/build.manifest
@@ -40,5 +40,5 @@ ubuntu-xenial		python2,nocriterion,nokafka,nojava,nomqtt
 ubuntu-bionic		python2,nocriterion,nokafka,nomqtt
 ubuntu-focal		python3,nocriterion,nomqtt
 
-centos-7		python2,nokafka,nomqtt
+centos-7		python2
 fedora			python3

--- a/news/packaging-3797.md
+++ b/news/packaging-3797.md
@@ -1,0 +1,5 @@
+`centos-7`: `kafka` and `mqtt` modules are now tested in our CI.
+
+We are using:
+ * `librdkafka-devel` from EPEL 7
+ * `paho-c-devel` from copr:copr.fedorainfracloud.org:czanik:syslog-ng-githead


### PR DESCRIPTION
`librdkafka-devel` 1.5.3 is available in Czanik's COPR.
`paho-c-devel` 1.3.1 is available in EPEL 7.

```
$ dbld/rules shell-centos-7
...

bash-4.2$ yum info librdkafka-devel
...
Name        : librdkafka-devel                                                                                                                                                                                       
Arch        : x86_64
Version     : 1.5.3
Release     : 1.el7
Size        : 575 k
Repo        : installed
From repo   : copr:copr.fedorainfracloud.org:czanik:syslog-ng-githead
Summary     : The Apache Kafka C library (Development Environment)
URL         : https://github.com/edenhill/librdkafka
License     : BSD
Description : librdkafka is a C/C++ library implementation of the Apache Kafka protocol,
            : containing both Producer and Consumer support.
            : This package contains headers and libraries required to build applications
            : using librdkafka.


bash-4.2$ yum info paho-c-devel
...
Name        : paho-c-devel
Arch        : x86_64
Version     : 1.3.1
Release     : 0.el7
Size        : 247 k
Repo        : installed
From repo   : epel
Summary     : MQTT C Client development kit
URL         : https://eclipse.org/paho/clients/c/
License     : BSD and EPL
Description : Development files and samples for the the Paho MQTT C Client.
```
Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>