### PR TITLE
Generate serialized messages

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -140,6 +140,7 @@ endif
 
 ${check_PROGRAMS}: LDFLAGS+=${test_ldflags}
 
+noinst_PROGRAMS         =
 noinst_LIBRARIES	=
 noinst_DATA		=
 noinst_LTLIBRARIES	=

--- a/lib/logmsg/tests/Makefile.am
+++ b/lib/logmsg/tests/Makefile.am
@@ -44,3 +44,8 @@ noinst_PROGRAMS +=				\
 lib_logmsg_tests_dump_logmsg_CFLAGS = $(TEST_CFLAGS)
 lib_logmsg_tests_dump_logmsg_LDADD = $(TEST_LDADD) $(PREOPEN_SYSLOGFORMAT)
 
+.PHONY: dump-logmsg
+dump-logmsg: lib/logmsg/tests/dump_logmsg
+	DIR=lib/logmsg/tests/messages/ && \
+	mkdir -p $${DIR} && \
+	lib/logmsg/tests/dump_logmsg $(VERSION) > $${DIR}/syslog-ng-$(VERSION)-msg.h

--- a/lib/logmsg/tests/Makefile.am
+++ b/lib/logmsg/tests/Makefile.am
@@ -37,3 +37,10 @@ lib_logmsg_tests_test_logmsg_ack_CFLAGS = $(TEST_CFLAGS)
 
 lib_logmsg_tests_test_nvhandle_desc_array_LDADD = $(TEST_LDADD)
 lib_logmsg_tests_test_nvhandle_desc_array_CFLAGS = $(TEST_CFLAGS)
+
+noinst_PROGRAMS +=				\
+	lib/logmsg/tests/dump_logmsg
+
+lib_logmsg_tests_dump_logmsg_CFLAGS = $(TEST_CFLAGS)
+lib_logmsg_tests_dump_logmsg_LDADD = $(TEST_LDADD) $(PREOPEN_SYSLOGFORMAT)
+

--- a/lib/logmsg/tests/dump_logmsg.c
+++ b/lib/logmsg/tests/dump_logmsg.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021 Balazs Scheidler <bazsi77@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "test_logmsg_serialize.c"
+
+
+GString *
+_translate_version(const gchar *version)
+{
+  GString *r = g_string_new(version);
+
+  for (gsize i = 0; i < r->len; i++)
+    {
+      if (r->str[i] == '.')
+        r->str[i] = '_';
+      if (r->str[i] == '+')
+        {
+          g_string_truncate(r, i);
+          break;
+        }
+    }
+  return r;
+}
+
+static void
+_dump_serialized_bytes(const gchar *translated_version)
+{
+  GString *data = g_string_new("");
+  SerializeArchive *sa = _serialize_message_for_test(data, RAW_MSG);
+
+  printf("unsigned char serialized_message_%s[] = {\n", translated_version);
+  printf("  /* serialized payload %d bytes */\n", (gint) data->len);
+  for (gsize line_start = 0; line_start < data->len; line_start += 16)
+    {
+      for (gint row = 0; row < 16 && line_start + row < data->len; row++)
+        {
+          gsize cell = line_start + row;
+
+          printf("%s0x%02x%s",
+                 row == 0 ? "  " : "",
+                 (guint8) data->str[cell],
+                 row == 15 ? ",\n" : ", ");
+        }
+    }
+
+  serialize_archive_free(sa);
+  printf("\n};\n");
+}
+
+int main(int argc, char *argv[])
+{
+  setup();
+
+  if (argc < 2)
+    {
+      fprintf(stderr, "Expected <version> number argument.\n");
+      teardown();
+      return 1;
+    }
+  GString *translated_version = _translate_version(argv[1]);
+
+  _dump_serialized_bytes(translated_version->str);
+
+  g_string_free(translated_version, TRUE);
+  teardown();
+}

--- a/lib/tests/Makefile.am
+++ b/lib/tests/Makefile.am
@@ -29,7 +29,7 @@ EXTRA_DIST += lib/tests/CMakeLists.txt
 check_PROGRAMS		+= ${lib_tests_TESTS}
 
 if ENABLE_TESTING
-noinst_PROGRAMS 	= \
+noinst_PROGRAMS 	+= \
 	lib/tests/test_host_resolve
 
 lib_tests_test_host_resolve_CFLAGS	=	\

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -64,6 +64,7 @@ lib/rewrite/tests/test_set_facility\.c
 lib/rewrite/rewrite-set-pri\.h
 lib/rewrite/rewrite-set-pri\.c
 lib/timeutils/timeutils\.h
+lib/logmsg/tests/dump_logmsg\.c
  LGPLv2.1+_SSL
 autogen\.sh$
 sub-configure\.sh$


### PR DESCRIPTION
This branch adds a 'dump-logmsg' make target to generate a binary dump (in the form of a C array) of a serialized log message,
as prepared by the _serialize_message_for_test() function in test_logmsg_serialize.c

I've used these patches on top of various syslog-ng versions to generate a test set for legacy, serialized message payloads,
but merging these means that it's going to be easier to add further testcases as the serialization code changes.