### PR TITLE
dbld/make: propagate VERSION value into the Makefile

### DIFF
--- a/dbld/make
+++ b/dbld/make
@@ -3,4 +3,4 @@
 set -e
 
 cd /build
-make "$@"
+make ${VERSION:+VERSION=$VERSION} "$@"


### PR DESCRIPTION
VERSION as a value is generated into Makefiles by autoconf/automake.
If we re-execute the configure script from the Makefile (which happens
automatically if configure.ac changes), this VERSION value gets exported
to configure, thus also exported to scripts/version.sh.

So even if we do have VERSION environment variable set at the time of
the make invocation, it will be clobbered:

 * make sets VERSION to its own value
 * re-executes configure, which picks the value as supplied by the Makefile
 * this configure script writes out a new Makefile, with the same, clobbered VERSION value

The same does not happen when a full bootstrap is done, because in that
case the configure script is not invoked from within the Makefile.

I needed this change when compiling various versions of syslog-ng in the
same build directory and only doing an incremental build (which speeded up
my process a lot).

Signed-off-by: Balazs Scheidler <bazsi77@gmail.com>