### PR TITLE
travis: upgrade to focal (fix for root CA issuue)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,10 +81,3 @@ matrix:
 branches:
   except:
     - /wip/
-notifications:
-  webhooks:
-      urls:
-        - https://webhooks.gitter.im/e/1c6e3a6f10348748585a
-      on_success: always  # options: [always|never|change] default: always
-      on_failure: always  # options: [always|never|change] default: always
-      on_start: true     # default: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,9 +58,6 @@ matrix:
         - sudo make install
         - cd ..
 
-        # we are using 3.5.1 because we want to test ubuntu-focal
-        # compatibility just in case we migrate away from ubuntu-focal in
-        # our devshell images (which is tested by our github actions)
         - wget https://ftp.gnu.org/gnu/bison/bison-3.7.6.tar.gz
         - tar xvf bison-3.7.6.tar.gz
         - cd bison-3.7.6
@@ -68,6 +65,7 @@ matrix:
         - make all
         - sudo make install
         - cd ..
+
         - mkdir build
         - cd build
         - cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ matrix:
             - libmongoc-dev
             - libjson-c-dev
             - m4
-            - python-dev
-            - python-pip
-            - python-setuptools
+            - python3-dev
+            - python3-pip
+            - python3-setuptools
             - libnet1-dev
             - libriemann-client-dev
             - librdkafka-dev
@@ -46,8 +46,8 @@ matrix:
             - libsnmp-dev
             - autopoint
       install:
-        - python2 -m pip install --user --cache-dir=$PWD/pip-cache -r requirements.txt
-        - python2 -m pip list
+        - python3 -m pip install --user --cache-dir=$PWD/pip-cache -r requirements.txt
+        - python3 -m pip list
       script:
         - set -e
         - git clone https://github.com/Snaipe/Criterion.git -b v2.3.3
@@ -72,7 +72,7 @@ matrix:
         - cd build
         - cmake
             -DCMAKE_C_FLAGS=-Werror
-            -DPYTHON_VERSION=2
+            -DPYTHON_VERSION=3
             -DCMAKE_INSTALL_PREFIX=$HOME/install/syslog-ng
             ..
         - make --keep-going -j $(nproc) all install

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
     - env: B=cmake-arm
       compiler: gcc
       sudo: required
+      dist: focal
       arch: arm64
       addons:
         apt:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/syslog-ng/syslog-ng?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=body_badge)
-[![Build Status](https://travis-ci.org/syslog-ng/syslog-ng.svg?branch=master)](https://travis-ci.org/syslog-ng/syslog-ng)
+[![Build Status](https://github.com/syslog-ng/syslog-ng/actions/workflows/devshell.yml/badge.svg)](https://github.com/syslog-ng/syslog-ng/actions/workflows/devshell.yml)
+[![Binary packages](https://github.com/syslog-ng/syslog-ng/actions/workflows/packages.yml/badge.svg)](https://github.com/syslog-ng/syslog-ng/actions/workflows/packages.yml)
+[![Compile dbld-images](https://github.com/syslog-ng/syslog-ng/actions/workflows/dbld-images.yml/badge.svg)](https://github.com/syslog-ng/syslog-ng/actions/workflows/dbld-images.yml)
 
 syslog-ng
 =========


### PR DESCRIPTION
> September 30, 2021 As planned, the DST Root CA X3 cross-sign has expired,
> and we’re now using our own ISRG Root X1 for trust on almost all devices.

> If clients of your API are using OpenSSL, they must use version 1.1.0 or
> later. In OpenSSL 1.0.x, a quirk in certificate verification means that
> even clients that trust ISRG Root X1 will fail

https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/

Unfortunately, it is not enough to add the mentioned Root CA to the
system's trusted certificates, an OpenSSL upgrade would have been also
required.

Instead of implementing the above workarounds, this commit upgrades to
Ubuntu Focal (from Xenial).
