### PR TITLE
github-actions: upload nightly and release packages to "incoming"

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -138,6 +138,6 @@ jobs:
         uses: azure/CLI@v1
         env:
           SRC_PATH: ${{ env.MY_WORKSPACE_NAME }}/syslog-ng/dbld/build/${{ env.DISTRIBUTION }}
-          DST_PATH: incoming-release/${{ github.run_id }}/${{ env.DISTRIBUTION }}
+          DST_PATH: incoming/release/${{ github.run_id }}/${{ env.DISTRIBUTION }}
         with:
           inlineScript: az storage blob upload-batch --sas-token '${{ secrets.AZURE_SAS_TOKEN }}' --account-name 'syslogngose' --source ${GITHUB_WORKSPACE}/${SRC_PATH} --destination ${DST_PATH}

--- a/.github/workflows/nightly-packages.yml
+++ b/.github/workflows/nightly-packages.yml
@@ -77,6 +77,6 @@ jobs:
         uses: azure/CLI@v1
         env:
           SRC_PATH: ${{ env.MY_WORKSPACE_NAME }}/syslog-ng/dbld/build/${{ env.DISTRIBUTION }}
-          DST_PATH: incoming-nightly/${{ env.DISTRIBUTION }}
+          DST_PATH: incoming/nightly/${{ env.DISTRIBUTION }}
         with:
           inlineScript: az storage blob upload-batch --sas-token '${{ secrets.AZURE_SAS_TOKEN }}' --account-name 'syslogngose' --source ${GITHUB_WORKSPACE}/${SRC_PATH} --destination ${DST_PATH}


### PR DESCRIPTION
Previously nightly was uploaded to the "incoming-nightly" container
and the release was uploaded to the "incoming-release" container.

It is easier to index the packages if they are uploaded to the same
container under different subdirs.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>