### PR TITLE
Add rewrite rule to rename a macro

### DIFF
--- a/scl/rewrite/rename.conf
+++ b/scl/rewrite/rename.conf
@@ -1,0 +1,41 @@
+@version: 3.19
+#############################################################################
+# Copyright (c) 2013 Balabit
+# Copyright (c) 2013 Márton Illés <marci@balabit.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+#
+# The rewrite rule below can be used to rename a macro
+#
+# Its usage is simple:
+#
+# log {
+#  source (s_local);
+#  rewrite { rename(source('old_name'), destination('new_name')); };
+#  destination (d_local);
+# };
+#
+
+block rewrite rename (source() destination())
+{
+	set("$`source`", value('`destination`'));
+	unset(value('`source`'));
+};
+

--- a/scl/rewrite/rename.conf
+++ b/scl/rewrite/rename.conf
@@ -1,4 +1,3 @@
-@version: 3.19
 #############################################################################
 # Copyright (c) 2013 Balabit
 # Copyright (c) 2013 Márton Illés <marci@balabit.com>


### PR DESCRIPTION
```
rewrite { rename(source('old_name'), destination('new_name')); };
```