### PR TITLE
Throttle filter add template support

### DIFF
--- a/lib/filter/filter-expr-grammar.ym
+++ b/lib/filter/filter-expr-grammar.ym
@@ -315,6 +315,11 @@ filter_throttle_arg
             filter_throttle_set_key(last_filter_expr, log_msg_get_value_handle($3));
             free($3);
           }
+  | KW_TEMPLATE '(' template_content ')'
+          {
+            filter_throttle_set_key_template(last_filter_expr, $3);
+            log_template_unref($3);
+          }
   | KW_RATE '(' positive_integer ')'
           {
             filter_throttle_set_rate(last_filter_expr, $3);

--- a/lib/filter/filter-expr-grammar.ym
+++ b/lib/filter/filter-expr-grammar.ym
@@ -310,12 +310,7 @@ filter_severity
 	;
 
 filter_throttle_arg
-  : KW_VALUE '(' string ')'
-          {
-            filter_throttle_set_key(last_filter_expr, log_msg_get_value_handle($3));
-            free($3);
-          }
-  | KW_TEMPLATE '(' template_content ')'
+  : KW_TEMPLATE '(' template_content ')'
           {
             filter_throttle_set_key_template(last_filter_expr, $3);
             log_template_unref($3);

--- a/lib/filter/filter-throttle.c
+++ b/lib/filter/filter-throttle.c
@@ -119,6 +119,11 @@ filter_throttle_generate_key_template(FilterExprNode *s, LogMessage *msg, LogTem
 {
   FilterThrottle *self = (FilterThrottle *)s;
 
+  if (log_template_is_trivial(self->key_template))
+    {
+      return log_template_get_trivial_value(self->key_template, msg, len);
+    }
+
   GString *key = scratch_buffers_alloc();
 
   log_template_format(self->key_template, msg, options, key);

--- a/lib/filter/filter-throttle.h
+++ b/lib/filter/filter-throttle.h
@@ -28,6 +28,7 @@
 
 FilterExprNode *filter_throttle_new(void);
 
+void filter_throttle_set_key_template(FilterExprNode *s, LogTemplate *template);
 void filter_throttle_set_key(FilterExprNode *s, NVHandle key_handle);
 void filter_throttle_set_rate(FilterExprNode *s, gint rate);
 


### PR DESCRIPTION
This PR adds template supports, and as a last step removes `value()` option.
`value("A")` can be replaced with `template("${A}")`.

This PR somewhat conflicts with:
*  https://github.com/syslog-ng/syslog-ng/pull/3816 (news entry)
* https://github.com/syslog-ng/syslog-ng/pull/3815 (light tests)

I'll provide patches in those, but as the result no separate news entry is needed here.

Example config:
```
   throttle(
     template("${.journald._UID}")
     rate(1)
   );
```