### PR TITLE
github-actions: add debian-testing to nightly package generation

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -97,6 +97,7 @@ jobs:
         dbld-builder-images:
         - { distro: 'debian-stretch',  pkg: 'deb', upload: 'true' }
         - { distro: 'debian-buster',   pkg: 'deb', upload: 'true' }
+        - { distro: 'debian-testing',  pkg: 'deb', upload: 'true' }
         - { distro: 'debian-sid',      pkg: 'deb', upload: 'true' }
         - { distro: 'ubuntu-xenial',   pkg: 'deb', upload: 'true' }
         - { distro: 'ubuntu-bionic',   pkg: 'deb', upload: 'true' }

--- a/.github/workflows/nightly-packages.yml
+++ b/.github/workflows/nightly-packages.yml
@@ -37,6 +37,7 @@ jobs:
         - { distro: 'debian-stretch',  pkg: 'deb', upload: 'true' }
         - { distro: 'debian-buster',   pkg: 'deb', upload: 'true' }
         - { distro: 'debian-bullseye', pkg: 'deb', upload: 'true' }
+        - { distro: 'debian-testing',  pkg: 'deb', upload: 'true' }
         - { distro: 'debian-sid',      pkg: 'deb', upload: 'true' }
         - { distro: 'ubuntu-xenial',   pkg: 'deb', upload: 'true' }
         - { distro: 'ubuntu-bionic',   pkg: 'deb', upload: 'true' }


### PR DESCRIPTION
Currently we do not generate nightly packages for debian-testing which is odd, because our tarball image is based on debian-testing so it would be appropriate to create nightly packages for it.

Signed-off-by: Szilárd Parrag <szilard.parrag@gmail.com>