### PR TITLE
dbld: install criterion from release tarball on debian-testing

### DIFF
--- a/dbld/build.manifest
+++ b/dbld/build.manifest
@@ -31,7 +31,7 @@
 debian-stretch		python2,nocriterion,nojava,nokafka,nomqtt
 debian-buster		python2,nocriterion,nojava,nokafka,nomqtt
 debian-bullseye		python3,nojava
-debian-testing		python3,nojava
+debian-testing		python3,nocriterion,nojava
 debian-sid		python3,nojava
 
 # on ubuntu, we start using Python3 at focal onwards.

--- a/dbld/images/debian-testing.dockerfile
+++ b/dbld/images/debian-testing.dockerfile
@@ -19,6 +19,7 @@ COPY . /dbld/
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps
+RUN /dbld/builddeps install_criterion
 RUN /dbld/builddeps fix_glib_atomic_warning
 
 VOLUME /source


### PR DESCRIPTION
libcriterion-dev was removed from debian-testing.
Until it gets fixed we can install criterion from their release tarball.

! Revert this, when libcriterion-dev gets fixed on debian-testing !

https://tracker.debian.org/pkg/criterion

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>