### PR TITLE
libtest: minor fixes for LogTransportMock

### DIFF
--- a/libtest/mock-transport.c
+++ b/libtest/mock-transport.c
@@ -240,8 +240,8 @@ log_transport_mock_read_method(LogTransport *s, gpointer buf, gsize count, LogTr
         }
       break;
     case DATA_ERROR:
-      self->current_value_ndx++;
       errno = g_array_index(self->value, data_t, self->current_value_ndx).error_code;
+      self->current_value_ndx++;
       return -1;
     default:
       g_assert_not_reached();

--- a/libtest/mock-transport.c
+++ b/libtest/mock-transport.c
@@ -66,7 +66,6 @@ struct _LogTransportMock
   /* position within the current I/O chunk */
   gint current_iov_pos;
   gboolean input_is_a_stream;
-  gboolean inject_eagain;
   gboolean eof_is_eagain;
   gpointer user_data;
 };
@@ -207,18 +206,6 @@ log_transport_mock_read_method(LogTransport *s, gpointer buf, gsize count, LogTr
     {
       count = 0;
       goto exit;
-    }
-
-
-  if (self->inject_eagain)
-    {
-      self->inject_eagain = FALSE;
-      errno = EAGAIN;
-      return -1;
-    }
-  else
-    {
-      self->inject_eagain = TRUE;
     }
 
   switch (g_array_index(self->value, data_t, self->current_value_ndx).type)

--- a/libtest/tests/test_mock_transport.c
+++ b/libtest/tests/test_mock_transport.c
@@ -35,13 +35,13 @@ Test(mock_transport, test_mock_transport_read)
   cr_assert(transport);
 
   log_transport_mock_inject_data(transport, "chunk1", sizeof("chunk1"));
+  log_transport_mock_inject_data(transport, LTM_INJECT_ERROR(EAGAIN));
   log_transport_mock_inject_data(transport, "chunk2", sizeof("chunk2"));
 
   gchar buffer[100];
   log_transport_read((LogTransport *)transport, buffer, sizeof(buffer), NULL);
   cr_assert_str_eq(buffer, "chunk1");
 
-  /* Only odd reads result in data transfer. Every even read results in EAGAIN */
   int rc;
   rc = log_transport_read((LogTransport *)transport, buffer, sizeof(buffer), NULL);
   cr_assert_eq(rc, -1);


### PR DESCRIPTION
This PR contains a bugfix and some modifications for the transport mock.
We've found these while writing unit tests for #3770.

No news file needed.