### PR TITLE
Fix loggen loading plugins on non linux platforms

### DIFF
--- a/news/bugfix-3832.md
+++ b/news/bugfix-3832.md
@@ -1,0 +1,2 @@
+loggen: cannot detect plugins on platforms with non .so shared libs (osx)
+

--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -174,11 +174,19 @@ load_plugin_info_with_fname(const gchar *plugin_path, const gchar *fname)
       return NULL;
     }
 
+
+  /* libloggen_name_of_the_plugin.{so,dll,dylib} */
+  const gchar *fname_start = fname + strlen(LOGGEN_PLUGIN_LIB_PREFIX);
+  const gchar *fname_end = strrchr(fname_start, '_');
+  if (!fname_end)
+    {
+      ERROR("error opening plugin module %s, module filename does not fit the pattern\n", fname);
+      return NULL;
+    }
+  const gint fname_len = fname_end - fname_start;
+
   gchar plugin_name[LOGGEN_PLUGIN_NAME_MAXSIZE + 1];
-  gchar *extracted_fname = g_strndup(fname + strlen(LOGGEN_PLUGIN_LIB_PREFIX),
-                                     strlen(fname) - strlen(LOGGEN_PLUGIN_LIB_PREFIX) - strlen(LOGGEN_PLUGIN_LIB_SUFFIX));
-  g_snprintf(plugin_name, LOGGEN_PLUGIN_NAME_MAXSIZE, "%s_%s", extracted_fname, LOGGEN_PLUGIN_INFO);
-  g_free(extracted_fname);
+  g_snprintf(plugin_name, LOGGEN_PLUGIN_NAME_MAXSIZE, "%.*s_%s", fname_len, fname_start, LOGGEN_PLUGIN_INFO);
 
   /* get plugin info from lib file */
   PluginInfo *plugin;

--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -161,8 +161,7 @@ gboolean is_plugin_already_loaded(GPtrArray *plugin_array, const gchar *name)
 static PluginInfo *
 load_plugin_info_with_fname(const gchar *plugin_path, const gchar *fname)
 {
-  if (!g_str_has_suffix(fname, G_MODULE_SUFFIX) || !g_str_has_prefix(fname, LOGGEN_PLUGIN_LIB_PREFIX) ||
-      !g_str_has_suffix(fname, LOGGEN_PLUGIN_LIB_SUFFIX))
+  if (!g_str_has_suffix(fname, G_MODULE_SUFFIX) || !g_str_has_prefix(fname, LOGGEN_PLUGIN_LIB_PREFIX))
     return NULL;
 
   gchar *full_lib_path = g_build_filename(plugin_path, fname, NULL);

--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -161,7 +161,8 @@ gboolean is_plugin_already_loaded(GPtrArray *plugin_array, const gchar *name)
 static PluginInfo *
 load_plugin_info_with_fname(const gchar *plugin_path, const gchar *fname)
 {
-  if (!g_str_has_suffix(fname, G_MODULE_SUFFIX) || !g_str_has_prefix(fname, LOGGEN_PLUGIN_LIB_PREFIX))
+  if (strlen(fname) <= strlen(LOGGEN_PLUGIN_LIB_PREFIX) || !g_str_has_suffix(fname, G_MODULE_SUFFIX)
+      || !g_str_has_prefix(fname, LOGGEN_PLUGIN_LIB_PREFIX))
     return NULL;
 
   gchar *full_lib_path = g_build_filename(plugin_path, fname, NULL);

--- a/tests/loggen/loggen_plugin.h
+++ b/tests/loggen/loggen_plugin.h
@@ -30,7 +30,6 @@
 
 #define LOGGEN_PLUGIN_INFO "loggen_plugin_info"
 #define LOGGEN_PLUGIN_LIB_PREFIX "libloggen_"
-#define LOGGEN_PLUGIN_LIB_SUFFIX "_plugin.so"
 #define LOGGEN_PLUGIN_NAME_MAXSIZE 100
 
 typedef struct _plugin_option


### PR DESCRIPTION
This was reported in https://github.com/syslog-ng/syslog-ng/issues/3829#issuecomment-962663348