### PR TITLE
Rewrite rename

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -510,6 +510,21 @@ _value_invalidates_legacy_header(NVHandle handle)
 }
 
 void
+log_msg_rename_value(LogMessage *self, NVHandle from, NVHandle to)
+{
+  if (from == to)
+    return;
+
+  gssize value_len = 0;
+  const gchar *value = log_msg_get_value_if_set(self, from, &value_len);
+  if (!value)
+    return;
+
+  log_msg_set_value(self, to, value, value_len);
+  log_msg_unset_value(self, from);
+}
+
+void
 log_msg_set_value_with_type(LogMessage *self, NVHandle handle, const gchar *value, gssize value_len, NVType type)
 {
   const gchar *name;

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -354,6 +354,8 @@ log_msg_set_value_by_name(LogMessage *self, const gchar *name, const gchar *valu
   log_msg_set_value(self, handle, value, length);
 }
 
+void log_msg_rename_value(LogMessage *self, NVHandle from, NVHandle to);
+
 void log_msg_append_format_sdata(const LogMessage *self, GString *result, guint32 seq_num);
 void log_msg_format_sdata(const LogMessage *self, GString *result, guint32 seq_num);
 

--- a/lib/rewrite/CMakeLists.txt
+++ b/lib/rewrite/CMakeLists.txt
@@ -6,6 +6,7 @@ set(REWRITE_HEADERS
     rewrite/rewrite-expr-parser.h
     rewrite/rewrite-groupset.h
     rewrite/rewrite-unset.h
+    rewrite/rewrite-rename.h
     rewrite/rewrite-set-pri.h
     rewrite/rewrite-set-severity.h
     rewrite/rewrite-set-facility.h
@@ -20,6 +21,7 @@ set(REWRITE_SOURCES
     rewrite/rewrite-expr-parser.c
     rewrite/rewrite-groupset.c
     rewrite/rewrite-unset.c
+    rewrite/rewrite-rename.c
     rewrite/rewrite-set-pri.c
     rewrite/rewrite-set-severity.c
     rewrite/rewrite-set-facility.c

--- a/lib/rewrite/Makefile.am
+++ b/lib/rewrite/Makefile.am
@@ -7,6 +7,7 @@ rewriteinclude_HEADERS = 			\
 	lib/rewrite/rewrite-set-tag.h		\
 	lib/rewrite/rewrite-set.h		\
 	lib/rewrite/rewrite-unset.h		\
+	lib/rewrite/rewrite-rename.h		\
 	lib/rewrite/rewrite-subst.h		\
 	lib/rewrite/rewrite-expr-parser.h	\
 	lib/rewrite/rewrite-groupset.h		\
@@ -20,6 +21,7 @@ rewrite_sources = 				\
 	lib/rewrite/rewrite-set-tag.c		\
 	lib/rewrite/rewrite-set.c		\
 	lib/rewrite/rewrite-unset.c		\
+	lib/rewrite/rewrite-rename.c		\
 	lib/rewrite/rewrite-subst.c		\
 	lib/rewrite/rewrite-expr-parser.c	\
 	lib/rewrite/rewrite-expr-grammar.y	\

--- a/lib/rewrite/rewrite-expr-grammar.ym
+++ b/lib/rewrite/rewrite-expr-grammar.ym
@@ -33,6 +33,7 @@
 #include "rewrite/rewrite-set-tag.h"
 #include "rewrite/rewrite-set.h"
 #include "rewrite/rewrite-unset.h"
+#include "rewrite/rewrite-rename.h"
 #include "rewrite/rewrite-subst.h"
 #include "rewrite/rewrite-groupset.h"
 #include "rewrite/rewrite-set-pri.h"
@@ -65,6 +66,7 @@
 %token KW_GROUP_UNSET
 %token KW_SET
 %token KW_UNSET
+%token KW_RENAME
 %token KW_SUBST
 %token KW_VALUES
 %token KW_SET_SEVERITY
@@ -108,6 +110,11 @@ rewrite_expr
             last_rewrite = log_rewrite_unset_new(configuration);
           }
           '(' rewrite_set_opts ')'              { $$ = last_rewrite; }
+        | KW_RENAME
+          {
+            last_rewrite = log_rewrite_rename_new(configuration);
+          }
+          '(' rewrite_rename_opts ')'              { $$ = last_rewrite; }
 	| KW_SET_TAG '(' string 
 	  { 
 	    last_rewrite = log_rewrite_set_tag_new($3, TRUE, configuration);
@@ -194,6 +201,17 @@ rewrite_subst_opts
 rewrite_subst_opt
 	: { last_matcher_options = log_rewrite_subst_get_matcher_options(last_rewrite); } matcher_option
 	| rewrite_expr_opt
+        ;
+
+rewrite_rename_opts
+        : rewrite_rename_opt rewrite_rename_opts
+        |
+        ;
+
+rewrite_rename_opt
+        : KW_SOURCE '(' string ')' { log_rewrite_rename_set_source(last_rewrite, $3); free($3); }
+        | KW_DESTINATION '(' string ')' { log_rewrite_rename_set_destination(last_rewrite, $3); free($3); }
+        | rewrite_condition_opt
         ;
 
 rewrite_set_opts

--- a/lib/rewrite/rewrite-expr-grammar.ym
+++ b/lib/rewrite/rewrite-expr-grammar.ym
@@ -110,11 +110,16 @@ rewrite_expr
             last_rewrite = log_rewrite_unset_new(configuration);
           }
           '(' rewrite_set_opts ')'              { $$ = last_rewrite; }
-        | KW_RENAME
+        | KW_RENAME '(' string string
           {
-            last_rewrite = log_rewrite_rename_new(configuration);
+            NVHandle from = log_msg_get_value_handle($3);
+            NVHandle to = log_msg_get_value_handle($4);
+            free($3);
+            free($4);
+
+            last_rewrite = log_rewrite_rename_new(configuration, from, to);
           }
-          '(' rewrite_rename_opts ')'              { $$ = last_rewrite; }
+          rewrite_rename_opts ')'              { $$ = last_rewrite; }
 	| KW_SET_TAG '(' string 
 	  { 
 	    last_rewrite = log_rewrite_set_tag_new($3, TRUE, configuration);
@@ -209,9 +214,7 @@ rewrite_rename_opts
         ;
 
 rewrite_rename_opt
-        : KW_SOURCE '(' string ')' { log_rewrite_rename_set_source(last_rewrite, $3); free($3); }
-        | KW_DESTINATION '(' string ')' { log_rewrite_rename_set_destination(last_rewrite, $3); free($3); }
-        | rewrite_condition_opt
+        : rewrite_condition_opt
         ;
 
 rewrite_set_opts

--- a/lib/rewrite/rewrite-expr-parser.c
+++ b/lib/rewrite/rewrite-expr-parser.c
@@ -39,6 +39,7 @@ static CfgLexerKeyword rewrite_expr_keywords[] =
   { "set_pri",            KW_SET_PRI },
   { "set_severity",       KW_SET_SEVERITY },
   { "set_facility",       KW_SET_FACILITY },
+  { "rename",             KW_RENAME },
 
   { "groupset",           KW_GROUP_SET },
   { "groupunset",         KW_GROUP_UNSET },

--- a/lib/rewrite/rewrite-rename.c
+++ b/lib/rewrite/rewrite-rename.c
@@ -33,22 +33,6 @@ struct _LogRewriteRename
   NVHandle destination_handle;
 };
 
-void
-log_rewrite_rename_set_source(LogRewrite *s, const gchar *source)
-{
-  LogRewriteRename *self = (LogRewriteRename *) s;
-
-  self->source_handle = log_msg_get_value_handle(source);
-}
-
-void
-log_rewrite_rename_set_destination(LogRewrite *s, const gchar *destination)
-{
-  LogRewriteRename *self = (LogRewriteRename *) s;
-
-  self->destination_handle = log_msg_get_value_handle(destination);
-}
-
 static void
 log_rewrite_rename_process(LogRewrite *s, LogMessage **pmsg, const LogPathOptions *path_options)
 {
@@ -68,9 +52,7 @@ log_rewrite_rename_clone(LogPipe *s)
   LogRewriteRename *self = (LogRewriteRename *) s;
   LogRewriteRename *cloned;
 
-  cloned = (LogRewriteRename *) log_rewrite_rename_new(s->cfg);
-  cloned->source_handle = self->source_handle;
-  cloned->destination_handle = self->destination_handle;
+  cloned = (LogRewriteRename *) log_rewrite_rename_new(s->cfg, self->source_handle, self->destination_handle);
 
   if (self->super.condition)
     cloned->super.condition = filter_expr_clone(self->super.condition);
@@ -98,9 +80,12 @@ log_rewrite_rename_init(LogPipe *s)
 }
 
 LogRewrite *
-log_rewrite_rename_new(GlobalConfig *cfg)
+log_rewrite_rename_new(GlobalConfig *cfg, NVHandle source, NVHandle destination)
 {
   LogRewriteRename *self = g_new0(LogRewriteRename, 1);
+
+  self->source_handle = source;
+  self->destination_handle = destination;
 
   log_rewrite_init_instance(&self->super, cfg);
   self->super.super.init = log_rewrite_rename_init;

--- a/lib/rewrite/rewrite-rename.c
+++ b/lib/rewrite/rewrite-rename.c
@@ -59,13 +59,7 @@ log_rewrite_rename_process(LogRewrite *s, LogMessage **pmsg, const LogPathOption
 
   log_msg_make_writable(pmsg, path_options);
 
-  gssize value_len = 0;
-  const gchar *value = log_msg_get_value_if_set(*pmsg, self->source_handle, &value_len);
-  if (!value)
-    return;
-
-  log_msg_set_value(*pmsg, self->destination_handle, value, value_len);
-  log_msg_unset_value(*pmsg, self->source_handle);
+  log_msg_rename_value(*pmsg, self->source_handle, self->destination_handle);
 }
 
 static LogPipe *

--- a/lib/rewrite/rewrite-rename.c
+++ b/lib/rewrite/rewrite-rename.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2021 Balabit
+ * Copyright (c) 2021 Kokan <kokaipeter@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "rewrite-rename.h"
+
+typedef struct _LogRewriteRename LogRewriteRename;
+
+struct _LogRewriteRename
+{
+  LogRewrite super;
+  NVHandle source_handle;
+  NVHandle destination_handle;
+};
+
+void
+log_rewrite_rename_set_source(LogRewrite *s, const gchar *source)
+{
+  LogRewriteRename *self = (LogRewriteRename *) s;
+
+  self->source_handle = log_msg_get_value_handle(source);
+}
+
+void
+log_rewrite_rename_set_destination(LogRewrite *s, const gchar *destination)
+{
+  LogRewriteRename *self = (LogRewriteRename *) s;
+
+  self->destination_handle = log_msg_get_value_handle(destination);
+}
+
+static void
+log_rewrite_rename_process(LogRewrite *s, LogMessage **pmsg, const LogPathOptions *path_options)
+{
+  LogRewriteRename *self = (LogRewriteRename *) s;
+
+  if (self->source_handle == self->destination_handle)
+    return;
+
+  log_msg_make_writable(pmsg, path_options);
+
+  gssize value_len = 0;
+  const gchar *value = log_msg_get_value_if_set(*pmsg, self->source_handle, &value_len);
+  if (!value)
+    return;
+
+  log_msg_set_value(*pmsg, self->destination_handle, value, value_len);
+  log_msg_unset_value(*pmsg, self->source_handle);
+}
+
+static LogPipe *
+log_rewrite_rename_clone(LogPipe *s)
+{
+  LogRewriteRename *self = (LogRewriteRename *) s;
+  LogRewriteRename *cloned;
+
+  cloned = (LogRewriteRename *) log_rewrite_rename_new(s->cfg);
+  cloned->source_handle = self->source_handle;
+  cloned->destination_handle = self->destination_handle;
+
+  if (self->super.condition)
+    cloned->super.condition = filter_expr_clone(self->super.condition);
+
+  return &cloned->super.super;
+}
+
+static gboolean
+log_rewrite_rename_init(LogPipe *s)
+{
+  LogRewriteRename *self = (LogRewriteRename *) s;
+  if (!self->source_handle)
+    {
+      msg_error("rename(): source() option is mandatory", log_pipe_location_tag(s));
+      return FALSE;
+    }
+
+  if (!self->destination_handle)
+    {
+      msg_error("rename(): destination() option is mandatory", log_pipe_location_tag(s));
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+LogRewrite *
+log_rewrite_rename_new(GlobalConfig *cfg)
+{
+  LogRewriteRename *self = g_new0(LogRewriteRename, 1);
+
+  log_rewrite_init_instance(&self->super, cfg);
+  self->super.super.init = log_rewrite_rename_init;
+  self->super.super.clone = log_rewrite_rename_clone;
+  self->super.process = log_rewrite_rename_process;
+  return &self->super;
+}

--- a/lib/rewrite/rewrite-rename.h
+++ b/lib/rewrite/rewrite-rename.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Balabit
+ * Copyright (c) 2021 Kokan <kokaipeter@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef REWRITE_RENAME_H_INCLUDED
+#define REWRITE_RENAME_H_INCLUDED
+
+#include "rewrite/rewrite-expr.h"
+
+LogRewrite *log_rewrite_rename_new(GlobalConfig *cfg);
+
+void log_rewrite_rename_set_source(LogRewrite *s, const gchar *source);
+void log_rewrite_rename_set_destination(LogRewrite *s, const gchar *destination);
+
+#endif

--- a/lib/rewrite/rewrite-rename.h
+++ b/lib/rewrite/rewrite-rename.h
@@ -27,9 +27,6 @@
 
 #include "rewrite/rewrite-expr.h"
 
-LogRewrite *log_rewrite_rename_new(GlobalConfig *cfg);
-
-void log_rewrite_rename_set_source(LogRewrite *s, const gchar *source);
-void log_rewrite_rename_set_destination(LogRewrite *s, const gchar *destination);
+LogRewrite *log_rewrite_rename_new(GlobalConfig *cfg, NVHandle source, NVHandle destination);
 
 #endif

--- a/lib/rewrite/tests/CMakeLists.txt
+++ b/lib/rewrite/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_unit_test(LIBTEST CRITERION TARGET test_rewrite)
 add_unit_test(LIBTEST CRITERION TARGET test_set_pri)
+add_unit_test(LIBTEST CRITERION TARGET test_rename)
 add_unit_test(LIBTEST CRITERION TARGET test_set_severity)
 add_unit_test(LIBTEST CRITERION TARGET test_set_facility)

--- a/lib/rewrite/tests/Makefile.am
+++ b/lib/rewrite/tests/Makefile.am
@@ -1,6 +1,7 @@
 lib_rewrite_tests_TESTS = \
     lib/rewrite/tests/test_rewrite \
     lib/rewrite/tests/test_set_pri \
+    lib/rewrite/tests/test_rename \
     lib/rewrite/tests/test_set_severity \
     lib/rewrite/tests/test_set_facility
 
@@ -13,6 +14,11 @@ lib_rewrite_tests_test_rewrite_LDADD = $(TEST_LDADD)    \
     $(PREOPEN_SYSLOGFORMAT)
 lib_rewrite_tests_test_rewrite_SOURCES =    \
     lib/rewrite/tests/test_rewrite.c
+
+lib_rewrite_tests_test_rename_CFLAGS = $(TEST_CFLAGS)
+lib_rewrite_tests_test_rename_LDADD = $(TEST_LDADD)
+lib_rewrite_tests_test_rename_SOURCES =    \
+    lib/rewrite/tests/test_rename.c
 
 lib_rewrite_tests_test_set_severity_CFLAGS = $(TEST_CFLAGS)
 lib_rewrite_tests_test_set_severity_LDADD = $(TEST_LDADD)

--- a/lib/rewrite/tests/test_rename.c
+++ b/lib/rewrite/tests/test_rename.c
@@ -48,9 +48,7 @@ _perform_rewrite(LogRewrite *rewrite, LogMessage *msg_)
 static void
 _perform_rename(const gchar *from, const char *to, LogMessage *msg_)
 {
-  LogRewrite *rename = log_rewrite_rename_new(cfg);
-  log_rewrite_rename_set_source(rename, from);
-  log_rewrite_rename_set_destination(rename, to);
+  LogRewrite *rename = log_rewrite_rename_new(cfg, log_msg_get_value_handle(from), log_msg_get_value_handle(to));
 
   _perform_rewrite(rename, msg_);
 }
@@ -98,8 +96,7 @@ Test(rename, rename_not_existing)
 
 Test(rename, source_option_mandatory)
 {
-  LogRewrite *rename = log_rewrite_rename_new(cfg);
-  log_rewrite_rename_set_destination(rename, "A");
+  LogRewrite *rename = log_rewrite_rename_new(cfg, 0, LM_V_MESSAGE);
 
   cr_assert_not(log_pipe_init(&rename->super));
 
@@ -108,8 +105,7 @@ Test(rename, source_option_mandatory)
 
 Test(rename, destination_option_mandatory)
 {
-  LogRewrite *rename = log_rewrite_rename_new(cfg);
-  log_rewrite_rename_set_source(rename, "A");
+  LogRewrite *rename = log_rewrite_rename_new(cfg, LM_V_MESSAGE, 0);
 
   cr_assert_not(log_pipe_init(&rename->super));
 

--- a/lib/rewrite/tests/test_rename.c
+++ b/lib/rewrite/tests/test_rename.c
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2021 Balabit
+ * Copyright (c) 2021 Kokan <kokaipeter@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+
+#include "apphook.h"
+#include "rewrite/rewrite-rename.h"
+#include "logmsg/logmsg.h"
+#include "scratch-buffers.h"
+#include "grab-logging.h"
+#include "msg_parse_lib.h"
+
+GlobalConfig *cfg = NULL;
+LogMessage *msg;
+
+static void
+_perform_rewrite(LogRewrite *rewrite, LogMessage *msg_)
+{
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+
+  cr_assert(log_pipe_init(&rewrite->super));
+  log_pipe_queue(&rewrite->super, log_msg_ref(msg_), &path_options);
+  log_pipe_deinit(&rewrite->super);
+  log_pipe_unref(&rewrite->super);
+}
+
+static void
+_perform_rename(const gchar *from, const char *to, LogMessage *msg_)
+{
+  LogRewrite *rename = log_rewrite_rename_new(cfg);
+  log_rewrite_rename_set_source(rename, from);
+  log_rewrite_rename_set_destination(rename, to);
+
+  _perform_rewrite(rename, msg_);
+}
+
+Test(rename, basic_rename)
+{
+  _perform_rename("MESSAGE", "m", msg);
+  assert_log_message_value_by_name(msg, "m", "example");
+  assert_msg_field_unset(msg, "MESSAGE", "source should not exists anymore");
+}
+
+Test(rename, override_existing)
+{
+  _perform_rename(".SDATA.bar", "MESSAGE", msg);
+  assert_log_message_value_by_name(msg, "MESSAGE", "foo");
+  assert_msg_field_unset(msg, ".SDATA.bar", "source should not exists anymore");
+}
+
+Test(rename, structued)
+{
+  _perform_rename(".SDATA.bar", ".json.bar", msg);
+  assert_log_message_value_by_name(msg, ".json.bar", "foo");
+  assert_msg_field_unset(msg, ".SDATA.bar", "source should not exists anymore");
+}
+
+Test(rename, rename_empty)
+{
+  _perform_rename("empty", "really-empty", msg);
+  assert_log_message_value_by_name(msg, "really-empty", "");
+  assert_msg_field_unset(msg, "empty", "source should not exists anymore");
+}
+
+Test(rename, source_destination_equals)
+{
+  _perform_rename("MESSAGE", "MESSAGE", msg);
+  assert_log_message_value_by_name(msg, "MESSAGE", "example");
+}
+
+Test(rename, rename_not_existing)
+{
+  _perform_rename("should-not-exists", "something-else", msg);
+  assert_msg_field_unset(msg, "should-not-exists", "source not existed");
+  assert_msg_field_unset(msg, "something-else", "if source not exists, destination should not be created");
+}
+
+Test(rename, source_option_mandatory)
+{
+  LogRewrite *rename = log_rewrite_rename_new(cfg);
+  log_rewrite_rename_set_destination(rename, "A");
+
+  cr_assert_not(log_pipe_init(&rename->super));
+
+  log_pipe_unref(&rename->super);
+}
+
+Test(rename, destination_option_mandatory)
+{
+  LogRewrite *rename = log_rewrite_rename_new(cfg);
+  log_rewrite_rename_set_source(rename, "A");
+
+  cr_assert_not(log_pipe_init(&rename->super));
+
+  log_pipe_unref(&rename->super);
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  cfg = cfg_new_snippet();
+  start_grabbing_messages();
+  msg = log_msg_new_empty();
+
+  log_msg_set_value(msg, LM_V_MESSAGE, "example", -1);
+  log_msg_set_value_by_name(msg, ".SDATA.bar", "foo", -1);
+  log_msg_set_value_by_name(msg, "empty", "", -1);
+}
+
+static void
+teardown(void)
+{
+  scratch_buffers_explicit_gc();
+  log_msg_unref(msg);
+  stop_grabbing_messages();
+  cfg_free(cfg);
+  app_shutdown();
+}
+
+TestSuite(rename, .init = setup, .fini = teardown);

--- a/news/feature-3838.md
+++ b/news/feature-3838.md
@@ -1,0 +1,8 @@
+add new rewrite: rename
+
+```
+rewrite {
+  rename( "renamed-from" "renamed-to" );
+};
+```
+


### PR DESCRIPTION
This is a native implementation of https://github.com/syslog-ng/syslog-ng/pull/3814. The interface has been tweaked a little with using positional options.

```
rewrite { rename("old_name" "new_name"); };
```

In the following cases the `rename()` does not changes the message:
* If `source()` equals to `destination()`
* If `source()` entry not present in the message

