### PR TITLE
cisco-parser: allow leading dot in timestamps

### DIFF
--- a/news/bugfix-3843.md
+++ b/news/bugfix-3843.md
@@ -1,0 +1,1 @@
+cisco-parser(): allow a leading dot in the timestamp (not synced clocks)

--- a/scl/cisco/plugin.conf
+++ b/scl/cisco/plugin.conf
@@ -34,6 +34,8 @@
 #<190>30: foo: *Apr 29 13:58:46.411: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 192.168.1.239 stopped - CLI initiated
 #<190>31: foo: *Apr 29 13:58:46.411: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 192.168.1.239 started - CLI initiated<189>32: 0.0.0.0: *Apr 29 13:59:12.491: %SYS-5-CONFIG_I: Configured from console by console<189>33: 0.0.0.0: *Apr 29 13:59:26.415: %SYS-5-CONFIG_I: Configured from console by console<189>34: 0.0.0.0: *Apr 29 13:59:56.603: %SYS-5-CONFIG_I: Configured from console by console^[[<189>35: *Apr 29 14:00:16.059: %SYS-5-CONFIG_I: Configured from console by console
 #<190>32: foo: *Apr 29 13:58:46.411: %SYSMGR-STANDBY-3-SHUTDOWN_START: The System Manager has started the shutdown procedure.
+# A leading dot marks an out-of-sync timestamp
+#<180>782431: machine1: .Nov 18 21:03:22.631 GMT: %CDP-4-NATIVE_VLAN_MISMATCH: Native VLAN mismatch discovered on TenGigabitEthernet.
 
 #
 # parses a cisco timestamp with explicit date-parser
@@ -42,7 +44,7 @@
 block parser cisco-timestamp-parser(template()) {
     channel {
         filter {
-            match('^\*?([A-Za-z]{3} [0-9 ]\d (\d{4} )?\d{2}:\d{2}:\d{2}(\.\d{3})?( (AM|PM))?)' template(`template`) flags(store-matches));
+            match('^[\*\.]?([A-Za-z]{3} [0-9 ]\d (\d{4} )?\d{2}:\d{2}:\d{2}(\.\d{3})?( (AM|PM))?)' template(`template`) flags(store-matches));
         };
         parser {
             date-parser(format('%b %d %I:%M:%S %p.%f',

--- a/tests/python_functional/functional_tests/parsers/app-parser/test_topic_syslog_raw.py
+++ b/tests/python_functional/functional_tests/parsers/app-parser/test_topic_syslog_raw.py
@@ -24,6 +24,8 @@ import pytest
 
 test_parameters_raw = [
     (r"""<189>29: foo: *Apr 29 13:58:40.411: %SYS-5-CONFIG_I: Configured from console by console""", "${.app.name}", "cisco"),
+    (r"""<189>29: foo: .Nov 19 13:58:40.411: %SYS-5-CONFIG_I: Configured from console by console""", "${.app.name}", "cisco"),
+    (r"""<189>29: foo: Nov 19 13:58:40.411: %SYS-5-CONFIG_I: Configured from console by console""", "${.app.name}", "cisco"),
     (r"""<190>30: foo: *Apr 29 13:58:46.411: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 192.168.1.239 stopped - CLI initiated""", "${.app.name}", "cisco"),
     (r"""<190>31: foo: *Apr 29 13:58:46.411: %SYS-6-LOGGINGHOST_STARTSTOP: Logging to host 192.168.1.239 started - CLI initiated<189>32: 0.0.0.0: *Apr 29 13:59:12.491: %SYS-5-CONFIG_I: Configured from console by console<189>33: 0.0.0.0: *Apr 29 13:59:26.415: %SYS-5-CONFIG_I: Configured from console by console<189>34: 0.0.0.0: *Apr 29 13:59:56.603: %SYS-5-CONFIG_I: Configured from console by console^[[<189>35: *Apr 29 14:00:16.059: %SYS-5-CONFIG_I: Configured from console by console""", "${.app.name}", "cisco"),
     (r"""<190>32: foo: *Apr 29 13:58:46.411: %SYSMGR-STANDBY-3-SHUTDOWN_START: The System Manager has started the shutdown procedure.""", "${.app.name}", "cisco"),


### PR DESCRIPTION
We've received an example log from the community, in which the timestamp had a leading dot.
I've slightly modified the hostname and the message parts
`<180>782431: machine1: .Nov 18 21:03:22.631 GMT: %CDP-4-NATIVE_VLAN_MISMATCH: Native VLAN mismatch discovered on TenGigabitEthernet.`

I haven't found an official documentation about the leading dot yet, only cisco community posts, e.g.:
https://community.cisco.com/t5/other-network-architecture/logging-shows-an-asterisk-quot-jan-13-11-05-40-quot/td-p/564707
https://community.cisco.com/t5/other-security-subjects/log-entries-with-a-dot-before-timestamp/td-p/590136

The leading asterisk is better documented in multiple system guides:
https://www.cisco.com/c/en/us/td/docs/routers/crs/software/crs_r4-1/system_monitoring/command/reference/sysmon_cr41crs_chapter4.html#wp255058350
> If the system clock has not been set, the date and time are preceded by an asterisk (*), which indicates that the date and time have not been set and should be verified.

Or here: https://www.cisco.com/c/en/us/td/docs/routers/access/wireless/software/guide/SysMsgLogging.html#wp1054710