### PR TITLE
qdisk: fix a race condition crash in serialization

### DIFF
--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -117,7 +117,7 @@ _serialize_and_write_message_to_disk(LogQueueDiskNonReliable *self, LogMessage *
 {
   ScratchBuffersMarker marker;
   GString *write_serialized = scratch_buffers_alloc_and_mark(&marker);
-  if (!qdisk_serialize_msg(self->super.qdisk, msg, write_serialized))
+  if (!log_queue_disk_serialize_msg(&self->super, msg, write_serialized))
     {
       scratch_buffers_reclaim_marked(marker);
       return FALSE;
@@ -424,7 +424,7 @@ _push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
   if (_is_msg_serialization_needed_hint(self))
     {
       serialized_msg = scratch_buffers_alloc_and_mark(&marker);
-      if (!qdisk_serialize_msg(self->super.qdisk, msg, serialized_msg))
+      if (!log_queue_disk_serialize_msg(&self->super, msg, serialized_msg))
         {
           msg_error("Failed to serialize message for non-reliable disk-buffer, dropping message",
                     evt_tag_str("filename", qdisk_get_filename(self->super.qdisk)),

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -317,7 +317,7 @@ _push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
 
   ScratchBuffersMarker marker;
   GString *serialized_msg = scratch_buffers_alloc_and_mark(&marker);
-  if (!qdisk_serialize_msg(self->super.qdisk, msg, serialized_msg))
+  if (!log_queue_disk_serialize_msg(&self->super, msg, serialized_msg))
     {
       msg_error("Failed to serialize message for reliable disk-buffer, dropping message",
                 evt_tag_str("filename", qdisk_get_filename(self->super.qdisk)),

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -108,7 +108,7 @@ _pop_disk(LogQueueDisk *self, LogMessage **msg)
       return FALSE;
     }
 
-  if (!qdisk_deserialize_msg(self->qdisk, read_serialized, msg))
+  if (!log_queue_disk_deserialize_msg(self, read_serialized, msg))
     {
       msg_error("Cannot read correct message from disk-queue file",
                 evt_tag_str("filename", qdisk_get_filename(self->qdisk)),
@@ -231,6 +231,36 @@ log_queue_disk_serialize_msg(LogQueueDisk *self, LogMessage *msg, GString *seria
       g_error_free(error);
       return FALSE;
     }
+
+  return TRUE;
+}
+
+static gboolean
+_deserialize_msg(SerializeArchive *sa, gpointer user_data)
+{
+  LogMessage *msg = user_data;
+
+  return log_msg_deserialize(msg, sa);
+}
+
+gboolean
+log_queue_disk_deserialize_msg(LogQueueDisk *self, GString *serialized, LogMessage **msg)
+{
+  LogMessage *local_msg = log_msg_new_empty();
+  gpointer user_data = local_msg;
+  GError *error = NULL;
+
+  if (!qdisk_deserialize(serialized, _deserialize_msg, user_data, &error))
+    {
+      msg_error("Error deserializing message from the disk-queue file",
+                evt_tag_str("error", error->message),
+                evt_tag_str("persist-name", self->super.persist_name));
+      log_msg_unref(local_msg);
+      g_error_free(error);
+      return FALSE;
+    }
+
+  *msg = local_msg;
 
   return TRUE;
 }

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -203,6 +203,8 @@ log_queue_disk_init_instance(LogQueueDisk *self, DiskQueueOptions *options, cons
   log_queue_init_instance(&self->super, persist_name);
   self->super.type = log_queue_disk_type;
 
+  self->compaction = options->compaction;
+
   self->qdisk = qdisk_new(options, qdisk_file_id);
 }
 
@@ -212,9 +214,7 @@ _serialize_msg(SerializeArchive *sa, gpointer user_data)
   LogQueueDisk *self = ((gpointer *) user_data)[0];
   LogMessage *msg = ((gpointer *) user_data)[1];
 
-  DiskQueueOptions *options = qdisk_get_options(self->qdisk);
-
-  return log_msg_serialize(msg, sa, options->compaction ? LMSF_COMPACTION : 0);
+  return log_msg_serialize(msg, sa, self->compaction ? LMSF_COMPACTION : 0);
 }
 
 gboolean

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -35,6 +35,11 @@ struct _LogQueueDisk
 {
   LogQueue super;
   QDisk *qdisk;         /* disk based queue */
+  /* TODO:
+   * LogQueueDisk should have a separate options class, which should only contain compaction, reliable, etc...
+   * Similarly, QDisk should have a separate options class, which should only contain disk_buf_size, mem_buf_size, etc...
+   */
+  gboolean compaction;
   gboolean (*save_queue)(LogQueueDisk *s, gboolean *persistent);
   gboolean (*load_queue)(LogQueueDisk *s, const gchar *filename);
   gboolean (*start)(LogQueueDisk *s, const gchar *filename);

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -54,5 +54,6 @@ void log_queue_disk_free_method(LogQueueDisk *self);
 
 LogMessage *log_queue_disk_read_message(LogQueueDisk *self, LogPathOptions *path_options);
 void log_queue_disk_drop_message(LogQueueDisk *self, LogMessage *msg, const LogPathOptions *path_options);
+gboolean log_queue_disk_serialize_msg(LogQueueDisk *self, LogMessage *msg, GString *serialized);
 
 #endif

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -55,5 +55,6 @@ void log_queue_disk_free_method(LogQueueDisk *self);
 LogMessage *log_queue_disk_read_message(LogQueueDisk *self, LogPathOptions *path_options);
 void log_queue_disk_drop_message(LogQueueDisk *self, LogMessage *msg, const LogPathOptions *path_options);
 gboolean log_queue_disk_serialize_msg(LogQueueDisk *self, LogMessage *msg, GString *serialized);
+gboolean log_queue_disk_deserialize_msg(LogQueueDisk *self, GString *serialized, LogMessage **msg);
 
 #endif

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -84,6 +84,20 @@ struct _QDisk
   DiskQueueOptions *options;
 };
 
+#define QDISK_ERROR qdisk_error_quark()
+#define QDISK_ERROR_SERIALIZE 0
+
+GQuark
+qdisk_error_quark(void)
+{
+  static GQuark q = 0;
+
+  if (q == 0)
+    q = g_quark_from_static_string("qdisk-error");
+
+  return q;
+}
+
 static gboolean
 pwrite_strict(gint fd, const void *buf, size_t count, off_t offset)
 {
@@ -577,40 +591,32 @@ _overwrite_with_real_record_length(GString *serialized)
 }
 
 gboolean
-qdisk_serialize_msg(QDisk *self, LogMessage *msg, GString *serialized)
+qdisk_serialize(GString *serialized, QDiskSerializeFunc serialize_func, gpointer user_data, GError **error)
 {
-  gchar *error = NULL;
   SerializeArchive *sa = serialize_string_archive_new(serialized);
 
   /* Leave space for the real record_length for later */
   if (!serialize_write_uint32(sa, 0))
     {
-      error = "cannot write record length";
+      g_set_error(error, QDISK_ERROR, QDISK_ERROR_SERIALIZE, "failed to write record length");
       goto exit;
     }
 
-  if (!log_msg_serialize(msg, sa, self->options->compaction ? LMSF_COMPACTION : 0))
+  if (!serialize_func(sa, user_data))
     {
-      error = "cannot serialize LogMessage";
+      g_set_error(error, QDISK_ERROR, QDISK_ERROR_SERIALIZE, "failed to serialize data");
       goto exit;
     }
 
   if (!_overwrite_with_real_record_length(serialized))
     {
-      error = "message is empty";
+      g_set_error(error, QDISK_ERROR, QDISK_ERROR_SERIALIZE, "serializable data is empty");
       goto exit;
     }
 
 exit:
-  if (error)
-    {
-      msg_error("Error serializing message for the disk-queue file",
-                evt_tag_str("error", error),
-                evt_tag_str("filename", qdisk_get_filename(self)));
-    }
-
   serialize_archive_free(sa);
-  return error == NULL;
+  return *error == NULL;
 }
 
 gboolean

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -899,7 +899,7 @@ _save_queue(QDisk *self, GQueue *q, QDiskQueuePosition *q_pos)
        * disk anyway. */
 
       POINTER_TO_LOG_PATH_OPTIONS(g_queue_pop_head(q), &path_options);
-      log_msg_serialize(msg, sa, self->options->compaction ? LMSF_COMPACTION : 0);
+      log_msg_serialize(msg, sa, 0);
       log_msg_ack(msg, &path_options, AT_PROCESSED);
       log_msg_unref(msg);
       if (string_reached_memory_limit(serialized))

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -37,6 +37,8 @@
  */
 #define POINTER_TO_LOG_PATH_OPTIONS(ptr, lpo) (lpo)->ack_needed = (GPOINTER_TO_INT(ptr) & ~0x80000000)
 
+typedef gboolean (*QDiskSerializeFunc)(SerializeArchive *sa, gpointer user_data);
+
 typedef struct
 {
   gint64 ofs;
@@ -84,7 +86,7 @@ const gchar *qdisk_get_filename(QDisk *self);
 
 guint64 qdisk_skip_record(QDisk *self, guint64 position);
 
-gboolean qdisk_serialize_msg(QDisk *self, LogMessage *msg, GString *serialized);
+gboolean qdisk_serialize(GString *serialized, QDiskSerializeFunc serialize_func, gpointer user_data, GError **error);
 gboolean qdisk_deserialize_msg(QDisk *self, GString *serialized, LogMessage **msg);
 
 #endif /* QDISK_H_ */

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -38,6 +38,7 @@
 #define POINTER_TO_LOG_PATH_OPTIONS(ptr, lpo) (lpo)->ack_needed = (GPOINTER_TO_INT(ptr) & ~0x80000000)
 
 typedef gboolean (*QDiskSerializeFunc)(SerializeArchive *sa, gpointer user_data);
+typedef gboolean (*QDiskDeSerializeFunc)(SerializeArchive *sa, gpointer user_data);
 
 typedef struct
 {
@@ -87,6 +88,7 @@ const gchar *qdisk_get_filename(QDisk *self);
 guint64 qdisk_skip_record(QDisk *self, guint64 position);
 
 gboolean qdisk_serialize(GString *serialized, QDiskSerializeFunc serialize_func, gpointer user_data, GError **error);
-gboolean qdisk_deserialize_msg(QDisk *self, GString *serialized, LogMessage **msg);
+gboolean qdisk_deserialize(GString *serialized, QDiskDeSerializeFunc deserialize_func, gpointer user_data,
+                           GError **error);
 
 #endif /* QDISK_H_ */

--- a/news/bugfix-3845.md
+++ b/news/bugfix-3845.md
@@ -1,0 +1,1 @@
+`disk-buffer`: Fixed a crash which could happen in very rare cases, while a corrupted `disk-buffer` was getting replaced.


### PR DESCRIPTION
This PR does 3 things:
  * Removes a layering violation in `qdisk.c` regarding message serialization.
  * Fixes the crash mentioned in the title of the PR.
  * Force disables compaction when saving the memory queues of non-reliable `disk-buffer` for safety reasons.

More details can be seen in the commit messages.

Signed-off-by: Balázs Barkó <Balazs.Barko@oneidentity.com>
Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>