### PR TITLE
reset queued stats if disk queue corrupted and restarted

### DIFF
--- a/lib/logqueue.c
+++ b/lib/logqueue.c
@@ -71,6 +71,14 @@ log_queue_queued_messages_dec(LogQueue *self)
   atomic_gssize_dec(&self->stats_cache.queued_messages);
 }
 
+void
+log_queue_queued_messages_reset(LogQueue *self)
+{
+  const gssize queue_length = log_queue_get_length(self);
+  stats_counter_set(self->queued_messages, queue_length);
+  atomic_gssize_set_and_get(&self->stats_cache.queued_messages, queue_length);
+}
+
 /*
  * When this is called, it is assumed that the output thread is currently
  * not running (since this is the function that wakes it up), thus we can

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -213,6 +213,7 @@ void log_queue_queued_messages_add(LogQueue *self, gsize value);
 void log_queue_queued_messages_sub(LogQueue *self, gsize value);
 void log_queue_queued_messages_inc(LogQueue *self);
 void log_queue_queued_messages_dec(LogQueue *self);
+void log_queue_queued_messages_reset(LogQueue *self);
 
 void log_queue_push_notify(LogQueue *self);
 void log_queue_reset_parallel_push(LogQueue *self);

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -192,6 +192,7 @@ void
 log_queue_disk_restart_corrupted(LogQueueDisk *self)
 {
   _restart_diskq(self);
+  log_queue_queued_messages_reset(&self->super);
 }
 
 

--- a/news/bugfix-3851.md
+++ b/news/bugfix-3851.md
@@ -1,0 +1,1 @@
+disk-buffer: fix queued stats were not adjusted when a disk-buffer became corrupt


### PR DESCRIPTION
The disk buffer is re-created when it detects it became corrupt, but the queued message statistics is not set accordingly.