### PR TITLE
Fix credit card regex

### DIFF
--- a/news/bugfix-3853.md
+++ b/news/bugfix-3853.md
@@ -1,0 +1,1 @@
+cc-mask: fix visa and mastercard and jcb card regex pattern

--- a/scl/rewrite/cc-mask.conf
+++ b/scl/rewrite/cc-mask.conf
@@ -38,22 +38,63 @@
 # A notable difference compared to the blog post, is that the hash_cc
 # rule is called credit-card-hash and mask_cc is credit-card-mask.
 
-@define balabit.credit-card-regexp "(:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\d{3})\d{11})"
-
-block rewrite credit-card-hash(value("MESSAGE"))
+block rewrite credit-card-internal(regex() value() template())
 {
-        subst("`balabit.credit-card-regexp`",
-              "$(sha1 --length 16 $1)",
-              value(`value`),
-              flags(global, store-matches),
-              type(pcre));
+   subst("`regex`"
+         "`template`"
+         value(`value`)
+         flags(global, store-matches)
+         type(pcre)
+    );
 };
 
-block rewrite credit-card-mask(value("MESSAGE"))
+block rewrite credit-card-visa(value() template())
 {
-        subst("`balabit.credit-card-regexp`",
-              "$(substr $1 0 6)******$(substr $1 -4 4)"
-              value(`value`),
-              flags(global, store-matches),
-              type(pcre));
+  credit-card-internal(regex("(:4[0-9]{12}(?:[0-9]{3})?)") value(`value`) template(`template`));
+};
+
+block rewrite credit-card-mastercard(value() template())
+{
+  credit-card-internal(regex("(5[1-5][0-9]{14})") value(`value`) template(`template`));
+};
+
+block rewrite credit-card-american_express(value() template())
+{
+  credit-card-internal(regex("(3[47][0-9]{13})") value(`value`) template(`template`));
+};
+
+block rewrite credit-card-diners_club(value() template())
+{
+  credit-card-internal(regex("(3(?:0[0-5]|[68][0-9])[0-9]{11})") value(`value`) template(`template`));
+};
+
+block rewrite credit-card-discover(value() template())
+{
+  credit-card-internal(regex("(6(?:011|5[0-9][0-9])[0-9]{12})") value(`value`) template(`template`));
+};
+
+block rewrite credit-card-jcb(value() template())
+{
+  credit-card-internal(regex("((?:2131|1800|35\d{3})\d{11})") value(`value`) template(`template`));
+};
+
+
+block rewrite credit-card-mask(value("MESSAGE") template("$(substr $0 0 6)******$(substr $0 -4 4)"))
+{
+    credit-card-visa(value(`value`) template("`template`"));
+    credit-card-mastercard(value(`value`) template("`template`"));
+    credit-card-american_express(value(`value`) template("`template`"));
+    credit-card-jcb(value(`value`) template("`template`"));
+    credit-card-diners_club(value(`value`) template("`template`"));
+    credit-card-discover(value(`value`) template("`template`"));
+};
+
+block rewrite credit-card-hash(value("MESSAGE") template("$(sha1 --length 16 $0)"))
+{
+    credit-card-visa(value(`value`) template("`template`"));
+    credit-card-mastercard(value(`value`) template("`template`"));
+    credit-card-american_express(value(`value`) template("`template`"));
+    credit-card-jcb(value(`value`) template("`template`"));
+    credit-card-diners_club(value(`value`) template("`template`"));
+    credit-card-discover(value(`value`) template("`template`"));
 };

--- a/scl/rewrite/cc-mask.conf
+++ b/scl/rewrite/cc-mask.conf
@@ -50,12 +50,12 @@ block rewrite credit-card-internal(regex() value() template())
 
 block rewrite credit-card-visa(value() template())
 {
-  credit-card-internal(regex("(:4[0-9]{12}(?:[0-9]{3})?)") value(`value`) template(`template`));
+  credit-card-internal(regex("(?:4[0-9]{12}(?:[0-9]{3})?)") value(`value`) template(`template`));
 };
 
 block rewrite credit-card-mastercard(value() template())
 {
-  credit-card-internal(regex("(5[1-5][0-9]{14})") value(`value`) template(`template`));
+  credit-card-internal(regex("((5[1-5][0-9]{14})|((?:5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12}))") value(`value`) template(`template`));
 };
 
 block rewrite credit-card-american_express(value() template())
@@ -70,12 +70,12 @@ block rewrite credit-card-diners_club(value() template())
 
 block rewrite credit-card-discover(value() template())
 {
-  credit-card-internal(regex("(6(?:011|5[0-9][0-9])[0-9]{12})") value(`value`) template(`template`));
+  credit-card-internal(regex("(6(?:011|5[0-9]{2})[0-9]{12})") value(`value`) template(`template`));
 };
 
 block rewrite credit-card-jcb(value() template())
 {
-  credit-card-internal(regex("((?:2131|1800|35\d{3})\d{11})") value(`value`) template(`template`));
+  credit-card-internal(regex("((?:2131|1800|35[0-9]{3})[0-9]{11})") value(`value`) template(`template`));
 };
 
 

--- a/tests/python_functional/functional_tests/Makefile.am
+++ b/tests/python_functional/functional_tests/Makefile.am
@@ -25,6 +25,7 @@ EXTRA_DIST += \
 	tests/python_functional/functional_tests/parsers/panos/test_panos_parser.py \
 	tests/python_functional/functional_tests/parsers/regexp-parser/test_regexp_parser.py \
 	tests/python_functional/functional_tests/rewrites/set-tag/test_set_tag.py \
+	tests/python_functional/functional_tests/rewrites/cc-mask/test_cc_mask_and_cc_hash.py \
 	tests/python_functional/functional_tests/source_drivers/file_source/test_acceptance.py \
 	tests/python_functional/functional_tests/source_drivers/file_source/test_follow_freq_value.py \
 	tests/python_functional/functional_tests/source_drivers/generator_source/test_generator_source.py \

--- a/tests/python_functional/functional_tests/rewrites/cc-mask/test_cc_mask_and_cc_hash.py
+++ b/tests/python_functional/functional_tests/rewrites/cc-mask/test_cc_mask_and_cc_hash.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2021 One Identity
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+_Input_String = "American Express  378282246310005" \
+                "American Express  371449635398431" \
+                "American Express Corporate  378734493671000" \
+                "Diners Club  30569309025904" \
+                "Diners Club  38520000023237" \
+                "Discover  6011111111111117" \
+                "Discover  6011000990139424" \
+                "JCB  3530111333300000" \
+                "JCB  3566002020360505" \
+                "MasterCard  5555555555554444" \
+                "MasterCard  5105105105105100" \
+                "Visa  4111111111111111" \
+                "Visa  4012888888881881" \
+                "Visa  4222222222222"
+
+_Expected_mask_output = "American Express  378282******0005" \
+                        "American Express  371449******8431" \
+                        "American Express Corporate  378734******1000" \
+                        "Diners Club  305693******5904" \
+                        "Diners Club  385200******3237" \
+                        "Discover  601111******1117" \
+                        "Discover  601100******9424" \
+                        "JCB  353011******0000" \
+                        "JCB  356600******0505" \
+                        "MasterCard  555555******4444" \
+                        "MasterCard  510510******5100" \
+                        "Visa  411111******1111" \
+                        "Visa  401288******1881" \
+                        "Visa  422222******2222"
+
+_Expected_hash_output = "American Express  ea4654336c140e70" \
+                        "American Express  5e7d7549d9a51a21" \
+                        "American Express Corporate  b83feb75b1ce505d" \
+                        "Diners Club  58b3e8b7f99a5ab1" \
+                        "Diners Club  002f83eefd0b7e53" \
+                        "Discover  0ccaaf4da33d3e26" \
+                        "Discover  ff659bd8ffefdb2b" \
+                        "JCB  4c1d57bdab8338e7" \
+                        "JCB  9d9cafd187ba5590" \
+                        "MasterCard  6589b0d46b6f2f0d" \
+                        "MasterCard  21b95eabb14f0726" \
+                        "Visa  68bfb396f35af387" \
+                        "Visa  62163a017b168ad4" \
+                        "Visa  eb0f3622c9362fe9"
+
+
+def test_cc_mask_and_cc_hash(config, syslog_ng):
+    config.add_include("scl.conf")
+    rewrite_cc_mask = config.create_rewrite_credit_card_mask()
+    rewrite_cc_hash = config.create_rewrite_credit_card_hash()
+
+    generator_source = config.create_example_msg_generator_source(num=1, template=config.stringify(_Input_String))
+    file_destination_mask = config.create_file_destination(file_name="output_mask.log", template=config.stringify('${MSG}\n'))
+    file_destination_hash = config.create_file_destination(file_name="output_hash.log", template=config.stringify('${MSG}\n'))
+    config.create_logpath(statements=[generator_source, rewrite_cc_hash, file_destination_hash])
+    config.create_logpath(statements=[generator_source, rewrite_cc_mask, file_destination_mask])
+
+    syslog_ng.start(config)
+    assert file_destination_mask.read_log().strip() == _Expected_mask_output
+    assert file_destination_hash.read_log().strip() == _Expected_hash_output

--- a/tests/python_functional/src/syslog_ng_config/statements/rewrite/rewrite.py
+++ b/tests/python_functional/src/syslog_ng_config/statements/rewrite/rewrite.py
@@ -39,3 +39,13 @@ class SetTag(Rewrite):
 class SetPri(Rewrite):
     def __init__(self, pri, **options):
         super(SetPri, self).__init__("set_pri", [pri], **options)
+
+
+class CreditCardHash(Rewrite):
+    def __init__(self, **options):
+        super(CreditCardHash, self).__init__("credit-card-hash", [], **options)
+
+
+class CreditCardMask(Rewrite):
+    def __init__(self, **options):
+        super(CreditCardMask, self).__init__("credit-card-mask", [], **options)

--- a/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
@@ -33,6 +33,8 @@ from src.syslog_ng_config.statements.filters.filter import Filter
 from src.syslog_ng_config.statements.logpath.logpath import LogPath
 from src.syslog_ng_config.statements.parsers.db_parser import DBParser
 from src.syslog_ng_config.statements.parsers.parser import Parser
+from src.syslog_ng_config.statements.rewrite.rewrite import CreditCardHash
+from src.syslog_ng_config.statements.rewrite.rewrite import CreditCardMask
 from src.syslog_ng_config.statements.rewrite.rewrite import SetPri
 from src.syslog_ng_config.statements.rewrite.rewrite import SetTag
 from src.syslog_ng_config.statements.sources.example_msg_generator_source import ExampleMsgGeneratorSource
@@ -131,6 +133,12 @@ class SyslogNgConfig(object):
 
     def create_db_parser(self, config, **options):
         return DBParser(config, **options)
+
+    def create_rewrite_credit_card_mask(self, **options):
+        return CreditCardMask(**options)
+
+    def create_rewrite_credit_card_hash(self, **options):
+        return CreditCardHash(**options)
 
     def create_logpath(self, statements=None, flags=None):
         logpath = self.__create_logpath_with_conversion(statements, flags)


### PR DESCRIPTION
A user reported the VISA credit regex isn't working correctly.

More info about the regex: https://www.regular-expressions.info/creditcard.html
This site has some example credit card numbers, so can check it is working correctly: https://www.paypalobjects.com/en_GB/vhelp/paypalmanager_help/credit_card_numbers.htm