### PR TITLE
Github Actions: continue to build dbld images even if one platform fails

### DIFF
--- a/.github/workflows/dbld-images.yml
+++ b/.github/workflows/dbld-images.yml
@@ -35,9 +35,10 @@ jobs:
           gh_export CONTAINER_REGISTRY
 
       - name: Build the images
-        run: dbld/rules images -j $(nproc)
+        run: dbld/rules images -j $(nproc) --keep-going
 
       - name: Should we upload the images?
+        if: always()
         run: |
           if [ "${{ github.event.inputs.upload_images }}" = "true" ] || \
              ( \
@@ -55,7 +56,7 @@ jobs:
           gh_export UPLOAD_IMAGES_INTERNAL
 
       - name: Log in to the Container registry
-        if: env.UPLOAD_IMAGES_INTERNAL == 'true'
+        if: always() && env.UPLOAD_IMAGES_INTERNAL == 'true'
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -63,7 +64,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push the images
-        if: env.UPLOAD_IMAGES_INTERNAL == 'true'
+        if: always() && env.UPLOAD_IMAGES_INTERNAL == 'true'
         run: |
           IMAGES=$(docker image ls --filter "reference=${{ env.CONTAINER_REGISTRY }}/dbld-*:latest" --format '{{.Repository}}:{{.Tag}}')
           for IMAGE in $IMAGES; do

--- a/.github/workflows/dbld-images.yml
+++ b/.github/workflows/dbld-images.yml
@@ -44,7 +44,7 @@ jobs:
              ( \
               [ "${{ github.repository_owner }}" = "syslog-ng" ] && \
               [ "${{ github.ref }}" = "refs/heads/master" ] && \
-              [ "${{ github.event_name }}" = "push" ] \
+              [[ "${{ github.event_name }}" =~ ^(push|workflow_dispatch|schedule)$ ]] \
             )
           then
             UPLOAD_IMAGES_INTERNAL="true"

--- a/.github/workflows/dbld-images.yml
+++ b/.github/workflows/dbld-images.yml
@@ -60,8 +60,4 @@ jobs:
       - name: Push the images
         if: always() && env.UPLOAD_IMAGES_INTERNAL == 'true'
         run: |
-          IMAGES=$(docker image ls --filter "reference=${{ env.CONTAINER_REGISTRY }}/dbld-*:latest" --format '{{.Repository}}:{{.Tag}}')
-          for IMAGE in $IMAGES; do
-            echo "Pushing image: $IMAGE"
-            docker push $IMAGE
-          done
+          dbld/rules push-images -j $(nproc) --keep-going --output-sync

--- a/.github/workflows/dbld-images.yml
+++ b/.github/workflows/dbld-images.yml
@@ -13,7 +13,7 @@ on:
     - cron: '00 03 * * *'
   workflow_dispatch:
     inputs:
-      upload_images:
+      testing_image_upload:
         description: Should we upload the images into GitHub Packages? (true/false)
         required: false
         default: "false"
@@ -40,7 +40,7 @@ jobs:
       - name: Should we upload the images?
         if: always()
         run: |
-          if [ "${{ github.event.inputs.upload_images }}" = "true" ] || \
+          if [ "${{ github.event.inputs.testing_image_upload }}" = "true" ] || \
              ( \
               [ "${{ github.repository_owner }}" = "syslog-ng" ] && \
               [ "${{ github.ref }}" = "refs/heads/master" ] && \

--- a/.github/workflows/dbld-images.yml
+++ b/.github/workflows/dbld-images.yml
@@ -29,7 +29,7 @@ jobs:
           gh_export CONTAINER_REGISTRY
 
       - name: Build the images
-        run: dbld/rules images -j $(nproc) --keep-going
+        run: dbld/rules images -j $(nproc) --keep-going --output-sync
 
       - name: Should we upload the images?
         if: always()

--- a/.github/workflows/dbld-images.yml
+++ b/.github/workflows/dbld-images.yml
@@ -3,12 +3,6 @@ name: Compile dbld-images
 on:
   pull_request:
   push:
-    paths:
-      - .github/workflows/dbld-images.yml
-      # List is from dbld/rules cache-image-% "WATCHED_FILES"
-      - "dbld/**"
-      - "packaging/rhel/syslog-ng.spec"
-      - "packaging/debian/control"
   schedule:
     - cron: '00 03 * * *'
   workflow_dispatch:

--- a/dbld/rules
+++ b/dbld/rules
@@ -217,6 +217,11 @@ image-%:
 	$(DBLD_DIR)/prepare-image-build $* && \
         $(DOCKER) build $(DOCKER_BUILD_ARGS) --build-arg=ARG_IMAGE_PLATFORM=$* --build-arg=COMMIT=$$($(GIT) rev-parse --short HEAD || echo "") --build-arg=CONTAINER_REGISTRY=${CONTAINER_REGISTRY} --network=host -t ${CONTAINER_REGISTRY}/dbld-$* -f $(DBLD_DIR)/images/$*.dockerfile $(DBLD_DIR)
 
+push-images: $(foreach image,$(IMAGES), push-image-$(image))
+push-image-%:
+	@echo "Pushing image: $(image)"
+	$(DOCKER) push ${CONTAINER_REGISTRY}/dbld-$*
+
 pull-images: $(foreach image,$(BUILDER_IMAGES), pull-image-$(image))
 pull-image: pull-image-$(DEFAULT_IMAGE)
 pull-image-%:


### PR DESCRIPTION
Sometimes an image build fails, but most of the time due to some infrastructure failure.

We discussed that we should build the other images and also upload them regularly, not just in case of special events (e.g. dbld folder's content is changed).

I've tested image build failure (in a dummy way though), see some workflow runs on my fork:
- [with synchronized output](https://github.com/gaborznagy/syslog-ng/actions/runs/1587504844)
- [with image upload](https://github.com/gaborznagy/syslog-ng/runs/4498754819) (by explicitly enabling image upload)
- [ordinary run](https://github.com/gaborznagy/syslog-ng/actions/runs/1587371301) (no image upload due to running on fork) 