### PR TITLE
libtest/msg_parse_lib: fix memory leak in assert_log_message_value()

### DIFF
--- a/libtest/msg_parse_lib.c
+++ b/libtest/msg_parse_lib.c
@@ -88,6 +88,8 @@ assert_log_message_value(LogMessage *self, NVHandle handle, const gchar *expecte
     }
   else
     cr_assert_str_eq(actual_value, "", "No value is expected for key %s but its value is %s", key_name, actual_value);
+
+  g_free(actual_value);
 }
 
 void


### PR DESCRIPTION

This is a fixup patch pointed out by @gaborznagy in relation to #3857
