### PR TITLE
Fix cloning negated filters 

### DIFF
--- a/lib/filter/filter-expr.c
+++ b/lib/filter/filter-expr.c
@@ -98,10 +98,10 @@ filter_expr_unref(FilterExprNode *self)
 FilterExprNode *
 filter_expr_clone(FilterExprNode *self)
 {
-  if (self->clone)
-    {
-      return self->clone(self);
-    }
+  if (!self->clone)
+    return filter_expr_ref(self);
 
-  return filter_expr_ref(self);
+  FilterExprNode *cloned = self->clone(self);
+  cloned->comp = self->comp;
+  return cloned;
 }

--- a/lib/filter/filter-throttle.c
+++ b/lib/filter/filter-throttle.c
@@ -161,7 +161,7 @@ filter_throttle_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg, LogTemp
   }
   g_mutex_unlock(&self->map_lock);
 
-  return throttle_ratelimit_process_new_logs(rl, num_msg);
+  return throttle_ratelimit_process_new_logs(rl, num_msg) ^ s->comp;
 }
 
 static void

--- a/lib/filter/tests/test_filters_common.c
+++ b/lib/filter/tests/test_filters_common.c
@@ -150,7 +150,7 @@ testcase_with_socket(const gchar *msg, const gchar *sockaddr,
   res = filter_expr_eval(f, logmsg);
   cr_assert_eq(res, expected_result, "Filter test failed; msg='%s'\n", msg);
 
-  f->comp = 1;
+  f->comp = !f->comp;
   res = filter_expr_eval(f, logmsg);
   cr_assert_eq(res, !expected_result, "Filter test failed (negated); msg='%s'\n", msg);
 

--- a/lib/filter/tests/test_filters_fop.c
+++ b/lib/filter/tests/test_filters_fop.c
@@ -94,4 +94,16 @@ ParameterizedTest(FilterParams *params, filter_op, test_or_evaluation)
   testcase(msg, filter, params->expected_result);
 }
 
+Test(filter_op, cloned_filter_with_negation_should_behave_the_same)
+{
+  const gchar *msg = "<16> openvpn[2499]: PTHREAD support initialized";
+  FilterExprNode *filter = _compile_standalone_filter("not (program('noprog') and message('nomsg'))");
+  FilterExprNode *cloned_filter = filter_expr_clone(filter);
+
+  testcase(msg, filter, TRUE);
+  testcase(msg, cloned_filter, TRUE);
+
+  filter_expr_unref(cloned_filter);
+}
+
 TestSuite(filter_op, .init = setup, .fini = teardown);

--- a/news/bugfix-3863-2.md
+++ b/news/bugfix-3863-2.md
@@ -1,0 +1,1 @@
+`throttle()` filter: support negation

--- a/news/bugfix-3863.md
+++ b/news/bugfix-3863.md
@@ -1,0 +1,5 @@
+filters: fix `not` operator in filter expressions (regression in v3.35.1)
+
+Reusing a filter that contains the `not` operator more than once, or
+referencing a complex expression containing `not` might have caused invalid results
+in the previous syslog-ng version (v3.35.1).  This has been fixed.

--- a/tests/python_functional/functional_tests/filters/test_filter_reference.py
+++ b/tests/python_functional/functional_tests/filters/test_filter_reference.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2021 One Identity
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from src.message_builder.bsd_format import BSDFormat
+from src.message_builder.log_message import LogMessage
+
+
+def test_filter_multiple_reference(config, syslog_ng):
+    config.update_global_options(keep_hostname="yes")
+
+    file_source = config.create_file_source(file_name="input.log")
+    file_src_group = config.create_statement_group(file_source)
+    negated_filter = config.create_statement_group(config.create_filter("not (program('noprog') and message('nomsg'))"))
+    file_destination1 = config.create_file_destination(file_name="output1.log")
+    file_destination2 = config.create_file_destination(file_name="output2.log")
+
+    config.create_logpath(statements=[file_src_group, negated_filter, file_destination1])
+    config.create_logpath(statements=[file_src_group, negated_filter, file_destination2])
+
+    log_msg = LogMessage().program("PROGRAM").message("MESSAGE")
+    bsd_msg = BSDFormat.format_message(log_msg.remove_priority())
+
+    file_source.write_log(bsd_msg)
+
+    syslog_ng.start(config)
+
+    dest1_logs = file_destination1.read_logs(counter=1)
+    assert bsd_msg in dest1_logs
+
+    dest2_logs = file_destination2.read_logs(counter=1)
+    assert bsd_msg in dest2_logs

--- a/tests/python_functional/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/python_functional/src/syslog_ng/syslog_ng_cli.py
@@ -77,7 +77,7 @@ class SyslogNgCli(object):
             raise Exception("syslog-ng can not started exit_code={}".format(result["exit_code"]))
 
     def is_process_running(self):
-        return self.__process.poll() is None
+        return self.__process and self.__process.poll() is None
 
     def __wait_for_control_socket_alive(self):
         def is_alive(s):

--- a/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/python_functional/src/syslog_ng_config/syslog_ng_config.py
@@ -102,8 +102,8 @@ class SyslogNgConfig(object):
     def create_rewrite_set_pri(self, pri, **options):
         return SetPri(pri, **options)
 
-    def create_filter(self, **options):
-        return Filter([], **options)
+    def create_filter(self, expr=None, **options):
+        return Filter([expr] if expr else [], **options)
 
     def create_app_parser(self, **options):
         return Parser("app-parser", **options)


### PR DESCRIPTION
When cloning negated filter expressions, the negation field was left out.

This was a regression in v3.35.

Config to reproduce the issue:

```
filter f_f2 {
  not (program("a") and message("b"));
};

filter f_f3 {
  filter(f_f2)
};

log {
  source { stdin(); };
  filter(f_f3);
  destination { file("/dev/stdout"); };
};
```

Prior to this fix, `f_f2` and `f_f3` produced non-identical results.

Note: this PR is about fixing the actual issue. I'm preparing another branch for some refactor around filter expressions and for another filter-related bugfix.

Reported by @hbakken on IRC.