### PR TITLE
lgtm: minor fixes

### DIFF
--- a/lib/ringbuffer.c
+++ b/lib/ringbuffer.c
@@ -44,7 +44,7 @@ ring_buffer_alloc(RingBuffer *self, guint32 element_size, guint32 capacity)
   self->count = 0;
   self->capacity = capacity;
   self->element_size = element_size;
-  self->buffer = g_malloc0(element_size * self->capacity);
+  self->buffer = g_malloc0((gsize) element_size * self->capacity);
 }
 
 gboolean

--- a/modules/basicfuncs/str-funcs.c
+++ b/modules/basicfuncs/str-funcs.c
@@ -206,7 +206,8 @@ TEMPLATE_FUNCTION_SIMPLE(tf_strip);
 typedef struct _TFSanitizeState
 {
   TFSimpleFuncState super;
-  gint ctrl_chars:1, replacement:8;
+  gboolean ctrl_chars;
+  gchar replacement;
   gchar *invalid_chars;
 } TFSanitizeState;
 

--- a/modules/dbparser/radix.c
+++ b/modules/dbparser/radix.c
@@ -523,17 +523,26 @@ r_parser_ip(gchar *str, gint *len, const gchar *param, gpointer state, RParserMa
   return r_parser_ipv4(str, len, param, state, match) || r_parser_ipv6(str, len, param, state, match);
 }
 
+static inline void
+_scan_digits(gchar *str, gint *len)
+{
+  while (g_ascii_isdigit(str[*len]))
+    (*len)++;
+}
+
 gboolean
 r_parser_float(gchar *str, gint *len, const gchar *param, gpointer state, RParserMatch *match)
 {
-  gboolean dot = FALSE;
-
   *len = 0;
   if (str[*len] == '-')
     (*len)++;
 
-  while (g_ascii_isdigit(str[*len]) || (!dot && str[*len] == '.' && (dot = TRUE)))
-    (*len)++;
+  _scan_digits(str, len);
+  if (str[*len] == '.')
+    {
+      (*len)++;
+      _scan_digits(str, len);
+    }
 
   if (*len > 0 && (str[*len] == 'e' || str[*len] == 'E'))
     {


### PR DESCRIPTION
LGTM reports gboolean bit fields as ambiguously signed declarations.

This is because `gboolean` is typedefed to `gint`, and it is implementation specific whether an int is signed or unsigned.

Since `gboolean` is meant to represent a TRUE/FALSE value, this is not a real issue.

I've added a [modified CodeQL query](https://github.com/github/codeql/blob/main/cpp/ql/src/Likely%20Bugs/AmbiguouslySignedBitField.ql) that accepts gboolean bit fields.