### PR TITLE
Publish syslog-ng Docker image automatically

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,37 @@
+# When started manually, a syslog-ng-* tag has to be selected
+name: Publish Docker image
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'syslog-ng-*'
+
+jobs:
+  publish-docker-image:
+    name: Publish syslog-ng Docker image
+    if: github.repository_owner == 'syslog-ng'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout syslog-ng source
+        uses: actions/checkout@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Extract metadata (syslog-ng version) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: balabit/syslog-ng
+          tags: type=match,pattern=syslog-ng-(.*),group=1
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: docker/
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -101,7 +101,21 @@ EXTRA_DIST += \
 	contrib/config_option_database/utils/__init__.py \
 	contrib/config_option_database/utils/test/test_BisonGraph.py \
 	contrib/config_option_database/utils/test/test_OptionParser.py \
-	contrib/config_option_database/utils/test/test_Yacc2Graph.py
+	contrib/config_option_database/utils/test/test_Yacc2Graph.py \
+	\
+	contrib/syslog-ng-helm-chart/.helmignore \
+	contrib/syslog-ng-helm-chart/values.yaml \
+	contrib/syslog-ng-helm-chart/Chart.yaml \
+	contrib/syslog-ng-helm-chart/templates/NOTES.txt \
+	contrib/syslog-ng-helm-chart/templates/_helpers.tpl \
+	contrib/syslog-ng-helm-chart/templates/compress-job.yaml \
+	contrib/syslog-ng-helm-chart/templates/config.yaml \
+	contrib/syslog-ng-helm-chart/templates/deployment.yaml \
+	contrib/syslog-ng-helm-chart/templates/hpa.yaml \
+	contrib/syslog-ng-helm-chart/templates/pvc.yaml \
+	contrib/syslog-ng-helm-chart/templates/service.yaml \
+	contrib/syslog-ng-helm-chart/templates/serviceaccount.yaml \
+	contrib/syslog-ng-helm-chart/templates/tests/test-connection.yaml
 
 if ENABLE_SYSTEMD_UNIT_INSTALL
 systemdsystemunit_DATA = contrib/systemd/syslog-ng@.service

--- a/contrib/syslog-ng-helm-chart/.helmignore
+++ b/contrib/syslog-ng-helm-chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/contrib/syslog-ng-helm-chart/Chart.yaml
+++ b/contrib/syslog-ng-helm-chart/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+name: syslog-ng
+description: Syslog-ng
+version: 0.2
+appVersion: 3.27.1
+maintainers:
+  - name: zakkg3
+sources:
+  - https://github.com/syslog-ng/syslog-ng
+keywords:
+  - Syslog
+  - syslog-ng
+  - logrotate

--- a/contrib/syslog-ng-helm-chart/LICENSE
+++ b/contrib/syslog-ng-helm-chart/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2020 Nicolas Kowenski
+
+The syslog-ng Helm chart contained in this directory is free software; you can
+redistribute it and/or modify it under the terms of the GNU Lesser General
+Public License as published by the Free Software Foundation; either version 2.1
+of the License, or (at your option) any later version (please refer to the file
+LGPL.txt for more details).

--- a/contrib/syslog-ng-helm-chart/templates/NOTES.txt
+++ b/contrib/syslog-ng-helm-chart/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. syslog-ng deployment.
+
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "syslog-ng.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "syslog-ng.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "syslog-ng.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "syslog-ng.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Syslogng watch on tcp 601 and udp 514 port"
+{{- end }}
+
+########################################################
+# Syslogng watch on tcp  601 and udp 514 port          #
+########################################################

--- a/contrib/syslog-ng-helm-chart/templates/_helpers.tpl
+++ b/contrib/syslog-ng-helm-chart/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "syslog-ng.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "syslog-ng.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "syslog-ng.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "syslog-ng.labels" -}}
+helm.sh/chart: {{ include "syslog-ng.chart" . }}
+{{ include "syslog-ng.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "syslog-ng.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "syslog-ng.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "syslog-ng.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "syslog-ng.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/contrib/syslog-ng-helm-chart/templates/compress-job.yaml
+++ b/contrib/syslog-ng-helm-chart/templates/compress-job.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.compressor.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: job-script
+data:
+  entrypoint.sh: |-
+      #!/bin/bash
+      ls -lh /var/log/*-syslog
+      for filename in /var/log/*-syslog; do
+       if [[ $(find "$filename" -mtime +{{ .Values.compressor.retention_days }} -print) ]]; then
+         echo "$filename is older than {{ .Values.compressor.retention_days }} days, Compressing."
+         tar -zcvf "$filename"-$(date +%d-%m-%y).tar.gz $filename
+         rm $filename
+       else
+         echo skippig $filename not older than {{ .Values.compressor.retention_days }} days.
+       fi
+      done
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "syslog-ng.fullname" . }}-compressor
+spec:
+  schedule: "{{ .Values.compressor.schedule }}"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+          - name: compress
+            image: "ubuntu:20.10"
+            command:
+            - /bin/entrypoint.sh
+            volumeMounts:
+            - name: configmap-volume
+              mountPath: /bin/entrypoint.sh
+              readOnly: true
+              subPath: entrypoint.sh
+          {{- if .Values.storage.enable }}
+            - mountPath: /var/log
+              name: logs
+          {{- end }}
+          volumes:
+          - name: configmap-volume
+            configMap:
+              defaultMode: 0700
+              name: job-script
+          {{- if .Values.storage.enable }}
+          - name: logs
+            persistentVolumeClaim:
+              claimName: {{ include "syslog-ng.fullname" . }}-pvc
+          {{- end }}
+{{- end }}

--- a/contrib/syslog-ng-helm-chart/templates/config.yaml
+++ b/contrib/syslog-ng-helm-chart/templates/config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    {{- include "syslog-ng.labels" . | nindent 4 }}
+  name: {{ include "syslog-ng.fullname" . }}
+data:
+  syslog-ng.conf: {{  tpl (toYaml .Values.config) . | indent 4 }}

--- a/contrib/syslog-ng-helm-chart/templates/deployment.yaml
+++ b/contrib/syslog-ng-helm-chart/templates/deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "syslog-ng.fullname" . }}
+  labels:
+    {{- include "syslog-ng.labels" . | nindent 4 }}
+spec:
+{{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "syslog-ng.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ tpl (toYaml .Values.config) . | sha256sum }}
+    {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      labels:
+        {{- include "syslog-ng.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+          - name: tcp-port
+            containerPort: 601
+            protocol: TCP
+          - name: udp-port
+            containerPort: 514
+            protocol: UDP
+          volumeMounts:
+          - mountPath: /etc/syslog-ng/syslog-ng.conf
+            name: config
+            subPath: syslog-ng.conf
+        {{- if .Values.storage.enable }}
+          - mountPath: /var/log
+            name: logs
+        {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "syslog-ng.fullname" . }}
+      {{- if .Values.storage.enable }}
+      - name: logs
+        persistentVolumeClaim:
+          claimName: {{ include "syslog-ng.fullname" . }}-pvc
+      {{- end }}
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/contrib/syslog-ng-helm-chart/templates/hpa.yaml
+++ b/contrib/syslog-ng-helm-chart/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "syslog-ng.fullname" . }}
+  labels:
+    {{- include "syslog-ng.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "syslog-ng.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/contrib/syslog-ng-helm-chart/templates/pvc.yaml
+++ b/contrib/syslog-ng-helm-chart/templates/pvc.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.storage.enable }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "syslog-ng.fullname" . }}-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.storage.size }} 
+  storageClassName: {{ .Values.storage.storageClass }} 
+{{- end }}

--- a/contrib/syslog-ng-helm-chart/templates/service.yaml
+++ b/contrib/syslog-ng-helm-chart/templates/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "syslog-ng.fullname" . }}
+  labels:
+    {{- include "syslog-ng.labels" . | nindent 4 }}
+spec:
+  {{- if eq .Values.service.type "externalip" }}
+  
+  {{- with .Values.service.externalIPs }}
+  externalIPs:
+    {{- toYaml . | nindent 3 }}
+  {{- end }}
+  {{- else}}
+  type: {{ .Values.service.type }}
+  {{- end }}
+  ports:
+    - name: udp-port
+      port: 514
+      targetPort: 514
+      protocol: UDP
+    - name: tcp-port
+      port: 601
+      targetPort: 601
+      protocol: TCP 
+  selector:
+    {{- include "syslog-ng.selectorLabels" . | nindent 4 }}

--- a/contrib/syslog-ng-helm-chart/templates/serviceaccount.yaml
+++ b/contrib/syslog-ng-helm-chart/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "syslog-ng.serviceAccountName" . }}
+  labels:
+    {{- include "syslog-ng.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/contrib/syslog-ng-helm-chart/templates/tests/test-connection.yaml
+++ b/contrib/syslog-ng-helm-chart/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "syslog-ng.fullname" . }}-test-connection"
+  labels:
+    {{- include "syslog-ng.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "syslog-ng.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/contrib/syslog-ng-helm-chart/values.yaml
+++ b/contrib/syslog-ng-helm-chart/values.yaml
@@ -1,0 +1,108 @@
+# Default values for syslog-ng.
+
+replicaCount: 1
+
+image:
+  repository: balabit/syslog-ng
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "3.27.1"
+
+# By default, the network() driver binds to 0.0.0.0, meaning that it listens 
+# on every available IPV4 interface on the TCP/601 port.
+
+config: |
+  @version: 3.27
+  @include "scl.conf"
+  options {
+    # enable or disable directory creation for destination files
+    create_dirs(yes);
+
+    # keep hostnames from source host
+    keep_hostname(yes);
+
+    # use ISO8601 timestamps
+    ts_format(iso);
+  };
+  log {
+  	source {
+  		network();
+  	};
+  	destination { file("/var/log/${YEAR}-${MONTH}-syslog"); };
+  };
+
+storage:
+  enable: True
+  storageClass: ""
+  size: 500Gi
+  
+# Enable compressor to run a cron-job to compress files in /var/log/*-syslog older than retention_days
+# it also delete the plain-text file in order to keep the folder size as low as possible.
+# (if changes destination in server.config other than `/var/log/${YEAR}-${MONTH}-syslog` be aware you could breake this)
+compressor:
+  enabled: True
+  #“At 04:25 on day 1 and 15, every month every year”
+  schedule: "25 4 1,15 * *"
+  retention_days: 120
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+# Syslog-ng manages its own capabilities as well, just make sure the two doesn't collide.
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# syslog-ng have fixed ports tcp 601  and udp 514
+service:
+  type: ClusterIP
+  # use externalip for a pre routede exter al ip.
+  # TO-DO: LoadBalancer
+  # type: externalip
+  # externalIPs: 
+  #   - 10.205.212.12
+
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 1
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/dbld/prepare-release
+++ b/dbld/prepare-release
@@ -16,6 +16,7 @@ USER_EMAIL=$(git config --get user.email || echo "noemail@set.any.where")
 USER_NAME=$(git config --get user.name || echo "unknown user")
 VERSION_FILE_LIST="README.md doc/man/*.xml
 	scl/syslog-ng.conf
+	docker/syslog-ng.conf
 	contrib/openbsd-packaging/syslog-ng.conf
 	packaging/debian/syslog-ng.conf
 	packaging/rhel/syslog-ng.conf"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,27 @@
+FROM debian:testing
+LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>"
+
+
+RUN apt-get update -qq && apt-get install -y \
+    wget \
+    ca-certificates \
+    gnupg2
+
+RUN wget -qO - https://ose-repo.syslog-ng.com/apt/syslog-ng-ose-pub.asc | gpg --dearmor > /usr/share/keyrings/ose-repo-archive-keyring.gpg && \
+  echo "deb [ signed-by=/usr/share/keyrings/ose-repo-archive-keyring.gpg ] https://ose-repo.syslog-ng.com/apt/ stable debian-testing" | tee --append /etc/apt/sources.list.d/syslog-ng-ose.list
+
+RUN apt-get update -qq && apt-get install -y \
+    libdbd-mysql libdbd-pgsql libdbd-sqlite3 syslog-ng
+
+ADD syslog-ng.conf /etc/syslog-ng/syslog-ng.conf
+
+EXPOSE 514/udp
+EXPOSE 601/tcp
+EXPOSE 6514/tcp
+
+HEALTHCHECK --interval=2m --timeout=3s --start-period=30s CMD /usr/sbin/syslog-ng-ctl stats || exit 1
+
+
+
+
+ENTRYPOINT ["/usr/sbin/syslog-ng", "-F"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,17 +1,18 @@
 FROM debian:testing
-LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>"
-
+LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, László Várady <laszlo.varady@balabit.com>"
 
 RUN apt-get update -qq && apt-get install -y \
     wget \
     ca-certificates \
-    gnupg2
+    gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN wget -qO - https://ose-repo.syslog-ng.com/apt/syslog-ng-ose-pub.asc | gpg --dearmor > /usr/share/keyrings/ose-repo-archive-keyring.gpg && \
-  echo "deb [ signed-by=/usr/share/keyrings/ose-repo-archive-keyring.gpg ] https://ose-repo.syslog-ng.com/apt/ stable debian-testing" | tee --append /etc/apt/sources.list.d/syslog-ng-ose.list
+  echo "deb [signed-by=/usr/share/keyrings/ose-repo-archive-keyring.gpg] https://ose-repo.syslog-ng.com/apt/ stable debian-testing" | tee --append /etc/apt/sources.list.d/syslog-ng-ose.list
 
 RUN apt-get update -qq && apt-get install -y \
-    libdbd-mysql libdbd-pgsql libdbd-sqlite3 syslog-ng
+    libdbd-mysql libdbd-pgsql libdbd-sqlite3 syslog-ng \
+    && rm -rf /var/lib/apt/lists/*
 
 ADD syslog-ng.conf /etc/syslog-ng/syslog-ng.conf
 
@@ -20,8 +21,5 @@ EXPOSE 601/tcp
 EXPOSE 6514/tcp
 
 HEALTHCHECK --interval=2m --timeout=3s --start-period=30s CMD /usr/sbin/syslog-ng-ctl stats || exit 1
-
-
-
 
 ENTRYPOINT ["/usr/sbin/syslog-ng", "-F"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,83 @@
+# `balabit/syslog-ng`
+  * Syslog-ng is installed with all of its modules
+  * Within the container syslog-ng will start in foreground. This is useful because if there is some error with syslog-ng we can easily check the output console log through the `docker logs [containerID]` command
+  * You can use your own `syslog-ng.conf` or fall back to use the default one
+
+The following ports are exposed:
+ * Syslog UDP: 514,
+ * Syslog TCP: 601,
+ * Syslog TLS: 6514
+
+Syslog-ng will listen on these ports and forwards the logs into the file
+`/var/log/syslog`. You can check the default configuration in the source
+repository of this image.
+
+Please check the syslog-ng image tags at the official docker repository to know what image versions exist  [https://registry.hub.docker.com/u/balabit]
+
+## Using default configuration
+Assume that the following ports are not used on host machine, because they can conflict: `514`, `601`:
+
+```bash
+sudo docker run -it -p 514:514/udp -p 601:601 --name syslog-ng balabit/syslog-ng:latest
+```
+By default syslog-ng will not print any debug messages to the console. If you want to see more debug messages you need to start the containers in this way:
+
+```bash
+sudo docker run -it -p 514:514/udp -p 601:601 --name syslog-ng balabit/syslog-ng:latest -edv
+```
+
+## Using custom syslog-ng configuration
+You can override the default configuration by mounting a configuration file under `/etc/syslog-ng/syslog-ng.conf`:
+
+```bash
+sudo docker run -it -v "$PWD/syslog-ng.conf":/etc/syslog-ng/syslog-ng.conf balabit/syslog-ng:latest
+```
+
+## Reading logs from other containers
+An example is used to describe how syslog-ng can read logs from other containers.
+
+Assume that you have already running an `apache2` container which exposes its logs as a mounted volume under "/var/log/apache2/". We will read the apache logs and send them to a remote host (`1.2.3.4:514`). The example syslog-ng configuration file is stored in the current directory as `syslog-ng.conf`.
+
+```
+@version: 3.7
+
+source s_apache {
+  file("/var/log/apache2/access.log");
+};
+
+destination d_remote {
+  tcp("1.2.3.4" port(514));
+};
+
+log {
+  source(s_apache);
+  destination(d_remote);
+};
+```
+
+Now we can start syslog-ng:
+
+```bash
+sudo docker run -it --volumes-from [containerID for apache2] -v "$PWD/syslog-ng.conf":/etc/syslog-ng/syslog-ng.conf balabit/syslog-ng:latest
+```
+
+## Entering into a container
+Assume that your running container has a name "syslog-ng". In this case we can enter into this container by executing the following command:
+
+```bash
+sudo docker exec -it syslog-ng /bin/bash
+```
+
+## More information
+For detailed information on how to run your central log server in Docker and other Docker-related syslog-ng use cases, see the blog post [Your central log server in Docker](https://syslog-ng.com/blog/central-log-server-docker/).
+
+
+## FAQ
+
+### capabilities
+
+If the given configuration requires, syslog-ng tries to set some POSIX capabilities at startup, but (by default) Docker do not grant capabilities to the containers. Mainly there are three methods to circumvent this:
+ * If you do not require any capability (i.e. don't want to listen on ports under 1024 - NET_BIND_SERVICE), simply start syslog-ng with the `--no-caps` option.
+ * If you know precisely the type of capability you need, use the `--cap-add` option of the Docker service.
+ * (For development/testing purpose only!) To grant ALL of the capabilities to your container, start it with the `privileged` option. However, we do not recommend this method in production environments.
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -39,8 +39,6 @@ An example is used to describe how syslog-ng can read logs from other containers
 Assume that you have already running an `apache2` container which exposes its logs as a mounted volume under "/var/log/apache2/". We will read the apache logs and send them to a remote host (`1.2.3.4:514`). The example syslog-ng configuration file is stored in the current directory as `syslog-ng.conf`.
 
 ```
-@version: 3.7
-
 source s_apache {
   file("/var/log/apache2/access.log");
 };

--- a/docker/syslog-ng.conf
+++ b/docker/syslog-ng.conf
@@ -1,0 +1,42 @@
+#############################################################################
+# Default syslog-ng.conf file which collects all local logs into a
+# single file called /var/log/messages tailored to container usage.
+#
+# The changes from the stock, default syslog-ng.conf file is that we've
+# dropped the system() source that is not needed and that we enabled network
+# connections using default-network-drivers(). Customize as needed and
+# override using the -v option to docker, such as:
+#
+#  docker run ...  -v "$PWD/syslog-ng.conf":/etc/syslog-ng/syslog-ng.conf
+#
+
+@version: 3.29
+@include "scl.conf"
+
+source s_local {
+	internal();
+};
+
+source s_network {
+	default-network-drivers(
+		# NOTE: TLS support
+		#
+		# the default-network-drivers() source driver opens the TLS
+		# enabled ports as well, however without an actual key/cert
+		# pair they will not operate and syslog-ng would display a
+		# warning at startup.
+		#
+		#tls(key-file("/path/to/ssl-private-key") cert-file("/path/to/ssl-cert"))
+	);
+};
+
+destination d_local {
+	file("/var/log/messages");
+	file("/var/log/messages-kv.log" template("$ISODATE $HOST $(format-welf --scope all-nv-pairs)\n") frac-digits(3));
+};
+
+log {
+	source(s_local);
+	source(s_network);
+	destination(d_local);
+};

--- a/docker/syslog-ng.conf
+++ b/docker/syslog-ng.conf
@@ -10,7 +10,7 @@
 #  docker run ...  -v "$PWD/syslog-ng.conf":/etc/syslog-ng/syslog-ng.conf
 #
 
-@version: 3.29
+@version: 3.35
 @include "scl.conf"
 
 source s_local {

--- a/news/other-3870.md
+++ b/news/other-3870.md
@@ -1,0 +1,2 @@
+The [syslog-ng Docker image](https://hub.docker.com/r/balabit/syslog-ng/)
+is now automatically tagged and pushed to Docker Hub after each release

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -18,6 +18,7 @@ dev-utils/plugin_skeleton_creator/plugin_template.*
 dist\.conf$
 .*/\.gradle
 scl/syslog-ng\.conf$
+docker/syslog-ng\.conf$
 tests/copyright/policy$
 (syslog-ng-)?config\.h$
 lib/cfg-lex\.[ch]$


### PR DESCRIPTION
This PR moves our "production" Docker image from https://github.com/balabit/syslog-ng-docker to the main syslog-ng repo.

A separate docker directory has been created.
Note: this is not added as a dbld image, because most of the dbld commands do not make sense on the production syslog-ng image, which uses the syslog-ng APT repository.

A GitHub Actions job has been added that pushes the image to Docker Hub when the release is published.

Important note: APT packages has to be published before pushing the release button (we should update the Wiki if this gets in).

Example run:
https://github.com/MrAnno/syslog-ng/actions/runs/1664402242

Fixes balabit/syslog-ng-docker#38

Deprecation warning for the syslog-ng-docker repo: balabit/syslog-ng-docker#78

Since I had 2 approvals on this PR before the rebase, I went ahead and added the necessary credentials, so the workflow will function properly after merge.