### PR TITLE
Bugfixes and enhancements to the SELinux policy installer script and syslog-ng-debun

### DIFF
--- a/contrib/selinux/syslog_ng.sh
+++ b/contrib/selinux/syslog_ng.sh
@@ -95,7 +95,7 @@ extract_version_string() {
 detect_os_version() {
 	echo "Detecting RHEL/CentOS/Oracle Linux version..."
 	if [ -x "/usr/bin/lsb_release" ]; then
-		if lsb_release -d | grep -qE "Description:[[:space:]]+(CentOS|CentOS Linux|Red Hat Enterprise Linux Server|Oracle Linux Server|Enterprise Linux Enterprise Linux Server) release"; then
+		if lsb_release -d | grep -qE "Description:[[:space:]]+(CentOS|Red Hat Enterprise|Oracle|Enterprise Linux Enterprise)( Linux)?( Server)? release"; then
 			OS_VERSION=$( lsb_release -r | cut -f 2 )
 		else
 			echo "You don't seem to be running a supported Linux distribution!" >&2

--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -47,13 +47,15 @@ ipconfig="ip addr"
 routeconfig () { netstat -nr ; }
 netstatnlp () { netstat -nlp ; }
 netstatlunp () { netstat -lunp ; }
+netstatpunt () { netstat -punt ; }
+netstatpn () { netstat -pn ; }
 netstatsu="netstat -su"
-netstatpunt="netstat -punt"
 binprefix=/opt/syslog-ng
 absscldirs="/usr/share/syslog-ng/include/scl"
 relscldirs="share/include/scl share/syslog-ng/include/scl"
 workdir=/tmp
 lsof="lsof -p"
+no_lsof_fallback() { echo "No lsof in path."; }
 pscmd="ps auxwwwwwf"
 pseao="ps -eao"
 cpiopdL="cpio -pdL"
@@ -438,8 +440,9 @@ acquire_system_other_info () {
 	$w >${tmpdir}/sys.w
 	$dmesg >${tmpdir}/sys.dmesg
 	netstatnlp >${tmpdir}/sys.netstat.ltn
-	$netstatpunt >${tmpdir}/sys.netstat.est
 	netstatlunp >${tmpdir}/sys.netstat.lunp
+	netstatpunt >${tmpdir}/sys.netstat.est
+	netstatpn >${tmpdir}/sys.netstat.pn
 	$netstatsu >${tmpdir}/sys.netstat.su
 	[ -f /proc/net/udp ] && cp /proc/net/udp ${tmpdir}/sys.proc.net.udp
 }
@@ -766,6 +769,8 @@ acquire_syslog_info () {
 	$syslogbin --version > ${tmpdir}/syslog.version
 	head -1 ${tmpdir}/syslog.version
 
+	[ -x ${binprefix}/sbin/wec ] && ${binprefix}/sbin/wec -v 2>&1 > ${tmpdir}/wec.version
+
 	if [ -z "$debug_mode" ]; then
 		acquire_syslog_stats
 	fi
@@ -778,13 +783,13 @@ acquire_syslog_info () {
 	echo ${syslogngctlbin} credentials status
 
 	for i in ${sngallpids} ; do
-		is_available ${lsof%% *} && $lsof $i >${tmpdir}/syslog.$i.lsof 2>/dev/null || echo "No lsof in path." >${tmpdir}/syslog.$i.lsof
+		is_available ${lsof%% *} && $lsof $i >${tmpdir}/syslog.$i.lsof 2>/dev/null || no_lsof_fallback $i >${tmpdir}/syslog.$i.lsof
 		myplimit $i >${tmpdir}/syslog.$i.limits
 	done
 
 	if [ -n "$wecpid" ]; then
 		while read i; do
-			is_available ${lsof%% *} && $lsof $i >${tmpdir}/wec.$i.lsof || echo "No lsof in path." >${tmpdir}/wec.$i.lsof
+			is_available ${lsof%% *} && $lsof $i >${tmpdir}/wec.$i.lsof || no_lsof_fallback $i >${tmpdir}/wec.$i.lsof
 		done < ${tmpdir}/wec.pid
 	fi
 
@@ -991,6 +996,7 @@ debun_extra_suse() {
 		#we value our customer's sense of privacy
 		if [ -z "$privacy_mode" ]; then
 			netstat -punt >${tmpdir}/sys.netstat.est.noss
+			netstat -pn >${tmpdir}/sys.netstat.pn.noss
 		fi
 	fi
 
@@ -1278,8 +1284,9 @@ setup_env_slackware  () {
 }
 
 setup_env_genlinux () {
-	unset myplimit
+	unset myplimit no_lsof_fallback
 	myplimit () { [ -f "/proc/$1/limits" ] && cat /proc/$1/limits ; }
+	no_lsof_fallback() { ls -l /proc/${1}/fd ; }
 
 	if is_available systemctl ; then
 		service_stop="systemctl stop syslog-ng"
@@ -1329,7 +1336,8 @@ setup_env_solaris () {
 	tcpdumpopts="-P -q -o"
 	pcapifparm="-d"
 	trace="truss -r all -w all -u libc:: -f"
-	netstatpunt="netstat -n"
+	netstatpunt() { netstat -n ; }
+	netstatpn() { netstat -n ; }
 	netstatsu="netstat -s"
 	grepq="/usr/xpg4/bin/grep -q"
 	sed_equivalent_cmd="perl -p -e"
@@ -1408,7 +1416,8 @@ setup_env_solaris () {
 }
 
 setup_env_freebsd () {
-	netstatpunt="netstat -n"
+	netstatpunt() { netstat -n ; }
+	netstatpn() { netstat -n ; }
 	netstatsu="netstat -s"
 	ipconfig="ifconfig -a"
 	pseao="ps xao"
@@ -1446,7 +1455,8 @@ setup_env_hpux () {
 	lddcmd="/usr/ccs/bin/ldd"
 	trace="/usr/local/bin/tusc -p -l -u -f"
 	netstatsu="netstat -s"
-	netstatpunt="netstat -n"
+	netstatpunt() { netstat -n ; }
+	netstatpn() { netstat -n ; }
 	ipconfig="netstat -ni"
 	pscmd="ps -eaf"
 	dfh="df"
@@ -1547,7 +1557,8 @@ setup_env_aix () {
 	pscmd="ps -eaf"
 	dfh="df -k"
 	netstatsu="netstat -s"
-	netstatpunt="netstat -n"
+	netstatpunt() { netstat -n ; }
+	netstatpn() { netstat -n ; }
 	dmesg="alog -o -t boot"
 	trace="truss -r all -w all -u libc:: -f"
 	initfile=
@@ -1618,7 +1629,8 @@ setup_env_generic_post () {
 		routeconfig () { ip route show ; }
 		netstatnlp () { ss -nlp ; }
 		netstatlunp () { ss -lunp ; }
-		netstatpunt="ss -punt"
+		netstatpunt() { ss -punt ; }
+		netstatpn() { ss -pn ; }
 	fi
 	if is_available netstat; then
 		:

--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -3,7 +3,7 @@
 
 ### syslog-ng-debun: syslog debug bundle generator
 ### Written/Copyright: Gyorgy Pasztor <pasztor@linux.gyakg.u-szeged.hu>, (c) 2014-2016.
-### Further enhancements: Janos Szigetvari - jszigetvari at gmail dot com, (c) 2016-2019.
+### Further enhancements: Janos Szigetvari - jszigetvari at gmail dot com, (c) 2016-2022.
 ### This software may be used and distributed according to the terms of GNU GPLv2
 ### http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -12,7 +12,7 @@ LANG=en_US
 LC_ALL=C
 export LANG LC_ALL
 
-version="0.3.19.20191111"
+version="0.3.20.20220117"
 
 ### Check for "local" variable support
 if type local | grep builtin >/dev/null; then
@@ -66,7 +66,7 @@ grepq="fgrep -q"
 lddcmd="ldd"
 topcmd () { top -b -n 1 -c >"${1}"; }
 opensslcmd="openssl"
-sed_equivalent_cmd="sed -E"
+sed_equivalent_cmd="sed -Ee"
 mount=mount
 varlimit=1000
 myplimit () { echo "Plimit query is not supported on this platform" >&3 ; }
@@ -694,7 +694,7 @@ acquire_syslog_config () {
 	for dir in ${absscldirs}; do
 		if [ -d "${dir}" ]; then
 			cd "${dir}"
-			local dirname=$( echo "${dir}" | sed -e 's/\//_/g' )
+			local dirname=$( echo "${dir}" | ${sed_equivalent_cmd} 's/\//_/g' )
 			mkdir "${tmpdir}/scl/${dirname}"
 			findL . | $cpiopdL "${tmpdir}/scl/${dirname}"
 		fi
@@ -702,7 +702,7 @@ acquire_syslog_config () {
 	for dir in ${relscldirs}; do
 		if [ -d "${binprefix}/${dir}" ]; then
 			cd "${binprefix}/${dir}"
-			local dirname=$( echo "${binprefix}/${dir}" | sed -e 's/\//_/g' )
+			local dirname=$( echo "${binprefix}/${dir}" | ${sed_equivalent_cmd} 's/\//_/g' )
 			mkdir "${tmpdir}/scl/${dirname}"
 			findL . | $cpiopdL "${tmpdir}/scl/${dirname}"
 		fi
@@ -1388,7 +1388,7 @@ setup_env_solaris () {
 		}
 	elif is_available digest; then
 		os_hash_helper () {
-			find . '!' \( -name debun.manifest -o -name syslog-ng.debun.txt \) -type f -exec digest -a md5 -v '{}' \; | sed -e 's:^md5 (\(.*\)) = \([a-z0-9]\{32\}\)$:\2  \1:'
+			find . '!' \( -name debun.manifest -o -name syslog-ng.debun.txt \) -type f -exec digest -a md5 -v '{}' \; | ${sed_equivalent_cmd} 's:^md5 (\(.*\)) = \([a-z0-9]\{32\}\)$:\2  \1:'
 		}
 	else
 		os_hash_helper () { : ; }
@@ -1437,7 +1437,7 @@ setup_env_freebsd () {
 	distpkgoffile () { : ; }
 	distpkgstatus () { : ; }
 	os_hash_helper () {
-		find . '!' \( -name debun.manifest -o -name syslog-ng.debun.txt \) -type f -exec md5 '{}' \; | sed -e 's:^MD5 (\(.*\)) = \([a-z0-9]\{32\}\)$:\2  \1:'
+		find . '!' \( -name debun.manifest -o -name syslog-ng.debun.txt \) -type f -exec md5 '{}' \; | ${sed_equivalent_cmd} 's:^MD5 (\(.*\)) = \([a-z0-9]\{32\}\)$:\2  \1:'
 	}
 }
 
@@ -1569,7 +1569,7 @@ setup_env_aix () {
 	unset -f format_ldd_output
 	unset -f os_hash_helper
 
-	format_ldd_output () { sed -e 's:^[^/]*\(.*\)$:\1:' -e 's:^\(.*\)(.*)$:\1:'; }
+	format_ldd_output () { ${sed_equivalent_cmd} 's:^[^/]*\(.*\)$:\1:' -e 's:^\(.*\)(.*)$:\1:'; }
 	netstatnlp () { netstat -na | grep -E "(Active|Proto|LISTEN)" ; }
 	netstatlunp () { netstat -na | grep -E "(Internet|Proto|udp)" ; }
 	dfk_parser () { tail -1 | while read FS ALL AVAIL UPERC IUPERC MP; do echo ${AVAIL}; done }

--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -1038,7 +1038,7 @@ debun_linux () {
 		"Debian"|"Ubuntu")
 			add_extra debun_extra_debian
 			;;
-		"CentOS"|"RedHatEnterpriseServer"|"RHEL"|"OracleServer"|"EnterpriseEnterpriseServer")
+		"CentOS"|"RedHatEnterprise"|"RedHatEnterpriseServer"|"RHEL"|"OracleServer"|"EnterpriseEnterpriseServer")
 			add_extra debun_extra_redhat
 			;;
 		"SUSE LINUX")
@@ -1303,7 +1303,7 @@ setup_env_linux () {
 		"Debian"|"Ubuntu")
 			setup_env_debian
 			;;
-		"CentOS"|"RedHatEnterpriseServer"|"RHEL"|"OracleServer"|"EnterpriseEnterpriseServer")
+		"CentOS"|"RedHatEnterprise"|"RedHatEnterpriseServer"|"RHEL"|"OracleServer"|"EnterpriseEnterpriseServer")
 			setup_env_redhat
 			;;
 		"SUSE LINUX")


### PR DESCRIPTION
Added bugfixes and enhancements to the SELinux policy installer script and syslog-ng-debun

* corrected an OS-detection related bug in the SELinux policy installer's code
* updated syslog-ng-debun's OS-detection code to cope with the same problem
* bumped the version number and updated copyright information
* updated syslog-ng-debun to gather more, useful information
  (these include wec version, lsof-like information if lsof is not installed, information about socket files)


Signed-off-by: Janos SZIGETVARI jszigetvari@gmail.com