### PR TITLE
versioning: add versioning framework for the syslog-ng 4.0 transition (4.0)

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -423,11 +423,21 @@ cfg_set_version(GlobalConfig *self, gint version)
     }
   else if (version_convert_from_user(self->user_version) > VERSION_VALUE_CURRENT)
     {
-      msg_warning("WARNING: Configuration file format is newer than the current version, please specify the "
-                  "current version number ("  VERSION_STR_CURRENT ") in the @version directive. "
-                  "syslog-ng will operate at its highest supported version in this mode",
-                  cfg_format_config_version_tag(self));
-      self->user_version = VERSION_VALUE_CURRENT;
+      if (cfg_is_experimental_feature_enabled(self))
+        {
+          msg_warning("WARNING: experimental behaviors of the future " VERSION_4_0 " are now enabled. This mode of "
+                      "operation is meant to solicit feedback and allow the evaluation of the new features. USE THIS "
+                      "MODE AT YOUR OWN RISK, please share feedback via GitHub, Gitter.im or email to the authors",
+                      cfg_format_config_version_tag(self));
+        }
+      else
+        {
+          msg_warning("WARNING: Configuration file format is newer than the current version, please specify the "
+                      "current version number ("  VERSION_STR_CURRENT ") in the @version directive. "
+                      "syslog-ng will operate at its highest supported version in this mode",
+                      cfg_format_config_version_tag(self));
+          self->user_version = VERSION_VALUE_CURRENT;
+        }
     }
 
   if (cfg_is_config_version_older(self, VERSION_VALUE_3_3))

--- a/lib/tests/test_lexer.c
+++ b/lib/tests/test_lexer.c
@@ -312,6 +312,7 @@ Test(lexer, at_version_stores_config_version_in_parsed_version_in_hex_form)
 {
   parser->lexer->ignore_pragma = FALSE;
 
+  start_grabbing_messages();
   cfg_set_version_without_validation(configuration, 0);
   _input("@version: 3.1\n\
 bar\n");
@@ -319,12 +320,17 @@ bar\n");
   cr_assert_eq(configuration->user_version, 0x0301,
                "@version parsing mismatch, value %04x expected %04x", configuration->user_version, 0x0301);
 
+  assert_grabbed_log_contains("Configuration file format is too old");
+
+  reset_grabbed_messages();
   cfg_set_version_without_validation(configuration, 0);
   _input("@version: 3.5\n\
 baz\n");
   assert_parser_identifier("baz");
   cr_assert_eq(configuration->user_version, 0x0305,
                "@version parsing mismatch, value %04x expected %04x", configuration->user_version, 0x0305);
+
+  assert_grabbed_log_contains("Configuration file format is too old");
 }
 
 Test(lexer, current_version)
@@ -337,6 +343,40 @@ foo\n");
   assert_parser_identifier("foo");
   cr_assert_eq(configuration->user_version, VERSION_VALUE_CURRENT,
                "@version parsing mismatch, value %04x expected %04x", configuration->user_version, VERSION_VALUE_CURRENT);
+}
+
+Test(lexer, feature_flip_to_typing)
+{
+  gchar buf[128];
+  parser->lexer->ignore_pragma = FALSE;
+
+  start_grabbing_messages();
+
+  cfg_set_version_without_validation(configuration, 0);
+
+  gint flip_version = FEATURE_TYPING_MIN_VERSION - 1;
+  g_snprintf(buf, sizeof(buf), "@version: %d.%d\nbar\n",
+             (flip_version & 0xFF00) >> 8,
+             flip_version & 0xFF);
+  _input(buf);
+  assert_parser_identifier("bar");
+  cr_assert(configuration->user_version == flip_version);
+  assert_grabbed_log_contains("experimental behaviors of the future syslog-ng");
+
+  cr_assert(cfg_is_config_version_older(configuration, VERSION_VALUE_4_0));
+  cr_assert(cfg_is_typing_feature_enabled(configuration));
+
+  reset_grabbed_messages();
+
+  cfg_set_version_without_validation(configuration, 0);
+  g_snprintf(buf, sizeof(buf), "@version: %d.%d\nbar\n",
+             (VERSION_VALUE_4_0 & 0xFF00) >> 8,
+             VERSION_VALUE_4_0 & 0xFF);
+  _input(buf);
+  assert_parser_identifier("bar");
+  assert_grabbed_log_contains("experimental behaviors of the future syslog-ng");
+  cr_assert(!cfg_is_config_version_older(configuration, VERSION_VALUE_4_0));
+  cr_assert(cfg_is_typing_feature_enabled(configuration));
 }
 
 Test(lexer, test_lexer_others)

--- a/lib/versioning.h
+++ b/lib/versioning.h
@@ -132,6 +132,8 @@
 #define VERSION_3_35 "syslog-ng 3.35"
 #define VERSION_3_36 "syslog-ng 3.36"
 
+#define VERSION_4_0 "syslog-ng 4.0"
+
 /* VERSION_VALUE_* references versions as integers to be compared against stuff like cfg->user_version */
 /* VERSION_STR_* references versions as strings to be shown to the user */
 
@@ -172,6 +174,10 @@
 #define VERSION_VALUE_3_34 0x0322
 #define VERSION_VALUE_3_35 0x0323
 
+/* these are defined to allow 4.0 related changes to be introduced while we
+ * are still producing 3.x releases. */
+#define VERSION_VALUE_4_0     0x0400
+
 /* config version code, in the same format as GlobalConfig->version */
 #define VERSION_VALUE_CURRENT   VERSION_VALUE_3_35
 #define VERSION_STR_CURRENT     "3.35"
@@ -185,6 +191,10 @@
 #define VERSION_STR_LAST_SEMANTIC_CHANGE    "3.35"
 
 #define version_convert_from_user(v)  (v)
+
+/* version based feature flips */
+#define VERSION_VALUE_NEXT_MAJOR         VERSION_VALUE_4_0
+#define FEATURE_TYPING_MIN_VERSION       VERSION_VALUE_4_0
 
 #include "pe-versioning.h"
 #endif


### PR DESCRIPTION
The plan to release syslog-ng 4.0 would be as follows:

  * we are accumulating changes destined for 4.0 by merging them into
    subsequent syslog-ng 3.x releases, but working in a compatible mode so
    that no changes would be visible to 3.x users.

  * Usually we report changes to behavior using warnings at
    startup and we do this release-by-release. With 4.0, we expect a broader
    set of changes that we would like to present to users as a whole. For
    this reason we will suppress these warnings for changes we plan for
    4.0 at least until the user explicitly indicates interest in the
    experimental features.

  * the user can start using the new features as follows:

    - by using @version: 3.255 in a config, the warnings about changes get
      enabled (while continuing to work in 3.x compatibility mode)

    - by using @version: 4.0 in a config, the changes are enabled and
      syslog-ng would start working in the new mode we plan for 4.0.

    - in a way all new features/changes would operate behind a feature flip,
      which the user can control using the @version line in a
      configuration.

  * the features provided by the 4.0 mode are experimental and this mode is
    not intended for production use.

  * once the 4.0 features/changes are all baked, we release syslog-ng 4.0,
    which would make the new features/behaviours official. The v3.255 mode
    of operation would be disabled and the feature flip removed. Essentially
    the only change would be that upgrade warnings would always get enabled.

Signed-off-by: Balazs Scheidler <bazsi77@gmail.com>