### PR TITLE
Propagate types over set operations (4.0)

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1392,7 +1392,7 @@ matcher_flags
 value_pair_option
 	: KW_VALUE_PAIRS
           {
-            last_value_pairs = value_pairs_new();
+            last_value_pairs = value_pairs_new(configuration);
           }
           '(' vp_options ')'
           { $$ = last_value_pairs; }

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -330,12 +330,13 @@
 %token KW_REKEY                       10508
 %token KW_ADD_PREFIX                  10509
 %token KW_REPLACE_PREFIX              10510
+%token KW_CAST                        10511
 
-%token KW_ON_ERROR                    10511
+%token KW_ON_ERROR                    10520
 
-%token KW_RETRIES                     10512
+%token KW_RETRIES                     10521
 
-%token KW_FETCH_NO_DATA_DELAY         10513
+%token KW_FETCH_NO_DATA_DELAY         10522
 /* END_DECLS */
 
 %type   <ptr> expr_stmt
@@ -1430,6 +1431,7 @@ vp_option
           vp_rekey_options ')'                           { value_pairs_add_transforms(last_value_pairs, last_vp_transset); }
         | KW_EXCLUDE '(' string_list ')'                 { value_pairs_add_glob_patterns(last_value_pairs, $3, FALSE); }
 	| KW_SCOPE '(' vp_scope_list ')'
+	| KW_CAST '(' yesno ')'                          { value_pairs_set_cast_to_strings(last_value_pairs, $3); }
 	;
 
 vp_scope_list

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -79,6 +79,7 @@ static CfgLexerKeyword main_keywords[] =
   { "add_prefix",         KW_ADD_PREFIX },
   { "replace",            KW_REPLACE_PREFIX, KWS_OBSOLETE, "replace_prefix" },
   { "replace_prefix",     KW_REPLACE_PREFIX },
+  { "cast",               KW_CAST },
 
   /* option items */
   { "flags",              KW_FLAGS },

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -421,6 +421,14 @@ cfg_set_version(GlobalConfig *self, gint version)
                   "file",
                   cfg_format_config_version_tag(self));
     }
+  else if (version_convert_from_user(self->user_version) >= VERSION_VALUE_3_LAST &&
+           version_convert_from_user(self->user_version) <= VERSION_VALUE_4_0)
+    {
+      msg_warning("WARNING: experimental behavior of the future syslog-ng 4.0 are now enabled. This mode of "
+                  "operation is meant to solicit feedback and allow the evaluation of the new features. USE THIS "
+                  "MODE AT YOUR OWN RISK, please share feedback via GitHub, Gitter.im or email to the authors",
+                  cfg_format_config_version_tag(self));
+    }
   else if (version_convert_from_user(self->user_version) > VERSION_VALUE_CURRENT)
     {
       msg_warning("WARNING: Configuration file format is newer than the current version, please specify the "

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -715,7 +715,7 @@ log_msg_set_match_with_type(LogMessage *self, gint index_,
                             const gchar *value, gssize value_len,
                             LogMessageValueType type)
 {
-  g_assert(index_ < LOGMSG_MAX_MATCHES);
+  g_assert(index_ >= 0 && index_ < LOGMSG_MAX_MATCHES);
 
   if (index_ >= self->num_matches)
     self->num_matches = index_ + 1;
@@ -725,13 +725,15 @@ log_msg_set_match_with_type(LogMessage *self, gint index_,
 void
 log_msg_set_match(LogMessage *self, gint index_, const gchar *value, gssize value_len)
 {
+  g_assert(index_ >= 0 && index_ < LOGMSG_MAX_MATCHES);
+
   log_msg_set_match_with_type(self, index_, value, value_len, LM_VT_STRING);
 }
 
 void
 log_msg_set_match_indirect(LogMessage *self, gint index_, NVHandle ref_handle, guint16 ofs, guint16 len)
 {
-  g_assert(index_ < 256);
+  g_assert(index_ >= 0 && index_ < LOGMSG_MAX_MATCHES);
 
   log_msg_set_value_indirect(self, match_handles[index_], ref_handle, ofs, len);
 }
@@ -741,7 +743,7 @@ log_msg_set_match_indirect_with_type(LogMessage *self, gint index_,
                                      NVHandle ref_handle, guint16 ofs, guint16 len,
                                      LogMessageValueType type)
 {
-  g_assert(index_ < 256);
+  g_assert(index_ >= 0 && index_ < LOGMSG_MAX_MATCHES);
 
   log_msg_set_value_indirect_with_type(self, match_handles[index_], ref_handle, ofs, len, type);
 }

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -748,6 +748,31 @@ log_msg_set_match_indirect_with_type(LogMessage *self, gint index_,
   log_msg_set_value_indirect_with_type(self, match_handles[index_], ref_handle, ofs, len, type);
 }
 
+const gchar *
+log_msg_get_match_with_type(const LogMessage *self, gint index_, gssize *value_len,
+                            LogMessageValueType *type)
+{
+  g_assert(index_ >= 0 && index_ < LOGMSG_MAX_MATCHES);
+
+  return log_msg_get_value_with_type(self, match_handles[index_], value_len, type);
+}
+
+const gchar *
+log_msg_get_match(const LogMessage *self, gint index_, gssize *value_len)
+{
+  g_assert(index_ >= 0 && index_ < LOGMSG_MAX_MATCHES);
+
+  return log_msg_get_value(self, match_handles[index_], value_len);
+}
+
+void
+log_msg_unset_match(LogMessage *self, gint index_)
+{
+  g_assert(index_ >= 0 && index_ < LOGMSG_MAX_MATCHES);
+
+  log_msg_unset_value(self, match_handles[index_]);
+}
+
 void
 log_msg_clear_matches(LogMessage *self)
 {

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -402,6 +402,10 @@ void log_msg_set_match_with_type(LogMessage *self, gint index,
 void log_msg_set_match_indirect(LogMessage *self, gint index, NVHandle ref_handle, guint16 ofs, guint16 len);
 void log_msg_set_match_indirect_with_type(LogMessage *self, gint index, NVHandle ref_handle,
                                           guint16 ofs, guint16 len, LogMessageValueType type);
+void log_msg_unset_match(LogMessage *self, gint index_);
+const gchar *log_msg_get_match_with_type(const LogMessage *self, gint index_, gssize *value_len,
+                                         LogMessageValueType *type);
+const gchar *log_msg_get_match(const LogMessage *self, gint index_, gssize *value_len);
 void log_msg_clear_matches(LogMessage *self);
 
 static inline void

--- a/lib/rewrite/rewrite-groupset.c
+++ b/lib/rewrite/rewrite-groupset.c
@@ -137,7 +137,7 @@ log_rewrite_groupset_new(LogTemplate *template, GlobalConfig *cfg)
   self->super.super.clone = log_rewrite_groupset_clone;
 
   self->replacement = log_template_ref(template);
-  self->query = value_pairs_new();
+  self->query = value_pairs_new(cfg);
   self->vp_func = log_rewrite_groupset_foreach_func;
 
   return &self->super;

--- a/lib/value-pairs/cmdline.c
+++ b/lib/value-pairs/cmdline.c
@@ -385,6 +385,24 @@ vp_cmdline_parse_rekey_shift_levels (const gchar *option_name, const gchar *valu
   return TRUE;
 }
 
+static gboolean
+vp_cmdline_parse_cast(const gchar *option_name, const gchar *value,
+                      gpointer data, GError **error)
+{
+  gpointer *args = (gpointer *) data;
+  ValuePairs *vp = (ValuePairs *) args[1];
+
+  if (strcmp(option_name, "--no-cast") == 0)
+    value_pairs_set_cast_to_strings(vp, FALSE);
+  else if (strcmp(option_name, "--cast") == 0)
+    value_pairs_set_cast_to_strings(vp, TRUE);
+  else if (strcmp(option_name, "--auto-cast") == 0)
+    value_pairs_set_auto_cast(vp);
+  else
+    return FALSE;
+  return TRUE;
+}
+
 ValuePairs *
 value_pairs_new_from_cmdline (GlobalConfig *cfg,
                               gint *argc, gchar ***argv,
@@ -444,6 +462,18 @@ value_pairs_new_from_cmdline (GlobalConfig *cfg,
     },
     {
       "omit-empty-values", 0, 0, G_OPTION_ARG_NONE, &vp->omit_empty_values,
+      NULL, NULL
+    },
+    {
+      "cast", 0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, vp_cmdline_parse_cast,
+      NULL, NULL
+    },
+    {
+      "no-cast", 0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, vp_cmdline_parse_cast,
+      NULL, NULL
+    },
+    {
+      "auto-cast", 0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, vp_cmdline_parse_cast,
       NULL, NULL
     },
     {

--- a/lib/value-pairs/cmdline.c
+++ b/lib/value-pairs/cmdline.c
@@ -209,7 +209,7 @@ vp_cmdline_parse_pair (const gchar *option_name, const gchar *value,
   template = log_template_new(cfg, NULL);
   if (!log_template_compile(template, v, error))
     goto error;
-  if (!log_template_set_type_hint(template, t, error))
+  if (t && !log_template_set_type_hint(template, t, error))
     goto error;
 
   value_pairs_add_pair(vp, kv[0], template);

--- a/lib/value-pairs/cmdline.c
+++ b/lib/value-pairs/cmdline.c
@@ -394,7 +394,7 @@ value_pairs_new_from_cmdline (GlobalConfig *cfg,
   ValuePairs *vp;
   GOptionContext *ctx;
 
-  vp = value_pairs_new();
+  vp = value_pairs_new(cfg);
 
   GOptionEntry vp_options[] =
   {

--- a/lib/value-pairs/internals.h
+++ b/lib/value-pairs/internals.h
@@ -40,6 +40,11 @@ struct _ValuePairs
 
   /* guint32 as CfgFlagHandler only supports 32 bit integers */
   guint32 scopes;
+
+  /* for compatibility with 3.x versions, apply automatic conversion to
+   * strings to avoid leaking type information to callers */
+  gboolean cast_to_strings;
+  gboolean explicit_cast_to_strings;
 };
 
 

--- a/lib/value-pairs/tests/test_value_pairs.c
+++ b/lib/value-pairs/tests/test_value_pairs.c
@@ -118,7 +118,7 @@ testcase(const gchar *scope, const gchar *exclude, const gchar *expected)
   gboolean test_key_found = FALSE;
   LogTemplate *template;
 
-  vp = value_pairs_new();
+  vp = value_pairs_new(configuration);
   value_pairs_add_scope(vp, scope);
   if (exclude)
     value_pairs_add_glob_pattern(vp, exclude, FALSE);
@@ -150,7 +150,7 @@ transformers_testcase(const gchar *scope, const gchar *transformed_keys, const g
   gpointer args[2];
   gboolean test_key_found = FALSE;
 
-  vp = value_pairs_new();
+  vp = value_pairs_new(configuration);
   value_pairs_add_scope(vp, scope);
 
   if (transformers)
@@ -284,8 +284,6 @@ Test(value_pairs, test_transformer_shift_levels)
   g_ptr_array_free(transformers, TRUE);
 }
 
-GlobalConfig *cfg;
-
 void
 setup(void)
 {
@@ -293,17 +291,17 @@ setup(void)
   setenv("TZ", "MET-1METDST", TRUE);
   tzset();
 
-  cfg = cfg_new_snippet();
-  cfg_load_module(cfg, "syslogformat");
+  configuration = cfg_new_snippet();
+  cfg_load_module(configuration, "syslogformat");
   msg_format_options_defaults(&parse_options);
-  msg_format_options_init(&parse_options, cfg);
+  msg_format_options_init(&parse_options, configuration);
   parse_options.flags |= LP_SYSLOG_PROTOCOL;
 }
 
 void
 teardown(void)
 {
-  cfg_free(cfg);
+  cfg_free(configuration);
   app_shutdown();
 }
 

--- a/lib/value-pairs/tests/test_value_pairs_walk.c
+++ b/lib/value-pairs/tests/test_value_pairs_walk.c
@@ -117,7 +117,7 @@ Test(value_pairs_walker, prefix_dat)
   log_template_options_init(&template_options, cfg);
   msg_format_options_init(&parse_options, cfg);
 
-  vp = value_pairs_new();
+  vp = value_pairs_new(cfg);
   value_pairs_add_glob_pattern(vp, "root.*", TRUE);
   msg = log_msg_new("test", 4, &parse_options);
 

--- a/lib/value-pairs/value-pairs.c
+++ b/lib/value-pairs/value-pairs.c
@@ -896,6 +896,16 @@ value_pairs_new(GlobalConfig *cfg)
   vp->patterns = g_ptr_array_new();
   vp->transforms = g_ptr_array_new();
 
+  if (cfg_is_config_version_older(cfg, VERSION_VALUE_4_0))
+    {
+      /* we don't have an upgrade warning here, as it could only be a very
+       * generic message, not helping our users too much.  I've added this
+       * kind of warning to affected modules instead, like $(format-json)
+       * and mongo-db() */
+
+      vp->cast_to_strings = TRUE;
+    }
+
   return vp;
 }
 

--- a/lib/value-pairs/value-pairs.c
+++ b/lib/value-pairs/value-pairs.c
@@ -287,6 +287,10 @@ vp_msg_nvpairs_foreach(NVHandle handle, const gchar *name,
   sb = scratch_buffers_alloc();
 
   g_string_append_len(sb, value, value_len);
+
+  if (vp->cast_to_strings)
+    type = LM_VT_STRING;
+
   vp_results_insert(results, vp_transform_apply(vp, name), type, sb);
 
   return FALSE;
@@ -395,6 +399,9 @@ vp_merge_builtins(ValuePairs *vp, VPResults *results, LogMessage *msg, LogTempla
         {
           continue;
         }
+
+      if (vp->cast_to_strings)
+        type = LM_VT_STRING;
 
       vp_results_insert(results, vp_transform_apply(vp, spec->name), type, sb);
     }
@@ -854,6 +861,27 @@ value_pairs_add_transforms(ValuePairs *vp, ValuePairsTransformSet *vpts)
 {
   g_ptr_array_add(vp->transforms, vpts);
   vp_update_builtin_list_of_values(vp);
+}
+
+void
+value_pairs_set_cast_to_strings(ValuePairs *vp, gboolean enable)
+{
+  vp->cast_to_strings = enable;
+  vp->explicit_cast_to_strings = TRUE;
+}
+
+void
+value_pairs_set_auto_cast(ValuePairs *vp)
+{
+  /* cast is based on @version, in 3.x mode we use strings, in 4.x we use
+   * types but we won't get the warning */
+  vp->explicit_cast_to_strings = TRUE;
+}
+
+gboolean
+value_pairs_is_cast_to_strings_explicit(ValuePairs *vp)
+{
+  return vp->explicit_cast_to_strings;
 }
 
 ValuePairs *

--- a/lib/value-pairs/value-pairs.c
+++ b/lib/value-pairs/value-pairs.c
@@ -855,7 +855,7 @@ value_pairs_add_transforms(ValuePairs *vp, ValuePairsTransformSet *vpts)
 }
 
 ValuePairs *
-value_pairs_new(void)
+value_pairs_new(GlobalConfig *cfg)
 {
   ValuePairs *vp;
 
@@ -872,7 +872,7 @@ value_pairs_new(void)
 ValuePairs *
 value_pairs_new_default(GlobalConfig *cfg)
 {
-  ValuePairs *vp = value_pairs_new();
+  ValuePairs *vp = value_pairs_new(cfg);
 
   value_pairs_add_scope(vp, "selected-macros");
   value_pairs_add_scope(vp, "nv-pairs");

--- a/lib/value-pairs/value-pairs.c
+++ b/lib/value-pairs/value-pairs.c
@@ -287,7 +287,7 @@ vp_msg_nvpairs_foreach(NVHandle handle, const gchar *name,
   sb = scratch_buffers_alloc();
 
   g_string_append_len(sb, value, value_len);
-  vp_results_insert(results, vp_transform_apply(vp, name), LM_VT_STRING, sb);
+  vp_results_insert(results, vp_transform_apply(vp, name), type, sb);
 
   return FALSE;
 }
@@ -368,6 +368,7 @@ vp_merge_builtins(ValuePairs *vp, VPResults *results, LogMessage *msg, LogTempla
   for (i = 0; i < vp->builtins->len; i++)
     {
       ValuePairSpec *spec = (ValuePairSpec *) g_ptr_array_index(vp->builtins, i);
+      LogMessageValueType type;
 
       sb = scratch_buffers_alloc();
 
@@ -375,13 +376,14 @@ vp_merge_builtins(ValuePairs *vp, VPResults *results, LogMessage *msg, LogTempla
         {
         case VPT_MACRO:
           log_macro_expand(sb, spec->id, FALSE, options, msg);
+          type = LM_VT_STRING;
           break;
         case VPT_NVPAIR:
         {
           const gchar *nv;
           gssize len;
 
-          nv = log_msg_get_value(msg, (NVHandle) spec->id, &len);
+          nv = log_msg_get_value_with_type(msg, (NVHandle) spec->id, &len, &type);
           g_string_append_len(sb, nv, len);
           break;
         }
@@ -394,7 +396,7 @@ vp_merge_builtins(ValuePairs *vp, VPResults *results, LogMessage *msg, LogTempla
           continue;
         }
 
-      vp_results_insert(results, vp_transform_apply(vp, spec->name), LM_VT_STRING, sb);
+      vp_results_insert(results, vp_transform_apply(vp, spec->name), type, sb);
     }
 }
 

--- a/lib/value-pairs/value-pairs.h
+++ b/lib/value-pairs/value-pairs.h
@@ -69,7 +69,7 @@ gboolean value_pairs_walk(ValuePairs *vp,
                           LogMessage *msg, LogTemplateEvalOptions *options,
                           gpointer user_data);
 
-ValuePairs *value_pairs_new(void);
+ValuePairs *value_pairs_new(GlobalConfig *cfg);
 ValuePairs *value_pairs_new_default(GlobalConfig *cfg);
 ValuePairs *value_pairs_ref(ValuePairs *self);
 void value_pairs_unref(ValuePairs *self);

--- a/lib/value-pairs/value-pairs.h
+++ b/lib/value-pairs/value-pairs.h
@@ -53,6 +53,9 @@ void value_pairs_add_glob_patterns(ValuePairs *vp, GList *patterns, gboolean inc
 void value_pairs_add_pair(ValuePairs *vp, const gchar *key, LogTemplate *value);
 
 void value_pairs_add_transforms(ValuePairs *vp, ValuePairsTransformSet *vpts);
+void value_pairs_set_cast_to_strings(ValuePairs *vp, gboolean enable);
+void value_pairs_set_auto_cast(ValuePairs *vp);
+gboolean value_pairs_is_cast_to_strings_explicit(ValuePairs *vp);
 
 gboolean value_pairs_foreach_sorted(ValuePairs *vp, VPForeachFunc func,
                                     GCompareFunc compare_func,

--- a/lib/versioning.h
+++ b/lib/versioning.h
@@ -131,6 +131,8 @@
 #define VERSION_3_34 "syslog-ng 3.34"
 #define VERSION_3_35 "syslog-ng 3.35"
 
+#define VERSION_4_0 "syslog-ng 4.0"
+
 /* VERSION_VALUE_* references versions as integers to be compared against stuff like cfg->user_version */
 /* VERSION_STR_* references versions as strings to be shown to the user */
 
@@ -170,6 +172,11 @@
 #define VERSION_VALUE_3_33 0x0321
 #define VERSION_VALUE_3_34 0x0322
 #define VERSION_VALUE_3_35 0x0323
+
+/* these are defined to allow 4.0 related changes to be introduced while we
+ * are still producing 3.x releases. */
+#define VERSION_VALUE_3_LAST  0x0363
+#define VERSION_VALUE_4_0     0x0400
 
 /* config version code, in the same format as GlobalConfig->version */
 #define VERSION_VALUE_CURRENT   VERSION_VALUE_3_35

--- a/libtest/cr_template.c
+++ b/libtest/cr_template.c
@@ -132,6 +132,8 @@ create_sample_message(void)
   log_msg_set_value_by_name(msg, "comma_value", "value,with,a,comma", -1);
   log_msg_set_value_by_name(msg, "empty_value", "", -1);
   log_msg_set_value_by_name(msg, "template_name", "dummy", -1);
+  log_msg_set_value_by_name_with_type(msg, "number1", "123", -1, LM_VT_INT64);
+  log_msg_set_value_by_name_with_type(msg, "number2", "456", -1, LM_VT_INT64);
 
   return msg;
 }

--- a/libtest/msg_parse_lib.c
+++ b/libtest/msg_parse_lib.c
@@ -112,6 +112,36 @@ assert_log_message_value_and_type_by_name(LogMessage *self, const gchar *name,
 }
 
 void
+assert_log_message_match_value_and_type(LogMessage *self, gint index_,
+                                        const gchar *expected_value, LogMessageValueType expected_type)
+{
+  gssize value_length;
+  LogMessageValueType actual_type;
+  const gchar *actual_value_r = log_msg_get_match_with_type(self, index_, &value_length, &actual_type);
+  gchar *actual_value = g_strndup(actual_value_r, value_length);
+
+  if (expected_value)
+    {
+      cr_assert_str_eq(actual_value, expected_value, "Invalid value for $%d; actual: %s, expected: %s", index_,
+                       actual_value, expected_value);
+    }
+  else
+    cr_assert_str_eq(actual_value, "", "No value is expected for $%d but its value is %s", index_, actual_value);
+
+  if (expected_type != LM_VT_NONE)
+    cr_assert_eq(actual_type, expected_type,
+                 "Invalid value type for $%d; actual: %d, expected %d", index_, actual_type, expected_type);
+
+  g_free(actual_value);
+}
+
+void
+assert_log_message_match_value(LogMessage *self, gint index_, const gchar *expected_value)
+{
+  assert_log_message_match_value_and_type(self, index_, expected_value, LM_VT_NONE);
+}
+
+void
 assert_log_message_value_by_name(LogMessage *self, const gchar *name, const gchar *expected_value)
 {
   assert_log_message_value_and_type_by_name(self, name, expected_value, LM_VT_NONE);

--- a/libtest/msg_parse_lib.h
+++ b/libtest/msg_parse_lib.h
@@ -41,6 +41,10 @@ void assert_log_message_value_and_type(LogMessage *self, NVHandle handle,
 void assert_log_message_value_by_name(LogMessage *self, const gchar *name, const gchar *expected_value);
 void assert_log_message_value_and_type_by_name(LogMessage *self, const gchar *name,
                                                const gchar *expected_value, LogMessageValueType expected_type);
+void assert_log_message_value_and_type_by_name(LogMessage *self, const gchar *name,
+                                               const gchar *expected_value, LogMessageValueType expected_type);
+void assert_log_message_match_value(LogMessage *self, gint index_, const gchar *expected_value);
+
 void assert_log_message_has_tag(LogMessage *log_message, const gchar *tag_name);
 void assert_log_message_doesnt_have_tag(LogMessage *log_message, const gchar *tag_name);
 void assert_log_messages_saddr(LogMessage *log_message_a, LogMessage *log_message_b);

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -234,6 +234,24 @@ _init(LogPipe *s)
   if (!log_threaded_dest_driver_init_method(s))
     return FALSE;
 
+  if (cfg_is_config_version_older(cfg, VERSION_VALUE_4_0) &&
+      !value_pairs_is_cast_to_strings_explicit(self->vp))
+    {
+      if (cfg_is_config_to_be_migrated_to_post_4_0(cfg))
+        {
+          msg_warning("WARNING: the mongodb() destination starts using type information "
+                      "associated with name-value pairs in " VERSION_4_0
+                      ". This can possibly cause fields in the BSON "
+                      "document to change types if no explicit type hint is "
+                      "specified. This change will cause the type in the output "
+                      "document match the original type that was parsed "
+                      "using json-parser(), add cast(yes) option to mongodb() "
+                      "to keep using strings instead of typed values",
+                      log_pipe_location_tag(s));
+        }
+      value_pairs_set_cast_to_strings(self->vp, TRUE);
+    }
+
   return TRUE;
 }
 

--- a/modules/json/format-json.c
+++ b/modules/json/format-json.c
@@ -83,6 +83,23 @@ tf_json_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
       value_pairs_add_transforms(state->vp, vpts);
     }
 
+  if (cfg_is_config_version_older(parent->cfg, VERSION_VALUE_4_0) &&
+      !value_pairs_is_cast_to_strings_explicit(state->vp))
+    {
+      if (cfg_is_config_to_be_migrated_to_post_4_0(parent->cfg))
+        {
+          msg_warning("WARNING: $(format-json) starts using type information "
+                      "associated with name-value pairs in " VERSION_4_0
+                      ". This can possibly cause fields in the formatted JSON "
+                      "document to change types if no explicit type hint is "
+                      "specified. This change will cause the type in the output "
+                      "document match the original type that was parsed "
+                      "using json-parser(), add --no-cast argument "
+                      "to $(format-json) to keep the old behavior");
+        }
+      value_pairs_set_cast_to_strings(state->vp, TRUE);
+    }
+
   return TRUE;
 }
 

--- a/modules/json/format-json.c
+++ b/modules/json/format-json.c
@@ -301,6 +301,11 @@ tf_json_append_with_type_hint(const gchar *name, LogMessageValueType type, json_
         }
       break;
     }
+    case LM_VT_NULL:
+    {
+      tf_json_append_value(name, "null", -1, state, FALSE);
+      break;
+    }
     }
   return FALSE;
 }

--- a/modules/json/json-parser.c
+++ b/modules/json/json-parser.c
@@ -85,6 +85,7 @@ json_parser_process_single(struct json_object *jso,
 {
   GString *key, *value;
   gboolean parsed = FALSE;
+  LogMessageValueType type = LM_VT_STRING;
 
   if (!jso)
     return;
@@ -101,21 +102,25 @@ json_parser_process_single(struct json_object *jso,
         g_string_assign(value, "true");
       else
         g_string_assign(value, "false");
+      type = LM_VT_BOOLEAN;
       break;
     case json_type_double:
       parsed = TRUE;
       g_string_printf(value, "%f",
                       json_object_get_double(jso));
+      type = LM_VT_DOUBLE;
       break;
     case json_type_int:
       parsed = TRUE;
       g_string_printf(value, "%"PRId64,
                       json_object_get_int64(jso));
+      type = LM_VT_INT64;
       break;
     case json_type_string:
       parsed = TRUE;
       g_string_assign(value,
                       json_object_get_string(jso));
+      type = LM_VT_STRING;
       break;
     case json_type_object:
       if (prefix)
@@ -156,16 +161,10 @@ json_parser_process_single(struct json_object *jso,
         {
           g_string_assign(key, prefix);
           g_string_append(key, obj_key);
-          log_msg_set_value_by_name(msg,
-                                    key->str,
-                                    value->str,
-                                    value->len);
+          log_msg_set_value_by_name_with_type(msg, key->str, value->str, value->len, type);
         }
       else
-        log_msg_set_value_by_name(msg,
-                                  obj_key,
-                                  value->str,
-                                  value->len);
+        log_msg_set_value_by_name_with_type(msg, obj_key, value->str, value->len, type);
     }
 
   scratch_buffers_reclaim_marked(marker);

--- a/modules/json/json-parser.c
+++ b/modules/json/json-parser.c
@@ -72,6 +72,57 @@ json_parser_set_extract_prefix(LogParser *s, const gchar *extract_prefix)
   self->extract_prefix = g_strdup(extract_prefix);
 }
 
+static gboolean
+json_parser_extract_value(struct json_object *jso, GString *value, LogMessageValueType *type)
+{
+  switch (json_object_get_type(jso))
+    {
+    case json_type_boolean:
+      if (json_object_get_boolean(jso))
+        g_string_assign(value, "true");
+      else
+        g_string_assign(value, "false");
+      *type = LM_VT_BOOLEAN;
+      return TRUE;
+    case json_type_double:
+      g_string_printf(value, "%f",
+                      json_object_get_double(jso));
+      *type = LM_VT_DOUBLE;
+      return TRUE;
+    case json_type_int:
+      g_string_printf(value, "%"PRId64,
+                      json_object_get_int64(jso));
+      *type = LM_VT_INT64;
+      return TRUE;
+    case json_type_string:
+      g_string_assign(value,
+                      json_object_get_string(jso));
+      *type = LM_VT_STRING;
+      return TRUE;
+    case json_type_null:
+
+      /* null values are represented as an empty string (so when expands to
+       * "nothing" in type unaware situations, while type-aware consumers
+       * may reproduce it as a NULL).
+       *
+       * I was thinking about using a very specific string representation
+       * (e.g.  "NULL" as a value), however if we encounter a null at a
+       * place where we might also have a sub-object, and we explicitly
+       * reference a field within that sub-object, we would get an empty
+       * string in that case too (due to the key being unknown).  All in
+       * all, the base case is I think to use an empty string as value, and
+       * LM_VT_NULL as type.  Type aware consumers would ignore the string
+       * anyway.
+       */
+      g_string_truncate(value, 0);
+      *type = LM_VT_NULL;
+      return TRUE;
+    default:
+      break;
+    }
+  return FALSE;
+}
+
 static void
 json_parser_process_object(struct json_object *jso,
                            const gchar *prefix,
@@ -94,30 +145,11 @@ json_parser_process_single(struct json_object *jso,
   switch (json_object_get_type(jso))
     {
     case json_type_boolean:
-      parsed = TRUE;
-      if (json_object_get_boolean(jso))
-        g_string_assign(value, "true");
-      else
-        g_string_assign(value, "false");
-      type = LM_VT_BOOLEAN;
-      break;
     case json_type_double:
-      parsed = TRUE;
-      g_string_printf(value, "%f",
-                      json_object_get_double(jso));
-      type = LM_VT_DOUBLE;
-      break;
     case json_type_int:
-      parsed = TRUE;
-      g_string_printf(value, "%"PRId64,
-                      json_object_get_int64(jso));
-      type = LM_VT_INT64;
-      break;
     case json_type_string:
-      parsed = TRUE;
-      g_string_assign(value,
-                      json_object_get_string(jso));
-      type = LM_VT_STRING;
+    case json_type_null:
+      parsed = json_parser_extract_value(jso, value, &type);
       break;
     case json_type_object:
       if (prefix)
@@ -144,25 +176,7 @@ json_parser_process_single(struct json_object *jso,
         }
       break;
     }
-    case json_type_null:
-
-      /* null values are represented as an empty string (so when expands to
-       * "nothing" in type unaware situations, while type-aware consumers
-       * may reproduce it as a NULL).
-       *
-       * I was thinking about using a very specific string representation
-       * (e.g.  "NULL" as a value), however if we encounter a null at a
-       * place where we might also have a sub-object, and we explicitly
-       * reference a field within that sub-object, we would get an empty
-       * string in that case too (due to the key being unknown).  All in
-       * all, the base case is I think to use an empty string as value, and
-       * LM_VT_NULL as type.  Type aware consumers would ignore the string
-       * anyway.
-       */
-
       parsed = TRUE;
-      g_string_truncate(value, 0);
-      type = LM_VT_NULL;
       break;
     default:
       msg_debug("JSON parser encountered an unknown type, skipping",

--- a/modules/json/json-parser.c
+++ b/modules/json/json-parser.c
@@ -251,6 +251,33 @@ json_parser_process_object(struct json_object *jso,
   }
 }
 
+static void
+json_parser_process_array(struct json_object *jso,
+                          const gchar *prefix,
+                          LogMessage *msg)
+{
+  gint i;
+
+  msg->num_matches = 0;
+  log_msg_unset_match(msg, 0);
+  for (i = 0; i < json_object_array_length(jso) && i < LOGMSG_MAX_MATCHES; i++)
+    {
+      struct json_object *el = json_object_array_get_idx(jso, i);
+      GString *element_value = scratch_buffers_alloc();
+      LogMessageValueType element_type;
+
+      if (json_parser_extract_string_from_simple_json_object(el, element_value, &element_type))
+        {
+          log_msg_set_match_with_type(msg, i + 1, element_value->str, element_value->len, element_type);
+        }
+      else
+        {
+          /* unknown type, encode the entire value as JSON */
+          log_msg_set_match_with_type(msg, i + 1, json_object_to_json_string_ext(el, JSON_C_TO_STRING_PLAIN), -1, LM_VT_JSON);
+        }
+    }
+}
+
 static gboolean
 json_parser_extract(JSONParser *self, struct json_object *jso, LogMessage *msg)
 {
@@ -263,6 +290,11 @@ json_parser_extract(JSONParser *self, struct json_object *jso, LogMessage *msg)
   if (json_object_is_type(jso, json_type_object))
     {
       json_parser_process_object(jso, self->prefix, msg);
+      return TRUE;
+    }
+  if (json_object_is_type(jso, json_type_array))
+    {
+      json_parser_process_array(jso, self->prefix, msg);
       return TRUE;
     }
   return FALSE;

--- a/modules/json/json-parser.c
+++ b/modules/json/json-parser.c
@@ -257,13 +257,15 @@ json_parser_extract(JSONParser *self, struct json_object *jso, LogMessage *msg)
   if (self->extract_prefix)
     jso = json_extract(jso, self->extract_prefix);
 
-  if (!jso || !json_object_is_type(jso, json_type_object))
-    {
-      return FALSE;
-    }
+  if (!jso)
+    return FALSE;
 
-  json_parser_process_object(jso, self->prefix, msg);
-  return TRUE;
+  if (json_object_is_type(jso, json_type_object))
+    {
+      json_parser_process_object(jso, self->prefix, msg);
+      return TRUE;
+    }
+  return FALSE;
 }
 
 #ifndef JSON_C_VERSION

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -135,6 +135,12 @@ Test(format_json, test_format_json_with_type_hints)
                          "{\"i\":\"ifoo(\"}");
   assert_template_format("$(format-json b=boolean(TRUE))",
                          "{\"b\":true}");
+  assert_template_format("$(format-json null=null())",
+                         "{\"null\":null}");
+  assert_template_format("$(format-json null=null(whatever))",
+                         "{\"null\":null}");
+  assert_template_format("$(format-json null=null($DATE))",
+                         "{\"null\":null}");
   assert_template_format("$(format-json l=list($comma_value))",
                          "{\"l\":[\"value\",\"with\",\"a\",\"comma\"]}");
   assert_template_format("$(format-json b=literal(whatever))",

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -144,6 +144,105 @@ Test(format_json, test_format_json_with_type_hints)
 
 }
 
+Test(format_json, test_v3x_value_pairs_yields_string_values)
+{
+  /* in 3.x mode, numbers remain strings */
+
+  /* template */
+  assert_template_format("$(format-json foo=$number1)",
+                         "{\"foo\":\"123\"}");
+
+  /* name value pair */
+  assert_template_format("$(format-json number1)",
+                         "{\"number1\":\"123\"}");
+
+  /* macro */
+  assert_template_format("$(format-json FACILITY_NUM)",
+                         "{\"FACILITY_NUM\":\"19\"}");
+
+
+  /* auto-cast is the same but suppresses warning */
+
+  /* name value pair */
+  assert_template_format("$(format-json --auto-cast number1)",
+                         "{\"number1\":\"123\"}");
+
+}
+
+Test(format_json, test_v40_value_pairs_yields_typed_values)
+{
+  cfg_set_version_without_validation(configuration, VERSION_VALUE_4_0);
+
+  /* in 4.x mode, numbers become numbers */
+
+  /* templates not yet supported */
+
+  /* name value pair */
+  assert_template_format("$(format-json number1)",
+                         "{\"number1\":123}");
+
+  /* macros not yet supported */
+
+  /* auto-cast is the same but suppresses warning */
+
+
+  /* name value pair */
+  assert_template_format("$(format-json --auto-cast number1)",
+                         "{\"number1\":123}");
+
+}
+
+Test(format_json, test_cast_option_always_yields_strings_regardless_of_versions)
+{
+  /* template */
+  assert_template_format("$(format-json --cast foo=$number1)",
+                         "{\"foo\":\"123\"}");
+
+  /* name value pair */
+  assert_template_format("$(format-json --cast number1)",
+                         "{\"number1\":\"123\"}");
+
+  /* macro */
+  assert_template_format("$(format-json --cast FACILITY_NUM)",
+                         "{\"FACILITY_NUM\":\"19\"}");
+
+  cfg_set_version_without_validation(configuration, VERSION_VALUE_4_0);
+  /* unless forced to be strings */
+
+  /* template */
+  assert_template_format("$(format-json --cast foo=$number1)",
+                         "{\"foo\":\"123\"}");
+
+  /* name value pair */
+  assert_template_format("$(format-json --cast number1)",
+                         "{\"number1\":\"123\"}");
+
+  /* macro */
+  assert_template_format("$(format-json --cast FACILITY_NUM)",
+                         "{\"FACILITY_NUM\":\"19\"}");
+}
+
+Test(format_json, test_no_cast_option_always_yields_types_regardless_of_versions)
+{
+  /* template not yet supported */
+
+  /* name value pair */
+  assert_template_format("$(format-json --no-cast number1)",
+                         "{\"number1\":123}");
+
+  /* macros not yet supported */
+
+  cfg_set_version_without_validation(configuration, VERSION_VALUE_4_0);
+
+  /* template not yet supported */
+
+  /* name value pair */
+  assert_template_format("$(format-json --no-cast number1)",
+                         "{\"number1\":123}");
+
+  /* macros not yet supported */
+}
+
 Test(format_json, test_format_json_on_error)
 {
   configuration->template_options.on_error = ON_ERROR_DROP_MESSAGE | ON_ERROR_SILENT;

--- a/modules/json/tests/test_json_parser.c
+++ b/modules/json/tests/test_json_parser.c
@@ -145,6 +145,7 @@ Test(json_parser, test_json_parser_validate_type_representation)
   assert_log_message_value_and_type_by_name(msg, ".prefix.array[0]", "1", LM_VT_INT64);
   assert_log_message_value_and_type_by_name(msg, ".prefix.array[1]", "2", LM_VT_INT64);
   assert_log_message_value_and_type_by_name(msg, ".prefix.array[2]", "3", LM_VT_INT64);
+  assert_log_message_value_and_type_by_name(msg, ".prefix.null", "", LM_VT_NULL);
   log_msg_unref(msg);
   log_pipe_unref(&json_parser->super);
 }

--- a/modules/json/tests/test_json_parser.c
+++ b/modules/json/tests/test_json_parser.c
@@ -136,15 +136,15 @@ Test(json_parser, test_json_parser_validate_type_representation)
   json_parser_set_prefix(json_parser, ".prefix.");
   msg = parse_json_into_log_message("{'int': 123, 'booltrue': true, 'boolfalse': false, 'double': 1.23, 'object': {'member1': 'foo', 'member2': 'bar'}, 'array': [1, 2, 3], 'null': null}",
                                     json_parser);
-  assert_log_message_value(msg, log_msg_get_value_handle(".prefix.int"), "123");
-  assert_log_message_value(msg, log_msg_get_value_handle(".prefix.booltrue"), "true");
-  assert_log_message_value(msg, log_msg_get_value_handle(".prefix.boolfalse"), "false");
-  assert_log_message_value(msg, log_msg_get_value_handle(".prefix.double"), "1.230000");
-  assert_log_message_value(msg, log_msg_get_value_handle(".prefix.object.member1"), "foo");
-  assert_log_message_value(msg, log_msg_get_value_handle(".prefix.object.member2"), "bar");
-  assert_log_message_value(msg, log_msg_get_value_handle(".prefix.array[0]"), "1");
-  assert_log_message_value(msg, log_msg_get_value_handle(".prefix.array[1]"), "2");
-  assert_log_message_value(msg, log_msg_get_value_handle(".prefix.array[2]"), "3");
+  assert_log_message_value_and_type_by_name(msg, ".prefix.int", "123", LM_VT_INT64);
+  assert_log_message_value_and_type_by_name(msg, ".prefix.booltrue", "true", LM_VT_BOOLEAN);
+  assert_log_message_value_and_type_by_name(msg, ".prefix.boolfalse", "false", LM_VT_BOOLEAN);
+  assert_log_message_value_and_type_by_name(msg, ".prefix.double", "1.230000", LM_VT_DOUBLE);
+  assert_log_message_value_and_type_by_name(msg, ".prefix.object.member1", "foo", LM_VT_STRING);
+  assert_log_message_value_and_type_by_name(msg, ".prefix.object.member2", "bar", LM_VT_STRING);
+  assert_log_message_value_and_type_by_name(msg, ".prefix.array[0]", "1", LM_VT_INT64);
+  assert_log_message_value_and_type_by_name(msg, ".prefix.array[1]", "2", LM_VT_INT64);
+  assert_log_message_value_and_type_by_name(msg, ".prefix.array[2]", "3", LM_VT_INT64);
   log_msg_unref(msg);
   log_pipe_unref(&json_parser->super);
 }

--- a/modules/map-value-pairs/map-value-pairs-grammar.ym
+++ b/modules/map-value-pairs/map-value-pairs-grammar.ym
@@ -50,7 +50,7 @@
 start
 	: LL_CONTEXT_PARSER KW_MAP_VALUE_PAIRS
           {
-            last_value_pairs = value_pairs_new();
+            last_value_pairs = value_pairs_new(configuration);
             *instance = last_parser = map_value_pairs_new(configuration, last_value_pairs);
           }
           '(' map_names_options ')'				{ YYACCEPT; }

--- a/modules/map-value-pairs/map-value-pairs.c
+++ b/modules/map-value-pairs/map-value-pairs.c
@@ -30,7 +30,7 @@ _map_name_values(const gchar *name,
 {
   LogMessage *msg = (LogMessage *) user_data;
 
-  log_msg_set_value_by_name(msg, name, value, value_len);
+  log_msg_set_value_by_name_with_type(msg, name, value, value_len, type);
   return FALSE;
 }
 

--- a/modules/riemann/riemann-grammar.ym
+++ b/modules/riemann/riemann-grammar.ym
@@ -137,7 +137,7 @@ riemann_option
           }
         | KW_ATTRIBUTES
           {
-            last_value_pairs = value_pairs_new();
+            last_value_pairs = value_pairs_new(configuration);
           }
           '(' attribute_options ')'
           {

--- a/scl/cim/template.conf
+++ b/scl/cim/template.conf
@@ -22,4 +22,4 @@
 
 @requires json-plugin
 
-template-function "format-cim" "$(format-json --pair @timestamp='${R_ISODATE}' --pair @message='${MSG}' --key .cim.* --shift 5 --key _* --key .* --replace-prefix .=_ --key *.*)\n";
+template-function "format-cim" "$(format-json --auto-cast --pair @timestamp='${R_ISODATE}' --pair @message='${MSG}' --key .cim.* --shift 5 --key _* --key .* --replace-prefix .=_ --key *.*)\n";

--- a/scl/discord/discord.conf
+++ b/scl/discord/discord.conf
@@ -45,7 +45,7 @@ block destination discord(
     url('`url`')
     method("POST")
     headers("Content-type: application/json")
-    body("$(format-json
+    body("$(format-json --cast
       content=$(substr '`template`' 0 `max-msg-length`)
       username='`username`'
       avatar_url='`avatar-url`'

--- a/scl/ewmm/ewmm.conf
+++ b/scl/ewmm/ewmm.conf
@@ -56,7 +56,7 @@ block parser ewmm-parser() {
 	};
 };
 
-template-function "format-ewmm" "<$PRI>1 $ISODATE $LOGHOST @syslog-ng - - ${SDATA:--} $(format-json --leave-initial-dot --scope all-nv-pairs --exclude 0* --exclude 1* --exclude 2* --exclude 3* --exclude 4* --exclude 5* --exclude 6* --exclude 7* --exclude 8* --exclude 9* --exclude SOURCE --exclude .SDATA.* ._TAGS=${TAGS})\n";
+template-function "format-ewmm" "<$PRI>1 $ISODATE $LOGHOST @syslog-ng - - ${SDATA:--} $(format-json --auto-cast --leave-initial-dot --scope all-nv-pairs --exclude 0* --exclude 1* --exclude 2* --exclude 3* --exclude 4* --exclude 5* --exclude 6* --exclude 7* --exclude 8* --exclude 9* --exclude SOURCE --exclude .SDATA.* ._TAGS=${TAGS})\n";
 
 #
 # syslog-ng is just an alias for the ewmm destination there's no syslog-ng()

--- a/scl/graylog2/plugin.conf
+++ b/scl/graylog2/plugin.conf
@@ -23,7 +23,7 @@
 
 @requires json-plugin
 
-template-function "format-gelf" "$(format-json --omit-empty-values version='1.1' host='${HOST:--}' short_message='${MSG:--}' level=int(${LEVEL_NUM}) timestamp=int64(${R_UNIXTIME}) _program='${PROGRAM}' _pid=int(${PID}) _facility='${FACILITY}' _class='${.classifier.class}' --key .* --key _*)$(binary 0x00)";
+template-function "format-gelf" "$(format-json --auto-cast --omit-empty-values version='1.1' host='${HOST:--}' short_message='${MSG:--}' level=int(${LEVEL_NUM}) timestamp=int64(${R_UNIXTIME}) _program='${PROGRAM}' _pid=int(${PID}) _facility='${FACILITY}' _class='${.classifier.class}' --key .* --key _*)$(binary 0x00)";
 
 block destination graylog2(host("127.0.0.1") port(12201) transport(tcp) template("$(format-gelf)") ...) {
 	network("`host`"

--- a/scl/slack/slack.conf
+++ b/scl/slack/slack.conf
@@ -52,7 +52,7 @@ block destination slack(
     method('POST')
     headers('Content-type: application/json')
     body-prefix('{"attachments":[')
-    body('$(format-json
+    body('$(format-json --cast
             fallback="`fallback`"
             color="$(list-nth `color-chooser` `colors`)"
             pretext="`pretext`"


### PR DESCRIPTION
This branch adds support for the propagation of typing in map-value-pairs() and groupset() operations and depends on #3885.

These are relatively simple changes that only depend on value-pairs handing over type information to them. There's not much compatibility concern here, as value-pairs does the right  thing (e.g. casts everything to strings in 3.x mode).

Even if this wasn't the case, all these changes do is *set* new name-value pairs and if they wouldn't become strings, that type information should be ignored in 3.x mode anyway.