### PR TITLE
disk-buffer: fix "memory leak" and inconsistent buffer handling 

### DIFF
--- a/lib/stats/stats-counter.h
+++ b/lib/stats/stats-counter.h
@@ -86,17 +86,15 @@ stats_counter_dec(StatsCounterItem *counter)
     }
 }
 
-/* NOTE: this is _not_ atomic and doesn't have to be as sets would race anyway */
 static inline void
 stats_counter_set(StatsCounterItem *counter, gsize value)
 {
   if (counter && !stats_counter_read_only(counter))
     {
-      atomic_gssize_racy_set(&counter->value, value);
+      atomic_gssize_set(&counter->value, value);
     }
 }
 
-/* NOTE: this is _not_ atomic and doesn't have to be as sets would race anyway */
 static inline gsize
 stats_counter_get(StatsCounterItem *counter)
 {

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -257,7 +257,7 @@ _rewind_backlog(LogQueue *s, guint rewind_count)
 static void
 _rewind_backlog_all(LogQueue *s)
 {
-  _rewind_backlog(s, -1);
+  _rewind_backlog(s, G_MAXUINT);
 }
 
 static inline LogMessage *

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -463,8 +463,12 @@ _push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
     }
 
 queued:
-  log_queue_push_notify(s);
   log_queue_queued_messages_inc(s);
+
+  /* this releases the queue's lock for a short time, which may violate the
+   * consistency of the disk-buffer, so it must be the last call under lock in this function
+   */
+  log_queue_push_notify(s);
 
 exit:
   g_mutex_unlock(&s->lock);

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -130,7 +130,8 @@ _ack_backlog(LogQueue *s, gint num_msg_to_ack)
             }
         }
       gint64 new_backlog = qdisk_get_backlog_head(self->super.qdisk);
-      new_backlog = qdisk_skip_record(self->super.qdisk, new_backlog);
+      if (!qdisk_skip_record(self->super.qdisk, new_backlog, &new_backlog))
+        msg_error("Error acking in disk-queue file", evt_tag_str("filename", qdisk_get_filename(self->super.qdisk)));
       qdisk_set_backlog_head(self->super.qdisk, new_backlog);
       qdisk_dec_backlog(self->super.qdisk);
     }
@@ -203,7 +204,11 @@ _rewind_backlog(LogQueue *s, guint rewind_count)
   new_read_head = qdisk_get_backlog_head(self->super.qdisk);
   for (i = 0; i < number_of_messages_stay_in_backlog; i++)
     {
-      new_read_head = qdisk_skip_record(self->super.qdisk, new_read_head);
+      if (!qdisk_skip_record(self->super.qdisk, new_read_head, &new_read_head))
+        {
+          msg_error("Error rewinding backlog in disk-queue file",
+                    evt_tag_str("filename", qdisk_get_filename(self->super.qdisk)));
+        }
     }
   _rewind_from_qbacklog(self, new_read_head);
 

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -367,8 +367,12 @@ _push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
   log_msg_unref(msg);
 
 exit:
-  log_queue_push_notify(s);
   log_queue_queued_messages_inc(s);
+
+  /* this releases the queue's lock for a short time, which may violate the
+   * consistency of the disk-buffer, so it must be the last call under lock in this function
+   */
+  log_queue_push_notify(s);
   g_mutex_unlock(&s->lock);
 }
 

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -129,7 +129,7 @@ _ack_backlog(LogQueue *s, gint num_msg_to_ack)
               log_msg_unref(msg);
             }
         }
-      guint64 new_backlog = qdisk_get_backlog_head(self->super.qdisk);
+      gint64 new_backlog = qdisk_get_backlog_head(self->super.qdisk);
       new_backlog = qdisk_skip_record(self->super.qdisk, new_backlog);
       qdisk_set_backlog_head(self->super.qdisk, new_backlog);
       qdisk_dec_backlog(self->super.qdisk);

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -204,7 +204,7 @@ _rewind_backlog(LogQueue *s, guint rewind_count)
 static void
 _rewind_backlog_all(LogQueue *s)
 {
-  _rewind_backlog(s, -1);
+  _rewind_backlog(s, G_MAXUINT);
 }
 
 static inline gboolean

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -114,7 +114,7 @@ _ack_backlog(LogQueue *s, gint num_msg_to_ack)
 
   for (i = 0; i < num_msg_to_ack; i++)
     {
-      if (qdisk_get_backlog_head (self->super.qdisk) == qdisk_get_head_position(self->super.qdisk))
+      if (qdisk_get_backlog_head (self->super.qdisk) == qdisk_get_next_head_position(self->super.qdisk))
         {
           goto exit_reliable;
         }
@@ -194,7 +194,7 @@ _rewind_backlog(LogQueue *s, guint rewind_count)
 
   rewind_count = MIN(rewind_count, qdisk_get_backlog_count(self->super.qdisk));
   qdisk_rewind_backlog(self->super.qdisk, rewind_count);
-  _rewind_from_qbacklog(self, qdisk_get_head_position(self->super.qdisk));
+  _rewind_from_qbacklog(self, qdisk_get_next_head_position(self->super.qdisk));
 
   log_queue_queued_messages_add(s, rewind_count);
 
@@ -213,7 +213,7 @@ _is_next_message_in_qreliable(LogQueueDiskReliable *self)
   if (self->qreliable->length == 0)
     return FALSE;
 
-  return _peek_memory_queue_head_position(self->qreliable) == qdisk_get_head_position(self->super.qdisk);
+  return _peek_memory_queue_head_position(self->qreliable) == qdisk_get_next_head_position(self->super.qdisk);
 }
 
 static inline gboolean
@@ -222,7 +222,7 @@ _is_next_message_in_qout(LogQueueDiskReliable *self)
   if (self->qout->length == 0)
     return FALSE;
 
-  return _peek_memory_queue_head_position(self->qout) == qdisk_get_head_position(self->super.qdisk);
+  return _peek_memory_queue_head_position(self->qout) == qdisk_get_next_head_position(self->super.qdisk);
 }
 
 static LogMessage *

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -271,9 +271,7 @@ exit:
       return NULL;
     }
 
-  if (s->use_backlog)
-    qdisk_inc_backlog(self->super.qdisk);
-  else
+  if (!s->use_backlog)
     qdisk_empty_backlog(self->super.qdisk);
 
   log_queue_queued_messages_dec(s);

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -97,7 +97,7 @@ _pop_disk(LogQueueDisk *self, LogMessage **msg)
   ScratchBuffersMarker marker;
   GString *read_serialized = scratch_buffers_alloc_and_mark(&marker);
 
-  gint64 read_head = qdisk_get_head_position(self->qdisk);
+  gint64 read_head = qdisk_get_next_head_position(self->qdisk);
 
   if (!qdisk_pop_head(self->qdisk, read_serialized))
     {

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -578,7 +578,7 @@ qdisk_pop_head(QDisk *self, GString *record)
 }
 
 static gboolean
-qdisk_skip_record(QDisk *self, gint64 position, gint64 *new_position)
+_skip_record(QDisk *self, gint64 position, gint64 *new_position)
 {
   if (position == self->hdr->write_head)
     return FALSE;
@@ -599,7 +599,7 @@ qdisk_skip_record(QDisk *self, gint64 position, gint64 *new_position)
 gboolean
 qdisk_remove_head(QDisk *self)
 {
-  gboolean success = qdisk_skip_record(self, self->hdr->read_head, &self->hdr->read_head);
+  gboolean success = _skip_record(self, self->hdr->read_head, &self->hdr->read_head);
 
   if (success)
     {
@@ -617,7 +617,7 @@ qdisk_ack_backlog(QDisk *self)
   if (self->hdr->backlog_len == 0)
     return FALSE;
 
-  if (!qdisk_skip_record(self, self->hdr->backlog_head, &self->hdr->backlog_head))
+  if (!_skip_record(self, self->hdr->backlog_head, &self->hdr->backlog_head))
     {
       msg_error("Error acking in disk-queue file", evt_tag_str("filename", qdisk_get_filename(self)));
       return FALSE;
@@ -639,7 +639,7 @@ qdisk_rewind_backlog(QDisk *self, guint rewind_count)
   gint64 new_read_head = self->hdr->backlog_head;
   for (gint64 i = 0; i < number_of_messages_stay_in_backlog; i++)
     {
-      if (!qdisk_skip_record(self, new_read_head, &new_read_head))
+      if (!_skip_record(self, new_read_head, &new_read_head))
         {
           msg_error("Error rewinding backlog in disk-queue file",
                     evt_tag_str("filename", qdisk_get_filename(self)));

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -535,12 +535,12 @@ _maybe_apply_non_reliable_corrections(QDisk *self)
 static inline void
 _update_positions_after_read(QDisk *self, guint32 record_length, gint64 *position)
 {
-  gint64 new_read_head_position = *position + record_length + sizeof(record_length);
+  gint64 new_position = *position + record_length + sizeof(record_length);
 
-  if (new_read_head_position > self->hdr->write_head)
-    new_read_head_position = _correct_position_if_max_size_is_reached(self, new_read_head_position);
+  if (new_position > self->hdr->write_head)
+    new_position = _correct_position_if_max_size_is_reached(self, new_position);
 
-  *position = new_read_head_position;
+  *position = new_position;
 }
 
 gint64

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -544,9 +544,13 @@ _update_position_after_read(QDisk *self, guint32 record_length, gint64 *position
 }
 
 gint64
-qdisk_get_head_position(QDisk *self)
+qdisk_get_next_head_position(QDisk *self)
 {
-  return self->hdr->read_head;
+  gint64 next_read_head_position = self->hdr->read_head;
+  if (next_read_head_position > self->hdr->write_head)
+    next_read_head_position = _correct_position_if_max_size_is_reached(self, next_read_head_position);
+
+  return next_read_head_position;
 }
 
 gboolean

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -589,22 +589,22 @@ qdisk_read(QDisk *self, gpointer buffer, gsize bytes_to_read, gint64 position)
   return res;
 }
 
-gint64
-qdisk_skip_record(QDisk *self, gint64 position)
+gboolean
+qdisk_skip_record(QDisk *self, gint64 position, gint64 *new_position)
 {
   if (position > self->hdr->write_head)
     position = _correct_position_if_max_size_is_reached(self, position);
 
-  gint64 new_position = position;
   guint32 record_length;
   qdisk_read(self, (gchar *) &record_length, sizeof(record_length), position);
   record_length = GUINT32_FROM_BE(record_length);
-  new_position += record_length + sizeof(record_length);
+  *new_position = position;
+  *new_position += record_length + sizeof(record_length);
 
-  if (new_position > self->hdr->write_head)
-    new_position = _correct_position_if_max_size_is_reached(self, new_position);
+  if (*new_position > self->hdr->write_head)
+    *new_position = _correct_position_if_max_size_is_reached(self, *new_position);
 
-  return new_position;
+  return TRUE;
 }
 
 gboolean

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -592,6 +592,9 @@ qdisk_read(QDisk *self, gpointer buffer, gsize bytes_to_read, gint64 position)
 gboolean
 qdisk_skip_record(QDisk *self, gint64 position, gint64 *new_position)
 {
+  if (position == self->hdr->write_head)
+    return FALSE;
+
   if (position > self->hdr->write_head)
     position = _correct_position_if_max_size_is_reached(self, position);
 

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -126,24 +126,24 @@ _has_position_reached_max_size(QDisk *self, gint64 position)
 }
 
 static inline guint64
-_correct_position_if_max_size_is_reached(QDisk *self, gint64 *position)
+_correct_position_if_max_size_is_reached(QDisk *self, gint64 position)
 {
   if (G_UNLIKELY(self->hdr->use_v1_wrap_condition))
     {
-      gboolean position_is_eof = *position >= self->file_size;
+      gboolean position_is_eof = position >= self->file_size;
       if (position_is_eof)
         {
-          *position = QDISK_RESERVED_SPACE;
+          position = QDISK_RESERVED_SPACE;
           self->hdr->use_v1_wrap_condition = FALSE;
         }
-      return *position;
+      return position;
     }
 
-  if (_has_position_reached_max_size(self, *position))
+  if (_has_position_reached_max_size(self, position))
     {
-      *position = QDISK_RESERVED_SPACE;
+      position = QDISK_RESERVED_SPACE;
     }
-  return *position;
+  return position;
 }
 
 static gchar *
@@ -525,7 +525,7 @@ _calculate_new_read_head_position(QDisk *self, guint32 record_length)
   gint64 new_read_head_position = self->hdr->read_head + record_length + sizeof(record_length);
 
   if (new_read_head_position > self->hdr->write_head)
-    new_read_head_position = _correct_position_if_max_size_is_reached(self, &new_read_head_position);
+    new_read_head_position = _correct_position_if_max_size_is_reached(self, new_read_head_position);
 
   return new_read_head_position;
 }
@@ -561,7 +561,7 @@ qdisk_pop_head(QDisk *self, GString *record)
     return FALSE;
 
   if (self->hdr->read_head > self->hdr->write_head)
-    self->hdr->read_head = _correct_position_if_max_size_is_reached(self, &self->hdr->read_head);
+    self->hdr->read_head = _correct_position_if_max_size_is_reached(self, self->hdr->read_head);
 
   guint32 record_length;
   if (!_try_reading_record_length(self, &record_length))
@@ -582,7 +582,7 @@ qdisk_remove_head(QDisk *self)
     return FALSE;
 
   if (self->hdr->read_head > self->hdr->write_head)
-    self->hdr->read_head = _correct_position_if_max_size_is_reached(self, &self->hdr->read_head);
+    self->hdr->read_head = _correct_position_if_max_size_is_reached(self, self->hdr->read_head);
 
   guint32 record_length;
   if (!_try_reading_record_length(self, &record_length))
@@ -1241,7 +1241,7 @@ guint64
 qdisk_skip_record(QDisk *self, guint64 position)
 {
   if (position > self->hdr->write_head)
-    position = _correct_position_if_max_size_is_reached(self, (gint64 *)&position);
+    position = _correct_position_if_max_size_is_reached(self, (gint64) position);
 
   guint64 new_position = position;
   guint32 record_length;
@@ -1250,7 +1250,7 @@ qdisk_skip_record(QDisk *self, guint64 position)
   new_position += record_length + sizeof(record_length);
 
   if (new_position > self->hdr->write_head)
-    new_position = _correct_position_if_max_size_is_reached(self, (gint64 *)&new_position);
+    new_position = _correct_position_if_max_size_is_reached(self, (gint64) new_position);
 
   return new_position;
 }

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -526,7 +526,6 @@ _maybe_apply_non_reliable_corrections(QDisk *self)
     return;
 
   qdisk_empty_backlog(self);
-  g_assert(self->hdr->backlog_len == 0);
   if (!self->options->read_only)
     qdisk_reset_file_if_empty(self);
 }

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -610,6 +610,9 @@ qdisk_remove_head(QDisk *self)
 gboolean
 qdisk_ack_backlog(QDisk *self)
 {
+  if (self->hdr->backlog_len == 0)
+    return FALSE;
+
   if (!qdisk_skip_record(self, self->hdr->backlog_head, &self->hdr->backlog_head))
     {
       msg_error("Error acking in disk-queue file", evt_tag_str("filename", qdisk_get_filename(self)));

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -533,7 +533,7 @@ _maybe_apply_non_reliable_corrections(QDisk *self)
 
 
 static inline void
-_update_positions_after_read(QDisk *self, guint32 record_length, gint64 *position)
+_update_position_after_read(QDisk *self, guint32 record_length, gint64 *position)
 {
   gint64 new_position = *position + record_length + sizeof(record_length);
 
@@ -565,7 +565,7 @@ qdisk_pop_head(QDisk *self, GString *record)
   if (!_read_record_from_disk(self, record, record_length))
     return FALSE;
 
-  _update_positions_after_read(self, record_length, &self->hdr->read_head);
+  _update_position_after_read(self, record_length, &self->hdr->read_head);
   self->hdr->length--;
   self->hdr->backlog_len++;
 
@@ -588,7 +588,7 @@ qdisk_skip_record(QDisk *self, gint64 position, gint64 *new_position)
   if (!_try_reading_record_length(self, *new_position, &record_length))
     return FALSE;
 
-  _update_positions_after_read(self, record_length, new_position);
+  _update_position_after_read(self, record_length, new_position);
   return TRUE;
 }
 

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -589,20 +589,20 @@ qdisk_read(QDisk *self, gpointer buffer, gsize bytes_to_read, gint64 position)
   return res;
 }
 
-guint64
-qdisk_skip_record(QDisk *self, guint64 position)
+gint64
+qdisk_skip_record(QDisk *self, gint64 position)
 {
   if (position > self->hdr->write_head)
-    position = _correct_position_if_max_size_is_reached(self, (gint64) position);
+    position = _correct_position_if_max_size_is_reached(self, position);
 
-  guint64 new_position = position;
+  gint64 new_position = position;
   guint32 record_length;
   qdisk_read(self, (gchar *) &record_length, sizeof(record_length), position);
   record_length = GUINT32_FROM_BE(record_length);
   new_position += record_length + sizeof(record_length);
 
   if (new_position > self->hdr->write_head)
-    new_position = _correct_position_if_max_size_is_reached(self, (gint64) new_position);
+    new_position = _correct_position_if_max_size_is_reached(self, new_position);
 
   return new_position;
 }

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -61,7 +61,7 @@ gboolean qdisk_ack_backlog(QDisk *self);
 gboolean qdisk_rewind_backlog(QDisk *self, guint rewind_count);
 void qdisk_empty_backlog(QDisk *self);
 gint64 qdisk_get_next_tail_position(QDisk *self);
-gint64 qdisk_get_head_position(QDisk *self);
+gint64 qdisk_get_next_head_position(QDisk *self);
 gboolean qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow);
 void qdisk_init_instance(QDisk *self, DiskQueueOptions *options, const gchar *file_id);
 void qdisk_stop(QDisk *self);

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -86,7 +86,7 @@ gboolean qdisk_is_read_only(QDisk *self);
 const gchar *qdisk_get_filename(QDisk *self);
 gint64 qdisk_get_file_size(QDisk *self);
 
-guint64 qdisk_skip_record(QDisk *self, guint64 position);
+gint64 qdisk_skip_record(QDisk *self, gint64 position);
 
 gboolean qdisk_serialize(GString *serialized, QDiskSerializeFunc serialize_func, gpointer user_data, GError **error);
 gboolean qdisk_deserialize(GString *serialized, QDiskDeSerializeFunc deserialize_func, gpointer user_data,

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -57,6 +57,10 @@ gint64 qdisk_get_empty_space(QDisk *self);
 gboolean qdisk_push_tail(QDisk *self, GString *record);
 gboolean qdisk_pop_head(QDisk *self, GString *record);
 gboolean qdisk_remove_head(QDisk *self);
+gboolean qdisk_ack_backlog(QDisk *self);
+gboolean qdisk_rewind_backlog(QDisk *self, guint rewind_count);
+void qdisk_inc_backlog(QDisk *self);
+void qdisk_empty_backlog(QDisk *self);
 gint64 qdisk_get_next_tail_position(QDisk *self);
 gint64 qdisk_get_head_position(QDisk *self);
 gboolean qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow);
@@ -70,23 +74,15 @@ gboolean qdisk_save_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *q
 
 DiskQueueOptions *qdisk_get_options(QDisk *self);
 gint64 qdisk_get_length(QDisk *self);
-void qdisk_set_length(QDisk *self, gint64 new_value);
 gint64 qdisk_get_maximum_size(QDisk *self);
 gint64 qdisk_get_writer_head(QDisk *self);
 gint64 qdisk_get_reader_head(QDisk *self);
-void qdisk_set_reader_head(QDisk *self, gint64 new_value);
 gint64 qdisk_get_backlog_head(QDisk *self);
-void qdisk_set_backlog_head(QDisk *self, gint64 new_value);
-void qdisk_inc_backlog(QDisk *self);
-void qdisk_dec_backlog(QDisk *self);
 gint64 qdisk_get_backlog_count(QDisk *self);
-void qdisk_set_backlog_count(QDisk *self, gint64 new_value);
 gint qdisk_get_memory_size(QDisk *self);
 gboolean qdisk_is_read_only(QDisk *self);
 const gchar *qdisk_get_filename(QDisk *self);
 gint64 qdisk_get_file_size(QDisk *self);
-
-gboolean qdisk_skip_record(QDisk *self, gint64 position, gint64 *new_position);
 
 gboolean qdisk_serialize(GString *serialized, QDiskSerializeFunc serialize_func, gpointer user_data, GError **error);
 gboolean qdisk_deserialize(GString *serialized, QDiskDeSerializeFunc deserialize_func, gpointer user_data,

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -86,7 +86,7 @@ gboolean qdisk_is_read_only(QDisk *self);
 const gchar *qdisk_get_filename(QDisk *self);
 gint64 qdisk_get_file_size(QDisk *self);
 
-gint64 qdisk_skip_record(QDisk *self, gint64 position);
+gboolean qdisk_skip_record(QDisk *self, gint64 position, gint64 *new_position);
 
 gboolean qdisk_serialize(GString *serialized, QDiskSerializeFunc serialize_func, gpointer user_data, GError **error);
 gboolean qdisk_deserialize(GString *serialized, QDiskDeSerializeFunc deserialize_func, gpointer user_data,

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -59,7 +59,6 @@ gboolean qdisk_pop_head(QDisk *self, GString *record);
 gboolean qdisk_remove_head(QDisk *self);
 gboolean qdisk_ack_backlog(QDisk *self);
 gboolean qdisk_rewind_backlog(QDisk *self, guint rewind_count);
-void qdisk_inc_backlog(QDisk *self);
 void qdisk_empty_backlog(QDisk *self);
 gint64 qdisk_get_next_tail_position(QDisk *self);
 gint64 qdisk_get_head_position(QDisk *self);

--- a/modules/diskq/tests/test_qdisk.c
+++ b/modules/diskq/tests/test_qdisk.c
@@ -123,7 +123,7 @@ reliable_pop_record_without_backlog(QDisk *qdisk, GString *record)
   if (!qdisk_pop_head(qdisk, record))
     return FALSE;
 
-  qdisk_set_backlog_head(qdisk, qdisk_get_head_position(qdisk));
+  qdisk_empty_backlog(qdisk);
   return TRUE;
 }
 

--- a/news/bugfix-3887-2.md
+++ b/news/bugfix-3887-2.md
@@ -1,0 +1,1 @@
+`disk-buffer()`: fixed underflowing "queued" stats counter

--- a/news/bugfix-3887.md
+++ b/news/bugfix-3887.md
@@ -1,0 +1,1 @@
+`disk-buffer()`: fixed a memory leak issue and inconsistent buffer handling in rare cases


### PR DESCRIPTION
The reliable disk buffer maintains in-memory copies of the "beginning" and the "end" of the disk buffer for performance and flow-control purposes.

These memory buffers are not necessarily continuous slices of the disk buffer file, so they are emptied by a logic that queries the reader head of QDisk.

Currently, it is not allowed for the reader and writer heads to overlap when the buffer is full, so it is possible that the read head points to the very end of the file, but the next read will be done from the beginning of the file.

This corner case has to be taken into account when comparing the current position with in-memory copies.

Note: In the next PR, I'll try to get rid of all the reader/writer/backlog head correction trickeries. It would greatly reduce the complexity of QDisk.

Fixes #2474 (as well)