### PR TITLE
dbld: workaround RPM repos for fedora-33

### DIFF
--- a/dbld/builddeps
+++ b/dbld/builddeps
@@ -10,6 +10,15 @@ APT_INSTALL="apt-get install -y --no-install-recommends"
 set -e
 set -x
 
+function workaround_rpm_repos() {
+    case "${OS_DISTRIBUTION}" in
+        fedora)
+            # Workaround for often getting 503 from mirrors.fedoraproject.org.
+            sed -i -e '/metalink=.*/s/^/#/' -e '/.*baseurl.*/c\baseurl=https://ftp.halifax.rwth-aachen.de/fedora/linux/releases/$releasever/Everything/$basearch/os/' /etc/yum.repos.d/fedora*.repo
+            ;;
+    esac
+}
+
 # this function is run first and is responsible for installing stuff that is
 # needed by this script _before_ installing packages from packages.manifest.
 #

--- a/dbld/images/fedora-33.dockerfile
+++ b/dbld/images/fedora-33.dockerfile
@@ -12,6 +12,7 @@ COPY images/fake-sudo.sh /usr/bin/sudo
 COPY images/entrypoint.sh /
 COPY . /dbld/
 
+RUN /dbld/builddeps workaround_rpm_repos
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps add_copr_repo
 RUN /dbld/builddeps install_yum_packages


### PR DESCRIPTION
https://mirrors.fedoraproject.org/ often returns 503 error code, when we are trying to pull the metalink.

We can work this around by using a dedicated mirror, and not trying to look for mirrors via the metalink file at all.

The actual server was chosen from this list: https://admin.fedoraproject.org/mirrormanager/mirrors/Fedora/33/x86_64

I tried to choose a server which is EU based, and has large bandwidth.

Fixes #3882

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>