### PR TITLE
syslog-format: add support for no-rfc3164-fallback flag

### DIFF
--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -243,7 +243,7 @@ CfgFlagHandler msg_format_flag_handlers[] =
   { "no-hostname",              CFH_CLEAR, offsetof(MsgFormatOptions, flags), LP_EXPECT_HOSTNAME },
   { "guess-timezone",             CFH_SET, offsetof(MsgFormatOptions, flags), LP_GUESS_TIMEZONE },
   { "no-header",                  CFH_SET, offsetof(MsgFormatOptions, flags), LP_NO_HEADER },
-
+  { "no-rfc3164-fallback",        CFH_SET, offsetof(MsgFormatOptions, flags), LP_NO_RFC3164_FALLBACK },
   { NULL },
 };
 

--- a/lib/msg-format.h
+++ b/lib/msg-format.h
@@ -58,6 +58,7 @@ enum
   LP_STORE_RAW_MESSAGE = 0x0800,
   LP_GUESS_TIMEZONE = 0x1000,
   LP_NO_HEADER = 0x2000,
+  LP_NO_RFC3164_FALLBACK = 0x4000,
 };
 
 typedef struct _MsgFormatHandler MsgFormatHandler;

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -906,7 +906,9 @@ log_msg_parse_syslog_proto(const MsgFormatOptions *parse_options, const guchar *
   if (!log_msg_parse_pri(self, &src, &left, parse_options->flags, parse_options->default_pri) ||
       !log_msg_parse_version(self, &src, &left))
     {
-      return log_msg_parse_legacy(parse_options, data, length, self, position);
+      if ((parse_options->flags & LP_NO_RFC3164_FALLBACK) == 0)
+        return log_msg_parse_legacy(parse_options, data, length, self, position);
+      return FALSE;
     }
 
   if (!log_msg_parse_skip_space(self, &src, &left))

--- a/news/feature-3891.md
+++ b/news/feature-3891.md
@@ -1,0 +1,6 @@
+`flags(no-rfc3164-fallback)`: we added a new flag to sources that parse
+incoming syslog data and operate in RFC5424 mode (e.g. syslog-protocol is
+also set). With the new flag the automatic fallback to RFC3164 format
+is disabled. In this case if the parsing in RFC5424 fails, the
+syslog parser would result in an error message. In the case of
+syslog-parser(drop-invalid(yes)), the message would be dropped.

--- a/tests/unit/test_msgparse.c
+++ b/tests/unit/test_msgparse.c
@@ -173,7 +173,8 @@ test_log_messages_can_be_parsed(struct msgparse_params *param)
                 (gint)now, (gint)parsed_timestamp->ut_sec);
     }
 
-  cr_assert_eq(parsed_message->pri, param->expected_pri, "Unexpected message priority");
+  cr_assert_eq(parsed_message->pri, param->expected_pri, "Unexpected message priority %d != %d",
+               parsed_message->pri, param->expected_pri);
   assert_log_message_value(parsed_message, LM_V_HOST, param->expected_host);
   assert_log_message_value(parsed_message, LM_V_PROGRAM, param->expected_program);
   assert_log_message_value(parsed_message, LM_V_MESSAGE, param->expected_msg);
@@ -1195,6 +1196,23 @@ Test(msgparse, test_no_header_flag)
       .expected_program = "",
       .expected_host = "",
       .expected_msg = "some message",
+    },
+    {NULL}
+  };
+  run_parameterized_test(params);
+}
+
+Test(msgparse, test_no_rfc3164_fallback_flag)
+{
+  struct msgparse_params params[] =
+  {
+    {
+      .msg = "<189>some message",
+      .parse_flags = LP_SYSLOG_PROTOCOL | LP_NO_RFC3164_FALLBACK,
+      .expected_pri = 43,
+      .expected_program = "syslog-ng",
+      .expected_host = "",
+      .expected_msg = "Error processing log message: <189>some message",
     },
     {NULL}
   };


### PR DESCRIPTION
This flag would allow you to attempt parsing RFC5424 first without
an automatic fallback to RFC3164.

RFC3164. With this option it is possible to use drop-invalid(yes)
plus no-rfc3164-fallback, effectively being able to filter on RFC5424 only.

Signed-off-by: Balazs Scheidler <bazsi77@gmail.com>