### PR TITLE
logproto: fix invalid buffer handling when encoding() is used

### DIFF
--- a/lib/logproto/logproto-buffered-server.c
+++ b/lib/logproto/logproto-buffered-server.c
@@ -594,6 +594,116 @@ log_proto_buffered_server_read_data_method(LogProtoBufferedServer *self, guchar 
   return log_transport_read(self->super.transport, buf, len, aux);
 }
 
+static void
+log_proto_buffered_server_maybe_realloc_reverse_buffer(LogProtoBufferedServer *self, gsize buffer_length)
+{
+  if (self->reverse_buffer_len >= buffer_length)
+    return;
+
+  /* we free and malloc, since we never need the data still in reverse buffer */
+  g_free(self->reverse_buffer);
+  self->reverse_buffer_len = buffer_length;
+  self->reverse_buffer = g_malloc(buffer_length);
+}
+
+/*
+ * returns the number of bytes that represent the UTF8 encoding buffer
+ * in the original encoding that the user specified.
+ *
+ * NOTE: this is slow, but we only call this for the remainder of our
+ * buffer (e.g. the partial line at the end of our last chunk of read
+ * data). Also, this is only invoked if the file uses an encoding.
+ */
+static gsize
+log_proto_buffered_server_get_raw_size_of_buffer(LogProtoBufferedServer *self, const guchar *buffer, gsize buffer_len)
+{
+  gchar *out;
+  const guchar *in;
+  gsize avail_out, avail_in;
+  gint ret;
+
+  if (self->reverse_convert == ((GIConv) -1) && !self->convert_scale)
+    {
+      /* try to speed up raw size calculation by recognizing the most
+       * prominent character encodings and in the case the encoding
+       * uses fixed size characters set that in self->convert_scale,
+       * which in turn will speed up the reversal of the UTF8 buffer
+       * size to raw buffer sizes.
+       */
+      self->convert_scale = log_proto_get_char_size_for_fixed_encoding(self->super.options->encoding);
+      if (self->convert_scale == 0)
+        {
+          /* this encoding is not known, do the conversion for real :( */
+          self->reverse_convert = g_iconv_open(self->super.options->encoding, "utf-8");
+        }
+    }
+
+  if (self->convert_scale)
+    return g_utf8_strlen((gchar *) buffer, buffer_len) * self->convert_scale;
+
+
+  /* Multiplied by 6, because 1 character can be maximum 6 bytes in UTF-8 encoding */
+  log_proto_buffered_server_maybe_realloc_reverse_buffer(self, buffer_len * 6);
+
+  avail_out = self->reverse_buffer_len;
+  out = self->reverse_buffer;
+
+  avail_in = buffer_len;
+  in = buffer;
+
+  ret = g_iconv(self->reverse_convert, (gchar **) &in, &avail_in, &out, &avail_out);
+  if (ret == (gsize) -1)
+    {
+      /* oops, we cannot reverse that we ourselves converted to UTF-8,
+       * this is simply impossible, but never say never */
+      msg_error("Internal error, couldn't reverse the internal UTF8 string to the original encoding",
+                evt_tag_printf("buffer", "%.*s", (gint) buffer_len, buffer));
+      return 0;
+    }
+  else
+    {
+      return self->reverse_buffer_len - avail_out;
+    }
+}
+
+void
+log_proto_buffered_server_split_buffer(LogProtoBufferedServer *self, LogProtoBufferedServerState *state,
+                                       const guchar *buffer_start, gsize buffer_bytes)
+{
+  gsize raw_split_size;
+
+  /* buffer is not full, but no EOL is present, move partial line
+   * to the beginning of the buffer to make space for new data.
+   */
+
+  memmove(self->buffer, buffer_start, buffer_bytes);
+  state->pending_buffer_pos = 0;
+  state->pending_buffer_end = buffer_bytes;
+  buffer_start = self->buffer;
+
+  if (G_UNLIKELY(self->pos_tracking))
+    {
+      /* NOTE: we modify the current file position _after_ updating
+         buffer_pos, since if we crash right here, at least we
+         won't lose data on the next restart, but rather we
+         duplicate some data */
+
+
+      if (self->super.options->encoding)
+        raw_split_size = log_proto_buffered_server_get_raw_size_of_buffer(self, buffer_start, buffer_bytes);
+      else
+        raw_split_size = buffer_bytes;
+
+      state->pending_raw_stream_pos += (gint64) (state->pending_raw_buffer_size - raw_split_size);
+      state->pending_raw_buffer_size = raw_split_size;
+
+      msg_trace("Buffer split",
+                evt_tag_int("raw_split_size", raw_split_size),
+                evt_tag_int("buffer_bytes", buffer_bytes));
+    }
+
+}
+
 static gboolean
 log_proto_buffered_server_fetch_from_buffer(LogProtoBufferedServer *self, const guchar **msg, gsize *msg_len,
                                             LogTransportAuxData *aux)
@@ -913,116 +1023,6 @@ exit:
         }
     }
   return result;
-}
-
-static void
-log_proto_buffered_server_maybe_realloc_reverse_buffer(LogProtoBufferedServer *self, gsize buffer_length)
-{
-  if (self->reverse_buffer_len >= buffer_length)
-    return;
-
-  /* we free and malloc, since we never need the data still in reverse buffer */
-  g_free(self->reverse_buffer);
-  self->reverse_buffer_len = buffer_length;
-  self->reverse_buffer = g_malloc(buffer_length);
-}
-
-/*
- * returns the number of bytes that represent the UTF8 encoding buffer
- * in the original encoding that the user specified.
- *
- * NOTE: this is slow, but we only call this for the remainder of our
- * buffer (e.g. the partial line at the end of our last chunk of read
- * data). Also, this is only invoked if the file uses an encoding.
- */
-static gsize
-log_proto_buffered_server_get_raw_size_of_buffer(LogProtoBufferedServer *self, const guchar *buffer, gsize buffer_len)
-{
-  gchar *out;
-  const guchar *in;
-  gsize avail_out, avail_in;
-  gint ret;
-
-  if (self->reverse_convert == ((GIConv) -1) && !self->convert_scale)
-    {
-      /* try to speed up raw size calculation by recognizing the most
-       * prominent character encodings and in the case the encoding
-       * uses fixed size characters set that in self->convert_scale,
-       * which in turn will speed up the reversal of the UTF8 buffer
-       * size to raw buffer sizes.
-       */
-      self->convert_scale = log_proto_get_char_size_for_fixed_encoding(self->super.options->encoding);
-      if (self->convert_scale == 0)
-        {
-          /* this encoding is not known, do the conversion for real :( */
-          self->reverse_convert = g_iconv_open(self->super.options->encoding, "utf-8");
-        }
-    }
-
-  if (self->convert_scale)
-    return g_utf8_strlen((gchar *) buffer, buffer_len) * self->convert_scale;
-
-
-  /* Multiplied by 6, because 1 character can be maximum 6 bytes in UTF-8 encoding */
-  log_proto_buffered_server_maybe_realloc_reverse_buffer(self, buffer_len * 6);
-
-  avail_out = self->reverse_buffer_len;
-  out = self->reverse_buffer;
-
-  avail_in = buffer_len;
-  in = buffer;
-
-  ret = g_iconv(self->reverse_convert, (gchar **) &in, &avail_in, &out, &avail_out);
-  if (ret == (gsize) -1)
-    {
-      /* oops, we cannot reverse that we ourselves converted to UTF-8,
-       * this is simply impossible, but never say never */
-      msg_error("Internal error, couldn't reverse the internal UTF8 string to the original encoding",
-                evt_tag_printf("buffer", "%.*s", (gint) buffer_len, buffer));
-      return 0;
-    }
-  else
-    {
-      return self->reverse_buffer_len - avail_out;
-    }
-}
-
-void
-log_proto_buffered_server_split_buffer(LogProtoBufferedServer *self, LogProtoBufferedServerState *state,
-                                       const guchar *buffer_start, gsize buffer_bytes)
-{
-  gsize raw_split_size;
-
-  /* buffer is not full, but no EOL is present, move partial line
-   * to the beginning of the buffer to make space for new data.
-   */
-
-  memmove(self->buffer, buffer_start, buffer_bytes);
-  state->pending_buffer_pos = 0;
-  state->pending_buffer_end = buffer_bytes;
-  buffer_start = self->buffer;
-
-  if (G_UNLIKELY(self->pos_tracking))
-    {
-      /* NOTE: we modify the current file position _after_ updating
-         buffer_pos, since if we crash right here, at least we
-         won't lose data on the next restart, but rather we
-         duplicate some data */
-
-
-      if (self->super.options->encoding)
-        raw_split_size = log_proto_buffered_server_get_raw_size_of_buffer(self, buffer_start, buffer_bytes);
-      else
-        raw_split_size = buffer_bytes;
-
-      state->pending_raw_stream_pos += (gint64) (state->pending_raw_buffer_size - raw_split_size);
-      state->pending_raw_buffer_size = raw_split_size;
-
-      msg_trace("Buffer split",
-                evt_tag_int("raw_split_size", raw_split_size),
-                evt_tag_int("buffer_bytes", buffer_bytes));
-    }
-
 }
 
 gboolean

--- a/lib/logproto/logproto-buffered-server.c
+++ b/lib/logproto/logproto-buffered-server.c
@@ -915,6 +915,116 @@ exit:
   return result;
 }
 
+static void
+log_proto_buffered_server_maybe_realloc_reverse_buffer(LogProtoBufferedServer *self, gsize buffer_length)
+{
+  if (self->reverse_buffer_len >= buffer_length)
+    return;
+
+  /* we free and malloc, since we never need the data still in reverse buffer */
+  g_free(self->reverse_buffer);
+  self->reverse_buffer_len = buffer_length;
+  self->reverse_buffer = g_malloc(buffer_length);
+}
+
+/*
+ * returns the number of bytes that represent the UTF8 encoding buffer
+ * in the original encoding that the user specified.
+ *
+ * NOTE: this is slow, but we only call this for the remainder of our
+ * buffer (e.g. the partial line at the end of our last chunk of read
+ * data). Also, this is only invoked if the file uses an encoding.
+ */
+static gsize
+log_proto_buffered_server_get_raw_size_of_buffer(LogProtoBufferedServer *self, const guchar *buffer, gsize buffer_len)
+{
+  gchar *out;
+  const guchar *in;
+  gsize avail_out, avail_in;
+  gint ret;
+
+  if (self->reverse_convert == ((GIConv) -1) && !self->convert_scale)
+    {
+      /* try to speed up raw size calculation by recognizing the most
+       * prominent character encodings and in the case the encoding
+       * uses fixed size characters set that in self->convert_scale,
+       * which in turn will speed up the reversal of the UTF8 buffer
+       * size to raw buffer sizes.
+       */
+      self->convert_scale = log_proto_get_char_size_for_fixed_encoding(self->super.options->encoding);
+      if (self->convert_scale == 0)
+        {
+          /* this encoding is not known, do the conversion for real :( */
+          self->reverse_convert = g_iconv_open(self->super.options->encoding, "utf-8");
+        }
+    }
+
+  if (self->convert_scale)
+    return g_utf8_strlen((gchar *) buffer, buffer_len) * self->convert_scale;
+
+
+  /* Multiplied by 6, because 1 character can be maximum 6 bytes in UTF-8 encoding */
+  log_proto_buffered_server_maybe_realloc_reverse_buffer(self, buffer_len * 6);
+
+  avail_out = self->reverse_buffer_len;
+  out = self->reverse_buffer;
+
+  avail_in = buffer_len;
+  in = buffer;
+
+  ret = g_iconv(self->reverse_convert, (gchar **) &in, &avail_in, &out, &avail_out);
+  if (ret == (gsize) -1)
+    {
+      /* oops, we cannot reverse that we ourselves converted to UTF-8,
+       * this is simply impossible, but never say never */
+      msg_error("Internal error, couldn't reverse the internal UTF8 string to the original encoding",
+                evt_tag_printf("buffer", "%.*s", (gint) buffer_len, buffer));
+      return 0;
+    }
+  else
+    {
+      return self->reverse_buffer_len - avail_out;
+    }
+}
+
+void
+log_proto_buffered_server_split_buffer(LogProtoBufferedServer *self, LogProtoBufferedServerState *state,
+                                       const guchar *buffer_start, gsize buffer_bytes)
+{
+  gsize raw_split_size;
+
+  /* buffer is not full, but no EOL is present, move partial line
+   * to the beginning of the buffer to make space for new data.
+   */
+
+  memmove(self->buffer, buffer_start, buffer_bytes);
+  state->pending_buffer_pos = 0;
+  state->pending_buffer_end = buffer_bytes;
+  buffer_start = self->buffer;
+
+  if (G_UNLIKELY(self->pos_tracking))
+    {
+      /* NOTE: we modify the current file position _after_ updating
+         buffer_pos, since if we crash right here, at least we
+         won't lose data on the next restart, but rather we
+         duplicate some data */
+
+
+      if (self->super.options->encoding)
+        raw_split_size = log_proto_buffered_server_get_raw_size_of_buffer(self, buffer_start, buffer_bytes);
+      else
+        raw_split_size = buffer_bytes;
+
+      state->pending_raw_stream_pos += (gint64) (state->pending_raw_buffer_size - raw_split_size);
+      state->pending_raw_buffer_size = raw_split_size;
+
+      msg_trace("Buffer split",
+                evt_tag_int("raw_split_size", raw_split_size),
+                evt_tag_int("buffer_bytes", buffer_bytes));
+    }
+
+}
+
 gboolean
 log_proto_buffered_server_validate_options_method(LogProtoServer *s)
 {
@@ -933,6 +1043,11 @@ void
 log_proto_buffered_server_free_method(LogProtoServer *s)
 {
   LogProtoBufferedServer *self = (LogProtoBufferedServer *) s;
+
+  if (self->reverse_convert != (GIConv) -1)
+    g_iconv_close(self->reverse_convert);
+
+  g_free(self->reverse_buffer);
 
   log_transport_aux_data_destroy(&self->buffer_aux);
 
@@ -958,6 +1073,7 @@ log_proto_buffered_server_init(LogProtoBufferedServer *self, LogTransport *trans
   self->super.restart_with_state = log_proto_buffered_server_restart_with_state;
   self->super.validate_options = log_proto_buffered_server_validate_options_method;
   self->convert = (GIConv) -1;
+  self->reverse_convert = (GIConv) -1;
   self->read_data = log_proto_buffered_server_read_data_method;
   self->io_status = G_IO_STATUS_NORMAL;
   if (options->encoding)

--- a/lib/logproto/logproto-buffered-server.c
+++ b/lib/logproto/logproto-buffered-server.c
@@ -22,6 +22,7 @@
  *
  */
 #include "logproto-buffered-server.h"
+#include "logproto.h"
 #include "messages.h"
 #include "serialize.h"
 #include "compat/string.h"

--- a/lib/logproto/logproto-buffered-server.c
+++ b/lib/logproto/logproto-buffered-server.c
@@ -670,12 +670,10 @@ static void
 log_proto_buffered_server_split_buffer(LogProtoBufferedServer *self, LogProtoBufferedServerState *state,
                                        const guchar **buffer_start, gsize buffer_bytes)
 {
-  gsize raw_split_size;
+  if (*buffer_start == self->buffer)
+    return;
 
-  /* buffer is not full, but no EOL is present, move partial line
-   * to the beginning of the buffer to make space for new data.
-   */
-
+  /* move partial message to the beginning of the buffer to make space for new data */
   memmove(self->buffer, *buffer_start, buffer_bytes);
   state->pending_buffer_pos = 0;
   state->pending_buffer_end = buffer_bytes;
@@ -688,7 +686,7 @@ log_proto_buffered_server_split_buffer(LogProtoBufferedServer *self, LogProtoBuf
          won't lose data on the next restart, but rather we
          duplicate some data */
 
-
+      gsize raw_split_size;
       if (self->super.options->encoding)
         raw_split_size = log_proto_buffered_server_get_raw_size_of_buffer(self, *buffer_start, buffer_bytes);
       else

--- a/lib/logproto/logproto-buffered-server.c
+++ b/lib/logproto/logproto-buffered-server.c
@@ -624,6 +624,8 @@ log_proto_buffered_server_fetch_from_buffer(LogProtoBufferedServer *self, const 
       goto exit;
     }
 
+  /* buffer_start should not be used after the fetch_from_buffer() call as one
+   * of its implementations splits the buffer */
   success = self->fetch_from_buffer(self, buffer_start, buffer_bytes, msg, msg_len);
   if (aux)
     log_transport_aux_data_copy(aux, &self->buffer_aux);

--- a/lib/logproto/logproto-buffered-server.h
+++ b/lib/logproto/logproto-buffered-server.h
@@ -128,8 +128,4 @@ void log_proto_buffered_server_free_method(LogProtoServer *s);
 LogProtoStatus log_proto_buffered_server_fetch(LogProtoServer *s, const guchar **msg, gsize *msg_len,
                                                gboolean *may_read, LogTransportAuxData *aux, Bookmark *bookmark);
 
-/* protected */
-void log_proto_buffered_server_split_buffer(LogProtoBufferedServer *self, LogProtoBufferedServerState *state,
-                                            const guchar *buffer_start, gsize buffer_bytes);
-
 #endif

--- a/lib/logproto/logproto-buffered-server.h
+++ b/lib/logproto/logproto-buffered-server.h
@@ -92,6 +92,11 @@ struct _LogProtoBufferedServer
   GIConv convert;
   guchar *buffer;
 
+  GIConv reverse_convert;
+  gchar *reverse_buffer;
+  gsize reverse_buffer_len;
+  gint convert_scale;
+
   /* auxiliary data (e.g. GSockAddr, other transport related meta
    * data) associated with the already buffered data */
   LogTransportAuxData buffer_aux;
@@ -122,5 +127,9 @@ void log_proto_buffered_server_free_method(LogProtoServer *s);
 
 LogProtoStatus log_proto_buffered_server_fetch(LogProtoServer *s, const guchar **msg, gsize *msg_len,
                                                gboolean *may_read, LogTransportAuxData *aux, Bookmark *bookmark);
+
+/* protected */
+void log_proto_buffered_server_split_buffer(LogProtoBufferedServer *self, LogProtoBufferedServerState *state,
+                                            const guchar *buffer_start, gsize buffer_bytes);
 
 #endif

--- a/lib/logproto/logproto-text-server.c
+++ b/lib/logproto/logproto-text-server.c
@@ -206,8 +206,6 @@ _fetch_msg_from_buffer(LogProtoTextServer *self, LogProtoBufferedServerState *st
           goto success;
         }
 
-      /* buffer_start should not be used after calling split_buffer() */
-      log_proto_buffered_server_split_buffer(&self->super, state, buffer_start, buffer_bytes);-
       return FALSE;
     }
 
@@ -220,8 +218,6 @@ _fetch_msg_from_buffer(LogProtoTextServer *self, LogProtoBufferedServerState *st
       goto success;
     }
 
-  /* buffer_start should not be used after calling split_buffer() */
-  log_proto_buffered_server_split_buffer(&self->super, state, buffer_start, buffer_bytes);
   return FALSE;
 
 success:

--- a/lib/logproto/logproto-text-server.c
+++ b/lib/logproto/logproto-text-server.c
@@ -189,6 +189,7 @@ log_proto_text_server_split_buffer(LogProtoTextServer *self, LogProtoBufferedSer
   memmove(self->super.buffer, buffer_start, buffer_bytes);
   state->pending_buffer_pos = 0;
   state->pending_buffer_end = buffer_bytes;
+  buffer_start = self->super.buffer;
 
   if (G_UNLIKELY(self->super.pos_tracking))
     {

--- a/lib/logproto/logproto-text-server.c
+++ b/lib/logproto/logproto-text-server.c
@@ -26,63 +26,6 @@
 
 #include <string.h>
 
-/*
- * log_proto_get_fixed_encoding_scale:
- *
- * This function returns the number of bytes of a single character in the
- * encoding specified by the @encoding parameter, provided it is listed in
- * the limited set hard-wired in the fixed_encodings array above.
- *
- * syslog-ng sometimes needs to calculate the size of the original, raw data
- * that relates to its already utf8 converted input buffer.  For that the
- * slow solution is to actually perform the utf8 -> raw conversion, however
- * since we don't really need the actual conversion, just the size of the
- * data in bytes we can be faster than that by multiplying the number of
- * input characters with the size of the character in the known
- * fixed-length-encodings in the list above.
- *
- * This function returns 0 if the encoding is not known, in which case the
- * slow path is to be executed.
- */
-gint
-log_proto_get_char_size_for_fixed_encoding(const gchar *encoding)
-{
-  static struct
-  {
-    const gchar *prefix;
-    gint scale;
-  } fixed_encodings[] =
-  {
-    { "ascii", 1 },
-    { "us-ascii", 1 },
-    { "iso-8859", 1 },
-    { "iso8859", 1 },
-    { "latin", 1 },
-    { "ucs2", 2 },
-    { "ucs-2", 2 },
-    { "ucs4", 4 },
-    { "ucs-4", 4 },
-    { "koi", 1 },
-    { "unicode", 2 },
-    { "windows", 1 },
-    { "wchar_t", sizeof(wchar_t) },
-    { NULL, 0 }
-  };
-  gint scale = 0;
-  gint i;
-
-  for (i = 0; fixed_encodings[i].prefix; i++)
-    {
-      if (strncasecmp(encoding, fixed_encodings[i].prefix, strlen(fixed_encodings[i].prefix)) == 0)
-        {
-          scale = fixed_encodings[i].scale;
-          break;
-        }
-    }
-  return scale;
-}
-
-
 LogProtoPrepareAction
 log_proto_text_server_prepare_method(LogProtoServer *s, GIOCondition *cond, gint *timeout)
 {

--- a/lib/logproto/logproto-text-server.c
+++ b/lib/logproto/logproto-text-server.c
@@ -40,121 +40,11 @@ log_proto_text_server_prepare_method(LogProtoServer *s, GIOCondition *cond, gint
   return avail ? LPPA_FORCE_SCHEDULE_FETCH : LPPA_POLL_IO;
 }
 
-static void
-log_proto_text_server_maybe_realloc_reverse_buffer(LogProtoTextServer *self, gsize buffer_length)
-{
-  if (self->reverse_buffer_len >= buffer_length)
-    return;
-
-  /* we free and malloc, since we never need the data still in reverse buffer */
-  g_free(self->reverse_buffer);
-  self->reverse_buffer_len = buffer_length;
-  self->reverse_buffer = g_malloc(buffer_length);
-}
-
-/*
- * returns the number of bytes that represent the UTF8 encoding buffer
- * in the original encoding that the user specified.
- *
- * NOTE: this is slow, but we only call this for the remainder of our
- * buffer (e.g. the partial line at the end of our last chunk of read
- * data). Also, this is only invoked if the file uses an encoding.
- */
-static gsize
-log_proto_text_server_get_raw_size_of_buffer(LogProtoTextServer *self, const guchar *buffer, gsize buffer_len)
-{
-  gchar *out;
-  const guchar *in;
-  gsize avail_out, avail_in;
-  gint ret;
-
-  if (self->reverse_convert == ((GIConv) -1) && !self->convert_scale)
-    {
-      /* try to speed up raw size calculation by recognizing the most
-       * prominent character encodings and in the case the encoding
-       * uses fixed size characters set that in self->convert_scale,
-       * which in turn will speed up the reversal of the UTF8 buffer
-       * size to raw buffer sizes.
-       */
-      self->convert_scale = log_proto_get_char_size_for_fixed_encoding(self->super.super.options->encoding);
-      if (self->convert_scale == 0)
-        {
-          /* this encoding is not known, do the conversion for real :( */
-          self->reverse_convert = g_iconv_open(self->super.super.options->encoding, "utf-8");
-        }
-    }
-
-  if (self->convert_scale)
-    return g_utf8_strlen((gchar *) buffer, buffer_len) * self->convert_scale;
-
-
-  /* Multiplied by 6, because 1 character can be maximum 6 bytes in UTF-8 encoding */
-  log_proto_text_server_maybe_realloc_reverse_buffer(self, buffer_len * 6);
-
-  avail_out = self->reverse_buffer_len;
-  out = self->reverse_buffer;
-
-  avail_in = buffer_len;
-  in = buffer;
-
-  ret = g_iconv(self->reverse_convert, (gchar **) &in, &avail_in, &out, &avail_out);
-  if (ret == (gsize) -1)
-    {
-      /* oops, we cannot reverse that we ourselves converted to UTF-8,
-       * this is simply impossible, but never say never */
-      msg_error("Internal error, couldn't reverse the internal UTF8 string to the original encoding",
-                evt_tag_printf("buffer", "%.*s", (gint) buffer_len, buffer));
-      return 0;
-    }
-  else
-    {
-      return self->reverse_buffer_len - avail_out;
-    }
-}
-
 static gint
 log_proto_text_server_accumulate_line_method(LogProtoTextServer *self, const guchar *msg, gsize msg_len,
                                              gssize consumed_len)
 {
   return LPT_CONSUME_LINE | LPT_EXTRACTED;
-}
-
-static void
-log_proto_text_server_split_buffer(LogProtoTextServer *self, LogProtoBufferedServerState *state,
-                                   const guchar *buffer_start, gsize buffer_bytes)
-{
-  gsize raw_split_size;
-
-  /* buffer is not full, but no EOL is present, move partial line
-   * to the beginning of the buffer to make space for new data.
-   */
-
-  memmove(self->super.buffer, buffer_start, buffer_bytes);
-  state->pending_buffer_pos = 0;
-  state->pending_buffer_end = buffer_bytes;
-  buffer_start = self->super.buffer;
-
-  if (G_UNLIKELY(self->super.pos_tracking))
-    {
-      /* NOTE: we modify the current file position _after_ updating
-         buffer_pos, since if we crash right here, at least we
-         won't lose data on the next restart, but rather we
-         duplicate some data */
-
-
-      if (self->super.super.options->encoding)
-        raw_split_size = log_proto_text_server_get_raw_size_of_buffer(self, buffer_start, buffer_bytes);
-      else
-        raw_split_size = buffer_bytes;
-
-      state->pending_raw_stream_pos += (gint64) (state->pending_raw_buffer_size - raw_split_size);
-      state->pending_raw_buffer_size = raw_split_size;
-
-      msg_trace("Buffer split",
-                evt_tag_int("raw_split_size", raw_split_size),
-                evt_tag_int("buffer_bytes", buffer_bytes));
-    }
-
 }
 
 static gboolean
@@ -328,7 +218,7 @@ log_proto_text_server_fetch_from_buffer(LogProtoBufferedServer *s, const guchar 
         }
       else
         {
-          log_proto_text_server_split_buffer(self, state, buffer_start, buffer_bytes);
+          log_proto_buffered_server_split_buffer(&self->super, state, buffer_start, buffer_bytes);
           goto exit;
         }
     }
@@ -340,7 +230,7 @@ log_proto_text_server_fetch_from_buffer(LogProtoBufferedServer *s, const guchar 
         }
       else
         {
-          log_proto_text_server_split_buffer(self, state, buffer_start, buffer_bytes);
+          log_proto_buffered_server_split_buffer(&self->super, state, buffer_start, buffer_bytes);
           goto exit;
         }
     }
@@ -367,12 +257,9 @@ void
 log_proto_text_server_free(LogProtoServer *s)
 {
   LogProtoTextServer *self = (LogProtoTextServer *) s;
-  if (self->reverse_convert != (GIConv) -1)
-    g_iconv_close(self->reverse_convert);
-
-  g_free(self->reverse_buffer);
   log_proto_buffered_server_free_method(&self->super.super);
 }
+
 
 void
 log_proto_text_server_init(LogProtoTextServer *self, LogTransport *transport, const LogProtoServerOptions *options)
@@ -384,7 +271,6 @@ log_proto_text_server_init(LogProtoTextServer *self, LogTransport *transport, co
   self->super.flush = log_proto_text_server_flush;
   self->accumulate_line = log_proto_text_server_accumulate_line_method;
   self->super.stream_based = TRUE;
-  self->reverse_convert = (GIConv) -1;
   self->consumed_len = -1;
 }
 

--- a/lib/logproto/logproto-text-server.c
+++ b/lib/logproto/logproto-text-server.c
@@ -402,6 +402,8 @@ log_proto_text_server_fetch_from_buffer(LogProtoBufferedServer *s, const guchar 
         }
     }
 
+  /* buffer_start should not be used after calling split_buffer() */
+
   log_proto_text_server_remove_trailing_newline(msg, msg_len);
   result = TRUE;
 

--- a/lib/logproto/logproto-text-server.h
+++ b/lib/logproto/logproto-text-server.h
@@ -48,11 +48,6 @@ struct _LogProtoTextServer
                           gsize msg_len,
                           gssize consumed_len);
 
-  GIConv reverse_convert;
-  gchar *reverse_buffer;
-  gsize reverse_buffer_len;
-  gint convert_scale;
-
   gint32 consumed_len;
   gint32 cached_eol_pos;
 };
@@ -75,8 +70,6 @@ log_proto_text_server_accumulate_line(LogProtoTextServer *self,
 {
   return self->accumulate_line(self, msg, msg_len, consumed_len);
 }
-
-gint log_proto_get_char_size_for_fixed_encoding(const gchar *encoding);
 
 static inline gboolean
 log_proto_text_server_validate_options_method(LogProtoServer *s)

--- a/lib/logproto/logproto.h
+++ b/lib/logproto/logproto.h
@@ -36,5 +36,60 @@ typedef enum
   LPS_AGAIN,
 } LogProtoStatus;
 
+/*
+ * log_proto_get_char_size_for_fixed_encoding:
+ *
+ * This function returns the number of bytes of a single character in the
+ * encoding specified by the @encoding parameter, provided it is listed in
+ * the limited set hard-wired in the fixed_encodings array above.
+ *
+ * syslog-ng sometimes needs to calculate the size of the original, raw data
+ * that relates to its already utf8 converted input buffer.  For that the
+ * slow solution is to actually perform the utf8 -> raw conversion, however
+ * since we don't really need the actual conversion, just the size of the
+ * data in bytes we can be faster than that by multiplying the number of
+ * input characters with the size of the character in the known
+ * fixed-length-encodings in the list above.
+ *
+ * This function returns 0 if the encoding is not known, in which case the
+ * slow path is to be executed.
+ */
+static inline gint
+log_proto_get_char_size_for_fixed_encoding(const gchar *encoding)
+{
+  static struct
+  {
+    const gchar *prefix;
+    gint scale;
+  } fixed_encodings[] =
+  {
+    { "ascii", 1 },
+    { "us-ascii", 1 },
+    { "iso-8859", 1 },
+    { "iso8859", 1 },
+    { "latin", 1 },
+    { "ucs2", 2 },
+    { "ucs-2", 2 },
+    { "ucs4", 4 },
+    { "ucs-4", 4 },
+    { "koi", 1 },
+    { "unicode", 2 },
+    { "windows", 1 },
+    { "wchar_t", sizeof(wchar_t) },
+    { NULL, 0 }
+  };
+  gint scale = 0;
+  gint i;
+
+  for (i = 0; fixed_encodings[i].prefix; i++)
+    {
+      if (strncasecmp(encoding, fixed_encodings[i].prefix, strlen(fixed_encodings[i].prefix)) == 0)
+        {
+          scale = fixed_encodings[i].scale;
+          break;
+        }
+    }
+  return scale;
+}
 
 #endif

--- a/lib/logproto/tests/test_logproto.c
+++ b/lib/logproto/tests/test_logproto.c
@@ -27,6 +27,7 @@
 #include "libtest/proto_lib.h"
 #include "libtest/msg_parse_lib.h"
 
+#include "logproto/logproto.h"
 #include "logproto/logproto-text-server.h"
 #include "logproto/logproto-framed-server.h"
 #include "logproto/logproto-dgram-server.h"

--- a/libtest/proto_lib.c
+++ b/libtest/proto_lib.c
@@ -94,7 +94,8 @@ assert_proto_server_fetch(LogProtoServer *proto, const gchar *expected_msg, gssi
   if (expected_msg_len < 0)
     expected_msg_len = strlen(expected_msg);
 
-  cr_assert_eq(msg_len, expected_msg_len, "LogProtoServer expected message mismatch (length)");
+  cr_assert_eq(msg_len, expected_msg_len, "LogProtoServer expected message mismatch (length) "
+               "actual: %" G_GSIZE_FORMAT " expected: %" G_GSIZE_FORMAT, msg_len, expected_msg_len);
   cr_assert_arr_eq((const gchar *) msg, expected_msg, expected_msg_len,
                    "LogProtoServer expected message mismatch");
 }

--- a/news/bugfix-3892.md
+++ b/news/bugfix-3892.md
@@ -1,0 +1,5 @@
+`file()` source: fixed invalid buffer handling when `encoding()` is used
+
+A bug has been fixed that - under rare circumstances - could cause message
+duplication or partial message loss when non-fixed length or less known
+fixed-length encodings are used.


### PR DESCRIPTION
`log_proto_text_server_split_buffer()` moves data within `self->data` for which we maintain additional pointers: `buffer_start`.

This pointer needs to be updated after the `memmove()` call, otherwise it could point to partially overwritten data in case the `memmove()` operation overlaps.

A few lines below my fix, `buffer_start` is passed to a decoder function called `log_proto_text_server_get_raw_size_of_buffer()`, which could fail and report incorrect positions.

This could result in message duplication, partial message loss, but it only occurs when non-fixed length or less known fixed-length encodings are used (encodings that are not listed in `fixed_encodings`).