### PR TITLE
Accept iso timestamp with a space instead of t

### DIFF
--- a/lib/timeutils/scan-timestamp.c
+++ b/lib/timeutils/scan-timestamp.c
@@ -193,7 +193,7 @@ __is_iso_stamp(const gchar *stamp, gint length)
   return (length >= 19
           && stamp[4] == '-'
           && stamp[7] == '-'
-          && stamp[10] == 'T'
+          && (stamp[10] == 'T' || stamp[10] == ' ')
           && stamp[13] == ':'
           && stamp[16] == ':'
          );
@@ -207,7 +207,7 @@ scan_iso_timestamp(const gchar **buf, gint *left, WallClockTime *wct)
       !scan_positive_int(buf, left, 2, &wct->wct_mon) ||
       !scan_expect_char(buf, left, '-') ||
       !scan_positive_int(buf, left, 2, &wct->wct_mday) ||
-      !scan_expect_char(buf, left, 'T') ||
+      !(scan_expect_char(buf, left, 'T') || scan_expect_char(buf, left, ' ')) ||
       !scan_positive_int(buf, left, 2, &wct->wct_hour) ||
       !scan_expect_char(buf, left, ':') ||
       !scan_positive_int(buf, left, 2, &wct->wct_min) ||

--- a/lib/timeutils/tests/test_scan-timestamp.c
+++ b/lib/timeutils/tests/test_scan-timestamp.c
@@ -134,6 +134,16 @@ Test(parse_timestamp, bsd_extensions)
   _expect_rfc3164_timestamp_eq("Dec  3 2019 09:10:12 ", "2019-12-03T09:10:12.000+01:00");
 }
 
+Test(parse_timestamp, accept_iso_timestamps_with_space)
+{
+  _expect_rfc3164_timestamp_eq("2017-12-03 09:10:12.987+01:00", "2017-12-03T09:10:12.987+01:00");
+  _expect_rfc3164_timestamp_eq("2017-12-03 09:10:12.987", "2017-12-03T09:10:12.987+01:00");
+  _expect_rfc3164_timestamp_eq("2017-12-03 09:10:12", "2017-12-03T09:10:12.000+01:00");
+  _expect_rfc5424_timestamp_eq("2017-12-03 09:10:12.987+01:00", "2017-12-03T09:10:12.987+01:00");
+  _expect_rfc5424_timestamp_eq("2017-12-03 09:10:12.987", "2017-12-03T09:10:12.987+01:00");
+  _expect_rfc5424_timestamp_eq("2017-12-03 09:10:12", "2017-12-03T09:10:12.000+01:00");
+}
+
 Test(parse_timestamp, standard_bsd_format_year_in_the_future)
 {
   /* compared to 2017-12-13, this timestamp is from the future, so in the year 2018 */

--- a/news/feature-3893.md
+++ b/news/feature-3893.md
@@ -1,0 +1,7 @@
+syslog-format: accept ISO timestamps that incorrectly use a space instead of
+a 'T' to delimit the date from the time portion.  For example, a
+"2021-01-01T12:12:12" timestamp is well formed according to RFC5424 (which
+uses a subset of ISO8601, see https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.3).
+Some systems simply use a space instead of a 'T'.  The same format is
+accepted for both RFC3164 (e.g.  udp(), tcp() and network() sources) and
+RFC5424 (e.g.  syslog() source).

--- a/tests/unit/test_msgparse.c
+++ b/tests/unit/test_msgparse.c
@@ -498,6 +498,16 @@ Test(msgparse, test_timestamp_others)
       "", // msg
       NULL, NULL, NULL, ignore_sdata_pairs
     },
+    /* some stuff forget the 'T' in the ISO timestamp */
+    {
+      "<7>2006-10-29 02:00:00.156+01:00", LP_EXPECT_HOSTNAME, NULL,
+      7,             // pri
+      1162083600, 156000, 3600,    // timestamp (sec/usec/zone)
+      "",                // host
+      "",        // openvpn
+      "", // msg
+      NULL, NULL, NULL, ignore_sdata_pairs
+    },
     {
       "<7>2006-10-29T02:00:00.156+01:00 ctld snmpd[2499]: PTHREAD support initialized", LP_EXPECT_HOSTNAME, "^ctld",
       7,             // pri


### PR DESCRIPTION
This patch implements accepting ISO8601 timestamps with a space instead of a 'T' in the middle, as this format happens a lot in the wild.

For instance ZScaler produces this syslog header:
```
<134>2022-01-27 10:32:35      reason=Allowed... # message continues
```

The patch causes syslog-ng to accept this timestamp both in RFC5424 and RFC3164 mode. I've decided this way as even if we permitted the incorrect formatting only in RFC3164 mode, I expect the same to happen in 5424 implementations too. And I know it's against the spec, but this seems to be an uphill battle.