### PR TITLE
remove module-path and autoload-compiled-modules global defines (4.0)

### DIFF
--- a/lib/block-ref-grammar.ym
+++ b/lib/block-ref-grammar.ym
@@ -55,15 +55,7 @@ block_args
         ;
 
 block_arg
-        : LL_IDENTIFIER
-          {
-            cfg_lexer_push_context(lexer, LL_CONTEXT_BLOCK_ARG, NULL, "block argument");
-          }
-          LL_BLOCK
-          {
-            cfg_lexer_pop_context(lexer);
-            cfg_args_set(*result, $1, $3); free($1); free($3);
-          }
+        : LL_IDENTIFIER _block_arg_context_push LL_BLOCK _block_arg_context_pop  { cfg_args_set(*result, $1, $3); free($1); free($3); }
         ;
 
 /* INCLUDE_RULES */

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -316,6 +316,7 @@
 %token <cptr> LL_STRING               10433
 %token <token> LL_TOKEN               10434
 %token <cptr> LL_BLOCK                10435
+%token <cptr> LL_PLUGIN	              10436
 
 %destructor { free($$); } <cptr>
 
@@ -503,7 +504,7 @@ log_stmt
 
 
 plugin_stmt
-        : LL_IDENTIFIER
+        : LL_PLUGIN
           {
             Plugin *p;
             gint context = LL_CONTEXT_ROOT;
@@ -537,7 +538,7 @@ source_item
 	;
 
 source_plugin
-        : LL_IDENTIFIER
+        : LL_PLUGIN
           {
             Plugin *p;
             gint context = LL_CONTEXT_SOURCE;
@@ -625,7 +626,7 @@ dest_item
 	;
 
 dest_plugin
-        : LL_IDENTIFIER
+        : LL_PLUGIN
           {
             Plugin *p;
             gint context = LL_CONTEXT_DESTINATION;
@@ -915,7 +916,7 @@ options_item
 	| { last_stats_options = &configuration->stats_options; } stat_option
 	| { last_dns_cache_options = &configuration->dns_cache_options; } dns_cache_option
 	| { last_file_perm_options = &configuration->file_perm_options; } file_perm_option
-	| LL_IDENTIFIER
+	| LL_PLUGIN
           {
             Plugin *p;
             gint context = LL_CONTEXT_OPTIONS;
@@ -1099,7 +1100,7 @@ driver_option
         ;
 
 inner_source
-        : LL_IDENTIFIER
+        : LL_PLUGIN
           {
             Plugin *p;
             gint context = LL_CONTEXT_INNER_SRC;
@@ -1130,7 +1131,7 @@ source_driver_option
         ;
 
 inner_dest
-        : LL_IDENTIFIER
+        : LL_PLUGIN
           {
             Plugin *p;
             gint context = LL_CONTEXT_INNER_DEST;

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -498,14 +498,7 @@ rewrite_stmt
           }
 
 log_stmt
-        : KW_LOG
-          { cfg_lexer_push_context(lexer, LL_CONTEXT_LOG, NULL, "log statement"); }
-          '{' log_content '}'
-          { cfg_lexer_pop_context(lexer); }
-          {
-            $$ = $4;
-          }
-
+        : KW_LOG _log_context_push '{' log_content '}' _log_context_pop             { $$ = $4;}
 	;
 
 
@@ -529,13 +522,7 @@ plugin_stmt
 /* START_RULES */
 
 source_content
-        :
-          { cfg_lexer_push_context(lexer, LL_CONTEXT_SOURCE, NULL, "source statement"); }
-          source_items
-          { cfg_lexer_pop_context(lexer); }
-          {
-            $$ = log_expr_node_new_junction($2, &@$);
-          }
+        : _source_context_push source_items _source_context_pop   { $$ = log_expr_node_new_junction($2, &@$); }
         ;
 
 source_items
@@ -622,12 +609,7 @@ rewrite_content
         ;
 
 dest_content
-         : { cfg_lexer_push_context(lexer, LL_CONTEXT_DESTINATION, NULL, "destination statement"); }
-            dest_items
-           { cfg_lexer_pop_context(lexer); }
-           {
-             $$ = log_expr_node_new_junction($2, &@$);
-           }
+         : _destination_context_push dest_items _destination_context_pop               { $$ = log_expr_node_new_junction($2, &@$); }
          ;
 
 
@@ -761,10 +743,7 @@ log_flags_items
 /* END_RULES */
 
 options_stmt
-        : KW_OPTIONS
-          { cfg_lexer_push_context(lexer, LL_CONTEXT_OPTIONS, NULL, "global options"); }
-          '{' options_items '}'
-          { cfg_lexer_pop_context(lexer); }
+        : KW_OPTIONS _options_context_push '{' options_items '}' _options_context_pop
 	;
 
 template_stmt
@@ -855,18 +834,15 @@ template_item
 
 block_stmt
         : KW_BLOCK
-          { cfg_lexer_push_context(lexer, LL_CONTEXT_BLOCK_DEF, block_def_keywords, "block definition"); }
+          _block_def_context_push
           LL_IDENTIFIER LL_IDENTIFIER
           '(' { last_block_args = cfg_args_new(); } block_definition ')'
-          { cfg_lexer_push_context(lexer, LL_CONTEXT_BLOCK_CONTENT, NULL, "block content"); }
+          _block_content_context_push
           LL_BLOCK
+          _block_content_context_pop
+          _block_def_context_pop
           {
             CfgBlockGenerator *block;
-
-            /* block content */
-            cfg_lexer_pop_context(lexer);
-            /* block definition */
-            cfg_lexer_pop_context(lexer);
 
             gint context_type = cfg_lexer_lookup_context_type_by_name($3);
             CHECK_ERROR(context_type, @3, "unknown context \"%s\"", $3);
@@ -891,15 +867,7 @@ block_args
         ;
 
 block_arg
-        : LL_IDENTIFIER
-          {
-            cfg_lexer_push_context(lexer, LL_CONTEXT_BLOCK_ARG, NULL, "block argument");
-          }
-          LL_BLOCK
-          {
-            cfg_lexer_pop_context(lexer);
-            cfg_args_set(last_block_args, $1, $3); free($1); free($3);
-          }
+        : LL_IDENTIFIER _block_arg_context_push LL_BLOCK _block_arg_context_pop      { cfg_args_set(last_block_args, $1, $3); free($1); free($3); }
         ;
 
 options_items
@@ -1480,6 +1448,35 @@ rewrite_condition_opt
           } ')'
         ;
 
+
+_root_context_push: { cfg_lexer_push_context(lexer, LL_CONTEXT_ROOT, NULL, "root context"); };
+_root_context_pop: { cfg_lexer_pop_context(lexer); };
+_destination_context_push: { cfg_lexer_push_context(lexer, LL_CONTEXT_DESTINATION, NULL, "destination statement"); };
+_destination_context_pop: { cfg_lexer_pop_context(lexer); };
+_source_context_push: { cfg_lexer_push_context(lexer, LL_CONTEXT_SOURCE, NULL, "source statement"); };
+_source_context_pop:  { cfg_lexer_pop_context(lexer); };
+_parser_context_push: { cfg_lexer_push_context(lexer, LL_CONTEXT_PARSER, NULL, "parser statement"); };
+_parser_context_pop: { cfg_lexer_pop_context(lexer); };
+_rewrite_context_push: { cfg_lexer_push_context(lexer, LL_CONTEXT_REWRITE, NULL, "rewrite statement"); };
+_rewrite_context_pop: { cfg_lexer_pop_context(lexer); };
+_filter_context_push: { cfg_lexer_push_context(lexer, LL_CONTEXT_FILTER, NULL, "filter statement"); };
+_filter_context_pop: { cfg_lexer_pop_context(lexer); };
+_log_context_push: { cfg_lexer_push_context(lexer, LL_CONTEXT_LOG, NULL, "log statement"); };
+_log_context_pop: { cfg_lexer_pop_context(lexer); };
+_block_def_context_push: { cfg_lexer_push_context(lexer, LL_CONTEXT_BLOCK_DEF, block_def_keywords, "block definition"); };
+_block_def_context_pop: { cfg_lexer_pop_context(lexer); };
+_block_ref_context_push: { cfg_lexer_push_context(lexer, LL_CONTEXT_BLOCK_REF, NULL, "block reference"); };
+_block_ref_context_pop: { cfg_lexer_pop_context(lexer); };
+_block_content_context_push: { cfg_lexer_push_context(lexer, LL_CONTEXT_BLOCK_CONTENT, NULL, "block content"); };
+_block_content_context_pop: { cfg_lexer_pop_context(lexer); };
+_block_arg_context_push: { cfg_lexer_push_context(lexer, LL_CONTEXT_BLOCK_ARG, NULL, "block argument"); };
+_block_arg_context_pop: { cfg_lexer_pop_context(lexer); };
+_inner_dest_context_push: { cfg_lexer_push_context(lexer, LL_CONTEXT_INNER_DEST, NULL, "within destination"); };
+_inner_dest_context_pop: { cfg_lexer_pop_context(lexer); };
+_inner_src_context_push: { cfg_lexer_push_context(lexer, LL_CONTEXT_INNER_SRC, NULL, "within source"); };
+_inner_src_context_pop: { cfg_lexer_pop_context(lexer); };
+_options_context_push: { cfg_lexer_push_context(lexer, LL_CONTEXT_OPTIONS, NULL, "options statement"); };
+_options_context_pop: { cfg_lexer_pop_context(lexer); };
 
 /* END_RULES */
 

--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -321,7 +321,7 @@ word	[^ \#'"\(\)\{\}\[\]\\;\r\n\t,|\.@:]
                                }
                              return LL_NUMBER;
                            }
-({word}+(\.)?)*{word}+ 	   { return cfg_lexer_lookup_keyword(yyextra, yylval, yylloc, yytext); }
+({word}+(\.)?)*{word}+ 	   { return cfg_lexer_map_word_to_token(yyextra, yylval, yylloc, yytext); }
 \,			   ;
 
 \"                         {

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -1020,23 +1020,6 @@ cfg_lexer_preprocess(CfgLexer *self, gint tok, CFG_STYPE *yylval, CFG_LTYPE *yyl
 
       return CLPR_LEX_AGAIN;
     }
-  else if (cfg_lexer_get_context_type(self) != LL_CONTEXT_PRAGMA && !self->non_pragma_seen)
-    {
-      /* first non-pragma token */
-
-      if (self->cfg->user_version == 0)
-        {
-          msg_error("ERROR: configuration files without a version number has become unsupported in " VERSION_3_13
-                    ", please specify a version number using @version and update your configuration accordingly");
-          return CLPR_ERROR;
-        }
-
-      cfg_discover_candidate_modules(self->cfg);
-
-      cfg_load_forced_modules(self->cfg);
-
-      self->non_pragma_seen = TRUE;
-    }
 
   return CLPR_OK;
 }

--- a/lib/cfg-lexer.h
+++ b/lib/cfg-lexer.h
@@ -176,7 +176,7 @@ struct _CfgLexer
   GString *token_pretext;
   GString *token_text;
   GlobalConfig *cfg;
-  gboolean non_pragma_seen:1, ignore_pragma:1;
+  gboolean ignore_pragma:1;
 };
 
 /* pattern buffer */

--- a/lib/cfg-lexer.h
+++ b/lib/cfg-lexer.h
@@ -190,7 +190,7 @@ void cfg_lexer_append_char(CfgLexer *self, char c);
 /* keyword handling */
 void cfg_lexer_set_current_keywords(CfgLexer *self, CfgLexerKeyword *keywords);
 char *cfg_lexer_get_keyword_string(CfgLexer *self, int kw);
-int cfg_lexer_lookup_keyword(CfgLexer *self, CFG_STYPE *yylval, CFG_LTYPE *yylloc, const char *token);
+int cfg_lexer_map_word_to_token(CfgLexer *self, CFG_STYPE *yylval, CFG_LTYPE *yylloc, const char *token);
 
 /* include files */
 gboolean cfg_lexer_start_next_include(CfgLexer *self);

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -255,7 +255,7 @@ _construct_plugin_prelude(GlobalConfig *cfg, Plugin *plugin, CFG_LTYPE *yylloc)
   /* start a new lexer context, so plugin specific keywords are recognized,
    * we only do this to lookup the parser name. */
   cfg_lexer_push_context(cfg->lexer, plugin->parser->context, plugin->parser->keywords, plugin->parser->name);
-  cfg_lexer_lookup_keyword(cfg->lexer, &token, yylloc, plugin->name);
+  cfg_lexer_map_word_to_token(cfg->lexer, &token, yylloc, plugin->name);
   cfg_lexer_pop_context(cfg->lexer);
 
   /* add plugin name token */

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -647,6 +647,9 @@ cfg_read_config(GlobalConfig *self, const gchar *fname, gchar *preprocess_into)
   FILE *cfg_file;
   gint res;
 
+  cfg_discover_candidate_modules(self);
+  cfg_load_forced_modules(self);
+
   self->filename = fname;
 
   if ((cfg_file = fopen(fname, "r")) != NULL)
@@ -661,6 +664,13 @@ cfg_read_config(GlobalConfig *self, const gchar *fname, gchar *preprocess_into)
       if (preprocess_into)
         {
           cfg_dump_processed_config(self->preprocess_config, preprocess_into);
+        }
+
+      if (self->user_version == 0)
+        {
+          msg_error("ERROR: configuration files without a version number have become unsupported in " VERSION_3_13
+                    ", please specify a version number using @version as the first line in the configuration file");
+          return FALSE;
         }
 
       if (res)

--- a/lib/filter/filter-expr-grammar.ym
+++ b/lib/filter/filter-expr-grammar.ym
@@ -139,8 +139,8 @@ filter_simple_expr
             free($6);
           }
 	| filter_re					{ $$ = last_filter_expr; }
-	| filter_plugin
 	| filter_comparison
+	| filter_plugin
 	;
 
 filter_plugin
@@ -164,15 +164,15 @@ filter_plugin
 	;
 
 filter_identifier
-  : LL_IDENTIFIER
-  | KW_THROTTLE
-      {
-        msg_warning_once("WARNING: the throttle() filter has been renamed to rate-limit() in " VERSION_3_36
-                         ", please update your configuration to use the name rate-limit() instead of throttle()",
-                         cfg_lexer_format_location_tag(lexer, &@0));
-        $$ = g_strdup("rate-limit");
-      }
-  ;
+        : LL_PLUGIN
+        | KW_THROTTLE
+            {
+              msg_warning_once("WARNING: the throttle() filter has been renamed to rate-limit() in " VERSION_3_36
+                               ", please update your configuration to use the name rate-limit() instead of throttle()",
+                               cfg_lexer_format_location_tag(lexer, &@0));
+              $$ = g_strdup("rate-limit");
+            }
+        ;
 
 filter_comparison
 	: LL_STRING operator LL_STRING

--- a/lib/logmsg/tests/Makefile.am
+++ b/lib/logmsg/tests/Makefile.am
@@ -53,6 +53,8 @@ lib_logmsg_tests_test_logmsg_ack_CFLAGS = $(TEST_CFLAGS)
 lib_logmsg_tests_test_nvhandle_desc_array_LDADD = $(TEST_LDADD)
 lib_logmsg_tests_test_nvhandle_desc_array_CFLAGS = $(TEST_CFLAGS)
 
+.PHONY: dump-logmsg
+
 if ENABLE_TESTING
 noinst_PROGRAMS +=				\
 	lib/logmsg/tests/dump_logmsg
@@ -60,7 +62,6 @@ noinst_PROGRAMS +=				\
 lib_logmsg_tests_dump_logmsg_CFLAGS = $(TEST_CFLAGS)
 lib_logmsg_tests_dump_logmsg_LDADD = $(TEST_LDADD) $(PREOPEN_SYSLOGFORMAT)
 
-.PHONY: dump-logmsg
 dump-logmsg: lib/logmsg/tests/dump_logmsg
 	DIR=lib/logmsg/tests/messages/ && \
 	mkdir -p $${DIR} && \

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -596,6 +596,9 @@ main_loop_init(MainLoop *self, MainLoopOptions *options)
   setup_signals(self);
 
   self->current_configuration = cfg_new(0);
+
+  if (self->options->disable_module_discovery)
+    self->current_configuration->use_plugin_discovery = FALSE;
 }
 
 /*

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -37,6 +37,7 @@ typedef struct _MainLoopOptions
   gboolean syntax_only;
   gboolean interactive_mode;
   gboolean server_mode;
+  gboolean disable_module_discovery;
 } MainLoopOptions;
 
 extern ThreadId main_thread_handle;

--- a/lib/parser/parser-expr-grammar.ym
+++ b/lib/parser/parser-expr-grammar.ym
@@ -62,7 +62,7 @@ parser_expr_list
 
 
 parser_expr
-        : LL_IDENTIFIER
+        : LL_PLUGIN
           {
             Plugin *p;
             gint context = LL_CONTEXT_PARSER;

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -425,6 +425,21 @@ plugin_is_module_available(PluginContext *context, const gchar *module_name)
   return FALSE;
 }
 
+gboolean
+plugin_is_plugin_available(PluginContext *context, gint plugin_type, const gchar *plugin_name)
+{
+  Plugin *p;
+  PluginCandidate *candidate;
+
+  p = _find_plugin_in_list(context->plugins, plugin_type, plugin_name);
+  if (p)
+    return TRUE;
+
+  candidate = (PluginCandidate *) _find_plugin_in_list(context->candidate_plugins, plugin_type, plugin_name);
+  return !!candidate;
+}
+
+
 /************************************************************
  * Candidate modules
  ************************************************************/

--- a/lib/plugin.h
+++ b/lib/plugin.h
@@ -106,6 +106,7 @@ void plugin_candidate_free(PluginCandidate *self);
 
 void plugin_register(PluginContext *context, Plugin *p, gint number);
 gboolean plugin_load_module(PluginContext *context, const gchar *module_name, CfgArgs *args);
+gboolean plugin_is_plugin_available(PluginContext *context, gint plugin_type, const gchar *plugin_name);
 gboolean plugin_is_module_available(PluginContext *context, const gchar *module_name);
 
 void plugin_list_modules(FILE *out, gboolean verbose);

--- a/lib/pragma-grammar.ym
+++ b/lib/pragma-grammar.ym
@@ -59,6 +59,15 @@
 
 CfgArgs *last_module_args = NULL;
 
+static void
+pragma_define_global(GlobalConfig *cfg, const gchar *name, const gchar *value)
+{
+  msg_debug("Global value changed",
+            evt_tag_str("define", name),
+            evt_tag_str("value", value));
+  cfg_args_set(cfg->globals, name, value);
+}
+
 }
 
 %type   <cptr> requires_message
@@ -107,10 +116,7 @@ version_stmt
 define_stmt
 	: KW_DEFINE LL_IDENTIFIER string_or_number
           {
-            msg_debug("Global value changed",
-                      evt_tag_str("define", $2),
-                      evt_tag_str("value", $3));
-	    cfg_args_set(configuration->globals, $2, $3);
+            pragma_define_global(configuration, $2, $3);
             free($2);
             free($3);
           }

--- a/lib/pragma-grammar.ym
+++ b/lib/pragma-grammar.ym
@@ -60,11 +60,26 @@
 CfgArgs *last_module_args = NULL;
 
 static void
+_report_define_deprecations(const gchar *name, const gchar *value)
+{
+  if (strcmp(name, "autoload-compiled-modules") == 0 && atoi(value) == 0)
+    msg_warning("WARNING: disabling plugin discovery via the autoload-compiled-modules "
+                "@define has become unsupported in " VERSION_3_36
+                ", use the syslog-ng command line option --no-module-discovery instead");
+  else if (strcmp(name, "module-path") == 0)
+    msg_warning("WARNING: changing the path to runtime loaded modules via the module-path "
+                "@define has become unsupported in " VERSION_3_36
+                ", use the command line option --module-path instead");
+}
+
+static void
 pragma_define_global(GlobalConfig *cfg, const gchar *name, const gchar *value)
 {
   msg_debug("Global value changed",
             evt_tag_str("define", name),
             evt_tag_str("value", value));
+
+  _report_define_deprecations(name, value);
   cfg_args_set(cfg->globals, name, value);
 }
 

--- a/lib/rewrite/rewrite-expr-grammar.ym
+++ b/lib/rewrite/rewrite-expr-grammar.ym
@@ -158,7 +158,7 @@ rewrite_expr
             last_rewrite = log_rewrite_set_facility_new($3, configuration);
             log_template_unref($3);
           } rewrite_set_facility_opts ')'       { $$ = last_rewrite; };
-        | LL_IDENTIFIER
+        | LL_PLUGIN
           {
             Plugin *p;
             gint context = LL_CONTEXT_REWRITE;

--- a/modules/afamqp/afamqp-grammar.ym
+++ b/modules/afamqp/afamqp-grammar.ym
@@ -70,7 +70,7 @@ start
           {
             last_driver = *instance = afamqp_dd_new(configuration);
           }
-          '(' afamqp_options ')'		{ YYACCEPT; }
+          '(' _inner_dest_context_push afamqp_options _inner_dest_context_pop ')'		{ YYACCEPT; }
 	;
 
 afamqp_options

--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -119,15 +119,15 @@ start
         ;
 
 source_affile
-	: KW_FILE '(' source_affile_params ')'	{ $$ = $3; }
-	| KW_PIPE '(' source_afpipe_params ')'	{ $$ = $3; }
-	| KW_STDIN '(' source_stdin_params ')'	{ $$ = $3; }
+	: KW_FILE '(' _inner_src_context_push source_affile_params _inner_src_context_pop ')'	{ $$ = $4; }
+	| KW_PIPE '(' _inner_src_context_push source_afpipe_params _inner_src_context_pop ')'	{ $$ = $4; }
+	| KW_STDIN '(' _inner_src_context_push source_stdin_params _inner_src_context_pop ')'	{ $$ = $4; }
 	| KW_WILDCARD_FILE
 	{
 	  WildcardSourceDriver *sd = (WildcardSourceDriver *) wildcard_sd_new(configuration);;
 	  *instance = &sd->super.super;
 	  affile_grammar_set_wildcard_file_source_driver(sd);
-	} '(' source_wildcard_params ')' { $$ = last_driver; }
+	} '(' _inner_src_context_push source_wildcard_params _inner_src_context_pop ')' { $$ = last_driver; }
 	;
 
 source_wildcard_params
@@ -269,8 +269,8 @@ multi_line_timeout
 	;
 
 dest_affile
-	: KW_FILE '(' dest_affile_params ')'	{ $$ = $3; }
-	| KW_PIPE '(' dest_afpipe_params ')'    { $$ = $3; }
+	: KW_FILE '(' _inner_dest_context_push dest_affile_params _inner_dest_context_pop ')'	{ $$ = $4; }
+	| KW_PIPE '(' _inner_dest_context_push dest_afpipe_params _inner_dest_context_pop ')'   { $$ = $4; }
 	;
 
 dest_affile_params

--- a/modules/afmongodb/afmongodb-grammar.ym
+++ b/modules/afmongodb/afmongodb-grammar.ym
@@ -55,7 +55,7 @@ start
         {
             last_driver = *instance = afmongodb_dd_new(configuration);
         }
-        '(' afmongodb_options ')'         { YYACCEPT; }
+        '(' _inner_dest_context_push afmongodb_options _inner_dest_context_pop ')'         { YYACCEPT; }
     ;
 
 afmongodb_options

--- a/modules/afprog/afprog-grammar.ym
+++ b/modules/afprog/afprog-grammar.ym
@@ -69,7 +69,7 @@ start
         ;
 
 source_afprogram
-	: KW_PROGRAM '(' source_afprogram_params ')' { $$ = $3; }
+	: KW_PROGRAM '(' _inner_src_context_push source_afprogram_params _inner_src_context_pop ')' { $$ = $4; }
 	;
 
 source_afprogram_params
@@ -93,7 +93,7 @@ source_afprogram_option
 	;
 
 dest_afprogram
-	: KW_PROGRAM '(' dest_afprogram_params ')' { $$ = $3; }
+	: KW_PROGRAM '(' _inner_dest_context_push dest_afprogram_params _inner_dest_context_pop ')' { $$ = $4; }
 	;
 
 dest_afprogram_params

--- a/modules/afsmtp/afsmtp-grammar.ym
+++ b/modules/afsmtp/afsmtp-grammar.ym
@@ -63,7 +63,7 @@ start
           {
             last_driver = *instance = afsmtp_dd_new(configuration);
           }
-          '(' afsmtp_options ')'         { YYACCEPT; }
+          '(' _inner_dest_context_push afsmtp_options _inner_dest_context_pop ')'         { YYACCEPT; }
         ;
 
 afsmtp_options

--- a/modules/afsnmp/afsnmp-grammar.ym
+++ b/modules/afsnmp/afsnmp-grammar.ym
@@ -78,7 +78,7 @@ start
         ;
 
 dest_snmpdest
-	: KW_SNMPDEST '(' dest_snmpdest_params ')'
+	: KW_SNMPDEST '(' _inner_dest_context_push dest_snmpdest_params _inner_dest_context_pop ')'
 	;
 
 dest_snmpdest_params

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -260,8 +260,8 @@ driver
 
 
 source_afunix
-        : KW_UNIX_DGRAM '(' source_afunix_dgram_params ')'	                                { $$ = $3; }
-	| KW_UNIX_STREAM '(' source_afunix_stream_params ')' 	                                { $$ = $3; }
+        : KW_UNIX_DGRAM '(' _inner_src_context_push source_afunix_dgram_params _inner_src_context_pop ')'	        { $$ = $4; }
+	| KW_UNIX_STREAM '(' _inner_src_context_push source_afunix_stream_params _inner_src_context_pop ')' 	        { $$ = $4; }
 	;
 
 source_afunix_dgram_params
@@ -306,10 +306,10 @@ source_afunix_option
 	;
 
 source_afinet
-	: KW_UDP '(' source_afinet_udp_params ')'		{ $$ = $3; }
-	| KW_TCP '(' source_afinet_tcp_params ')'		{ $$ = $3; }
-	| KW_UDP6 '(' source_afinet_udp6_params ')'		{ $$ = $3; }
-	| KW_TCP6 '(' source_afinet_tcp6_params ')'		{ $$ = $3; }
+	: KW_UDP '(' _inner_src_context_push source_afinet_udp_params _inner_src_context_pop ')'	{ $$ = $4; }
+	| KW_TCP '(' _inner_src_context_push source_afinet_tcp_params _inner_src_context_pop ')'	{ $$ = $4; }
+	| KW_UDP6 '(' _inner_src_context_push source_afinet_udp6_params _inner_src_context_pop ')'	{ $$ = $4; }
+	| KW_TCP6 '(' _inner_src_context_push source_afinet_tcp6_params _inner_src_context_pop ')'	{ $$ = $4; }
         ;
 
 source_afinet_udp_params
@@ -401,7 +401,7 @@ source_afsocket_stream_params
 	;
 
 source_afsyslog
-	: KW_SYSLOG '(' source_afsyslog_params ')'		{ $$ = $3; }
+	: KW_SYSLOG '(' _inner_src_context_push source_afsyslog_params _inner_src_context_pop ')'	{ $$ = $4; }
 	;
 
 source_afsyslog_params
@@ -427,7 +427,7 @@ source_afsyslog_option
 	;
 
 source_afnetwork
-	: KW_NETWORK '(' source_afnetwork_params ')'    { $$ = $3; }
+	: KW_NETWORK '(' _inner_src_context_push source_afnetwork_params _inner_src_context_pop ')'    { $$ = $4; }
 	;
 
 source_afnetwork_params
@@ -485,7 +485,7 @@ source_afsocket_transport
         ;
 
 source_systemd_syslog
-	: KW_SYSTEMD_SYSLOG '(' source_systemd_syslog_params ')'  { $$ = $3; }
+	: KW_SYSTEMD_SYSLOG '(' _inner_src_context_push source_systemd_syslog_params _inner_src_context_pop ')'  { $$ = $4; }
 	;
 
 source_systemd_syslog_params
@@ -515,8 +515,8 @@ source_systemd_syslog_option
         ;
 
 dest_afunix
-	: KW_UNIX_DGRAM '(' dest_afunix_dgram_params ')'	{ $$ = $3; }
-	| KW_UNIX_STREAM '(' dest_afunix_stream_params ')'	{ $$ = $3; }
+	: KW_UNIX_DGRAM '(' _inner_dest_context_push dest_afunix_dgram_params _inner_dest_context_pop ')'	{ $$ = $4; }
+	| KW_UNIX_STREAM '(' _inner_dest_context_push dest_afunix_stream_params _inner_dest_context_pop ')'	{ $$ = $4; }
 	;
 
 dest_afunix_dgram_params
@@ -552,10 +552,10 @@ dest_afunix_option
 	;
 
 dest_afinet
-	: KW_UDP '(' dest_afinet_udp_params ')'			{ $$ = $3; }
-	| KW_TCP '(' dest_afinet_tcp_params ')'			{ $$ = $3; }
-	| KW_UDP6 '(' dest_afinet_udp6_params ')'		{ $$ = $3; }
-	| KW_TCP6 '(' dest_afinet_tcp6_params ')'		{ $$ = $3; }
+	: KW_UDP '(' _inner_dest_context_push dest_afinet_udp_params _inner_dest_context_pop ')'			{ $$ = $4; }
+	| KW_TCP '(' _inner_dest_context_push dest_afinet_tcp_params _inner_dest_context_pop ')'			{ $$ = $4; }
+	| KW_UDP6 '(' _inner_dest_context_push dest_afinet_udp6_params _inner_dest_context_pop ')'		{ $$ = $4; }
+	| KW_TCP6 '(' _inner_dest_context_push dest_afinet_tcp6_params	_inner_dest_context_pop ')'		{ $$ = $4; }
 	;
 
 dest_afinet_udp_params
@@ -680,7 +680,7 @@ dest_afsocket_option
 
 
 dest_afsyslog
-        : KW_SYSLOG '(' dest_afsyslog_params ')'   { $$ = $3; }
+        : KW_SYSLOG '(' _inner_dest_context_push dest_afsyslog_params _inner_dest_context_pop ')'   { $$ = $4; }
 
 dest_afsyslog_params
         : string
@@ -704,7 +704,7 @@ dest_afsyslog_option
 	;
 
 dest_afnetwork
-	: KW_NETWORK '(' dest_afnetwork_params ')'	{ $$ = $3; }
+	: KW_NETWORK '(' _inner_dest_context_push dest_afnetwork_params _inner_dest_context_pop ')'	{ $$ = $4; }
 	;
 
 dest_afnetwork_params

--- a/modules/afsql/afsql-grammar.ym
+++ b/modules/afsql/afsql-grammar.ym
@@ -79,7 +79,7 @@ start
 
 
 dest_afsql
-        : KW_SQL '(' dest_afsql_params ')'	{ $$ = $3; }
+        : KW_SQL '(' _inner_dest_context_push dest_afsql_params _inner_dest_context_pop ')'	{ $$ = $4; }
         ;
 
 dest_afsql_params

--- a/modules/afstomp/afstomp-grammar.ym
+++ b/modules/afstomp/afstomp-grammar.ym
@@ -61,7 +61,7 @@ start
           {
             last_driver = *instance = afstomp_dd_new(configuration);
           }
-          '(' afstomp_options ')'		{ YYACCEPT; }
+          '(' _inner_dest_context_push afstomp_options _inner_dest_context_pop ')'		{ YYACCEPT; }
           ;
 
 afstomp_options

--- a/modules/afstreams/afstreams-grammar.ym
+++ b/modules/afstreams/afstreams-grammar.ym
@@ -64,7 +64,7 @@ start
   ;
 
 source_afstreams
-	: KW_SUN_STREAMS '(' source_afstreams_params ')'	{ $$ = $3; }
+	: KW_SUN_STREAMS '(' _inner_src_context_push source_afstreams_params _inner_src_context_pop ')'	{ $$ = $4; }
 	;
 
 source_afstreams_params

--- a/modules/appmodel/appmodel-grammar.ym
+++ b/modules/appmodel/appmodel-grammar.ym
@@ -84,22 +84,8 @@ application_options
 	;
 
 application_option
-	: KW_FILTER
-          { cfg_lexer_push_context(lexer, LL_CONTEXT_BLOCK_CONTENT, NULL, "app filter block"); }
-	  LL_BLOCK
-          { cfg_lexer_pop_context(lexer); }
-          {
-            application_set_filter(last_application, $3);
-            free($3);
-          }
-	| KW_PARSER
-          { cfg_lexer_push_context(lexer, LL_CONTEXT_BLOCK_CONTENT, NULL, "app parser block"); }
-	  LL_BLOCK
-          { cfg_lexer_pop_context(lexer); }
-          {
-            application_set_parser(last_application, $3);
-            free($3);
-          }
+	: KW_FILTER _block_content_context_push LL_BLOCK _block_content_context_pop  { application_set_filter(last_application, $3); free($3); }
+	| KW_PARSER _block_content_context_push LL_BLOCK _block_content_context_pop  { application_set_parser(last_application, $3); free($3); }
 	;
 
 /* INCLUDE_RULES */

--- a/modules/examples/destinations/example_destination/example_destination-grammar.ym
+++ b/modules/examples/destinations/example_destination/example_destination-grammar.ym
@@ -52,7 +52,7 @@ start
           {
             last_driver = *instance = example_destination_dd_new(configuration);
           }
-          '(' example_destination_option ')' { YYACCEPT; }
+          '(' _inner_dest_context_push example_destination_option _inner_dest_context_pop ')' { YYACCEPT; }
 ;
 
 example_destination_options

--- a/modules/examples/sources/msg-generator/msg-generator-grammar.ym
+++ b/modules/examples/sources/msg-generator/msg-generator-grammar.ym
@@ -76,7 +76,7 @@ source_msg_generator
       last_msg_generator_source_options = msg_generator_sd_get_source_options(last_driver);
       last_source_options = &last_msg_generator_source_options->super;
     }
-    '(' source_msg_generator_options ')' { $$ = last_driver; }
+    '(' _inner_src_context_push source_msg_generator_options _inner_src_context_pop ')' { $$ = last_driver; }
   ;
 
 source_msg_generator_options

--- a/modules/examples/sources/threaded-diskq-source/threaded-diskq-source-grammar.ym
+++ b/modules/examples/sources/threaded-diskq-source/threaded-diskq-source-grammar.ym
@@ -69,7 +69,7 @@ threaded_diskq_source
     {
       last_driver = *instance = threaded_diskq_sd_new(configuration);
     }
-    '(' threaded_diskq_source_options ')' { $$ = last_driver; }
+    '(' _inner_src_context_push threaded_diskq_source_options _inner_src_context_pop ')' { $$ = last_driver; }
   ;
 
 threaded_diskq_source_options

--- a/modules/examples/sources/threaded-random-generator/threaded-random-generator-grammar.ym
+++ b/modules/examples/sources/threaded-random-generator/threaded-random-generator-grammar.ym
@@ -71,7 +71,7 @@ source_threaded_random_generator
     {
       last_driver = *instance = threaded_random_generator_sd_new(configuration);
     }
-    '(' source_threaded_random_generator_options ')' { $$ = last_driver; }
+    '(' _inner_src_context_push source_threaded_random_generator_options _inner_src_context_pop ')' { $$ = last_driver; }
   ;
 
 source_threaded_random_generator_options

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -111,7 +111,7 @@ http_destination
       {
         last_driver = http_dd_new(configuration);
       }
-      '(' http_options ')'  { $$ = last_driver; }
+      '(' _inner_dest_context_push http_options _inner_dest_context_pop ')'  { $$ = last_driver; }
     ;
 
 http_options

--- a/modules/java/native/java-grammar.ym
+++ b/modules/java/native/java-grammar.ym
@@ -59,7 +59,7 @@ start
           {
             last_driver = *instance = java_dd_new(configuration);
           }
-          '(' java_dest_options ')'		{ YYACCEPT; }
+          '(' _inner_dest_context_push java_dest_options  _inner_dest_context_pop ')'		{ YYACCEPT; }
         | LL_CONTEXT_OPTIONS java_global_option { YYACCEPT; }
         ;
 

--- a/modules/kafka/kafka-grammar.ym
+++ b/modules/kafka/kafka-grammar.ym
@@ -72,7 +72,7 @@ start
           {
             last_driver = *instance = kafka_dd_new(configuration);
           }
-          '(' kafka_options ')' { YYACCEPT; }
+          '(' _inner_dest_context_push kafka_options _inner_dest_context_push ')' { YYACCEPT; }
         ;
 
 kafka_options

--- a/modules/mqtt/mqtt-grammar.ym
+++ b/modules/mqtt/mqtt-grammar.ym
@@ -80,13 +80,13 @@ start
             last_driver = *instance = mqtt_dd_new(configuration);
             last_options = mqtt_dd_get_options(last_driver);
           }
-          '(' mqtt_destination_options ')' { YYACCEPT; }
+          '(' _inner_dest_context_push mqtt_destination_options _inner_dest_context_pop ')' { YYACCEPT; }
         | LL_CONTEXT_SOURCE KW_MQTT
           {
             last_driver = *instance = mqtt_sd_new(configuration);
             last_options = mqtt_sd_get_options(last_driver);
           }
-          '(' mqtt_source_options ')' { YYACCEPT; }
+          '(' _inner_src_context_push mqtt_source_options _inner_src_context_pop ')' { YYACCEPT; }
 ;
 
 mqtt_destination_options

--- a/modules/openbsd/openbsd-grammar.ym
+++ b/modules/openbsd/openbsd-grammar.ym
@@ -66,7 +66,7 @@ start
 
 
 source_openbsd
-	: KW_OPENBSD '(' source_openbsd_options ')'
+	: KW_OPENBSD '(' _inner_src_context_push source_openbsd_options _inner_src_context_pop ')'
 	  {
 	    last_driver = *instance = openbsd_sd_new(configuration);
 	  }

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -69,27 +69,27 @@ start
           {
             last_driver = *instance = python_dd_new(configuration);
           }
-          '(' python_dd_options ')'         { YYACCEPT; }
+          '(' _inner_dest_context_push python_dd_options _inner_dest_context_pop ')'         { YYACCEPT; }
         | LL_CONTEXT_PARSER KW_PYTHON
 	      {
 	        last_parser = *instance = python_parser_new(configuration);
           }
-          '(' python_parser_options ')' { YYACCEPT; }
+          '(' python_parser_options ')'                                                      { YYACCEPT; }
         | LL_CONTEXT_SOURCE KW_PYTHON
           {
             last_driver = *instance = python_sd_new(configuration);
           }
-          '(' python_sd_options ')'         { YYACCEPT; }
+          '(' _inner_src_context_push python_sd_options _inner_src_context_pop ')'           { YYACCEPT; }
         | LL_CONTEXT_SOURCE KW_PYTHON_FETCHER
           {
             last_driver = *instance = python_fetcher_new(configuration);
           }
-          '(' python_fetcher_options ')'         { YYACCEPT; }
+          '(' _inner_src_context_push python_fetcher_options _inner_src_context_pop ')'      { YYACCEPT; }
         | LL_CONTEXT_INNER_DEST KW_PYTHON_HTTP_HEADER
           {
             last_header = *instance = python_http_header_new();
           }
-          '(' python_http_header_options ')'    { YYACCEPT; }
+          '(' python_http_header_options ')'                                                 { YYACCEPT; }
         | LL_CONTEXT_ROOT KW_PYTHON _block_content_context_push LL_BLOCK _block_content_context_pop
           {
             gboolean result;

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -90,10 +90,7 @@ start
             last_header = *instance = python_http_header_new();
           }
           '(' python_http_header_options ')'    { YYACCEPT; }
-        | LL_CONTEXT_ROOT KW_PYTHON
-          { cfg_lexer_push_context(lexer, LL_CONTEXT_BLOCK_CONTENT, NULL, "Python code"); }
-          LL_BLOCK
-          { cfg_lexer_pop_context(lexer); }
+        | LL_CONTEXT_ROOT KW_PYTHON _block_content_context_push LL_BLOCK _block_content_context_pop
           {
             gboolean result;
 

--- a/modules/redis/redis-grammar.ym
+++ b/modules/redis/redis-grammar.ym
@@ -53,7 +53,7 @@ start
           {
             last_driver = *instance = redis_dd_new(configuration);
           }
-          '(' redis_options ')' { YYACCEPT; }
+          '(' _inner_dest_context_push redis_options _inner_dest_context_pop ')' { YYACCEPT; }
 ;
 
 redis_options

--- a/modules/riemann/riemann-grammar.ym
+++ b/modules/riemann/riemann-grammar.ym
@@ -68,7 +68,7 @@ start
           {
             last_driver = *instance = riemann_dd_new(configuration);
           }
-          '(' riemann_options ')'         { YYACCEPT; }
+          '(' _inner_dest_context_push riemann_options _inner_dest_context_pop ')'         { YYACCEPT; }
         ;
 
 riemann_options

--- a/modules/systemd-journal/systemd-journal-grammar.ym
+++ b/modules/systemd-journal/systemd-journal-grammar.ym
@@ -68,7 +68,7 @@ start
         ;
 
 source_systemd_journal
-	: KW_SYSTEMD_JOURNAL '(' source_systemd_journal_params ')' { $$ = $3; }
+	: KW_SYSTEMD_JOURNAL '(' _inner_src_context_push source_systemd_journal_params _inner_src_context_pop ')' { $$ = $4; }
 	;
 
 source_systemd_journal_params

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -73,6 +73,7 @@ static GOptionEntry syslogng_options[] =
   { "version",           'V',         0, G_OPTION_ARG_NONE, &display_version, "Display version number (" SYSLOG_NG_PACKAGE_NAME " " SYSLOG_NG_COMBINED_VERSION ")", NULL },
   { "module-path",         0,         0, G_OPTION_ARG_STRING, &resolvedConfigurablePaths.initial_module_path, "Set the list of colon separated directories to search for modules, default=" SYSLOG_NG_MODULE_PATH, "<path>" },
   { "module-registry",     0,         0, G_OPTION_ARG_NONE, &display_module_registry, "Display module information", NULL },
+  { "no-module-discovery", 0,         0, G_OPTION_ARG_NONE, &main_loop_options.disable_module_discovery, "Disable module auto-discovery, all modules need to be loaded explicitly by the configuration", NULL },
   { "seed",              'S',         0, G_OPTION_ARG_NONE, &dummy, "Does nothing, the need to seed the random generator is autodetected", NULL},
 #ifdef YYDEBUG
   { "yydebug",           'y',         0, G_OPTION_ARG_NONE, &cfg_parser_debug, "Enable configuration parser debugging", NULL },


### PR DESCRIPTION
This branch introduces a significant simplification of the startup process by eliminating a couple of global `@defines` in the configuration. At the same time it lays the groundwork for a more elaborate expression language in filter comparisons.

Let's go one by one:
  * in a way this is part of the 4.0 patches, however can be merged earlier, as it is based on master and not on any other part of the typing branch
  * this branch gets rid of two defines: `module-path` (replaced by a similarly named command line option), and also `autoload-compiled-modules` (replaced by --no-module-discovery command line option)
  * by getting rid of these, we can simplify startup a lot. Previously even the lexer was involved in deciding when to start plugin discovery.
  * also, this enables the use of a new token LL_PLUGIN for plugin insertion points, instead of the generic LL_IDENTIFIER that we used. This allowed me to greatly extend the filter comparison grammar.

Compatibility concerns:
  * this patch introduces an incompatible change, but I have never seen the use of `module-path` or `autoload-compiled-modules`. I even tried to google them for 10 minutes.
  * These options are documented though.

Other than these concerns, My opinion is that this could be pulled in to a regular 3.x release as well.