### PR TITLE
Fix SIGSEGV in the "CONFIG" command over syslog-ng-ctl

### DIFF
--- a/lib/control/tests/test_control_cmds.c
+++ b/lib/control/tests/test_control_cmds.c
@@ -117,7 +117,7 @@ Test(control_cmds, test_log)
   const gchar *response;
 
   _run_command("LOG", &response);
-  cr_assert(first_line_eq(response, "Invalid arguments received, expected at least one argument"),
+  cr_assert(first_line_eq(response, "FAIL Invalid arguments received"),
             "Bad reply: [%s]", response);
 
   _run_command("LOG fakelog", &response);

--- a/lib/mainloop-control.c
+++ b/lib/mainloop-control.c
@@ -94,6 +94,12 @@ control_connection_config(ControlConnection *cc, GString *command, gpointer user
   GString *result = g_string_sized_new(128);
   gchar **arguments = g_strsplit(command->str, " ", 0);
 
+  if (!arguments[1])
+    {
+      g_string_assign(result, "FAIL Invalid arguments");
+      goto exit;
+    }
+
   if (g_str_equal(arguments[1], "GET"))
     {
       if (g_str_equal(arguments[2], "ORIGINAL"))

--- a/lib/mainloop-control.c
+++ b/lib/mainloop-control.c
@@ -44,7 +44,7 @@ control_connection_message_log(ControlConnection *cc, GString *command, gpointer
 
   if (!cmds[1])
     {
-      g_string_assign(result, "Invalid arguments received, expected at least one argument");
+      g_string_assign(result, "FAIL Invalid arguments received");
       goto exit;
     }
 

--- a/news/bugfix-3900.md
+++ b/news/bugfix-3900.md
@@ -1,0 +1,5 @@
+`syslog-ng`: fix a SIGSEGV triggered by an incorrectly formatted "CONFIG"
+command, received on the syslog-ng control socket.  The only known
+implementation of the control protocol is syslog-ng-ctl itself, which always
+sends a correct command, but anyone with access to the UNIX domain socket
+`syslog-ng.ctl` (root only by default) can trigger a crash.


### PR DESCRIPTION
Fix a SIGSEGV triggered by an incorrectly formatted "CONFIG"
command, received on the syslog-ng control socket.  The only known
implementation of the control protocol is syslog-ng-ctl itself, which always
sends a correct command, but anyone with access to the UNIX domain socket
`syslog-ng.ctl` (root only by default) can trigger a crash.
