### PR TITLE
system-source: added macOS system source

### DIFF
--- a/modules/system-source/system-source.c
+++ b/modules/system-source/system-source.c
@@ -319,6 +319,10 @@ system_generate_system_transports(GString *sysblock, CfgArgs *args)
     {
       g_string_append(sysblock, "openbsd();");
     }
+  else if (strcmp(u.sysname, "Darwin") == 0)
+    {
+      system_sysblock_add_file(sysblock, "/var/log/system.log", 1, NULL, NULL, NULL, FALSE);
+    }
   else
     {
       msg_error("system(): Error detecting platform, unable to define the system() source. "

--- a/news/feature-3710.md
+++ b/news/feature-3710.md
@@ -1,0 +1,4 @@
+`system()` source: added basic support for reading macOS system logs
+
+The current implementation processes the output of the original macOS syslogd:
+`/var/log/system.log`.


### PR DESCRIPTION
This patch was originally created by @yashmathne, see more in #3710.
I've fixed the commit message format and wrote a news entry.

----

The system-source() source driver for syslog-ng automatically identifies the system and then links the appropriate source to read the system and kernel logs from.
On macOS, since macOS version 10.8, there is no separate kernel log file, instead both system logs and kernel logs get logged onto a file named system.log. ( /var/log/system.log ).
I have modified the system-source.c file to add a file driver to this file using a function already defined for creating files drivers for the different systems in accordance with the system-source() [documentation](https://www.syslog-ng.com/technical-documents/doc/syslog-ng-open-source-edition/3.30/administration-guide/27#TOPIC-1594950).

The application logs are excluded since application logs are highly dependent on what applications you run and shouldn't be in the standard system source.