### PR TITLE
packaging/rhel: Add `Requires` fields with minimum versions to specfile

### DIFF
--- a/news/packaging-3910-1.md
+++ b/news/packaging-3910-1.md
@@ -1,0 +1,4 @@
+`rhel`: Removed `bison` and `flex` from the specfile.
+
+The tarball has the grammar files built already, so these are not necessary.
+Also, the distros have too old `bison` anyways to build the grammar files, if it would be necessary.

--- a/news/packaging-3910.md
+++ b/news/packaging-3910.md
@@ -1,0 +1,3 @@
+`rhel`: Added multiple `Requires` fields to the specfile with minimum versions if possible.
+
+This will make sure, that the package manager updates the dependencies if necessary.

--- a/packaging/rhel/syslog-ng.spec
+++ b/packaging/rhel/syslog-ng.spec
@@ -29,13 +29,17 @@ Source4: syslog-ng.logrotate7
 
 %if 0%{?rhel} == 8
 %global		python_devel python39-devel
+%global         python_package  python39-libs
 %global         py_ver  3.9
 %else
 %if 0%{?rhel} == 7
 %global		python_devel python36-devel
+# There is no python36-libs package
+%global         python_package  python3-libs
 %global         py_ver  3.6
 %else
 %global		python_devel python3-devel
+%global         python_package  python3-libs
 %global         py_ver  %{python3_version}
 %endif
 %endif
@@ -46,26 +50,39 @@ Source4: syslog-ng.logrotate7
 %bcond_with java
 %endif
 
+%global glib2_ver 2.32
+%global openssl_ver 0.9.8
+%global libdbi_ver 0.9.0
+%global librabbitmq_ver 0.5.3
 %global ivykis_ver 0.36.1
+%global json_c_ver 0.9
+%global pcre_ver 6.1
+%global mongo_c_driver_ver 1.0.0
+%global riemann_c_client_ver 1.6.0
+%global java_ver 1.8
+%global hiredis_ver 0.11.0
 
+# Build tools
 BuildRequires: pkgconfig
 BuildRequires: libtool
 BuildRequires: bison
 BuildRequires: flex
 BuildRequires: libxslt
-BuildRequires: glib2-devel
-BuildRequires: ivykis-devel
-BuildRequires: json-c-devel
+
+# Core package's build dependencies
+BuildRequires: glib2-devel >= %{glib2_ver}
+BuildRequires: ivykis-devel >= %{ivykis_ver}
+BuildRequires: json-c-devel >= %{json_c_ver}
 BuildRequires: libcap-devel
-BuildRequires: libdbi-devel
 BuildRequires: libnet-devel
-BuildRequires: openssl-devel
-BuildRequires: pcre-devel
+BuildRequires: openssl-devel >= %{openssl_ver}
+BuildRequires: pcre-devel >= %{pcre_ver}
 BuildRequires: libuuid-devel
+
+# Module packages' build dependencies
 BuildRequires: libesmtp-devel
 BuildRequires: libcurl-devel
-
-BuildRequires: %{python_devel}
+BuildRequires: %{python_devel} >= %{py_ver}
 
 %if %{with amqp}
 BuildRequires: librabbitmq-devel
@@ -89,6 +106,10 @@ BuildRequires: systemd-devel
 Requires(post): systemd-units
 Requires(preun): systemd-units
 Requires(postun): systemd-units
+%endif
+
+%if %{with sql}
+BuildRequires: libdbi-devel >= %{libdbi_ver}
 %endif
 
 %if %{with mongodb}
@@ -118,8 +139,16 @@ BuildRequires: tcp_wrappers-devel
 Obsoletes: syslog-ng-json
 %endif
 
+# Core package's runtime dependencies
 Requires: logrotate
 Requires: ivykis >= %{ivykis_ver}
+Requires: glib2 >= %{glib2_ver}
+Requires: openssl-libs >= %{openssl_ver}
+Requires: json-c >= %{json_c_ver}
+Requires: pcre >= %{pcre_ver}
+Requires: libcap
+Requires: libnet
+Requires: libuuid
 
 Provides: syslog
 # merge separate syslog-vim package into one
@@ -153,6 +182,7 @@ Key features:
 Summary: SQL support for %{name}
 Group: Development/Libraries
 Requires: %{name}%{?_isa} = %{version}-%{release}
+Requires: libdbi >= %{libdbi_ver}
 
 %description sql
 This module supports a large number of SQL database systems via libdbi.
@@ -161,6 +191,7 @@ This module supports a large number of SQL database systems via libdbi.
 Summary: AMQP support for %{name}
 Group: Development/Libraries
 Requires: %{name}%{?_isa} = %{version}-%{release}
+Requires: librabbitmq >= %{librabbitmq_ver}
 
 %description amqp
 This module supports AMQP via librabbitmq
@@ -169,6 +200,8 @@ This module supports AMQP via librabbitmq
 Summary: mongodb support for %{name}
 Group: Development/Libraries
 Requires: %{name}%{?_isa} = %{version}-%{release}
+Requires: mongo-c-driver-libs >= %{mongo_c_driver_ver}
+Requires: cyrus-sasl-lib >= %{cyrus_sasl_ver}
 
 %description mongodb
 This module supports the mongodb database via libmongo-client.
@@ -177,6 +210,7 @@ This module supports the mongodb database via libmongo-client.
 Summary: smtp support for %{name}
 Group: Development/Libraries
 Requires: %{name}%{?_isa} = %{version}-%{release}
+Requires: libesmtp
 
 %description smtp
 This module supports sending e-mail alerts through an smtp server.
@@ -185,6 +219,7 @@ This module supports sending e-mail alerts through an smtp server.
 Summary: kafka support for %{name}
 Group: Development/Libraries
 Requires: %{name}%{?_isa} = %{version}-%{release}
+Requires: librdkafka >= %{librdkafka_ver}
 
 %description kafka
 This module supports sending logs to kafka through librdkafka.
@@ -193,6 +228,7 @@ This module supports sending logs to kafka through librdkafka.
 Summary: SNMP support for %{name}
 Group: Development/Libraries
 Requires: %{name}%{?_isa} = %{version}-%{release}
+Requires: net-snmp-libs
 
 %description afsnmp
 This module supports sending SNMP traps using net-snmp.
@@ -201,6 +237,7 @@ This module supports sending SNMP traps using net-snmp.
 Summary: mqtt support for %{name}
 Group: Development/Libraries
 Requires: %{name}%{?_isa} = %{version}-%{release}
+Requires: paho-c
 
 %description mqtt
 This module supports sending logs to mqtt through MQTT.
@@ -209,6 +246,7 @@ This module supports sending logs to mqtt through MQTT.
 Summary:        Java destination support for syslog-ng
 Group:          System/Libraries
 Requires:       %{name} = %{version}
+Requires:       jre-headless >= %{java_ver}
 
 %description java
 This package provides java destination support for syslog-ng. It
@@ -219,6 +257,7 @@ only contains the java bindings, no drivers.
 Summary: geoip support for %{name}
 Group: Development/Libraries
 Requires: %{name}%{?_isa} = %{version}-%{release}
+Requires: libmaxminddb
 
 %description geoip
 This package provides GeoIP support for syslog-ng
@@ -228,6 +267,7 @@ This package provides GeoIP support for syslog-ng
 Summary: redis support for %{name}
 Group: Development/Libraries
 Requires: %{name}%{?_isa} = %{version}-%{release}
+Requires: hiredis >= %{hiredis_ver}
 
 %description redis
 This module supports the redis key-value store via hiredis.
@@ -236,6 +276,7 @@ This module supports the redis key-value store via hiredis.
 Summary: riemann support for %{name}
 Group: Development/Libraries
 Requires: %{name}%{?_isa} = %{version}-%{release}
+Requires: riemann-c-client >= %{riemann_c_client_ver}
 
 %description riemann
 This module supports the riemann monitoring server.
@@ -244,6 +285,7 @@ This module supports the riemann monitoring server.
 Summary: HTTP support for %{name}
 Group: Development/Libraries
 Requires: %{name}%{?_isa} = %{version}-%{release}
+Requires: libcurl
 
 %description http
 This module supports the HTTP destination.
@@ -260,6 +302,7 @@ This module adds support for the $(slog) template function plus command line uti
 Summary:        Python destination support for syslog-ng
 Group:          System/Libraries
 Requires:       %{name} = %{version}
+Requires:       %{python_package} >= %{py_ver}
 
 %description python
 This package provides python destination support for syslog-ng.

--- a/packaging/rhel/syslog-ng.spec
+++ b/packaging/rhel/syslog-ng.spec
@@ -65,8 +65,6 @@ Source4: syslog-ng.logrotate7
 # Build tools
 BuildRequires: pkgconfig
 BuildRequires: libtool
-BuildRequires: bison
-BuildRequires: flex
 BuildRequires: libxslt
 
 # Core package's build dependencies


### PR DESCRIPTION
This will make sure, that the package manager updates the dependencies if necessary.

---

`yum install dbld/build/centos-7/*` before the added `Requires` fields:
<details>

```
Dependencies Resolved

=====================================================================================================================================================================================================================
 Package                                     Arch                   Version                                                  Repository                                                                         Size
=====================================================================================================================================================================================================================
Installing:
 syslog-ng                                   x86_64                 3.35.1.285.g8cd7af7-2+20220210T083243                    /syslog-ng-3.35.1.285.g8cd7af7-2+20220210T083243.x86_64                           3.3 M
 syslog-ng-afsnmp                            x86_64                 3.35.1.285.g8cd7af7-2+20220210T083243                    /syslog-ng-afsnmp-3.35.1.285.g8cd7af7-2+20220210T083243.x86_64                     64 k
 syslog-ng-amqp                              x86_64                 3.35.1.285.g8cd7af7-2+20220210T083243                    /syslog-ng-amqp-3.35.1.285.g8cd7af7-2+20220210T083243.x86_64                       61 k
 syslog-ng-debuginfo                         x86_64                 3.35.1.285.g8cd7af7-2+20220210T083243                    /syslog-ng-debuginfo-3.35.1.285.g8cd7af7-2+20220210T083243.x86_64                  24 M
 syslog-ng-devel                             x86_64                 3.35.1.285.g8cd7af7-2+20220210T083243                    /syslog-ng-devel-3.35.1.285.g8cd7af7-2+20220210T083243.x86_64                     878 k
 syslog-ng-geoip                             x86_64                 3.35.1.285.g8cd7af7-2+20220210T083243                    /syslog-ng-geoip-3.35.1.285.g8cd7af7-2+20220210T083243.x86_64                      48 k
 syslog-ng-http                              x86_64                 3.35.1.285.g8cd7af7-2+20220210T083243                    /syslog-ng-http-3.35.1.285.g8cd7af7-2+20220210T083243.x86_64                      117 k
 syslog-ng-java                              x86_64                 3.35.1.285.g8cd7af7-2+20220210T083243                    /syslog-ng-java-3.35.1.285.g8cd7af7-2+20220210T083243.x86_64                       75 k
 syslog-ng-kafka                             x86_64                 3.35.1.285.g8cd7af7-2+20220210T083243                    /syslog-ng-kafka-3.35.1.285.g8cd7af7-2+20220210T083243.x86_64                      65 k
 syslog-ng-mongodb                           x86_64                 3.35.1.285.g8cd7af7-2+20220210T083243                    /syslog-ng-mongodb-3.35.1.285.g8cd7af7-2+20220210T083243.x86_64                    56 k
 syslog-ng-mqtt                              x86_64                 3.35.1.285.g8cd7af7-2+20220210T083243                    /syslog-ng-mqtt-3.35.1.285.g8cd7af7-2+20220210T083243.x86_64                       69 k
 syslog-ng-python                            x86_64                 3.35.1.285.g8cd7af7-2+20220210T083243                    /syslog-ng-python-3.35.1.285.g8cd7af7-2+20220210T083243.x86_64                    322 k
 syslog-ng-redis                             x86_64                 3.35.1.285.g8cd7af7-2+20220210T083243                    /syslog-ng-redis-3.35.1.285.g8cd7af7-2+20220210T083243.x86_64                      52 k
 syslog-ng-riemann                           x86_64                 3.35.1.285.g8cd7af7-2+20220210T083243                    /syslog-ng-riemann-3.35.1.285.g8cd7af7-2+20220210T083243.x86_64                    61 k
 syslog-ng-slog                              x86_64                 3.35.1.285.g8cd7af7-2+20220210T083243                    /syslog-ng-slog-3.35.1.285.g8cd7af7-2+20220210T083243.x86_64                      165 k
 syslog-ng-smtp                              x86_64                 3.35.1.285.g8cd7af7-2+20220210T083243                    /syslog-ng-smtp-3.35.1.285.g8cd7af7-2+20220210T083243.x86_64                       52 k
 syslog-ng-sql                               x86_64                 3.35.1.285.g8cd7af7-2+20220210T083243                    /syslog-ng-sql-3.35.1.285.g8cd7af7-2+20220210T083243.x86_64                        65 k
Installing for dependencies:
 avahi-libs                                  x86_64                 0.6.31-20.el7                                            base                                                                               62 k
 copy-jdk-configs                            noarch                 3.3-10.el7_5                                             base                                                                               21 k
 cups-libs                                   x86_64                 1:1.6.3-51.el7                                           base                                                                              359 k
 freetype                                    x86_64                 2.8-14.el7_9.1                                           updates                                                                           380 k
 glib2-devel                                 x86_64                 2.56.1-9.el7_9                                           updates                                                                           453 k
 gnutls                                      x86_64                 3.3.29-9.el7_6                                           base                                                                              680 k
 hiredis                                     x86_64                 0.12.1-2.el7                                             epel                                                                               30 k
 ivykis                                      x86_64                 0.36.2-2.el7                                             epel                                                                               35 k
 java-1.8.0-openjdk-headless                 x86_64                 1:1.8.0.322.b06-1.el7_9                                  updates                                                                            33 M
 javapackages-tools                          noarch                 3.4.1-11.el7                                             base                                                                               73 k
 libbson                                     x86_64                 1.3.5-6.el7                                              epel                                                                              196 k
 libdbi                                      x86_64                 0.9.0-6.el7                                              copr:copr.fedorainfracloud.org:czanik:syslog-ng335                                 47 k
 libesmtp                                    x86_64                 1.0.6-7.el7                                              base                                                                               63 k
 libjpeg-turbo                               x86_64                 1.2.90-8.el7                                             base                                                                              135 k
 libmaxminddb                                x86_64                 1.2.0-6.el7                                              base                                                                               20 k
 libnet                                      x86_64                 1.1.6-7.el7                                              base                                                                               59 k
 libpng                                      x86_64                 2:1.5.13-8.el7                                           base                                                                              213 k
 librabbitmq                                 x86_64                 0.8.0-3.el7                                              base                                                                               37 k
 librdkafka                                  x86_64                 1.5.3-1.el7                                              copr:copr.fedorainfracloud.org:czanik:syslog-ng335                                560 k
 libtirpc                                    x86_64                 0.2.4-0.16.el7                                           base                                                                               89 k
 libxslt                                     x86_64                 1.1.28-6.el7                                             base                                                                              242 k
 lksctp-tools                                x86_64                 1.0.17-2.el7                                             base                                                                               88 k
 logrotate                                   x86_64                 3.8.6-19.el7                                             base                                                                               70 k
 mongo-c-driver-libs                         x86_64                 1.3.6-1.el7                                              epel                                                                              146 k
 net-snmp-libs                               x86_64                 1:5.7.2-49.el7_9.1                                       updates                                                                           751 k
 nettle                                      x86_64                 2.7.1-9.el7_9                                            updates                                                                           328 k
 paho-c                                      x86_64                 1.3.1-0.el7                                              epel                                                                              662 k
 pcre-devel                                  x86_64                 8.32-17.el7                                              base                                                                              480 k
 pcsc-lite-libs                              x86_64                 1.8.8-8.el7                                              base                                                                               34 k
 protobuf-c                                  x86_64                 1.0.2-3.el7                                              base                                                                               28 k
 python-javapackages                         noarch                 3.4.1-11.el7                                             base                                                                               31 k
 python-lxml                                 x86_64                 3.2.1-4.el7                                              base                                                                              758 k
 python3                                     x86_64                 3.6.8-18.el7                                             updates                                                                            70 k
 python3-libs                                x86_64                 3.6.8-18.el7                                             updates                                                                           6.9 M
 python3-pip                                 noarch                 9.0.3-8.el7                                              base                                                                              1.6 M
 python3-setuptools                          noarch                 39.2.0-10.el7                                            base                                                                              629 k
 riemann-c-client                            x86_64                 1.10.4-2.el7                                             copr:copr.fedorainfracloud.org:czanik:syslog-ng335                                 33 k
 tcp_wrappers-libs                           x86_64                 7.6-77.el7                                               base                                                                               66 k
 trousers                                    x86_64                 0.3.14-2.el7                                             base                                                                              289 k
 tzdata-java                                 noarch                 2021e-1.el7                                              updates                                                                           190 k
Updating for dependencies:
 glib2                                       x86_64                 2.56.1-9.el7_9                                           updates                                                                           2.5 M

Transaction Summary
=====================================================================================================================================================================================================================
Install  17 Packages (+40 Dependent packages)
Upgrade              (  1 Dependent package)
```
</details>

`yum install dbld/build/centos-7/*` after the added `Requires` fields:
<details>

```
Dependencies Resolved

=====================================================================================================================================================================================================================
 Package                                     Arch                   Version                                                  Repository                                                                         Size
=====================================================================================================================================================================================================================
Installing:
 syslog-ng                                   x86_64                 3.35.1.288.gc0adb6d-2+20220210T114620                    /syslog-ng-3.35.1.288.gc0adb6d-2+20220210T114620.x86_64                           3.3 M
 syslog-ng-afsnmp                            x86_64                 3.35.1.288.gc0adb6d-2+20220210T114620                    /syslog-ng-afsnmp-3.35.1.288.gc0adb6d-2+20220210T114620.x86_64                     64 k
 syslog-ng-amqp                              x86_64                 3.35.1.288.gc0adb6d-2+20220210T114620                    /syslog-ng-amqp-3.35.1.288.gc0adb6d-2+20220210T114620.x86_64                       61 k
 syslog-ng-debuginfo                         x86_64                 3.35.1.288.gc0adb6d-2+20220210T114620                    /syslog-ng-debuginfo-3.35.1.288.gc0adb6d-2+20220210T114620.x86_64                  24 M
 syslog-ng-devel                             x86_64                 3.35.1.288.gc0adb6d-2+20220210T114620                    /syslog-ng-devel-3.35.1.288.gc0adb6d-2+20220210T114620.x86_64                     878 k
 syslog-ng-geoip                             x86_64                 3.35.1.288.gc0adb6d-2+20220210T114620                    /syslog-ng-geoip-3.35.1.288.gc0adb6d-2+20220210T114620.x86_64                      48 k
 syslog-ng-http                              x86_64                 3.35.1.288.gc0adb6d-2+20220210T114620                    /syslog-ng-http-3.35.1.288.gc0adb6d-2+20220210T114620.x86_64                      117 k
 syslog-ng-java                              x86_64                 3.35.1.288.gc0adb6d-2+20220210T114620                    /syslog-ng-java-3.35.1.288.gc0adb6d-2+20220210T114620.x86_64                       75 k
 syslog-ng-kafka                             x86_64                 3.35.1.288.gc0adb6d-2+20220210T114620                    /syslog-ng-kafka-3.35.1.288.gc0adb6d-2+20220210T114620.x86_64                      65 k
 syslog-ng-mongodb                           x86_64                 3.35.1.288.gc0adb6d-2+20220210T114620                    /syslog-ng-mongodb-3.35.1.288.gc0adb6d-2+20220210T114620.x86_64                    56 k
 syslog-ng-mqtt                              x86_64                 3.35.1.288.gc0adb6d-2+20220210T114620                    /syslog-ng-mqtt-3.35.1.288.gc0adb6d-2+20220210T114620.x86_64                       69 k
 syslog-ng-python                            x86_64                 3.35.1.288.gc0adb6d-2+20220210T114620                    /syslog-ng-python-3.35.1.288.gc0adb6d-2+20220210T114620.x86_64                    322 k
 syslog-ng-redis                             x86_64                 3.35.1.288.gc0adb6d-2+20220210T114620                    /syslog-ng-redis-3.35.1.288.gc0adb6d-2+20220210T114620.x86_64                      52 k
 syslog-ng-riemann                           x86_64                 3.35.1.288.gc0adb6d-2+20220210T114620                    /syslog-ng-riemann-3.35.1.288.gc0adb6d-2+20220210T114620.x86_64                    61 k
 syslog-ng-slog                              x86_64                 3.35.1.288.gc0adb6d-2+20220210T114620                    /syslog-ng-slog-3.35.1.288.gc0adb6d-2+20220210T114620.x86_64                      165 k
 syslog-ng-smtp                              x86_64                 3.35.1.288.gc0adb6d-2+20220210T114620                    /syslog-ng-smtp-3.35.1.288.gc0adb6d-2+20220210T114620.x86_64                       52 k
 syslog-ng-sql                               x86_64                 3.35.1.288.gc0adb6d-2+20220210T114620                    /syslog-ng-sql-3.35.1.288.gc0adb6d-2+20220210T114620.x86_64                        65 k
Installing for dependencies:
 avahi-libs                                  x86_64                 0.6.31-20.el7                                            base                                                                               62 k
 copy-jdk-configs                            noarch                 3.3-10.el7_5                                             base                                                                               21 k
 cups-libs                                   x86_64                 1:1.6.3-51.el7                                           base                                                                              359 k
 freetype                                    x86_64                 2.8-14.el7_9.1                                           updates                                                                           380 k
 glib2-devel                                 x86_64                 2.56.1-9.el7_9                                           updates                                                                           453 k
 gnutls                                      x86_64                 3.3.29-9.el7_6                                           base                                                                              680 k
 hiredis                                     x86_64                 0.12.1-2.el7                                             epel                                                                               30 k
 ivykis                                      x86_64                 0.36.2-2.el7                                             epel                                                                               35 k
 java-1.8.0-openjdk-headless                 x86_64                 1:1.8.0.322.b06-1.el7_9                                  updates                                                                            33 M
 javapackages-tools                          noarch                 3.4.1-11.el7                                             base                                                                               73 k
 libbson                                     x86_64                 1.3.5-6.el7                                              epel                                                                              196 k
 libdbi                                      x86_64                 0.9.0-6.el7                                              copr:copr.fedorainfracloud.org:czanik:syslog-ng335                                 47 k
 libesmtp                                    x86_64                 1.0.6-7.el7                                              base                                                                               63 k
 libjpeg-turbo                               x86_64                 1.2.90-8.el7                                             base                                                                              135 k
 libmaxminddb                                x86_64                 1.2.0-6.el7                                              base                                                                               20 k
 libnet                                      x86_64                 1.1.6-7.el7                                              base                                                                               59 k
 libpng                                      x86_64                 2:1.5.13-8.el7                                           base                                                                              213 k
 librabbitmq                                 x86_64                 0.8.0-3.el7                                              base                                                                               37 k
 librdkafka                                  x86_64                 1.5.3-1.el7                                              copr:copr.fedorainfracloud.org:czanik:syslog-ng335                                560 k
 libtirpc                                    x86_64                 0.2.4-0.16.el7                                           base                                                                               89 k
 libxslt                                     x86_64                 1.1.28-6.el7                                             base                                                                              242 k
 lksctp-tools                                x86_64                 1.0.17-2.el7                                             base                                                                               88 k
 logrotate                                   x86_64                 3.8.6-19.el7                                             base                                                                               70 k
 mongo-c-driver-libs                         x86_64                 1.3.6-1.el7                                              epel                                                                              146 k
 net-snmp-libs                               x86_64                 1:5.7.2-49.el7_9.1                                       updates                                                                           751 k
 nettle                                      x86_64                 2.7.1-9.el7_9                                            updates                                                                           328 k
 paho-c                                      x86_64                 1.3.1-0.el7                                              epel                                                                              662 k
 pcre-devel                                  x86_64                 8.32-17.el7                                              base                                                                              480 k
 pcsc-lite-libs                              x86_64                 1.8.8-8.el7                                              base                                                                               34 k
 protobuf-c                                  x86_64                 1.0.2-3.el7                                              base                                                                               28 k
 python-javapackages                         noarch                 3.4.1-11.el7                                             base                                                                               31 k
 python-lxml                                 x86_64                 3.2.1-4.el7                                              base                                                                              758 k
 python3                                     x86_64                 3.6.8-18.el7                                             updates                                                                            70 k
 python3-libs                                x86_64                 3.6.8-18.el7                                             updates                                                                           6.9 M
 python3-pip                                 noarch                 9.0.3-8.el7                                              base                                                                              1.6 M
 python3-setuptools                          noarch                 39.2.0-10.el7                                            base                                                                              629 k
 riemann-c-client                            x86_64                 1.10.4-2.el7                                             copr:copr.fedorainfracloud.org:czanik:syslog-ng335                                 33 k
 tcp_wrappers-libs                           x86_64                 7.6-77.el7                                               base                                                                               66 k
 trousers                                    x86_64                 0.3.14-2.el7                                             base                                                                              289 k
 tzdata-java                                 noarch                 2021e-1.el7                                              updates                                                                           190 k
Updating for dependencies:
 glib2                                       x86_64                 2.56.1-9.el7_9                                           updates                                                                           2.5 M

Transaction Summary
=====================================================================================================================================================================================================================
Install  17 Packages (+40 Dependent packages)
Upgrade              (  1 Dependent package)
```
</details>

There is no diff between the installs.

Files for convenience:
[before.txt](https://github.com/syslog-ng/syslog-ng/files/8039546/before.txt)
[after.txt](https://github.com/syslog-ng/syslog-ng/files/8041058/after.txt)

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>