### PR TITLE
basicfuncs: add $(names) and $(values) template functions

### DIFF
--- a/modules/basicfuncs/Makefile.am
+++ b/modules/basicfuncs/Makefile.am
@@ -27,6 +27,7 @@ EXTRA_DIST					+=	\
 	modules/basicfuncs/tf-iterate.c			\
 	modules/basicfuncs/tf-map.c			\
 	modules/basicfuncs/tf-filter.c			\
+	modules/basicfuncs/vp-funcs.c			\
 	modules/basicfuncs/CMakeLists.txt
 
 modules/basicfuncs modules/basicfuncs/ mod-basicfuncs: modules/basicfuncs/libbasicfuncs.la

--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -67,6 +67,7 @@ _append_args_with_separator(gint argc, GString *argv[], GString *result, gchar s
 #include "tf-iterate.c"
 #include "tf-map.c"
 #include "tf-filter.c"
+#include "vp-funcs.c"
 
 static Plugin basicfuncs_plugins[] =
 {
@@ -93,6 +94,10 @@ static Plugin basicfuncs_plugins[] =
   TEMPLATE_FUNCTION_PLUGIN(tf_binary, "binary"),
   TEMPLATE_FUNCTION_PLUGIN(tf_implode, "implode"),
   TEMPLATE_FUNCTION_PLUGIN(tf_explode, "explode"),
+
+  /* vp-funcs */
+  TEMPLATE_FUNCTION_PLUGIN(tf_value_pairs, "values"),
+  TEMPLATE_FUNCTION_PLUGIN(tf_value_pairs, "names"),
 
   /* fname-funcs */
   TEMPLATE_FUNCTION_PLUGIN(tf_dirname, "dirname"),

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -551,6 +551,20 @@ Test(basicfuncs, test_context_funcs)
                                       "\"value,with,a,comma\",\"value,with,a,comma\"");
 }
 
+Test(basicfuncs, test_vp_funcs)
+{
+  assert_template_format_with_context("$(values .unix.*)", "command,1000,1000");
+  assert_template_format_with_context("$(values .foo.*)", "");
+  assert_template_format_with_context("$(values PID PROGRAM)", "23323,syslog-ng");
+  assert_template_format_with_context("$(values PROGRAM PID)", "23323,syslog-ng");
+  assert_template_format_with_context("$(values)", "");
+  assert_template_format_with_context("$(names .unix.*)", ".unix.cmd,.unix.gid,.unix.uid");
+  assert_template_format_with_context("$(names .foo.*)", "");
+  assert_template_format_with_context("$(names PID PROGRAM)", "PID,PROGRAM");
+  assert_template_format_with_context("$(names PROGRAM PID)", "PID,PROGRAM");
+  assert_template_format_with_context("$(names)", "");
+}
+
 
 Test(basicfuncs, test_tfurlencode)
 {

--- a/modules/basicfuncs/vp-funcs.c
+++ b/modules/basicfuncs/vp-funcs.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2022 Balazs Scheidler <bazsi77@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "value-pairs/cmdline.h"
+
+typedef enum
+{
+  TFVP_NAMES,
+  TFVP_VALUES,
+} TFValuePairsResultType;
+
+typedef struct _TFValuePairsState
+{
+  TFSimpleFuncState super;
+  ValuePairs *vp;
+  TFValuePairsResultType result_type;
+} TFValuePairsState;
+
+typedef struct _TFValuePairsIterState
+{
+  GString *result;
+  gsize initial_len;
+  TFValuePairsResultType result_type;
+} TFValuePairsIterState;
+
+static gboolean
+tf_value_pairs_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
+                       gint argc, gchar *argv[],
+                       GError **error)
+{
+  TFValuePairsState *state = (TFValuePairsState *)s;
+
+  if (strcmp(argv[0], "values") == 0)
+    state->result_type = TFVP_VALUES;
+  else if(strcmp(argv[0], "names") == 0)
+    state->result_type = TFVP_NAMES;
+  else
+    g_assert_not_reached();
+
+  state->vp = value_pairs_new_from_cmdline (parent->cfg, &argc, &argv, TRUE, error);
+  return state->vp != NULL;
+}
+
+static gboolean
+tf_value_pairs_foreach(const gchar *name,
+                       LogMessageValueType type,
+                       const gchar *value, gsize value_len,
+                       gpointer user_data)
+{
+  TFValuePairsIterState *iter_state = (TFValuePairsIterState *) user_data;
+
+  _append_comma_between_list_elements_if_needed(iter_state->result, iter_state->initial_len);
+
+  switch (iter_state->result_type)
+    {
+    case TFVP_VALUES:
+      str_repr_encode_append(iter_state->result, value, value_len, ",");
+      break;
+    case TFVP_NAMES:
+      str_repr_encode_append(iter_state->result, name, -1, ",");
+      break;
+    default:
+      g_assert_not_reached();
+    }
+
+  return FALSE;
+}
+
+static void
+tf_value_pairs_call(LogTemplateFunction *self, gpointer s,
+                    const LogTemplateInvokeArgs *args, GString *result)
+{
+  TFValuePairsState *state = (TFValuePairsState *)s;
+  TFValuePairsIterState iter_state =
+  {
+    .result = result,
+    .initial_len = result->len,
+    .result_type = state->result_type,
+  };
+
+  value_pairs_foreach(state->vp,
+                      tf_value_pairs_foreach,
+                      args->messages[args->num_messages-1],
+                      args->options, &iter_state);
+}
+
+static void
+tf_value_pairs_free_state(gpointer s)
+{
+  TFValuePairsState *state = (TFValuePairsState *)s;
+
+  value_pairs_unref(state->vp);
+  tf_simple_func_free_state(&state->super);
+}
+
+TEMPLATE_FUNCTION(TFValuePairsState, tf_value_pairs, tf_value_pairs_prepare, NULL, tf_value_pairs_call,
+                  tf_value_pairs_free_state, NULL);

--- a/news/feature-3911.md
+++ b/news/feature-3911.md
@@ -1,0 +1,15 @@
+`$(values)` and `$(names)`: these new template functions can be used to
+query a list of name-value pairs in the current message. The list of name
+value pairs queried are specified by a value-pairs expression, just like
+with `$(format-json)`.
+
+Examples:
+
+  This expression sets the JSON array `values` to contain the list of SDATA
+  values, while the JSON array `names` would contain the associated names, in
+  the same order.
+
+  $(format-json values=list($(values .SDATA.*)) names=list($(names .SDATA.*)))
+
+The resulting name-value pairs are always sorted by their key, regardless of
+the argument order.

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -90,6 +90,7 @@ modules/add-contextual-data/add-contextual-data-glob-selector\.[ch]$
 modules/add-contextual-data/tests/test_glob_selector\.c$
 modules/affile/tests/test_file_writer\.c$
 modules/afsocket/socket-options-unix\.[ch]$
+modules/basicfuncs/vp-funcs\.[ch]$
 scl/fortigate/.*\.conf$
 scl/cee/.*\.conf$
  GPLv2+_SSL


### PR DESCRIPTION
These template functions can be used to:
 1) convert a set of name-value pairs to a list:

      $(format-json a=list($values .SDATA.*))

 2) check if a name-value with a specific prefix exists:

      $(if '$(list-count $(names .SDATA.*)) > 0' WE-HAVE-SDATA WE-DONT-HAVE_SDATA)

Signed-off-by: Balazs Scheidler <bazsi77@gmail.com>