### PR TITLE
Allow embedded nuls

### DIFF
--- a/lib/eventlog/src/evtlog.h
+++ b/lib/eventlog/src/evtlog.h
@@ -140,6 +140,7 @@ void evt_rec_free(EVTREC *e);
  * Return value: 0 to indicate failure and 1 for success
  **/
 EVTTAG *evt_tag_str(const char *tag, const char *value);
+EVTTAG *evt_tag_mem(const char *tag, const void *value, size_t len);
 EVTTAG *evt_tag_int(const char *tag, int value);
 EVTTAG *evt_tag_long(const char *tag, long long value);
 EVTTAG *evt_tag_errno(const char *tag, int err);

--- a/lib/eventlog/src/evttags.c
+++ b/lib/eventlog/src/evttags.c
@@ -81,6 +81,24 @@ evt_tag_str(const char *tag, const char *value)
 }
 
 EVTTAG *
+evt_tag_mem(const char *tag, const void *value, size_t len)
+{
+  char *buf = malloc(len + 1);
+
+  memcpy(buf, value, len);
+  for (int i = 0; i < len; i++)
+    {
+      if (buf[i] == 0)
+        buf[i] = '.';
+    }
+  buf[len] = 0;
+
+  EVTTAG *p = evt_tag_str(tag, buf);
+  free(buf);
+  return p;
+}
+
+EVTTAG *
 evt_tag_int(const char *tag, int value)
 {
   char buf[32]; /* a 64 bit int fits into 20 characters */

--- a/lib/find-crlf.c
+++ b/lib/find-crlf.c
@@ -32,7 +32,7 @@
  * It uses an algorithm very similar to what there's in libc memchr/strchr.
  **/
 gchar *
-find_cr_or_lf(gchar *s, gsize n)
+find_cr_or_lf_or_nul(gchar *s, gsize n)
 {
   gchar *char_ptr;
   gulong *longword_ptr;
@@ -43,10 +43,8 @@ find_cr_or_lf(gchar *s, gsize n)
   /* align input to long boundary */
   for (char_ptr = s; n > 0 && ((gulong) char_ptr & (sizeof(longword) - 1)) != 0; ++char_ptr, n--)
     {
-      if (*char_ptr == CR || *char_ptr == LF)
+      if (*char_ptr == CR || *char_ptr == LF || *char_ptr == 0)
         return char_ptr;
-      else if (*char_ptr == 0)
-        return NULL;
     }
 
   longword_ptr = (gulong *) char_ptr;
@@ -74,10 +72,8 @@ find_cr_or_lf(gchar *s, gsize n)
 
           for (i = 0; i < sizeof(longword); i++)
             {
-              if (*char_ptr == CR || *char_ptr == LF)
+              if (*char_ptr == CR || *char_ptr == LF || *char_ptr == 0)
                 return char_ptr;
-              else if (*char_ptr == 0)
-                return NULL;
               char_ptr++;
             }
         }
@@ -88,10 +84,8 @@ find_cr_or_lf(gchar *s, gsize n)
 
   while (n-- > 0)
     {
-      if (*char_ptr == CR || *char_ptr == LF)
+      if (*char_ptr == CR || *char_ptr == LF || *char_ptr == 0)
         return char_ptr;
-      else if (*char_ptr == 0)
-        return NULL;
       ++char_ptr;
     }
 

--- a/lib/find-crlf.h
+++ b/lib/find-crlf.h
@@ -26,6 +26,6 @@
 
 #include "syslog-ng.h"
 
-gchar *find_cr_or_lf(gchar *s, gsize n);
+gchar *find_cr_or_lf_or_nul(gchar *s, gsize n);
 
 #endif

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -543,16 +543,16 @@ log_msg_set_value_with_type(LogMessage *self, NVHandle handle,
   name_len = 0;
   name = log_msg_get_value_name(handle, &name_len);
 
+  if (value_len < 0)
+    value_len = strlen(value);
+
   if (_log_name_value_updates(self))
     {
       msg_trace("Setting value",
                 evt_tag_str("name", name),
-                evt_tag_printf("value", "%.*s", (gint) value_len, value),
+                evt_tag_mem("value", value, value_len),
                 evt_tag_printf("msg", "%p", self));
     }
-
-  if (value_len < 0)
-    value_len = strlen(value);
 
   if (!log_msg_chk_flag(self, LF_STATE_OWN_PAYLOAD))
     {

--- a/lib/logproto/logproto-builtins.c
+++ b/lib/logproto/logproto-builtins.c
@@ -38,6 +38,7 @@
 DEFINE_LOG_PROTO_SERVER(log_proto_dgram);
 DEFINE_LOG_PROTO_CLIENT(log_proto_text);
 DEFINE_LOG_PROTO_SERVER(log_proto_text);
+DEFINE_LOG_PROTO_SERVER(log_proto_text_with_nuls);
 DEFINE_LOG_PROTO_SERVER(log_proto_proxied_text);
 DEFINE_LOG_PROTO_SERVER(log_proto_proxied_text_tls_passthrough, .use_multitransport = TRUE);
 DEFINE_LOG_PROTO_SERVER(log_proto_indented_multiline);
@@ -51,6 +52,7 @@ static Plugin framed_server_plugins[] =
   LOG_PROTO_SERVER_PLUGIN(log_proto_dgram, "dgram"),
   LOG_PROTO_CLIENT_PLUGIN(log_proto_text, "text"),
   LOG_PROTO_SERVER_PLUGIN(log_proto_text, "text"),
+  LOG_PROTO_SERVER_PLUGIN(log_proto_text_with_nuls, "text-with-nuls"),
   LOG_PROTO_SERVER_PLUGIN(log_proto_proxied_text, "proxied-tcp"),
   LOG_PROTO_SERVER_PLUGIN(log_proto_proxied_text_tls_passthrough, "proxied-tls-passthrough"),
   LOG_PROTO_SERVER_PLUGIN(log_proto_indented_multiline, "indented-multiline"),

--- a/lib/logproto/logproto-text-server.c
+++ b/lib/logproto/logproto-text-server.c
@@ -276,3 +276,19 @@ log_proto_text_server_new(LogTransport *transport, const LogProtoServerOptions *
   log_proto_text_server_init(self, transport, options);
   return &self->super.super;
 }
+
+static const guchar *
+_find_nl_as_eom(const guchar *s, gsize n)
+{
+  return memchr(s, '\n', n);
+}
+
+LogProtoServer *
+log_proto_text_with_nuls_server_new(LogTransport *transport, const LogProtoServerOptions *options)
+{
+  LogProtoTextServer *self = g_new0(LogProtoTextServer, 1);
+
+  log_proto_text_server_init(self, transport, options);
+  self->find_eom = _find_nl_as_eom;
+  return &self->super.super;
+}

--- a/lib/logproto/logproto-text-server.c
+++ b/lib/logproto/logproto-text-server.c
@@ -65,7 +65,7 @@ log_proto_text_server_try_extract(LogProtoTextServer *self, LogProtoBufferedServ
        * read further data, or the buffer already contains a
        * complete line */
 
-      eom = find_eom(self->super.buffer + next_line_pos, state->pending_buffer_end - next_line_pos);
+      eom = self->find_eom(self->super.buffer + next_line_pos, state->pending_buffer_end - next_line_pos);
       if (eom)
         next_eol_pos = eom - self->super.buffer;
     }
@@ -179,7 +179,7 @@ log_proto_text_server_locate_next_eol(LogProtoTextServer *self, LogProtoBuffered
     }
   else
     {
-      eol = find_eom(buffer_start + self->consumed_len + 1, buffer_bytes - self->consumed_len - 1);
+      eol = self->find_eom(buffer_start + self->consumed_len + 1, buffer_bytes - self->consumed_len - 1);
     }
   return eol;
 }
@@ -263,6 +263,7 @@ log_proto_text_server_init(LogProtoTextServer *self, LogTransport *transport, co
   self->super.fetch_from_buffer = log_proto_text_server_fetch_from_buffer;
   self->super.flush = log_proto_text_server_flush;
   self->accumulate_line = log_proto_text_server_accumulate_line_method;
+  self->find_eom = find_eom;
   self->super.stream_based = TRUE;
   self->consumed_len = -1;
 }

--- a/lib/logproto/logproto-text-server.h
+++ b/lib/logproto/logproto-text-server.h
@@ -43,6 +43,7 @@ struct _LogProtoTextServer
 {
   LogProtoBufferedServer super;
 
+  const guchar *(*find_eom)(const guchar *s, gsize n);
   gint (*accumulate_line)(LogProtoTextServer *self,
                           const guchar *msg,
                           gsize msg_len,

--- a/lib/logproto/logproto-text-server.h
+++ b/lib/logproto/logproto-text-server.h
@@ -58,6 +58,8 @@ struct _LogProtoTextServer
  * This class processes text files/streams. Each record is terminated via an EOL character.
  */
 LogProtoServer *log_proto_text_server_new(LogTransport *transport, const LogProtoServerOptions *options);
+LogProtoServer *log_proto_text_with_nuls_server_new(LogTransport *transport, const LogProtoServerOptions *options);
+
 void log_proto_text_server_free(LogProtoServer *self);
 void log_proto_text_server_init(LogProtoTextServer *self, LogTransport *transport,
                                 const LogProtoServerOptions *options);

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1097,7 +1097,7 @@ log_writer_format_log(LogWriter *self, LogMessage *lm, GString *result)
 
       p = result->str;
       /* NOTE: the size is calculated to leave trailing new line */
-      while ((p = find_cr_or_lf(p, result->str + result->len - p - 1)))
+      while ((p = find_cr_or_lf_or_nul(p, result->str + result->len - p - 1)))
         {
           *p = ' ';
           p++;

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -91,7 +91,7 @@ msg_format_postprocess_message(MsgFormatOptions *options, LogMessage *msg,
       gchar *p;
 
       p = msg_text = (gchar *) log_msg_get_value(msg, LM_V_MESSAGE, &msg_len);
-      while ((p = find_cr_or_lf(p, msg_text + msg_len - p)))
+      while ((p = find_cr_or_lf_or_nul(p, msg_text + msg_len - p)))
         {
           *p = ' ';
           p++;

--- a/news/feature-3913.md
+++ b/news/feature-3913.md
@@ -1,0 +1,5 @@
+`transport(text-with-nuls)`: a new transport mechanism was added for
+the `network()` driver that allows NUL characters within the message. NOTE:
+syslog-ng does not support embedded NUL characters everywhere, so it is
+recommended that you also use `flags(no-multi-line)` that causes NUL
+characters to be replaced by space.

--- a/tests/light/functional_tests/source_drivers/network_source/text_with_nuls/test_nul_acceptance.py
+++ b/tests/light/functional_tests/source_drivers/network_source/text_with_nuls/test_nul_acceptance.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2020 One Identity
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+TEMPLATE = r'"${MESSAGE}\n"'
+INPUT_MESSAGES = "prog message\x00embedded\x00nul"
+EXPECTED_MESSAGE0 = "message embedded nul\n"
+
+
+def test_nul_acceptance(config, syslog_ng, loggen, port_allocator):
+    network_source = config.create_network_source(ip="localhost", port=port_allocator(), transport='"text-with-nuls"', flags="no-multi-line")
+    file_destination = config.create_file_destination(file_name="output.log", template=TEMPLATE)
+    config.create_logpath(statements=[network_source, file_destination])
+
+    syslog_ng.start(config)
+
+    network_source.write_log(INPUT_MESSAGES)
+
+    assert file_destination.read_log() == EXPECTED_MESSAGE0

--- a/tests/light/src/syslog_ng_config/statements/sources/network_source.py
+++ b/tests/light/src/syslog_ng_config/statements/sources/network_source.py
@@ -27,6 +27,7 @@ from src.syslog_ng_config.statements.sources.source_driver import SourceDriver
 def map_transport(transport):
     mapping = {
         "tcp": NetworkIO.Transport.TCP,
+        "text-with-nuls": NetworkIO.Transport.TCP,
         "udp": NetworkIO.Transport.UDP,
         "tls": NetworkIO.Transport.TLS,
         "proxied-tcp": NetworkIO.Transport.PROXIED_TCP,

--- a/tests/loggen/file_reader.c
+++ b/tests/loggen/file_reader.c
@@ -334,6 +334,17 @@ parse_line(const char *line, SyslogMsgElements *elements)
 }
 
 int
+calc_linelen(const char *buf, int buflen)
+{
+  for (int i = buflen - 1; i >= 0; i--)
+    {
+      if (buf[i] != 0)
+        return i+1;
+    }
+  return 0;
+}
+
+int
 read_next_message_from_file(char *buf, int buflen, int syslog_proto, int thread_index)
 {
   static int lineno = 0;
@@ -357,6 +368,7 @@ read_next_message_from_file(char *buf, int buflen, int syslog_proto, int thread_
           else
             return -1;
         }
+      memset(buf, 0, buflen);
       char *temp = fgets(buf, buflen, source[thread_index]);
       if (!temp)
         {
@@ -382,7 +394,7 @@ read_next_message_from_file(char *buf, int buflen, int syslog_proto, int thread_
 
   if (dont_parse)
     {
-      linelen = strnlen(buf, buflen);
+      linelen = calc_linelen(buf, buflen);
       return linelen;
     }
 

--- a/tests/loggen/socket_plugin/socket_plugin.c
+++ b/tests/loggen/socket_plugin/socket_plugin.c
@@ -441,9 +441,9 @@ static gboolean
 send_msg(int fd, char *msg, size_t msg_len)
 {
   ssize_t sent = 0;
-  while (sent < strlen(msg))
+  while (sent < msg_len)
     {
-      ssize_t rc = send_plain(fd, msg + sent, strlen(msg) - sent);
+      ssize_t rc = send_plain(fd, msg + sent, msg_len - sent);
       if (rc < 0)
         {
           ERROR("error sending buffer on %d (rc=%zd)\n", fd, rc);

--- a/tests/loggen/ssl_plugin/ssl_plugin.c
+++ b/tests/loggen/ssl_plugin/ssl_plugin.c
@@ -389,9 +389,9 @@ active_thread_func(gpointer user_data)
         }
 
       ssize_t sent = 0;
-      while (sent < strlen(message))
+      while (sent < str_len)
         {
-          ssize_t rc = SSL_write(ssl, message + sent, strlen(message) - sent);
+          ssize_t rc = SSL_write(ssl, message + sent, str_len - sent);
           if (rc < 0)
             {
               ERROR("error sending buffer on %p (rc=%zd)\n", ssl, rc);

--- a/tests/unit/test_findcrlf.c
+++ b/tests/unit/test_findcrlf.c
@@ -65,6 +65,33 @@ ParameterizedTestParameters(findcrlf, test)
     { "abcdefghijklmnopqrstuvwxy\nb\nc\n", 30, 25 },
     { "abcdefghijklmnopqrstuvwxyz\nb\nc\n", 31, 26 },
 
+    { "a\0b\0c\0",  6,  1 },
+    { "ab\0b\0c\0",  7,  2 },
+    { "abc\0b\0c\0",  8,  3 },
+    { "abcd\0b\0c\0",  9,  4 },
+    { "abcde\0b\0c\0", 10,  5 },
+    { "abcdef\0b\0c\0", 11,  6 },
+    { "abcdefg\0b\0c\0", 12,  7 },
+    { "abcdefgh\0b\0c\0", 13,  8 },
+    { "abcdefghi\0b\0c\0", 14,  9 },
+    { "abcdefghij\0b\0c\0", 15, 10 },
+    { "abcdefghijk\0b\0c\0", 16, 11 },
+    { "abcdefghijkl\0b\0c\0", 17, 12 },
+    { "abcdefghijklm\0b\0c\0", 18, 13 },
+    { "abcdefghijklmn\0b\0c\0", 19, 14 },
+    { "abcdefghijklmno\0b\0c\0", 20, 15 },
+    { "abcdefghijklmnop\0b\0c\0", 21, 16 },
+    { "abcdefghijklmnopq\0b\0c\0", 22, 17 },
+    { "abcdefghijklmnopqr\0b\0c\0", 23, 18 },
+    { "abcdefghijklmnopqrs\0b\0c\0", 24, 19 },
+    { "abcdefghijklmnopqrst\0b\0c\0", 25, 20 },
+    { "abcdefghijklmnopqrstu\0b\0c\0", 26, 21 },
+    { "abcdefghijklmnopqrstuv\0b\0c\0", 27, 22 },
+    { "abcdefghijklmnopqrstuvw\0b\0c\0", 28, 23 },
+    { "abcdefghijklmnopqrstuvwx\0b\0c\0", 29, 24 },
+    { "abcdefghijklmnopqrstuvwxy\0b\0c\0", 30, 25 },
+    { "abcdefghijklmnopqrstuvwxyz\0b\0c\0", 31, 26 },
+
     { "a\rb\rc\r",  6,  1 },
     { "ab\rb\rc\r",  7,  2 },
     { "abc\rb\rc\r",  8,  3 },
@@ -125,7 +152,7 @@ ParameterizedTestParameters(findcrlf, test)
 
 ParameterizedTest(struct findcrlf_params *params, findcrlf, test)
 {
-  gchar *eom = find_cr_or_lf(params->msg, params->msg_len);
+  gchar *eom = find_cr_or_lf_or_nul(params->msg, params->msg_len);
 
   cr_expect_not(params->eom_ofs == -1 && eom != NULL,
                 "EOM returned is not NULL, which was expected. eom_ofs=%d, eom=%s\n",


### PR DESCRIPTION
This patch adds a new transport "text-with-nuls" that can be used to accept log messages that have embedded NULs in them.

It is recommended to use flags(no-multi-line) on the source in this case, so that NULs are replaced with a space upon
reception. Otherwise funny things could happen.

This sample source works for me;

```
	source { network(port(2000) transport(text-with-nuls) flags(no-multi-line)); };
```

Resolves #3755