### PR TITLE
WIP: LogThreadedSourceDriver batching support AND increase the maximum number of threads to 256

### DIFF
--- a/lib/logthrsource/logthrsourcedrv.c
+++ b/lib/logthrsource/logthrsourcedrv.c
@@ -311,12 +311,35 @@ _apply_default_priority_and_facility(LogThreadedSourceDriver *self, LogMessage *
   msg->pri = parse_options->default_pri;
 }
 
+/*
+ * Call this every some messages so consumers that accumulate multiple
+ * messages (LogQueueFifo for instance) can finish accumulation and go on
+ * processing a batch.
+ *
+ * Basically this calls main_loop_worker_invoke_batch_callbacks(), which is
+ * done by the minaloop-io-worker layer whenever we go back to the main
+ * loop.  Whether this is done automatically by LogThreadedSourceDriver is
+ * controlled by the auto_close_batches member, in which case we do this
+ * every message.
+ *
+ * Doing it every message defeats the purpose more or less, as consumers
+ * tend to do batching to improve performance.
+ */
+void
+log_threaded_source_close_batch(LogThreadedSourceDriver *self)
+{
+  main_loop_worker_invoke_batch_callbacks();
+}
+
 void
 log_threaded_source_post(LogThreadedSourceDriver *self, LogMessage *msg)
 {
   msg_debug("Incoming log message", evt_tag_str("msg", log_msg_get_value(msg, LM_V_MESSAGE, NULL)));
   _apply_default_priority_and_facility(self, msg);
   log_source_post(&self->worker->super, msg);
+
+  if (self->auto_close_batches)
+    log_threaded_source_close_batch(self);
 }
 
 gboolean
@@ -361,4 +384,6 @@ log_threaded_source_driver_init_instance(LogThreadedSourceDriver *self, GlobalCo
   self->super.super.super.on_config_inited = log_threaded_source_driver_start_worker;
 
   self->wakeup = log_threaded_source_wakeup;
+
+  self->auto_close_batches = TRUE;
 }

--- a/lib/logthrsource/logthrsourcedrv.h
+++ b/lib/logthrsource/logthrsourcedrv.h
@@ -57,7 +57,6 @@ struct _LogThreadedSourceWorker
   LogThreadedSourceDriver *control;
   WakeupCondition wakeup_cond;
   gboolean under_termination;
-
 };
 
 struct _LogThreadedSourceDriver
@@ -65,6 +64,7 @@ struct _LogThreadedSourceDriver
   LogSrcDriver super;
   LogThreadedSourceWorkerOptions worker_options;
   LogThreadedSourceWorker *worker;
+  gboolean auto_close_batches;
 
   const gchar *(*format_stats_instance)(LogThreadedSourceDriver *self);
   gboolean (*thread_init)(LogThreadedSourceDriver *self);
@@ -99,6 +99,8 @@ log_threaded_source_driver_get_parse_options(LogDriver *s)
 
   return &self->worker_options.parse_options;
 }
+
+void log_threaded_source_close_batch(LogThreadedSourceDriver *self);
 
 /* blocking API */
 void log_threaded_source_blocking_post(LogThreadedSourceDriver *self, LogMessage *msg);

--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -63,33 +63,47 @@ static struct iv_task main_loop_workers_reenable_jobs_task;
 /* thread ID allocation */
 static GMutex main_loop_workers_idmap_lock;
 
-static guint64 main_loop_workers_idmap;
+#define MAIN_LOOP_IDMAP_BITS_PER_ROW    (sizeof(guint64)*8)
+#define MAIN_LOOP_IDMAP_ROWS            (MAIN_LOOP_MAX_WORKER_THREADS / MAIN_LOOP_IDMAP_BITS_PER_ROW)
+
+static guint64 main_loop_workers_idmap[MAIN_LOOP_IDMAP_ROWS + 1];
 
 static void
 _allocate_thread_id(void)
 {
   gint id;
-
   g_mutex_lock(&main_loop_workers_idmap_lock);
 
-  /* NOTE: this algorithm limits the number of I/O worker threads to 64,
-   * since the ID map is stored in a single 64 bit integer.  If we ever need
-   * more threads than that, we can generalize this algorithm further. */
+  /* the maximum number of threads must be divisible by 64 */
+  G_STATIC_ASSERT((MAIN_LOOP_MAX_WORKER_THREADS % MAIN_LOOP_IDMAP_BITS_PER_ROW) == 0);
 
   main_loop_worker_id = 0;
 
   for (id = 0; id < MAIN_LOOP_MAX_WORKER_THREADS; id++)
     {
-      if ((main_loop_workers_idmap & (1ULL << id)) == 0)
+      gint row = id / MAIN_LOOP_IDMAP_BITS_PER_ROW;
+      gint bit_in_row = id % MAIN_LOOP_IDMAP_BITS_PER_ROW;
+
+      if ((main_loop_workers_idmap[row] & (1ULL << bit_in_row)) == 0)
         {
           /* id not yet used */
 
+          main_loop_workers_idmap[row] |= (1ULL << bit_in_row);
           main_loop_worker_id = (id + 1);
-          main_loop_workers_idmap |= (1ULL << id);
           break;
         }
     }
   g_mutex_unlock(&main_loop_workers_idmap_lock);
+
+  if (main_loop_worker_id == 0)
+    {
+      msg_warning("Unable to allocate a unique thread ID. This can only "
+                  "happen if the number of syslog-ng threads exceeds the "
+                  "compile time constant MAIN_LOOP_MAX_WORKER_THREADS. "
+                  "Increase this number and recompile or contact the "
+                  "syslog-ng authors",
+                  evt_tag_int("max-worker-threads", MAIN_LOOP_MAX_WORKER_THREADS));
+    }
 }
 
 static void
@@ -98,8 +112,11 @@ _release_thread_id(void)
   g_mutex_lock(&main_loop_workers_idmap_lock);
   if (main_loop_worker_id)
     {
-      const gint id = main_loop_worker_id;
-      main_loop_workers_idmap &= ~(1ULL << (id - 1));
+      const gint id = main_loop_worker_id - 1;
+      gint row = id / MAIN_LOOP_IDMAP_BITS_PER_ROW;
+      gint bit_in_row = id % MAIN_LOOP_IDMAP_BITS_PER_ROW;
+
+      main_loop_workers_idmap[row] &= ~(1ULL << (bit_in_row));
       main_loop_worker_id = 0;
     }
   g_mutex_unlock(&main_loop_workers_idmap_lock);

--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -78,18 +78,15 @@ _allocate_thread_id(void)
 
   main_loop_worker_id = 0;
 
-  if(main_loop_worker_type != MLW_THREADED_INPUT_WORKER)
+  for (id = 0; id < MAIN_LOOP_MAX_WORKER_THREADS; id++)
     {
-      for (id = 0; id < MAIN_LOOP_MAX_WORKER_THREADS; id++)
+      if ((main_loop_workers_idmap & (1ULL << id)) == 0)
         {
-          if ((main_loop_workers_idmap & (1ULL << id)) == 0)
-            {
-              /* id not yet used */
+          /* id not yet used */
 
-              main_loop_worker_id = (id + 1);
-              main_loop_workers_idmap |= (1ULL << id);
-              break;
-            }
+          main_loop_worker_id = (id + 1);
+          main_loop_workers_idmap |= (1ULL << id);
+          break;
         }
     }
   g_mutex_unlock(&main_loop_workers_idmap_lock);

--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -63,7 +63,7 @@ static struct iv_task main_loop_workers_reenable_jobs_task;
 /* thread ID allocation */
 static GMutex main_loop_workers_idmap_lock;
 
-static guint64 main_loop_workers_idmap[MAIN_LOOP_WORKER_TYPE_MAX];
+static guint64 main_loop_workers_idmap;
 
 static void
 _allocate_thread_id(void)
@@ -82,12 +82,12 @@ _allocate_thread_id(void)
     {
       for (id = 0; id < MAIN_LOOP_MAX_WORKER_THREADS; id++)
         {
-          if ((main_loop_workers_idmap[main_loop_worker_type] & (1ULL << id)) == 0)
+          if ((main_loop_workers_idmap & (1ULL << id)) == 0)
             {
               /* id not yet used */
 
-              main_loop_worker_id = (id + 1)  + (main_loop_worker_type * MAIN_LOOP_MAX_WORKER_THREADS);
-              main_loop_workers_idmap[main_loop_worker_type] |= (1ULL << id);
+              main_loop_worker_id = (id + 1);
+              main_loop_workers_idmap |= (1ULL << id);
               break;
             }
         }
@@ -101,8 +101,8 @@ _release_thread_id(void)
   g_mutex_lock(&main_loop_workers_idmap_lock);
   if (main_loop_worker_id)
     {
-      const gint id = main_loop_worker_id & (sizeof(guint64) * CHAR_BIT - 1);
-      main_loop_workers_idmap[main_loop_worker_type] &= ~(1ULL << (id - 1));
+      const gint id = main_loop_worker_id;
+      main_loop_workers_idmap &= ~(1ULL << (id - 1));
       main_loop_worker_id = 0;
     }
   g_mutex_unlock(&main_loop_workers_idmap_lock);

--- a/lib/mainloop-worker.h
+++ b/lib/mainloop-worker.h
@@ -29,7 +29,7 @@
 #include <iv_list.h>
 
 #define MAIN_LOOP_MIN_WORKER_THREADS 2
-#define MAIN_LOOP_MAX_WORKER_THREADS 64
+#define MAIN_LOOP_MAX_WORKER_THREADS 256
 
 typedef enum
 {

--- a/lib/tests/test_logqueue.c
+++ b/lib/tests/test_logqueue.c
@@ -244,7 +244,7 @@ Test(logqueue, test_with_threads)
   GThread *other_threads[FEEDERS];
   gint i, j;
 
-  log_queue_set_max_threads(FEEDERS);
+  log_queue_set_max_threads(FEEDERS * 2);
   for (i = 0; i < TEST_RUNS; i++)
     {
       fprintf(stderr, "starting testrun: %d\n", i);


### PR DESCRIPTION
This branch implements batching support in LogThreadedSourceDriver, making it
possible to perform better in LogQueueFifo, due to the ability to use per-thread input queues.

At the same time this branch simplifies thread_id allocation and removes the previously hard-coded limit of 64 worker threads and bumps the current maximum to 256. 

@MrAnno we've discussed these changes IRL a few weeks ago.
@czanik I think you already tried syslog-ng on a box that had more than 64 cores, would be great to test it on more.
