### PR TITLE
afstomp: this patch corrects memory-leak in stomp.c; diskq: this ptach corrects use-after-free in dqtool.c

### DIFF
--- a/modules/afstomp/stomp.c
+++ b/modules/afstomp/stomp.c
@@ -104,6 +104,7 @@ stomp_connect(stomp_connection **connection_ref, char *hostname, int port)
   if (conn->socket == -1)
     {
       msg_error("Failed to create socket!");
+      g_free(conn);
       return FALSE;
     }
 
@@ -111,7 +112,7 @@ stomp_connect(stomp_connection **connection_ref, char *hostname, int port)
     {
       msg_error("Failed to resolve hostname in stomp driver",
                 evt_tag_str("hostname", hostname));
-
+      _stomp_connection_free(conn);
       return FALSE;
     }
 

--- a/modules/diskq/dqtool.c
+++ b/modules/diskq/dqtool.c
@@ -440,7 +440,7 @@ _relocate_qfile(PersistState *state, const gchar *name)
       if (!relocated_qfile)
         {
           fprintf(stderr, "Invalid path. new_diskq_dir: %s, qfile: %s\n", new_diskq_path, qfile);
-          g_free(qfile);
+          goto exit;
         }
 
       if (_move_file(qfile, relocated_qfile))
@@ -452,6 +452,7 @@ _relocate_qfile(PersistState *state, const gchar *name)
         {
           fprintf(stderr, "Failed to move file to new qfile_path: %s\n", relocated_qfile);
         }
+exit:
       g_free(base);
       g_free(qfile);
       g_free(relocated_qfile);


### PR DESCRIPTION
This patch corrects following bugs: https://github.com/syslog-ng/syslog-ng/issues/3917

Fixes  #3917