### PR TITLE
Fix threaded source tests

### DIFF
--- a/lib/logmsg/tags.c
+++ b/lib/logmsg/tags.c
@@ -170,6 +170,7 @@ log_tags_reinit_stats(void)
 {
   gint id;
 
+  g_mutex_lock(&log_tags_lock);
   stats_lock();
 
   for (id = 0; id < log_tags_num; id++)
@@ -185,6 +186,7 @@ log_tags_reinit_stats(void)
     }
 
   stats_unlock();
+  g_mutex_unlock(&log_tags_lock);
 }
 
 void

--- a/lib/logthrsource/tests/test_logthrfetcherdrv.c
+++ b/lib/logthrsource/tests/test_logthrfetcherdrv.c
@@ -131,7 +131,6 @@ start_test_threaded_fetcher(TestThreadedFetcherDriver *s)
 {
   cr_assert(log_pipe_init(&s->super.super.super.super.super));
   cr_assert(log_pipe_on_config_inited(&s->super.super.super.super.super));
-  app_config_changed();
 }
 
 static void

--- a/lib/logthrsource/tests/test_logthrsourcedrv.c
+++ b/lib/logthrsource/tests/test_logthrsourcedrv.c
@@ -128,7 +128,6 @@ start_test_threaded_source(TestThreadedSourceDriver *s)
 {
   cr_assert(log_pipe_init(&s->super.super.super.super));
   cr_assert(log_pipe_on_config_inited(&s->super.super.super.super));
-  app_config_changed();
 }
 
 static void


### PR DESCRIPTION
This fixes only the unit test failure described in #3920.

The PR won't stop the race from happening in production, I just removed the unnecessary `app_config_changed()` call from the unit test.
