### PR TITLE
Logthrdestdrv dont count non local messages in seq num

### DIFF
--- a/lib/logthrdest/logthrdestdrv.h
+++ b/lib/logthrdest/logthrdestdrv.h
@@ -191,10 +191,15 @@ log_threaded_dest_worker_disconnect(LogThreadedDestWorker *self)
 static inline LogThreadedResult
 log_threaded_dest_worker_insert(LogThreadedDestWorker *self, LogMessage *msg)
 {
-  if (self->owner->num_workers > 1)
-    self->seq_num = step_sequence_number_atomic(&self->owner->shared_seq_num);
+  if (msg->flags & LF_LOCAL)
+    {
+      if (self->owner->num_workers > 1)
+        self->seq_num = step_sequence_number_atomic(&self->owner->shared_seq_num);
+      else
+        self->seq_num = step_sequence_number(&self->owner->shared_seq_num);
+    }
   else
-    self->seq_num = step_sequence_number(&self->owner->shared_seq_num);
+    self->seq_num = 0;
   return self->insert(self, msg);
 }
 

--- a/lib/logthrdest/tests/test_logthrdestdrv.c
+++ b/lib/logthrdest/tests/test_logthrdestdrv.c
@@ -30,7 +30,6 @@
 #include "mainloop-worker.h"
 #include "apphook.h"
 
-
 typedef struct TestThreadedDestDriver
 {
   LogThreadedDestDriver super;
@@ -109,7 +108,7 @@ _spin_for_counter_value(StatsCounterItem *counter, gssize expected_value)
 }
 
 static void
-_generate_messages(TestThreadedDestDriver *dd, gint n)
+_generate_messages(TestThreadedDestDriver *dd, gint n, gboolean local)
 {
   LogMessage *msg;
   LogPathOptions path_options = LOG_PATH_OPTIONS_INIT_NOACK;
@@ -121,6 +120,10 @@ _generate_messages(TestThreadedDestDriver *dd, gint n)
 
       g_snprintf(buf, sizeof(buf), "%d", i);
       log_msg_set_value(msg, LM_V_PID, buf, -1);
+      if (local)
+        msg->flags |= LF_LOCAL;
+      else
+        msg->flags &= ~LF_LOCAL;
 
       log_pipe_queue(&dd->super.super.super.super, msg, &path_options);
     }
@@ -129,7 +132,7 @@ _generate_messages(TestThreadedDestDriver *dd, gint n)
 static void
 _generate_messages_and_wait_for_processing(TestThreadedDestDriver *dd, gint n, StatsCounterItem *counter)
 {
-  _generate_messages(dd, n);
+  _generate_messages(dd, n, TRUE);
   _spin_for_counter_value(counter, n);
 }
 
@@ -165,6 +168,7 @@ _insert_single_message_success(LogThreadedDestDriver *s, LogMessage *msg)
   TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
 
   self->insert_counter++;
+  cr_expect_neq(self->super.worker.instance.seq_num, 0);
   return LTR_SUCCESS;
 }
 
@@ -182,6 +186,34 @@ Test(logthrdestdrv, driver_can_be_instantiated_and_one_message_is_properly_proce
   cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
   cr_assert(dd->super.shared_seq_num == 2,
             "seq_num expected to be 1 larger than the amount of messages generated, found %d", dd->super.shared_seq_num);
+}
+
+static LogThreadedResult
+_insert_single_message_with_zero_seq_num(LogThreadedDestDriver *s, LogMessage *msg)
+{
+  TestThreadedDestDriver *self = (TestThreadedDestDriver *) s;
+
+  self->insert_counter++;
+  cr_expect_eq(self->super.worker.instance.seq_num, 0);
+  return LTR_SUCCESS;
+}
+
+Test(logthrdestdrv, non_local_messages_dont_increment_seq_num)
+{
+  dd->super.worker.insert = _insert_single_message_with_zero_seq_num;
+
+  _generate_messages(dd, 1, FALSE);
+  _spin_for_counter_value(dd->super.written_messages, 1);
+  cr_assert(dd->insert_counter == 1,
+            "insert()-ed message count expected to match the amount generated, found %d", dd->insert_counter);
+
+  cr_assert(stats_counter_get(dd->super.processed_messages) == 1);
+  cr_assert(stats_counter_get(dd->super.written_messages) == 1);
+  cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
+  cr_assert(dd->super.shared_seq_num == 1,
+            "seq_num expected to be unchanged while non-local messages get derilered, found %d, expected: %d",
+            dd->super.shared_seq_num, 1);
 }
 
 static LogThreadedResult
@@ -630,7 +662,7 @@ Test(logthrdestdrv, batch_timeout_delays_flush_to_the_specified_interval)
   dd->super.batch_timeout = 1000;
 
   start_stopwatch();
-  _generate_messages(dd, 2);
+  _generate_messages(dd, 2, TRUE);
   gint flush_counter = dd->flush_counter;
   guint64 initial_feed_time = stop_stopwatch_and_get_result();
 
@@ -671,7 +703,7 @@ Test(logthrdestdrv, batch_timeout_limits_flush_frequency)
       gint flush_counter;
 
       start_stopwatch();
-      _generate_messages(dd, 2);
+      _generate_messages(dd, 2, TRUE);
       _sleep_msec(100);
       flush_counter = dd->flush_counter;
       guint64 initial_feed_time = stop_stopwatch_and_get_result();
@@ -782,6 +814,7 @@ setup(void)
 
   main_loop = main_loop_get_instance();
   main_loop_init(main_loop, &main_loop_options);
+  cfg_set_current_version(main_loop_get_current_config(main_loop));
   _setup_dd();
 }
 

--- a/news/bugfix-3928.md
+++ b/news/bugfix-3928.md
@@ -1,0 +1,4 @@
+`http()` and other threaded destinations: fix $SEQNUM processing so that
+only local messages get an associated $SEQNUM, just like normal
+syslog()-like destinations.  This avoids a [meta sequenceId="XXX"] SD-PARAM
+being added to $SDATA for non-local messages.

--- a/news/other-3928.md
+++ b/news/other-3928.md
@@ -1,0 +1,6 @@
+`java()/python() destinations`: the $SEQNUM macro (and "seqnum" attribute in
+Python) was erroneously for both local and non-local logs, while it should
+have had a value only in case of local logs to match RFC5424 behavior
+(section 7.3.1).  This bug is now fixed, but that means that all non-local
+logs will have $SEQNUM set to zero from this version on, e.g.  the $SEQNUM
+macro would expand to an string, to match the syslog() driver behaviour.


### PR DESCRIPTION
    logthrdestdrv: don't set sequenceId for non-local messages
    
    The SDATA meta.sequenceId is the concept behind our SEQNUM macro, e.g.  it
    is a destination specific sequence number of local messages being sent.
    
    But this sequenceId only needs to be assigned to messages where we are the
    originator, as described here:
    
        7.3.1.  sequenceId
    
           The "sequenceId" parameter tracks the sequence in which the
           originator submits messages to the syslog transport for sending.  It
           is an integer that MUST be set to 1 when the syslog function is
           started and MUST be increased with every message up to a maximum
           value of 2147483647.  If that value is reached, the next message MUST
           be sent with a sequenceId of 1.
    
    NOTE the word "originator" in the first sentence.  Non-local messages don't
    have a locally generated SEQNUM unless the original message (coming from its
    originator) had one.
    
    There are two ways sequenceId are associated with incoming messages: the
    structured data meta.sequenceId, or in the case of Cisco messages the
    sequence number prepended to each messages.
    
    Now, LogThreadedDestDriver based plugins don't ever implement RFC5424, but
    $SEQNUM as macro is available even in these cases, and up to this patch, we
    generated a sequenceId for all outgoing messages, local and non-local alike.
    
    Our $SDATA macro then automatically patches in the sequence number if one is
    specified by the driver which was the case.  This meant that if you are
    using the $SDATA macro in the context of http() for instance, your SDATA
    will magically include an extra meta.sequenceId element, which is not what
    you want.  This behavior is fine when _we_ are the originator of said
    message (as in that case, syslog-ng itself is free to add such an meta
    element), but can be confusing and to be avoided when we are forwarding
    incoming logs.
    
    This patch changes LogThreadedDestDriver behavior to match that of LogWriter
    instances.
