### PR TITLE
amqp: handle error from amqp_ssl_socket_new()

### DIFF
--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -460,6 +460,14 @@ static gboolean
 _tcp_socket_init(AMQPDestDriver *self)
 {
   self->sockfd = amqp_tcp_socket_new(self->conn);
+  if (self->sockfd == NULL)
+    {
+      msg_error("Error connecting to AMQP server while initializing socket",
+                evt_tag_str("driver", self->super.super.super.id),
+                evt_tag_int("time_reopen", self->super.time_reopen));
+
+      return FALSE;
+    }
 
   return TRUE;
 }

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -449,6 +449,14 @@ _tls_socket_init(AMQPDestDriver *self)
 }
 
 static gboolean
+_tcp_socket_init(AMQPDestDriver *self)
+{
+  self->sockfd = amqp_tcp_socket_new(self->conn);
+
+  return TRUE;
+}
+
+static gboolean
 afamqp_dd_socket_init(AMQPDestDriver *self)
 {
   self->conn = amqp_new_connection();
@@ -460,10 +468,8 @@ afamqp_dd_socket_init(AMQPDestDriver *self)
 
   if (_is_using_tls(self))
     return _tls_socket_init(self);
-  else
-    self->sockfd = amqp_tcp_socket_new(self->conn);
 
-  return TRUE;
+  return _tcp_socket_init(self);
 }
 
 static gboolean

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -408,6 +408,12 @@ afamqp_is_ok(AMQPDestDriver *self, const gchar *context, amqp_rpc_reply_t ret)
 }
 
 static gboolean
+_is_using_tls(AMQPDestDriver *self)
+{
+  return self->ca_file != NULL;
+}
+
+static gboolean
 afamqp_dd_socket_init(AMQPDestDriver *self)
 {
 
@@ -419,7 +425,7 @@ afamqp_dd_socket_init(AMQPDestDriver *self)
       return FALSE;
     }
 
-  if (self->ca_file)
+  if (_is_using_tls(self))
     {
       int ca_file_ret;
       self->sockfd = amqp_ssl_socket_new(self->conn);

--- a/modules/afamqp/afamqp.c
+++ b/modules/afamqp/afamqp.c
@@ -417,6 +417,14 @@ static gboolean
 _tls_socket_init(AMQPDestDriver *self)
 {
   self->sockfd = amqp_ssl_socket_new(self->conn);
+  if (self->sockfd == NULL)
+    {
+      msg_error("Error connecting to AMQP server while initializing socket with TLS",
+                evt_tag_str("driver", self->super.super.super.id),
+                evt_tag_int("time_reopen", self->super.time_reopen));
+
+      return FALSE;
+    }
 
   int ca_file_ret = amqp_ssl_socket_set_cacert(self->sockfd, self->ca_file);
   if (ca_file_ret != AMQP_STATUS_OK)

--- a/news/bugfix-3929.md
+++ b/news/bugfix-3929.md
@@ -1,0 +1,1 @@
+`amqp`: Fixed a crash, which happened with `librabbitmq` v0.9.0 while using the `tls()` block.


### PR DESCRIPTION
`amqp_ssl_socket_new()` can return with `NULL`, which causes a segfault in `amqp_ssl_socket_set_cacert()`.
This change does not fix the problem coming from `amqp_ssl_socket_new()`, but handles its error gracefully.

Fixes #3924

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>