### PR TITLE
github-actions: do concurrent image building (dbld-build-images)

### DIFF
--- a/.github/workflows/dbld-images.yml
+++ b/.github/workflows/dbld-images.yml
@@ -16,6 +16,24 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - centos-7
+          - fedora-33
+          - debian-bullseye
+          - debian-buster
+          - debian-sid
+          - debian-stretch
+          - debian-testing
+          - ubuntu-bionic
+          - ubuntu-focal
+          - ubuntu-impish
+          - ubuntu-xenial
+          - devshell
+          - kira
+          - tarball
+      fail-fast: false
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -29,7 +47,7 @@ jobs:
           gh_export CONTAINER_REGISTRY
 
       - name: Build the images
-        run: dbld/rules images -j $(nproc) --keep-going --output-sync
+        run: dbld/rules image-${{ matrix.image }}
 
       - name: Should we upload the images?
         if: always()
@@ -60,4 +78,4 @@ jobs:
       - name: Push the images
         if: always() && env.UPLOAD_IMAGES_INTERNAL == 'true'
         run: |
-          dbld/rules push-images -j $(nproc) --keep-going --output-sync
+          dbld/rules push-image-${{ matrix.image }}

--- a/.github/workflows/dbld-images.yml
+++ b/.github/workflows/dbld-images.yml
@@ -2,7 +2,17 @@ name: Compile dbld-images
 
 on:
   pull_request:
+    paths:
+      - 'dbld/**'
+      - 'packaging/rhel/**'
+      - 'packaging/debian/**'
+      - '.github/workflows/dbld-images.yml'
   push:
+    paths:
+      - 'dbld/**'
+      - 'packaging/rhel/**'
+      - 'packaging/debian/**'
+      - '.github/workflows/dbld-images.yml'
   schedule:
     - cron: '00 03 * * *'
   workflow_dispatch:

--- a/dbld/rules
+++ b/dbld/rules
@@ -219,7 +219,7 @@ image-%:
 
 push-images: $(foreach image,$(IMAGES), push-image-$(image))
 push-image-%:
-	@echo "Pushing image: $(image)"
+	@echo "Pushing image: $*"
 	$(DOCKER) push ${CONTAINER_REGISTRY}/dbld-$*
 
 pull-images: $(foreach image,$(BUILDER_IMAGES), pull-image-$(image))


### PR DESCRIPTION
It scales better and much easier to debug what had failed.

Depending images (e.g. `tarball` -> `debian-testing`) still not resolved.

Also changed the cases when the github actions is triggered: in cases of PR/push events the github action will only start if
the content of `dbld`, the `packaging/(rhel|debian)` directories or the github actions yaml file itself change.

Example run, where `centos-7` failed: https://github.com/gaborznagy/syslog-ng/actions/runs/1924046749