### PR TITLE
github-actions: fix nightly version-checking

### DIFF
--- a/.github/workflows/test-apt-packages.yml
+++ b/.github/workflows/test-apt-packages.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Check revision
         run: |
           if [ ${{ inputs.pkg_type }} = "nightly" ]; then
-            echo "${{ steps.syslog_ng_revision.outputs.REVISION }}" | egrep "^[0-9]{1}.[0-9]{1,2}.[0-9]{1}.[0-9]{3}.[a-z0-9]{8}-snapshot\+[0-9]{8}T[0-9]{6}$";
+            echo "${{ steps.syslog_ng_revision.outputs.REVISION }}" | egrep "^[0-9]{1}.[0-9]{1,2}.[0-9]{1}(?:.[0-9]{3}.[a-z0-9]{8})?-snapshot\+[0-9]{8}T[0-9]{6}$";
           elif [ ${{ inputs.pkg_type }} = "stable" ]; then
             echo "${{ steps.syslog_ng_revision.outputs.REVISION }}" | egrep "^[0-9]{1}.[0-9]{1,2}.[0-9]{1}-[0-9]{1}$"
           fi


### PR DESCRIPTION
A nightly package usually looks like this:
`3.35.1.449.ge27fb36-snapshot+20220301T230257`

However we forgot that the git describe part of the version (`.449.ge27fb36`) can be empty
if the nightly package is built on a recent tag.
Now the version for the nightly package is this:
`3.36.1-snapshot+20220306T230226`

In short, if the nightly package is created on a tag, we shouldn't
expect the git-describe part of the version, so I've made that part of
the regex optional.