### PR TITLE
github-actions: more version-checking fix for nightly APT repo tests

### DIFF
--- a/.github/workflows/test-apt-packages.yml
+++ b/.github/workflows/test-apt-packages.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Check revision
         run: |
           if [ ${{ inputs.pkg_type }} = "nightly" ]; then
-            echo "${{ steps.syslog_ng_revision.outputs.REVISION }}" | egrep "^[0-9]{1}.[0-9]{1,2}.[0-9]{1,2}(?:.[0-9]{1,3}.[a-z0-9]{8})?-snapshot\+[0-9]{8}T[0-9]{6}$"
+            echo "${{ steps.syslog_ng_revision.outputs.REVISION }}" | egrep "^[0-9]{1}.[0-9]{1,2}.[0-9]{1,2}(.[0-9]{1,3}.[a-z0-9]{8})?-snapshot\+[0-9]{8}T[0-9]{6}$"
           elif [ ${{ inputs.pkg_type }} = "stable" ]; then
             echo "${{ steps.syslog_ng_revision.outputs.REVISION }}" | egrep "^[0-9]{1}.[0-9]{1,2}.[0-9]{1,2}-[0-9]{1,2}$"
           fi

--- a/.github/workflows/test-apt-packages.yml
+++ b/.github/workflows/test-apt-packages.yml
@@ -60,9 +60,9 @@ jobs:
       - name: Check revision
         run: |
           if [ ${{ inputs.pkg_type }} = "nightly" ]; then
-            echo "${{ steps.syslog_ng_revision.outputs.REVISION }}" | egrep "^[0-9]{1}.[0-9]{1,2}.[0-9]{1}(?:.[0-9]{3}.[a-z0-9]{8})?-snapshot\+[0-9]{8}T[0-9]{6}$";
+            echo "${{ steps.syslog_ng_revision.outputs.REVISION }}" | egrep "^[0-9]{1}.[0-9]{1,2}.[0-9]{1,2}(?:.[0-9]{1,3}.[a-z0-9]{8})?-snapshot\+[0-9]{8}T[0-9]{6}$"
           elif [ ${{ inputs.pkg_type }} = "stable" ]; then
-            echo "${{ steps.syslog_ng_revision.outputs.REVISION }}" | egrep "^[0-9]{1}.[0-9]{1,2}.[0-9]{1}-[0-9]{1}$"
+            echo "${{ steps.syslog_ng_revision.outputs.REVISION }}" | egrep "^[0-9]{1}.[0-9]{1,2}.[0-9]{1,2}-[0-9]{1,2}$"
           fi
 
       - name: Check if installed package version matches with install revision

--- a/.github/workflows/test-apt-packages.yml
+++ b/.github/workflows/test-apt-packages.yml
@@ -60,9 +60,9 @@ jobs:
       - name: Check revision
         run: |
           if [ ${{ inputs.pkg_type }} = "nightly" ]; then
-            echo "${{ steps.syslog_ng_revision.outputs.REVISION }}" | egrep "^[0-9]{1}.[0-9]{1,2}.[0-9]{1,2}(.[0-9]{1,3}.[a-z0-9]{8})?-snapshot\+[0-9]{8}T[0-9]{6}$"
+            echo "${{ steps.syslog_ng_revision.outputs.REVISION }}" | egrep "^[0-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}(\.[0-9]{1,3}\.[a-z0-9]{8})?-snapshot\+[0-9]{8}T[0-9]{6}$"
           elif [ ${{ inputs.pkg_type }} = "stable" ]; then
-            echo "${{ steps.syslog_ng_revision.outputs.REVISION }}" | egrep "^[0-9]{1}.[0-9]{1,2}.[0-9]{1,2}-[0-9]{1,2}$"
+            echo "${{ steps.syslog_ng_revision.outputs.REVISION }}" | egrep "^[0-9]{1}\.[0-9]{1,2}\.[0-9]{1,2}-[0-9]{1,2}$"
           fi
 
       - name: Check if installed package version matches with install revision


### PR DESCRIPTION
New day, new fix for the nightly APT repo github-actions!!

Unfortunately, I didn't check before that both the patch version (e.g 3.36.1)
and the commit distance in git describe (e.g. 3.36.1.2)
had a very strict quantifier check:

I've relaxed the criteria for both of them.

Some examples of the recent package versions:
3.35.1.361.g1cd66f0-snapshot+20220226T230235
3.36.1-snapshot+20220304T230252
3.36.1.2.g134cd38-snapshot+20220307T230230

I've tested the regex against additional versions too:
3.36.1.66.g7ae5f3f-snapshot+20220308T093606
3.36.1.81.g4bfb039-snapshot+20220308T093744

Test runs:
* nightly: https://github.com/gaborznagy/syslog-ng/actions/runs/1952410456
* stable: https://github.com/gaborznagy/syslog-ng/actions/runs/1952411863