### PR TITLE
logmsg: add "type" field to set_value()'s trace logs

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -203,6 +203,28 @@ const gchar *builtin_value_names[] =
   NULL,
 };
 
+const gchar *
+log_msg_value_type_to_str(LogMessageValueType self)
+{
+  g_assert(self <= LM_VT_NONE);
+
+  static const gchar *as_str[] =
+  {
+    [LM_VT_STRING] = "string",
+    [LM_VT_JSON] = "json",
+    [LM_VT_BOOLEAN] = "boolean",
+    [LM_VT_INT32] = "int32",
+    [LM_VT_INT64] = "int64",
+    [LM_VT_DOUBLE] = "double",
+    [LM_VT_DATETIME] = "datetime",
+    [LM_VT_LIST] = "list",
+    [LM_VT_NULL] = "null",
+    [LM_VT_NONE] = "none",
+  };
+
+  return as_str[self];
+}
+
 static void
 __free_macro_value(void *val)
 {
@@ -549,6 +571,7 @@ log_msg_set_value_with_type(LogMessage *self, NVHandle handle,
       msg_trace("Setting value",
                 evt_tag_str("name", name),
                 evt_tag_mem("value", value, value_len),
+                evt_tag_str("type", log_msg_value_type_to_str(type)),
                 evt_tag_printf("msg", "%p", self));
     }
 
@@ -659,6 +682,7 @@ log_msg_set_value_indirect_with_type(LogMessage *self, NVHandle handle,
       msg_trace("Setting indirect value",
                 evt_tag_printf("msg", "%p", self),
                 evt_tag_str("name", name),
+                evt_tag_str("type", log_msg_value_type_to_str(type)),
                 evt_tag_int("ref_handle", ref_handle),
                 evt_tag_int("ofs", ofs),
                 evt_tag_int("len", len));

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -225,6 +225,35 @@ log_msg_value_type_to_str(LogMessageValueType self)
   return as_str[self];
 }
 
+gboolean
+log_msg_value_type_from_str(const gchar *in_str, LogMessageValueType *out_type)
+{
+  if (strcmp(in_str, "string") == 0)
+    *out_type = LM_VT_STRING;
+  else if (strcmp(in_str, "json") == 0 || strcmp(in_str, "literal") == 0)
+    *out_type = LM_VT_JSON;
+  else if (strcmp(in_str, "boolean") == 0)
+    *out_type = LM_VT_BOOLEAN;
+  else if (strcmp(in_str, "int32") == 0 || strcmp(in_str, "int") == 0)
+    *out_type = LM_VT_INT32;
+  else if (strcmp(in_str, "int64") == 0)
+    *out_type = LM_VT_INT64;
+  else if (strcmp(in_str, "double") == 0 || strcmp(in_str, "float") == 0)
+    *out_type = LM_VT_DOUBLE;
+  else if (strcmp(in_str, "datetime") == 0)
+    *out_type = LM_VT_DATETIME;
+  else if (strcmp(in_str, "list") == 0)
+    *out_type = LM_VT_LIST;
+  else if (strcmp(in_str, "null") == 0)
+    *out_type = LM_VT_NULL;
+  else if (strcmp(in_str, "none") == 0)
+    *out_type = LM_VT_NONE;
+  else
+    return FALSE;
+
+  return TRUE;
+};
+
 static void
 __free_macro_value(void *val)
 {

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -170,6 +170,7 @@ enum _LogMessageValueType
   LM_VT_NONE = 255
 };
 
+const gchar *log_msg_value_type_to_str(LogMessageValueType self);
 
 typedef struct _LogMessageQueueNode
 {

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -171,6 +171,7 @@ enum _LogMessageValueType
 };
 
 const gchar *log_msg_value_type_to_str(LogMessageValueType self);
+gboolean log_msg_value_type_from_str(const gchar *in_str, LogMessageValueType *out_type);
 
 typedef struct _LogMessageQueueNode
 {

--- a/lib/logmsg/type-hinting.c
+++ b/lib/logmsg/type-hinting.c
@@ -40,25 +40,7 @@ type_hinting_error_quark(void)
 gboolean
 type_hint_parse(const gchar *hint, LogMessageValueType *out_type, GError **error)
 {
-  if (strcmp(hint, "string") == 0)
-    *out_type = LM_VT_STRING;
-  else if (strcmp(hint, "json") == 0 || strcmp(hint, "literal") == 0)
-    *out_type = LM_VT_JSON;
-  else if (strcmp(hint, "int32") == 0 || strcmp(hint, "int") == 0)
-    *out_type = LM_VT_INT32;
-  else if (strcmp(hint, "int64") == 0)
-    *out_type = LM_VT_INT64;
-  else if (strcmp(hint, "double") == 0 || strcmp(hint, "float") == 0)
-    *out_type = LM_VT_DOUBLE;
-  else if (strcmp(hint, "datetime") == 0)
-    *out_type = LM_VT_DATETIME;
-  else if (strcmp(hint, "list") == 0)
-    *out_type = LM_VT_LIST;
-  else if (strcmp(hint, "boolean") == 0)
-    *out_type = LM_VT_BOOLEAN;
-  else if (strcmp(hint, "null") == 0)
-    *out_type = LM_VT_NULL;
-  else
+  if (!log_msg_value_type_from_str(hint, out_type) || *out_type == LM_VT_NONE)
     {
       g_set_error(error, TYPE_HINTING_ERROR, TYPE_HINTING_INVALID_TYPE,
                   "Unknown type specified in type hinting: %s", hint);


### PR DESCRIPTION
News entry is not needed IMO.

Question for the reviewers:
  * The new field in the log message hints type features on the source side, which is a 4.0 feature. I think it is not a problem, but if we want, we can show it only if 4.0 is enabled. What do you think?

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>