### PR TITLE
scan-timestamp: add support for using comma instead of a dot for frac part

### DIFF
--- a/lib/timeutils/scan-timestamp.c
+++ b/lib/timeutils/scan-timestamp.c
@@ -313,7 +313,11 @@ __parse_usec(const guchar **data, gint *length)
 {
   guint32 usec = 0;
   const guchar *src = *data;
-  if (*length > 0 && *src == '.')
+
+  /* Fractions of a second are in most cases using a dot, but some devices
+   * use a comma (e.g.  Aruba) to separate the fractions of a seconds part */
+
+  if (*length > 0 && (*src == '.' || *src == ','))
     {
       gulong frac = 0;
       gint div = 1;

--- a/lib/timeutils/tests/test_scan-timestamp.c
+++ b/lib/timeutils/tests/test_scan-timestamp.c
@@ -125,6 +125,7 @@ Test(parse_timestamp, bsd_extensions)
 {
   /* fractions of a second */
   _expect_rfc3164_timestamp_eq("Dec  3 09:10:12.987", "2017-12-03T09:10:12.987+01:00");
+  _expect_rfc3164_timestamp_eq("Dec  3 09:10:12,987", "2017-12-03T09:10:12.987+01:00");
 
   /* year added at the end (linksys) */
   _expect_rfc3164_timestamp_eq("Dec  3 09:10:12 2019 ", "2019-12-03T09:10:12.000+01:00");
@@ -137,10 +138,14 @@ Test(parse_timestamp, bsd_extensions)
 Test(parse_timestamp, accept_iso_timestamps_with_space)
 {
   _expect_rfc3164_timestamp_eq("2017-12-03 09:10:12.987+01:00", "2017-12-03T09:10:12.987+01:00");
+  _expect_rfc3164_timestamp_eq("2017-12-03 09:10:12,987+01:00", "2017-12-03T09:10:12.987+01:00");
   _expect_rfc3164_timestamp_eq("2017-12-03 09:10:12.987", "2017-12-03T09:10:12.987+01:00");
+  _expect_rfc3164_timestamp_eq("2017-12-03 09:10:12,987", "2017-12-03T09:10:12.987+01:00");
   _expect_rfc3164_timestamp_eq("2017-12-03 09:10:12", "2017-12-03T09:10:12.000+01:00");
   _expect_rfc5424_timestamp_eq("2017-12-03 09:10:12.987+01:00", "2017-12-03T09:10:12.987+01:00");
+  _expect_rfc5424_timestamp_eq("2017-12-03 09:10:12,987+01:00", "2017-12-03T09:10:12.987+01:00");
   _expect_rfc5424_timestamp_eq("2017-12-03 09:10:12.987", "2017-12-03T09:10:12.987+01:00");
+  _expect_rfc5424_timestamp_eq("2017-12-03 09:10:12,987", "2017-12-03T09:10:12.987+01:00");
   _expect_rfc5424_timestamp_eq("2017-12-03 09:10:12", "2017-12-03T09:10:12.000+01:00");
 }
 

--- a/news/feature-3949.md
+++ b/news/feature-3949.md
@@ -1,0 +1,4 @@
+`syslog-parser()`: allow comma (e.g. ',') to separate the seconds and the fraction of a
+second part as some devices use that character. This change applies to both
+to syslog-parser() and the builtin syslog parsing functionality of network
+source drivers (e.g. udp(), tcp(), network() and syslog()).


### PR DESCRIPTION
Fixes #3943 