### PR TITLE
Fix grouping-by() use through parser references

### DIFF
--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -1379,10 +1379,14 @@ _verify_unique_persist_names_among_pipes(const GPtrArray *initialized_pipes)
           LogPipe *other_pipe = g_hash_table_lookup(pipe_persist_names, current_pipe_name);
           if (other_pipe)
             {
-              msg_error("Error checking the uniqueness of the persist names, please override it "
-                        "with persist-name option. Shutting down.",
+              msg_error("Automatic assignment of persist names failed, as "
+                        "conflicting persist-names were found. Please override "
+                        "the automatically assigned identifier using an "
+                        "explicit perist-name() option or remove the duplicated "
+                        "configuration elements",
                         evt_tag_str("persist_name", current_pipe_name),
-                        log_pipe_location_tag(current_pipe), NULL);
+                        log_pipe_location_tag(current_pipe),
+                        log_pipe_location_tag(other_pipe));
               result = FALSE;
             }
           else

--- a/lib/filter/filter-expr.c
+++ b/lib/filter/filter-expr.c
@@ -98,6 +98,8 @@ filter_expr_unref(FilterExprNode *self)
 FilterExprNode *
 filter_expr_clone(FilterExprNode *self)
 {
+  if (!self)
+    return NULL;
   if (!self->clone)
     return filter_expr_ref(self);
 

--- a/lib/rewrite/rewrite-groupset.c
+++ b/lib/rewrite/rewrite-groupset.c
@@ -103,9 +103,7 @@ log_rewrite_groupset_clone(LogPipe *s)
   value_pairs_unref(cloned->query);
   cloned->query = value_pairs_ref(self->query);
   cloned->vp_func = self->vp_func;
-
-  if (self->super.condition)
-    cloned->super.condition = filter_expr_clone(self->super.condition);
+  cloned->super.condition = filter_expr_clone(self->super.condition);
 
   return &cloned->super.super;
 }

--- a/lib/rewrite/rewrite-rename.c
+++ b/lib/rewrite/rewrite-rename.c
@@ -53,9 +53,7 @@ log_rewrite_rename_clone(LogPipe *s)
   LogRewriteRename *cloned;
 
   cloned = (LogRewriteRename *) log_rewrite_rename_new(s->cfg, self->source_handle, self->destination_handle);
-
-  if (self->super.condition)
-    cloned->super.condition = filter_expr_clone(self->super.condition);
+  cloned->super.condition = filter_expr_clone(self->super.condition);
 
   return &cloned->super.super;
 }

--- a/lib/rewrite/rewrite-set-facility.c
+++ b/lib/rewrite/rewrite-set-facility.c
@@ -116,8 +116,7 @@ log_rewrite_set_facility_clone(LogPipe *s)
   LogRewriteSetFacility *cloned = (LogRewriteSetFacility *)log_rewrite_set_facility_new(log_template_ref(self->facility),
                                   s->cfg);
 
-  if (self->super.condition)
-    cloned->super.condition = filter_expr_clone(self->super.condition);
+  cloned->super.condition = filter_expr_clone(self->super.condition);
 
   return &cloned->super.super;
 }

--- a/lib/rewrite/rewrite-set-pri.c
+++ b/lib/rewrite/rewrite-set-pri.c
@@ -87,8 +87,7 @@ log_rewrite_set_pri_clone(LogPipe *s)
   LogRewriteSetPri *cloned = (LogRewriteSetPri *) log_rewrite_set_pri_new(log_template_ref(self->pri),
                              s->cfg);
 
-  if (self->super.condition)
-    cloned->super.condition = filter_expr_clone(self->super.condition);
+  cloned->super.condition = filter_expr_clone(self->super.condition);
 
   return &cloned->super.super;
 }

--- a/lib/rewrite/rewrite-set-severity.c
+++ b/lib/rewrite/rewrite-set-severity.c
@@ -117,8 +117,7 @@ log_rewrite_set_severity_clone(LogPipe *s)
   LogRewriteSetSeverity *cloned = (LogRewriteSetSeverity *)log_rewrite_set_severity_new(log_template_ref(self->severity),
                                   s->cfg);
 
-  if (self->super.condition)
-    cloned->super.condition = filter_expr_clone(self->super.condition);
+  cloned->super.condition = filter_expr_clone(self->super.condition);
 
   return &cloned->super.super;
 }

--- a/lib/rewrite/rewrite-set-tag.c
+++ b/lib/rewrite/rewrite-set-tag.c
@@ -56,9 +56,7 @@ log_rewrite_set_tag_clone(LogPipe *s)
   log_rewrite_init_instance(&cloned->super, s->cfg);
   cloned->super.super.clone = log_rewrite_set_tag_clone;
   cloned->super.process = log_rewrite_set_tag_process;
-
-  if (self->super.condition)
-    cloned->super.condition = filter_expr_clone(self->super.condition);
+  cloned->super.condition = filter_expr_clone(self->super.condition);
 
   cloned->tag_id = self->tag_id;
   cloned->value = self->value;

--- a/lib/rewrite/rewrite-set.c
+++ b/lib/rewrite/rewrite-set.c
@@ -69,9 +69,7 @@ log_rewrite_set_clone(LogPipe *s)
 
   cloned = (LogRewriteSet *) log_rewrite_set_new(self->value_template, s->cfg);
   cloned->super.value_handle = self->super.value_handle;
-
-  if (self->super.condition)
-    cloned->super.condition = filter_expr_clone(self->super.condition);
+  cloned->super.condition = filter_expr_clone(self->super.condition);
 
   return &cloned->super.super;
 }

--- a/lib/rewrite/rewrite-subst.c
+++ b/lib/rewrite/rewrite-subst.c
@@ -117,9 +117,7 @@ log_rewrite_subst_clone(LogPipe *s)
   cloned = (LogRewriteSubst *) log_rewrite_subst_new(self->replacement, s->cfg);
   cloned->matcher = log_matcher_ref(self->matcher);
   cloned->super.value_handle = self->super.value_handle;
-
-  if (self->super.condition)
-    cloned->super.condition = filter_expr_clone(self->super.condition);
+  cloned->super.condition = filter_expr_clone(self->super.condition);
 
   return &cloned->super.super;
 }

--- a/lib/rewrite/rewrite-unset.c
+++ b/lib/rewrite/rewrite-unset.c
@@ -52,9 +52,7 @@ log_rewrite_unset_clone(LogPipe *s)
 
   cloned = (LogRewriteUnset *) log_rewrite_unset_new(s->cfg);
   cloned->super.value_handle = self->super.value_handle;
-
-  if (self->super.condition)
-    cloned->super.condition = filter_expr_clone(self->super.condition);
+  cloned->super.condition = filter_expr_clone(self->super.condition);
 
   return &cloned->super.super;
 }

--- a/modules/dbparser/correlation.c
+++ b/modules/dbparser/correlation.c
@@ -28,6 +28,7 @@
 void
 correlation_state_init_instance(CorrelationState *self)
 {
+  g_rw_lock_init(&self->lock);
   self->state = g_hash_table_new_full(correlation_key_hash, correlation_key_equal, NULL,
                                       (GDestroyNotify) correlation_context_unref);
   self->timer_wheel = timer_wheel_new();
@@ -40,6 +41,7 @@ correlation_state_deinit_instance(CorrelationState *self)
   if (self->state)
     g_hash_table_destroy(self->state);
   timer_wheel_free(self->timer_wheel);
+  g_rw_lock_clear(&self->lock);
 }
 
 CorrelationState *

--- a/modules/dbparser/correlation.c
+++ b/modules/dbparser/correlation.c
@@ -108,7 +108,9 @@ correlation_state_set_time(CorrelationState *self, guint64 sec, gpointer caller_
   if (sec < now.tv_sec)
     now.tv_sec = sec;
 
+  g_mutex_lock(&self->lock);
   timer_wheel_set_time(self->timer_wheel, now.tv_sec, caller_context);
+  g_mutex_unlock(&self->lock);
 }
 
 guint64

--- a/modules/dbparser/correlation.c
+++ b/modules/dbparser/correlation.c
@@ -23,6 +23,7 @@
 #include "correlation.h"
 #include "correlation-key.h"
 #include "correlation-context.h"
+#include "timeutils/cache.h"
 
 void
 correlation_state_init_instance(CorrelationState *self)
@@ -30,6 +31,7 @@ correlation_state_init_instance(CorrelationState *self)
   self->state = g_hash_table_new_full(correlation_key_hash, correlation_key_equal, NULL,
                                       (GDestroyNotify) correlation_context_unref);
   self->timer_wheel = timer_wheel_new();
+  cached_g_current_time(&self->last_tick);
 }
 
 void

--- a/modules/dbparser/correlation.c
+++ b/modules/dbparser/correlation.c
@@ -29,6 +29,7 @@ correlation_state_init_instance(CorrelationState *self)
 {
   self->state = g_hash_table_new_full(correlation_key_hash, correlation_key_equal, NULL,
                                       (GDestroyNotify) correlation_context_unref);
+  self->timer_wheel = timer_wheel_new();
 }
 
 void
@@ -36,6 +37,7 @@ correlation_state_deinit_instance(CorrelationState *self)
 {
   if (self->state)
     g_hash_table_destroy(self->state);
+  timer_wheel_free(self->timer_wheel);
 }
 
 CorrelationState *

--- a/modules/dbparser/correlation.c
+++ b/modules/dbparser/correlation.c
@@ -74,6 +74,14 @@ correlation_state_tx_update_context(CorrelationState *self, CorrelationContext *
 }
 
 void
+correlation_state_expire_all(CorrelationState *self, gpointer caller_context)
+{
+  g_mutex_lock(&self->lock);
+  timer_wheel_expire_all(self->timer_wheel, caller_context);
+  g_mutex_unlock(&self->lock);
+}
+
+void
 correlation_state_set_time(CorrelationState *self, guint64 sec, gpointer caller_context)
 {
   GTimeVal now;

--- a/modules/dbparser/correlation.c
+++ b/modules/dbparser/correlation.c
@@ -28,7 +28,7 @@
 void
 correlation_state_init_instance(CorrelationState *self)
 {
-  g_rw_lock_init(&self->lock);
+  g_mutex_init(&self->lock);
   self->state = g_hash_table_new_full(correlation_key_hash, correlation_key_equal, NULL,
                                       (GDestroyNotify) correlation_context_unref);
   self->timer_wheel = timer_wheel_new();
@@ -41,7 +41,7 @@ correlation_state_deinit_instance(CorrelationState *self)
   if (self->state)
     g_hash_table_destroy(self->state);
   timer_wheel_free(self->timer_wheel);
-  g_rw_lock_clear(&self->lock);
+  g_mutex_clear(&self->lock);
 }
 
 CorrelationState *

--- a/modules/dbparser/correlation.c
+++ b/modules/dbparser/correlation.c
@@ -82,6 +82,17 @@ correlation_state_expire_all(CorrelationState *self, gpointer caller_context)
 }
 
 void
+correlation_state_advance_time(CorrelationState *self, gint timeout, gpointer caller_context)
+{
+  guint64  new_time;
+
+  g_mutex_lock(&self->lock);
+  new_time = timer_wheel_get_time(self->timer_wheel) + timeout;
+  timer_wheel_set_time(self->timer_wheel, new_time, caller_context);
+  g_mutex_unlock(&self->lock);
+}
+
+void
 correlation_state_set_time(CorrelationState *self, guint64 sec, gpointer caller_context)
 {
   GTimeVal now;

--- a/modules/dbparser/correlation.c
+++ b/modules/dbparser/correlation.c
@@ -26,6 +26,25 @@
 #include "timeutils/cache.h"
 
 void
+correlation_state_set_time(CorrelationState *self, guint64 sec, gpointer caller_context)
+{
+  GTimeVal now;
+
+  /* clamp the current time between the timestamp of the current message
+   * (low limit) and the current system time (high limit).  This ensures
+   * that incorrect clocks do not skew the current time know by the
+   * correlation engine too much. */
+
+  cached_g_current_time(&now);
+  self->last_tick = now;
+
+  if (sec < now.tv_sec)
+    now.tv_sec = sec;
+
+  timer_wheel_set_time(self->timer_wheel, now.tv_sec, caller_context);
+}
+
+void
 correlation_state_init_instance(CorrelationState *self)
 {
   g_mutex_init(&self->lock);

--- a/modules/dbparser/correlation.c
+++ b/modules/dbparser/correlation.c
@@ -45,7 +45,8 @@ correlation_state_tx_lookup_context(CorrelationState *self, const CorrelationKey
 }
 
 void
-correlation_state_tx_store_context(CorrelationState *self, CorrelationContext *context, gint timeout, TWCallbackFunc expire)
+correlation_state_tx_store_context(CorrelationState *self, CorrelationContext *context, gint timeout,
+                                   TWCallbackFunc expire)
 {
   g_assert(context->timer == NULL);
 

--- a/modules/dbparser/correlation.c
+++ b/modules/dbparser/correlation.c
@@ -45,6 +45,12 @@ correlation_state_set_time(CorrelationState *self, guint64 sec, gpointer caller_
   timer_wheel_set_time(self->timer_wheel, now.tv_sec, caller_context);
 }
 
+guint64
+correlation_state_get_time(CorrelationState *self)
+{
+  return timer_wheel_get_time(self->timer_wheel);
+}
+
 gboolean
 correlation_state_timer_tick(CorrelationState *self, gpointer caller_context)
 {

--- a/modules/dbparser/correlation.h
+++ b/modules/dbparser/correlation.h
@@ -31,6 +31,7 @@ typedef struct _CorrelationState
 {
   GHashTable *state;
   TimerWheel *timer_wheel;
+  GTimeVal last_tick;
 } CorrelationState;
 
 void correlation_state_init_instance(CorrelationState *self);

--- a/modules/dbparser/correlation.h
+++ b/modules/dbparser/correlation.h
@@ -25,6 +25,7 @@
 
 #include "syslog-ng.h"
 #include "correlation-key.h"
+#include "correlation-context.h"
 #include "timerwheel.h"
 #include "timeutils/unixtime.h"
 
@@ -35,6 +36,13 @@ typedef struct _CorrelationState
   TimerWheel *timer_wheel;
   GTimeVal last_tick;
 } CorrelationState;
+
+void correlation_state_tx_begin(CorrelationState *self);
+void correlation_state_tx_end(CorrelationState *self);
+CorrelationContext *correlation_state_tx_lookup_context(CorrelationState *self, const CorrelationKey *key);
+void correlation_state_tx_store_context(CorrelationState *self, CorrelationContext *context, gint timeout, TWCallbackFunc expire);
+void correlation_state_tx_remove_context(CorrelationState *self, CorrelationContext *context);
+void correlation_state_tx_update_context(CorrelationState *self, CorrelationContext *context, gint timeout);
 
 void correlation_state_set_time(CorrelationState *self, guint64 sec, gpointer caller_context);
 guint64 correlation_state_get_time(CorrelationState *self);

--- a/modules/dbparser/correlation.h
+++ b/modules/dbparser/correlation.h
@@ -26,6 +26,7 @@
 #include "syslog-ng.h"
 #include "correlation-key.h"
 #include "timerwheel.h"
+#include "timeutils/unixtime.h"
 
 typedef struct _CorrelationState
 {
@@ -34,6 +35,8 @@ typedef struct _CorrelationState
   TimerWheel *timer_wheel;
   GTimeVal last_tick;
 } CorrelationState;
+
+void correlation_state_set_time(CorrelationState *self, guint64 sec, gpointer caller_context);
 
 void correlation_state_init_instance(CorrelationState *self);
 void correlation_state_deinit_instance(CorrelationState *self);

--- a/modules/dbparser/correlation.h
+++ b/modules/dbparser/correlation.h
@@ -47,6 +47,7 @@ void correlation_state_tx_update_context(CorrelationState *self, CorrelationCont
 void correlation_state_set_time(CorrelationState *self, guint64 sec, gpointer caller_context);
 guint64 correlation_state_get_time(CorrelationState *self);
 gboolean correlation_state_timer_tick(CorrelationState *self, gpointer caller_context);
+void correlation_state_expire_all(CorrelationState *self, gpointer caller_context);
 
 void correlation_state_init_instance(CorrelationState *self);
 void correlation_state_deinit_instance(CorrelationState *self);

--- a/modules/dbparser/correlation.h
+++ b/modules/dbparser/correlation.h
@@ -31,6 +31,7 @@
 
 typedef struct _CorrelationState
 {
+  GAtomicCounter ref_cnt;
   GMutex lock;
   GHashTable *state;
   TimerWheel *timer_wheel;
@@ -53,6 +54,7 @@ void correlation_state_advance_time(CorrelationState *self, gint timeout, gpoint
 void correlation_state_init_instance(CorrelationState *self);
 void correlation_state_deinit_instance(CorrelationState *self);
 CorrelationState *correlation_state_new(void);
-void correlation_state_free(CorrelationState *self);
+CorrelationState *correlation_state_ref(CorrelationState *self);
+void correlation_state_unref(CorrelationState *self);
 
 #endif

--- a/modules/dbparser/correlation.h
+++ b/modules/dbparser/correlation.h
@@ -29,6 +29,7 @@
 
 typedef struct _CorrelationState
 {
+  GRWLock lock;
   GHashTable *state;
   TimerWheel *timer_wheel;
   GTimeVal last_tick;

--- a/modules/dbparser/correlation.h
+++ b/modules/dbparser/correlation.h
@@ -29,7 +29,7 @@
 
 typedef struct _CorrelationState
 {
-  GRWLock lock;
+  GMutex lock;
   GHashTable *state;
   TimerWheel *timer_wheel;
   GTimeVal last_tick;

--- a/modules/dbparser/correlation.h
+++ b/modules/dbparser/correlation.h
@@ -25,10 +25,12 @@
 
 #include "syslog-ng.h"
 #include "correlation-key.h"
+#include "timerwheel.h"
 
 typedef struct _CorrelationState
 {
   GHashTable *state;
+  TimerWheel *timer_wheel;
 } CorrelationState;
 
 void correlation_state_init_instance(CorrelationState *self);

--- a/modules/dbparser/correlation.h
+++ b/modules/dbparser/correlation.h
@@ -48,6 +48,7 @@ void correlation_state_set_time(CorrelationState *self, guint64 sec, gpointer ca
 guint64 correlation_state_get_time(CorrelationState *self);
 gboolean correlation_state_timer_tick(CorrelationState *self, gpointer caller_context);
 void correlation_state_expire_all(CorrelationState *self, gpointer caller_context);
+void correlation_state_advance_time(CorrelationState *self, gint timeout, gpointer caller_context);
 
 void correlation_state_init_instance(CorrelationState *self);
 void correlation_state_deinit_instance(CorrelationState *self);

--- a/modules/dbparser/correlation.h
+++ b/modules/dbparser/correlation.h
@@ -41,7 +41,8 @@ typedef struct _CorrelationState
 void correlation_state_tx_begin(CorrelationState *self);
 void correlation_state_tx_end(CorrelationState *self);
 CorrelationContext *correlation_state_tx_lookup_context(CorrelationState *self, const CorrelationKey *key);
-void correlation_state_tx_store_context(CorrelationState *self, CorrelationContext *context, gint timeout, TWCallbackFunc expire);
+void correlation_state_tx_store_context(CorrelationState *self, CorrelationContext *context, gint timeout,
+                                        TWCallbackFunc expire);
 void correlation_state_tx_remove_context(CorrelationState *self, CorrelationContext *context);
 void correlation_state_tx_update_context(CorrelationState *self, CorrelationContext *context, gint timeout);
 

--- a/modules/dbparser/correlation.h
+++ b/modules/dbparser/correlation.h
@@ -37,6 +37,7 @@ typedef struct _CorrelationState
 } CorrelationState;
 
 void correlation_state_set_time(CorrelationState *self, guint64 sec, gpointer caller_context);
+gboolean correlation_state_timer_tick(CorrelationState *self, gpointer caller_context);
 
 void correlation_state_init_instance(CorrelationState *self);
 void correlation_state_deinit_instance(CorrelationState *self);

--- a/modules/dbparser/correlation.h
+++ b/modules/dbparser/correlation.h
@@ -37,6 +37,7 @@ typedef struct _CorrelationState
 } CorrelationState;
 
 void correlation_state_set_time(CorrelationState *self, guint64 sec, gpointer caller_context);
+guint64 correlation_state_get_time(CorrelationState *self);
 gboolean correlation_state_timer_tick(CorrelationState *self, gpointer caller_context);
 
 void correlation_state_init_instance(CorrelationState *self);

--- a/modules/dbparser/dbparser-grammar.ym
+++ b/modules/dbparser/dbparser-grammar.ym
@@ -112,6 +112,7 @@ parser_db_opt
 
 stateful_parser_opt
 	: KW_INJECT_MODE '(' stateful_parser_inject_mode ')'	{ stateful_parser_set_inject_mode(((StatefulParser *) last_parser), $3); }
+        | KW_PERSIST_NAME '(' string ')'                        { log_pipe_set_persist_name(&last_driver->super, $3); free($3); }
 	| parser_opt
 	;
 

--- a/modules/dbparser/dbparser.c
+++ b/modules/dbparser/dbparser.c
@@ -266,6 +266,9 @@ log_db_parser_clone(LogPipe *s)
 
   cloned = (LogDBParser *) log_db_parser_new(s->cfg);
   log_db_parser_set_db_file(cloned, self->db_file);
+  log_db_parser_set_drop_unmatched(cloned, self->drop_unmatched);
+  log_db_parser_set_program_template_ref(&cloned->super.super, log_template_ref(self->program_template));
+  log_parser_set_template(&cloned->super.super, log_template_ref(self->super.super.template));
   return &cloned->super.super.super;
 }
 

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -199,7 +199,7 @@ grouping_by_set_time(GroupingBy *self, const UnixTime *ls, GPMessageEmitter *msg
 {
   correlation_state_set_time(self->correlation, ls->ut_sec, msg_emitter);
   msg_debug("Advancing grouping-by() current time because of an incoming message",
-            evt_tag_long("utc", timer_wheel_get_time(self->correlation->timer_wheel)),
+            evt_tag_long("utc", correlation_state_get_time(self->correlation)),
             log_pipe_location_tag(&self->super.super.super));
 }
 
@@ -219,7 +219,7 @@ _grouping_by_timer_tick(GroupingBy *self)
   if (correlation_state_timer_tick(self->correlation, &msg_emitter))
     {
       msg_debug("Advancing grouping-by() current time because of timer tick",
-                evt_tag_long("utc", timer_wheel_get_time(self->correlation->timer_wheel)),
+                evt_tag_long("utc", correlation_state_get_time(self->correlation)),
                 log_pipe_location_tag(&self->super.super.super));
     }
   _flush_emitted_messages(self, &msg_emitter);
@@ -306,7 +306,7 @@ grouping_by_expire_entry(TimerWheel *wheel, guint64 now, gpointer user_data, gpo
   GroupingBy *self = (GroupingBy *) timer_wheel_get_associated_data(wheel);
 
   msg_debug("Expiring grouping-by() correlation context",
-            evt_tag_long("utc", timer_wheel_get_time(wheel)),
+            evt_tag_long("utc", correlation_state_get_time(self->correlation)),
             evt_tag_str("context-id", context->key.session_id),
             log_pipe_location_tag(&self->super.super.super));
 
@@ -346,7 +346,7 @@ _lookup_or_create_context(GroupingBy *self, LogMessage *msg)
       msg_debug("Correlation context lookup failure, starting a new context",
                 evt_tag_str("key", key.session_id),
                 evt_tag_int("timeout", self->timeout),
-                evt_tag_int("expiration", timer_wheel_get_time(self->correlation->timer_wheel) + self->timeout),
+                evt_tag_int("expiration", correlation_state_get_time(self->correlation) + self->timeout),
                 log_pipe_location_tag(&self->super.super.super));
 
       context = correlation_context_new(&key);
@@ -358,7 +358,7 @@ _lookup_or_create_context(GroupingBy *self, LogMessage *msg)
       msg_debug("Correlation context lookup successful",
                 evt_tag_str("key", key.session_id),
                 evt_tag_int("timeout", self->timeout),
-                evt_tag_int("expiration", timer_wheel_get_time(self->correlation->timer_wheel) + self->timeout),
+                evt_tag_int("expiration", correlation_state_get_time(self->correlation) + self->timeout),
                 evt_tag_int("num_messages", context->messages->len),
                 log_pipe_location_tag(&self->super.super.super));
     }

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -232,7 +232,7 @@ _grouping_by_timer_tick(GroupingBy *self)
 
   GPMessageEmitter msg_emitter = {0};
 
-  g_rw_lock_writer_lock(&self->correlation->lock);
+  g_mutex_lock(&self->correlation->lock);
   cached_g_current_time(&now);
   diff = g_time_val_diff(&now, &self->correlation->last_tick);
 
@@ -257,7 +257,7 @@ _grouping_by_timer_tick(GroupingBy *self)
        */
       self->correlation->last_tick = now;
     }
-  g_rw_lock_writer_unlock(&self->correlation->lock);
+  g_mutex_unlock(&self->correlation->lock);
   _flush_emitted_messages(self, &msg_emitter);
 }
 
@@ -407,7 +407,7 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
 {
   GPMessageEmitter msg_emitter = {0};
 
-  g_rw_lock_writer_lock(&self->correlation->lock);
+  g_mutex_lock(&self->correlation->lock);
   grouping_by_set_time(self, &msg->timestamps[LM_TS_STAMP], &msg_emitter);
 
   CorrelationContext *context = _lookup_or_create_context(self, msg);
@@ -427,7 +427,7 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
 
       LogMessage *genmsg = grouping_by_update_context_and_generate_msg(self, context);
 
-      g_rw_lock_writer_unlock(&self->correlation->lock);
+      g_mutex_unlock(&self->correlation->lock);
       _flush_emitted_messages(self, &msg_emitter);
 
       if (genmsg)
@@ -456,7 +456,7 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
 
   log_msg_write_protect(msg);
 
-  g_rw_lock_writer_unlock(&self->correlation->lock);
+  g_mutex_unlock(&self->correlation->lock);
   _flush_emitted_messages(self, &msg_emitter);
 
   return TRUE;

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -197,20 +197,7 @@ grouping_by_set_synthetic_message(LogParser *s, SyntheticMessage *message)
 void
 grouping_by_set_time(GroupingBy *self, const UnixTime *ls, GPMessageEmitter *msg_emitter)
 {
-  GTimeVal now;
-
-  /* clamp the current time between the timestamp of the current message
-   * (low limit) and the current system time (high limit).  This ensures
-   * that incorrect clocks do not skew the current time know by the
-   * correlation engine too much. */
-
-  cached_g_current_time(&now);
-  self->correlation->last_tick = now;
-
-  if (ls->ut_sec < now.tv_sec)
-    now.tv_sec = ls->ut_sec;
-
-  timer_wheel_set_time(self->correlation->timer_wheel, now.tv_sec, msg_emitter);
+  correlation_state_set_time(self->correlation, ls->ut_sec, msg_emitter);
   msg_debug("Advancing grouping-by() current time because of an incoming message",
             evt_tag_long("utc", timer_wheel_get_time(self->correlation->timer_wheel)),
             log_pipe_location_tag(&self->super.super.super));

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -407,7 +407,7 @@ _evaluate_where(GroupingBy *self, LogMessage **pmsg, const LogPathOptions *path_
 
 static gboolean
 _process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, const char *input,
-                    gsize input_len)
+         gsize input_len)
 {
   GroupingBy *self = (GroupingBy *) s;
 
@@ -422,7 +422,8 @@ _format_persist_name(const LogPipe *s)
   static gchar persist_name[512];
   GroupingBy *self = (GroupingBy *)s;
 
-  g_snprintf(persist_name, sizeof(persist_name), "grouping-by(%s,scope=%d,clone=%d)", self->key_template->template, self->scope, self->clone_id);
+  g_snprintf(persist_name, sizeof(persist_name), "grouping-by(%s,scope=%d,clone=%d)", self->key_template->template,
+             self->scope, self->clone_id);
   return persist_name;
 }
 
@@ -430,20 +431,22 @@ static void
 _load_correlation_state(GroupingBy *self, GlobalConfig *cfg)
 {
   CorrelationState *persisted_correlation = cfg_persist_config_fetch(cfg,
-                                                                     log_pipe_get_persist_name(&self->super.super.super));
+                                            log_pipe_get_persist_name(&self->super.super.super));
   if (persisted_correlation)
     {
       correlation_state_unref(self->correlation);
       self->correlation = persisted_correlation;
     }
 
-  timer_wheel_set_associated_data(self->correlation->timer_wheel, log_pipe_ref((LogPipe *)self), (GDestroyNotify)log_pipe_unref);
+  timer_wheel_set_associated_data(self->correlation->timer_wheel, log_pipe_ref((LogPipe *)self),
+                                  (GDestroyNotify)log_pipe_unref);
 }
 
 static void
 _store_data_in_persist(GroupingBy *self, GlobalConfig *cfg)
 {
-  cfg_persist_config_add(cfg, log_pipe_get_persist_name(&self->super.super.super), correlation_state_ref(self->correlation),
+  cfg_persist_config_add(cfg, log_pipe_get_persist_name(&self->super.super.super),
+                         correlation_state_ref(self->correlation),
                          (GDestroyNotify) correlation_state_unref, FALSE);
 }
 

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -191,7 +191,7 @@ _flush_emitted_messages(GroupingBy *self, GPMessageEmitter *msg_emitter)
 static void
 _free_persist_data(GroupingByPersistData *self)
 {
-  correlation_state_free(self->correlation);
+  correlation_state_unref(self->correlation);
   g_free(self);
 }
 

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -375,8 +375,9 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
 {
   GPMessageEmitter msg_emitter = {0};
 
-  correlation_state_tx_begin(self->correlation);
   _advance_time_based_on_message(self, &msg->timestamps[LM_TS_STAMP], &msg_emitter);
+
+  correlation_state_tx_begin(self->correlation);
 
   CorrelationContext *context = _lookup_or_create_context(self, msg);
   g_ptr_array_add(context->messages, log_msg_ref(msg));

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -526,8 +526,6 @@ _clone(LogPipe *s)
   grouping_by_set_where_condition(&cloned->super.super, filter_expr_clone(self->where_condition_expr));
   grouping_by_set_having_condition(&cloned->super.super, filter_expr_clone(self->having_condition_expr));
 
-  correlation_state_unref(cloned->correlation);
-  cloned->correlation = correlation_state_ref(self->correlation);
   cloned->clone_id = self->clone_id++;
   return &cloned->super.super.super;
 }

--- a/modules/dbparser/groupingby.h
+++ b/modules/dbparser/groupingby.h
@@ -34,7 +34,6 @@ void grouping_by_set_synthetic_message(LogParser *s, SyntheticMessage *message);
 void grouping_by_set_trigger_condition(LogParser *s, FilterExprNode *filter_expr);
 void grouping_by_set_where_condition(LogParser *s, FilterExprNode *filter_expr);
 void grouping_by_set_having_condition(LogParser *s, FilterExprNode *filter_expr);
-gchar *grouping_by_format_persist_name(LogParser *s);
 LogParser *grouping_by_new(GlobalConfig *cfg);
 void grouping_by_global_init(void);
 

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -464,12 +464,8 @@ void
 pattern_db_advance_time(PatternDB *self, gint timeout)
 {
   PDBProcessParams process_params= {0};
-  time_t new_time;
 
-  g_mutex_lock(&self->correlation.lock);
-  new_time = timer_wheel_get_time(self->correlation.timer_wheel) + timeout;
-  timer_wheel_set_time(self->correlation.timer_wheel, new_time, &process_params);
-  g_mutex_unlock(&self->correlation.lock);
+  correlation_state_advance_time(&self->correlation, timeout, &process_params);
   _flush_emitted_messages(self, &process_params);
 }
 

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -340,7 +340,8 @@ _execute_action_create_context(PatternDB *db, PDBProcessParams *process_params)
 
   correlation_key_init(&key, syn_context->scope, context_msg, buffer->str);
   new_context = pdb_context_new(&key);
-  correlation_state_tx_store_context(db->correlation, &new_context->super, rule->context.timeout, pattern_db_expire_entry);
+  correlation_state_tx_store_context(db->correlation, &new_context->super, rule->context.timeout,
+                                     pattern_db_expire_entry);
   g_string_free(buffer, FALSE);
 
   g_ptr_array_add(new_context->super.messages, context_msg);

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -442,36 +442,13 @@ pattern_db_expire_entry(TimerWheel *wheel, guint64 now, gpointer user_data, gpoi
 void
 pattern_db_timer_tick(PatternDB *self)
 {
-  GTimeVal now;
-  glong diff;
   PDBProcessParams process_params = {0};
 
-  g_mutex_lock(&self->correlation.lock);
-  cached_g_current_time(&now);
-  diff = g_time_val_diff(&now, &self->correlation.last_tick);
-
-  if (diff > 1e6)
+  if (correlation_state_timer_tick(&self->correlation, &process_params))
     {
-      glong diff_sec = (glong) (diff / 1e6);
-
-      timer_wheel_set_time(self->correlation.timer_wheel, timer_wheel_get_time(self->correlation.timer_wheel) + diff_sec, &process_params);
       msg_debug("Advancing patterndb current time because of timer tick",
                 evt_tag_long("utc", timer_wheel_get_time(self->correlation.timer_wheel)));
-      /* update last_tick, take the fraction of the seconds not calculated into this update into account */
-
-      self->correlation.last_tick = now;
-      g_time_val_add(&self->correlation.last_tick, - (glong)(diff - diff_sec * 1e6));
     }
-  else if (diff < 0)
-    {
-      /* time moving backwards, this can only happen if the computer's time
-       * is changed.  We don't update patterndb's idea of the time now, wait
-       * another tick instead to update that instead.
-       */
-      self->correlation.last_tick = now;
-    }
-
-  g_mutex_unlock(&self->correlation.lock);
   _flush_emitted_messages(self, &process_params);
 }
 

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -684,9 +684,7 @@ pattern_db_expire_state(PatternDB *self)
 {
   PDBProcessParams process_params = {0};
 
-  g_mutex_lock(&self->correlation.lock);
-  timer_wheel_expire_all(self->correlation.timer_wheel, &process_params);
-  g_mutex_unlock(&self->correlation.lock);
+  correlation_state_expire_all(&self->correlation, &process_params);
   _flush_emitted_messages(self, &process_params);
 
 }

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -479,20 +479,7 @@ pattern_db_timer_tick(PatternDB *self)
 static void
 _advance_time_based_on_message(PatternDB *self, PDBProcessParams *process_params, const UnixTime *ls)
 {
-  GTimeVal now;
-
-  /* clamp the current time between the timestamp of the current message
-   * (low limit) and the current system time (high limit).  This ensures
-   * that incorrect clocks do not skew the current time know by the
-   * correlation engine too much. */
-
-  cached_g_current_time(&now);
-  self->correlation.last_tick = now;
-
-  if (ls->ut_sec < now.tv_sec)
-    now.tv_sec = ls->ut_sec;
-
-  timer_wheel_set_time(self->correlation.timer_wheel, now.tv_sec, process_params);
+  correlation_state_set_time(&self->correlation, ls->ut_sec, process_params);
 
   msg_debug("Advancing patterndb current time because of an incoming message",
             evt_tag_long("utc", timer_wheel_get_time(self->correlation.timer_wheel)));

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -605,9 +605,7 @@ _pattern_db_advance_time_and_flush_expired(PatternDB *self, LogMessage *msg)
 {
   PDBProcessParams process_params = {0};
 
-  correlation_state_tx_begin(&self->correlation);
   _advance_time_based_on_message(self, &process_params, &msg->timestamps[LM_TS_STAMP]);
-  correlation_state_tx_end(&self->correlation);
   _flush_emitted_messages(self, &process_params);
 }
 

--- a/modules/dbparser/tests/CMakeLists.txt
+++ b/modules/dbparser/tests/CMakeLists.txt
@@ -9,4 +9,4 @@ target_compile_options(test_radix PRIVATE "-Wno-error=pointer-sign")
 add_unit_test(CRITERION TARGET test_parsers INCLUDES ${PATTERNDB_INCLUDE_DIR})
 target_compile_options(test_parsers PRIVATE "-Wno-error=pointer-sign")
 
-add_unit_test(CRITERION TARGET test_grouping_by DEPENDS dbparser)
+add_unit_test(CRITERION LIBTEST TARGET test_grouping_by DEPENDS dbparser basicfuncs)

--- a/modules/dbparser/tests/test_grouping_by.c
+++ b/modules/dbparser/tests/test_grouping_by.c
@@ -67,13 +67,13 @@ Test(grouping_by, cfg_persist_name_not_equal)
   grouping_by_set_key_template(parser, template);
   log_template_unref(template);
 
-  gchar *persist_name1 = g_strdup(grouping_by_format_persist_name(parser));
+  gchar *persist_name1 = g_strdup(log_pipe_get_persist_name(&parser->super));
 
   template = _get_template("$TEMPLATE2", cfg);
   grouping_by_set_key_template(parser, template);
   log_template_unref(template);
 
-  gchar *persist_name2 = g_strdup(grouping_by_format_persist_name(parser));
+  gchar *persist_name2 = g_strdup(log_pipe_get_persist_name(&parser->super));
 
   cr_assert_str_neq(persist_name1, persist_name2);
 
@@ -93,13 +93,13 @@ Test(grouping_by, cfg_persist_name_equal)
   grouping_by_set_key_template(parser, template);
   log_template_unref(template);
 
-  gchar *persist_name1 = g_strdup(grouping_by_format_persist_name(parser));
+  gchar *persist_name1 = g_strdup(log_pipe_get_persist_name(&parser->super));
 
   template = _get_template("$TEMPLATE1", cfg);
   grouping_by_set_key_template(parser, template);
   log_template_unref(template);
 
-  gchar *persist_name2 = g_strdup(grouping_by_format_persist_name(parser));
+  gchar *persist_name2 = g_strdup(log_pipe_get_persist_name(&parser->super));
 
   cr_assert_str_eq(persist_name1, persist_name2);
 

--- a/modules/dbparser/tests/test_grouping_by.c
+++ b/modules/dbparser/tests/test_grouping_by.c
@@ -28,9 +28,9 @@
 #include "cfg.h"
 
 static LogTemplate *
-_get_template(const gchar *template, GlobalConfig *cfg)
+_get_template(const gchar *template)
 {
-  LogTemplate *self = log_template_new(cfg, "dummy");
+  LogTemplate *self = log_template_new(configuration, NULL);
 
   cr_assert(log_template_compile(self, template, NULL));
 
@@ -39,14 +39,13 @@ _get_template(const gchar *template, GlobalConfig *cfg)
 
 Test(grouping_by, create_grouping_by)
 {
-  GlobalConfig *cfg = cfg_new_snippet();
-  LogParser *parser = grouping_by_new(cfg);
+  LogParser *parser = grouping_by_new(configuration);
 
   grouping_by_set_synthetic_message(parser, synthetic_message_new());
 
   grouping_by_set_timeout(parser, 1);
 
-  LogTemplate *template = _get_template("$TEMPLATE", cfg);
+  LogTemplate *template = _get_template("$TEMPLATE");
   grouping_by_set_key_template(parser, template);
   log_template_unref(template);
 
@@ -55,21 +54,19 @@ Test(grouping_by, create_grouping_by)
   cr_assert(log_pipe_deinit(&parser->super));
 
   log_pipe_unref(&parser->super);
-  cfg_free(cfg);
 }
 
 Test(grouping_by, cfg_persist_name_not_equal)
 {
-  GlobalConfig *cfg = cfg_new_snippet();
-  LogParser *parser = grouping_by_new(cfg);
+  LogParser *parser = grouping_by_new(configuration);
 
-  LogTemplate *template = _get_template("$TEMPLATE1", cfg);
+  LogTemplate *template = _get_template("$TEMPLATE1");
   grouping_by_set_key_template(parser, template);
   log_template_unref(template);
 
   gchar *persist_name1 = g_strdup(log_pipe_get_persist_name(&parser->super));
 
-  template = _get_template("$TEMPLATE2", cfg);
+  template = _get_template("$TEMPLATE2");
   grouping_by_set_key_template(parser, template);
   log_template_unref(template);
 
@@ -81,21 +78,19 @@ Test(grouping_by, cfg_persist_name_not_equal)
   g_free(persist_name2);
 
   log_pipe_unref(&parser->super);
-  cfg_free(cfg);
 }
 
 Test(grouping_by, cfg_persist_name_equal)
 {
-  GlobalConfig *cfg = cfg_new_snippet();
-  LogParser *parser = grouping_by_new(cfg);
+  LogParser *parser = grouping_by_new(configuration);
 
-  LogTemplate *template = _get_template("$TEMPLATE1", cfg);
+  LogTemplate *template = _get_template("$TEMPLATE1");
   grouping_by_set_key_template(parser, template);
   log_template_unref(template);
 
   gchar *persist_name1 = g_strdup(log_pipe_get_persist_name(&parser->super));
 
-  template = _get_template("$TEMPLATE1", cfg);
+  template = _get_template("$TEMPLATE1");
   grouping_by_set_key_template(parser, template);
   log_template_unref(template);
 
@@ -107,18 +102,19 @@ Test(grouping_by, cfg_persist_name_equal)
   g_free(persist_name2);
 
   log_pipe_unref(&parser->super);
-  cfg_free(cfg);
 }
 
 static void
 setup(void)
 {
   app_startup();
-};
+  configuration = cfg_new_snippet();
+}
 
 static void
 teardown(void)
 {
+  cfg_free(configuration);
   app_shutdown();
 }
 

--- a/modules/dbparser/tests/test_grouping_by.c
+++ b/modules/dbparser/tests/test_grouping_by.c
@@ -22,10 +22,15 @@
  */
 
 #include <criterion/criterion.h>
+#include "libtest/cr_template.h"
+#include "libtest/msg_parse_lib.h"
 
 #include "groupingby.h"
+#include "filter/filter-expr-parser.h"
+#include "filter/filter-expr.h"
 #include "apphook.h"
 #include "cfg.h"
+#include "scratch-buffers.h"
 
 static LogTemplate *
 _get_template(const gchar *template)
@@ -34,6 +39,54 @@ _get_template(const gchar *template)
 
   cr_assert(log_template_compile(self, template, NULL));
 
+  return self;
+}
+
+static FilterExprNode *
+_compile_filter_expr(gchar *expr)
+{
+  FilterExprNode *expr_node;
+
+  CfgLexer *lexer = cfg_lexer_new_buffer(configuration, expr, strlen(expr));
+  cr_assert(lexer != NULL);
+
+  cr_assert(cfg_run_parser(configuration, lexer, &filter_expr_parser, (gpointer *) &expr_node, NULL));
+
+  return expr_node;
+}
+
+static LogMessage *
+_create_input_msg(const gchar *prog)
+{
+  LogMessage *msg = log_msg_new_empty();
+  log_msg_set_value_by_name(msg, "key", "thesamekey", -1);
+  log_msg_set_value_by_name(msg, "PROGRAM", prog, -1);
+  return msg;
+}
+
+typedef struct _TestCapturePipe
+{
+  LogPipe super;
+  LogMessage *captured_message;
+} TestCapturePipe;
+
+static void
+test_capture_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
+{
+  TestCapturePipe *self = (TestCapturePipe *) s;
+
+  log_msg_unref(self->captured_message);
+  self->captured_message = log_msg_ref(msg);
+  log_pipe_forward_msg(s, msg, path_options);
+}
+
+TestCapturePipe *
+test_capture_pipe_new(GlobalConfig *cfg)
+{
+  TestCapturePipe *self = g_new0(TestCapturePipe, 1);
+
+  log_pipe_init_instance(&self->super, cfg);
+  self->super.queue = test_capture_pipe_queue;
   return self;
 }
 
@@ -54,6 +107,50 @@ Test(grouping_by, create_grouping_by)
   cr_assert(log_pipe_deinit(&parser->super));
 
   log_pipe_unref(&parser->super);
+}
+
+Test(grouping_by, grouping_by_aggregates_messages)
+{
+  TestCapturePipe *capture = test_capture_pipe_new(configuration);
+  LogParser *parser = grouping_by_new(configuration);
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+
+  LogTemplate *template = _get_template("$key");
+  grouping_by_set_key_template(parser, template);
+  log_template_unref(template);
+
+  SyntheticMessage *sm = synthetic_message_new();
+  cr_assert(synthetic_message_add_value_template_string(sm, configuration, "aggr", "$(list-slice :-1 $(context-values $PROGRAM))", NULL) == TRUE);
+
+  grouping_by_set_synthetic_message(parser, sm);
+  grouping_by_set_timeout(parser, 1);
+
+  log_pipe_append(&parser->super, &capture->super);
+  cr_assert(log_pipe_init(&capture->super) == TRUE);
+  cr_assert(log_pipe_init(&parser->super) == TRUE);
+
+  FilterExprNode *trigger = _compile_filter_expr("\"$(context-length)\" == \"3\"");
+  grouping_by_set_trigger_condition(parser, trigger);
+
+  LogMessage *msg = _create_input_msg("first");
+  gboolean success = log_parser_process_message(parser, &msg, &path_options);
+  cr_assert(success == TRUE);
+  log_msg_unref(msg);
+
+  msg = _create_input_msg("second");
+  success = log_parser_process_message(parser, &msg, &path_options);
+  cr_assert(success == TRUE);
+  log_msg_unref(msg);
+
+  msg = _create_input_msg("third");
+  success = log_parser_process_message(parser, &msg, &path_options);
+  cr_assert(success == TRUE);
+  log_msg_unref(msg);
+
+  assert_log_message_value_by_name(capture->captured_message, "aggr", "first,second,third");
+
+  log_pipe_unref(&parser->super);
+  log_pipe_unref(&capture->super);
 }
 
 Test(grouping_by, cfg_persist_name_not_equal)
@@ -109,11 +206,13 @@ setup(void)
 {
   app_startup();
   configuration = cfg_new_snippet();
+  cfg_load_module(configuration, "basicfuncs");
 }
 
 static void
 teardown(void)
 {
+  scratch_buffers_explicit_gc();
   cfg_free(configuration);
   app_shutdown();
 }

--- a/modules/dbparser/tests/test_grouping_by.c
+++ b/modules/dbparser/tests/test_grouping_by.c
@@ -120,7 +120,8 @@ Test(grouping_by, grouping_by_aggregates_messages)
   log_template_unref(template);
 
   SyntheticMessage *sm = synthetic_message_new();
-  cr_assert(synthetic_message_add_value_template_string(sm, configuration, "aggr", "$(list-slice :-1 $(context-values $PROGRAM))", NULL) == TRUE);
+  cr_assert(synthetic_message_add_value_template_string(sm, configuration, "aggr",
+                                                        "$(list-slice :-1 $(context-values $PROGRAM))", NULL) == TRUE);
 
   grouping_by_set_synthetic_message(parser, sm);
   grouping_by_set_timeout(parser, 1);

--- a/modules/dbparser/timerwheel.c
+++ b/modules/dbparser/timerwheel.c
@@ -207,9 +207,14 @@ timer_wheel_del_timer(TimerWheel *self, TWEntry *entry)
 void
 timer_wheel_mod_timer(TimerWheel *self, TWEntry *entry, gint new_timeout)
 {
-  tw_entry_unlink(entry);
-  entry->target = self->now + new_timeout;
-  timer_wheel_add_timer_entry(self, entry);
+  guint64 new_target = self->now + new_timeout;
+
+  if (new_target != entry->target)
+    {
+      tw_entry_unlink(entry);
+      entry->target = new_target;
+      timer_wheel_add_timer_entry(self, entry);
+    }
 }
 
 guint64

--- a/modules/timestamp/rewrite-fix-timezone.c
+++ b/modules/timestamp/rewrite-fix-timezone.c
@@ -85,8 +85,7 @@ _clone(LogPipe *s)
 
   rewrite_fix_time_zone_set_zone_template_ref(cloned, log_template_ref(self->zone_template));
   rewrite_fix_time_zone_set_time_stamp(cloned, self->stamp);
-  if (self->super.condition)
-    cloned->condition = filter_expr_clone(self->super.condition);
+  cloned->condition = filter_expr_clone(self->super.condition);
 
   return &cloned->super;
 }

--- a/modules/timestamp/rewrite-guess-timezone.c
+++ b/modules/timestamp/rewrite-guess-timezone.c
@@ -61,8 +61,7 @@ _clone(LogPipe *s)
   cloned = rewrite_guess_time_zone_new(s->cfg);
 
   rewrite_guess_time_zone_set_time_stamp(cloned, self->stamp);
-  if (self->super.condition)
-    cloned->condition = filter_expr_clone(self->super.condition);
+  cloned->condition = filter_expr_clone(self->super.condition);
 
   return &cloned->super;
 }

--- a/modules/timestamp/rewrite-set-timezone.c
+++ b/modules/timestamp/rewrite-set-timezone.c
@@ -84,8 +84,7 @@ _clone(LogPipe *s)
 
   rewrite_set_time_zone_set_zone_template_ref(cloned, log_template_ref(self->zone_template));
   rewrite_set_time_zone_set_time_stamp(cloned, self->stamp);
-  if (self->super.condition)
-    cloned->condition = filter_expr_clone(self->super.condition);
+  cloned->condition = filter_expr_clone(self->super.condition);
 
   return &cloned->super;
 }

--- a/news/bugfix-3957.md
+++ b/news/bugfix-3957.md
@@ -1,0 +1,10 @@
+`grouping-by()`: fix `grouping-by()` use through parser references.
+Originally if a grouping-by() was part of a named parser statement and was
+referenced from multiple log statements, only the first grouping-by()
+instance behaved properly, 2nd and subsequent references were ignoring all
+configuration options and have reverted using defaults instead.
+
+`db-parser()`: similarly to `grouping-by()`, `db-parser()` also had issues
+propagating some of its options to 2nd and subsequent references of a parser
+statement. This includes `drop-unmatched()`, `program-template()` and
+`template()` options.


### PR DESCRIPTION
grouping-by() had an incomplete log_pipe_clone() implementation, which meant that whenever we were using a grouping-by() through a reference (e.g. not as an inline block), not all settings propagated to different references.

This branch is a much larger than I anticipated as ~~it also implements state sharing between these clones and~~ refactors a lot of similarities between db-parser() and grouping-by() as they share a common infrastructure.

I added a test to get at least some unit test coverage for grouping-by(), but that's still far from complete. db-parser() has a more complete testsuite and a lot of the code is shared between the code. I do hope that @kira-syslogng and light has some end-to-end tests.

~~Albeit this branch makes it possible it does not add similar state sharing to db-parser(), yet. I opened the PR as I felt I needed to get some feedback (from both reviewers and kira).~~

~~Also, it's a tricky question which of the clones would handle timer expirations. I do know the answer, but it's a great question to answer if you are doing the review.~~

I've used this config to test:

```
@version: 3.36


parser p_gby {
        grouping-by(
                key("$PROGRAM")
                aggregate(
                        value("aggr" "$(list-slice :-1 $(context-values $mod))")
                )
                timeout(3)
        );
};

log {
        source { tcp(port(2000)); };
        if ("$(% $SEC 2)" == "0") {
                rewrite { set("0" value("mod")); };
                parser(p_gby);
        } else {
                rewrite { set("1" value("mod")); };
                parser(p_gby);
        };
        filter { "$aggr" ne "" };
        destination { file("aggr.log" template("$(format-json aggr)\n")); };
};
```