### PR TITLE
afstomp: always use "0" in the receipt header

### DIFF
--- a/modules/afstomp/afstomp.c
+++ b/modules/afstomp/afstomp.c
@@ -279,7 +279,6 @@ afstomp_worker_publish(STOMPDestDriver *self, LogMessage *msg)
   GString *body = NULL;
   stomp_frame frame;
   stomp_frame recv_frame;
-  gchar seq_num[16];
 
   if (!self->conn)
     {
@@ -296,8 +295,14 @@ afstomp_worker_publish(STOMPDestDriver *self, LogMessage *msg)
   stomp_frame_add_header(&frame, "destination", self->destination);
   if (self->ack_needed)
     {
-      g_snprintf(seq_num, sizeof(seq_num), "%i", self->super.worker.instance.seq_num);
-      stomp_frame_add_header(&frame, "receipt", seq_num);
+      /*
+       * We check the server's response before sending a new frame to it.
+       * Because of this, we do not need a unique receipt header.
+       *
+       * This changes if multiple workers and/or batching support is introduced.
+       * Make sure to use a unique receipt-id if one of the above gets implemented.
+       */
+      stomp_frame_add_header(&frame, "receipt", "0");
     };
 
   LogTemplateEvalOptions options = {&self->template_options, LTZ_SEND, self->super.worker.instance.seq_num, NULL, LM_VT_STRING};


### PR DESCRIPTION
After 3d124fb the uniqueness of the `seq_num` field is not guaranteed.
In theory this could cause a problem in the STOMP communication, but with the current implementation it works correctly.

With this commit I intend to emphasize that we do not need a unique ID in the receipt header by using the same one each time. I also added a comment which explains why it is not a problem currently, and how it could cause a problem in the future.

------------------------------------------------------------------------

Explanation:

We check the server's response before sending a new frame to it.
Because of this, we do not need a unique receipt header.

This changes if multiple workers and/or batching support is introduced.
Make sure to use a unique receipt-id if one of the above gets implemented.

------------------------------------------------------------------------

Useful links:

https://stomp.github.io/stomp-specification-1.2.html#Header_receipt
https://stomp.github.io/stomp-specification-1.2.html#RECEIPT

------------------------------------------------------------------------

No news entry needed IMO.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>