### PR TITLE
pragma-grammar: fix version number in deprecation warnings

### DIFF
--- a/lib/pragma-grammar.ym
+++ b/lib/pragma-grammar.ym
@@ -64,11 +64,11 @@ _report_define_deprecations(const gchar *name, const gchar *value)
 {
   if (strcmp(name, "autoload-compiled-modules") == 0 && atoi(value) == 0)
     msg_warning("WARNING: disabling plugin discovery via the autoload-compiled-modules "
-                "@define has become unsupported in " VERSION_3_36
+                "@define has become unsupported in " VERSION_3_37
                 ", use the syslog-ng command line option --no-module-discovery instead");
   else if (strcmp(name, "module-path") == 0)
     msg_warning("WARNING: changing the path to runtime loaded modules via the module-path "
-                "@define has become unsupported in " VERSION_3_36
+                "@define has become unsupported in " VERSION_3_37
                 ", use the command line option --module-path instead");
 }
 

--- a/lib/versioning.h
+++ b/lib/versioning.h
@@ -131,6 +131,7 @@
 #define VERSION_3_34 "syslog-ng 3.34"
 #define VERSION_3_35 "syslog-ng 3.35"
 #define VERSION_3_36 "syslog-ng 3.36"
+#define VERSION_3_37 "syslog-ng 3.37"
 
 #define VERSION_4_0 "syslog-ng 4.0"
 
@@ -174,6 +175,7 @@
 #define VERSION_VALUE_3_34 0x0322
 #define VERSION_VALUE_3_35 0x0323
 #define VERSION_VALUE_3_36 0x0324
+#define VERSION_VALUE_3_37 0x0325
 
 /* these are defined to allow 4.0 related changes to be introduced while we
  * are still producing 3.x releases. */


### PR DESCRIPTION
#3896  was opened before 3.36 had been released.