### PR TITLE
Support template expressions in set-tag()

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -959,6 +959,11 @@ log_msg_set_tag_by_id_onoff(LogMessage *self, LogTagId id, gboolean on)
   gboolean inline_tags;
 
   g_assert(!log_msg_is_write_protected(self));
+
+  msg_trace("Setting tag",
+            evt_tag_str("name", log_tags_get_by_id(id)),
+            evt_tag_int("value", on),
+            evt_tag_printf("msg", "%p", self));
   if (!log_msg_chk_flag(self, LF_STATE_OWN_TAGS) && self->num_tags)
     {
       self->tags = g_memdup(self->tags, sizeof(self->tags[0]) * self->num_tags);

--- a/lib/logmsg/tags.h
+++ b/lib/logmsg/tags.h
@@ -41,6 +41,8 @@ typedef guint16 LogTagId;
 #define LOG_TAGS_MAX   16384
 #endif
 
+#define LOG_TAGS_UNDEF  0xFFFF
+
 LogTagId log_tags_get_by_name(const gchar *name);
 const gchar *log_tags_get_by_id(LogTagId id);
 

--- a/lib/rewrite/rewrite-expr-grammar.ym
+++ b/lib/rewrite/rewrite-expr-grammar.ym
@@ -136,16 +136,16 @@ rewrite_expr
             last_rewrite = log_rewrite_rename_new(configuration, from, to);
           }
           rewrite_rename_opts ')'              { $$ = last_rewrite; }
-	| KW_SET_TAG '(' string 
+	| KW_SET_TAG '(' template_content
 	  { 
 	    last_rewrite = log_rewrite_set_tag_new($3, TRUE, configuration);
-            free($3);
+            log_template_unref($3);
           }
 	  rewrite_settag_opts ')'             	{ $$ = last_rewrite; }
-	| KW_CLEAR_TAG '(' string
+	| KW_CLEAR_TAG '(' template_content
           {
             last_rewrite = log_rewrite_set_tag_new($3, FALSE, configuration);
-            free($3);
+            log_template_unref($3);
           }
           rewrite_settag_opts ')'               { $$ = last_rewrite; }
         | KW_GROUP_SET '(' template_content

--- a/lib/rewrite/rewrite-set-tag.c
+++ b/lib/rewrite/rewrite-set-tag.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
+ * Copyright (c) 2022 Balazs Scheidler <bazsi77@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -23,6 +24,8 @@
  */
 
 #include "rewrite-set-tag.h"
+#include "template/templates.h"
+#include "scratch-buffers.h"
 
 /* LogRewriteSetTag
  *
@@ -35,43 +38,78 @@ struct _LogRewriteSetTag
   LogRewrite super;
   LogTagId tag_id;
   gboolean value;
+  LogTemplate *tag_template;
 };
 
 static void
-log_rewrite_set_tag_process(LogRewrite *s, LogMessage **pmsg, const LogPathOptions *path_options)
+_set_tag(LogRewriteSetTag *self, LogMessage *msg)
+{
+  if (self->tag_id != LOG_TAGS_UNDEF)
+    {
+      log_msg_set_tag_by_id_onoff(msg, self->tag_id, self->value);
+      return;
+    }
+
+  GString *result = scratch_buffers_alloc();
+
+  log_template_format(self->tag_template, msg, &DEFAULT_TEMPLATE_EVAL_OPTIONS, result);
+
+  LogTagId tag_id = log_tags_get_by_name(result->str);
+  log_msg_set_tag_by_id_onoff(msg, tag_id, self->value);
+}
+
+static void
+_process(LogRewrite *s, LogMessage **pmsg, const LogPathOptions *path_options)
 {
   LogRewriteSetTag *self = (LogRewriteSetTag *) s;
 
   log_msg_make_writable(pmsg, path_options);
-  log_msg_set_tag_by_id_onoff(*pmsg, self->tag_id, self->value);
+
+  _set_tag(self, *pmsg);
 }
 
 static LogPipe *
-log_rewrite_set_tag_clone(LogPipe *s)
+_clone(LogPipe *s)
 {
   LogRewriteSetTag *self = (LogRewriteSetTag *) s;
   LogRewriteSetTag *cloned;
 
-  cloned = g_new0(LogRewriteSetTag, 1);
-  log_rewrite_init_instance(&cloned->super, s->cfg);
-  cloned->super.super.clone = log_rewrite_set_tag_clone;
-  cloned->super.process = log_rewrite_set_tag_process;
-  cloned->super.condition = filter_expr_clone(self->super.condition);
+  cloned = (LogRewriteSetTag *) log_rewrite_set_tag_new(self->tag_template, self->value, self->super.super.cfg);
 
-  cloned->tag_id = self->tag_id;
-  cloned->value = self->value;
+  cloned->super.condition = filter_expr_clone(self->super.condition);
   return &cloned->super.super;
 }
 
+static void
+_free(LogPipe *s)
+{
+  LogRewriteSetTag *self = (LogRewriteSetTag *) s;
+
+  log_template_unref(self->tag_template);
+  log_rewrite_free_method(s);
+}
+
 LogRewrite *
-log_rewrite_set_tag_new(const gchar *tag_name, gboolean value, GlobalConfig *cfg)
+log_rewrite_set_tag_new(LogTemplate *tag_template, gboolean value, GlobalConfig *cfg)
 {
   LogRewriteSetTag *self = g_new0(LogRewriteSetTag, 1);
 
   log_rewrite_init_instance(&self->super, cfg);
-  self->super.super.clone = log_rewrite_set_tag_clone;
-  self->super.process = log_rewrite_set_tag_process;
-  self->tag_id = log_tags_get_by_name(tag_name);
+  self->super.super.clone = _clone;
+  self->super.super.free_fn = _free;
+  self->super.process = _process;
   self->value = value;
+
+  if (log_template_is_literal_string(tag_template))
+    {
+      const gchar *tag_name = log_template_get_literal_value(tag_template, NULL);
+      self->tag_id = log_tags_get_by_name(tag_name);
+    }
+  else
+    {
+      self->tag_template = log_template_ref(tag_template);
+      self->tag_id = LOG_TAGS_UNDEF;
+    }
+
   return &self->super;
 }

--- a/lib/rewrite/rewrite-set-tag.h
+++ b/lib/rewrite/rewrite-set-tag.h
@@ -28,6 +28,6 @@
 #include "rewrite-expr.h"
 
 /* LogRewriteSetTag */
-LogRewrite *log_rewrite_set_tag_new(const gchar *tag_name, gboolean onoff, GlobalConfig *cfg);
+LogRewrite *log_rewrite_set_tag_new(LogTemplate *tag_template, gboolean onoff, GlobalConfig *cfg);
 
 #endif

--- a/lib/rewrite/rewrite-set.c
+++ b/lib/rewrite/rewrite-set.c
@@ -71,6 +71,7 @@ log_rewrite_set_clone(LogPipe *s)
   cloned->super.value_handle = self->super.value_handle;
   cloned->super.condition = filter_expr_clone(self->super.condition);
 
+  log_template_options_clone(&self->template_options, &cloned->template_options);
   return &cloned->super.super;
 }
 

--- a/lib/rewrite/tests/CMakeLists.txt
+++ b/lib/rewrite/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_unit_test(LIBTEST CRITERION TARGET test_rewrite)
 add_unit_test(LIBTEST CRITERION TARGET test_set_pri)
+add_unit_test(LIBTEST CRITERION TARGET test_set_tag)
 add_unit_test(LIBTEST CRITERION TARGET test_rename)
 add_unit_test(LIBTEST CRITERION TARGET test_set_severity)
 add_unit_test(LIBTEST CRITERION TARGET test_set_facility)

--- a/lib/rewrite/tests/Makefile.am
+++ b/lib/rewrite/tests/Makefile.am
@@ -2,6 +2,7 @@ lib_rewrite_tests_TESTS = \
     lib/rewrite/tests/test_rewrite \
     lib/rewrite/tests/test_set_pri \
     lib/rewrite/tests/test_set_matches \
+    lib/rewrite/tests/test_set_tag \
     lib/rewrite/tests/test_rename \
     lib/rewrite/tests/test_set_severity \
     lib/rewrite/tests/test_set_facility
@@ -40,3 +41,8 @@ lib_rewrite_tests_test_set_matches_CFLAGS = $(TEST_CFLAGS)
 lib_rewrite_tests_test_set_matches_LDADD = $(TEST_LDADD)
 lib_rewrite_tests_test_set_matches_SOURCES =    \
     lib/rewrite/tests/test_set_matches.c
+
+lib_rewrite_tests_test_set_tag_CFLAGS = $(TEST_CFLAGS)
+lib_rewrite_tests_test_set_tag_LDADD = $(TEST_LDADD)
+lib_rewrite_tests_test_set_tag_SOURCES =    \
+    lib/rewrite/tests/test_set_tag.c

--- a/lib/rewrite/tests/test_rewrite.c
+++ b/lib/rewrite/tests/test_rewrite.c
@@ -31,6 +31,7 @@
 #include "plugin.h"
 #include "cfg-grammar.h"
 #include "rewrite/rewrite-expr.h"
+#include "scratch-buffers.h"
 
 void
 expect_config_parse_failure(const char *raw_rewrite_rule)
@@ -347,6 +348,7 @@ setup(void)
 void
 teardown(void)
 {
+  scratch_buffers_explicit_gc();
   stop_grabbing_messages();
   app_shutdown();
 }

--- a/lib/rewrite/tests/test_set_tag.c
+++ b/lib/rewrite/tests/test_set_tag.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2022 Balazs Scheidler <bazsi77@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include "libtest/msg_parse_lib.h"
+
+#include "apphook.h"
+#include "rewrite/rewrite-set-tag.h"
+#include "logmsg/logmsg.h"
+#include "scratch-buffers.h"
+
+GlobalConfig *cfg = NULL;
+LogMessage *msg;
+
+static LogTemplate *
+_create_template(const gchar *str)
+{
+  GError *error = NULL;
+  LogTemplate *template = log_template_new(cfg, NULL);
+  cr_assert(log_template_compile(template, str, &error));
+
+  cr_expect_null(error);
+
+  return template;
+}
+
+static void
+_perform_rewrite(LogRewrite *rewrite, LogMessage *msg_)
+{
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+
+  log_pipe_init(&rewrite->super);
+  log_pipe_queue(&rewrite->super, log_msg_ref(msg_), &path_options);
+  log_pipe_deinit(&rewrite->super);
+  log_pipe_unref(&rewrite->super);
+}
+
+static void
+_perform_set_tag(LogTemplate *template, gboolean onoff, LogMessage *msg_)
+{
+  LogRewrite *rewrite = log_rewrite_set_tag_new(template, onoff, cfg);
+  log_template_unref(template);
+
+  _perform_rewrite(rewrite, msg_);
+}
+
+Test(set_tag, literal_tags)
+{
+  _perform_set_tag(_create_template("literal-tag"), TRUE, msg);
+  assert_log_message_has_tag(msg, "literal-tag");
+
+  _perform_set_tag(_create_template("literal-tag"), FALSE, msg);
+  assert_log_message_doesnt_have_tag(msg, "literal-tag");
+}
+
+Test(set_tag, templates_in_set_tag)
+{
+  log_msg_set_value_by_name(msg, "tag_name", "FOOBAR", -1);
+  _perform_set_tag(_create_template("tag-${tag_name}"), TRUE, msg);
+
+  log_msg_set_value_by_name(msg, "tag_name", "BARFOO", -1);
+  _perform_set_tag(_create_template("tag-${tag_name}"), TRUE, msg);
+  assert_log_message_has_tag(msg, "tag-FOOBAR");
+  assert_log_message_has_tag(msg, "tag-BARFOO");
+
+  _perform_set_tag(_create_template("tag-${tag_name}"), FALSE, msg);
+  assert_log_message_doesnt_have_tag(msg, "tag-BARFOO");
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  cfg = cfg_new_snippet();
+  msg = log_msg_new_empty();
+}
+
+static void
+teardown(void)
+{
+  scratch_buffers_explicit_gc();
+  log_msg_unref(msg);
+  cfg_free(cfg);
+  app_shutdown();
+}
+
+TestSuite(set_tag, .init = setup, .fini = teardown);

--- a/lib/template/templates.c
+++ b/lib/template/templates.c
@@ -342,6 +342,24 @@ log_template_options_init(LogTemplateOptions *options, GlobalConfig *cfg)
 }
 
 void
+log_template_options_clone(LogTemplateOptions *source, LogTemplateOptions *dest)
+{
+  dest->ts_format = source->ts_format;
+  for (gint i = 0; i < LTZ_MAX; i++)
+    {
+      if (source->time_zone[i])
+        dest->time_zone[i] = g_strdup(source->time_zone[i]);
+    }
+  dest->frac_digits = source->frac_digits;
+  dest->on_error = source->on_error;
+  dest->use_fqdn = source->use_fqdn;
+
+  /* NOTE: this still needs to be initialized by the owner as clone results
+   * in an uninitialized state.  */
+  dest->initialized = FALSE;
+}
+
+void
 log_template_options_destroy(LogTemplateOptions *options)
 {
   gint i;

--- a/lib/template/templates.h
+++ b/lib/template/templates.h
@@ -82,6 +82,7 @@ LogTemplate *log_template_new(GlobalConfig *cfg, const gchar *name);
 LogTemplate *log_template_ref(LogTemplate *s);
 void log_template_unref(LogTemplate *s);
 
+void log_template_options_clone(LogTemplateOptions *source, LogTemplateOptions *dest);
 void log_template_options_init(LogTemplateOptions *options, GlobalConfig *cfg);
 void log_template_options_destroy(LogTemplateOptions *options);
 void log_template_options_defaults(LogTemplateOptions *options);

--- a/news/bugfix-3962.md
+++ b/news/bugfix-3962.md
@@ -1,0 +1,6 @@
+`set()`: make sure that template formatting options (such as time-zone() or
+frac-digits()) are propagated to all references of the rewrite rule
+containing a set(). Previously the clone() operation used to implement
+multiple references missed the template related options while cloning set(),
+causing template formatting options to be set differently, depending on
+where the set() was referenced from.

--- a/news/feature-3962.md
+++ b/news/feature-3962.md
@@ -1,0 +1,3 @@
+`set-tag()`: add support for using template expressions in set-tag() rewrite
+operations, which makes it possible to use tag names that include macro
+references.

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -68,6 +68,7 @@ lib/rewrite/rewrite-set-matches\.[ch]
 lib/rewrite/rewrite-unset-matches\.[ch]
 lib/rewrite/tests/test_set_matches\.c
 lib/rewrite/tests/test_set_facility\.c
+lib/rewrite/tests/test_set_tag\.c
 lib/rewrite/rewrite-set-pri\.h
 lib/rewrite/rewrite-set-pri\.c
 lib/timeutils/timeutils\.h

--- a/tests/light/functional_tests/rewrites/set-tag/test_set_tag.py
+++ b/tests/light/functional_tests/rewrites/set-tag/test_set_tag.py
@@ -28,8 +28,8 @@ def test_set_tag(config, syslog_ng):
     notmatch = Match(config.stringify("NONE"), value=config.stringify("MSG"))
 
     generator_source = config.create_example_msg_generator_source(num=1, template=config.stringify("input with MATCHSTRING in it"))
-    set_tag_with_matching = config.create_rewrite_set_tag("SHOULDMATCH", condition=match)
-    set_tag_without_matching = config.create_rewrite_set_tag("DONOTMATCH", condition=notmatch)
+    set_tag_with_matching = config.create_rewrite_set_tag(config.stringify("SHOULDMATCH"), condition=match)
+    set_tag_without_matching = config.create_rewrite_set_tag(config.stringify("DONOTMATCH"), condition=notmatch)
     file_destination = config.create_file_destination(file_name="output.log", template=config.stringify('${TAGS}\n'))
     config.create_logpath(statements=[generator_source, set_tag_with_matching, set_tag_without_matching, file_destination])
 

--- a/tests/light/functional_tests/rewrites/set-tag/test_set_tag.py
+++ b/tests/light/functional_tests/rewrites/set-tag/test_set_tag.py
@@ -37,3 +37,14 @@ def test_set_tag(config, syslog_ng):
     log_line = file_destination.read_log().strip()
     assert "SHOULDMATCH" in log_line
     assert "DONOTMATCH" not in log_line
+
+
+def test_set_tag_with_template(config, syslog_ng):
+    generator_source = config.create_example_msg_generator_source(num=1, template=config.stringify("FOO"))
+    set_tag_with_template = config.create_rewrite_set_tag(config.stringify("TAG-${MSG}"))
+    file_destination = config.create_file_destination(file_name="output.log", template=config.stringify('${TAGS}\n'))
+    config.create_logpath(statements=[generator_source, set_tag_with_template, file_destination])
+
+    syslog_ng.start(config)
+    log_line = file_destination.read_log().strip()
+    assert "TAG-FOO" in log_line


### PR DESCRIPTION
Fixes #3956 and adds both light and unit test coverage.

Test config:
```
@version: 3.36

rewrite foo {
	set-tag("dyn::$PROGRAM");
};

log {
	source { tcp(port(2000)); };
	rewrite(foo);
	rewrite { set-tag("dyn::$HOST"); };
	rewrite(foo);
};
```

The result of the above config is that we get trace messages on the tags being set properly.
