### PR TITLE
Add scalable FIFO support to LogThreadedSource based sources

### DIFF
--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -406,6 +406,13 @@ afinter_source_options_defaults(AFInterSourceOptions *options)
 }
 
 static gboolean
+afinter_sd_pre_config_init(LogPipe *s)
+{
+  main_loop_worker_allocate_thread_space(1);
+  return TRUE;
+}
+
+static gboolean
 afinter_sd_init(LogPipe *s)
 {
   AFInterSourceDriver *self = (AFInterSourceDriver *) s;
@@ -485,6 +492,7 @@ afinter_sd_new(GlobalConfig *cfg)
   AFInterSourceDriver *self = g_new0(AFInterSourceDriver, 1);
 
   log_src_driver_init_instance((LogSrcDriver *)&self->super, cfg);
+  self->super.super.super.pre_config_init = afinter_sd_pre_config_init;
   self->super.super.super.init = afinter_sd_init;
   self->super.super.super.deinit = afinter_sd_deinit;
   self->super.super.super.free_fn = afinter_sd_free;

--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -122,6 +122,7 @@ afinter_source_post(gpointer s)
 
       stats_counter_dec(internal_queue_length);
       log_source_post(&self->super, msg);
+      main_loop_worker_invoke_batch_callbacks();
     }
   afinter_source_update_watches(self);
 }

--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -443,7 +443,7 @@ afinter_sd_init(LogPipe *s)
 }
 
 static gboolean
-afinter_sd_on_config_inited(LogPipe *s)
+afinter_sd_post_config_init(LogPipe *s)
 {
   AFInterSourceDriver *self = (AFInterSourceDriver *) s;
 
@@ -488,7 +488,7 @@ afinter_sd_new(GlobalConfig *cfg)
   self->super.super.super.init = afinter_sd_init;
   self->super.super.super.deinit = afinter_sd_deinit;
   self->super.super.super.free_fn = afinter_sd_free;
-  self->super.super.super.on_config_inited = afinter_sd_on_config_inited;
+  self->super.super.super.post_config_init = afinter_sd_post_config_init;
 
   afinter_source_options_defaults(&self->source_options);
 

--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -249,6 +249,18 @@ app_shutdown(void)
 }
 
 void
+app_config_pre_pre_init(void)
+{
+  run_application_hook(AH_CONFIG_PRE_PRE_INIT);
+}
+
+void
+app_config_pre_init(void)
+{
+  run_application_hook(AH_CONFIG_PRE_INIT);
+}
+
+void
 app_config_stopped(void)
 {
   run_application_hook(AH_CONFIG_STOPPED);

--- a/lib/apphook.h
+++ b/lib/apphook.h
@@ -42,9 +42,11 @@ enum
 
   /* these happen from time to time and don't update the current state of
    * the process */
-  AH_CONFIG_STOPPED,   /* configuration is deinitialized, threads have stopped */
-  AH_CONFIG_CHANGED,   /* configuration changed, threads are running again */
-  AH_REOPEN_FILES,     /* reopen files signal from syslog-ng-ctl */
+  AH_CONFIG_PRE_PRE_INIT,  /* configuration pre_init() is to be called */
+  AH_CONFIG_PRE_INIT,      /* configuration init() is to be called */
+  AH_CONFIG_STOPPED,       /* configuration is deinitialized, threads have stopped */
+  AH_CONFIG_CHANGED,       /* configuration changed, threads are running again */
+  AH_REOPEN_FILES,         /* reopen files signal from syslog-ng-ctl */
 };
 
 typedef enum
@@ -61,6 +63,8 @@ void app_pre_shutdown(void);
 void app_shutdown(void);
 
 /* stateless entry points */
+void app_config_pre_pre_init(void);
+void app_config_pre_init(void);
 void app_config_stopped(void);
 void app_config_changed(void);
 void app_reopen_files(void);

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -1438,8 +1438,6 @@ cfg_tree_stop(CfgTree *self)
   gboolean success = TRUE;
   gint i;
 
-  g_assert(self->compiled);
-
   for (i = 0; i < self->initialized_pipes->len; i++)
     {
       if (!log_pipe_deinit(g_ptr_array_index(self->initialized_pipes, i)))

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -1449,7 +1449,7 @@ cfg_tree_stop(CfgTree *self)
 }
 
 gboolean
-cfg_tree_on_inited(CfgTree *self)
+cfg_tree_post_config_init(CfgTree *self)
 {
   gint i;
 
@@ -1457,9 +1457,9 @@ cfg_tree_on_inited(CfgTree *self)
     {
       LogPipe *pipe = g_ptr_array_index(self->initialized_pipes, i);
 
-      if (!log_pipe_on_config_inited(pipe))
+      if (!log_pipe_post_config_init(pipe))
         {
-          msg_error("Error executing on_config_inited hook",
+          msg_error("Error executing post_config_init hook",
                     evt_tag_str("plugin_name", pipe->plugin_name ? pipe->plugin_name : "not a plugin"),
                     log_pipe_location_tag(pipe));
           return FALSE;

--- a/lib/cfg-tree.h
+++ b/lib/cfg-tree.h
@@ -181,8 +181,10 @@ LogTemplate *cfg_tree_check_inline_template(CfgTree *self, const gchar *template
 gchar *cfg_tree_get_rule_name(CfgTree *self, gint content, LogExprNode *node);
 gchar *cfg_tree_get_child_id(CfgTree *self, gint content, LogExprNode *node);
 
+gboolean cfg_tree_compile(CfgTree *self);
 gboolean cfg_tree_start(CfgTree *self);
 gboolean cfg_tree_stop(CfgTree *self);
+gboolean cfg_tree_pre_config_init(CfgTree *self);
 gboolean cfg_tree_post_config_init(CfgTree *self);
 
 void cfg_tree_init_instance(CfgTree *self, GlobalConfig *cfg);

--- a/lib/cfg-tree.h
+++ b/lib/cfg-tree.h
@@ -183,7 +183,7 @@ gchar *cfg_tree_get_child_id(CfgTree *self, gint content, LogExprNode *node);
 
 gboolean cfg_tree_start(CfgTree *self);
 gboolean cfg_tree_stop(CfgTree *self);
-gboolean cfg_tree_on_inited(CfgTree *self);
+gboolean cfg_tree_post_config_init(CfgTree *self);
 
 void cfg_tree_init_instance(CfgTree *self, GlobalConfig *cfg);
 void cfg_tree_free_instance(CfgTree *self);

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -360,6 +360,10 @@ cfg_init(GlobalConfig *cfg)
   log_template_options_init(&cfg->template_options, cfg);
   if (!cfg_init_modules(cfg))
     return FALSE;
+  if (!cfg_tree_compile(&cfg->tree))
+    return FALSE;
+  if (!cfg_tree_pre_config_init(&cfg->tree))
+    return FALSE;
   if (!cfg_tree_start(&cfg->tree))
     return FALSE;
 

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -364,6 +364,7 @@ cfg_init(GlobalConfig *cfg)
     return FALSE;
   if (!cfg_tree_pre_config_init(&cfg->tree))
     return FALSE;
+  main_loop_worker_finalize_thread_space();
   if (!cfg_tree_start(&cfg->tree))
     return FALSE;
 

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -370,7 +370,7 @@ cfg_init(GlobalConfig *cfg)
    * task/timer/fdwatch ordering in ivykis during this action).
    * See: https://github.com/syslog-ng/syslog-ng/pull/3176#issuecomment-638849597
    */
-  g_assert(cfg_tree_on_inited(&cfg->tree));
+  g_assert(cfg_tree_post_config_init(&cfg->tree));
   return TRUE;
 }
 

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -43,6 +43,7 @@
 #include "resolved-configurable-paths.h"
 #include "mainloop.h"
 #include "timeutils/format.h"
+#include "apphook.h"
 
 #include <sys/types.h>
 #include <signal.h>
@@ -362,8 +363,10 @@ cfg_init(GlobalConfig *cfg)
     return FALSE;
   if (!cfg_tree_compile(&cfg->tree))
     return FALSE;
+  app_config_pre_pre_init();
   if (!cfg_tree_pre_config_init(&cfg->tree))
     return FALSE;
+  app_config_pre_init();
   main_loop_worker_finalize_thread_space();
   if (!cfg_tree_start(&cfg->tree))
     return FALSE;

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -367,7 +367,6 @@ cfg_init(GlobalConfig *cfg)
   if (!cfg_tree_pre_config_init(&cfg->tree))
     return FALSE;
   app_config_pre_init();
-  main_loop_worker_finalize_thread_space();
   if (!cfg_tree_start(&cfg->tree))
     return FALSE;
 

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -236,7 +236,7 @@ struct _LogPipe
    * starting worker thread, and etc. therefore, syslog-ng will terminate if
    * return value is false.
    */
-  gboolean (*on_config_inited)(LogPipe *self);
+  gboolean (*post_config_init)(LogPipe *self);
 
   const gchar *(*generate_persist_name)(const LogPipe *self);
   GList *(*arcs)(LogPipe *self);
@@ -328,10 +328,10 @@ log_pipe_deinit(LogPipe *s)
 }
 
 static inline gboolean
-log_pipe_on_config_inited(LogPipe *s)
+log_pipe_post_config_init(LogPipe *s)
 {
-  if (s->on_config_inited)
-    return s->on_config_inited(s);
+  if (s->post_config_init)
+    return s->post_config_init(s);
   return TRUE;
 }
 

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -232,6 +232,7 @@ struct _LogPipe
   gboolean (*deinit)(LogPipe *self);
   void (*post_deinit)(LogPipe *self);
 
+  gboolean (*pre_config_init)(LogPipe *self);
   /* this event function is used to perform necessary operation, such as
    * starting worker thread, and etc. therefore, syslog-ng will terminate if
    * return value is false.
@@ -324,6 +325,14 @@ log_pipe_deinit(LogPipe *s)
         }
       return FALSE;
     }
+  return TRUE;
+}
+
+static inline gboolean
+log_pipe_pre_config_init(LogPipe *s)
+{
+  if (s->pre_config_init)
+    return s->pre_config_init(s);
   return TRUE;
 }
 

--- a/lib/logqueue-fifo.c
+++ b/lib/logqueue-fifo.c
@@ -659,9 +659,9 @@ LogQueue *
 log_queue_fifo_new(gint log_fifo_size, const gchar *persist_name)
 {
   LogQueueFifo *self;
-  gint i;
 
-  self = g_malloc0(sizeof(LogQueueFifo) + log_queue_max_threads * sizeof(self->input_queues[0]));
+  gint max_threads = main_loop_worker_get_max_number_of_threads();
+  self = g_malloc0(sizeof(LogQueueFifo) + max_threads * sizeof(self->input_queues[0]));
 
   log_queue_init_instance(&self->super, persist_name);
   self->super.type = log_queue_fifo_type;
@@ -678,8 +678,8 @@ log_queue_fifo_new(gint log_fifo_size, const gchar *persist_name)
 
   self->super.free_fn = log_queue_fifo_free;
 
-  self->num_input_queues = log_queue_max_threads;
-  for (i = 0; i < num_input_queues; i++)
+  self->num_input_queues = max_threads;
+  for (gint i = 0; i < self->num_input_queues; i++)
     {
       INIT_IV_LIST_HEAD(&self->input_queues[i].items);
       worker_batch_callback_init(&self->input_queues[i].cb);

--- a/lib/logqueue-fifo.c
+++ b/lib/logqueue-fifo.c
@@ -255,26 +255,26 @@ log_queue_fifo_calculate_num_of_messages_to_drop(LogQueueFifo *self, InputQueue 
 
 /* move items from the per-thread input queue to the lock-protected "wait" queue */
 static void
-log_queue_fifo_move_input_unlocked(LogQueueFifo *self, gint thread_id)
+log_queue_fifo_move_input_unlocked(LogQueueFifo *self, gint thread_index)
 {
   gint num_of_messages_to_drop;
-  gboolean drop_messages = log_queue_fifo_calculate_num_of_messages_to_drop(self, &self->input_queues[thread_id],
+  gboolean drop_messages = log_queue_fifo_calculate_num_of_messages_to_drop(self, &self->input_queues[thread_index],
                            &num_of_messages_to_drop);
 
   if (drop_messages)
     {
       /* slow path, the input thread's queue would overflow the queue, let's drop some messages */
-      log_queue_fifo_drop_messages_from_input_queue(self, &self->input_queues[thread_id], num_of_messages_to_drop);
+      log_queue_fifo_drop_messages_from_input_queue(self, &self->input_queues[thread_index], num_of_messages_to_drop);
     }
 
-  log_queue_queued_messages_add(&self->super, self->input_queues[thread_id].len);
-  iv_list_update_msg_size(self, &self->input_queues[thread_id].items);
+  log_queue_queued_messages_add(&self->super, self->input_queues[thread_index].len);
+  iv_list_update_msg_size(self, &self->input_queues[thread_index].items);
 
-  iv_list_splice_tail_init(&self->input_queues[thread_id].items, &self->wait_queue.items);
-  self->wait_queue.len += self->input_queues[thread_id].len;
-  self->wait_queue.non_flow_controlled_len += self->input_queues[thread_id].non_flow_controlled_len;
-  self->input_queues[thread_id].len = 0;
-  self->input_queues[thread_id].non_flow_controlled_len = 0;
+  iv_list_splice_tail_init(&self->input_queues[thread_index].items, &self->wait_queue.items);
+  self->wait_queue.len += self->input_queues[thread_index].len;
+  self->wait_queue.non_flow_controlled_len += self->input_queues[thread_index].non_flow_controlled_len;
+  self->input_queues[thread_index].len = 0;
+  self->input_queues[thread_index].non_flow_controlled_len = 0;
 }
 
 /* move items from the per-thread input queue to the lock-protected
@@ -286,17 +286,16 @@ static gpointer
 log_queue_fifo_move_input(gpointer user_data)
 {
   LogQueueFifo *self = (LogQueueFifo *) user_data;
-  gint thread_id;
+  gint thread_index;
 
-  thread_id = main_loop_worker_get_thread_id();
-
-  g_assert(thread_id >= 0);
+  thread_index = main_loop_worker_get_thread_index();
+  g_assert(thread_index >= 0);
 
   g_mutex_lock(&self->super.lock);
-  log_queue_fifo_move_input_unlocked(self, thread_id);
+  log_queue_fifo_move_input_unlocked(self, thread_index);
   log_queue_push_notify(&self->super);
   g_mutex_unlock(&self->super.lock);
-  self->input_queues[thread_id].finish_cb_registered = FALSE;
+  self->input_queues[thread_index].finish_cb_registered = FALSE;
   log_queue_unref(&self->super);
   return NULL;
 }
@@ -325,7 +324,7 @@ _drop_message(LogMessage *msg, const LogPathOptions *path_options)
 }
 
 /**
- * Assumed to be called from one of the input threads. If the thread_id
+ * Assumed to be called from one of the input threads. If the thread_index
  * cannot be determined, the item is put directly in the wait queue.
  *
  * Puts the message to the queue, and logs an error if it caused the
@@ -339,16 +338,16 @@ static void
 log_queue_fifo_push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
 {
   LogQueueFifo *self = (LogQueueFifo *) s;
-  gint thread_id;
+  gint thread_index;
   LogMessageQueueNode *node;
 
-  thread_id = main_loop_worker_get_thread_id();
+  thread_index = main_loop_worker_get_thread_index();
 
   /* if this thread has an ID than the number of input queues we have (due
    * to a config change), handle the load via the slow path */
 
-  if (thread_id >= self->num_input_queues)
-    thread_id = -1;
+  if (thread_index >= self->num_input_queues)
+    thread_index = -1;
 
   /* NOTE: we don't use high-water marks for now, as log_fetch_limit
    * limits the number of items placed on the per-thread input queue
@@ -361,10 +360,10 @@ log_queue_fifo_push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *pat
    * the "wait" queue.
    */
 
-  if (thread_id >= 0)
+  if (thread_index >= 0)
     {
       /* fastpath, use per-thread input FIFOs */
-      if (!self->input_queues[thread_id].finish_cb_registered)
+      if (!self->input_queues[thread_index].finish_cb_registered)
         {
           /* this is the first item in the input FIFO, register a finish
            * callback to make sure it gets moved to the wait_queue if the
@@ -373,17 +372,17 @@ log_queue_fifo_push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *pat
            * avoiding use-after-free situation
            */
 
-          main_loop_worker_register_batch_callback(&self->input_queues[thread_id].cb);
-          self->input_queues[thread_id].finish_cb_registered = TRUE;
+          main_loop_worker_register_batch_callback(&self->input_queues[thread_index].cb);
+          self->input_queues[thread_index].finish_cb_registered = TRUE;
           log_queue_ref(&self->super);
         }
 
       node = log_msg_alloc_queue_node(msg, path_options);
-      iv_list_add_tail(&node->list, &self->input_queues[thread_id].items);
-      self->input_queues[thread_id].len++;
+      iv_list_add_tail(&node->list, &self->input_queues[thread_index].items);
+      self->input_queues[thread_index].len++;
 
       if (!path_options->flow_control_requested)
-        self->input_queues[thread_id].non_flow_controlled_len++;
+        self->input_queues[thread_index].non_flow_controlled_len++;
 
       log_msg_unref(msg);
       return;

--- a/lib/logqueue.c
+++ b/lib/logqueue.c
@@ -27,8 +27,6 @@
 #include "messages.h"
 #include "timeutils/misc.h"
 
-gint log_queue_max_threads = 0;
-
 void
 log_queue_memory_usage_add(LogQueue *self, gsize value)
 {
@@ -274,10 +272,4 @@ log_queue_free_method(LogQueue *self)
   g_mutex_clear(&self->lock);
   g_free(self->persist_name);
   g_free(self);
-}
-
-void
-log_queue_set_max_threads(gint max_threads)
-{
-  log_queue_max_threads = max_threads;
 }

--- a/lib/logthrdest/logthrdestdrv.c
+++ b/lib/logthrdest/logthrdestdrv.c
@@ -1123,9 +1123,9 @@ log_threaded_dest_driver_init_method(LogPipe *s)
 }
 
 /* This method is only used when a LogThreadedDestDriver is directly used
- * without overriding its on_config_inited method.  If there's an overridden
+ * without overriding its post_config_init method.  If there's an overridden
  * method, the caller is responsible for explicitly calling _start_workers() at
- * the end of on_config_inited(). */
+ * the end of post_config_init(). */
 gboolean
 log_threaded_dest_driver_start_workers(LogPipe *s)
 {
@@ -1183,7 +1183,7 @@ log_threaded_dest_driver_init_instance(LogThreadedDestDriver *self, GlobalConfig
   self->super.super.super.deinit = log_threaded_dest_driver_deinit_method;
   self->super.super.super.queue = log_threaded_dest_driver_queue;
   self->super.super.super.free_fn = log_threaded_dest_driver_free;
-  self->super.super.super.on_config_inited = log_threaded_dest_driver_start_workers;
+  self->super.super.super.post_config_init = log_threaded_dest_driver_start_workers;
   self->time_reopen = -1;
   self->batch_lines = -1;
   self->batch_timeout = -1;

--- a/lib/logthrdest/logthrdestdrv.c
+++ b/lib/logthrdest/logthrdestdrv.c
@@ -1095,6 +1095,15 @@ _create_workers(LogThreadedDestDriver *self)
 }
 
 gboolean
+log_threaded_dest_driver_pre_config_init(LogPipe *s)
+{
+  LogThreadedDestDriver *self = (LogThreadedDestDriver *)s;
+
+  main_loop_worker_allocate_thread_space(self->num_workers);
+  return TRUE;
+}
+
+gboolean
 log_threaded_dest_driver_init_method(LogPipe *s)
 {
   LogThreadedDestDriver *self = (LogThreadedDestDriver *)s;
@@ -1183,6 +1192,7 @@ log_threaded_dest_driver_init_instance(LogThreadedDestDriver *self, GlobalConfig
   self->super.super.super.deinit = log_threaded_dest_driver_deinit_method;
   self->super.super.super.queue = log_threaded_dest_driver_queue;
   self->super.super.super.free_fn = log_threaded_dest_driver_free;
+  self->super.super.super.pre_config_init = log_threaded_dest_driver_pre_config_init;
   self->super.super.super.post_config_init = log_threaded_dest_driver_start_workers;
   self->time_reopen = -1;
   self->batch_lines = -1;

--- a/lib/logthrdest/tests/test_logthrdestdrv.c
+++ b/lib/logthrdest/tests/test_logthrdestdrv.c
@@ -815,6 +815,9 @@ setup(void)
   main_loop = main_loop_get_instance();
   main_loop_init(main_loop, &main_loop_options);
   cfg_set_current_version(main_loop_get_current_config(main_loop));
+
+  main_loop_worker_allocate_thread_space(2);
+  main_loop_worker_finalize_thread_space();
   _setup_dd();
 }
 

--- a/lib/logthrdest/tests/test_logthrdestdrv.c
+++ b/lib/logthrdest/tests/test_logthrdestdrv.c
@@ -151,7 +151,7 @@ _setup_dd(void)
   dd = test_threaded_dd_new(main_loop_get_current_config(main_loop));
 
   cr_assert(log_pipe_init(&dd->super.super.super.super));
-  cr_assert(log_pipe_on_config_inited(&dd->super.super.super.super));
+  cr_assert(log_pipe_post_config_init(&dd->super.super.super.super));
 }
 
 static void
@@ -755,7 +755,7 @@ Test(logthrdestdrv, test_connect_failure_kicks_in_suspend_retry_logic_which_keep
   dd->super.worker.insert = _insert_single_message_success;
   dd->super.worker.instance.time_reopen = 0;
   cr_assert(log_pipe_init(&dd->super.super.super.super));
-  cr_assert(log_pipe_on_config_inited(&dd->super.super.super.super));
+  cr_assert(log_pipe_post_config_init(&dd->super.super.super.super));
 
   _generate_message_and_wait_for_processing(dd, dd->super.written_messages);
   cr_assert(dd->connect_counter == 11, "%d", dd->connect_counter);

--- a/lib/logthrsource/logthrsourcedrv.c
+++ b/lib/logthrsource/logthrsourcedrv.c
@@ -236,6 +236,13 @@ log_threaded_source_worker_new(GlobalConfig *cfg)
 }
 
 gboolean
+log_threaded_source_driver_pre_config_init(LogPipe *s)
+{
+  main_loop_worker_allocate_thread_space(1);
+  return TRUE;
+}
+
+gboolean
 log_threaded_source_driver_init_method(LogPipe *s)
 {
   LogThreadedSourceDriver *self = (LogThreadedSourceDriver *) s;
@@ -383,6 +390,7 @@ log_threaded_source_driver_init_instance(LogThreadedSourceDriver *self, GlobalCo
   self->super.super.super.init = log_threaded_source_driver_init_method;
   self->super.super.super.deinit = log_threaded_source_driver_deinit_method;
   self->super.super.super.free_fn = log_threaded_source_driver_free_method;
+  self->super.super.super.pre_config_init = log_threaded_source_driver_pre_config_init;
   self->super.super.super.post_config_init = log_threaded_source_driver_start_worker;
 
   self->wakeup = log_threaded_source_wakeup;

--- a/lib/logthrsource/logthrsourcedrv.c
+++ b/lib/logthrsource/logthrsourcedrv.c
@@ -383,7 +383,7 @@ log_threaded_source_driver_init_instance(LogThreadedSourceDriver *self, GlobalCo
   self->super.super.super.init = log_threaded_source_driver_init_method;
   self->super.super.super.deinit = log_threaded_source_driver_deinit_method;
   self->super.super.super.free_fn = log_threaded_source_driver_free_method;
-  self->super.super.super.on_config_inited = log_threaded_source_driver_start_worker;
+  self->super.super.super.post_config_init = log_threaded_source_driver_start_worker;
 
   self->wakeup = log_threaded_source_wakeup;
 

--- a/lib/logthrsource/logthrsourcedrv.h
+++ b/lib/logthrsource/logthrsourcedrv.h
@@ -58,7 +58,6 @@ struct _LogThreadedSourceWorker
   LogThreadedSourceDriver *control;
   WakeupCondition wakeup_cond;
   gboolean under_termination;
-
 };
 
 struct _LogThreadedSourceDriver
@@ -66,6 +65,7 @@ struct _LogThreadedSourceDriver
   LogSrcDriver super;
   LogThreadedSourceWorkerOptions worker_options;
   LogThreadedSourceWorker *worker;
+  gboolean auto_close_batches;
 
   const gchar *(*format_stats_instance)(LogThreadedSourceDriver *self);
   gboolean (*thread_init)(LogThreadedSourceDriver *self);
@@ -100,6 +100,8 @@ log_threaded_source_driver_get_parse_options(LogDriver *s)
 
   return &self->worker_options.parse_options;
 }
+
+void log_threaded_source_close_batch(LogThreadedSourceDriver *self);
 
 /* blocking API */
 void log_threaded_source_blocking_post(LogThreadedSourceDriver *self, LogMessage *msg);

--- a/lib/logthrsource/tests/test_logthrfetcherdrv.c
+++ b/lib/logthrsource/tests/test_logthrfetcherdrv.c
@@ -130,7 +130,7 @@ static void
 start_test_threaded_fetcher(TestThreadedFetcherDriver *s)
 {
   cr_assert(log_pipe_init(&s->super.super.super.super.super));
-  cr_assert(log_pipe_on_config_inited(&s->super.super.super.super.super));
+  cr_assert(log_pipe_post_config_init(&s->super.super.super.super.super));
 }
 
 static void

--- a/lib/logthrsource/tests/test_logthrsourcedrv.c
+++ b/lib/logthrsource/tests/test_logthrsourcedrv.c
@@ -127,7 +127,7 @@ static void
 start_test_threaded_source(TestThreadedSourceDriver *s)
 {
   cr_assert(log_pipe_init(&s->super.super.super.super));
-  cr_assert(log_pipe_on_config_inited(&s->super.super.super.super));
+  cr_assert(log_pipe_post_config_init(&s->super.super.super.super));
 }
 
 static void

--- a/lib/mainloop-io-worker.c
+++ b/lib/mainloop-io-worker.c
@@ -25,6 +25,7 @@
 #include "mainloop-worker.h"
 #include "mainloop-call.h"
 #include "logqueue.h"
+#include "apphook.h"
 
 /************************************************************************************
  * I/O worker threads
@@ -112,6 +113,12 @@ main_loop_io_worker_thread_stop(void *cookie)
   main_loop_worker_thread_stop();
 }
 
+static void
+__pre_pre_init_hook(gint type, gpointer user_data)
+{
+  main_loop_worker_allocate_thread_space(main_loop_io_workers.max_threads);
+}
+
 void
 main_loop_io_worker_init(void)
 {
@@ -124,7 +131,7 @@ main_loop_io_worker_init(void)
   main_loop_io_workers.thread_start = main_loop_io_worker_thread_start;
   main_loop_io_workers.thread_stop = main_loop_io_worker_thread_stop;
   iv_work_pool_create(&main_loop_io_workers);
-  main_loop_worker_allocate_thread_space(main_loop_io_workers.max_threads);
+  register_application_hook(AH_CONFIG_PRE_PRE_INIT, __pre_pre_init_hook, NULL, AHM_RUN_REPEAT);
 }
 
 void

--- a/lib/mainloop-io-worker.c
+++ b/lib/mainloop-io-worker.c
@@ -126,6 +126,7 @@ main_loop_io_worker_init(void)
   iv_work_pool_create(&main_loop_io_workers);
 
   log_queue_set_max_threads(MIN(main_loop_io_workers.max_threads, MAIN_LOOP_MAX_WORKER_THREADS));
+  main_loop_worker_allocate_thread_space(main_loop_io_workers.max_threads);
 }
 
 void

--- a/lib/mainloop-io-worker.c
+++ b/lib/mainloop-io-worker.c
@@ -124,8 +124,6 @@ main_loop_io_worker_init(void)
   main_loop_io_workers.thread_start = main_loop_io_worker_thread_start;
   main_loop_io_workers.thread_stop = main_loop_io_worker_thread_stop;
   iv_work_pool_create(&main_loop_io_workers);
-
-  log_queue_set_max_threads(MIN(main_loop_io_workers.max_threads, MAIN_LOOP_MAX_WORKER_THREADS));
   main_loop_worker_allocate_thread_space(main_loop_io_workers.max_threads);
 }
 

--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -424,12 +424,18 @@ main_loop_worker_finalize_thread_space(void)
   main_loop_estimated_number_of_workers = 0;
 }
 
+static void
+__pre_init_hook(gint type, gpointer user_data)
+{
+  main_loop_worker_finalize_thread_space();
+}
+
 void
 main_loop_worker_init(void)
 {
   IV_TASK_INIT(&main_loop_workers_reenable_jobs_task);
   main_loop_workers_reenable_jobs_task.handler = _reenable_worker_jobs;
-
+  register_application_hook(AH_CONFIG_PRE_INIT, __pre_init_hook, NULL, AHM_RUN_REPEAT);
 }
 
 void

--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -67,6 +67,8 @@ static GMutex main_loop_workers_idmap_lock;
 #define MAIN_LOOP_IDMAP_ROWS            (MAIN_LOOP_MAX_WORKER_THREADS / MAIN_LOOP_IDMAP_BITS_PER_ROW)
 
 static guint64 main_loop_workers_idmap[MAIN_LOOP_IDMAP_ROWS];
+static gint main_loop_max_workers = 0;
+static gint main_loop_estimated_number_of_workers = 0;
 
 static void
 _allocate_thread_id(void)
@@ -388,6 +390,25 @@ main_loop_sync_worker_startup_and_teardown(void)
   iv_task_register(&request_exit);
   _register_sync_call_action(&sync_call_actions, (void (*)(gpointer user_data)) iv_quit, NULL);
   iv_main();
+}
+
+gint
+main_loop_worker_get_max_number_of_threads(void)
+{
+  return main_loop_max_workers;
+}
+
+void
+main_loop_worker_allocate_thread_space(gint num_threads)
+{
+  main_loop_estimated_number_of_workers += num_threads;
+}
+
+void
+main_loop_worker_finalize_thread_space(void)
+{
+  main_loop_max_workers = main_loop_estimated_number_of_workers;
+  main_loop_estimated_number_of_workers = 0;
 }
 
 void

--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -102,12 +102,25 @@ _allocate_thread_id(void)
 
   if (main_loop_worker_id == 0)
     {
-      msg_warning("Unable to allocate a unique thread ID. This can only "
-                  "happen if the number of syslog-ng threads exceeds the "
-                  "compile time constant MAIN_LOOP_MAX_WORKER_THREADS. "
-                  "Increase this number and recompile or contact the "
-                  "syslog-ng authors",
-                  evt_tag_int("max-worker-threads", MAIN_LOOP_MAX_WORKER_THREADS));
+      msg_warning_once("Unable to allocate a unique thread ID. This can only "
+                       "happen if the number of syslog-ng worker threads exceeds the "
+                       "compile time constant MAIN_LOOP_MAX_WORKER_THREADS. "
+                       "This is not a fatal problem but can be a cause for "
+                       "decreased performance. Increase this number and recompile "
+                       "or contact the syslog-ng authors",
+                       evt_tag_int("max-worker-threads-hard-limit", MAIN_LOOP_MAX_WORKER_THREADS));
+    }
+
+  if (main_loop_worker_id >= main_loop_max_workers)
+    {
+      msg_warning_once("The actual number of worker threads exceeds the number of threads "
+                       "estimated at startup. This indicates a bug in thread estimation, "
+                       "which is not fatal but could cause decreased performance. Please "
+                       "contact the syslog-ng authors with your config to help troubleshoot "
+                       "this issue",
+                       evt_tag_int("worker-id", main_loop_worker_id),
+                       evt_tag_int("max-worker-threads", main_loop_max_workers));
+      main_loop_worker_id = 0;
     }
 }
 

--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -140,14 +140,6 @@ _release_thread_id(void)
   g_mutex_unlock(&main_loop_workers_idmap_lock);
 }
 
-/* NOTE: only used by the unit test program to emulate worker threads with
- * LogQueue, other threads acquire a thread id when they start up. */
-void
-main_loop_worker_set_thread_id(gint id)
-{
-  main_loop_worker_id = id + 1;
-}
-
 gint
 main_loop_worker_get_thread_id(void)
 {

--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -78,18 +78,15 @@ _allocate_thread_id(void)
 
   main_loop_worker_id = 0;
 
-  if(main_loop_worker_type != MLW_THREADED_INPUT_WORKER)
+  for (id = 0; id < MAIN_LOOP_MAX_WORKER_THREADS; id++)
     {
-      for (id = 0; id < MAIN_LOOP_MAX_WORKER_THREADS; id++)
+      if ((main_loop_workers_idmap & (1ULL << id)) == 0)
         {
-          if ((main_loop_workers_idmap & (1ULL << id)) == 0)
-            {
-              /* id not yet used */
+          /* id not yet used */
 
-              main_loop_worker_id = (id + 1);
-              main_loop_workers_idmap |= (1ULL << id);
-              break;
-            }
+          main_loop_worker_id = (id + 1);
+          main_loop_workers_idmap |= (1ULL << id);
+          break;
         }
     }
   g_mutex_unlock(&main_loop_workers_idmap_lock);

--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -63,7 +63,7 @@ static struct iv_task main_loop_workers_reenable_jobs_task;
 /* thread ID allocation */
 static GMutex main_loop_workers_idmap_lock;
 
-static guint64 main_loop_workers_idmap[MAIN_LOOP_WORKER_TYPE_MAX];
+static guint64 main_loop_workers_idmap;
 
 static void
 _allocate_thread_id(void)
@@ -82,12 +82,12 @@ _allocate_thread_id(void)
     {
       for (id = 0; id < MAIN_LOOP_MAX_WORKER_THREADS; id++)
         {
-          if ((main_loop_workers_idmap[main_loop_worker_type] & (1ULL << id)) == 0)
+          if ((main_loop_workers_idmap & (1ULL << id)) == 0)
             {
               /* id not yet used */
 
-              main_loop_worker_id = (id + 1)  + (main_loop_worker_type * MAIN_LOOP_MAX_WORKER_THREADS);
-              main_loop_workers_idmap[main_loop_worker_type] |= (1ULL << id);
+              main_loop_worker_id = (id + 1);
+              main_loop_workers_idmap |= (1ULL << id);
               break;
             }
         }
@@ -101,8 +101,8 @@ _release_thread_id(void)
   g_mutex_lock(&main_loop_workers_idmap_lock);
   if (main_loop_worker_id)
     {
-      const gint id = main_loop_worker_id & (sizeof(guint64) * CHAR_BIT - 1);
-      main_loop_workers_idmap[main_loop_worker_type] &= ~(1ULL << (id - 1));
+      const gint id = main_loop_worker_id;
+      main_loop_workers_idmap &= ~(1ULL << (id - 1));
       main_loop_worker_id = 0;
     }
   g_mutex_unlock(&main_loop_workers_idmap_lock);

--- a/lib/mainloop-worker.h
+++ b/lib/mainloop-worker.h
@@ -84,6 +84,10 @@ void main_loop_sync_worker_startup_and_teardown(void);
 void main_loop_worker_init(void);
 void main_loop_worker_deinit(void);
 
+gint main_loop_worker_get_max_number_of_threads(void);
+void main_loop_worker_allocate_thread_space(gint num_threads);
+void main_loop_worker_finalize_thread_space(void);
+
 extern volatile gboolean main_loop_workers_quit;
 extern volatile gboolean is_reloading_scheduled;
 

--- a/lib/mainloop-worker.h
+++ b/lib/mainloop-worker.h
@@ -67,7 +67,6 @@ void main_loop_worker_assert_batch_callbacks_were_processed(void);
 
 typedef void (*WorkerExitNotificationFunc)(gpointer user_data);
 
-void main_loop_worker_set_thread_id(gint id);
 gint main_loop_worker_get_thread_id(void);
 
 void main_loop_worker_job_start(void);

--- a/lib/mainloop-worker.h
+++ b/lib/mainloop-worker.h
@@ -29,7 +29,7 @@
 #include <iv_list.h>
 
 #define MAIN_LOOP_MIN_WORKER_THREADS 2
-#define MAIN_LOOP_MAX_WORKER_THREADS 64
+#define MAIN_LOOP_MAX_WORKER_THREADS 256
 
 typedef enum
 {

--- a/lib/mainloop-worker.h
+++ b/lib/mainloop-worker.h
@@ -67,7 +67,7 @@ void main_loop_worker_assert_batch_callbacks_were_processed(void);
 
 typedef void (*WorkerExitNotificationFunc)(gpointer user_data);
 
-gint main_loop_worker_get_thread_id(void);
+gint main_loop_worker_get_thread_index(void);
 
 void main_loop_worker_job_start(void);
 void main_loop_worker_job_complete(void);

--- a/lib/tests/test_cfg_tree.c
+++ b/lib/tests/test_cfg_tree.c
@@ -124,6 +124,8 @@ ParameterizedTest(PipeParameter *test_data, cfg_tree, test_pipe_init)
 
   pipe = create_and_attach_almighty_pipe(&tree, test_data->always_pipe_value);
 
+  cr_assert(cfg_tree_compile (&tree));
+
   cr_assert_eq(cfg_tree_start(&tree), test_data->tree_start_expected,
                "cfg_tree_start() did not return the expected value");
   cr_assert_eq(cfg_tree_stop(&tree), test_data->tree_stop_expected,
@@ -147,6 +149,8 @@ Test(cfg_tree, test_pipe_init_multi_success)
   create_and_attach_almighty_pipe (&tree, TRUE);
   create_and_attach_almighty_pipe (&tree, TRUE);
 
+  cr_assert(cfg_tree_compile (&tree));
+
   cr_assert(cfg_tree_start (&tree),
             "Starting a tree of all-good nodes works");
   cr_assert(cfg_tree_stop (&tree),
@@ -165,6 +169,8 @@ Test(cfg_tree, test_pipe_init_multi_with_bad_node)
   pipe1 = create_and_attach_almighty_pipe (&tree, TRUE);
   pipe2 = create_and_attach_almighty_pipe (&tree, FALSE);
   pipe3 = create_and_attach_almighty_pipe (&tree, TRUE);
+
+  cr_assert(cfg_tree_compile (&tree));
 
   cr_assert_not(cfg_tree_start (&tree),
                 "Starting a tree of all-good nodes works");

--- a/lib/tests/test_logqueue.c
+++ b/lib/tests/test_logqueue.c
@@ -244,7 +244,7 @@ Test(logqueue, test_with_threads)
   GThread *other_threads[FEEDERS];
   gint i, j;
 
-  log_queue_set_max_threads(FEEDERS);
+  log_queue_set_max_threads(FEEDERS * 2);
   for (i = 0; i < TEST_RUNS; i++)
     {
       fprintf(stderr, "starting testrun: %d\n", i);

--- a/lib/tests/test_logqueue.c
+++ b/lib/tests/test_logqueue.c
@@ -244,7 +244,8 @@ Test(logqueue, test_with_threads)
   GThread *other_threads[FEEDERS];
   gint i, j;
 
-  log_queue_set_max_threads(FEEDERS * 2);
+  main_loop_worker_allocate_thread_space(FEEDERS * 2);
+  main_loop_worker_finalize_thread_space();
   for (i = 0; i < TEST_RUNS; i++)
     {
       fprintf(stderr, "starting testrun: %d\n", i);
@@ -390,7 +391,10 @@ Test(logqueue, log_queue_fifo_should_drop_only_non_flow_controlled_messages_thre
      .description = "Flow-controlled messages should never be dropped (using input queues with threads")
 {
   gint fifo_size = 5;
-  log_queue_set_max_threads(1);
+
+  main_loop_worker_allocate_thread_space(1);
+  main_loop_worker_finalize_thread_space();
+
   LogQueue *q = log_queue_fifo_new(fifo_size, NULL);
   log_queue_set_use_backlog(q, TRUE);
   _register_stats_counters(q);

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -269,7 +269,9 @@ Test(diskq, testcase_with_threads)
   GString *filename;
   gint i, j;
 
-  log_queue_set_max_threads(FEEDERS);
+  main_loop_worker_allocate_thread_space(FEEDERS);
+  main_loop_worker_finalize_thread_space();
+
   for (i = 0; i < TEST_RUNS; i++)
     {
       DiskQueueOptions options = {0};

--- a/modules/http/tests/test_http-signal_slot.c
+++ b/modules/http/tests/test_http-signal_slot.c
@@ -110,7 +110,7 @@ Test(test_http_signal_slot, basic)
   CONNECT(ssc, signal_http_header_request, _check, test_msg);
 
   cr_assert(log_pipe_init((LogPipe *)driver));
-  cr_assert(log_pipe_on_config_inited((LogPipe *)driver));
+  cr_assert(log_pipe_post_config_init((LogPipe *)driver));
 
   _generate_message(driver, test_msg);
 
@@ -128,7 +128,7 @@ Test(test_http_signal_slot, single_with_prefix_suffix)
   CONNECT(ssc, signal_http_header_request, _check, "[almafa]");
 
   cr_assert(log_pipe_init((LogPipe *)driver));
-  cr_assert(log_pipe_on_config_inited((LogPipe *)driver));
+  cr_assert(log_pipe_post_config_init((LogPipe *)driver));
 
   _generate_message(driver, "almafa");
 
@@ -148,7 +148,7 @@ Test(test_http_signal_slot, batch_with_prefix_suffix)
   CONNECT(ssc, signal_http_header_request, _check, "[1,2]");
 
   cr_assert(log_pipe_init((LogPipe *)driver));
-  cr_assert(log_pipe_on_config_inited((LogPipe *)driver));
+  cr_assert(log_pipe_post_config_init((LogPipe *)driver));
 
   _generate_message(driver, "1");
   _generate_message(driver, "2");

--- a/modules/mqtt/destination/mqtt-worker.c
+++ b/modules/mqtt/destination/mqtt-worker.c
@@ -66,7 +66,7 @@ _publish_result_evaluation (LogThreadedDestWorker *self, gint result)
     case MQTTCLIENT_NULL_PARAMETER:
     case MQTTCLIENT_BAD_UTF8_STRING:
       msg_error("An unrecoverable error occurred during publish, dropping message.",
-                evt_tag_str("error code", MQTTClient_strerror(result)),
+                evt_tag_str("error_code", MQTTClient_strerror(result)),
                 log_pipe_location_tag(&self->owner->super.super.super));
       return LTR_DROP;
     }
@@ -88,7 +88,7 @@ _wait_result_evaluation(LogThreadedDestWorker *self, gint result)
     case MQTTCLIENT_FAILURE:
     default:
       msg_error("Error while waiting the response!",
-                evt_tag_str("error code", MQTTClient_strerror(result)),
+                evt_tag_str("error_code", MQTTClient_strerror(result)),
                 log_pipe_location_tag(&self->owner->super.super.super));
       return LTR_ERROR;
     }
@@ -112,7 +112,7 @@ mqtt_dest_worker_resolve_template_topic_name(MQTTDestinationWorker *self, LogMes
   msg_error("Error constructing topic", evt_tag_str("topic_name", self->topic_name_buffer->str),
             evt_tag_str("driver", owner->super.super.super.id),
             log_pipe_location_tag(&owner->super.super.super.super),
-            evt_tag_str("error message", error->message));
+            evt_tag_str("error_message", error->message));
 
   g_error_free(error);
 
@@ -197,7 +197,7 @@ _connect(LogThreadedDestWorker *s)
   if ((rc = MQTTClient_connect(self->client, &conn_opts)) != MQTTCLIENT_SUCCESS)
     {
       msg_error("Error connecting mqtt client",
-                evt_tag_str("error code", MQTTClient_strerror(rc)),
+                evt_tag_str("error_code", MQTTClient_strerror(rc)),
                 evt_tag_str("client_id", mqtt_client_options_get_client_id(&owner->options)),
                 log_pipe_location_tag(&owner->super.super.super.super));
       return FALSE;
@@ -228,7 +228,7 @@ _init(LogThreadedDestWorker *s)
     {
       msg_error("Error creating mqtt client",
                 evt_tag_str("address", mqtt_client_options_get_address(&owner->options)),
-                evt_tag_str("error code", MQTTClient_strerror(rc)),
+                evt_tag_str("error_code", MQTTClient_strerror(rc)),
                 evt_tag_str("client_id", mqtt_client_options_get_client_id(&owner->options)),
                 log_pipe_location_tag(&owner->super.super.super.super));
       return FALSE;

--- a/modules/mqtt/source/mqtt-source.c
+++ b/modules/mqtt/source/mqtt-source.c
@@ -85,7 +85,7 @@ _client_init(MQTTSourceDriver *self)
     {
       msg_error("Error creating mqtt client",
                 evt_tag_str("address", mqtt_client_options_get_address(&self->options)),
-                evt_tag_str("error code", MQTTClient_strerror(rc)),
+                evt_tag_str("error_code", MQTTClient_strerror(rc)),
                 evt_tag_str("client_id", mqtt_client_options_get_client_id(&self->options)),
                 log_pipe_location_tag(&self->super.super.super.super.super));
       return FALSE;
@@ -113,7 +113,7 @@ _subscribe_topic(MQTTSourceDriver *self)
       msg_error("mqtt: Error while subscribing to topic",
                 evt_tag_str("topic", self->topic),
                 evt_tag_int("qos", mqtt_client_options_get_qos(&self->options)),
-                evt_tag_str("error code", MQTTClient_strerror(rc)),
+                evt_tag_str("error_code", MQTTClient_strerror(rc)),
                 evt_tag_str("driver", self->super.super.super.super.id),
                 log_pipe_location_tag(&self->super.super.super.super.super));
       return FALSE;
@@ -151,7 +151,7 @@ _connect(LogThreadedFetcherDriver *s)
   if ((rc = MQTTClient_connect(self->client, &conn_opts)) != MQTTCLIENT_SUCCESS)
     {
       msg_error("Error connecting mqtt client",
-                evt_tag_str("error code", MQTTClient_strerror(rc)),
+                evt_tag_str("error_code", MQTTClient_strerror(rc)),
                 evt_tag_str("client_id", mqtt_client_options_get_client_id(&self->options)),
                 log_pipe_location_tag(&self->super.super.super.super.super));
       return FALSE;
@@ -210,7 +210,7 @@ _fetch(LogThreadedFetcherDriver *s)
   if (result == THREADED_FETCH_ERROR)
     {
       msg_error("Error while receiving msg",
-                evt_tag_str("error code", MQTTClient_strerror(rc)),
+                evt_tag_str("error_code", MQTTClient_strerror(rc)),
                 evt_tag_str("client_id", mqtt_client_options_get_client_id(&self->options)),
                 log_pipe_location_tag(&self->super.super.super.super.super));
     }

--- a/news/developer-note-3969.md
+++ b/news/developer-note-3969.md
@@ -1,0 +1,6 @@
+`LogThreadedSourceDriver` and `Fetcher`: implement source-side batching
+support on the input path by assigning a thread_id to dynamically spawned
+input threads (e.g. those spawned by LogThreadedSourceDriver) too.  To
+actually improve performance the source driver should disable automatic
+closing of batches by setting `auto_close_batches` to FALSE and calling
+log_threaded_source_close_batch() explicitly.


### PR DESCRIPTION
This is a spin-off from #3966 which merges the thread ID space for worker threads and associates a thread_id even with
threads spawned by LogThreadedSourceDriver. This will enable the scalable input processing in LogQueueFifo and makes a few things simpler.

It also increases the number of supported threads to 256 which is becoming a simple compile-time constant, instead of a constraint imposed by the underlying data structure (the previous limit of 64 being the number of bits in a guint64).

While #3966 still depends on an ivykis change (https://github.com/buytenh/ivykis/issues/24) but I don't want to stall the commits that make sense even without the ivykis dependency.
