### PR TITLE
github-actions/dbld-images: do not try to automatically push docker images

### DIFF
--- a/.github/workflows/dbld-images.yml
+++ b/.github/workflows/dbld-images.yml
@@ -60,7 +60,6 @@ jobs:
         run: dbld/rules image-${{ matrix.image }}
 
       - name: Should we upload the images?
-        if: always()
         run: |
           if [ "${{ github.event.inputs.testing_image_upload }}" = "true" ] || \
              ( \
@@ -78,7 +77,7 @@ jobs:
           gh_export UPLOAD_IMAGES_INTERNAL
 
       - name: Log in to the Container registry
-        if: always() && env.UPLOAD_IMAGES_INTERNAL == 'true'
+        if: env.UPLOAD_IMAGES_INTERNAL == 'true'
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -86,6 +85,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push the images
-        if: always() && env.UPLOAD_IMAGES_INTERNAL == 'true'
+        if: env.UPLOAD_IMAGES_INTERNAL == 'true'
         run: |
           dbld/rules push-image-${{ matrix.image }}


### PR DESCRIPTION
Currently, we try to push an image even if the build step failed.

This is a leftover of when the image build job was refactored in [edb1d06](https://github.com/syslog-ng/syslog-ng/pull/3932/commits/edb1d06371d1a3ed15f3ceacf1a79ae86de88dfa).
Previously we built the images in 1 job concurrently and then tried to push the built images.
Since even 1 image build resulted in a job failure, we used the `always()` condition in the later steps.

Thanks @MrAnno for noticing this behaviour!!! :+1: 