### PR TITLE
add rcptid to message related trace messages

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -504,6 +504,11 @@ cfg_new(gint version)
 
   self->use_uniqid = FALSE;
 
+  /* The rcptid part of use_uniqid() is used in trace messages, enable it
+   * explicitly.  We don't care about performance if trace is enabled.  */
+  if (trace_flag)
+    self->use_uniqid = TRUE;
+
   stats_options_defaults(&self->stats_options);
 
   self->min_iw_size_per_reader = 100;

--- a/lib/filter/filter-call.c
+++ b/lib/filter/filter-call.c
@@ -52,7 +52,7 @@ filter_call_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg, LogTemplate
 
   msg_trace("filter() evaluation started",
             evt_tag_str("called-rule", self->rule),
-            evt_tag_printf("msg", "%p", msgs[num_msg - 1]));
+            evt_tag_msg_reference(msgs[num_msg - 1]));
 
   return res ^ s->comp;
 }

--- a/lib/filter/filter-cmp.c
+++ b/lib/filter/filter-cmp.c
@@ -93,7 +93,7 @@ fop_cmp_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg, LogTemplateEval
             evt_tag_str("left", left_buf->str),
             evt_tag_str("operator", self->super.type),
             evt_tag_str("right", right_buf->str),
-            evt_tag_printf("msg", "%p", msgs[num_msg - 1]));
+            evt_tag_msg_reference(msgs[num_msg - 1]));
 
   scratch_buffers_reclaim_marked(marker);
   return result ^ s->comp;

--- a/lib/filter/filter-in-list.c
+++ b/lib/filter/filter-in-list.c
@@ -52,7 +52,7 @@ filter_in_list_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg, LogTempl
   gboolean result = (g_tree_lookup(self->tree, value) != NULL);
   msg_trace("in-list() evaluation started",
             evt_tag_str("value", value),
-            evt_tag_printf("msg", "%p", msg));
+            evt_tag_msg_reference(msg));
 
   return result ^ s->comp;
 }

--- a/lib/filter/filter-netmask.c
+++ b/lib/filter/filter-netmask.c
@@ -67,7 +67,7 @@ filter_netmask_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg, LogTempl
             evt_tag_inaddr("msg_address", addr),
             evt_tag_inaddr("address", &self->address),
             evt_tag_inaddr("netmask", &self->netmask),
-            evt_tag_printf("msg", "%p", msg));
+            evt_tag_msg_reference(msg));
   return res ^ s->comp;
 }
 

--- a/lib/filter/filter-netmask6.c
+++ b/lib/filter/filter-netmask6.c
@@ -132,7 +132,7 @@ _eval(FilterExprNode *s, LogMessage **msgs, gint num_msg, LogTemplateEvalOptions
             evt_tag_inaddr6("msg_address", address),
             evt_tag_inaddr6("address", &self->address),
             evt_tag_int("prefix", self->prefix),
-            evt_tag_printf("msg", "%p", msg));
+            evt_tag_msg_reference(msg));
   return result ^ s->comp;
 }
 

--- a/lib/filter/filter-pipe.c
+++ b/lib/filter/filter-pipe.c
@@ -61,7 +61,7 @@ log_filter_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_op
   msg_trace(">>>>>> filter rule evaluation begin",
             evt_tag_str("rule", self->name),
             log_pipe_location_tag(s),
-            evt_tag_printf("msg", "%p", msg));
+            evt_tag_msg_reference(msg));
 
   res = filter_expr_eval_root(self->expr, &msg, path_options);
 
@@ -83,7 +83,7 @@ log_filter_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_op
             evt_tag_str("result", filter_result),
             evt_tag_str("rule", self->name),
             log_pipe_location_tag(s),
-            evt_tag_printf("msg", "%p", msg));
+            evt_tag_msg_reference(msg));
 }
 
 static LogPipe *

--- a/lib/filter/filter-pri.c
+++ b/lib/filter/filter-pri.c
@@ -52,7 +52,7 @@ filter_facility_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg, LogTemp
   msg_trace("facility() evaluation started",
             evt_tag_int("fac", fac_num),
             evt_tag_printf("valid_fac", "%08x", self->valid),
-            evt_tag_printf("msg", "%p", msg));
+            evt_tag_msg_reference(msg));
 
   return res ^ s->comp;
 }
@@ -82,7 +82,7 @@ filter_severity_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg, LogTemp
   msg_trace("severity() evaluation started",
             evt_tag_int("pri", pri),
             evt_tag_printf("valid_pri", "%08x", self->valid),
-            evt_tag_printf("msg", "%p", msg));
+            evt_tag_msg_reference(msg));
 
   return res ^ s->comp;
 }

--- a/lib/filter/filter-re.c
+++ b/lib/filter/filter-re.c
@@ -49,7 +49,7 @@ filter_re_eval_string(FilterExprNode *s, LogMessage *msg, gint value_handle, con
             evt_tag_str("input", str),
             evt_tag_str("pattern", self->matcher->pattern),
             evt_tag_str("value", log_msg_get_value_name(value_handle, NULL)),
-            evt_tag_printf("msg", "%p", msg));
+            evt_tag_msg_reference(msg));
   result = log_matcher_match(self->matcher, msg, value_handle, str, str_len);
   return result ^ s->comp;
 }

--- a/lib/filter/filter-tags.c
+++ b/lib/filter/filter-tags.c
@@ -48,14 +48,14 @@ filter_tags_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg, LogTemplate
           res = TRUE;
           msg_trace("tags() evaluation started",
                     evt_tag_str("tag", log_tags_get_by_id(tag_id)),
-                    evt_tag_printf("msg", "%p", msg));
+                    evt_tag_msg_reference(msg));
           return res ^ s->comp;
         }
     }
 
   res = FALSE;
   msg_trace("tags() evaluation started",
-            evt_tag_printf("msg", "%p", msg));
+            evt_tag_msg_reference(msg));
   return res ^ s->comp;
 }
 

--- a/lib/filter/tests/test_filters_common.c
+++ b/lib/filter/tests/test_filters_common.c
@@ -39,6 +39,7 @@
 #include "apphook.h"
 #include "plugin.h"
 #include "scratch-buffers.h"
+#include "msg-format.h"
 
 #include <time.h>
 #include <string.h>
@@ -144,7 +145,7 @@ testcase_with_socket(const gchar *msg, const gchar *sockaddr,
   res = filter_expr_init(f, configuration);
   cr_assert(res, "Filter init failed; msg='%s'\n", msg);
 
-  logmsg = log_msg_new(msg, strlen(msg), &parse_options);
+  logmsg = msg_format_parse(&parse_options, (const guchar *) msg, strlen(msg));
   log_msg_set_saddr_ref(logmsg, _get_sockaddr(sockaddr));
 
   res = filter_expr_eval(f, logmsg);
@@ -183,7 +184,7 @@ testcase_with_backref_chk(const gchar *msg,
   gssize msglen;
   gchar buf[1024];
 
-  logmsg = log_msg_new(msg, strlen(msg), &parse_options);
+  logmsg = msg_format_parse(&parse_options, (const guchar *) msg, strlen(msg));
   log_msg_set_saddr_ref(logmsg, g_sockaddr_inet_new("10.10.0.1", 5000));
 
   /* NOTE: we test how our filters cope with non-zero terminated values. We don't change message_len, only the value */

--- a/lib/filter/tests/test_filters_in_list.c
+++ b/lib/filter/tests/test_filters_in_list.c
@@ -31,6 +31,7 @@
 #include "apphook.h"
 #include "plugin.h"
 #include "filter/filter-in-list.h"
+#include "msg-format.h"
 
 #include <stdlib.h>
 #include <glib.h>
@@ -54,7 +55,7 @@ evaluate_testcase(const gchar *msg,
   gboolean result;
 
   cr_assert_not_null(filter_node, "Constructing an in-list filter");
-  log_msg = log_msg_new(msg, strlen(msg), &parse_options);
+  log_msg = msg_format_parse(&parse_options, (const guchar *) msg, strlen(msg));
   result = filter_expr_eval(filter_node, log_msg);
 
   log_msg_unref(log_msg);

--- a/lib/filter/tests/test_filters_statistics.c
+++ b/lib/filter/tests/test_filters_statistics.c
@@ -29,6 +29,7 @@
 #include "stats/stats-registry.h"
 #include "filter/filter-pipe.h"
 #include "filter/filter-pri.h"
+#include "msg-format.h"
 
 static gint
 level_bits(gchar *lev)
@@ -55,7 +56,7 @@ static void
 queue_and_assert_statistics(LogFilterPipe *pipe, gchar *msg, guint32 matched_expected, guint32 not_matched_expected)
 {
   LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
-  LogMessage *logmsg = log_msg_new(msg, strlen(msg), &parse_options);
+  LogMessage *logmsg = msg_format_parse(&parse_options, (const guchar *) msg, strlen(msg));
   LogPipe *p = (LogPipe *)pipe;
   p->queue(p, logmsg, &path_options);
   cr_assert_eq(stats_counter_get(pipe->not_matched), not_matched_expected);

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1441,47 +1441,19 @@ log_msg_clone_cow(LogMessage *msg, const LogPathOptions *path_options)
   return self;
 }
 
-static gsize
-_determine_payload_size(gint length, MsgFormatOptions *parse_options)
-{
-  gsize payload_size;
-
-  if ((parse_options->flags & LP_STORE_RAW_MESSAGE))
-    payload_size = length * 4;
-  else
-    payload_size = length * 2;
-
-  return MAX(payload_size, 256);
-}
-
-/**
- * log_msg_new:
- * @msg: message to parse
- * @length: length of @msg
- * @flags: parse flags (LP_*)
- *
- * This function allocates, parses and returns a new LogMessage instance.
- **/
 LogMessage *
-log_msg_new(const gchar *msg, gint length,
-            MsgFormatOptions *parse_options)
+log_msg_sized_new(gsize payload_size)
 {
-  LogMessage *self = log_msg_alloc(_determine_payload_size(length, parse_options));
+  LogMessage *self = log_msg_alloc(payload_size);
 
   log_msg_init(self);
-
-  msg_trace("Initial message parsing follows");
-  msg_format_parse_into(parse_options, self, (guchar *) msg, length);
   return self;
 }
 
 LogMessage *
 log_msg_new_empty(void)
 {
-  LogMessage *self = log_msg_alloc(256);
-
-  log_msg_init(self);
-  return self;
+  return log_msg_sized_new(256);
 }
 
 /* This function creates a new log message that should be considered local */

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -601,7 +601,7 @@ log_msg_set_value_with_type(LogMessage *self, NVHandle handle,
                 evt_tag_str("name", name),
                 evt_tag_mem("value", value, value_len),
                 evt_tag_str("type", log_msg_value_type_to_str(type)),
-                evt_tag_printf("msg", "%p", self));
+                evt_tag_msg_reference(self));
     }
 
   if (!log_msg_chk_flag(self, LF_STATE_OWN_PAYLOAD))
@@ -709,12 +709,12 @@ log_msg_set_value_indirect_with_type(LogMessage *self, NVHandle handle,
   if (_log_name_value_updates(self))
     {
       msg_trace("Setting indirect value",
-                evt_tag_printf("msg", "%p", self),
                 evt_tag_str("name", name),
                 evt_tag_str("type", log_msg_value_type_to_str(type)),
                 evt_tag_int("ref_handle", ref_handle),
                 evt_tag_int("ofs", ofs),
-                evt_tag_int("len", len));
+                evt_tag_int("len", len),
+                evt_tag_msg_reference(self));
     }
 
   if (!log_msg_chk_flag(self, LF_STATE_OWN_PAYLOAD))
@@ -1412,7 +1412,7 @@ log_msg_clone_cow(LogMessage *msg, const LogPathOptions *path_options)
 
   msg_trace("Message was cloned",
             evt_tag_printf("original_msg", "%p", msg),
-            evt_tag_printf("new_msg", "%p", self));
+            evt_tag_msg_reference(self));
 
   /* every field _must_ be initialized explicitly if its direct
    * copying would cause problems (like copying a pointer by value) */

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1471,7 +1471,7 @@ log_msg_new(const gchar *msg, gint length,
   log_msg_init(self);
 
   msg_trace("Initial message parsing follows");
-  msg_format_parse(parse_options, self, (guchar *) msg, length);
+  msg_format_parse_into(parse_options, self, (guchar *) msg, length);
   return self;
 }
 

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -31,7 +31,6 @@
 #include "serialize.h"
 #include "timeutils/unixtime.h"
 #include "logmsg/nvtable.h"
-#include "msg-format.h"
 #include "logmsg/tags.h"
 
 #include <sys/types.h>
@@ -451,8 +450,7 @@ void log_msg_free_queue_node(LogMessageQueueNode *node);
 void log_msg_clear(LogMessage *self);
 void log_msg_merge_context(LogMessage *self, LogMessage **context, gsize context_len);
 
-LogMessage *log_msg_new(const gchar *msg, gint length,
-                        MsgFormatOptions *parse_options);
+LogMessage *log_msg_sized_new(gsize payload_size);
 LogMessage *log_msg_new_mark(void);
 LogMessage *log_msg_new_internal(gint prio, const gchar *msg);
 LogMessage *log_msg_new_empty(void);

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -479,4 +479,8 @@ gint log_msg_lookup_time_stamp_name(const gchar *name);
 
 gssize log_msg_get_size(LogMessage *self);
 
+#define evt_tag_msg_reference(msg)             \
+    evt_tag_printf("msg", "%p", (msg)),        \
+    evt_tag_printf("rcptid", "%" G_GUINT64_FORMAT, (msg)->rcptid)
+
 #endif

--- a/lib/logmsg/tests/test_log_message.c
+++ b/lib/logmsg/tests/test_log_message.c
@@ -47,7 +47,7 @@ _construct_log_message(void)
   const gchar *raw_msg = "foo";
   LogMessage *msg;
 
-  msg = log_msg_new(raw_msg, strlen(raw_msg), &parse_options);
+  msg = msg_format_parse(&parse_options, (const guchar *) raw_msg, strlen(raw_msg));
   log_msg_set_value(msg, LM_V_HOST, raw_msg, -1);
   return msg;
 }

--- a/lib/logmsg/tests/test_logmsg_serialize.c
+++ b/lib/logmsg/tests/test_logmsg_serialize.c
@@ -97,7 +97,7 @@ _create_message_to_be_serialized(const gchar *raw_msg, const int raw_msg_len)
   parse_options.flags |= LP_SYSLOG_PROTOCOL;
   NVHandle test_handle = log_msg_get_value_handle("aaa");
 
-  LogMessage *msg = log_msg_new(raw_msg, raw_msg_len, &parse_options);
+  LogMessage *msg = msg_format_parse(&parse_options, (const guchar *) raw_msg, raw_msg_len);
   log_msg_set_value(msg, test_handle, "test_value53", -1);
 
   NVHandle indirect_handle = log_msg_get_value_handle("indirect_1");

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -454,7 +454,7 @@ log_reader_handle_line(LogReader *self, const guchar *line, gint length, LogTran
             evt_tag_printf("input", "%.*s", length, line),
             evt_tag_msg_reference(m));
 
-  msg_format_parse(&self->options->parse_options, m, line, length);
+  msg_format_parse_into(&self->options->parse_options, m, line, length);
 
   _log_reader_insert_msg_length_stats(self, length);
   if (aux)

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -449,7 +449,7 @@ log_reader_handle_line(LogReader *self, const guchar *line, gint length, LogTran
 {
   LogMessage *m;
 
-  m = log_msg_new_empty();
+  m = msg_format_construct_message(&self->options->parse_options, line, length);
   msg_debug("Incoming log entry",
             evt_tag_printf("input", "%.*s", length, line),
             evt_tag_msg_reference(m));

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -449,11 +449,12 @@ log_reader_handle_line(LogReader *self, const guchar *line, gint length, LogTran
 {
   LogMessage *m;
 
+  m = log_msg_new_empty();
   msg_debug("Incoming log entry",
-            evt_tag_printf("line", "%.*s", length, line));
-  /* use the current time to get the time zone offset */
-  m = log_msg_new((gchar *) line, length,
-                  &self->options->parse_options);
+            evt_tag_printf("input", "%.*s", length, line),
+            evt_tag_msg_reference(m));
+
+  msg_format_parse(&self->options->parse_options, m, line, length);
 
   _log_reader_insert_msg_length_stats(self, length);
   if (aux)

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -31,6 +31,7 @@
 #include "logproto/logproto-server.h"
 #include "poll-events.h"
 #include "mainloop-io-worker.h"
+#include "msg-format.h"
 #include <iv_event.h>
 
 /* flags */

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -611,7 +611,7 @@ log_source_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
   msg_diagnostics(">>>>>> Source side message processing begin",
                   evt_tag_str("instance", self->stats_instance ? self->stats_instance : "internal"),
                   log_pipe_location_tag(s),
-                  evt_tag_printf("msg", "%p", msg));
+                  evt_tag_msg_reference(msg));
 
   /* $HOST setup */
   log_source_mangle_hostname(self, msg);
@@ -660,7 +660,7 @@ log_source_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
   msg_diagnostics("<<<<<< Source side message processing finish",
                   evt_tag_str("instance", self->stats_instance ? self->stats_instance : "internal"),
                   log_pipe_location_tag(s),
-                  evt_tag_printf("msg", "%p", msg));
+                  evt_tag_msg_reference(msg));
 
   msg_set_context(NULL);
 }

--- a/lib/logthrsource/logthrsourcedrv.c
+++ b/lib/logthrsource/logthrsourcedrv.c
@@ -314,7 +314,9 @@ _apply_default_priority_and_facility(LogThreadedSourceDriver *self, LogMessage *
 void
 log_threaded_source_post(LogThreadedSourceDriver *self, LogMessage *msg)
 {
-  msg_debug("Incoming log message", evt_tag_str("msg", log_msg_get_value(msg, LM_V_MESSAGE, NULL)));
+  msg_debug("Incoming log message",
+            evt_tag_str("input", log_msg_get_value(msg, LM_V_MESSAGE, NULL)),
+            evt_tag_msg_reference(msg));
   _apply_default_priority_and_facility(self, msg);
   log_source_post(&self->worker->super, msg);
 }

--- a/lib/logthrsource/logthrsourcedrv.h
+++ b/lib/logthrsource/logthrsourcedrv.h
@@ -31,6 +31,7 @@
 #include "cfg.h"
 #include "logpipe.h"
 #include "logmsg/logmsg.h"
+#include "msg-format.h"
 #include "mainloop-threaded-worker.h"
 
 typedef struct _LogThreadedSourceDriver LogThreadedSourceDriver;

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -158,6 +158,36 @@ msg_format_parse_into(MsgFormatOptions *options, LogMessage *msg,
     }
 }
 
+static gsize
+_determine_payload_size(MsgFormatOptions *parse_options, const guchar *data, gsize length)
+{
+  gsize payload_size;
+
+  if ((parse_options->flags & LP_STORE_RAW_MESSAGE))
+    payload_size = length * 4;
+  else
+    payload_size = length * 2;
+
+  return MAX(payload_size, 256);
+}
+
+LogMessage *
+msg_format_construct_message(MsgFormatOptions *options, const guchar *data, gsize length)
+{
+  LogMessage *msg = log_msg_sized_new(_determine_payload_size(options, data, length));
+  return msg;
+}
+
+LogMessage *
+msg_format_parse(MsgFormatOptions *options, const guchar *data, gsize length)
+{
+  LogMessage *msg = msg_format_construct_message(options, data, length);
+
+  msg_trace("Initial message parsing follows");
+  msg_format_parse_into(options, msg, data, length);
+  return msg;
+}
+
 void
 msg_format_options_defaults(MsgFormatOptions *options)
 {

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -121,9 +121,9 @@ msg_format_process_message(MsgFormatOptions *options, LogMessage *msg,
 }
 
 gboolean
-msg_format_parse_conditional(MsgFormatOptions *options, LogMessage *msg,
-                             const guchar *data, gsize length,
-                             gsize *problem_position)
+msg_format_try_parse_into(MsgFormatOptions *options, LogMessage *msg,
+                          const guchar *data, gsize length,
+                          gsize *problem_position)
 {
   if (G_UNLIKELY(!options->format_handler))
     {
@@ -144,12 +144,12 @@ msg_format_parse_conditional(MsgFormatOptions *options, LogMessage *msg,
 }
 
 void
-msg_format_parse(MsgFormatOptions *options, LogMessage *msg,
-                 const guchar *data, gsize length)
+msg_format_parse_into(MsgFormatOptions *options, LogMessage *msg,
+                      const guchar *data, gsize length)
 {
   gsize problem_position = 0;
 
-  if (!msg_format_parse_conditional(options, msg, data, length, &problem_position))
+  if (!msg_format_try_parse_into(options, msg, data, length, &problem_position))
     {
       msg_format_inject_parse_error(msg, data, _rstripped_message_length(data, length), problem_position);
 

--- a/lib/msg-format.h
+++ b/lib/msg-format.h
@@ -95,6 +95,9 @@ gboolean msg_format_try_parse_into(MsgFormatOptions *options, LogMessage *msg,
 void msg_format_parse_into(MsgFormatOptions *options, LogMessage *msg,
                            const guchar *data, gsize length);
 
+LogMessage *msg_format_construct_message(MsgFormatOptions *options, const guchar *data, gsize length);
+LogMessage *msg_format_parse(MsgFormatOptions *options, const guchar *data, gsize length);
+
 void msg_format_options_defaults(MsgFormatOptions *options);
 void msg_format_options_init(MsgFormatOptions *parse_options, GlobalConfig *cfg);
 void msg_format_options_destroy(MsgFormatOptions *parse_options);

--- a/lib/msg-format.h
+++ b/lib/msg-format.h
@@ -89,11 +89,11 @@ struct _MsgFormatHandler
                     gsize *problem_position);
 };
 
-gboolean msg_format_parse_conditional(MsgFormatOptions *options, LogMessage *msg,
-                                      const guchar *data, gsize length,
-                                      gsize *problem_position);
-void msg_format_parse(MsgFormatOptions *options, LogMessage *msg,
-                      const guchar *data, gsize length);
+gboolean msg_format_try_parse_into(MsgFormatOptions *options, LogMessage *msg,
+                                   const guchar *data, gsize length,
+                                   gsize *problem_position);
+void msg_format_parse_into(MsgFormatOptions *options, LogMessage *msg,
+                           const guchar *data, gsize length);
 
 void msg_format_options_defaults(MsgFormatOptions *options);
 void msg_format_options_init(MsgFormatOptions *parse_options, GlobalConfig *cfg);

--- a/lib/parser/parser-expr.c
+++ b/lib/parser/parser-expr.c
@@ -86,7 +86,7 @@ log_parser_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
   msg_trace(">>>>>> parser rule evaluation begin",
             evt_tag_str("rule", self->name),
             log_pipe_location_tag(s),
-            evt_tag_printf("msg", "%p", msg));
+            evt_tag_msg_reference(msg));
 
   success = log_parser_process_message(self, &msg, path_options);
 
@@ -106,7 +106,7 @@ log_parser_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options
             evt_tag_str("result", parser_result),
             evt_tag_str("rule", self->name),
             log_pipe_location_tag(s),
-            evt_tag_printf("msg", "%p", msg));
+            evt_tag_msg_reference(msg));
 }
 
 gboolean

--- a/lib/rewrite/rewrite-expr.c
+++ b/lib/rewrite/rewrite-expr.c
@@ -40,14 +40,14 @@ log_rewrite_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_option
   msg_trace(">>>>>> rewrite rule evaluation begin",
             evt_tag_str("rule", self->name),
             log_pipe_location_tag(s),
-            evt_tag_printf("msg", "%p", msg));
+            evt_tag_msg_reference(msg));
   if (self->condition && !filter_expr_eval_root(self->condition, &msg, path_options))
     {
       msg_trace("Rewrite condition unmatched, skipping rewrite",
                 evt_tag_str("value", log_msg_get_value_name(self->value_handle, NULL)),
                 evt_tag_str("rule", self->name),
                 log_pipe_location_tag(s),
-                evt_tag_printf("msg", "%p", msg));
+                evt_tag_msg_reference(msg));
     }
   else
     {
@@ -56,7 +56,7 @@ log_rewrite_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_option
   msg_trace("<<<<<< rewrite rule evaluation finished",
             evt_tag_str("rule", self->name),
             log_pipe_location_tag(s),
-            evt_tag_printf("msg", "%p", msg));
+            evt_tag_msg_reference(msg));
   log_pipe_forward_msg(s, msg, path_options);
 }
 

--- a/lib/rewrite/rewrite-set-facility.c
+++ b/lib/rewrite/rewrite-set-facility.c
@@ -102,7 +102,7 @@ log_rewrite_set_facility_process(LogRewrite *s, LogMessage **pmsg, const LogPath
   msg_trace("Setting syslog facility",
             evt_tag_int("old_facility", (*pmsg)->pri & LOG_FACMASK),
             evt_tag_int("new_facility", facility),
-            evt_tag_printf("msg", "%p", *pmsg));
+            evt_tag_msg_reference(*pmsg));
   _set_msg_facility(*pmsg, facility);
 
 error:

--- a/lib/rewrite/rewrite-set-pri.c
+++ b/lib/rewrite/rewrite-set-pri.c
@@ -76,7 +76,7 @@ log_rewrite_set_pri_process(LogRewrite *s, LogMessage **pmsg, const LogPathOptio
   msg_trace("Setting syslog pri",
             evt_tag_int("old_pri", (*pmsg)->pri),
             evt_tag_int("new_pri", pri),
-            evt_tag_printf("msg", "%p", *pmsg));
+            evt_tag_msg_reference(*pmsg));
   (*pmsg)->pri = pri;
 }
 

--- a/lib/rewrite/rewrite-set-severity.c
+++ b/lib/rewrite/rewrite-set-severity.c
@@ -103,7 +103,7 @@ log_rewrite_set_severity_process(LogRewrite *s, LogMessage **pmsg, const LogPath
   msg_trace("Setting syslog severity",
             evt_tag_int("old_severity", LOG_PRI((*pmsg)->pri)),
             evt_tag_int("new_severity", severity),
-            evt_tag_printf("msg", "%p", *pmsg));
+            evt_tag_msg_reference(*pmsg));
   _set_msg_severity(*pmsg, severity);
 
 error:

--- a/lib/value-pairs/tests/CMakeLists.txt
+++ b/lib/value-pairs/tests/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_unit_test(CRITERION TARGET test_value_pairs DEPENDS syslogformat)
-add_unit_test(CRITERION LIBTEST TARGET test_value_pairs_walk DEPENDS syslogformat)
+add_unit_test(CRITERION LIBTEST TARGET test_value_pairs_walk)

--- a/lib/value-pairs/tests/test_value_pairs.c
+++ b/lib/value-pairs/tests/test_value_pairs.c
@@ -30,6 +30,7 @@
 #include "apphook.h"
 #include "cfg.h"
 #include "plugin.h"
+#include "msg-format.h"
 
 #include <stdlib.h>
 
@@ -71,7 +72,7 @@ create_message(void)
     "<134>1 2009-10-16T11:51:56+02:00 exchange.macartney.esbjerg MSExchange_ADAccess 20208 _MSGID_ [origin ip=\"exchange.macartney.esbjerg\"][meta sequenceId=\"191732\" sysUpTime=\"68807696\"][EventData@18372.4 Data=\"MSEXCHANGEOWAAPPPOOL.CONFIG\\\" -W \\\"\\\" -M 1 -AP \\\"MSEXCHANGEOWAAPPPOOL5244fileserver.macartney.esbjerg CDG 1 7 7 1 0 1 1 7 1 mail.macartney.esbjerg CDG 1 7 7 1 0 1 1 7 1 maindc.macartney.esbjerg CD- 1 6 6 0 0 1 1 6 1 \"][Keywords@18372.4 Keyword=\"Classic\"] ApplicationMSExchangeADAccess: message";
   const gchar *unset_nvpair = "unset_value";
 
-  msg = log_msg_new(text, strlen(text), &parse_options);
+  msg = msg_format_parse(&parse_options, (const guchar *) text, strlen(text));
   log_msg_set_tag_by_name(msg, "almafa");
   log_msg_set_value_by_name(msg, unset_nvpair, "value that has been unset", -1);
   log_msg_unset_value_by_name(msg, unset_nvpair);

--- a/lib/value-pairs/tests/test_value_pairs_walk.c
+++ b/lib/value-pairs/tests/test_value_pairs_walk.c
@@ -29,9 +29,7 @@
 #include "plugin.h"
 #include "cfg.h"
 #include "logmsg/logmsg.h"
-#include "msg-format.h"
 
-MsgFormatOptions parse_options;
 LogTemplateOptions template_options;
 GlobalConfig *cfg;
 
@@ -116,11 +114,11 @@ Test(value_pairs_walker, prefix_dat)
   const char *value = "value";
 
   log_template_options_init(&template_options, cfg);
-  msg_format_options_init(&parse_options, cfg);
 
   vp = value_pairs_new(cfg);
   value_pairs_add_glob_pattern(vp, "root.*", TRUE);
-  msg = msg_format_parse(&parse_options, (const guchar *) "test", 4);
+  msg = log_msg_new_empty();
+  log_msg_set_value_by_name(msg, "PROGRAM", "test", -1);
 
   log_msg_set_value_by_name(msg, "root.test.alma", value, strlen(value));
   log_msg_set_value_by_name(msg, "root.test.korte", value, strlen(value));
@@ -139,9 +137,6 @@ setup(void)
   app_startup();
 
   cfg = cfg_new_snippet();
-  cfg_load_module(cfg, "syslogformat");
-  msg_format_options_defaults(&parse_options);
-  msg_format_options_init(&parse_options, cfg);
 }
 
 void

--- a/lib/value-pairs/tests/test_value_pairs_walk.c
+++ b/lib/value-pairs/tests/test_value_pairs_walk.c
@@ -29,6 +29,7 @@
 #include "plugin.h"
 #include "cfg.h"
 #include "logmsg/logmsg.h"
+#include "msg-format.h"
 
 MsgFormatOptions parse_options;
 LogTemplateOptions template_options;
@@ -119,7 +120,7 @@ Test(value_pairs_walker, prefix_dat)
 
   vp = value_pairs_new(cfg);
   value_pairs_add_glob_pattern(vp, "root.*", TRUE);
-  msg = log_msg_new("test", 4, &parse_options);
+  msg = msg_format_parse(&parse_options, (const guchar *) "test", 4);
 
   log_msg_set_value_by_name(msg, "root.test.alma", value, strlen(value));
   log_msg_set_value_by_name(msg, "root.test.korte", value, strlen(value));

--- a/libtest/cr_template.c
+++ b/libtest/cr_template.c
@@ -76,9 +76,9 @@ LogMessage *
 create_empty_message(void)
 {
   LogMessage *msg;
-  const char *msg_str = "<155>2006-02-11T10:34:56+01:00 bzorp syslog-ng[23323]:árvíztűrőtükörfúrógép";
+  const gchar *msg_str = "<155>2006-02-11T10:34:56+01:00 bzorp syslog-ng[23323]:árvíztűrőtükörfúrógép";
 
-  msg = log_msg_new(msg_str, strlen(msg_str), &parse_options);
+  msg = msg_format_parse(&parse_options, (const guchar *) msg_str, strlen(msg_str));
   log_msg_set_saddr_ref(msg, g_sockaddr_inet_new("10.11.12.13", 1010));
   log_msg_set_daddr_ref(msg, g_sockaddr_inet_new("127.0.0.5", 6514));
   log_msg_set_match(msg, 0, "whole-match", -1);

--- a/libtest/msg_parse_lib.h
+++ b/libtest/msg_parse_lib.h
@@ -27,6 +27,7 @@
 
 #include "cfg.h"
 #include "logmsg/logmsg.h"
+#include "msg-format.h"
 
 void init_parse_options_and_load_syslogformat(MsgFormatOptions *parse_options);
 void deinit_syslogformat_module(void);

--- a/modules/add-contextual-data/add-contextual-data.c
+++ b/modules/add-contextual-data/add-contextual-data.c
@@ -123,7 +123,7 @@ _process(LogParser *s, LogMessage **pmsg,
             evt_tag_str("message", input),
             evt_tag_str("resolved_selector", resolved_selector),
             evt_tag_str("selector", selector),
-            evt_tag_printf("msg", "%p", *pmsg));
+            evt_tag_msg_reference(*pmsg));
 
   if (selector)
     context_info_db_foreach_record(self->context_info_db, selector,

--- a/modules/afsnmp/snmptrapd-parser.c
+++ b/modules/afsnmp/snmptrapd-parser.c
@@ -179,7 +179,7 @@ snmptrapd_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *
   msg_trace("snmptrapd-parser message processing started",
             evt_tag_str ("input", input),
             evt_tag_str ("prefix", self->prefix->str),
-            evt_tag_printf("msg", "%p", *pmsg));
+            evt_tag_msg_reference(*pmsg));
 
   APPEND_ZERO(input, input, input_len);
 

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -142,7 +142,7 @@ csv_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_o
   msg_trace("csv-parser message processing started",
             evt_tag_str ("input", input),
             evt_tag_str ("prefix", self->prefix),
-            evt_tag_printf("msg", "%p", *pmsg));
+            evt_tag_msg_reference(*pmsg));
   CSVScanner scanner;
   csv_scanner_init(&scanner, &self->options, input);
 

--- a/modules/csvparser/tests/CMakeLists.txt
+++ b/modules/csvparser/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_unit_test(CRITERION TARGET test_csvparser DEPENDS csvparser syslogformat)
-add_unit_test(LIBTEST CRITERION TARGET test_csvparser_from_config DEPENDS csvparser syslogformat)
+add_unit_test(CRITERION TARGET test_csvparser DEPENDS csvparser)
+add_unit_test(LIBTEST CRITERION TARGET test_csvparser_from_config DEPENDS csvparser)
 add_unit_test(CRITERION TARGET test_csvparser_perf DEPENDS csvparser)
 add_unit_test(CRITERION TARGET test_csvparser_statistics DEPENDS csvparser)

--- a/modules/csvparser/tests/Makefile.am
+++ b/modules/csvparser/tests/Makefile.am
@@ -12,21 +12,18 @@ modules_csvparser_tests_test_csvparser_CFLAGS	=	\
 	$(TEST_CFLAGS) -I$(top_srcdir)/modules/csvparser
 modules_csvparser_tests_test_csvparser_LDADD	=	\
 	$(TEST_LDADD)					\
-	$(PREOPEN_SYSLOGFORMAT)				\
 	-dlpreopen $(top_builddir)/modules/csvparser/libcsvparser.la
 
 modules_csvparser_tests_test_csvparser_from_config_CFLAGS	=	\
 	$(TEST_CFLAGS) -I$(top_srcdir)/modules/csvparser
 modules_csvparser_tests_test_csvparser_from_config_LDADD	=	\
 	$(TEST_LDADD)					\
-	$(PREOPEN_SYSLOGFORMAT)				\
 	-dlpreopen $(top_builddir)/modules/csvparser/libcsvparser.la
 
 modules_csvparser_tests_test_csvparser_perf_CFLAGS	=	\
 	$(TEST_CFLAGS) -I$(top_srcdir)/modules/csvparser
 modules_csvparser_tests_test_csvparser_perf_LDADD	=	\
 	$(TEST_LDADD)					\
-	$(PREOPEN_SYSLOGFORMAT)				\
 	-dlpreopen $(top_builddir)/modules/csvparser/libcsvparser.la
 
 modules_csvparser_tests_TESTS += modules/csvparser/tests/test_csvparser_statistics

--- a/modules/csvparser/tests/test_csvparser.c
+++ b/modules/csvparser/tests/test_csvparser.c
@@ -31,6 +31,7 @@
 #include "cfg.h"
 #include "plugin.h"
 #include "scratch-buffers.h"
+#include "msg-format.h"
 
 #include <time.h>
 #include <string.h>
@@ -869,7 +870,7 @@ ParameterizedTest(CsvParserTestParam *param, parser, test_csv_parser)
     }
 
   parse_options.flags = param->parse_flags;
-  logmsg = log_msg_new(param->msg, strlen(param->msg), &parse_options);
+  logmsg = msg_format_parse(&parse_options, (const guchar *) param->msg, strlen(param->msg));
 
   p = csv_parser_new(NULL);
   csv_parser_set_drop_invalid(p, param->drop_invalid);

--- a/modules/csvparser/tests/test_csvparser.c
+++ b/modules/csvparser/tests/test_csvparser.c
@@ -43,7 +43,6 @@ MsgFormatOptions parse_options;
 typedef struct _csvparser_test_param
 {
   const gchar *msg;
-  guint parse_flags;
   gint max_columns;
   gboolean drop_invalid;
   gint dialect;
@@ -61,8 +60,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
   {
     // string delim & single char & a char is in the string
     {
-      .msg = "<15> openvpn[2499]: PTHREAD support :initialized",
-      .parse_flags = 0,
+      .msg = "PTHREAD support :initialized",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
@@ -76,8 +74,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
 
     // empty message
     {
-      .msg = "<15> openvpn[2499]:",
-      .parse_flags = 0,
+      .msg = "",
       .max_columns = -1,
       .drop_invalid = TRUE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
@@ -91,8 +88,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
 
     // string delim & single char & a char not in the string
     {
-      .msg = "<15> openvpn[2499]: PTHREAD,support :initialized",
-      .parse_flags = 0,
+      .msg = "PTHREAD,support :initialized",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
@@ -106,9 +102,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
 
     // string delim & multi char & a char is in the string
     {
-      .msg = "<15> openvpn[2499]: PTHREAD support :initialized",
-      .parse_flags = 0,
-      .max_columns = -1,
+      .msg = "PTHREAD support :initialized",
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
       .flags = 0,
@@ -121,8 +115,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
 
     // string delim & multi char & a char not in the string
     {
-      .msg = "<15> openvpn[2499]: PTHREAD,support :initialized",
-      .parse_flags = 0,
+      .msg = "PTHREAD,support :initialized",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
@@ -136,8 +129,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
 
     // quote + string delim & multi char & char is in the string too
     {
-      .msg = "<15> openvpn[2499]: 'PTHREAD' 'support' :'initialized'",
-      .parse_flags = 0,
+      .msg = "'PTHREAD' 'support' :'initialized'",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
@@ -151,8 +143,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
 
     // BE + quote + string delim & multi char & char is in the string too
     {
-      .msg = "<15> openvpn[2499]: 'PTHRE\\\'AD' 'support' :'initialized'",
-      .parse_flags = 0,
+      .msg = "'PTHRE\\\'AD' 'support' :'initialized'",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_BACKSLASH,
@@ -166,8 +157,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
 
     // DCE + quote + string delim & multi char & char not in the string
     {
-      .msg = "<15> openvpn[2499]: 'PTHREAD','sup''port' :'initialized'",
-      .parse_flags = 0,
+      .msg = "'PTHREAD','sup''port' :'initialized'",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_DOUBLE_CHAR,
@@ -180,8 +170,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<15> openvpn[2499]: PTHREAD support initialized",
-      .parse_flags = 0,
+      .msg = "PTHREAD support initialized",
       .max_columns = 3,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
@@ -194,8 +183,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<16> openvpn[2499]: PTHREAD support initialized",
-      .parse_flags = 0,
+      .msg = "PTHREAD support initialized",
       .max_columns = 2,
       .drop_invalid = TRUE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
@@ -208,8 +196,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<17> openvpn[2499]: PTHREAD support initialized",
-      .parse_flags = 0,
+      .msg = "PTHREAD support initialized",
       .max_columns = 2,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
@@ -222,8 +209,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<18> openvpn[2499]: PTHREAD support initialized",
-      .parse_flags = 0,
+      .msg = "PTHREAD support initialized",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
@@ -236,8 +222,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<19> openvpn[2499]: PTHREAD support initialized",
-      .parse_flags = 0,
+      .msg = "PTHREAD support initialized",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
@@ -250,8 +235,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<15> openvpn[2499]: \"PTHREAD\" \"support\" \"initialized\"",
-      .parse_flags = 0,
+      .msg = "\"PTHREAD\" \"support\" \"initialized\"",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
@@ -264,8 +248,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<15> openvpn[2499]: \"  PTHREAD  \" \" support\" \"initialized \"",
-      .parse_flags = 0,
+      .msg = "\"  PTHREAD  \" \" support\" \"initialized \"",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
@@ -278,8 +261,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<15> openvpn[2499]: \"PTHREAD support\" \"initialized\"",
-      .parse_flags = 0,
+      .msg = "\"PTHREAD support\" \"initialized\"",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
@@ -292,8 +274,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<15> openvpn[2499]: \"PTHREAD support initialized\"",
-      .parse_flags = 0,
+      .msg = "\"PTHREAD support initialized\"",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
@@ -306,8 +287,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<15> openvpn[2499]: \"PTHREAD support initialized",
-      .parse_flags = 0,
+      .msg = "\"PTHREAD support initialized",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
@@ -320,8 +300,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<20> openvpn[2499]: PTHREAD support initialized",
-      .parse_flags = 0,
+      .msg = "PTHREAD support initialized",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_BACKSLASH,
@@ -334,8 +313,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<21> openvpn[2499]: PTHREAD support initialized",
-      .parse_flags = 0,
+      .msg = "PTHREAD support initialized",
       .max_columns = 2,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_BACKSLASH,
@@ -348,8 +326,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<22> openvpn[2499]: PTHREAD support initialized",
-      .parse_flags = 0,
+      .msg = "PTHREAD support initialized",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_BACKSLASH,
@@ -362,8 +339,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<15> openvpn[2499]: \"PTHREAD\" \"support\" \"initialized\"",
-      .parse_flags = 0,
+      .msg = "\"PTHREAD\" \"support\" \"initialized\"",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_BACKSLASH,
@@ -376,8 +352,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<15> openvpn[2499]: \"PTHREAD\" \"support\" \"initialized\"",
-      .parse_flags = 0,
+      .msg = "\"PTHREAD\" \"support\" \"initialized\"",
       .max_columns = 2,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_BACKSLASH,
@@ -390,8 +365,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<15> openvpn[2499]: \"  PTHREAD \" \"  support\" \"initialized  \"",
-      .parse_flags = 0,
+      .msg = "\"  PTHREAD \" \"  support\" \"initialized  \"",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_BACKSLASH,
@@ -404,8 +378,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<15> openvpn[2499]: \"PTHREAD support\" \"initialized\"",
-      .parse_flags = 0,
+      .msg = "\"PTHREAD support\" \"initialized\"",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_BACKSLASH,
@@ -418,8 +391,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<15> openvpn[2499]: \"PTHREAD \\\"support initialized\"",
-      .parse_flags = 0,
+      .msg = "\"PTHREAD \\\"support initialized\"",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_BACKSLASH,
@@ -432,8 +404,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<15> openvpn[2499]: \"PTHREAD support initialized",
-      .parse_flags = 0,
+      .msg = "\"PTHREAD support initialized",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_BACKSLASH,
@@ -446,8 +417,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<23> openvpn[2499]: PTHREAD support initialized",
-      .parse_flags = 0,
+      .msg = "PTHREAD support initialized",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_DOUBLE_CHAR,
@@ -460,8 +430,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<15> openvpn[2499]: \"PTHREAD\" \"support\" \"initialized\"",
-      .parse_flags = 0,
+      .msg = "\"PTHREAD\" \"support\" \"initialized\"",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_DOUBLE_CHAR,
@@ -474,8 +443,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<15> openvpn[2499]: \"PTHREAD\" \"support\" \"initialized\"",
-      .parse_flags = 0,
+      .msg = "\"PTHREAD\" \"support\" \"initialized\"",
       .max_columns = 2,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_DOUBLE_CHAR,
@@ -488,8 +456,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<15> openvpn[2499]: \"  PTHREAD \" \"  support\" \"initialized  \"",
-      .parse_flags = 0,
+      .msg = "\"  PTHREAD \" \"  support\" \"initialized  \"",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_DOUBLE_CHAR,
@@ -502,8 +469,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<15> openvpn[2499]: \"  PTHREAD \" \"  support\" \"initialized  \"",
-      .parse_flags = 0,
+      .msg = "\"  PTHREAD \" \"  support\" \"initialized  \"",
       .max_columns = 2,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_DOUBLE_CHAR,
@@ -516,8 +482,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<15> openvpn[2499]: \"PTHREAD support\" \"initialized\"",
-      .parse_flags = 0,
+      .msg = "\"PTHREAD support\" \"initialized\"",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_DOUBLE_CHAR,
@@ -530,8 +495,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<15> openvpn[2499]: \"PTHREAD \"\"support initialized\"",
-      .parse_flags = 0,
+      .msg = "\"PTHREAD \"\"support initialized\"",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_DOUBLE_CHAR,
@@ -544,8 +508,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "<15> openvpn[2499]: \"PTHREAD support initialized",
-      .parse_flags = 0,
+      .msg = "\"PTHREAD support initialized",
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_DOUBLE_CHAR,
@@ -559,7 +522,6 @@ ParameterizedTestParameters(parser, test_csv_parser)
 
     {
       .msg = "postfix/smtpd",
-      .parse_flags = LP_NOPARSE,
       .max_columns = 2,
       .drop_invalid = TRUE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
@@ -573,7 +535,6 @@ ParameterizedTestParameters(parser, test_csv_parser)
 
     {
       .msg = "postfix",
-      .parse_flags = LP_NOPARSE,
       .max_columns = 3,
       .drop_invalid = TRUE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
@@ -587,7 +548,6 @@ ParameterizedTestParameters(parser, test_csv_parser)
 
     {
       .msg = "postfix/smtpd/ququ",
-      .parse_flags = LP_NOPARSE,
       .max_columns = 2,
       .drop_invalid = TRUE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
@@ -600,8 +560,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     },
 
     {
-      .msg = "Jul 27 19:55:33 myhost zabbix: ZabbixConnector.log : 19:55:32,782 INFO  [Thread-2834]     - [ZabbixEventSyncCommand] Processing   message <?xml version=\"1.0\" encoding=\"UTF-8\"?>",
-      .parse_flags = LP_EXPECT_HOSTNAME,
+      .msg = "ZabbixConnector.log : 19:55:32,782 INFO  [Thread-2834]     - [ZabbixEventSyncCommand] Processing   message <?xml version=\"1.0\" encoding=\"UTF-8\"?>",
       .max_columns = 2,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
@@ -617,7 +576,6 @@ ParameterizedTestParameters(parser, test_csv_parser)
 
     {
       .msg = "10.100.20.1 - - [31/Dec/2007:00:17:10 +0100] \"GET /cgi-bin/bugzilla/buglist.cgi?keywords_type=allwords&keywords=public&format=simple HTTP/1.1\" 200 2708 \"-\" \"curl/7.15.5 (i4 86-pc-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8c zlib/1.2.3 libidn/0.6.5\" 2 bugzilla.balabit",
-      .parse_flags = LP_NOPARSE,
       .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_BACKSLASH,
@@ -643,7 +601,6 @@ ParameterizedTestParameters(parser, test_csv_parser)
 
     {
       .msg = "10.100.20.1 - - [31/Dec/2007:00:17:10 +0100] \"GET /cgi-bin/bugzilla/buglist.cgi?keywords_type=allwords&keywords=public&format=simple HTTP/1.1\" 200 2708 \"-\" \"curl/7.15.5 (i4 86-pc-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8c zlib/1.2.3 libidn/0.6.5\" 2 bugzilla.balabit",
-      .parse_flags = LP_NOPARSE,
       .max_columns = 11,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_BACKSLASH,
@@ -667,7 +624,6 @@ ParameterizedTestParameters(parser, test_csv_parser)
 
     {
       .msg = "10.100.20.1 - - [31/Dec/2007:00:17:10 +0100] \"GET /cgi-bin/bugzilla/buglist.cgi?keywords_type=allwords&keywords=public&format=simple HTTP/1.1\" 200 2708 \"-\" \"curl/7.15.5 (i4 86-pc-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8c zlib/1.2.3 libidn/0.6.5\" 2 bugzilla.balabit",
-      .parse_flags = LP_NOPARSE,
       .max_columns = 10,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_BACKSLASH,
@@ -692,7 +648,6 @@ ParameterizedTestParameters(parser, test_csv_parser)
 
     {
       .msg = "10.100.20.1 - - [31/Dec/2007:00:17:10 +0100] \"GET /cgi-bin/bugzilla/buglist.cgi?keywords_type=allwords&keywords=public&format=simple HTTP/1.1\" 200 2708 \"-\" \"curl/7.15.5 (i4 86-pc-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8c zlib/1.2.3 libidn/0.6.5\" 2 bugzilla.balabit",
-      .parse_flags = LP_NOPARSE,
       .max_columns = 12,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_BACKSLASH,
@@ -719,7 +674,6 @@ ParameterizedTestParameters(parser, test_csv_parser)
 
     {
       .msg = "10.100.20.1 - - [31/Dec/2007:00:17:10 +0100] \"GET /cgi-bin/bugzilla/buglist.cgi?keywords_type=allwords&keywords=public&format=simple HTTP/1.1\" 200 2708 \"-\" \"curl/7.15.5 (i4 86-pc-linux-gnu) libcurl/7.15.5 OpenSSL/0.9.8c zlib/1.2.3 libidn/0.6.5\" 2 bugzilla.balabit almafa",
-      .parse_flags = LP_NOPARSE,
       .max_columns = 11,
       .drop_invalid = TRUE,
       .dialect = CSV_SCANNER_ESCAPE_BACKSLASH,
@@ -733,7 +687,6 @@ ParameterizedTestParameters(parser, test_csv_parser)
 
     {
       .msg = "random.vhost 10.0.0.1 - \"GET /index.html HTTP/1.1\" 200",
-      .parse_flags = LP_NOPARSE,
       .max_columns = 5,
       .drop_invalid = TRUE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
@@ -747,7 +700,6 @@ ParameterizedTestParameters(parser, test_csv_parser)
 
     {
       .msg = "random.vhost 10.0.0.1 - \"GET /index.html HTTP/1.1\" 200",
-      .parse_flags = LP_NOPARSE,
       .max_columns = 5,
       .drop_invalid = TRUE,
       .dialect = CSV_SCANNER_ESCAPE_BACKSLASH,
@@ -762,7 +714,6 @@ ParameterizedTestParameters(parser, test_csv_parser)
     /* greedy column can be empty */
     {
       .msg = "random.vhost 10.0.0.1 - \"GET /index.html HTTP/1.1\" 200",
-      .parse_flags = LP_NOPARSE,
       .max_columns = 6,
       .drop_invalid = TRUE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
@@ -776,7 +727,6 @@ ParameterizedTestParameters(parser, test_csv_parser)
 
     {
       .msg = "random.vhost 10.0.0.1 - \"GET /index.html HTTP/1.1\" 200",
-      .parse_flags = LP_NOPARSE,
       .max_columns = 6,
       .drop_invalid = TRUE,
       .dialect = CSV_SCANNER_ESCAPE_BACKSLASH,
@@ -790,7 +740,6 @@ ParameterizedTestParameters(parser, test_csv_parser)
 
     {
       .msg = "random.vhost\t10.0.0.1\t-\t\"GET /index.html HTTP/1.1\"\t200",
-      .parse_flags = LP_NOPARSE,
       .max_columns = 6,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_BACKSLASH,
@@ -804,7 +753,6 @@ ParameterizedTestParameters(parser, test_csv_parser)
 
     {
       .msg = "random.vhost\t10.0.0.1\t-\t\"GET /index.html HTTP/1.1\"\t\t200",
-      .parse_flags = LP_NOPARSE,
       .max_columns = 7,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_BACKSLASH,
@@ -869,8 +817,8 @@ ParameterizedTest(CsvParserTestParam *param, parser, test_csv_parser)
       column_array[param->max_columns] = NULL;
     }
 
-  parse_options.flags = param->parse_flags;
-  logmsg = msg_format_parse(&parse_options, (const guchar *) param->msg, strlen(param->msg));
+  logmsg = log_msg_new_empty();
+  log_msg_set_value(logmsg, LM_V_MESSAGE, param->msg, -1);
 
   p = csv_parser_new(NULL);
   csv_parser_set_drop_invalid(p, param->drop_invalid);

--- a/modules/dbparser/dbparser.c
+++ b/modules/dbparser/dbparser.c
@@ -222,8 +222,8 @@ log_db_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
     {
       log_msg_make_writable(pmsg, path_options);
       msg_trace("db-parser message processing started",
-                evt_tag_str ("input", input),
-                evt_tag_printf("msg", "%p", *pmsg));
+                evt_tag_str("input", input),
+                evt_tag_msg_reference(*pmsg));
       if (G_UNLIKELY(self->super.super.template))
         matched = pattern_db_process_with_custom_message(self->db, *pmsg, input, input_len);
       else

--- a/modules/dbparser/patternize.c
+++ b/modules/dbparser/patternize.c
@@ -24,6 +24,7 @@
 #include "logmsg/logmsg.h"
 #include "messages.h"
 #include "uuid.h"
+#include "msg-format.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -617,7 +618,7 @@ ptz_load_file(Patternizer *self, gchar *input_file, gboolean no_parse, GError **
       if (line[len-1] == '\n')
         line[len-1] = 0;
 
-      msg = log_msg_new(line, len, &parse_options);
+      msg = msg_format_parse(&parse_options, (const guchar *) line, len);
       g_ptr_array_add(self->logs, msg);
     }
 

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -515,7 +515,7 @@ pdbtool_match(int argc, char *argv[])
         {
           log_msg_unref(msg);
           msg = log_msg_new_empty();
-          msg_format_parse(&parse_options, msg, buf, buflen);
+          msg_format_parse_into(&parse_options, msg, buf, buflen);
         }
 
       if (G_UNLIKELY(debug_pattern))

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -46,6 +46,7 @@
 #include "scratch-buffers.h"
 #include "timeutils/cache.h"
 #include "mainloop.h"
+#include "msg-format.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -514,8 +515,7 @@ pdbtool_match(int argc, char *argv[])
       if (G_LIKELY(proto))
         {
           log_msg_unref(msg);
-          msg = log_msg_new_empty();
-          msg_format_parse_into(&parse_options, msg, buf, buflen);
+          msg = msg_format_parse(&parse_options, buf, buflen);
         }
 
       if (G_UNLIKELY(debug_pattern))

--- a/modules/dbparser/tests/test_patternize.c
+++ b/modules/dbparser/tests/test_patternize.c
@@ -29,6 +29,7 @@
 #include "cfg.h"
 #include "plugin.h"
 #include "apphook.h"
+#include "msg-format.h"
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -80,7 +81,7 @@ _get_logmessages(const gchar *logs)
       if (logline[len-1] == '\n')
         logline[len-1] = 0;
 
-      msg = log_msg_new(logline, len, &parse_options);
+      msg = msg_format_parse(&parse_options, (const guchar *) logline, len);
       g_ptr_array_add(self->logmessages, msg);
       ++(self->num_of_logs);
       g_free(logline);

--- a/modules/diskq/tests/test_reliable_backlog.c
+++ b/modules/diskq/tests/test_reliable_backlog.c
@@ -29,14 +29,12 @@
 #include "logqueue-disk-reliable.h"
 #include "apphook.h"
 #include "plugin.h"
-#include "msg-format.h"
 
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
 
-MsgFormatOptions parse_options;
 
 #define TEST_DISKQ_SIZE QDISK_RESERVED_SPACE + 1000 /* 4096 + 1000 */
 
@@ -47,8 +45,6 @@ static gint mark_message_serialized_size;
 DiskQueueOptions options;
 
 #define NUMBER_MESSAGES_IN_QUEUE(n) (n * 3)
-
-MsgFormatOptions parse_options;
 
 static void
 _dummy_ack(LogMessage *lm,  AckType ack_type)
@@ -386,10 +382,7 @@ setup(void)
   tzset();
 
   configuration = cfg_new_snippet();
-  cfg_load_module(configuration, "syslogformat");
   cfg_load_module(configuration, "disk-buffer");
-  msg_format_options_defaults(&parse_options);
-  msg_format_options_init(&parse_options, configuration);
 
   set_mark_message_serialized_size();
 }

--- a/modules/diskq/tests/test_reliable_backlog.c
+++ b/modules/diskq/tests/test_reliable_backlog.c
@@ -29,6 +29,7 @@
 #include "logqueue-disk-reliable.h"
 #include "apphook.h"
 #include "plugin.h"
+#include "msg-format.h"
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/modules/geoip2/geoip-parser.c
+++ b/modules/geoip2/geoip-parser.c
@@ -94,9 +94,9 @@ maxminddb_parser_process(LogParser *s, LogMessage **pmsg,
   GeoIPParser *self = (GeoIPParser *) s;
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
   msg_trace("geoip2-parser message processing started",
-            evt_tag_str ("input", input),
-            evt_tag_str ("prefix", self->prefix),
-            evt_tag_printf("msg", "%p", *pmsg));
+            evt_tag_str("input", input),
+            evt_tag_str("prefix", self->prefix),
+            evt_tag_msg_reference(*pmsg));
 
   MMDB_entry_data_list_s *entry_data_list;
   if (!_mmdb_load_entry_data_list(self, input, &entry_data_list))

--- a/modules/http/tests/test_http-signal_slot.c
+++ b/modules/http/tests/test_http-signal_slot.c
@@ -28,6 +28,7 @@
 #include "http-worker.h"
 #include "http-signals.h"
 #include "apphook.h"
+#include "msg-format.h"
 
 MainLoop *main_loop;
 MsgFormatOptions parse_options;

--- a/modules/http/tests/test_http-signal_slot.c
+++ b/modules/http/tests/test_http-signal_slot.c
@@ -28,10 +28,8 @@
 #include "http-worker.h"
 #include "http-signals.h"
 #include "apphook.h"
-#include "msg-format.h"
 
 MainLoop *main_loop;
-MsgFormatOptions parse_options;
 MainLoopOptions main_loop_options;
 
 HTTPDestinationDriver *driver;

--- a/modules/json/json-parser.c
+++ b/modules/json/json-parser.c
@@ -317,17 +317,17 @@ json_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_
   struct json_tokener *tok;
 
   msg_trace("json-parser message processing started",
-            evt_tag_str ("input", input),
-            evt_tag_str ("prefix", self->prefix),
-            evt_tag_str ("marker", self->marker),
-            evt_tag_printf("msg", "%p", *pmsg));
+            evt_tag_str("input", input),
+            evt_tag_str("prefix", self->prefix),
+            evt_tag_str("marker", self->marker),
+            evt_tag_msg_reference(*pmsg));
   if (self->marker)
     {
       if (strncmp(input, self->marker, self->marker_len) != 0)
         {
           msg_debug("json-parser(): no marker at the beginning of the message, skipping JSON parsing ",
-                    evt_tag_str ("input", input),
-                    evt_tag_str ("marker", self->marker));
+                    evt_tag_str("input", input),
+                    evt_tag_str("marker", self->marker));
           return FALSE;
         }
       input += self->marker_len;
@@ -341,7 +341,7 @@ json_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_
   if (tok->err != json_tokener_success || !jso)
     {
       msg_debug("json-parser(): failed to parse JSON payload",
-                evt_tag_str ("input", input),
+                evt_tag_str("input", input),
                 tok->err != json_tokener_success ? evt_tag_str ("json_error", json_tokener_error_desc(tok->err)) : NULL);
       json_tokener_free (tok);
       return FALSE;

--- a/modules/kvformat/kv-parser.c
+++ b/modules/kvformat/kv-parser.c
@@ -111,9 +111,9 @@ _process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, co
 
   log_msg_make_writable(pmsg, path_options);
   msg_trace("kv-parser message processing started",
-            evt_tag_str ("input", input),
-            evt_tag_str ("prefix", self->prefix),
-            evt_tag_printf("msg", "%p", *pmsg));
+            evt_tag_str("input", input),
+            evt_tag_str("prefix", self->prefix),
+            evt_tag_msg_reference(*pmsg));
   /* FIXME: input length */
   kv_scanner_input(&kv_scanner, input);
   while (kv_scanner_scan_next(&kv_scanner))

--- a/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
+++ b/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
@@ -36,7 +36,7 @@ kmsg_parse_message(const gchar *raw_message_str)
 {
   LogMessage *message;
 
-  message = log_msg_new(raw_message_str, strlen(raw_message_str), &parse_options);
+  message = msg_format_parse(&parse_options, (const guchar *) raw_message_str, strlen(raw_message_str));
   return message;
 }
 

--- a/modules/map-value-pairs/map-value-pairs.c
+++ b/modules/map-value-pairs/map-value-pairs.c
@@ -42,8 +42,8 @@ _process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options,
   GlobalConfig *cfg = log_pipe_get_config(&s->super);
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
   msg_trace("value-pairs message processing started",
-            evt_tag_str ("input", input),
-            evt_tag_printf("msg", "%p", *pmsg));
+            evt_tag_str("input", input),
+            evt_tag_msg_reference(*pmsg));
 
   LogTemplateEvalOptions options = {&cfg->template_options, LTZ_LOCAL, 0, NULL, LM_VT_STRING};
   value_pairs_foreach(self->value_pairs, _map_name_values,

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -30,6 +30,7 @@
 #include "str-utils.h"
 #include "timeutils/unixtime.h"
 #include "timeutils/misc.h"
+#include "msg-format.h"
 
 #include <datetime.h>
 
@@ -408,7 +409,7 @@ py_log_message_parse(PyObject *_none, PyObject *args, PyObject *kwrds)
       return NULL;
     }
 
-  py_msg->msg = log_msg_new(raw_msg, raw_msg_length, parse_options);
+  py_msg->msg = msg_format_parse(parse_options, (const guchar *) raw_msg, raw_msg_length);
   py_msg->bookmark_data = NULL;
 
   return (PyObject *) py_msg;

--- a/modules/python/python-logparser.c
+++ b/modules/python/python-logparser.c
@@ -185,10 +185,10 @@ python_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
     LogMessage *msg = log_msg_make_writable(pmsg, path_options);
 
     msg_trace("python-parser message processing started",
-              evt_tag_str ("input", input),
+              evt_tag_str("input", input),
               evt_tag_str("parser", self->super.name),
               evt_tag_str("class", self->class),
-              evt_tag_printf("msg", "%p", msg));
+              evt_tag_msg_reference(msg));
 
     PyObject *msg_object = py_log_message_new(msg);
     result = _py_invoke_parser_process(self, msg_object);

--- a/modules/python/python-tf.c
+++ b/modules/python/python-tf.c
@@ -64,7 +64,7 @@ _py_invoke_template_function(const gchar *function_name, LogMessage *msg, gint a
 
   msg_debug("$(python): Invoking Python template function",
             evt_tag_str("function", function_name),
-            evt_tag_printf("msg", "%p", msg));
+            evt_tag_msg_reference(msg));
 
   args = _py_construct_args_tuple(msg, argc, argv);
   ret = PyObject_CallObject(callable, args);

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -119,7 +119,7 @@ TestSuite(python_log_message, .init = setup, .fini = teardown);
 Test(python_log_message, test_python_logmessage_set_value)
 {
   const gchar *raw_msg = "test_msg";
-  LogMessage *msg = log_msg_new(raw_msg, strlen(raw_msg), &parse_options);
+  LogMessage *msg = msg_format_parse(&parse_options, (const guchar *) raw_msg, strlen(raw_msg));
 
   PyGILState_STATE gstate;
   gstate = PyGILState_Ensure();
@@ -147,7 +147,7 @@ Test(python_log_message, test_python_logmessage_set_value_indirect)
   const gchar *raw_msg = "test_msg";
   const gchar *test_value = "test_value";
   const gchar *test_key = "test_key";
-  LogMessage *msg = log_msg_new(raw_msg, strlen(raw_msg), &parse_options);
+  LogMessage *msg = msg_format_parse(&parse_options, (const guchar *) raw_msg, strlen(raw_msg));
   NVHandle test_key_handle = log_msg_get_value_handle(test_key);
   log_msg_set_value(msg, test_key_handle, test_value, -1);
 

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -28,7 +28,6 @@
 #include "python-helpers.h"
 #include "python-logmsg.h"
 #include "apphook.h"
-#include "msg-format.h"
 #include "logmsg/logmsg.h"
 
 static PyObject *_python_main;
@@ -118,8 +117,7 @@ TestSuite(python_log_message, .init = setup, .fini = teardown);
 
 Test(python_log_message, test_python_logmessage_set_value)
 {
-  const gchar *raw_msg = "test_msg";
-  LogMessage *msg = msg_format_parse(&parse_options, (const guchar *) raw_msg, strlen(raw_msg));
+  LogMessage *msg = log_msg_new_empty();
 
   PyGILState_STATE gstate;
   gstate = PyGILState_Ensure();
@@ -144,10 +142,9 @@ Test(python_log_message, test_python_logmessage_set_value)
 
 Test(python_log_message, test_python_logmessage_set_value_indirect)
 {
-  const gchar *raw_msg = "test_msg";
   const gchar *test_value = "test_value";
   const gchar *test_key = "test_key";
-  LogMessage *msg = msg_format_parse(&parse_options, (const guchar *) raw_msg, strlen(raw_msg));
+  LogMessage *msg = log_msg_new_empty();
   NVHandle test_key_handle = log_msg_get_value_handle(test_key);
   log_msg_set_value(msg, test_key_handle, test_value, -1);
 

--- a/modules/python/tests/test_python_template.c
+++ b/modules/python/tests/test_python_template.c
@@ -113,7 +113,7 @@ TestSuite(python_log_logtemplate, .init = setup, .fini = teardown);
 static PyLogMessage *
 create_parsed_message(const gchar *raw_msg)
 {
-  LogMessage *msg = log_msg_new(raw_msg, strlen(raw_msg), &parse_options);
+  LogMessage *msg = msg_format_parse(&parse_options, (const guchar *) raw_msg, strlen(raw_msg));
 
   PyLogMessage *py_log_msg = (PyLogMessage *)py_log_message_new(msg);
   log_msg_unref(msg);

--- a/modules/regexp-parser/regexp-parser.c
+++ b/modules/regexp-parser/regexp-parser.c
@@ -102,16 +102,16 @@ regexp_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
 
   log_msg_make_writable(pmsg, path_options);
   msg_trace("regexp-parser message processing started",
-            evt_tag_str ("input", input),
-            evt_tag_str ("prefix", self->prefix),
-            evt_tag_printf("msg", "%p", *pmsg));
+            evt_tag_str("input", input),
+            evt_tag_str("prefix", self->prefix),
+            evt_tag_msg_reference(*pmsg));
 
   gboolean result = FALSE;
   for (GList *item = self->matchers; item; item = item->next)
     {
       msg_trace("regexp-parser message processing for",
-                evt_tag_str ("input", input),
-                evt_tag_str ("pattern", ((LogMatcher *)item->data)->pattern));
+                evt_tag_str("input", input),
+                evt_tag_str("pattern", ((LogMatcher *)item->data)->pattern));
 
       gint value_handle = LM_V_MESSAGE;
       if (G_UNLIKELY(self->super.template))

--- a/modules/secure-logging/tests/test_secure_logging.c
+++ b/modules/secure-logging/tests/test_secure_logging.c
@@ -93,7 +93,7 @@ LogMessage *create_random_sample_message(void)
       g_string_append_c(msg_str, randomNumber(65, 90));
     }
 
-  msg = log_msg_new(msg_str->str, msg_str->len, &test_parse_options);
+  msg = msg_format_parse(&test_parse_options, (const guchar *) msg_str->str, msg_str->len);
   log_msg_set_saddr_ref(msg, g_sockaddr_inet_new("10.11.12.13", 1010));
   log_msg_set_match(msg, 0, "whole-match", -1);
   log_msg_set_match(msg, 1, "first-match", -1);
@@ -251,7 +251,7 @@ void verifyMessages(guchar *hostkey, gchar *macFileName, GString **templateOutpu
   for (int i=0; i<totalNumberOfMessages; i++)
     {
       char *plaintextMessage = (outputBuffer[i]->str) + CTR_LEN_SIMPLE + COLON + BLANK;
-      LogMessage *result = log_msg_new(plaintextMessage, strlen(plaintextMessage), &test_parse_options);
+      LogMessage *result = msg_format_parse(&test_parse_options, (const guchar *) plaintextMessage, strlen(plaintextMessage));
       log_msg_set_saddr(result, original[i]->saddr);
       assert_log_messages_equal(original[i], result);
       g_string_free(outputBuffer[i], TRUE);
@@ -572,7 +572,7 @@ void test_slog_corrupted_key(void)
       output[i] = applyTemplate(slog_templ, logs[i]);
 
       // Create new message from the text content of the original message
-      LogMessage *myOut = log_msg_new(output[i]->str, output[i]->len, &test_parse_options);
+      LogMessage *myOut = msg_format_parse(&test_parse_options, (const guchar *) output[i]->str, output[i]->len);
 
       // Initialize the new message with value from the original
       log_msg_set_saddr(myOut, logs[i]->saddr);

--- a/modules/stardate/tests/test_stardate.c
+++ b/modules/stardate/tests/test_stardate.c
@@ -38,7 +38,7 @@ void
 stardate_assert(const gchar *msg_str, const int precision, const gchar *expected)
 {
 
-  LogMessage *logmsg = log_msg_new(msg_str, strlen(msg_str), &parse_options);
+  LogMessage *logmsg = msg_format_parse(&parse_options, (const guchar *) msg_str, strlen(msg_str));
 
   char *template_command;
   int ret_val;

--- a/modules/syslogformat/syslog-parser.c
+++ b/modules/syslogformat/syslog-parser.c
@@ -41,8 +41,8 @@ syslog_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
 
   msg = log_msg_make_writable(pmsg, path_options);
   msg_trace("syslog-parser message processing started",
-            evt_tag_str ("input", input),
-            evt_tag_printf("msg", "%p", *pmsg));
+            evt_tag_str("input", input),
+            evt_tag_msg_reference(*pmsg));
 
   if (self->drop_invalid)
     {

--- a/modules/syslogformat/syslog-parser.c
+++ b/modules/syslogformat/syslog-parser.c
@@ -22,7 +22,6 @@
  */
 
 #include "syslog-parser.h"
-#include "syslog-format.h"
 
 void
 syslog_parser_set_drop_invalid(LogParser *s, gboolean drop_invalid)

--- a/modules/syslogformat/syslog-parser.c
+++ b/modules/syslogformat/syslog-parser.c
@@ -47,11 +47,11 @@ syslog_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
   if (self->drop_invalid)
     {
       gsize problem_position = 0;
-      return msg_format_parse_conditional(&self->parse_options, msg, (guchar *) input, input_len, &problem_position);
+      return msg_format_try_parse_into(&self->parse_options, msg, (guchar *) input, input_len, &problem_position);
     }
   else
     {
-      msg_format_parse(&self->parse_options, msg, (guchar *) input, input_len);
+      msg_format_parse_into(&self->parse_options, msg, (guchar *) input, input_len);
       return TRUE;
     }
 }

--- a/modules/syslogformat/syslog-parser.h
+++ b/modules/syslogformat/syslog-parser.h
@@ -24,6 +24,7 @@
 #define SYSLOG_PARSER_H_INCLUDED
 
 #include "parser/parser-expr.h"
+#include "msg-format.h"
 
 typedef struct _SyslogParser
 {

--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -160,8 +160,6 @@ _map_key_value_pairs_to_syslog_macros(LogMessage *msg, gchar *key, gchar *value,
   if (strcmp(key, "MESSAGE") == 0)
     {
       log_msg_set_value(msg, LM_V_MESSAGE, value, value_len);
-      msg_debug("Incoming log entry from journal",
-                evt_tag_printf("message", "%.*s", (int)value_len, value));
     }
   else if (strcmp(key, "_HOSTNAME") == 0)
     {
@@ -268,6 +266,10 @@ _handle_message(JournalReader *self)
 
   _set_message_timestamp(self, msg);
   _set_program(self->options, msg);
+
+  msg_debug("Incoming log entry from journal",
+            evt_tag_printf("input", "%s", log_msg_get_value(msg, LM_V_MESSAGE, NULL)),
+            evt_tag_msg_reference(msg));
 
   log_source_post(&self->super, msg);
   return log_source_free_to_send(&self->super);

--- a/modules/tagsparser/tags-parser.c
+++ b/modules/tagsparser/tags-parser.c
@@ -39,8 +39,8 @@ _process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, co
 {
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
   msg_trace("tags-parser message processing started",
-            evt_tag_str ("input", input),
-            evt_tag_printf("msg", "%p", *pmsg));
+            evt_tag_str("input", input),
+            evt_tag_msg_reference(*pmsg));
 
   ListScanner scanner;
   list_scanner_init(&scanner);

--- a/modules/timestamp/date-parser.c
+++ b/modules/timestamp/date-parser.c
@@ -142,8 +142,8 @@ date_parser_process(LogParser *s,
   DateParser *self = (DateParser *) s;
   LogMessage *msg = log_msg_make_writable(pmsg, path_options);
   msg_trace("date-parser message processing started",
-            evt_tag_str ("input", input),
-            evt_tag_printf("msg", "%p", *pmsg));
+            evt_tag_str("input", input),
+            evt_tag_msg_reference(*pmsg));
 
   /* this macro ensures zero termination by copying input to a
    * g_alloca()-d buffer if necessary. In most cases it's not though.

--- a/modules/xml/xml.c
+++ b/modules/xml/xml.c
@@ -98,7 +98,7 @@ xml_parser_process(LogParser *s, LogMessage **pmsg,
   msg_trace("xml-parser message processing started",
             evt_tag_str ("input", input),
             evt_tag_str ("prefix", self->prefix),
-            evt_tag_printf("msg", "%p", *pmsg));
+            evt_tag_msg_reference(*pmsg));
 
   PushParams push_params = {.msg = msg, .create_lists = self->create_lists};
   xml_scanner_init(&xml_scanner, &self->options, &scanner_push_function, &push_params, self->prefix);

--- a/news/feature-3972.md
+++ b/news/feature-3972.md
@@ -1,0 +1,3 @@
+`internal()`: add rcptid tag to all trace messages that relate to incoming
+log messages.  This makes it easier to correlate parsing, rewriting and
+routing actions with incoming log messages.

--- a/tests/unit/test_clone_logmsg.c
+++ b/tests/unit/test_clone_logmsg.c
@@ -103,9 +103,9 @@ ParameterizedTest(const gchar *msg, clone_logmsg, test_cloning_with_log_message)
   parse_options.flags = LP_SYSLOG_PROTOCOL;
   parse_options.bad_hostname = &bad_hostname;
 
-  original_log_message = log_msg_new(msg, strlen(msg), &parse_options);
+  original_log_message = msg_format_parse(&parse_options, (const guchar *) msg, strlen(msg));
   log_msg_set_saddr(original_log_message, addr);
-  log_message = log_msg_new(msg, strlen(msg), &parse_options);
+  log_message = msg_format_parse(&parse_options, (const guchar *) msg, strlen(msg));
   log_msg_set_saddr(log_message, addr);
 
   log_msg_set_tag_by_name(log_message, "newtag");

--- a/tests/unit/test_logwriter.c
+++ b/tests/unit/test_logwriter.c
@@ -31,6 +31,7 @@
 #include "plugin.h"
 #include "logqueue-fifo.h"
 #include "timeutils/misc.h"
+#include "msg-format.h"
 
 #include <time.h>
 #include <stdlib.h>
@@ -122,7 +123,7 @@ init_msg(const gchar *msg_string, gboolean use_syslog_protocol)
     parse_options.flags |= LP_SYSLOG_PROTOCOL;
   else
     parse_options.flags &= ~LP_SYSLOG_PROTOCOL;
-  msg = log_msg_new(msg_string, strlen(msg_string), &parse_options);
+  msg = msg_format_parse(&parse_options, (const guchar *) msg_string, strlen(msg_string));
   log_msg_set_value_by_name(msg, "APP.VALUE", "value", 5);
   log_msg_set_match(msg, 0, "whole-match", 11);
   log_msg_set_match(msg, 1, "first-match", 11);

--- a/tests/unit/test_msgparse.c
+++ b/tests/unit/test_msgparse.c
@@ -82,7 +82,7 @@ _parse_log_message(gchar *raw_message_str, gint parse_flags, gchar *bad_hostname
       parse_options.bad_hostname = &bad_hostname;
     }
 
-  message = log_msg_new(raw_message_str, strlen(raw_message_str), &parse_options);
+  message = msg_format_parse(&parse_options, (const guchar *) raw_message_str, strlen(raw_message_str));
 
   if (bad_hostname_re)
     {


### PR DESCRIPTION
The new log_msg_evt_tags() macro adds the rcptid value to the trace messages
making it easier to identify which msg we are manipulating at the moment.

In order to have a non-zero value for rcptid, one needs to enable
use-rcptid() in the configuration.

Fixes portions of #3967
