### PR TITLE
mainloop: add main_loop_get_pending_new_config()

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -805,6 +805,12 @@ void register_source_mangle_callback(GlobalConfig *src, mangle_callback cb)
   src->source_mangle_callback_list = g_list_append(src->source_mangle_callback_list, cb);
 }
 
+gboolean
+is_source_mangle_callback_registered(GlobalConfig *src, mangle_callback cb)
+{
+  return !!g_list_find(src->source_mangle_callback_list, cb);
+}
+
 void uregister_source_mangle_callback(GlobalConfig *src, mangle_callback cb)
 {
   src->source_mangle_callback_list = g_list_remove(src->source_mangle_callback_list, cb);
@@ -815,4 +821,3 @@ cfg_get_filename(const GlobalConfig *cfg)
 {
   return cfg->filename;
 }
-

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -170,6 +170,7 @@ gpointer cfg_persist_config_fetch(GlobalConfig *cfg, const gchar *name);
 typedef gboolean(* mangle_callback)(GlobalConfig *cfg, LogMessage *msg, gpointer user_data);
 
 void register_source_mangle_callback(GlobalConfig *src, mangle_callback cb);
+gboolean is_source_mangle_callback_registered(GlobalConfig *src, mangle_callback cb);
 void uregister_source_mangle_callback(GlobalConfig *src, mangle_callback cb);
 
 static inline gboolean

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -390,6 +390,12 @@ main_loop_get_current_config(MainLoop *self)
   return self->current_configuration;
 }
 
+GlobalConfig *
+main_loop_get_pending_new_config(MainLoop *self)
+{
+  return self->new_config;
+}
+
 /* main_loop_verify_config
  * compares active configuration versus config file */
 

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -73,6 +73,7 @@ void main_loop_run(MainLoop *self);
 
 MainLoop *main_loop_get_instance(void);
 GlobalConfig *main_loop_get_current_config(MainLoop *self);
+GlobalConfig *main_loop_get_pending_new_config(MainLoop *self);
 void main_loop_init(MainLoop *self, MainLoopOptions *options);
 void main_loop_deinit(MainLoop *self);
 


### PR DESCRIPTION
This method can be used to obtain the pending configuration we wish to switch to during reload.

One of our internal modules does some questionable things at an early stage of the reload process. Those things need to acquire the pending configuration.

This logic could be delayed easily by an apphook (`AH_CONFIG_CHANGED`), but unfortunately, it is currently not possible as we register source mangle callbacks there, and those need to be registered before cfg_init() to avoid data races with threaded sources.