### PR TITLE
Light: Fix --run-under execution parameter

### DIFF
--- a/tests/light/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/light/src/syslog_ng/syslog_ng_cli.py
@@ -96,7 +96,7 @@ class SyslogNgCli(object):
 
     def __start_syslog_ng(self):
         if self.__external_tool:
-            self.__process = self.__syslog_ng_executor.run_process_with_external_tool(self.__external_tool)
+            self.__process = self.__syslog_ng_executor.run_process_with_external_tool(self.__external_tool, self.__stderr, self.__debug, self.__trace, self.__verbose, self.__startup_debug, self.__no_caps, self.__config_path, self.__persist_path, self.__pid_path, self.__control_socket_path)
         else:
             self.__process = self.__syslog_ng_executor.run_process(self.__stderr, self.__debug, self.__trace, self.__verbose, self.__startup_debug, self.__no_caps, self.__config_path, self.__persist_path, self.__pid_path, self.__control_socket_path)
         if self.__stderr and self.__debug and self.__verbose:

--- a/tests/light/src/syslog_ng/syslog_ng_executor.py
+++ b/tests/light/src/syslog_ng/syslog_ng_executor.py
@@ -38,7 +38,7 @@ class SyslogNgExecutor(object):
             stderr_path=self.__instance_paths.get_stderr_path(),
         )
 
-    def run_process_with_external_tool(self, external_tool):
+    def run_process_with_external_tool(self, external_tool, stderr, debug, trace, verbose, startup_debug, no_caps, config_path, persist_path, pid_path, control_socket_path):
         self.__instance_paths.register_external_tool_output_path(external_tool)
         if external_tool == "valgrind":
             return self.run_process_with_valgrind()

--- a/tests/light/src/syslog_ng/syslog_ng_executor.py
+++ b/tests/light/src/syslog_ng/syslog_ng_executor.py
@@ -43,7 +43,7 @@ class SyslogNgExecutor(object):
         if external_tool == "valgrind":
             return self.run_process_with_valgrind(stderr, debug, trace, verbose, startup_debug, no_caps, config_path, persist_path, pid_path, control_socket_path)
         elif external_tool == "strace":
-            return self.run_process_with_strace()
+            return self.run_process_with_strace(stderr, debug, trace, verbose, startup_debug, no_caps, config_path, persist_path, pid_path, control_socket_path)
         else:
             raise Exception("Unknown external tool was selected: {}".format(external_tool))
 
@@ -68,7 +68,7 @@ class SyslogNgExecutor(object):
             stderr_path=self.__instance_paths.get_stderr_path(),
         )
 
-    def run_process_with_strace(self):
+    def run_process_with_strace(self, stderr, debug, trace, verbose, startup_debug, no_caps, config_path, persist_path, pid_path, control_socket_path):
         strace_command_args = [
             "strace",
             "-s",
@@ -79,7 +79,7 @@ class SyslogNgExecutor(object):
             "-o",
             self.__instance_paths.get_external_tool_output_path("strace"),
         ]
-        full_command_args = strace_command_args + self.__construct_syslog_ng_process()
+        full_command_args = strace_command_args + self.__construct_syslog_ng_process(stderr, debug, trace, verbose, startup_debug, no_caps, config_path, persist_path, pid_path, control_socket_path)
         return self.__process_executor.start(
             command=full_command_args,
             stdout_path=self.__instance_paths.get_stdout_path(),

--- a/tests/light/src/syslog_ng/syslog_ng_executor.py
+++ b/tests/light/src/syslog_ng/syslog_ng_executor.py
@@ -41,13 +41,13 @@ class SyslogNgExecutor(object):
     def run_process_with_external_tool(self, external_tool, stderr, debug, trace, verbose, startup_debug, no_caps, config_path, persist_path, pid_path, control_socket_path):
         self.__instance_paths.register_external_tool_output_path(external_tool)
         if external_tool == "valgrind":
-            return self.run_process_with_valgrind()
+            return self.run_process_with_valgrind(stderr, debug, trace, verbose, startup_debug, no_caps, config_path, persist_path, pid_path, control_socket_path)
         elif external_tool == "strace":
             return self.run_process_with_strace()
         else:
             raise Exception("Unknown external tool was selected: {}".format(external_tool))
 
-    def run_process_with_valgrind(self):
+    def run_process_with_valgrind(self, stderr, debug, trace, verbose, startup_debug, no_caps, config_path, persist_path, pid_path, control_socket_path):
         valgrind_command_args = [
             "valgrind",
             "--show-leak-kinds=all",
@@ -61,7 +61,7 @@ class SyslogNgExecutor(object):
             "--verbose",
             "--log-file={}".format(self.__instance_paths.get_external_tool_output_path("valgrind")),
         ]
-        full_command_args = valgrind_command_args + self.__construct_syslog_ng_process()
+        full_command_args = valgrind_command_args + self.__construct_syslog_ng_process(stderr, debug, trace, verbose, startup_debug, no_caps, config_path, persist_path, pid_path, control_socket_path)
         return self.__process_executor.start(
             command=full_command_args,
             stdout_path=self.__instance_paths.get_stdout_path(),


### PR DESCRIPTION
Light has a `--run-under=` execution parameter from the beginning. It is useful for debugging purposes. With it we can tell Light we want to start syslog-ng in testcases behind a chosen tool. For now the following tools are supported (strace, valgrind):

```bash
python3 -m pytest --installdir=/install --run-under=strace functional_tests/source_drivers/file_source/test_acceptance.py
python3 -m pytest --installdir=/install --run-under=valgrind functional_tests/source_drivers/file_source/test_acceptance.py
```
In booth cases output will be generated under: 
- reports/[current-run]/strace_*.log
- reports/[current-run]/valgrind_*.log

Our dbld/devshell container already contains these two tools, so it will be works out of the box.

Somewhere in the past we have updated parameters for `SyslogNgCli.start()`, but we did not follow the changes for `run_process_with_external_tool()`. This PR fixes it.


Additional info, for now running tests with `--run-under=valgrind` alerts for 'blocks are definitely lost in loss record' errors.
Could you please help me, is it a valid problem for now?

```python
==18769== 1,892 bytes in 473 blocks are definitely lost in loss record 66 of 74
==18769==    at 0x483F7B5: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==18769==    by 0x49E7E18: g_malloc (gmem.c:106)
==18769==    by 0x4A01E0F: g_strdup (gstrfuncs.c:364)
==18769==    by 0x491134C: _copy_timezone_state_to_locals (cache.c:154)
==18769==    by 0x4911485: _validate_timeutils_cache (cache.c:179)
==18769==    by 0x4911917: cached_localtime (cache.c:280)
==18769==    by 0x48B0DF2: msg_format_timestamp (messages.c:135)
==18769==    by 0x48B0EB7: msg_send_formatted_message_to_stderr (messages.c:150)
==18769==    by 0x48B0F27: msg_send_formatted_message (messages.c:158)
==18769==    by 0x48B1019: msg_event_send_with_suppression (messages.c:184)
==18769==    by 0x48B1076: msg_event_suppress_recursions_and_send (messages.c:198)
==18769==    by 0x48FF2F2: _thread (control-command-thread.c:65)
==18769==    by 0x4A0BF5C: g_thread_proxy (gthread.c:827)
==18769==    by 0x5197D7F: start_thread (pthread_create.c:481)
==18769==    by 0x4BBC76E: clone (clone.S:95)
```


Other finding with `--run-under=valgrind` run:
- Could this also be a valid issue?

```python
==77245== Conditional jump or move depends on uninitialised value(s)
==77245==    at 0x5A43011: ???
==77245==    by 0x6772C65: ???
==77245==  Uninitialised value was created by a heap allocation
==77245==    at 0x483F7B5: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==77245==    by 0x49E7E18: g_malloc (gmem.c:106)
==77245==    by 0x490B70B: nv_table_realloc (nvtable.c:753)
==77245==    by 0x4903726: log_msg_set_value_with_type (logmsg.c:570)
==77245==    by 0x49038E1: log_msg_set_value (logmsg.c:595)
==77245==    by 0x48EAE9E: log_rewrite_subst_process (rewrite-subst.c:76)
==77245==    by 0x48E9D64: log_rewrite_queue (rewrite-expr.c:54)
==77245==    by 0x48A0AC4: log_pipe_queue (logpipe.h:381)
==77245==    by 0x48A0970: log_pipe_forward_msg (logpipe.h:346)
==77245==    by 0x48A0ADD: log_pipe_queue (logpipe.h:385)
==77245==    by 0x48A0970: log_pipe_forward_msg (logpipe.h:346)
==77245==    by 0x48A0ADD: log_pipe_queue (logpipe.h:385)
==77245==    by 0x48A0D3A: log_multiplexer_queue (logmpx.c:105)
==77245==    by 0x4898C2B: log_pipe_queue (logpipe.h:381)
==77245==    by 0x4898AD7: log_pipe_forward_msg (logpipe.h:346)
==77245==    by 0x4898C44: log_pipe_queue (logpipe.h:385)
==77245==    by 0x4898AD7: log_pipe_forward_msg (logpipe.h:346)
==77245==    by 0x4898C44: log_pipe_queue (logpipe.h:385)
==77245==    by 0x4898AD7: log_pipe_forward_msg (logpipe.h:346)
==77245==    by 0x4899591: log_src_driver_queue_method (driver.c:222)
==77245==    by 0x48A62F3: log_pipe_queue (logpipe.h:381)
==77245==    by 0x48A619F: log_pipe_forward_msg (logpipe.h:346)
==77245==    by 0x48A80EC: log_source_queue (logsource.c:649)
==77245==    by 0x48A62F3: log_pipe_queue (logpipe.h:381)
==77245==    by 0x48A7C72: log_source_post (logsource.c:543)
==77245==    by 0x5A024C6: _send_generated_message (msg-generator-source.c:129)
==77245==    by 0x5A024EB: _timer_expired (msg-generator-source.c:137)
==77245==    by 0x491D09F: iv_run_timers (iv_timer.c:124)
==77245==    by 0x49202A4: iv_main (iv_main_posix.c:98)
==77245==    by 0x48AE2A3: main_loop_run (mainloop.c:671)
==77245==    by 0x10A9B9: main (main.c:312)
```