### PR TITLE
Update Criterion in macOS tests

### DIFF
--- a/contrib/Brewfile
+++ b/contrib/Brewfile
@@ -1,5 +1,3 @@
-tap "snaipe/soft"
-
 brew "automake"
 brew "autoconf"
 brew "autoconf-archive"

--- a/lib/transport/tests/test_transport_factory_id.c
+++ b/lib/transport/tests/test_transport_factory_id.c
@@ -26,10 +26,12 @@
 #include "transport/transport-factory-id.h"
 #include "apphook.h"
 
-TestSuite(transport_factory_id, .init = app_startup, .fini = app_shutdown);
+TestSuite(transport_factory_id, .init = transport_factory_id_global_init, .fini = transport_factory_id_global_deinit);
 
-Test(transport_factory_id, lifecycle)
+Test(transport_factory_id_lifecycle, lifecycle)
 {
+  transport_factory_id_global_init();
+
   GList *ids = _transport_factory_id_clone_registered_ids();
 
   cr_expect_null(ids);


### PR DESCRIPTION
Criterion is now part of the official brew repository.