### PR TITLE
logreader: stop processing if the connection is closed

### DIFF
--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -388,6 +388,10 @@ log_reader_work_finished(void *s)
 
       self->notify_code = 0;
       log_pipe_notify(self->control, notify_code, self);
+      if (notify_code == NC_CLOSE)
+        {
+          return;
+        }
     }
   if (self->super.super.flags & PIF_INITIALIZED)
     {


### PR DESCRIPTION
If the connection is closed and log_reader_work_finished was running,
calling log_pipe_notify will result in the LogReader object being no longer
usable because it was cleaned up.

So to prevent SEGV, don't allow execution to continue into the next block
when the connection is marked as NC_CLOSE

It seems more likely for this to occur when the log reader is a socket
that was opened by "logger" from busybox.

We started experiencing this after updating from glibc 2.29 to 2.35
and gcc from 8.3 to 11.2.

Signed-off-by: Scott Parlane <scott.parlane@alliedtelesis.co.nz>