### PR TITLE
devshell: workaround for python 3.10 on Debian Testing

### DIFF
--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -216,9 +216,14 @@ jobs:
         id: light-style-check
         if: always()
         working-directory: ./build
+        shell: bash
         run: |
+          python3.9 -m venv venv
+          source venv/bin/activate
+          python -m pip install -r "${GITHUB_WORKSPACE}/requirements.txt"
           make light-linters || \
             (git diff > ../light-style-problems.diff ; git reset --hard HEAD && exit 1)
+          deactivate
 
       - name: "Artifact: c-style-problems"
         uses: actions/upload-artifact@v2

--- a/dbld/packages.manifest
+++ b/dbld/packages.manifest
@@ -96,6 +96,11 @@ python3-dev                 [ubuntu-focal]
 python-pip                      [centos, fedora, debian-stretch, debian-buster, ubuntu-trusty, ubuntu-xenial, ubuntu-bionic]
 python3-pip                     [debian, ubuntu]
 
+# python 3.10 has issues on Debian Testing
+# Nevertheless we should only downgrade for Light style-check tests, which uses pre-commit
+python3.9                   [devshell]
+python3.9-venv              [devshell]
+
 # libmongoc and libbson packages on various platforms
 # Because we are using fixed version of libmongoc on Bionic, we need to
 # specify non versioned packages on other platforms to continiously support


### PR DESCRIPTION
pre-commit doesn't work on Debian Testing after python is upgraded to 3.10.

It seems that this issue is only going to be resolved in python 3.11

1. https://github.com/pre-commit/pre-commit/issues/2299
2. https://github.com/pre-commit/pre-commit/issues/2336
3. https://bugs.launchpad.net/ubuntu/+source/python3.10/+bug/1967920
4. https://github.com/python/cpython/issues/89576

Green CI workflow: https://github.com/gaborznagy/syslog-ng/runs/6171859432