### PR TITLE
disable caps API

### DIFF
--- a/lib/gprocess.c
+++ b/lib/gprocess.c
@@ -1572,6 +1572,13 @@ g_process_process_mode_arg(const gchar *option_name G_GNUC_UNUSED, const gchar *
   return TRUE;
 }
 
+void
+g_process_disable_caps(void)
+{
+  process_opts.caps = NULL;
+  process_opts.enable_caps = FALSE;
+}
+
 static gboolean
 g_process_process_no_caps(const gchar *option_name G_GNUC_UNUSED, const gchar *value G_GNUC_UNUSED,
                           gpointer data G_GNUC_UNUSED, GError *error)

--- a/lib/gprocess.c
+++ b/lib/gprocess.c
@@ -949,8 +949,7 @@ g_process_change_caps(void)
       if (cap == NULL)
         {
           g_process_message("Error parsing capabilities: %s", process_opts.caps);
-          process_opts.caps = NULL;
-          process_opts.enable_caps = FALSE;
+          g_process_disable_caps();
           return FALSE;
         }
       else
@@ -958,8 +957,7 @@ g_process_change_caps(void)
           if (cap_set_proc(cap) == -1)
             {
               g_process_message("Error setting capabilities, capability management disabled; error='%s'", g_strerror(errno));
-              process_opts.caps = NULL;
-              process_opts.enable_caps = FALSE;
+              g_process_disable_caps();
 
             }
           cap_free(cap);
@@ -1583,8 +1581,7 @@ static gboolean
 g_process_process_no_caps(const gchar *option_name G_GNUC_UNUSED, const gchar *value G_GNUC_UNUSED,
                           gpointer data G_GNUC_UNUSED, GError *error)
 {
-  process_opts.caps = NULL;
-  process_opts.enable_caps = FALSE;
+  g_process_disable_caps();
   return TRUE;
 }
 

--- a/lib/gprocess.h
+++ b/lib/gprocess.h
@@ -69,6 +69,7 @@ void g_process_set_chroot(const gchar *chroot);
 void g_process_set_pidfile(const gchar *pidfile);
 void g_process_set_pidfile_dir(const gchar *pidfile_dir);
 void g_process_set_working_dir(const gchar *cwd);
+void g_process_disable_caps(void);
 void g_process_set_caps(const gchar *caps);
 void g_process_set_argv_space(gint argc, gchar **argv);
 void g_process_set_use_fdlimit(gboolean use);


### PR DESCRIPTION
Some internal tools reuse code parts from syslog-ng modules, which uses capabilities.
For some of these tools this is not needed, so let's allow them to disable it, similarly to `--no-caps` option of syslog-ng.