### PR TITLE
logreader: fix use-after-free bug in non-threaded mode

### DIFF
--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -572,8 +572,10 @@ log_reader_io_handle_in(gpointer s)
        */
       if (!main_loop_worker_job_quit())
         {
+          log_pipe_ref(&self->super.super);
           log_reader_work_perform(s, G_IO_IN);
           log_reader_work_finished(s);
+          log_pipe_unref(&self->super.super);
         }
     }
 }

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -279,8 +279,10 @@ log_writer_io_handler(gpointer s, GIOCondition cond)
 
       if (!main_loop_worker_job_quit())
         {
+          log_pipe_ref(&self->super);
           log_writer_work_perform(s, cond);
           log_writer_work_finished(s);
+          log_pipe_unref(&self->super);
         }
     }
 }

--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -555,8 +555,10 @@ _io_process_input(gpointer s)
     {
       if (!main_loop_worker_job_quit())
         {
+          log_pipe_ref(&self->super.super);
           _work_perform(s, G_IO_IN);
           _work_finished(s);
+          log_pipe_unref(&self->super.super);
         }
     }
 }

--- a/news/bugfix-3997.md
+++ b/news/bugfix-3997.md
@@ -1,0 +1,9 @@
+fix `threaded(no)` related crash: if threaded mode is disabled for
+asynchronous sources and destinations (all syslog-like drivers such as
+tcp/udp/syslog/network qualify), a use-after-free condition can happen due
+to a reference counting bug in the non-threaded code path.  The
+`threaded(yes)` setting has been the default since 3.6.1 so if you are using
+a more recent version, you are most probably unaffected.  If you are using
+`threaded(no)` a use-after-free condition happens as the connection closes.
+The problem is more likely to surface on 32 bit platforms due to pointer
+sizes and struct layouts where this causes a NULL pointer dereference.


### PR DESCRIPTION
This is an alternative fix for #3985. 

fix `threaded(no)` related crash: if threaded mode is disabled for asynchronous sources and destinations (all syslog-like drivers such as tcp/udp/syslog/network qualify), a use-after-free condition can happen due to a reference counting bug in the non-threaded code path.  

The `threaded(yes)` setting has been the default since 3.6.1 so if you are using a more recent version, you are most probably unaffected.  If you are using `threaded(no)` a use-after-free condition happens as the connection closes.  The problem is more likely to surface on 32 bit platforms due to pointer sizes and struct layouts where this causes a NULL pointer ereference.
