### PR TITLE
Grouping by inject mode aggregate only

### DIFF
--- a/libtest/CMakeLists.txt
+++ b/libtest/CMakeLists.txt
@@ -3,6 +3,7 @@ set(LIBTEST_HEADERS
     fake-time.h
     mock-transport.h
     mock-cfg-parser.h
+    mock-logpipe.h
     msg_parse_lib.h
     persist_lib.h
     proto_lib.h
@@ -18,6 +19,7 @@ set(LIBTEST_SOURCES
     libtest.c
     mock-transport.c
     mock-cfg-parser.c
+    mock-logpipe.c
     msg_parse_lib.c
     persist_lib.c
     proto_lib.c

--- a/libtest/Makefile.am
+++ b/libtest/Makefile.am
@@ -17,6 +17,8 @@ libtest_libsyslog_ng_test_a_SOURCES =   \
 	libtest/libtest.c		\
 	libtest/mock-cfg-parser.c	\
 	libtest/mock-cfg-parser.h	\
+	libtest/mock-logpipe.c		\
+	libtest/mock-logpipe.h		\
 	libtest/mock-transport.c	\
 	libtest/mock-transport.h	\
 	libtest/fake-time.c		\

--- a/libtest/config_parse_lib.h
+++ b/libtest/config_parse_lib.h
@@ -26,7 +26,7 @@
 #ifndef CONFIG_PARSE_LIB_H_INCLUDED
 #define CONFIG_PARSE_LIB_H_INCLUDED 1
 
-#include <glib.h>
+#include "syslog-ng.h"
 
 gboolean parse_config(const gchar *config_to_parse, gint context, gpointer arg, gpointer *result);
 

--- a/libtest/config_parse_lib.h
+++ b/libtest/config_parse_lib.h
@@ -27,6 +27,7 @@
 #define CONFIG_PARSE_LIB_H_INCLUDED 1
 
 #include "syslog-ng.h"
+#include "plugin-types.h"
 
 gboolean parse_config(const gchar *config_to_parse, gint context, gpointer arg, gpointer *result);
 

--- a/libtest/mock-logpipe.c
+++ b/libtest/mock-logpipe.c
@@ -23,38 +23,38 @@
 #include "mock-logpipe.h"
 
 LogMessage *
-test_capture_pipe_get_message(TestCapturePipe *self, gint ndx)
+log_pipe_mock_get_message(LogPipeMock *self, gint ndx)
 {
   g_assert(ndx >= 0 && ndx < self->captured_messages->len);
   return (LogMessage *) g_ptr_array_index(self->captured_messages, ndx);
 }
 
 static void
-test_capture_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
+log_pipe_mock_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
-  TestCapturePipe *self = (TestCapturePipe *) s;
+  LogPipeMock *self = (LogPipeMock *) s;
 
   g_ptr_array_add(self->captured_messages, log_msg_ref(msg));
   log_pipe_forward_msg(s, msg, path_options);
 }
 
 static void
-test_capture_pipe_free(LogPipe *s)
+log_pipe_mock_free(LogPipe *s)
 {
-  TestCapturePipe *self = (TestCapturePipe *) s;
+  LogPipeMock *self = (LogPipeMock *) s;
 
   g_ptr_array_free(self->captured_messages, TRUE);
   log_pipe_free_method(s);
 }
 
-TestCapturePipe *
-test_capture_pipe_new(GlobalConfig *cfg)
+LogPipeMock *
+log_pipe_mock_new(GlobalConfig *cfg)
 {
-  TestCapturePipe *self = g_new0(TestCapturePipe, 1);
+  LogPipeMock *self = g_new0(LogPipeMock, 1);
 
   log_pipe_init_instance(&self->super, cfg);
   self->captured_messages = g_ptr_array_new_full(0, (GDestroyNotify) log_msg_unref);
-  self->super.queue = test_capture_pipe_queue;
-  self->super.free_fn = test_capture_pipe_free;
+  self->super.queue = log_pipe_mock_queue;
+  self->super.free_fn = log_pipe_mock_free;
   return self;
 }

--- a/libtest/mock-logpipe.c
+++ b/libtest/mock-logpipe.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022 Balázs Scheidler <bazsi77@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "mock-logpipe.h"
+
+LogMessage *
+test_capture_pipe_get_message(TestCapturePipe *self, gint ndx)
+{
+  g_assert(ndx >= 0 && ndx < self->captured_messages->len);
+  return (LogMessage *) g_ptr_array_index(self->captured_messages, ndx);
+}
+
+static void
+test_capture_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
+{
+  TestCapturePipe *self = (TestCapturePipe *) s;
+
+  g_ptr_array_add(self->captured_messages, log_msg_ref(msg));
+  log_pipe_forward_msg(s, msg, path_options);
+}
+
+static void
+test_capture_pipe_free(LogPipe *s)
+{
+  TestCapturePipe *self = (TestCapturePipe *) s;
+
+  g_ptr_array_free(self->captured_messages, TRUE);
+  log_pipe_free_method(s);
+}
+
+TestCapturePipe *
+test_capture_pipe_new(GlobalConfig *cfg)
+{
+  TestCapturePipe *self = g_new0(TestCapturePipe, 1);
+
+  log_pipe_init_instance(&self->super, cfg);
+  self->captured_messages = g_ptr_array_new_full(0, (GDestroyNotify) log_msg_unref);
+  self->super.queue = test_capture_pipe_queue;
+  self->super.free_fn = test_capture_pipe_free;
+  return self;
+}

--- a/libtest/mock-logpipe.h
+++ b/libtest/mock-logpipe.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022 Balázs Scheidler <bazsi77@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef MOCK_LOGPIPE_H_INCLUDED
+#define MOCK_LOGPIPE_H_INCLUDED
+
+#include "logpipe.h"
+
+typedef struct _TestCapturePipe
+{
+  LogPipe super;
+  GPtrArray *captured_messages;
+} TestCapturePipe;
+
+LogMessage *test_capture_pipe_get_message(TestCapturePipe *self, gint ndx);
+TestCapturePipe *test_capture_pipe_new(GlobalConfig *cfg);
+
+#endif

--- a/libtest/mock-logpipe.h
+++ b/libtest/mock-logpipe.h
@@ -25,13 +25,13 @@
 
 #include "logpipe.h"
 
-typedef struct _TestCapturePipe
+typedef struct _LogPipeMock
 {
   LogPipe super;
   GPtrArray *captured_messages;
-} TestCapturePipe;
+} LogPipeMock;
 
-LogMessage *test_capture_pipe_get_message(TestCapturePipe *self, gint ndx);
-TestCapturePipe *test_capture_pipe_new(GlobalConfig *cfg);
+LogMessage *log_pipe_mock_get_message(LogPipeMock *self, gint ndx);
+LogPipeMock *log_pipe_mock_new(GlobalConfig *cfg);
 
 #endif

--- a/modules/dbparser/dbparser.c
+++ b/modules/dbparser/dbparser.c
@@ -238,6 +238,8 @@ log_db_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
     }
   if (!self->drop_unmatched)
     matched = TRUE;
+  if (self->super.inject_mode == LDBP_IM_AGGREGATE_ONLY)
+    matched = FALSE;
   return matched;
 }
 

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -408,7 +408,7 @@ _process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, co
 
   if (_evaluate_where(self, pmsg, path_options))
     _perform_groupby(self, log_msg_make_writable(pmsg, path_options));
-  return TRUE;
+  return (self->super.inject_mode != LDBP_IM_AGGREGATE_ONLY);
 }
 
 static const gchar *

--- a/modules/dbparser/groupingby.c
+++ b/modules/dbparser/groupingby.c
@@ -347,7 +347,7 @@ _lookup_or_create_context(GroupingBy *self, LogMessage *msg)
   return context;
 }
 
-static gboolean
+static void
 _perform_groupby(GroupingBy *self, LogMessage *msg)
 {
   GPMessageEmitter msg_emitter = {0};
@@ -380,20 +380,15 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
         }
 
       log_msg_write_protect(msg);
-
-      return TRUE;
     }
   else
     {
       correlation_state_tx_update_context(self->correlation, context, self->timeout);
+      log_msg_write_protect(msg);
+
+      correlation_state_tx_end(self->correlation);
+      _flush_emitted_messages(self, &msg_emitter);
     }
-
-  log_msg_write_protect(msg);
-
-  correlation_state_tx_end(self->correlation);
-  _flush_emitted_messages(self, &msg_emitter);
-
-  return TRUE;
 }
 
 static gboolean
@@ -412,7 +407,7 @@ _process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, co
   GroupingBy *self = (GroupingBy *) s;
 
   if (_evaluate_where(self, pmsg, path_options))
-    return _perform_groupby(self, log_msg_make_writable(pmsg, path_options));
+    _perform_groupby(self, log_msg_make_writable(pmsg, path_options));
   return TRUE;
 }
 

--- a/modules/dbparser/stateful-parser.c
+++ b/modules/dbparser/stateful-parser.c
@@ -34,7 +34,7 @@ stateful_parser_set_inject_mode(StatefulParser *self, LogDBParserInjectMode inje
 void
 stateful_parser_emit_synthetic(StatefulParser *self, LogMessage *msg)
 {
-  if (self->inject_mode == LDBP_IM_PASSTHROUGH)
+  if (self->inject_mode != LDBP_IM_INTERNAL)
     {
       LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
 
@@ -67,5 +67,7 @@ stateful_parser_lookup_inject_mode(const gchar *inject_mode)
     return LDBP_IM_INTERNAL;
   else if (strcasecmp(inject_mode, "pass-through") == 0 || strcasecmp(inject_mode, "pass_through") == 0)
     return LDBP_IM_PASSTHROUGH;
+  else if (strcasecmp(inject_mode, "aggregate-only") == 0 || strcasecmp(inject_mode, "aggregate_only") == 0)
+    return LDBP_IM_AGGREGATE_ONLY;
   return -1;
 }

--- a/modules/dbparser/stateful-parser.h
+++ b/modules/dbparser/stateful-parser.h
@@ -30,6 +30,7 @@ typedef enum
 {
   LDBP_IM_PASSTHROUGH = 0,
   LDBP_IM_INTERNAL = 1,
+  LDBP_IM_AGGREGATE_ONLY
 } LogDBParserInjectMode;
 
 typedef struct _StatefulParser

--- a/modules/dbparser/tests/test_grouping_by.c
+++ b/modules/dbparser/tests/test_grouping_by.c
@@ -25,6 +25,7 @@
 #include "libtest/cr_template.h"
 #include "libtest/msg_parse_lib.h"
 #include "libtest/config_parse_lib.h"
+#include "libtest/mock-logpipe.h"
 
 #include "groupingby.h"
 #include "filter/filter-expr-parser.h"
@@ -60,48 +61,6 @@ _process_msg(LogParser *parser, const gchar *prog)
   log_pipe_queue(&parser->super, msg, &path_options);
 }
 
-typedef struct _TestCapturePipe
-{
-  LogPipe super;
-  GPtrArray *captured_messages;
-} TestCapturePipe;
-
-static LogMessage *
-test_capture_pipe_get_message(TestCapturePipe *self, gint ndx)
-{
-  g_assert(ndx >= 0 && ndx < self->captured_messages->len);
-  return (LogMessage *) g_ptr_array_index(self->captured_messages, ndx);
-}
-
-static void
-test_capture_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
-{
-  TestCapturePipe *self = (TestCapturePipe *) s;
-
-  g_ptr_array_add(self->captured_messages, log_msg_ref(msg));
-  log_pipe_forward_msg(s, msg, path_options);
-}
-
-static void
-test_capture_pipe_free(LogPipe *s)
-{
-  TestCapturePipe *self = (TestCapturePipe *) s;
-
-  g_ptr_array_free(self->captured_messages, TRUE);
-  log_pipe_free_method(s);
-}
-
-TestCapturePipe *
-test_capture_pipe_new(GlobalConfig *cfg)
-{
-  TestCapturePipe *self = g_new0(TestCapturePipe, 1);
-
-  log_pipe_init_instance(&self->super, cfg);
-  self->captured_messages = g_ptr_array_new_full(0, (GDestroyNotify) log_msg_unref);
-  self->super.queue = test_capture_pipe_queue;
-  self->super.free_fn = test_capture_pipe_free;
-  return self;
-}
 
 Test(grouping_by, grouping_by_produces_aggregate_as_the_trigger_is_received)
 {

--- a/modules/dbparser/tests/test_grouping_by.c
+++ b/modules/dbparser/tests/test_grouping_by.c
@@ -33,29 +33,6 @@
 #include "cfg.h"
 #include "scratch-buffers.h"
 
-static LogTemplate *
-_get_template(const gchar *template)
-{
-  LogTemplate *self = log_template_new(configuration, NULL);
-
-  cr_assert(log_template_compile(self, template, NULL));
-
-  return self;
-}
-
-static FilterExprNode *
-_compile_filter_expr(gchar *expr)
-{
-  FilterExprNode *expr_node;
-
-  CfgLexer *lexer = cfg_lexer_new_buffer(configuration, expr, strlen(expr));
-  cr_assert(lexer != NULL);
-
-  cr_assert(cfg_run_parser(configuration, lexer, &filter_expr_parser, (gpointer *) &expr_node, NULL));
-
-  return expr_node;
-}
-
 static LogParser *
 _compile_grouping_by(gchar *expr)
 {
@@ -99,48 +76,22 @@ test_capture_pipe_new(GlobalConfig *cfg)
   return self;
 }
 
-Test(grouping_by, create_grouping_by)
-{
-  LogParser *parser = grouping_by_new(configuration);
-
-  grouping_by_set_synthetic_message(parser, synthetic_message_new());
-
-  grouping_by_set_timeout(parser, 1);
-
-  LogTemplate *template = _get_template("$TEMPLATE");
-  grouping_by_set_key_template(parser, template);
-  log_template_unref(template);
-
-  cr_assert(log_pipe_init(&parser->super));
-
-  cr_assert(log_pipe_deinit(&parser->super));
-
-  log_pipe_unref(&parser->super);
-}
-
 Test(grouping_by, grouping_by_aggregates_messages)
 {
   TestCapturePipe *capture = test_capture_pipe_new(configuration);
-  LogParser *parser = grouping_by_new(configuration);
+  LogParser *parser = _compile_grouping_by(
+      "grouping-by(key(\"$key\")"
+      "    aggregate("
+      "        value(\"aggr\" \"$(list-slice :-1 $(context-values $PROGRAM))\")"
+      "    )"
+      "    timeout(1)"
+      "    trigger(\"$(context-length)\" == \"3\")"
+      ");");
   LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
-
-  LogTemplate *template = _get_template("$key");
-  grouping_by_set_key_template(parser, template);
-  log_template_unref(template);
-
-  SyntheticMessage *sm = synthetic_message_new();
-  cr_assert(synthetic_message_add_value_template_string(sm, configuration, "aggr",
-                                                        "$(list-slice :-1 $(context-values $PROGRAM))", NULL) == TRUE);
-
-  grouping_by_set_synthetic_message(parser, sm);
-  grouping_by_set_timeout(parser, 1);
 
   log_pipe_append(&parser->super, &capture->super);
   cr_assert(log_pipe_init(&capture->super) == TRUE);
   cr_assert(log_pipe_init(&parser->super) == TRUE);
-
-  FilterExprNode *trigger = _compile_filter_expr("\"$(context-length)\" == \"3\"");
-  grouping_by_set_trigger_condition(parser, trigger);
 
   LogMessage *msg = _create_input_msg("first");
   gboolean success = log_parser_process_message(parser, &msg, &path_options);
@@ -182,26 +133,18 @@ Test(grouping_by, cfg_persist_name_not_equal)
 
 Test(grouping_by, cfg_persist_name_equal)
 {
-  LogParser *parser = grouping_by_new(configuration);
-
-  LogTemplate *template = _get_template("$TEMPLATE1");
-  grouping_by_set_key_template(parser, template);
-  log_template_unref(template);
-
+  LogParser *parser = _compile_grouping_by("grouping-by(key(\"$TEMPLATE1\"));");
   gchar *persist_name1 = g_strdup(log_pipe_get_persist_name(&parser->super));
+  log_pipe_unref(&parser->super);
 
-  template = _get_template("$TEMPLATE1");
-  grouping_by_set_key_template(parser, template);
-  log_template_unref(template);
-
+  parser = _compile_grouping_by("grouping-by(key(\"$TEMPLATE1\"));");
   gchar *persist_name2 = g_strdup(log_pipe_get_persist_name(&parser->super));
+  log_pipe_unref(&parser->super);
 
   cr_assert_str_eq(persist_name1, persist_name2);
 
   g_free(persist_name1);
   g_free(persist_name2);
-
-  log_pipe_unref(&parser->super);
 }
 
 static void

--- a/modules/dbparser/tests/test_grouping_by.c
+++ b/modules/dbparser/tests/test_grouping_by.c
@@ -64,7 +64,7 @@ _process_msg(LogParser *parser, const gchar *prog)
 
 Test(grouping_by, grouping_by_produces_aggregate_as_the_trigger_is_received)
 {
-  TestCapturePipe *capture = test_capture_pipe_new(configuration);
+  LogPipeMock *capture = log_pipe_mock_new(configuration);
   LogParser *parser = _compile_grouping_by(
                         "grouping-by(key(\"$key\")"
                         "    aggregate("
@@ -84,11 +84,11 @@ Test(grouping_by, grouping_by_produces_aggregate_as_the_trigger_is_received)
   _process_msg(parser, "third");
 
   cr_assert(capture->captured_messages->len == 4);
-  assert_log_message_value_by_name(test_capture_pipe_get_message(capture, 0), "PROGRAM", "first");
-  assert_log_message_value_by_name(test_capture_pipe_get_message(capture, 1), "PROGRAM", "second");
+  assert_log_message_value_by_name(log_pipe_mock_get_message(capture, 0), "PROGRAM", "first");
+  assert_log_message_value_by_name(log_pipe_mock_get_message(capture, 1), "PROGRAM", "second");
   /* the aggregate comes before the triggering message */
-  assert_log_message_value_by_name(test_capture_pipe_get_message(capture, 2), "aggr", "first,second,third");
-  assert_log_message_value_by_name(test_capture_pipe_get_message(capture, 3), "PROGRAM", "third");
+  assert_log_message_value_by_name(log_pipe_mock_get_message(capture, 2), "aggr", "first,second,third");
+  assert_log_message_value_by_name(log_pipe_mock_get_message(capture, 3), "PROGRAM", "third");
 
   log_pipe_unref(&parser->super);
   log_pipe_unref(&capture->super);
@@ -96,7 +96,7 @@ Test(grouping_by, grouping_by_produces_aggregate_as_the_trigger_is_received)
 
 Test(grouping_by, grouping_by_drops_original_messages_if_inject_mode_is_aggregate_only)
 {
-  TestCapturePipe *capture = test_capture_pipe_new(configuration);
+  LogPipeMock *capture = log_pipe_mock_new(configuration);
   LogParser *parser = _compile_grouping_by(
                         "grouping-by(key(\"$key\")"
                         "    aggregate("
@@ -116,7 +116,7 @@ Test(grouping_by, grouping_by_drops_original_messages_if_inject_mode_is_aggregat
   _process_msg(parser, "third");
 
   cr_assert(capture->captured_messages->len == 1);
-  assert_log_message_value_by_name(test_capture_pipe_get_message(capture, 0), "aggr", "first,second,third");
+  assert_log_message_value_by_name(log_pipe_mock_get_message(capture, 0), "aggr", "first,second,third");
 
   log_pipe_unref(&parser->super);
   log_pipe_unref(&capture->super);

--- a/scl/kubernetes/kubernetes.conf
+++ b/scl/kubernetes/kubernetes.conf
@@ -105,17 +105,16 @@ block parser kubernetes-file-parser(prefix('.k8s.') cluster-name('k8s')) {
 	  value("`prefix`stream" "${2}@1")
           tags(".tmp.k8s")
           inherit-mode(none))
+        inject-mode(aggregate-only)
         timeout(10)
     );
 
-    channel { filter { tags('.tmp.k8s'); }; };
     kubernetes-metadata-parser(prefix(`prefix`));
     channel {
         rewrite {
 	    set("`cluster-name`/${`prefix`namespace_name}/${`prefix`pod_name}" value("HOST"));
             set("${`prefix`container_name}" value("PROGRAM"));
             set("$(if ('${`prefix`pod_uuid}' ne '') ${`prefix`pod_uuid} ${`prefix`container_id})/${`prefix`stream}" value("PID"));
-            clear-tag('.tmp.k8s');
         };
     };
 };

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -72,6 +72,7 @@ lib/rewrite/rewrite-set-pri\.h
 lib/rewrite/rewrite-set-pri\.c
 lib/timeutils/timeutils\.h
 lib/logmsg/tests/dump_logmsg\.c
+libtest/mock-logpipe\.[ch]
  LGPLv2.1+_SSL
 autogen\.sh$
 sub-configure\.sh$


### PR DESCRIPTION
This is a followup to #3990 to add ```inject-mode(aggregate-only) ``` to grouping-by(). It also adds a rework of test_grouping_by and improvements to libtest along the way.

Since this contains the patch to #3990 to actually use the new feature, there's an ordering dependency at the moment, #3990 should go in first and then this.

Also, this depends on my previous work on grouping-by state handling #3957 so that needs to go in too. The dependency is more in the unit tests as both PRs touched on that.
