### PR TITLE
dbld: remove setuptools version freeze

### DIFF
--- a/dbld/builddeps
+++ b/dbld/builddeps
@@ -190,11 +190,6 @@ function install_pip_packages {
                 $python_executable -m pip install --no-cache-dir --upgrade setuptools
                 filter_packages_by_platform $DBLD_DIR/pip_packages.manifest | xargs $python_executable -m pip install --no-cache-dir --ignore-installed -U
                 ;;
-            kira|devshell)
-                $python_executable -m pip install --no-cache-dir --upgrade pip
-                $python_executable -m pip install --no-cache-dir --upgrade "setuptools < 58.0.0" # Remove the version limit when funcparserlib v1.0.0 is released
-                filter_packages_by_platform $DBLD_DIR/pip_packages.manifest | xargs $python_executable -m pip install --no-cache-dir --ignore-installed -U
-                ;;
             fedora-*)
                 # don't update pip/setuptools on Fedora as RPM installed
                 # instances cause an error, at least in Fedora-35


### PR DESCRIPTION
funcparserlib v1.0.0 is released: https://github.com/vlasovskikh/funcparserlib/issues/65#issuecomment-1114668161
For more info, see: 661e546e820dfccf02813c5bfa5445c79c00efa0

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>