### PR TITLE
Add new TLS options sigalgs() and client-sigalgs() 

### DIFF
--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -134,6 +134,8 @@ void tls_context_set_crl_dir(TLSContext *self, const gchar *crl_dir);
 void tls_context_set_ca_file(TLSContext *self, const gchar *ca_file);
 void tls_context_set_cipher_suite(TLSContext *self, const gchar *cipher_suite);
 gboolean tls_context_set_tls13_cipher_suite(TLSContext *self, const gchar *tls13_cipher_suite, GError **error);
+void tls_context_set_sigalgs(TLSContext *self, const gchar *sigalgs);
+void tls_context_set_client_sigalgs(TLSContext *self, const gchar *sigalgs);
 void tls_context_set_ecdh_curve_list(TLSContext *self, const gchar *ecdh_curve_list);
 void tls_context_set_dhparam_file(TLSContext *self, const gchar *dhparam_file);
 void tls_context_set_sni(TLSContext *self, const gchar *sni);

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -189,6 +189,8 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 %token KW_CIPHER_SUITE
 %token KW_TLS12_AND_OLDER
 %token KW_TLS13
+%token KW_SIGALGS
+%token KW_CLIENT_SIGALGS
 %token KW_ECDH_CURVE_LIST
 %token KW_SSL_OPTIONS
 %token KW_SNI
@@ -855,6 +857,16 @@ tls_option
           {
             /* compat for specifying TLS 1.2-or-older ciphers */
             tls_context_set_cipher_suite(last_tls_context, $3);
+            free($3);
+          }
+        | KW_SIGALGS '(' string ')'
+          {
+            tls_context_set_sigalgs(last_tls_context, $3);
+            free($3);
+          }
+        | KW_CLIENT_SIGALGS '(' string ')'
+          {
+            tls_context_set_client_sigalgs(last_tls_context, $3);
             free($3);
           }
         | KW_ECDH_CURVE_LIST '(' string ')'

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -58,6 +58,8 @@ static CfgLexerKeyword afsocket_keywords[] =
   { "cipher_suite",       KW_CIPHER_SUITE },
   { "tls12_and_older",    KW_TLS12_AND_OLDER },
   { "tls13",              KW_TLS13 },
+  { "sigalgs",            KW_SIGALGS },
+  { "client_sigalgs",     KW_CLIENT_SIGALGS },
   { "ecdh_curve_list",    KW_ECDH_CURVE_LIST },
   { "curve_list",         KW_ECDH_CURVE_LIST, KWS_OBSOLETE, "ecdh_curve_list"},
   { "ssl_options",        KW_SSL_OPTIONS },

--- a/news/feature-4000.md
+++ b/news/feature-4000.md
@@ -1,0 +1,18 @@
+`network()`, `syslog()` sources and destinations: added new TLS options `sigalgs()` and `client-sigalgs()`
+
+They can be used to restrict which signature/hash pairs can be used in digital signatures.
+It sets the "signature_algorithms" extension specified in RFC5246 and RFC8446.
+
+Example configuration:
+
+```
+destination {
+    network("test.host" port(4444) transport(tls)
+        tls(
+            pkcs12-file("/home/anno/Work/syslog-ng/tls/test.host.p12")
+            peer-verify(yes)
+            sigalgs("RSA-PSS+SHA256:ed25519")
+        )
+    );
+};
+```


### PR DESCRIPTION
This PR adds 2 new TLS options, which make it possible to restrict which signature/hash pairs can be used in digital signatures.

This is a TLS extension specified by RFC5246:
https://datatracker.ietf.org/doc/html/rfc5246#section-7.4.1.4.1

sigalgs:
> This sets the supported signature algorithms for TLSv1.2 and TLSv1.3.
> For clients this value is used directly for the supported signature
> algorithms extension. For servers it is used to determine which
> signature algorithms to support.

client-sigalgs:
> This sets the supported signature algorithms associated with client
> authentication for TLSv1.2 and TLSv1.3. For servers the value is used
> in the signature_algorithms field of a CertificateRequest message.
> For clients it is used to determine which signature algorithm to use
> with the client certificate.

Example config:

```
source {
	network(port(4444) transport(tls)
		tls(
			pkcs12-file("/home/anno/Work/syslog-ng/tls/localhost.p12")
			peer-verify(yes)
			client-sigalgs("RSA-PSS+SHA256:ed25519")
		)
	);
};

destination {
	network("localhost" port(4444) transport(tls)
		tls(
			pkcs12-file("/home/anno/Work/syslog-ng/tls/localhost.p12")
			peer-verify(yes)
			sigalgs("RSA-PSS+SHA256:ed25519")
		)
	);
};
```

Partially resolves #3993