### PR TITLE
package-indexer: security enhancements

### DIFF
--- a/packaging/package-indexer/config/config.py
+++ b/packaging/package-indexer/config/config.py
@@ -88,7 +88,10 @@ class Config:
     """
 
     def __init__(self, config_content: str):
-        self.__cfg: dict = yaml.safe_load(config_content)
+        try:
+            self.__cfg: dict = yaml.safe_load(config_content)
+        except yaml.YAMLError:
+            raise Exception("Failed to load config content.")
 
     @classmethod
     def from_file(cls: Type, file_path: Path) -> Config:

--- a/packaging/package-indexer/config/config.py
+++ b/packaging/package-indexer/config/config.py
@@ -97,6 +97,10 @@ class Config:
 
         return cls(config_content)
 
+    @classmethod
+    def from_string(cls: Type, config_content: str) -> Config:
+        return cls(config_content)
+
     def create_incoming_remote_storage_synchronizer(
         self,
         suite: str,

--- a/packaging/package-indexer/config/config.py
+++ b/packaging/package-indexer/config/config.py
@@ -20,6 +20,7 @@
 #
 #############################################################################
 
+from __future__ import annotations
 from pathlib import Path
 
 import yaml
@@ -86,9 +87,15 @@ class Config:
     ```
     """
 
-    def __init__(self, file_path: Path) -> None:
+    def __init__(self, config_content: str):
+        self.__cfg: dict = yaml.safe_load(config_content)
+
+    @classmethod
+    def from_file(cls: Type, file_path: Path) -> Config:
         with Path(file_path).open("r") as f:
-            self.__cfg: dict = yaml.safe_load(f)
+            config_content = f.read()
+
+        return cls(config_content)
 
     def create_incoming_remote_storage_synchronizer(
         self,

--- a/packaging/package-indexer/index-packages.py
+++ b/packaging/package-indexer/index-packages.py
@@ -141,7 +141,7 @@ def main() -> None:
     args = parse_args()
     init_logging(args)
 
-    cfg = Config(Path(args["config"]))
+    cfg = Config.from_file(Path(args["config"]))
 
     indexers = construct_indexers(cfg, args)
     for indexer in indexers:

--- a/packaging/package-indexer/index-packages.py
+++ b/packaging/package-indexer/index-packages.py
@@ -24,6 +24,7 @@
 import logging
 from argparse import ArgumentParser, _ArgumentGroup, _SubParsersAction
 from pathlib import Path
+from sys import stdin
 from typing import List
 
 from indexer import Indexer, NightlyDebIndexer, ReleaseDebIndexer
@@ -45,6 +46,11 @@ def add_common_required_arguments(required_argument_group: _ArgumentGroup) -> No
 
 
 def add_common_optional_arguments(parser: ArgumentParser) -> None:
+    parser.add_argument(
+        "--gpg-key-passphrase-from-stdin",
+        action="store_true",
+        help="If this option is set, the passphrase of the GPG-key file will be read from STDIN.",
+    )
     parser.add_argument(
         "--log-file",
         type=str,
@@ -125,6 +131,8 @@ def construct_indexers(cfg: Config, args: dict) -> List[Indexer]:
     indexed_remote_storage_synchronizer = cfg.create_indexed_remote_storage_synchronizer(suite)
     cdn = cfg.create_cdn(suite)
 
+    gpg_key_passphrase = stdin.read() if args["gpg_key_passphrase_from_stdin"] else None
+
     indexers: List[Indexer] = []
 
     if suite == "nightly":
@@ -143,6 +151,7 @@ def construct_indexers(cfg: Config, args: dict) -> List[Indexer]:
                 cdn=cdn,
                 run_id=args["run_id"],
                 gpg_key_path=Path(cfg.get_gpg_key_path()),
+                gpg_key_passphrase=gpg_key_passphrase,
             )
         )
     else:

--- a/packaging/package-indexer/indexer/deb_indexer.py
+++ b/packaging/package-indexer/indexer/deb_indexer.py
@@ -178,7 +178,7 @@ class ReleaseDebIndexer(DebIndexer):
         utils.execute_command(command, env=env)
 
     def _sign_pkgs(self, indexed_dir: Path) -> None:
-        gnupghome = TemporaryDirectory()
+        gnupghome = TemporaryDirectory(dir=CURRENT_DIR)
         release_file_path = Path(indexed_dir, "Release")
 
         self.__add_gpg_key_to_chain(gnupghome.name)

--- a/packaging/package-indexer/indexer/deb_indexer.py
+++ b/packaging/package-indexer/indexer/deb_indexer.py
@@ -124,6 +124,16 @@ class ReleaseDebIndexer(DebIndexer):
             apt_conf_file_path=Path(CURRENT_DIR, "apt_conf", "stable.conf"),
         )
 
+    @staticmethod
+    def __add_gpg_security_params(command: list) -> list:
+        assert command[0] == "gpg"
+
+        return [
+            "gpg",
+            "--no-tty",
+            "--no-options",
+        ] + command[1:]
+
     def __add_gpg_passphrase_params_if_needed(self, command: list) -> list:
         if self.__gpg_key_passphrase is None:
             return command
@@ -141,6 +151,7 @@ class ReleaseDebIndexer(DebIndexer):
 
     def __add_gpg_key_to_chain(self, gnupghome: str) -> None:
         command = ["gpg", "--import", str(self.__gpg_key_path)]
+        command = self.__add_gpg_security_params(command)
         command = self.__add_gpg_passphrase_params_if_needed(command)
         env = {"GNUPGHOME": gnupghome}
 
@@ -158,6 +169,7 @@ class ReleaseDebIndexer(DebIndexer):
             "--sign",
             str(release_file_path),
         ]
+        command = self.__add_gpg_security_params(command)
         command = self.__add_gpg_passphrase_params_if_needed(command)
         env = {"GNUPGHOME": gnupghome}
 
@@ -183,6 +195,7 @@ class ReleaseDebIndexer(DebIndexer):
             "--clearsign",
             str(release_file_path),
         ]
+        command = self.__add_gpg_security_params(command)
         command = self.__add_gpg_passphrase_params_if_needed(command)
         env = {"GNUPGHOME": gnupghome}
 

--- a/packaging/package-indexer/indexer/deb_indexer.py
+++ b/packaging/package-indexer/indexer/deb_indexer.py
@@ -181,9 +181,13 @@ class ReleaseDebIndexer(DebIndexer):
         gnupghome = TemporaryDirectory(dir=CURRENT_DIR)
         release_file_path = Path(indexed_dir, "Release")
 
-        self.__add_gpg_key_to_chain(gnupghome.name)
-        self.__create_release_gpg_file(release_file_path, gnupghome.name)
-        self.__create_inrelease_file(release_file_path, gnupghome.name)
+        try:
+            self.__add_gpg_key_to_chain(gnupghome.name)
+            self.__create_release_gpg_file(release_file_path, gnupghome.name)
+            self.__create_inrelease_file(release_file_path, gnupghome.name)
+        finally:
+            self._log_info("Cleaning up `GNUPGHOME` directory.", gnupghome=gnupghome.name)
+            gnupghome.cleanup()
 
 
 class NightlyDebIndexer(DebIndexer):

--- a/packaging/package-indexer/indexer/deb_indexer.py
+++ b/packaging/package-indexer/indexer/deb_indexer.py
@@ -23,7 +23,7 @@
 import re
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import List
+from typing import List, Optional
 
 from cdn import CDN
 from remote_storage_synchronizer import RemoteStorageSynchronizer
@@ -111,8 +111,10 @@ class ReleaseDebIndexer(DebIndexer):
         run_id: str,
         cdn: CDN,
         gpg_key_path: Path,
+        gpg_key_passphrase: Optional[str],
     ) -> None:
         self.__gpg_key_path = gpg_key_path.expanduser()
+        self.__gpg_key_passphrase = gpg_key_passphrase
         super().__init__(
             incoming_remote_storage_synchronizer=incoming_remote_storage_synchronizer,
             indexed_remote_storage_synchronizer=indexed_remote_storage_synchronizer,

--- a/packaging/package-indexer/indexer/utils.py
+++ b/packaging/package-indexer/indexer/utils.py
@@ -22,7 +22,7 @@
 
 import logging
 from pathlib import Path
-from subprocess import call
+from subprocess import run
 from typing import Dict, List, TextIO, Optional
 
 logger = logging.getLogger("utils")
@@ -33,17 +33,19 @@ def execute_command(
     command: List[str],
     dir: Optional[Path] = None,
     env: Optional[Dict[str, str]] = None,
+    input: Optional[str] = None,
     stdout: Optional[TextIO] = None,
 ) -> None:
-    log_extras = {k: str(v) for k, v in filter(lambda kv: kv[1] is not None, locals().items())}
+    log_extras = {k: str(v) for k, v in filter(lambda kv: kv[1] is not None and kv[0] != "input", locals().items())}
     logger.info("Executing command.\t{}".format(log_extras))
 
-    rc = call(
+    rc = run(
         command,
+        input=bytes(input, "utf-8") if input is not None else None,
         stdout=stdout,
         cwd=dir,
         env=env,
-    )
+    ).returncode
     if rc != 0:
         raise ChildProcessError("`{}` failed. dir={} env={} rc={}.".format(" ".join(command), dir, env, rc))
 


### PR DESCRIPTION
We are planning to move the package indexing to GitHub Actions. With this PR I am adding some security enhancements to the indexing script.

Namely:
  - Loading the config content through a CLI with `--config-content`.
  - Hiding YAML loading errors, so we do not leak any part of the config in case of a load failure.
  - Cleaning up the temporary `GNUPGHOME` dir after it is no longer in use.
  - Moving the temporary `GNUPGHOME` dir to the script's current dir.
  - Supporting passphrase protected GPG keys, with the passhprase loaded from `STDIN`.

Note, that until we start indexing the packages in GitHub Actions, these changes do not get used anywhere.
I tested the changes locally with both passphrase protected and not protected GPG keys, if you need help to try the new code out, I am happy to help.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>