### PR TITLE
OpenSSL V3 (3.0) support

### DIFF
--- a/lib/compat/openssl_support.c
+++ b/lib/compat/openssl_support.c
@@ -162,7 +162,8 @@ openssl_init(void)
 #endif
 }
 
-void openssl_ctx_setup_ecdh(SSL_CTX *ctx)
+void
+openssl_ctx_setup_ecdh(SSL_CTX *ctx)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 
@@ -182,6 +183,78 @@ void openssl_ctx_setup_ecdh(SSL_CTX *ctx)
   EC_KEY_free(ecdh);
 
 #endif
+}
+
+gboolean
+openssl_ctx_setup_dh(SSL_CTX *ctx)
+{
+  DH *dh = DH_new();
+  if (!dh)
+    return 0;
+
+  /*
+   * "2048-bit MODP Group" from RFC3526, Section 3.
+   *
+   * The prime is: 2^2048 - 2^1984 - 1 + 2^64 * { [2^1918 pi] + 124476 }
+   *
+   * RFC3526 specifies a generator of 2.
+   */
+
+  BIGNUM *g = NULL;
+  BN_dec2bn(&g, "2");
+
+  if (!DH_set0_pqg(dh, BN_get_rfc3526_prime_2048(NULL), NULL, g))
+    {
+      BN_free(g);
+      DH_free(dh);
+      return 0;
+    }
+
+  long ctx_dh_success = SSL_CTX_set_tmp_dh(ctx, dh);
+
+  DH_free(dh);
+  return ctx_dh_success;
+}
+
+static long
+_is_dh_valid(DH *dh)
+{
+  if (!dh)
+    return 0;
+
+  int check_flags;
+  if (!DH_check(dh, &check_flags))
+    return 0;
+
+  long error_flag_is_set = check_flags &
+                           (DH_CHECK_P_NOT_PRIME
+                            | DH_UNABLE_TO_CHECK_GENERATOR
+                            | DH_CHECK_P_NOT_SAFE_PRIME
+                            | DH_NOT_SUITABLE_GENERATOR);
+
+  return !error_flag_is_set;
+}
+
+gboolean
+openssl_ctx_load_dh_from_file(SSL_CTX *ctx, const gchar *dhparam_file)
+{
+  BIO *bio = BIO_new_file(dhparam_file, "r");
+  if (!bio)
+    return 0;
+
+  DH *dh = PEM_read_bio_DHparams(bio, NULL, NULL, NULL);
+  BIO_free(bio);
+
+  if (!_is_dh_valid(dh))
+    {
+      DH_free(dh);
+      return 0;
+    }
+
+  long ctx_dh_success = SSL_CTX_set_tmp_dh(ctx, dh);
+
+  DH_free(dh);
+  return ctx_dh_success;
 }
 
 #if !SYSLOG_NG_HAVE_DECL_DH_SET0_PQG

--- a/lib/compat/openssl_support.h
+++ b/lib/compat/openssl_support.h
@@ -27,6 +27,7 @@
 #include "compat/compat.h"
 #include <openssl/ssl.h>
 #include <openssl/dh.h>
+#include <glib.h>
 
 #if !SYSLOG_NG_HAVE_DECL_SSL_CTX_GET0_PARAM
 X509_VERIFY_PARAM *SSL_CTX_get0_param(SSL_CTX *ctx);
@@ -65,6 +66,8 @@ BIGNUM *BN_get_rfc3526_prime_2048(BIGNUM *bn);
 void openssl_ctx_setup_session_tickets(SSL_CTX *ctx);
 
 void openssl_ctx_setup_ecdh(SSL_CTX *ctx);
+gboolean openssl_ctx_setup_dh(SSL_CTX *ctx);
+gboolean openssl_ctx_load_dh_from_file(SSL_CTX *ctx, const gchar *dhparam_file);
 
 void openssl_init(void);
 void openssl_crypto_init_threading(void);

--- a/lib/compat/openssl_support.h
+++ b/lib/compat/openssl_support.h
@@ -55,6 +55,10 @@ uint32_t X509_get_extension_flags(X509 *x);
 #define ASN1_STRING_get0_data ASN1_STRING_data
 #endif
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+#define SYSLOG_NG_HAVE_DECL_DIGEST_MD4 1
+#endif
+
 #if !SYSLOG_NG_HAVE_DECL_DH_SET0_PQG
 int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g);
 #endif

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -433,9 +433,10 @@ tls_context_format_tls_error_tag(TLSContext *self)
 {
   gint ssl_error = ERR_get_error();
 
-  return evt_tag_printf("tls_error", "%s:%s",
-                        ERR_lib_error_string(ssl_error),
-                        ERR_reason_error_string(ssl_error));
+  char buf[256];
+  ERR_error_string_n(ssl_error, buf, sizeof(buf));
+
+  return evt_tag_str("tls_error", buf);
 }
 
 EVTTAG *

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -433,9 +433,8 @@ tls_context_format_tls_error_tag(TLSContext *self)
 {
   gint ssl_error = ERR_get_error();
 
-  return evt_tag_printf("tls_error", "%s:%s:%s",
+  return evt_tag_printf("tls_error", "%s:%s",
                         ERR_lib_error_string(ssl_error),
-                        ERR_func_error_string(ssl_error),
                         ERR_reason_error_string(ssl_error));
 }
 

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -36,8 +36,6 @@
 #include <openssl/x509v3.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
-#include <openssl/dh.h>
-#include <openssl/bn.h>
 #include <openssl/pkcs12.h>
 
 struct _TLSContext
@@ -554,79 +552,6 @@ _set_optional_ecdh_curve_list(SSL_CTX *ctx, const gchar *ecdh_curve_list)
 }
 
 static gboolean
-_is_dh_valid(DH *dh)
-{
-  if (!dh)
-    return FALSE;
-
-  gint check_flags;
-  if (!DH_check(dh, &check_flags))
-    return FALSE;
-
-  gboolean error_flag_is_set = check_flags &
-                               (DH_CHECK_P_NOT_PRIME
-                                | DH_UNABLE_TO_CHECK_GENERATOR
-                                | DH_CHECK_P_NOT_SAFE_PRIME
-                                | DH_NOT_SUITABLE_GENERATOR);
-
-  return !error_flag_is_set;
-}
-
-static DH *
-_load_dh_from_file(TLSContext *self, const gchar *dhparam_file)
-{
-  if (!_is_file_accessible(self, dhparam_file))
-    return NULL;
-
-  BIO *bio = BIO_new_file(dhparam_file, "r");
-  if (!bio)
-    return NULL;
-
-  DH *dh = PEM_read_bio_DHparams(bio, NULL, NULL, NULL);
-  BIO_free(bio);
-
-  if (!_is_dh_valid(dh))
-    {
-      msg_error("Error setting up TLS session context, invalid DH parameters",
-                evt_tag_str("dhparam_file", dhparam_file));
-
-      DH_free(dh);
-      return NULL;
-    }
-
-  return dh;
-}
-
-static DH *
-_load_dh_fallback(TLSContext *self)
-{
-  DH *dh = DH_new();
-
-  if (!dh)
-    return NULL;
-
-  /*
-   * "2048-bit MODP Group" from RFC3526, Section 3.
-   *
-   * The prime is: 2^2048 - 2^1984 - 1 + 2^64 * { [2^1918 pi] + 124476 }
-   *
-   * RFC3526 specifies a generator of 2.
-   */
-
-  BIGNUM *g = NULL;
-  BN_dec2bn(&g, "2");
-
-  if (!DH_set0_pqg(dh, BN_get_rfc3526_prime_2048(NULL), NULL, g))
-    {
-      BN_free(g);
-      DH_free(dh);
-      return NULL;
-    }
-
-  return dh;
-}
-
-static gboolean
 tls_context_setup_ecdh(TLSContext *self)
 {
   if (!_set_optional_ecdh_curve_list(self->ssl_ctx, self->ecdh_curve_list))
@@ -640,15 +565,20 @@ tls_context_setup_ecdh(TLSContext *self)
 static gboolean
 tls_context_setup_dh(TLSContext *self)
 {
-  DH *dh = self->dhparam_file ? _load_dh_from_file(self, self->dhparam_file) : _load_dh_fallback(self);
+  if (!self->dhparam_file)
+    return openssl_ctx_setup_dh(self->ssl_ctx);
 
-  if (!dh)
+  if(!_is_file_accessible(self, self->dhparam_file))
     return FALSE;
 
-  gboolean ctx_dh_success = SSL_CTX_set_tmp_dh(self->ssl_ctx, dh);
+  if (!openssl_ctx_load_dh_from_file(self->ssl_ctx, self->dhparam_file))
+    {
+      msg_error("Error setting up TLS session context, invalid DH parameters",
+                evt_tag_str("dhparam_file", self->dhparam_file));
+      return FALSE;
+    }
 
-  DH_free(dh);
-  return ctx_dh_success;
+  return TRUE;
 }
 
 static gboolean

--- a/modules/cryptofuncs/tests/test_cryptofuncs.c
+++ b/modules/cryptofuncs/tests/test_cryptofuncs.c
@@ -23,6 +23,7 @@
 
 #include <criterion/criterion.h>
 #include "libtest/cr_template.h"
+#include "compat/openssl_support.h"
 
 #include "apphook.h"
 #include "cfg.h"
@@ -50,7 +51,9 @@ Test(cryptofuncs, test_hash)
   assert_template_format("$(sha1 bar)", "62cdb7020ff920e5aa642c3d4066950dd1f01f4d");
   assert_template_format("$(md5 foo)", "acbd18db4cc2f85cedef654fccc4a4d8");
   assert_template_format("$(hash foo)", "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae");
+#ifdef SYSLOG_NG_HAVE_DECL_DIGEST_MD4
   assert_template_format("$(md4 foo)", "0ac6700c491d70fb8650940b1ca1e4b2");
+#endif
   assert_template_format("$(sha256 foo)", "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae");
   assert_template_format("$(sha512 foo)",
                          "f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7");

--- a/modules/secure-logging/secure-logging.c
+++ b/modules/secure-logging/secure-logging.c
@@ -65,7 +65,6 @@ typedef struct _TFSlogState
   gboolean badKey;
   guchar key[KEY_LENGTH];
   guchar bigMAC[CMAC_LENGTH];
-
 } TFSlogState;
 
 /*
@@ -219,12 +218,14 @@ tf_slog_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArgs 
     {
       msg_error("[SLOG] ERROR: String of length 0 received");
       GString *errorString = g_string_new("[SLOG] ERROR: String of length 0 received");
-      sLogEntry(state->numberOfLogEntries, errorString, state->key, state->bigMAC, result, outputmacdata);
+      sLogEntry(state->numberOfLogEntries, errorString, state->key, state->bigMAC, result, outputmacdata,
+                G_N_ELEMENTS(outputmacdata));
       g_string_free(errorString, TRUE);
     }
   else
     {
-      sLogEntry(state->numberOfLogEntries, args->argv[0], state->key, state->bigMAC, result, outputmacdata);
+      sLogEntry(state->numberOfLogEntries, args->argv[0], state->key, state->bigMAC, result, outputmacdata,
+                G_N_ELEMENTS(outputmacdata));
     }
 
   memcpy(state->bigMAC, outputmacdata, CMAC_LENGTH);
@@ -288,9 +289,3 @@ const ModuleInfo module_info =
   .plugins = secure_logging_plugins,
   .plugins_len = G_N_ELEMENTS(secure_logging_plugins),
 };
-
-
-
-
-
-

--- a/modules/secure-logging/slog.c
+++ b/modules/secure-logging/slog.c
@@ -425,9 +425,9 @@ void cmac(unsigned char *key, const void *input, gsize length, unsigned char *ou
   CMAC_Init(ctx, key, KEY_LENGTH, EVP_aes_256_cbc(), NULL);
   CMAC_Update(ctx, input, length);
 
-  size_t outsize;
-  CMAC_Final(ctx, out, &outsize);
-  *outlen = outsize;
+  size_t out_len;
+  CMAC_Final(ctx, out, &out_len);
+  *outlen = out_len;
   CMAC_CTX_free(ctx);
 }
 

--- a/modules/secure-logging/slog.h
+++ b/modules/secure-logging/slog.h
@@ -114,12 +114,13 @@ int sLogDecrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *ta
  * 3. Parameter: Input length (input)
  * 4. Parameter: Pointer to output (output)
  * 5. Parameter: Length of output (output)
+ * 6. Parameter: Capacity of output buffer (input)
  *
  * If Parameter 5 == 0, there was an error.
  *
  * Note: Caller must take care of memory management.
  */
-void cmac(unsigned char *key, const void *input, gsize length, unsigned char *out, gsize *outlen);
+void cmac(unsigned char *key, const void *input, gsize length, unsigned char *out, gsize *outlen, gsize out_capacity);
 
 
 gchar *convertToBase64(unsigned char *input, gsize len);
@@ -148,9 +149,10 @@ void deriveKey(unsigned char *dst, guint64 index, guint64 currentKey);
  * 4. Parameter: The current MAC
  * 5. Parameter: The resulting encrypted log entry
  * 6. Parameter: The newly updated MAC
+ * 7. Parameter: The capacity of the newly updated MAC buffer
  */
 void sLogEntry(guint64 numberOfLogEntries, GString *text, unsigned char *key, unsigned char *inputBigMac,
-               GString *output, unsigned char *outputBigMac);
+               GString *output, unsigned char *outputBigMac, gsize outputBigMac_capacity);
 
 /*
  * Generate a master key
@@ -217,7 +219,7 @@ int initVerify(guint64 entriesInFile, unsigned char *key, guint64 *nextLogEntry,
 
 int iterateBuffer(guint64 entriesInBuffer, GString **input, guint64 *nextLogEntry, unsigned char *key,
                   unsigned char *keyZero, guint keyNumber, GString **output, guint64 *numberOfLogEntries, unsigned char *cmac_tag,
-                  GHashTable *tab);
+                  gsize cmac_tag_capacity, GHashTable *tab);
 
 int finalizeVerify(guint64 startingEntry, guint64 entriesInFile, unsigned char *bigMac, unsigned char *cmac_tag,
                    GHashTable *tab);

--- a/modules/secure-logging/slog.h
+++ b/modules/secure-logging/slog.h
@@ -119,10 +119,6 @@ int sLogDecrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *ta
  *
  * Note: Caller must take care of memory management.
  */
-int sLogDecrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *tag, unsigned char *key,
-                unsigned char *iv,
-                unsigned char *plaintext);
-
 void cmac(unsigned char *key, const void *input, gsize length, unsigned char *out, gsize *outlen);
 
 

--- a/modules/secure-logging/slogencrypt/slogencrypt.c
+++ b/modules/secure-logging/slogencrypt/slogencrypt.c
@@ -182,7 +182,9 @@ int main(int argc, char *argv[])
       // Remove trailing '\n' from string
       g_string_truncate(inputGString, (inputGString->len)-1);
 
-      sLogEntry(counter, inputGString, (unsigned char *)key, (unsigned char *)mac, result, (unsigned char *)outputmacdata);
+      gsize outputmacdata_capacity = G_N_ELEMENTS(outputmacdata);
+      sLogEntry(counter, inputGString, (unsigned char *)key, (unsigned char *)mac, result, (unsigned char *)outputmacdata,
+                outputmacdata_capacity);
 
       fprintf(outputFile, "%s\n", result->str);
 

--- a/modules/secure-logging/tests/test_secure_logging.c
+++ b/modules/secure-logging/tests/test_secure_logging.c
@@ -197,12 +197,13 @@ GString **verifyMaliciousMessages(guchar *hostkey, gchar *macFileName, GString *
   cr_assert(ret == 1, "Unable to read aggregated MAC from file %s", macFileName);
   int problemsFound = 0;
   unsigned char cmac_tag[CMAC_LENGTH];
+  gsize cmac_tag_capacity = G_N_ELEMENTS(cmac_tag);
   initVerify(totalNumberOfMessages, hostkey, &next, &start, templateOutput, &tab);
 
   for (int i = 0; i<totalNumberOfMessages; i++)
     {
       ret = iterateBuffer(1, &templateOutput[i], &next, hostkey, keyZero, 0, &outputBuffer[i], &numberOfLogEntries, cmac_tag,
-                          tab);
+                          cmac_tag_capacity, tab);
       if (ret == 0)
         {
           brokenEntries[problemsFound] = i;
@@ -237,11 +238,12 @@ void verifyMessages(guchar *hostkey, gchar *macFileName, GString **templateOutpu
   cr_assert(ret == 1, "Unable to read aggregated MAC from file %s", macFileName);
 
   unsigned char cmac_tag[CMAC_LENGTH];
+  gsize cmac_tag_capacity = G_N_ELEMENTS(cmac_tag);
   ret = initVerify(totalNumberOfMessages, hostkey, &next, &start, templateOutput, &tab);
   cr_assert(ret == 1, "initVerify failed");
 
   ret = iterateBuffer(totalNumberOfMessages, templateOutput, &next, hostkey, keyZero, 0, outputBuffer,
-                      &numberOfLogEntries, cmac_tag, tab);
+                      &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
   cr_assert(ret == 1, "iterateBuffer failed");
 
   ret = finalizeVerify(start, totalNumberOfMessages, (guchar *)mac, cmac_tag, tab);


### PR DESCRIPTION
This PR adds support for warning-free compilation with OpenSSL 3.0.
Kudos to @MrAnno

A few notes:
- MD4 hash template function will be deprecated  (see 67ae1c3 for details)
- Ubuntu 22.04 ships with OpenSSL 3.0 by default if you want to check the warning-free compilation without compiling OpenSSL for yourself
- Please do not merge it yet, I still want to run some (internal) tests

I was hesitant to move the modifications regarding `cmac` function to the compat layer, my reasoning:
-  It is in the `secure-log` module meaning that it is acceptable to directly interface with the OpenSSL API

If it should be in the compat layer, then please let me know and I will move it accordingly.