### PR TITLE
Rename type cast to datetime int

### DIFF
--- a/lib/logmsg/tests/test_type_hints.c
+++ b/lib/logmsg/tests/test_type_hints.c
@@ -288,8 +288,8 @@ ParameterizedTest(StringUInt64Pair *string_value_pair, type_hints, test_datetime
   guint64 value;
   GError *error = NULL;
 
-  cr_assert_eq(type_cast_to_datetime_int(string_value_pair->string, &value, &error), TRUE,
-               "Type cast of \"%s\" to guint64 failed", string_value_pair->string);
+  cr_assert_eq(type_cast_to_datetime_msec(string_value_pair->string, &value, &error), TRUE,
+               "Type cast of \"%s\" to msecs failed", string_value_pair->string);
   cr_assert_eq(value, string_value_pair->value);
   cr_assert_null(error);
 }
@@ -299,7 +299,7 @@ Test(type_hints, test_invalid_datetime_cast)
   GError *error = NULL;
   guint64 value;
 
-  cr_assert_eq(type_cast_to_datetime_int("invalid", &value, &error), FALSE,
+  cr_assert_eq(type_cast_to_datetime_msec("invalid", &value, &error), FALSE,
                "Type cast of invalid string to gint64 should be failed");
   cr_assert_not_null(error);
   cr_assert_eq(error->domain, TYPE_HINTING_ERROR);

--- a/lib/logmsg/tests/test_type_hints.c
+++ b/lib/logmsg/tests/test_type_hints.c
@@ -285,7 +285,7 @@ ParameterizedTestParameters(type_hints, test_datetime_cast)
 
 ParameterizedTest(StringUInt64Pair *string_value_pair, type_hints, test_datetime_cast)
 {
-  guint64 value;
+  gint64 value;
   GError *error = NULL;
 
   cr_assert_eq(type_cast_to_datetime_msec(string_value_pair->string, &value, &error), TRUE,
@@ -297,7 +297,7 @@ ParameterizedTest(StringUInt64Pair *string_value_pair, type_hints, test_datetime
 Test(type_hints, test_invalid_datetime_cast)
 {
   GError *error = NULL;
-  guint64 value;
+  gint64 value;
 
   cr_assert_eq(type_cast_to_datetime_msec("invalid", &value, &error), FALSE,
                "Type cast of invalid string to gint64 should be failed");

--- a/lib/logmsg/type-hinting.c
+++ b/lib/logmsg/type-hinting.c
@@ -140,7 +140,7 @@ type_cast_to_double(const gchar *value, gdouble *out, GError **error)
 }
 
 gboolean
-type_cast_to_datetime_msec(const gchar *value, guint64 *out, GError **error)
+type_cast_to_datetime_msec(const gchar *value, gint64 *out, GError **error)
 {
   gchar *endptr;
 

--- a/lib/logmsg/type-hinting.c
+++ b/lib/logmsg/type-hinting.c
@@ -140,7 +140,7 @@ type_cast_to_double(const gchar *value, gdouble *out, GError **error)
 }
 
 gboolean
-type_cast_to_datetime_int(const gchar *value, guint64 *out, GError **error)
+type_cast_to_datetime_msec(const gchar *value, guint64 *out, GError **error)
 {
   gchar *endptr;
 

--- a/lib/logmsg/type-hinting.h
+++ b/lib/logmsg/type-hinting.h
@@ -47,7 +47,7 @@ gboolean type_cast_to_boolean(const gchar *value, gboolean *out, GError **error)
 gboolean type_cast_to_int32(const gchar *value, gint32 *out, GError **error);
 gboolean type_cast_to_int64(const gchar *value, gint64 *out, GError **error);
 gboolean type_cast_to_double(const gchar *value, gdouble *out, GError **error);
-gboolean type_cast_to_datetime_msec(const gchar *value, guint64 *out, GError **error);
+gboolean type_cast_to_datetime_msec(const gchar *value, gint64 *out, GError **error);
 gboolean type_cast_to_datetime_str(const gchar *value, const char *format,
                                    gchar **out, GError **error);
 

--- a/lib/logmsg/type-hinting.h
+++ b/lib/logmsg/type-hinting.h
@@ -47,7 +47,7 @@ gboolean type_cast_to_boolean(const gchar *value, gboolean *out, GError **error)
 gboolean type_cast_to_int32(const gchar *value, gint32 *out, GError **error);
 gboolean type_cast_to_int64(const gchar *value, gint64 *out, GError **error);
 gboolean type_cast_to_double(const gchar *value, gdouble *out, GError **error);
-gboolean type_cast_to_datetime_int(const gchar *value, guint64 *out, GError **error);
+gboolean type_cast_to_datetime_msec(const gchar *value, guint64 *out, GError **error);
 gboolean type_cast_to_datetime_str(const gchar *value, const char *format,
                                    gchar **out, GError **error);
 

--- a/modules/afmongodb/afmongodb-worker.c
+++ b/modules/afmongodb/afmongodb-worker.c
@@ -289,10 +289,10 @@ _vp_process_value(const gchar *name, const gchar *prefix, LogMessageValueType ty
     }
     case LM_VT_DATETIME:
     {
-      guint64 i;
+      guint64 msec;
 
-      if (type_cast_to_datetime_int(value, &i, NULL))
-        bson_append_date_time(o, name, -1, (gint64)i);
+      if (type_cast_to_datetime_msec(value, &msec, NULL))
+        bson_append_date_time(o, name, -1, (gint64) msec);
       else
         {
           gboolean r = type_cast_drop_helper(owner->template_options.on_error, value, "datetime");

--- a/modules/afmongodb/afmongodb-worker.c
+++ b/modules/afmongodb/afmongodb-worker.c
@@ -289,10 +289,10 @@ _vp_process_value(const gchar *name, const gchar *prefix, LogMessageValueType ty
     }
     case LM_VT_DATETIME:
     {
-      guint64 msec;
+      gint64 msec;
 
       if (type_cast_to_datetime_msec(value, &msec, NULL))
-        bson_append_date_time(o, name, -1, (gint64) msec);
+        bson_append_date_time(o, name, -1, msec);
       else
         {
           gboolean r = type_cast_drop_helper(owner->template_options.on_error, value, "datetime");


### PR DESCRIPTION
This is a minor refactor to change a function name that was difficult to understand for me while working on typing. This patch is independent of everything so should be relatively straightforward to merge.
