### PR TITLE
basicfuncs: fix comparisons in test_basicfuncs testcases

### DIFF
--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -650,8 +650,8 @@ ParameterizedTestParameters(basicfuncs, test_filter)
     { "Something $(filter ('$_' eq '0') '')", "Something " },
     { "$(filter ('1' eq '0') '')", "" },
     { "$(filter message('árvíztűrőtükörfúrógép') 'doesnotchange')", "doesnotchange" },
-    { "$(filter (message('árvíz') and ('$APP.VALUE' == 'value')) 'doesnotchange')", "doesnotchange" },
-    { "$(filter (message('donotmatch') or ('$APP.VALUE' == 'value')) 'doesnotchange')", "doesnotchange" },
+    { "$(filter (message('árvíz') and ('${APP.VALUE}' eq 'value')) 'doesnotchange')", "doesnotchange" },
+    { "$(filter (message('donotmatch') or ('${APP.VALUE}' eq 'value')) 'doesnotchange')", "doesnotchange" },
     { "$(filter ('$YEAR' ge '1900') 'doesnotchange')", "doesnotchange" },
     { "$(filter ('$YEAR' le '1900') 'doesnotchange')", "" },
   };


### PR DESCRIPTION
There were two issues with these:
  * the $APP.VALUE wasn't using braces, so it expanded to the value
    of ${APP} and ".value" concatenated
  * it used numeric comparisons, meaning it compared two
    non-numbers numerically, which is always true (0 == 0)

Signed-off-by: Balazs Scheidler <bazsi77@gmail.com>