### PR TITLE
Implement === and !== operators (4.0)

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -804,7 +804,7 @@ template_content_inner
           CHECK_ERROR_GERROR(log_template_compile(last_template, $1, &error), @1, error, "Error compiling template");
           free($1);
         }
-        | LL_IDENTIFIER '(' string ')'
+        | LL_IDENTIFIER '(' string_or_number ')'
         {
           GError *error = NULL;
 

--- a/lib/filter/filter-cmp.h
+++ b/lib/filter/filter-cmp.h
@@ -28,15 +28,16 @@
 #include "filter-expr.h"
 #include "template/templates.h"
 
-#define FCMP_EQ           0x0001
-#define FCMP_LT           0x0002
-#define FCMP_GT           0x0004
-#define FCMP_TYPE_AWARE   0x0010
-#define FCMP_STRING_BASED 0x0020
-#define FCMP_NUM_BASED    0x0040
+#define FCMP_EQ                   0x0001
+#define FCMP_LT                   0x0002
+#define FCMP_GT                   0x0004
+#define FCMP_TYPE_AWARE           0x0010
+#define FCMP_STRING_BASED         0x0020
+#define FCMP_NUM_BASED            0x0040
+#define FCMP_TYPE_AND_VALUE_BASED 0x0080
 
 #define FCMP_OP_MASK      0x0007
-#define FCMP_MODE_MASK    0x0070
+#define FCMP_MODE_MASK    0x00F0
 
 FilterExprNode *fop_cmp_new(LogTemplate *left, LogTemplate *right,
                             const gchar *type, gint compare_mode,

--- a/lib/filter/filter-expr-grammar.ym
+++ b/lib/filter/filter-expr-grammar.ym
@@ -118,6 +118,7 @@ _translate_number_literals(CfgLexer *lexer, gint compare_mode, LogTemplate *expr
 %left   KW_NOT
 %left   KW_STR_LT KW_STR_LE KW_STR_EQ KW_STR_NE KW_STR_GE KW_STR_GT
 %left   KW_TA_LT KW_TA_LE KW_TA_EQ KW_TA_NE KW_TA_GE KW_TA_GT
+%left   KW_TAV_EQ KW_TAV_NE
 
 %type	<node> filter_expr
 %type	<node> filter_simple_expr
@@ -251,6 +252,8 @@ operator
 	| KW_STR_NE         { $$ = FCMP_STRING_BASED | FCMP_LT | FCMP_GT; }
 	| KW_STR_GE         { $$ = FCMP_STRING_BASED | FCMP_EQ | FCMP_GT; }
 	| KW_STR_GT         { $$ = FCMP_STRING_BASED | FCMP_GT; }
+	| KW_TAV_EQ	    { $$ = FCMP_TYPE_AND_VALUE_BASED | FCMP_EQ; }
+	| KW_TAV_NE         { $$ = FCMP_TYPE_AND_VALUE_BASED | FCMP_LT | FCMP_GT; }
 	;
 
 filter_re

--- a/lib/filter/filter-expr-parser.c
+++ b/lib/filter/filter-expr-parser.c
@@ -49,6 +49,10 @@ static CfgLexerKeyword filter_expr_keywords[] =
   { ">=",                 KW_TA_GE },
   { ">",                  KW_TA_GT },
 
+  /* equal type and value */
+  { "===",                KW_TAV_EQ },
+  { "!==",                KW_TAV_NE },
+
   /* filter expressions */
   { "severity",           KW_SEVERITY },
   { "level",              KW_SEVERITY },

--- a/lib/filter/tests/test_filters_fop_cmp.c
+++ b/lib/filter/tests/test_filters_fop_cmp.c
@@ -407,6 +407,27 @@ Test(filter, test_type_aware_comparison_nan_is_always_different_from_anything)
   cr_assert_not(evaluate("'$nanvalue' > '$nanvalue'"));
 }
 
+Test(filter, test_type_and_value_comparison_checks_whether_type_and_value_match_completely)
+{
+  cfg_set_version_without_validation(configuration, VERSION_VALUE_4_0);
+  cr_assert(evaluate("$strvalue === $strvalue"));
+  cr_assert(evaluate("$strvalue === string"));
+  cr_assert(evaluate("string(64) === string(64)"));
+  cr_assert_not(evaluate("string(64) !== string(64)"));
+  cr_assert_not(evaluate("string(64) === int64(64)"));
+  cr_assert(evaluate("string(64) !== int64(64)"));
+  cr_assert(evaluate("int32(64) !== int64(64)"));
+  cr_assert_not(evaluate("int32(64) === int64(64)"));
+
+  /* types match, values don't */
+  cr_assert_not(evaluate("foo === bar"));
+  cr_assert_not(evaluate("int64(123) === int64(256)"));
+  cr_assert_not(evaluate("123 === 456"));
+
+  /* string conversion */
+  cr_assert(evaluate("double(  1e1  ) === double(10)"));
+}
+
 static void
 setup(void)
 {


### PR DESCRIPTION
This branch implements === and !== operators to verify type AND value at the same time, similarly to the same-named JavaScript
operators.

Question: is it a good idea to have both int32 and int64 types? These operators would differentiate between int64(32) and int32(32), which is probably not what we want.
