### PR TITLE
Correct logrotate not reloading syslog-ng

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update -qq && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 ADD syslog-ng.conf /etc/syslog-ng/syslog-ng.conf
+ADD logrotate_syslog-ng /etc/logrotate.d/syslog-ng
 
 EXPOSE 514/udp
 EXPOSE 601/tcp

--- a/docker/logrotate_syslog-ng
+++ b/docker/logrotate_syslog-ng
@@ -1,0 +1,38 @@
+/var/log/syslog
+{
+        rotate 7
+        daily
+        missingok
+        notifempty
+        delaycompress
+        compress
+        postrotate
+                syslog-ng-ctl reload
+        endscript
+}
+
+/var/log/mail.info
+/var/log/mail.warn
+/var/log/mail.err
+/var/log/mail.log
+/var/log/daemon.log
+/var/log/kern.log
+/var/log/auth.log
+/var/log/user.log
+/var/log/lpr.log
+/var/log/cron.log
+/var/log/debug
+/var/log/messages
+/var/log/error
+{
+        rotate 4
+        weekly
+        missingok
+        notifempty
+        compress
+        delaycompress
+        sharedscripts
+        postrotate
+                syslog-ng-ctl reload
+        endscript
+}


### PR DESCRIPTION
The existing logritate config uses a postrotate command of:
  invoke-rc.d syslog-ng reload > /dev/null

This fails for several reasons.

A working equivalent is:
  syslog-ng-ctl reload

This commit simply replaces the existing /etc/logrotate.d/syslog-ng file
with an exact copy that has the failing command swapped out for the
working one.

The consequence of the failing command is that if cron is started,
logrotate will be called and will rotate the /var/logs/messages log
written by syslog-ng but syslog-ng will continue writing to the old log
because it fails to be reloaded.