### PR TITLE
Correct logrotate not reloading syslog-ng

### DIFF
--- a/packaging/debian/syslog-ng-core.syslog-ng.logrotate
+++ b/packaging/debian/syslog-ng-core.syslog-ng.logrotate
@@ -7,7 +7,7 @@
 	delaycompress
 	compress
 	postrotate
-		invoke-rc.d syslog-ng reload > /dev/null
+		syslog-ng-ctl reload > /dev/null
 	endscript
 }
 
@@ -33,6 +33,6 @@
 	delaycompress
 	sharedscripts
 	postrotate
-		invoke-rc.d syslog-ng reload > /dev/null
+		syslog-ng-ctl reload > /dev/null
 	endscript
 }


### PR DESCRIPTION
The existing logrotate config uses a postrotate command of:
  invoke-rc.d syslog-ng reload > /dev/null

This fails for several reasons.

A working equivalent is:
  syslog-ng-ctl reload > /dev/null

This commit simply swaps out the failing command for a working one

The consequence of the failing command is that if cron is started,
logrotate will be called and will rotate the /var/logs/messages log
written by syslog-ng but syslog-ng will continue writing to the old log
because it fails to be reloaded.