### PR TITLE
pdbtool: postpone stats_destroy() until after log_tags_global_deinit()

### DIFF
--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -1282,9 +1282,9 @@ main(int argc, char *argv[])
   ret = modes[mode].main(argc, argv);
   scratch_buffers_allocator_deinit();
   scratch_buffers_global_deinit();
-  stats_destroy();
   log_tags_global_deinit();
   log_msg_global_deinit();
+  stats_destroy();
 
   cfg_free(configuration);
   configuration = NULL;

--- a/news/bugfix-4037.md
+++ b/news/bugfix-4037.md
@@ -1,0 +1,4 @@
+`pdbtool`: fix a SIGABRT on FreeBSD that was triggered right before pdbtool
+exits. Apart from being an ugly crash that produces a core file,
+functionally the tool behaved correctly and this case does not affect
+syslog-ng itself.


### PR DESCRIPTION
This branch hopes to fix #4035. 

@czanik  maybe we should add this patch to  freebsd ports  as a patch, as 3.37 was released last Friday.