### PR TITLE
Add support for Ubuntu 22.04 Jammy Jellyfish

### DIFF
--- a/.github/workflows/create-packages.yml
+++ b/.github/workflows/create-packages.yml
@@ -23,6 +23,7 @@ on:
           "debian-bullseye",
           "ubuntu-focal",
           "ubuntu-impish",
+          "ubuntu-jammy",
           "centos-7",
           "fedora-35"
         ]'

--- a/.github/workflows/dbld-images.yml
+++ b/.github/workflows/dbld-images.yml
@@ -39,6 +39,7 @@ jobs:
           - ubuntu-bionic
           - ubuntu-focal
           - ubuntu-impish
+          - ubuntu-jammy
           - ubuntu-xenial
           - devshell
           - kira

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -38,5 +38,5 @@ jobs:
         "debian-bullseye",
         "debian-testing",
         "fedora-35",
-        "ubuntu-focal"
+        "ubuntu-jammy"
       ]'

--- a/.github/workflows/test-apt-packages.yml
+++ b/.github/workflows/test-apt-packages.yml
@@ -21,6 +21,7 @@ jobs:
           - "ubuntu:bionic"
           - "ubuntu:focal"
           - "ubuntu:impish"
+          - "ubuntu:jammy"
       fail-fast: false
     runs-on: ubuntu-latest
     container: ${{ matrix.distro }}

--- a/.github/workflows/upload-packages.yml
+++ b/.github/workflows/upload-packages.yml
@@ -20,6 +20,7 @@ on:
           "debian-bullseye",
           "ubuntu-focal",
           "ubuntu-impish"
+          "ubuntu-jammy"
         ]'
     secrets:
       azure-sas-token:

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ syslog-ng packages are released for the following distribution versions (x86-64)
 
 | Distro version | sources.list component name |
 |---|---|
+| Ubuntu 22.04 | ubuntu-jammy |
 | Ubuntu 21.10 | ubuntu-impish |
 | Ubuntu 20.04 | ubuntu-focal |
 | Ubuntu 18.04 | ubuntu-bionic |

--- a/dbld/Makefile.am
+++ b/dbld/Makefile.am
@@ -38,6 +38,7 @@ EXTRA_DIST += \
 	dbld/images/ubuntu-bionic.dockerfile \
 	dbld/images/ubuntu-focal.dockerfile \
 	dbld/images/ubuntu-impish.dockerfile \
+	dbld/images/ubuntu-jammy.dockerfile \
 	dbld/images/kira.dockerfile \
 	dbld/images/tarball.dockerfile \
 	dbld/images/hooks/build \

--- a/dbld/build.manifest
+++ b/dbld/build.manifest
@@ -40,6 +40,7 @@ ubuntu-xenial		python2,nocriterion,nokafka,nojava,nomqtt
 ubuntu-bionic		python2,nocriterion,nokafka,nomqtt
 ubuntu-focal		python3,nocriterion,nomqtt
 ubuntu-impish		python3
+ubuntu-jammy		python3
 
 centos-7		python2
 fedora			python3

--- a/dbld/images/ubuntu-jammy.dockerfile
+++ b/dbld/images/ubuntu-jammy.dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:jammy
+LABEL maintainer="Laszlo Varady <laszlo.varady@balabit.com>, Andras Mitzki <andras.mitzki@balabit.com>, Laszlo Szemere <laszlo.szemere@balabit.com>, Balazs Scheidler <balazs.scheidler@oneidentity.com>"
+ENV OS_DISTRIBUTION=ubuntu
+ENV OS_DISTRIBUTION_CODE_NAME=jammy
+
+ARG ARG_IMAGE_PLATFORM
+ARG COMMIT
+ENV IMAGE_PLATFORM ${ARG_IMAGE_PLATFORM}
+LABEL COMMIT=${COMMIT}
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN=true
+ENV LANG C.UTF-8
+
+COPY images/fake-sudo.sh /usr/bin/sudo
+COPY images/entrypoint.sh /
+COPY . /dbld/
+
+RUN /dbld/builddeps install_dbld_dependencies
+RUN /dbld/builddeps install_apt_packages
+RUN /dbld/builddeps install_debian_build_deps
+RUN /dbld/builddeps install_pip_packages
+
+VOLUME /source
+VOLUME /build
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/dbld/rules
+++ b/dbld/rules
@@ -12,6 +12,7 @@ BUILDER_IMAGES=		\
 	ubuntu-bionic	\
 	ubuntu-focal	\
 	ubuntu-impish \
+	ubuntu-jammy \
 	kira		\
 	tarball
 


### PR DESCRIPTION
This PR extends the supported platforms in `dbld` with the latest Ubuntu LTS (22.04 Jammy Jellyfish).