### PR TITLE
Fix log matcher abort with indirect values

### DIFF
--- a/lib/logmatcher.c
+++ b/lib/logmatcher.c
@@ -30,14 +30,6 @@
 #include "compat/string.h"
 #include "compat/pcre.h"
 
-static gboolean
-_shall_set_values_indirectly(NVHandle value_handle)
-{
-  return value_handle != LM_V_NONE &&
-         !log_msg_is_handle_macro(value_handle) &&
-         !log_msg_is_handle_match(value_handle);
-}
-
 static void
 log_matcher_store_pattern(LogMatcher *self, const gchar *pattern)
 {
@@ -416,7 +408,9 @@ log_matcher_pcre_re_feed_value(LogMatcherPcreRe *self, LogMessage *msg,
                                LogMatcherPcreMatchResult *result,
                                gint begin_index, gint end_index)
 {
-  gboolean indirect = _shall_set_values_indirectly(result->source_handle);
+  gboolean indirect = result->source_handle != LM_V_NONE &&
+                      log_msg_is_handle_settable_with_an_indirect_value(target_handle) &&
+                      log_msg_is_handle_referencable_from_an_indirect_value(result->source_handle);
 
   if (target_handle == result->source_handle)
     {

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -315,6 +315,25 @@ gboolean log_msg_is_handle_match(NVHandle handle);
   })
 
 static inline gboolean
+log_msg_is_handle_referencable_from_an_indirect_value(NVHandle handle)
+{
+  if (handle == LM_V_NONE)
+    return FALSE;
+
+  /* macro values should not be referenced as they are dynamic, store the actual value instead */
+  if (log_msg_is_handle_macro(handle))
+    return FALSE;
+
+  /* matches are pretty temporary, so we should not reference them, as the
+   * next matching operation would overwrite them anyway */
+
+  if (log_msg_is_handle_match(handle))
+    return FALSE;
+
+  return TRUE;
+}
+
+static inline gboolean
 log_msg_is_handle_settable_with_an_indirect_value(NVHandle handle)
 {
   return (handle >= LM_V_MAX);

--- a/libtest/msg_parse_lib.c
+++ b/libtest/msg_parse_lib.c
@@ -73,6 +73,20 @@ assert_log_message_value_unset_by_name(LogMessage *self, const gchar *name)
 }
 
 void
+assert_log_message_value_is_indirect(LogMessage *self, NVHandle handle)
+{
+  NVEntry *entry = nv_table_get_entry(self->payload, handle, NULL, NULL);
+  cr_assert(entry->indirect);
+}
+
+void
+assert_log_message_value_is_direct(LogMessage *self, NVHandle handle)
+{
+  NVEntry *entry = nv_table_get_entry(self->payload, handle, NULL, NULL);
+  cr_assert(!entry->indirect);
+}
+
+void
 assert_log_message_value_and_type(LogMessage *self, NVHandle handle,
                                   const gchar *expected_value, LogMessageValueType expected_type)
 {

--- a/libtest/msg_parse_lib.h
+++ b/libtest/msg_parse_lib.h
@@ -34,6 +34,8 @@ void deinit_syslogformat_module(void);
 
 void assert_log_messages_equal(LogMessage *log_message_a, LogMessage *log_message_b);
 
+void assert_log_message_value_is_direct(LogMessage *self, NVHandle handle);
+void assert_log_message_value_is_indirect(LogMessage *self, NVHandle handle);
 void assert_log_message_value_unset(LogMessage *self, NVHandle handle);
 void assert_log_message_value_unset_by_name(LogMessage *self, const gchar *name);
 void assert_log_message_value(LogMessage *self, NVHandle handle, const gchar *expected_value);

--- a/modules/regexp-parser/tests/test_regexp_parser.c
+++ b/modules/regexp-parser/tests/test_regexp_parser.c
@@ -84,6 +84,9 @@ ParameterizedTestParameters(regexp_parser, test_regexp_parser)
     {.msg = "foo", .pattern = "(?<key>foo)|(?<key>bar)", .prefix=".reg.", .expected_result = TRUE, .flags = LMF_DUPNAMES, .name = ".reg.key", .value = "foo"},
     {.msg = "abc", .pattern = "Abc", .prefix="", .flags = 0, .expected_result = FALSE, .name = NULL, .value = NULL},
     {.msg = "abc", .pattern = "(?<key>Abc)", .prefix="", .flags = LMF_ICASE, .expected_result = TRUE, .name = "key", .value = "abc"},
+
+    /* store into a builtin value */
+    {.msg = "abcdef", .pattern = "(?<PID>abc)", .prefix="", .flags = 0, .expected_result = TRUE, .name = "PID", .value = "abc"},
   };
   return cr_make_param_array(RegexpParserTestParam, parser_params, G_N_ELEMENTS(parser_params));
 }
@@ -92,9 +95,10 @@ ParameterizedTest(RegexpParserTestParam *parser_param, regexp_parser, test_regex
 {
   LogParser *p = _construct_regexp_parser(parser_param->prefix, parser_param->pattern, parser_param->flags);
   gboolean result;
+  GError *e = NULL;
 
-  result = regexp_parser_compile(p, NULL);
-  cr_assert(result, "unexpected compiling failure; pattern=%s\n", parser_param->pattern);
+  result = regexp_parser_compile(p, &e);
+  cr_assert(result, "unexpected compiling failure; pattern=%s, error=%s\n", parser_param->pattern, e->message);
 
   LogMessage *msg = log_msg_new_empty();
   log_msg_set_value(msg, LM_V_MESSAGE, parser_param->msg, -1);

--- a/news/bugfix-4043.md
+++ b/news/bugfix-4043.md
@@ -1,0 +1,11 @@
+`regexp-parser()`: due to a change introduced in 3.37, named capture groups
+are stored indirectly in the LogMessage to avoid copying of the value.  In
+this case the name-value pair created with the regexp is only stored as a
+reference (name + length of the original value), which improves performance
+and makes such name-value pairs use less memory.  One omission in the
+original change in 3.37 is that syslog-ng does not allow builtin values to
+be stored indirectly (e.g.  $MESSAGE and a few of others) and this case
+causes an assertion to fail and syslog-ng to crash with a SIGABRT. This
+abort is now fixed. Here's a sample config that reproduces the issue:
+
+    regexp-parser(patterns('(?<MESSAGE>.*)'));

--- a/tests/unit/test_matcher.c
+++ b/tests/unit/test_matcher.c
@@ -134,8 +134,8 @@ setup(void)
 void
 teardown(void)
 {
-  app_shutdown();
   scratch_buffers_explicit_gc();
+  app_shutdown();
   cfg_free(configuration);
 }
 


### PR DESCRIPTION
#3948 implemented that even named based captures would be stored as indirect values (this improves performance and makes the LogMessage->payload smaller as it avoids duplications).

However, not all name-value pairs can be stored in an indirect fashion and the abort described in #4042 was triggered as one of the assumptions was violated by the new behaviour.

Basically if you use a named capture group and use that to store a value into a builtin name-value pair (e.g. PROGRAM, PID, HOST, HOST_FROM, MESSAGE, MSGID, SOURCE) we are triggering that abort, which is a regression in 3.37. 

I am not sure how often this occurs in the wild, regexp-parser() being a relatively new feature, but we might want to release an emergency 3.37.2 release. 

With that said, this branch fixes the issue and adds new testcases to cover the expected behaviour.
