### PR TITLE
Fix crash in case of kept alive connections

### DIFF
--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1484,14 +1484,6 @@ log_writer_init(LogPipe *s)
   if ((self->options->options & LWO_NO_STATS) == 0 && !self->dropped_messages)
     _register_counters(self);
 
-  if (self->proto)
-    {
-      LogProtoClient *proto;
-
-      proto = self->proto;
-      log_writer_set_proto(self, NULL);
-      log_writer_reopen(self, proto);
-    }
 
   if (self->options->mark_mode == MM_PERIODICAL)
     {
@@ -1634,6 +1626,18 @@ log_writer_set_pending_proto(LogWriter *self, LogProtoClient *proto, gboolean pr
   self->pending_proto = proto;
   self->pending_proto_present = present;
 }
+
+LogProtoClient *
+log_writer_steal_proto(LogWriter *self)
+{
+  if (self->proto == NULL)
+    return NULL;
+
+  LogProtoClient *proto = self->proto;
+  log_writer_set_proto(self, NULL);
+  return proto;
+}
+
 
 /* run in the main thread in reaction to a log_writer_reopen to change
  * the destination LogProtoClient instance. It needs to be ran in the main

--- a/lib/logwriter.h
+++ b/lib/logwriter.h
@@ -82,6 +82,7 @@ void log_writer_format_log(LogWriter *self, LogMessage *lm, GString *result);
 gboolean log_writer_has_pending_writes(LogWriter *self);
 gboolean log_writer_opened(LogWriter *self);
 void log_writer_reopen(LogWriter *self, LogProtoClient *proto);
+LogProtoClient *log_writer_steal_proto(LogWriter *self);
 void log_writer_set_queue(LogWriter *self, LogQueue *queue);
 LogQueue *log_writer_get_queue(LogWriter *s);
 LogWriter *log_writer_new(guint32 flags, GlobalConfig *cfg);

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -544,7 +544,14 @@ afprogram_dd_init(LogPipe *s)
     }
   log_pipe_append(&self->super.super.super, (LogPipe *) self->writer);
 
-  return restore_successful ? TRUE : afprogram_dd_reopen(self);
+  if (restore_successful)
+    {
+      LogProtoClient *proto = log_writer_steal_proto(self->writer);
+      log_writer_reopen(self->writer, proto);
+      return TRUE;
+    }
+
+  return afprogram_dd_reopen(self);
 }
 
 static inline void

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -314,8 +314,17 @@ _setup_bind_addr(AFInetDestDriver *self)
 }
 
 static gboolean
+_already_connected_to_destination(AFInetDestDriver *self)
+{
+  return log_writer_opened(self->super.writer);
+}
+
+static gboolean
 _setup_dest_addr(AFInetDestDriver *self)
 {
+  if (_already_connected_to_destination(self))
+    return TRUE;
+
   g_sockaddr_unref(self->super.dest_addr);
   self->super.dest_addr = NULL;
 

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -558,6 +558,7 @@ afsocket_dd_setup_writer(AFSocketDestDriver *self)
           log_writer_reopen(self->writer, proto);
         }
     }
+  self->connection_initialized = TRUE;
   return TRUE;
 }
 
@@ -567,7 +568,6 @@ afsocket_dd_setup_connection(AFSocketDestDriver *self)
   if (!log_writer_opened(self->writer))
     _dd_reconnect_with_current_addresses(self);
 
-  self->connection_initialized = TRUE;
   return TRUE;
 }
 

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -176,7 +176,6 @@ afsocket_dd_stats_instance(AFSocketDestDriver *self)
 }
 
 static void _afsocket_dd_connection_in_progress(AFSocketDestDriver *self);
-static void afsocket_dd_try_connect(AFSocketDestDriver *self);
 
 static void
 afsocket_dd_init_watches(AFSocketDestDriver *self)
@@ -187,10 +186,7 @@ afsocket_dd_init_watches(AFSocketDestDriver *self)
 
   IV_TIMER_INIT(&self->reconnect_timer);
   self->reconnect_timer.cookie = self;
-  /* Using reinit as a handler before establishing the first successful connection.
-   * We'll change this to afsocket_dd_reconnect when the initialization of the
-   * connection succeeds.*/
-  self->reconnect_timer.handler = (void (*)(void *)) afsocket_dd_try_connect;
+  self->reconnect_timer.handler = (void (*)(void *)) afsocket_dd_reconnect;
 }
 
 static void
@@ -417,12 +413,6 @@ afsocket_dd_reconnect(AFSocketDestDriver *self)
   _dd_reconnect_with_setup_addresses(self);
 }
 
-static void
-afsocket_dd_try_connect(AFSocketDestDriver *self)
-{
-  afsocket_dd_reconnect(self);
-}
-
 static gboolean
 afsocket_dd_setup_proto_factory(AFSocketDestDriver *self)
 {
@@ -555,7 +545,7 @@ static gboolean
 _finalize_init(gpointer arg)
 {
   AFSocketDestDriver *self = (AFSocketDestDriver *)arg;
-  afsocket_dd_try_connect(self);
+  afsocket_dd_reconnect(self);
   return TRUE;
 }
 

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -177,7 +177,6 @@ afsocket_dd_stats_instance(AFSocketDestDriver *self)
 
 static void _afsocket_dd_connection_in_progress(AFSocketDestDriver *self);
 static void afsocket_dd_try_connect(AFSocketDestDriver *self);
-static gboolean afsocket_dd_setup_connection(AFSocketDestDriver *self);
 
 static void
 afsocket_dd_init_watches(AFSocketDestDriver *self)
@@ -421,14 +420,7 @@ afsocket_dd_reconnect(AFSocketDestDriver *self)
 static void
 afsocket_dd_try_connect(AFSocketDestDriver *self)
 {
-  if ((!afsocket_dd_setup_addresses(self)) || !afsocket_dd_setup_connection(self))
-    {
-      msg_error("Initiating connection failed, reconnecting",
-                evt_tag_int("time_reopen", self->writer_options.time_reopen));
-      afsocket_dd_start_reconnect_timer(self);
-      return;
-    }
-  self->reconnect_timer.handler = (void (*)(void *)) afsocket_dd_reconnect;
+  afsocket_dd_reconnect(self);
 }
 
 static gboolean
@@ -556,12 +548,6 @@ afsocket_dd_setup_writer(AFSocketDestDriver *self)
         }
     }
   self->connection_initialized = TRUE;
-  return TRUE;
-}
-
-static gboolean
-afsocket_dd_setup_connection(AFSocketDestDriver *self)
-{
   return TRUE;
 }
 

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -390,27 +390,15 @@ afsocket_dd_start_connect(AFSocketDestDriver *self)
   return TRUE;
 }
 
-static void
-_dd_reconnect(AFSocketDestDriver *self, gboolean request_setup_addr)
+void
+afsocket_dd_reconnect(AFSocketDestDriver *self)
 {
-  if ((request_setup_addr && !afsocket_dd_setup_addresses(self)) || !afsocket_dd_start_connect(self))
+  if (!afsocket_dd_setup_addresses(self) || !afsocket_dd_start_connect(self))
     {
       msg_error("Initiating connection failed, reconnecting",
                 evt_tag_int("time_reopen", self->writer_options.time_reopen));
       afsocket_dd_start_reconnect_timer(self);
     }
-}
-
-static void
-_dd_reconnect_with_setup_addresses(AFSocketDestDriver *self)
-{
-  _dd_reconnect(self, TRUE);
-}
-
-void
-afsocket_dd_reconnect(AFSocketDestDriver *self)
-{
-  _dd_reconnect_with_setup_addresses(self);
 }
 
 static gboolean

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -348,14 +348,13 @@ afsocket_dd_start_connect(AFSocketDestDriver *self)
 
   g_assert(self->transport_mapper->transport);
   g_assert(self->bind_addr);
+  g_assert(self->dest_addr);
 
   if (!transport_mapper_open_socket(self->transport_mapper, self->socket_options, self->bind_addr, self->dest_addr,
                                     AFSOCKET_DIR_SEND, &sock))
     {
       return FALSE;
     }
-
-  g_assert(self->dest_addr);
 
   rc = g_connect(sock, self->dest_addr);
   if (rc == G_IO_STATUS_NORMAL)

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -349,6 +349,9 @@ afsocket_dd_start_connect(AFSocketDestDriver *self)
 
   main_loop_assert_main_thread();
 
+  if (log_writer_opened(self->writer))
+    return TRUE;
+
   g_assert(self->transport_mapper->transport);
   g_assert(self->bind_addr);
   g_assert(self->dest_addr);
@@ -407,12 +410,6 @@ static void
 _dd_reconnect_with_setup_addresses(AFSocketDestDriver *self)
 {
   _dd_reconnect(self, TRUE);
-}
-
-static void
-_dd_reconnect_with_current_addresses(AFSocketDestDriver *self)
-{
-  _dd_reconnect(self, FALSE);
 }
 
 void
@@ -565,9 +562,6 @@ afsocket_dd_setup_writer(AFSocketDestDriver *self)
 static gboolean
 afsocket_dd_setup_connection(AFSocketDestDriver *self)
 {
-  if (!log_writer_opened(self->writer))
-    _dd_reconnect_with_current_addresses(self);
-
   return TRUE;
 }
 

--- a/modules/afsocket/afsocket-dest.h
+++ b/modules/afsocket/afsocket-dest.h
@@ -48,7 +48,6 @@ struct _AFSocketDestDriver
 
   GSockAddr *bind_addr;
   GSockAddr *dest_addr;
-  gint time_reopen;
   gboolean connection_initialized;
   struct iv_fd connect_fd;
   struct iv_timer reconnect_timer;

--- a/news/bugfix-4044.md
+++ b/news/bugfix-4044.md
@@ -1,0 +1,1 @@
+afsocket-dest: fixed a crash when a kept-alive connection after reload which was not initalized properly (e.g. due to name resolution issues of the remote hostname) receives a connection close from the remote.


### PR DESCRIPTION
We've found a crash when after reload a half-initialized dest-driver (e.g. hostname resolving fails) with kept-alive connections receives a connections close event from the remote.