### PR TITLE
Fix `make distcheck` failure with OpenSSL V3.0+

### DIFF
--- a/lib/compat/openssl_support.c
+++ b/lib/compat/openssl_support.c
@@ -279,7 +279,7 @@ openssl_ctx_load_dh_from_file(SSL_CTX *ctx, const gchar *dhparam_file)
 #endif
 }
 
-#if !SYSLOG_NG_HAVE_DECL_DH_SET0_PQG
+#if !SYSLOG_NG_HAVE_DECL_DH_SET0_PQG && OPENSSL_VERSION_NUMBER < 0x30000000L
 int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g)
 {
   if ((dh->p == NULL && p == NULL)

--- a/lib/compat/openssl_support.h
+++ b/lib/compat/openssl_support.h
@@ -59,7 +59,7 @@ uint32_t X509_get_extension_flags(X509 *x);
 #define SYSLOG_NG_HAVE_DECL_DIGEST_MD4 1
 #endif
 
-#if !SYSLOG_NG_HAVE_DECL_DH_SET0_PQG
+#if !SYSLOG_NG_HAVE_DECL_DH_SET0_PQG && OPENSSL_VERSION_NUMBER < 0x30000000L
 int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g);
 #endif
 


### PR DESCRIPTION
The error:
```
../../lib/compat/openssl_support.c:285:10: error: invalid use of incomplete typedef 'DH' {aka 'struct dh_st'}
  285 |   if ((dh->p == NULL && p == NULL)
  ....
```
https://github.com/syslog-ng/syslog-ng/runs/6852574427?check_suite_focus=true#step:7:1367

# Why it failed? Why only distcheck failed?
OpenSSL made its structs opaque in OpenSSL 1.1.1 hence the error for accessing its members. Here's how this piece of code ended up in the building phase:
Starting with 2022-06-11 OpenSSL 3.0 is in Debian testing (https://tracker.debian.org/pkg/openssl), which will give depracation warnings if deprecated features are used (e.g. `DH_set0_pqg`).

```
configure:17662: checking whether DH_set0_pqg is declared
configure:17662: gcc -c  -O2 -g -pthread -Werror   conftest.c >&5
conftest.c: In function 'main':
conftest.c:80:3: error: 'DH_set0_pqg' is deprecated: Since OpenSSL 3.0 [-Werror=deprecated-declarations]
   80 |   (void) DH_set0_pqg;
      |   ^
In file included from conftest.c:71:
/usr/include/openssl/dh.h:255:27: note: declared here
  255 | OSSL_DEPRECATEDIN_3_0 int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g);
      |                           ^~~~~~~~~~~
cc1: all warnings being treated as errors
```


Because of the `-Werror` flag in `DISTCHECK_CONFIGURE_FLAGS` checking for `DH_set0_pqg` results in a depracation warning, which will be considered an error, which will result in `#define HAVE_DEC_DH_SET0_PQG 0`.
The compat code is protected by the preprocessor macro `#if !SYSLOG_NG_HAVE_DECL_DH_SET0_PQG`, which will add the compat implementation of `DH_set0_pqg`.

---


Successful run: https://github.com/OverOrion/syslog-ng/runs/6878927076?check_suite_focus=true