### PR TITLE
Add Pull Request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+<!--
+Thank you for contributing to syslog-ng. Please make sure you:
+- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
+- Checked that tests pass (including stylechecks: `make style-check`)
+- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
+-->
+
+
+<!--
+PR description
+In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
+For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ submit your own.
 ### Testing
 
 An incredibly useful way to contribute is to test patches and pull
-requests - there's only so much [automated testing][ar:travis] can do.
+requests - there's only so much [automated testing][ar:github-actions] can do.
 For example, you can help testing on platforms the developers do not
 have access to, or try configurations not thought of before.
 
@@ -204,11 +204,11 @@ audience.
 We also have a [Gitter channel][ar:gitter], where developers hang out.
 
 We use [GitHub issues][ar:issue-tracker] to track issues, feature requests
-and patches. We are also using [Travis CI][ar:travis] for automatic
+and patches. We are also using [GitHub Actions][ar:github-actions] for automatic
 testing.
 
  [ar:gitter]: https://gitter.im/syslog-ng/syslog-ng
  [ar:mailing-list]: http://lists.balabit.com/mailman/listinfo/syslog-ng
  [ar:issue-tracker]: https://github.com/syslog-ng/syslog-ng/issues
  [ar:issues:good-first-issue]: https://github.com/syslog-ng/syslog-ng/labels/good%20first%20issue
- [ar:travis]: https://travis-ci.org/syslog-ng/syslog-ng/
+ [ar:github-actions]: https://github.com/syslog-ng/syslog-ng/actions


### PR DESCRIPTION
This PR tries to give a gentle reminder of some steps that are required, but might not be enforced by the current CI and/or might be overlooked.

We've agreed on that it should be similar to the current issue template format, meaning that there are no checkboxes to tick as it would make things unnecessary complicated for smaller contributions. 

You can check how it looks on my fork:
https://github.com/OverOrion/syslog-ng/compare/master...OverOrion:test_branch?expand=1

I was reluctant to add the whole `PR description` from the [`CONTRIBUTING.md`](https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description) as they might not be in sync in the future and first time contributors are already informed to read the guidelines, nevertheless I am open to adding it, just let me know.

And of course if you have other notes / ideas / etc, please let me know!