### PR TITLE
Type support add-contextual-data (4.0)

### DIFF
--- a/lib/template/templates.h
+++ b/lib/template/templates.h
@@ -68,6 +68,7 @@ struct _LogTemplate
 void log_template_set_escape(LogTemplate *self, gboolean enable);
 gboolean log_template_set_type_hint(LogTemplate *self, const gchar *hint, GError **error);
 gboolean log_template_compile(LogTemplate *self, const gchar *template, GError **error);
+gboolean log_template_compile_with_type_hint(LogTemplate *self, const gchar *template_and_typehint, GError **error);
 void log_template_compile_literal_string(LogTemplate *self, const gchar *literal);
 gboolean log_template_is_literal_string(const LogTemplate *self);
 const gchar *log_template_get_literal_value(const LogTemplate *self, gssize *value_len);

--- a/lib/template/tests/test_template.c
+++ b/lib/template/tests/test_template.c
@@ -692,3 +692,51 @@ Test(template, test_type_hint_overrides_the_calculated_type)
   log_msg_unref(msg);
   log_template_unref(template);
 }
+
+Test(template, test_log_template_compile_with_type_hint_sets_the_type_hint_member_too)
+{
+  cfg_set_version_without_validation(configuration, VERSION_VALUE_4_0);
+  LogTemplate *template = log_template_new(configuration, NULL);
+  GError *error = NULL;
+  gboolean result;
+
+  cr_assert_eq(template->type_hint, LM_VT_NONE);
+
+  result = log_template_compile_with_type_hint(template, "int64(1234)", &error);
+  cr_assert(result);
+  cr_assert_eq(error, NULL);
+  cr_assert_eq(template->type_hint, LM_VT_INT64);
+  result = log_template_compile_with_type_hint(template, "string(1234)", &error);
+  cr_assert(result);
+  cr_assert_eq(error, NULL);
+  cr_assert_eq(template->type_hint, LM_VT_STRING);
+  result = log_template_compile_with_type_hint(template, "list(foo,bar,baz)", &error);
+  cr_assert(result);
+  cr_assert_eq(error, NULL);
+  cr_assert_eq(template->type_hint, LM_VT_LIST);
+  result = log_template_compile_with_type_hint(template, "generic-string", &error);
+  cr_assert(result);
+  cr_assert_eq(error, NULL);
+  cr_assert_eq(template->type_hint, LM_VT_NONE);
+  log_template_unref(template);
+}
+
+Test(template, test_log_template_compile_with_invalid_type_hint_resets_the_type_hint_to_none)
+{
+  cfg_set_version_without_validation(configuration, VERSION_VALUE_4_0);
+  LogTemplate *template = log_template_new(configuration, NULL);
+  GError *error = NULL;
+  gboolean result;
+
+  cr_assert_eq(template->type_hint, LM_VT_NONE);
+
+  result = log_template_compile_with_type_hint(template, "int64(1234)", &error);
+  cr_assert(result);
+  cr_assert_eq(error, NULL);
+  cr_assert_eq(template->type_hint, LM_VT_INT64);
+  result = log_template_compile_with_type_hint(template, "unknown(generic-string)", &error);
+  cr_assert_not(result);
+  cr_assert_neq(error, NULL);
+  cr_assert_eq(template->type_hint, LM_VT_NONE);
+  log_template_unref(template);
+}

--- a/modules/add-contextual-data/add-contextual-data.c
+++ b/modules/add-contextual-data/add-contextual-data.c
@@ -101,9 +101,10 @@ _add_context_data_to_message(gpointer pmsg, const ContextualDataRecord *record)
 {
   LogMessage *msg = (LogMessage *) pmsg;
   GString *result = scratch_buffers_alloc();
+  LogMessageValueType type;
 
-  log_template_format(record->value, msg, &DEFAULT_TEMPLATE_EVAL_OPTIONS, result);
-  log_msg_set_value(msg, record->value_handle, result->str, result->len);
+  log_template_format_value_and_type(record->value, msg, &DEFAULT_TEMPLATE_EVAL_OPTIONS, result, &type);
+  log_msg_set_value_with_type(msg, record->value_handle, result->str, result->len, type);
 }
 
 static gboolean

--- a/modules/add-contextual-data/contextual-data-record-scanner.c
+++ b/modules/add-contextual-data/contextual-data-record-scanner.c
@@ -112,7 +112,7 @@ _fetch_value(ContextualDataRecordScanner *self, ContextualDataRecord *record)
     {
       GError *error = NULL;
 
-      if (!log_template_compile(record->value, value_template, &error))
+      if (!log_template_compile_with_type_hint(record->value, value_template, &error))
         {
           msg_error("add-contextual-data(): error compiling template",
                     evt_tag_str("selector", record->selector->str),

--- a/news/feature-4051.md
+++ b/news/feature-4051.md
@@ -1,0 +1,10 @@
+`add-contextual-data()`: add support for type propagation, e.g. set the
+type of name-value pairs as they are created/updated to the value returned
+by the template expression that we use to set the value.
+
+The 3rd column in the CSV file (e.g. the template expression) now supports
+specifying a type-hint, in the format of "type-hint(template-expr)".
+
+Example line in the CSV database:
+
+selector-value,name-value-pair-to-be-created,list(foo,bar,baz)


### PR DESCRIPTION
This PR adds type support to add-contextual-data(), two things:
  * the ability to propagate the type-hint from LogTemplate to a newly set name-value pair
  * the ability to use type-hints in the add-contextual-data() database, in the format of "type-hint(template_expression)"

