### PR TITLE
Use generic-number in riemann (4.0)

### DIFF
--- a/modules/riemann/riemann-worker.c
+++ b/modules/riemann/riemann-worker.c
@@ -25,6 +25,8 @@
 #include "riemann.h"
 #include "riemann-worker.h"
 #include "scratch-buffers.h"
+#include "generic-number.h"
+#include "parse-number.h"
 
 #include <riemann/simple.h>
 #include <stdlib.h>
@@ -124,8 +126,10 @@ riemann_dd_field_integer_maybe_add(riemann_event_t *event, LogMessage *msg,
 
   if (target->len != 0)
     {
-      gint64 as_int = g_ascii_strtoll(target->str, NULL, 10);
-      riemann_event_set(event, ftype, as_int, RIEMANN_EVENT_FIELD_NONE);
+      GenericNumber gn;
+
+      if (parse_generic_number(target->str, &gn))
+        riemann_event_set(event, ftype, gn_as_int64(&gn), RIEMANN_EVENT_FIELD_NONE);
     }
 }
 


### PR DESCRIPTION
This PR changes the riemann driver to use GenericNumber and its associated number parsing functions, instead of using  using strtoll() without error handling.

This is not really a functional change, rather it is a refactor, but has originally been done in the scope of the 4.0 typing work.
