### PR TITLE
fix conditional evaluation with a dangling filter

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -737,17 +737,17 @@ log_conditional
 log_if
         : KW_IF '(' filter_content ')' '{' log_content '}'
           {
-            $$ = log_expr_node_new_conditional_with_filter($3, $6, &@$);
+            $$ = log_expr_node_new_simple_conditional($3, $6, &@$);
           }
         | KW_IF '{' log_content '}'
           {
-            $$ = log_expr_node_new_conditional_with_block($3, &@$);
+            $$ = log_expr_node_new_compound_conditional($3, &@$);
           }
         | log_if KW_ELIF '(' filter_content ')' '{' log_content '}'
           {
             LogExprNode *false_branch;
 
-            false_branch = log_expr_node_new_conditional_with_filter($4, $7, &@$);
+            false_branch = log_expr_node_new_simple_conditional($4, $7, &@$);
             log_expr_node_conditional_set_false_branch_of_the_last_if($1, false_branch);
             $$ = $1;
           }
@@ -755,7 +755,7 @@ log_if
           {
             LogExprNode *false_branch;
 
-            false_branch = log_expr_node_new_conditional_with_block($4, &@$);
+            false_branch = log_expr_node_new_compound_conditional($4, &@$);
             log_expr_node_conditional_set_false_branch_of_the_last_if($1, false_branch);
             $$ = $1;
           }

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -541,7 +541,7 @@ plugin_stmt
 /* START_RULES */
 
 source_content
-        : _source_context_push source_items _source_context_pop   { $$ = log_expr_node_new_junction($2, &@$); }
+        : _source_context_push source_items _source_context_pop   { $$ = log_expr_node_new_source_junction($2, &@$); }
         ;
 
 source_items
@@ -628,7 +628,7 @@ rewrite_content
         ;
 
 dest_content
-         : _destination_context_push dest_items _destination_context_pop               { $$ = log_expr_node_new_junction($2, &@$); }
+         : _destination_context_push dest_items _destination_context_pop               { $$ = log_expr_node_new_destination_junction($2, &@$); }
          ;
 
 

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -890,6 +890,7 @@ cfg_tree_compile_reference(CfgTree *self, LogExprNode *node,
       */
 
       mpx = cfg_tree_new_mpx(self, node, "mpx(destination-reference)");
+      log_multiplexer_disable_delivery_propagation(mpx);
 
       if (sub_pipe_head)
         {
@@ -1207,6 +1208,8 @@ cfg_tree_compile_junction(CfgTree *self,
                                           ? "mpx(destination-junction)"
                                           : (node->content == ENC_SOURCE ? "mpx(source-junction)" : "mpx(junction)"));
 
+              if (node->content == ENC_DESTINATION)
+                log_multiplexer_disable_delivery_propagation(fork_mpx);
               *outer_pipe_head = &fork_mpx->super;
             }
           log_multiplexer_add_next_hop(fork_mpx, sub_pipe_head);

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -1206,6 +1206,7 @@ cfg_tree_compile_junction(CfgTree *self,
           if (!join_pipe)
             {
               join_pipe = cfg_tree_new_pipe(self, node, "junction-end");
+              join_pipe->flags |= PIF_JUNCTION_END;
             }
           log_pipe_append(sub_pipe_tail, join_pipe);
 

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -1202,7 +1202,11 @@ cfg_tree_compile_junction(CfgTree *self,
             }
           if (!fork_mpx)
             {
-              fork_mpx = cfg_tree_new_mpx(self, node, "mpx(junction)");
+              fork_mpx = cfg_tree_new_mpx(self, node,
+                                          node->content == ENC_DESTINATION
+                                          ? "mpx(destination-junction)"
+                                          : (node->content == ENC_SOURCE ? "mpx(source-junction)" : "mpx(junction)"));
+
               *outer_pipe_head = &fork_mpx->super;
             }
           log_multiplexer_add_next_hop(fork_mpx, sub_pipe_head);

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -541,7 +541,7 @@ log_expr_node_new_conditional_with_filter(LogExprNode *filter_pipe, LogExprNode 
   LogExprNode *true_branch = log_expr_node_new_log(
                                log_expr_node_append_tail(
                                  filter_node,
-                                 log_expr_node_new_log(true_expr, LC_DROP_UNMATCHED, NULL)
+                                 log_expr_node_new_log(true_expr, 0, NULL)
                                ),
                                LC_FINAL,
                                NULL
@@ -618,7 +618,11 @@ log_expr_node_lookup_flag(const gchar *flag)
   else if (strcmp(flag, "flow-control") == 0)
     return LC_FLOW_CONTROL;
   else if (strcmp(flag, "drop-unmatched") == 0)
-    return LC_DROP_UNMATCHED;
+    {
+      msg_warning_once("WARNING: The drop-unmatched flag has been removed starting with " VERSION_4_1 ". "
+                       "Setting it has no effect on the log path");
+      return 0;
+    }
   msg_error("Unknown log statement flag", evt_tag_str("flag", flag));
   return 0;
 }
@@ -899,9 +903,6 @@ cfg_tree_propagate_expr_node_properties_to_pipe(LogExprNode *node, LogPipe *pipe
 
   if (node->flags & LC_FLOW_CONTROL)
     pipe->flags |= PIF_HARD_FLOW_CONTROL;
-
-  if (node->flags & LC_DROP_UNMATCHED)
-    pipe->flags |= PIF_DROP_UNMATCHED;
 
   if (!pipe->expr_node)
     pipe->expr_node = node;

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -1231,11 +1231,34 @@ cfg_tree_compile_junction(CfgTree *self,
           if (!join_pipe)
             {
               join_pipe = cfg_tree_new_pipe(self, node, "junction-end");
-              join_pipe->flags |= PIF_JUNCTION_END;
             }
           log_pipe_append(sub_pipe_tail, join_pipe);
 
         }
+    }
+
+  if (fork_mpx)
+    {
+
+      /* Groups of source drivers are enclosed into junctions, so that we
+       * can attach to their tail end and do additional processing on the
+       * emitted messages.
+       *
+       * In the case of sources, messages do not enter the junction in the
+       * front, through the multiplexer, rather these messages originate from
+       * one of the source drivers.
+       *
+       * In this scenario, the junction does not have a multiplexer in front
+       * (hence fork_mpx == NULL) and this also means that we don't have to
+       * close the loop.
+       *
+       * This conditional is only executed for non-source junctions, in
+       * which case we do have a fork_mpx and we need to set
+       * PIF_JUNCTION_END on the tail of the junction.
+       */
+
+      g_assert(node->content != ENC_SOURCE);
+      join_pipe->flags |= PIF_JUNCTION_END;
     }
 
   if (outer_pipe_tail)

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -637,9 +637,9 @@ cfg_tree_assoc_pipe(CfgTree *self, LogExprNode *node, LogPipe *pipe, const gchar
 }
 
 static LogPipe *
-cfg_tree_new_pipe(CfgTree *self, LogExprNode *related_expr)
+cfg_tree_new_pipe(CfgTree *self, LogExprNode *related_expr, const gchar *info)
 {
-  return cfg_tree_assoc_pipe(self, related_expr, log_pipe_new(self->cfg), "cfg_tree_pipe");
+  return cfg_tree_assoc_pipe(self, related_expr, log_pipe_new(self->cfg), info);
 }
 
 static LogMultiplexer *
@@ -821,7 +821,7 @@ cfg_tree_compile_reference(CfgTree *self, LogExprNode *node,
           sub_pipe_tail = referenced_node->aux;
         }
 
-      attach_pipe = cfg_tree_new_pipe(self, node);
+      attach_pipe = cfg_tree_new_pipe(self, node, "source-attach");
 
       if (sub_pipe_tail)
         {
@@ -1057,7 +1057,7 @@ cfg_tree_compile_sequence(CfgTree *self, LogExprNode *node,
                 }
               else
                 {
-                  source_join_pipe = last_pipe = cfg_tree_new_pipe(self, node);
+                  source_join_pipe = last_pipe = cfg_tree_new_pipe(self, node, "source-join");
                 }
             }
           log_pipe_append(sub_pipe_tail, source_join_pipe);
@@ -1074,7 +1074,7 @@ cfg_tree_compile_sequence(CfgTree *self, LogExprNode *node,
   if (!first_pipe && !last_pipe)
     {
       /* this is an empty sequence, insert a do-nothing LogPipe */
-      first_pipe = last_pipe = cfg_tree_new_pipe(self, node);
+      first_pipe = last_pipe = cfg_tree_new_pipe(self, node, "noop");
     }
 
 
@@ -1205,7 +1205,7 @@ cfg_tree_compile_junction(CfgTree *self,
         {
           if (!join_pipe)
             {
-              join_pipe = cfg_tree_new_pipe(self, node);
+              join_pipe = cfg_tree_new_pipe(self, node, "junction-end");
             }
           log_pipe_append(sub_pipe_tail, join_pipe);
 

--- a/lib/cfg-tree.h
+++ b/lib/cfg-tree.h
@@ -55,6 +55,7 @@ enum
   ENL_REFERENCE,
   ENL_SEQUENCE,
   ENL_JUNCTION,
+  ENL_CONDITIONAL,
 };
 
 
@@ -85,6 +86,7 @@ typedef struct _LogExprNode LogExprNode;
  *   - reference:      used to reference log expressions defined elsewhere, no children
  *   - sequence:       holds a sequence of LogExprNodes
  *   - junction:       holds a junction
+ *   - conditional:    holds a conditional (simple or compound if), three children: filter, true_expr, false_expr
  *
  * Sometimes syslog-ng needs to know what kind of object the user
  * originally defined, this is stored in the "content" member.
@@ -153,9 +155,8 @@ LogExprNode *log_expr_node_new_log(LogExprNode *children, guint32 flags, CFG_LTY
 LogExprNode *log_expr_node_new_sequence(LogExprNode *children, CFG_LTYPE *yylloc);
 LogExprNode *log_expr_node_new_junction(LogExprNode *children, CFG_LTYPE *yylloc);
 void log_expr_node_conditional_set_false_branch_of_the_last_if(LogExprNode *conditional_node, LogExprNode *false_expr);
-LogExprNode *log_expr_node_new_conditional_with_filter(LogExprNode *filter_pipe, LogExprNode *true_expr,
-                                                       CFG_LTYPE *yylloc);
-LogExprNode *log_expr_node_new_conditional_with_block(LogExprNode *block, CFG_LTYPE *yylloc);
+LogExprNode *log_expr_node_new_simple_conditional(LogExprNode *filter_expr, LogExprNode *true_expr, CFG_LTYPE *yylloc);
+LogExprNode *log_expr_node_new_compound_conditional(LogExprNode *block, CFG_LTYPE *yylloc);
 
 typedef struct _CfgTree
 {

--- a/lib/cfg-tree.h
+++ b/lib/cfg-tree.h
@@ -37,7 +37,6 @@ const gchar *log_expr_node_get_content_name(gint content);
 #define LC_FALLBACK       2
 #define LC_FINAL          4
 #define LC_FLOW_CONTROL   8
-#define LC_DROP_UNMATCHED 16
 
 enum
 {

--- a/lib/cfg-tree.h
+++ b/lib/cfg-tree.h
@@ -154,6 +154,9 @@ LogExprNode *log_expr_node_new_rewrite_reference(const gchar *name, CFG_LTYPE *y
 LogExprNode *log_expr_node_new_log(LogExprNode *children, guint32 flags, CFG_LTYPE *yylloc);
 LogExprNode *log_expr_node_new_sequence(LogExprNode *children, CFG_LTYPE *yylloc);
 LogExprNode *log_expr_node_new_junction(LogExprNode *children, CFG_LTYPE *yylloc);
+LogExprNode *log_expr_node_new_source_junction(LogExprNode *children, CFG_LTYPE *yylloc);
+LogExprNode *log_expr_node_new_destination_junction(LogExprNode *children, CFG_LTYPE *yylloc);
+
 void log_expr_node_conditional_set_false_branch_of_the_last_if(LogExprNode *conditional_node, LogExprNode *false_expr);
 LogExprNode *log_expr_node_new_simple_conditional(LogExprNode *filter_expr, LogExprNode *true_expr, CFG_LTYPE *yylloc);
 LogExprNode *log_expr_node_new_compound_conditional(LogExprNode *block, CFG_LTYPE *yylloc);

--- a/lib/logmpx.c
+++ b/lib/logmpx.c
@@ -80,14 +80,12 @@ log_multiplexer_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_op
 {
   LogMultiplexer *self = (LogMultiplexer *) s;
   gint i;
-  LogPathOptions local_options = *path_options;
   gboolean matched;
+  LogPathOptions local_options;
   gboolean delivered = FALSE;
   gint fallback;
 
-  local_options.outer_matched = path_options->matched;
-  local_options.matched = &matched;
-
+  log_path_options_push_junction(&local_options, &matched, path_options);
   if (_has_multiple_arcs(self))
     {
       log_msg_write_protect(msg);

--- a/lib/logmpx.c
+++ b/lib/logmpx.c
@@ -79,6 +79,7 @@ log_multiplexer_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_op
   gboolean delivered = FALSE;
   gint fallback;
 
+  local_options.outer_matched = path_options->matched;
   local_options.matched = &matched;
 
   if (_has_multiple_arcs(self))

--- a/lib/logmpx.h
+++ b/lib/logmpx.h
@@ -41,10 +41,13 @@ typedef struct _LogMultiplexer
   LogPipe super;
   GPtrArray *next_hops;
   gboolean fallback_exists;
+  gboolean delivery_propagation;
 } LogMultiplexer;
 
-LogMultiplexer *log_multiplexer_new(GlobalConfig *cfg);
 void log_multiplexer_add_next_hop(LogMultiplexer *self, LogPipe *next_hop);
+void log_multiplexer_disable_delivery_propagation(LogMultiplexer *self);
+
+LogMultiplexer *log_multiplexer_new(GlobalConfig *cfg);
 
 
 #endif

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -46,21 +46,21 @@
 /* indicates that this LogPipe got cloned into the tree already */
 #define PIF_INLINED           0x0002
 
-/* log statement flags that are copied to the head of a branch */
-#define PIF_BRANCH_FINAL      0x0004
-#define PIF_BRANCH_FALLBACK   0x0008
-#define PIF_BRANCH_PROPERTIES (PIF_BRANCH_FINAL + PIF_BRANCH_FALLBACK)
-
-/* branch starting with this pipe wants hard flow control */
-#define PIF_HARD_FLOW_CONTROL 0x0020
-
 /* this pipe is a source for messages, it is not meant to be used to
  * forward messages, syslog-ng will only use these pipes for the
  * left-hand side of the processing graph, e.g. no other pipes may be
  * sending messages to these pipes and these are expected to generate
  * messages "automatically". */
 
-#define PIF_SOURCE            0x0040
+#define PIF_SOURCE            0x0004
+
+/* log statement flags that are copied to the head of a branch */
+#define PIF_BRANCH_FINAL      0x0008
+#define PIF_BRANCH_FALLBACK   0x0010
+#define PIF_BRANCH_PROPERTIES (PIF_BRANCH_FINAL + PIF_BRANCH_FALLBACK)
+
+/* branch starting with this pipe wants hard flow control */
+#define PIF_HARD_FLOW_CONTROL 0x0020
 
 /* node created directly by the user */
 #define PIF_CONFIG_RELATED    0x0080

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -51,8 +51,6 @@
 #define PIF_BRANCH_FALLBACK   0x0008
 #define PIF_BRANCH_PROPERTIES (PIF_BRANCH_FINAL + PIF_BRANCH_FALLBACK)
 
-#define PIF_DROP_UNMATCHED    0x0010
-
 /* branch starting with this pipe wants hard flow control */
 #define PIF_HARD_FLOW_CONTROL 0x0020
 
@@ -397,10 +395,6 @@ log_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
       log_pipe_forward_msg(s, msg, path_options);
     }
 
-  if (path_options->matched && !(*path_options->matched) && (s->flags & PIF_DROP_UNMATCHED))
-    {
-      (*path_options->matched) = TRUE;
-    }
 }
 
 static inline LogPipe *

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -62,8 +62,11 @@
 /* branch starting with this pipe wants hard flow control */
 #define PIF_HARD_FLOW_CONTROL 0x0020
 
+/* LogPipe right after the filter in an "if (filter)" expression */
+#define PIF_CONDITIONAL_MIDPOINT  0x0040
+
 /* LogPipe as the joining element of a junction */
-#define PIF_JUNCTION_END      0x0080
+#define PIF_JUNCTION_END          0x0080
 
 /* node created directly by the user */
 #define PIF_CONFIG_RELATED    0x0100
@@ -379,7 +382,7 @@ log_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
         }
     }
 
-  if (G_UNLIKELY(s->flags & (PIF_HARD_FLOW_CONTROL | PIF_JUNCTION_END)))
+  if (G_UNLIKELY(s->flags & (PIF_HARD_FLOW_CONTROL | PIF_JUNCTION_END | PIF_CONDITIONAL_MIDPOINT)))
     {
       local_path_options = *path_options;
 
@@ -392,6 +395,10 @@ log_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
         {
           local_path_options.matched = path_options->outer_matched;
           local_path_options.outer_matched = NULL;
+        }
+      if (s->flags & PIF_CONDITIONAL_MIDPOINT)
+        {
+          local_path_options.matched = path_options->outer_matched;
         }
       path_options = &local_path_options;
     }

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -62,8 +62,11 @@
 /* branch starting with this pipe wants hard flow control */
 #define PIF_HARD_FLOW_CONTROL 0x0020
 
+/* LogPipe as the joining element of a junction */
+#define PIF_JUNCTION_END      0x0080
+
 /* node created directly by the user */
-#define PIF_CONFIG_RELATED    0x0080
+#define PIF_CONFIG_RELATED    0x0100
 
 /* private flags range, to be used by other LogPipe instances for their own purposes */
 

--- a/lib/metrics-pipe.c
+++ b/lib/metrics-pipe.c
@@ -116,7 +116,6 @@ metrics_pipe_new(GlobalConfig *cfg, const gchar *log_path_name)
 
   self->log_path_name = g_strdup(log_path_name);
 
-  log_pipe_add_info(&self->super, "metrics-pipe");
   log_pipe_add_info(&self->super, self->log_path_name);
 
   return self;

--- a/lib/versioning.h
+++ b/lib/versioning.h
@@ -135,6 +135,7 @@
 #define VERSION_3_38 "syslog-ng 3.38"
 
 #define VERSION_4_0 "syslog-ng 4.0"
+#define VERSION_4_1 "syslog-ng 4.1"
 
 /* VERSION_VALUE_* references versions as integers to be compared against stuff like cfg->user_version */
 /* VERSION_STR_* references versions as strings to be shown to the user */

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -171,6 +171,7 @@ tests/light/functional_tests/logpath/test_named_logpaths_with_catchall_flag.py
 tests/light/functional_tests/logpath/test_named_logpaths_with_fallback_flag.py
 tests/light/functional_tests/logpath/test_named_logpaths_with_final_flag.py
 tests/light/functional_tests/parsers/sdata-parser/test_sdata_parser\.py
+tests/light/functional_tests/logpath/test_conditionals\.py
 tests/light/src/syslog_ng_ctl/prometheus_stats_handler.py
 
 ###########################################################################

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -172,6 +172,7 @@ tests/light/functional_tests/logpath/test_named_logpaths_with_fallback_flag.py
 tests/light/functional_tests/logpath/test_named_logpaths_with_final_flag.py
 tests/light/functional_tests/parsers/sdata-parser/test_sdata_parser\.py
 tests/light/functional_tests/logpath/test_conditionals\.py
+tests/light/functional_tests/logpath/test_midpoint_destinations\.py
 tests/light/src/syslog_ng_ctl/prometheus_stats_handler.py
 
 ###########################################################################

--- a/tests/light/functional_tests/logpath/test_conditionals.py
+++ b/tests/light/functional_tests/logpath/test_conditionals.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2023 Balazs Scheidler <bazsi77@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from src.syslog_ng_config.renderer import render_statement
+
+
+def create_config(config, test_config, msg="foobar"):
+    file_true = config.create_file_destination(file_name="dest-true.log", template="'$MSG\n'")
+    file_false = config.create_file_destination(file_name="dest-false.log", template="'$MSG\n'")
+    file_after = config.create_file_destination(file_name="dest-after.log", template="'$MSG\n'")
+    file_fallback = config.create_file_destination(file_name="dest-fallback.log", template="'$MSG\n'")
+
+    preamble = f"""
+@version: {config.get_version()}
+
+options {{ stats(level(1)); }};
+
+block filter true() {{
+    "1" eq "1"
+}};
+
+block filter false() {{
+    "0" eq "1"
+}};
+
+source genmsg {{
+    example-msg-generator(num(1) template("{msg}"));
+}};
+
+destination dest_after {{
+    {render_statement(file_after)};
+}};
+
+destination dest_true {{
+    {render_statement(file_true)};
+}};
+
+destination dest_false {{
+    {render_statement(file_false)};
+}};
+
+destination dest_fallback {{
+    {render_statement(file_fallback)};
+}};
+
+log {{
+    source(genmsg);
+    destination(dest_fallback);
+    flags(fallback);
+}};
+
+"""
+    config.set_raw_config(preamble + test_config)
+    return (file_true, file_false, file_after, file_fallback)
+
+
+def test_simple_if(config, syslog_ng):
+    test_config = """
+
+log {
+    source(genmsg);
+    if (true()) {
+        destination(dest_true);
+    } else {
+        destination(dest_false);
+    };
+
+    destination(dest_after);
+};
+"""
+    (file_true, file_false, file_after, file_fallback) = create_config(config, test_config)
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_after.get_stats()["processed"] == 1
+    assert "processed" not in file_fallback.get_stats()
+
+    assert file_true.read_log() == "foobar\n"
+    assert file_after.read_log() == "foobar\n"
+
+
+def test_simple_if_negated(config, syslog_ng):
+    test_config = """
+
+log {
+    source(genmsg);
+    if (false()) {
+        destination(dest_true);
+    } else {
+        destination(dest_false);
+    };
+
+    destination(dest_after);
+};
+"""
+    (file_true, file_false, file_after, file_fallback) = create_config(config, test_config)
+    syslog_ng.start(config)
+
+    assert "processed" not in file_true.get_stats()
+    assert file_false.get_stats()["processed"] == 1
+    assert file_after.get_stats()["processed"] == 1
+    assert "processed" not in file_fallback.get_stats()
+    assert file_false.read_log() == "foobar\n"
+    assert file_after.read_log() == "foobar\n"
+
+
+def test_simple_if_that_drops_in_all_branches(config, syslog_ng):
+    test_config = """
+
+log {
+    source(genmsg);
+    if (true()) {
+        filter { false(); };
+        destination(dest_true);
+    } else {
+        destination(dest_false);
+    };
+
+    destination(dest_after);
+};
+"""
+    (file_true, file_false, file_after, file_fallback) = create_config(config, test_config)
+    syslog_ng.start(config)
+
+    assert "processed" not in file_true.get_stats()
+    assert "processed" not in file_false.get_stats()
+    assert "processed" not in file_after.get_stats()
+    assert file_fallback.get_stats()["processed"] == 1
+
+    assert file_fallback.read_log() == "foobar\n"
+
+
+def test_compound_if(config, syslog_ng):
+    test_config = """
+
+log {
+    source(genmsg);
+    if {
+        filter { true(); };
+        destination(dest_true);
+    } else {
+        destination(dest_false);
+    };
+
+    destination(dest_after);
+};
+"""
+    (file_true, file_false, file_after, file_fallback) = create_config(config, test_config)
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_after.get_stats()["processed"] == 1
+    assert "processed" not in file_fallback.get_stats()
+
+    assert file_true.read_log() == "foobar\n"
+    assert file_after.read_log() == "foobar\n"
+
+
+def test_compound_if_negated_continues_in_the_false_expr(config, syslog_ng):
+    test_config = """
+
+log {
+    source(genmsg);
+    if {
+        filter { false(); };
+        destination(dest_true);
+    } else {
+        destination(dest_false);
+    };
+
+    destination(dest_after);
+};
+"""
+    (file_true, file_false, file_after, file_fallback) = create_config(config, test_config)
+    syslog_ng.start(config)
+
+    assert "processed" not in file_true.get_stats()
+    assert file_false.get_stats()["processed"] == 1
+    assert file_after.get_stats()["processed"] == 1
+    assert "processed" not in file_fallback.get_stats()
+    assert file_false.read_log() == "foobar\n"
+    assert file_after.read_log() == "foobar\n"
+
+
+def test_compound_if_that_drops_in_all_branches(config, syslog_ng):
+    test_config = """
+
+log {
+    source(genmsg);
+    if {
+        filter { false(); };
+        destination(dest_true);
+    } else {
+        filter { false(); };
+        destination(dest_false);
+    };
+
+    destination(dest_after);
+};
+"""
+    (file_true, file_false, file_after, file_fallback) = create_config(config, test_config)
+    syslog_ng.start(config)
+
+    assert "processed" not in file_true.get_stats()
+    assert "processed" not in file_false.get_stats()
+    assert "processed" not in file_after.get_stats()
+    assert file_fallback.get_stats()["processed"] == 1
+
+    assert file_fallback.read_log() == "foobar\n"
+
+
+def test_compound_if_with_messages_dropped_after_if(config, syslog_ng):
+    test_config = """
+
+log {
+    source(genmsg);
+    if {
+        filter { true(); };
+        destination(dest_true);
+    } else {
+        destination(dest_false);
+    };
+
+    filter { false(); };
+    destination(dest_after);
+};
+"""
+    (file_true, file_false, file_after, file_fallback) = create_config(config, test_config)
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert "processed" not in file_after.get_stats()
+    assert file_fallback.get_stats()["processed"] == 1
+
+    assert file_true.read_log() == "foobar\n"
+    assert file_fallback.read_log() == "foobar\n"

--- a/tests/light/functional_tests/logpath/test_midpoint_destinations.py
+++ b/tests/light/functional_tests/logpath/test_midpoint_destinations.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2023 Balazs Scheidler <bazsi77@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from src.syslog_ng_config.renderer import render_statement
+
+
+def create_config(config, test_config, msg="foobar"):
+    file_true = config.create_file_destination(file_name="dest-true.log", template="'$MSG\n'")
+    file_false = config.create_file_destination(file_name="dest-false.log", template="'$MSG\n'")
+    file_after = config.create_file_destination(file_name="dest-after.log", template="'$MSG\n'")
+    file_fallback = config.create_file_destination(file_name="dest-fallback.log", template="'$MSG\n'")
+    file_dropall = config.create_file_destination(file_name="dest-dropall.log", template="'$MSG\n'")
+
+    preamble = f"""
+@version: {config.get_version()}
+
+options {{ stats-level(1); }};
+
+block filter true() {{
+    "1" eq "1"
+}};
+
+block filter false() {{
+    "0" eq "1"
+}};
+
+source genmsg {{
+    example-msg-generator(num(1) template("{msg}"));
+}};
+
+destination dest_after {{
+    {render_statement(file_after)};
+}};
+
+destination dest_true {{
+    {render_statement(file_true)};
+}};
+
+destination dest_false {{
+    {render_statement(file_false)};
+}};
+
+destination dest_fallback {{
+    {render_statement(file_fallback)};
+}};
+
+destination dest_dropall {{
+    channel {{
+        filter {{ false(); }};
+        destination {{ {render_statement(file_dropall)}; }};
+    }};
+}};
+
+log {{
+    source(genmsg);
+    destination(dest_fallback);
+    flags(fallback);
+}};
+
+"""
+    config.set_raw_config(preamble + test_config)
+    return (file_true, file_false, file_after, file_fallback, file_dropall)
+
+
+def test_midpoint_destination_that_drops_all_messages_does_not_cause_message_to_be_unmatched(config, syslog_ng):
+    # Rationale:
+    #
+    #   midpoint destinations which drop messages completely do it in their
+    #   own context which should not affect the log path as a whole.  As far
+    #   as the log path is concerned, the message was successfully
+    #   dispatched to the destination.
+    test_config = """
+
+log {
+    source(genmsg);
+    destination(dest_dropall);
+    destination(dest_after);
+};
+"""
+    (file_true, file_false, file_after, file_fallback, file_dropall) = create_config(config, test_config)
+    syslog_ng.start(config)
+
+    assert "processed" not in file_dropall.get_stats()
+    assert file_after.get_stats()["processed"] == 1
+    assert "processed" not in file_fallback.get_stats()
+
+    assert file_after.read_log() == "foobar\n"
+
+
+def test_midpoint_inline_destination_that_drops_all_messages_does_not_cause_message_to_be_unmatched(config, syslog_ng):
+    # Rationale:
+    #
+    #   midpoint destinations which drop messages completely do it in their
+    #   own context which should not affect the log path as a whole.  As far
+    #   as the log path is concerned, the message was successfully
+    #   dispatched to the destination.
+    test_config = """
+
+log {
+    source(genmsg);
+    destination {
+        channel { filter { false(); }; };
+    };
+    destination(dest_after);
+};
+"""
+    (file_true, file_false, file_after, file_fallback, file_dropall) = create_config(config, test_config)
+    syslog_ng.start(config)
+
+    assert "processed" not in file_dropall.get_stats()
+    assert file_after.get_stats()["processed"] == 1
+    assert "processed" not in file_fallback.get_stats()
+
+    assert file_after.read_log() == "foobar\n"
+
+
+def test_filter_between_destinations_that_drops_all_messages_causes_the_message_to_be_unmatched(config, syslog_ng):
+    # Rationale:
+    #
+    #   In this case the filter() is part of the log path and the path is
+    #   not processed completely because the filter dropped the message.
+    #   The anticipated use-case here is that the first destination serves
+    #   debugging purposes only, and the delivery of the message to that
+    #   destination does not mean that the log path was successfully
+    #   finished.
+
+    test_config = """
+
+log {
+    source(genmsg);
+    destination(dest_true);
+    filter { false(); };
+    destination(dest_after);
+};
+"""
+    (file_true, file_false, file_after, file_fallback, _) = create_config(config, test_config)
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_after.get_stats()
+    assert file_fallback.get_stats()["processed"] == 1
+
+    assert file_true.read_log() == "foobar\n"
+    assert file_fallback.read_log() == "foobar\n"
+
+
+def test_junction_that_drops_messages_in_all_branches_causes_the_message_to_be_unmatched(config, syslog_ng):
+
+    test_config = """
+
+log {
+    source(genmsg);
+    destination(dest_true);
+    junction {
+        channel { filter { false(); }; };
+        channel { filter { false(); }; };
+    };
+    destination(dest_after);
+};
+"""
+    (file_true, file_false, file_after, file_fallback, _) = create_config(config, test_config)
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_after.get_stats()
+    assert file_fallback.get_stats()["processed"] == 1
+
+    assert file_true.read_log() == "foobar\n"
+    assert file_fallback.read_log() == "foobar\n"
+
+
+def test_junction_that_drops_messages_in_all_branches_causes_the_message_to_be_unmatched_even_if_they_reference_destinations(config, syslog_ng):
+
+    test_config = """
+
+log {
+    source(genmsg);
+    junction {
+        channel {
+            destination(dest_true);
+            filter { false(); };
+            destination(dest_false);
+        };
+        channel { filter { false(); }; };
+    };
+    destination(dest_after);
+};
+"""
+    (file_true, file_false, file_after, file_fallback, _) = create_config(config, test_config)
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert "processed" not in file_after.get_stats()
+    assert file_fallback.get_stats()["processed"] == 1
+
+    assert file_true.read_log() == "foobar\n"
+    assert file_fallback.read_log() == "foobar\n"
+
+
+def test_junction_that_contains_message_dropping_destination_continues_to_deliver_messages_on_the_same_path(config, syslog_ng):
+
+    test_config = """
+
+log {
+    source(genmsg);
+    junction {
+        channel {
+            destination(dest_dropall);
+            destination(dest_true);
+        };
+        channel { filter { false(); }; destination(dest_false); };
+    };
+    destination(dest_after);
+};
+"""
+    (file_true, file_false, file_after, file_fallback, file_dropall) = create_config(config, test_config)
+    syslog_ng.start(config)
+
+    assert "processed" not in file_dropall.get_stats()
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+
+    assert file_after.get_stats()["processed"] == 1
+    assert "processed" not in file_fallback.get_stats()
+
+    assert file_true.read_log() == "foobar\n"
+    assert file_after.read_log() == "foobar\n"

--- a/tests/light/src/syslog_ng_config/statements/destinations/destination_driver.py
+++ b/tests/light/src/syslog_ng_config/statements/destinations/destination_driver.py
@@ -25,6 +25,7 @@ from src.syslog_ng_ctl.driver_stats_handler import DriverStatsHandler
 
 class DestinationDriver(object):
     group_type = "destination"
+    driver_instance = ""
 
     def __init__(self, positional_parameters=None, options=None):
         if positional_parameters is None:
@@ -33,7 +34,7 @@ class DestinationDriver(object):
         if options is None:
             options = {}
         self.options = options
-        self.stats_handler = DriverStatsHandler(group_type=self.group_type, driver_name=self.driver_name)
+        self.stats_handler = DriverStatsHandler(group_type=self.group_type, driver_name=self.driver_name, instance=self.driver_instance)
 
     def get_stats(self):
         return self.stats_handler.get_stats()

--- a/tests/light/src/syslog_ng_config/statements/destinations/file_destination.py
+++ b/tests/light/src/syslog_ng_config/statements/destinations/file_destination.py
@@ -29,6 +29,7 @@ from src.syslog_ng_config.statements.destinations.destination_driver import Dest
 class FileDestination(DestinationDriver):
     def __init__(self, file_name, **options):
         self.driver_name = "file"
+        self.driver_instance = file_name
         self.path = Path(file_name)
         self.io = FileIO(self.path)
         super(FileDestination, self).__init__([self.path], options)

--- a/tests/light/src/syslog_ng_ctl/driver_stats_handler.py
+++ b/tests/light/src/syslog_ng_ctl/driver_stats_handler.py
@@ -27,7 +27,7 @@ from src.syslog_ng_ctl.syslog_ng_ctl import SyslogNgCtl
 
 
 class DriverStatsHandler(object):
-    def __init__(self, group_type, driver_name):
+    def __init__(self, group_type, driver_name, instance=""):
         if group_type == "destination":
             statement_short_name = "dst"
             self.component = "{}.{}".format(statement_short_name, driver_name)
@@ -41,6 +41,7 @@ class DriverStatsHandler(object):
         else:
             raise Exception("Unknown group_type: {}".format(group_type))
 
+        self.instance = instance
         self.syslog_ng_ctl = SyslogNgCtl(tc_parameters.INSTANCE_PATH)
 
     def build_query_pattern(self):
@@ -85,7 +86,7 @@ class DriverStatsHandler(object):
     def filter_stats_result(self, stats_result, stats_pattern):
         filtered_list = []
         for stats_line in stats_result:
-            if stats_pattern in stats_line:
+            if stats_pattern in stats_line and self.instance in stats_line:
                 filtered_list.append(stats_line)
         return filtered_list
 


### PR DESCRIPTION
This PR started out as a fix for an issue reported by @faxm0dem on gitter, with config and patterndb here: https://gist.github.com/faxm0dem/3dfc0873842d4c05ebcd8cb7f8eda8ab

The issue turned out to be an issue how we process the "unmatched" state for a log path. With time, another case came up in #4339 and it turns out we have a limited-incomplete definition on how we define that a log path did not match.

Since this is a complicated issue, let me try to write this up, hopefully it will be useful for my future self or anyone trying to understand the compilation process.

So let's take one step back. 

**Why do we need the notion of a message being "unmatched" for a log path?**

syslog-ng supports both independent and dependent log paths. An independent one is simple: let's take the stream of messages and route them to multiple outputs. These outputs are independent, as one output does not depend on the result of the other.

For example, there are two independent outgoing paths from the `whatever` source:

```
log {
    source(whatever);
    log {
        filter(app1);
        destination(app1_logfile);
   };
   log {
       filter(app2);
       destinatrion(app2_logfile);
   };
};
```

Sometimes however we only want to take a route if a previous did not match, like this:


```
log {
    source(whatever);
    log {
        filter(app1);
        destination(app1_logfile);
        flags(final);
   };
   log {
       destinatrion(catchall_logfile);
   };
};
```

Notice the "final" flag in the first log {} statement. This means that if the first log statement "matches", the 2nd is not processed at all. This form of routing is sometimes easier to write, but it also means that syslog-ng needs the notion of whether a message matched a specific log path.

Sometimes, we have hundreds of these log {} rules in a configuration, syslog-ng trying to match the right one automatically.

**So what does it mean that a message matches?**

In simple cases, a message is assumed to always match a path, **unless** a filter or parser drops it. From the example above:

```
    log {
        filter(app1);
        destination(app1_logfile);
        flags(final);
   };
```

if `filter(app1)` matches the message, this log path would match. If it does not, then the entire path is considered unmatching.

**What about complex cases?**

syslog-ng's language is flexible enough to route messages around based on complex criteria. So a simple filter might actually be a complex set of parsing/filtering/processing rules, hidden behind a single line of reference. Just look at our cisco parser (https://github.com/syslog-ng/syslog-ng/blob/master/scl/cisco/plugin.conf).

**What about destinations?**

So knowing what is "matching" is super useful. But what is considered a match, if we have "multiple" exit points from a log path:

Let's look at this example:

```
log {
    source(whatever);
    destination(dest1);
    filter(filter_app);
    destination(dest2);
};
```

As you can see, `dest1` and `dest2` are both destinations of this log path. `dest1` would get a copy of all messages while `dest2` would only get those that match the filter `filter_app`. What message is "matching" this log path?

Those that reach the first destination? Or those that also reach the second one too?

While this configuration may not make sense in most cases, sometimes it is pretty useful. If you want to debug your configuration for example, then using a destination right in the middle-point would make sense. You could get a sample of what the messages look like that traverse this part of the configuration.

I decided that a log path is considered matching if it fully matches _all_ filtering elements along a log path, with the exception of filtering done by destinations themselves.  If a destination were to drop messages as a part of its operation, the log path that references this destination would still be matching. This more or less matches existing behaviour except for implementation bugs. These bugs are now fixed and the definition above is the guiding rule.

This means that this rule would not match if `filter_app` does not match:

```
log {
    source(whatever);
    destination(dest1);
    filter(filter_app);
    destination(dest2);
};
```

While this is doing the same, this would actually be matching:

```
log {
    source(whatever);
    destination(dest1);
    destination {
        log {
            filter(filter_app);
            destination(dest2);
        };
    };
};
```

The reason this would match is that the filter at this time is part of a "destination" reference, and filtering embedded in destinations do not affect the parent log path. This is useful when a destination wants to be selective about what is delivered and what is not. It may have relatively complex rules that affect delivery of messages.

**What else?**

Another closely related issue was conditional evaluation, which is also fixed here.

The problem was roughly this:

```
log {
    if {
       parser { something-that-parses-a-message-and-drops-it-if-invalid-format() };
    } else {
       parser { unmatched-messages-are-processed-here(); };
    };
    ...
    ...
    filter { we-drop-message-here(); };
};
```

Without this PR, the else branch of the if statements could be taken, even if the parser in the if branch itself was successful/matching. The reason that happened was that the "unmatched" state from the subsequent filter was propagated back to the if (incorrectly!), which caused the else to be taken (as well).

**What is in this PR**

So here's a list of changes in this PR:
  * it fixes the bug in conditional evaluation (if/else/elif) by using a new ENL_CONDITIONAL expr node and dropping an older, partial solution of the same problem (LC_DROP_UNMATCHED)
  * it defines the midpoint destination problem and makes sure destinations don't propagate their matched state to the parent logpath.
  * it adds more details into the "info" member of log paths
  * it adds light based tests to exercise both the conditional evaluation and the midpoint destination cases
