### PR TITLE
afuser: Fix more utmp buffer overruns

### DIFF
--- a/modules/afuser/afuser.c
+++ b/modules/afuser/afuser.c
@@ -140,7 +140,7 @@ afuser_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
     {
       if (_utmp_entry_matches(ut, self->username))
         {
-          gchar line[128];
+          gchar line[5 + G_N_ELEMENTS(ut->ut_line) + 1]; /* /dev/ prefix, line device name, null terminator */
           gchar *p = line;
           int fd;
 
@@ -149,9 +149,11 @@ afuser_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
               strcpy(line, "/dev/");
               p = line + 5;
             }
-          else
-            line[0] = 0;
-          strncpy(p, ut->ut_line, MIN(sizeof(ut->ut_line), sizeof(line) - (p - line)));
+
+          /* ut_line may not be null-terminated. Copy it and ensure it's null-terminated. */
+          strncpy(p, ut->ut_line, G_N_ELEMENTS(ut->ut_line));
+          p[G_N_ELEMENTS(ut->ut_line)] = 0;
+
           msg_debug("Posting message to user terminal",
                     evt_tag_str("user", _get_utmp_username(ut)),
                     evt_tag_str("line", line));


### PR DESCRIPTION
Hello!

Previously commit 816d2eca2c already fixed an issue with a potential buffer overrun in afuser's utmp buffer handling, but it looks like there are two more issues:
* The `line` buffer was not getting null-terminated if `strncpy()` hit the requested limit of 32 chars without encountering a null terminator in `ut_line`, causing the `open()` and debug/error messages afterwards to potentially overrun the `line` buffer. This can only happen with tty device names >= 32 chars (which is rare, I know :)).
* The `ut_user/ut_name` field was used in debug/error messages as if it was null-terminated (`passed to evt_tag_str()`), but it may also be non-null-terminated, just like `ut_line`.

The two patches should fix this. I've been testing them here both with master and with syslog-ng 3.31.2, on an embedded Linux system.

For testing I used a hackish approach:
* Added some users with names with lengths 31, 32, 33. The user name with 33 chars is truncated to 32 chars in ut->ut_user, as expected. Both cases with 32 chars are not null-terminated.
* Simulated unique tty device names for each user by overwriting `ut_line` in `afuser_dd_queue()`: lengths 31, 32 and 32 (since 33 is not possible to store in ut_line). Both cases with 32 chars are not null-terminated.
* Created symlinks for the fake tty names to a real tty.

The user & tty names with lengths 31 work as before. The ones with length 32 now work as expected too (no more failing to open(), no more junk or worse in error & debug messages). Users > 32 chars may work, since `_utmp_entry_matches()` allows partial matches, but it may also match incorrectly (if there are multiple users or `usertty()` instances with names with common prefixes). The same issue exists with tty names > 32 chars - they're also truncated by utmp, so either `open()` will fail now, or it may open the wrong tty, if there is one that matches the truncated name.