### PR TITLE
Fix rewrite set tag

### DIFF
--- a/lib/rewrite/rewrite-set-tag.c
+++ b/lib/rewrite/rewrite-set-tag.c
@@ -100,6 +100,8 @@ log_rewrite_set_tag_new(LogTemplate *tag_template, gboolean value, GlobalConfig 
   self->super.process = _process;
   self->value = value;
 
+  self->tag_template = log_template_ref(tag_template);
+
   if (log_template_is_literal_string(tag_template))
     {
       const gchar *tag_name = log_template_get_literal_value(tag_template, NULL);
@@ -107,7 +109,6 @@ log_rewrite_set_tag_new(LogTemplate *tag_template, gboolean value, GlobalConfig 
     }
   else
     {
-      self->tag_template = log_template_ref(tag_template);
       self->tag_id = LOG_TAGS_UNDEF;
     }
 

--- a/lib/rewrite/tests/test_set_tag.c
+++ b/lib/rewrite/tests/test_set_tag.c
@@ -87,6 +87,42 @@ Test(set_tag, templates_in_set_tag)
   assert_log_message_doesnt_have_tag(msg, "tag-BARFOO");
 }
 
+Test(set_tag, clone_template)
+{
+  LogTemplate *template = log_template_new(cfg, "dummy");
+  cr_assert(log_template_compile(template, "not literal $MESSAGE", NULL));
+  LogRewrite *rewrite = log_rewrite_set_tag_new(template, true, cfg);
+
+  LogRewrite *clone = (LogRewrite *)log_pipe_clone(&rewrite->super);
+
+  cr_assert(log_pipe_init(&rewrite->super));
+  cr_assert(log_pipe_init(&clone->super));
+
+  cr_assert(log_pipe_deinit(&rewrite->super));
+  cr_assert(log_pipe_deinit(&clone->super));
+
+  log_pipe_unref(&rewrite->super);
+  log_pipe_unref(&clone->super);
+}
+
+Test(set_tag, clone_tag_id)
+{
+  LogTemplate *template = log_template_new(cfg, "dummy");
+  cr_assert(log_template_compile(template, "syslog", NULL));
+  LogRewrite *rewrite = log_rewrite_set_tag_new(template, true, cfg);
+
+  LogRewrite *clone = (LogRewrite *)log_pipe_clone(&rewrite->super);
+
+  cr_assert(log_pipe_init(&rewrite->super));
+  cr_assert(log_pipe_init(&clone->super));
+
+  cr_assert(log_pipe_deinit(&rewrite->super));
+  cr_assert(log_pipe_deinit(&clone->super));
+
+  log_pipe_unref(&rewrite->super);
+  log_pipe_unref(&clone->super);
+}
+
 static void
 setup(void)
 {

--- a/news/bugfix-4065.md
+++ b/news/bugfix-4065.md
@@ -1,0 +1,1 @@
+set-tag: fix cloning issue when string literal were used (see #4062)


### PR DESCRIPTION
Fixes #4062

The template were not saved when literal template were detected, in case of clonning the template is required to construct a new object.