### PR TITLE
github-actions: add "comment on missing news file" job

### DIFF
--- a/.github/workflows/comment-on-missing-news-file.yml
+++ b/.github/workflows/comment-on-missing-news-file.yml
@@ -1,0 +1,36 @@
+##################################################################################
+# If a new PR is opened and it lacks news file, then give them a gentle reminder.#
+##################################################################################
+
+name: Comment on missing news file
+
+on:
+  # For workflows that are triggered by the pull_request_target event,
+  # the GITHUB_TOKEN is granted read/write repository permission
+  # unless the permissions key is specified and the workflow can access secrets,
+  # even when it is triggered from a fork
+  # See: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+  pull_request_target:
+    types: [opened]
+    paths-ignore:
+      - 'news/*-*.md'
+
+jobs:
+  comment-on-missing-news-file:
+    runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write
+
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Comment
+        run: |
+          COMMENT_ENDPOINT=repos/${{ github.repository_owner }}/syslog-ng/issues/${{ github.event.number }}/comments
+          COMMENT="No news file has been detected. Please write one, if applicable."
+
+          hub api \
+            ${COMMENT_ENDPOINT} \
+            --field body="${COMMENT}"
+


### PR DESCRIPTION
This PR adds a new GitHub Actions job, which will give a subtle a reminder comment regarding missing news file(s) on Pull Request opening.

Currently it will only comment once, when the pull request is opened. If the PR branch had been updated and no news file was written, then it won't comment again.

See the following example runs (all other jobs had been disabled for clarity's sake):

- [news file exists](https://github.com/OverOrion/syslog-ng/pull/28)
- [news file does NOT exist](https://github.com/OverOrion/syslog-ng/pull/27)
- [news file did not exist at PR opening, was added later](https://github.com/OverOrion/syslog-ng/pull/26)
-----

Question(s) to the reviewers: 
- Should I add a link to the [news/README.md](https://github.com/syslog-ng/syslog-ng/blob/master/news/README.md) file?


Signed-off-by: Szilárd Parrag <szilard.parrag@gmail.com>
