### PR TITLE
Light: Add support for network based destinations

### DIFF
--- a/tests/light/functional_tests/Makefile.am
+++ b/tests/light/functional_tests/Makefile.am
@@ -5,6 +5,7 @@ EXTRA_DIST += \
 	tests/light/functional_tests/config_change/test_manipulating_config_between_reload.py \
 	tests/light/functional_tests/conftest.py \
 	tests/light/functional_tests/destination_drivers/example_destination/test_example_destination.py \
+	tests/light/functional_tests/destination_drivers/network_destination/test_network_destination_transport.py \
 	tests/light/functional_tests/destination_drivers/snmp_destination/general/test_snmp_destination_acceptance.py \
 	tests/light/functional_tests/destination_drivers/snmp_destination/general/test_snmp_destination_missing_snmp_obj.py \
 	tests/light/functional_tests/destination_drivers/snmp_destination/general/test_snmp_destination_missing_trap_obj.py \

--- a/tests/light/functional_tests/Makefile.am
+++ b/tests/light/functional_tests/Makefile.am
@@ -14,6 +14,8 @@ EXTRA_DIST += \
 	tests/light/functional_tests/destination_drivers/snmp_destination/v2c/test_snmp_destination_v2c_cisco_ios_traps.py \
 	tests/light/functional_tests/destination_drivers/snmp_destination/v2c/test_snmp_destination_v2c_custom_community.py \
 	tests/light/functional_tests/destination_drivers/snmp_destination/v2c/test_snmp_destination_v2c_using_macro_snmp_obj.py \
+	tests/light/functional_tests/destination_drivers/unix_dgram_destination/test_unix_dgram_destination.py \
+	tests/light/functional_tests/destination_drivers/unix_stream_destination/test_unix_stream_destination.py \
 	tests/light/functional_tests/filters/test_filter_reference.py \
 	tests/light/functional_tests/filters/rate-limit/test_rate_limit_filter_acceptance.py \
 	tests/light/functional_tests/logpath/test_flags_catch_all.py \

--- a/tests/light/functional_tests/destination_drivers/network_destination/test_network_destination_transport.py
+++ b/tests/light/functional_tests/destination_drivers/network_destination/test_network_destination_transport.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2022 One Identity
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import pytest
+
+
+@pytest.mark.parametrize(
+    "transport", [
+        None,
+        "tcp",
+        "udp",
+    ], ids=["default", "tcp", "udp"],
+)
+def test_network_destination_transport(config, syslog_ng, port_allocator, transport):
+    counter = 100
+    message = "message text"
+
+    generator_source = config.create_example_msg_generator_source(num=counter, freq=0.0001, template=config.stringify(message))
+    if transport is not None:
+        network_destination = config.create_network_destination(ip="localhost", port=port_allocator(), transport=transport)
+    else:
+        network_destination = config.create_network_destination(ip="localhost", port=port_allocator())
+    config.create_logpath(statements=[generator_source, network_destination])
+
+    network_destination.start_listener()
+    syslog_ng.start(config)
+    assert network_destination.read_until_logs([message] * counter)

--- a/tests/light/functional_tests/destination_drivers/unix_dgram_destination/test_unix_dgram_destination.py
+++ b/tests/light/functional_tests/destination_drivers/unix_dgram_destination/test_unix_dgram_destination.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2022 One Identity
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from pathlib2 import Path
+
+import src.testcase_parameters.testcase_parameters as tc_parameters
+
+
+def test_unix_dgram_destination(config, syslog_ng):
+    counter = 100
+    message = "message text"
+
+    generator_source = config.create_example_msg_generator_source(num=counter, freq=0.0001, template=config.stringify(message))
+    # NOTE: In this iteration testcase is responsible for generating proper output path (because of socket path length), this will be changed in the future
+    relative_unix_dgram_path = Path(tc_parameters.WORKING_DIR, "output_unix_dgram").relative_to(Path.cwd())
+    unix_dgram_destination = config.create_unix_dgram_destination(file_name=relative_unix_dgram_path)
+    config.create_logpath(statements=[generator_source, unix_dgram_destination])
+
+    unix_dgram_destination.start_listener()
+    syslog_ng.start(config)
+    assert unix_dgram_destination.read_until_logs([message] * counter)
+    assert unix_dgram_destination.get_stats()["written"] == counter

--- a/tests/light/functional_tests/destination_drivers/unix_stream_destination/test_unix_stream_destination.py
+++ b/tests/light/functional_tests/destination_drivers/unix_stream_destination/test_unix_stream_destination.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2022 One Identity
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from pathlib2 import Path
+
+import src.testcase_parameters.testcase_parameters as tc_parameters
+
+
+def test_unix_stream_destination(config, syslog_ng):
+    counter = 100
+    message = "message text"
+
+    generator_source = config.create_example_msg_generator_source(num=counter, freq=0.0001, template=config.stringify(message))
+    # NOTE: In this iteration testcase is responsible for generating proper output path (because of socket path length), this will be changed in the future
+    relative_unix_stream_path = Path(tc_parameters.WORKING_DIR, "output_unix_stream").relative_to(Path.cwd())
+    unix_stream_destination = config.create_unix_stream_destination(file_name=relative_unix_stream_path)
+    config.create_logpath(statements=[generator_source, unix_stream_destination])
+
+    unix_stream_destination.start_listener()
+    syslog_ng.start(config)
+    assert unix_stream_destination.read_until_logs([message] * counter)
+    assert unix_stream_destination.get_stats()["written"] == counter

--- a/tests/light/src/Makefile.am
+++ b/tests/light/src/Makefile.am
@@ -20,6 +20,7 @@ EXTRA_DIST += \
 	tests/light/src/driver_io/__init__.py \
 	tests/light/src/driver_io/network/__init__.py \
 	tests/light/src/driver_io/network/network_io.py \
+	tests/light/src/driver_io/message_readers.py \
 	tests/light/src/executors/command_executor.py \
 	tests/light/src/executors/__init__.py \
 	tests/light/src/executors/process_executor.py \

--- a/tests/light/src/Makefile.am
+++ b/tests/light/src/Makefile.am
@@ -5,6 +5,7 @@ EXTRA_DIST += \
 	tests/light/src/common/blocking.py \
 	tests/light/src/common/__init__.py \
 	tests/light/src/common/file.py \
+	tests/light/src/common/network.py \
 	tests/light/src/common/network_operations.py \
 	tests/light/src/common/operations.py \
 	tests/light/src/common/pytest_operations.py \

--- a/tests/light/src/Makefile.am
+++ b/tests/light/src/Makefile.am
@@ -1,6 +1,7 @@
 
 #find -name '*.py'|awk '{ print "\ttests/light/src/"substr($0,3); }'|sort
 EXTRA_DIST += \
+	tests/light/src/common/asynchronous.py \
 	tests/light/src/common/blocking.py \
 	tests/light/src/common/__init__.py \
 	tests/light/src/common/file.py \

--- a/tests/light/src/Makefile.am
+++ b/tests/light/src/Makefile.am
@@ -46,6 +46,7 @@ EXTRA_DIST += \
 	tests/light/src/syslog_ng_config/statements/destinations/example_destination.py \
 	tests/light/src/syslog_ng_config/statements/destinations/file_destination.py \
 	tests/light/src/syslog_ng_config/statements/destinations/__init__.py \
+	tests/light/src/syslog_ng_config/statements/destinations/network_destination.py \
 	tests/light/src/syslog_ng_config/statements/destinations/snmp_destination.py \
 	tests/light/src/syslog_ng_config/statements/filters/filter.py \
 	tests/light/src/syslog_ng_config/statements/filters/__init__.py \

--- a/tests/light/src/Makefile.am
+++ b/tests/light/src/Makefile.am
@@ -49,6 +49,7 @@ EXTRA_DIST += \
 	tests/light/src/syslog_ng_config/statements/destinations/network_destination.py \
 	tests/light/src/syslog_ng_config/statements/destinations/snmp_destination.py \
 	tests/light/src/syslog_ng_config/statements/destinations/unix_dgram_destination.py \
+	tests/light/src/syslog_ng_config/statements/destinations/unix_stream_destination.py \
 	tests/light/src/syslog_ng_config/statements/filters/filter.py \
 	tests/light/src/syslog_ng_config/statements/filters/__init__.py \
 	tests/light/src/syslog_ng_config/statements/__init__.py \

--- a/tests/light/src/Makefile.am
+++ b/tests/light/src/Makefile.am
@@ -48,6 +48,7 @@ EXTRA_DIST += \
 	tests/light/src/syslog_ng_config/statements/destinations/__init__.py \
 	tests/light/src/syslog_ng_config/statements/destinations/network_destination.py \
 	tests/light/src/syslog_ng_config/statements/destinations/snmp_destination.py \
+	tests/light/src/syslog_ng_config/statements/destinations/unix_dgram_destination.py \
 	tests/light/src/syslog_ng_config/statements/filters/filter.py \
 	tests/light/src/syslog_ng_config/statements/filters/__init__.py \
 	tests/light/src/syslog_ng_config/statements/__init__.py \

--- a/tests/light/src/common/asynchronous.py
+++ b/tests/light/src/common/asynchronous.py
@@ -1,0 +1,58 @@
+#############################################################################
+# Copyright (c) 2022 One Identity
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import asyncio
+import concurrent
+import threading
+
+
+class BackgroundEventLoop(object):
+    """Singleton event loop running in the background"""
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(BackgroundEventLoop, cls).__new__(cls)
+            cls._instance._init()
+        return cls._instance
+
+    def _init(self):
+        self.loop = asyncio.new_event_loop()
+        self.thread = threading.Thread(target=self._run_event_loop_func, daemon=True)
+        self.thread.start()
+
+    def _run_event_loop_func(self):
+        asyncio.set_event_loop(self.loop)
+        self.loop.run_forever()
+
+    def run_async(self, async_func):
+        return asyncio.run_coroutine_threadsafe(async_func, self.loop)
+
+    def wait_async_result(self, async_func, timeout=None):
+        future = self.run_async(async_func)
+        try:
+            return future.result(timeout=timeout)
+        except (asyncio.TimeoutError, TimeoutError, concurrent.futures.TimeoutError) as err:
+            future.cancel()
+            raise asyncio.TimeoutError("Timeout expired for background event. async_func={}, timeout={} sec".format(async_func, timeout)) from err
+
+    def stop(self):
+        self.loop.call_soon_threadsafe(self.loop.stop)

--- a/tests/light/src/common/file.py
+++ b/tests/light/src/common/file.py
@@ -20,6 +20,7 @@
 # COPYING for details.
 #
 #############################################################################
+import atexit
 import logging
 import shutil
 
@@ -59,7 +60,9 @@ class File(object):
         self.path = Path(file_path)
         self.__opened_file = None
 
-    def __del__(self):
+        atexit.register(self.deinit)
+
+    def deinit(self):
         if self.is_opened():
             self.close()
 

--- a/tests/light/src/common/network.py
+++ b/tests/light/src/common/network.py
@@ -1,0 +1,135 @@
+#############################################################################
+# Copyright (c) 2022 One Identity
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import asyncio
+import logging
+import socket
+from abc import ABC
+from abc import abstractmethod
+
+from src.common.asynchronous import BackgroundEventLoop
+
+
+logger = logging.getLogger(__name__)
+
+
+class SingleConnectionStreamServer(ABC):
+    def __init__(self):
+        self._event_loop = BackgroundEventLoop()
+        self._server = None
+        self._client = self._event_loop.run_async(self._create_client()).result()
+
+    async def start(self):
+        server_res = await self._start_server()
+        self._server = server_res
+
+    async def stop(self):
+        logger.debug("Shutting down SingleConnectionStreamServer")
+        await self._stop_server()
+        await self.close_client()
+
+    async def close_client(self):
+        """After a client connection is accepted, new connections will be rejected until this method is called"""
+        await self._client.close()
+
+    async def _create_client(self):
+        return self.Client()
+
+    @abstractmethod
+    async def _start_server(self):
+        pass
+
+    async def _stop_server(self):
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+
+    async def _client_accepted_cb(self, reader, writer):
+        self._client.accept_connection(reader, writer)
+
+    async def readexactly(self, n):
+        await self._client.wait_for_client_connection()
+        return await self._client._reader.readexactly(n)
+
+    async def readuntil(self, separator=b'\n'):
+        await self._client.wait_for_client_connection()
+        return await self._client._reader.readuntil(separator)
+
+    async def readline(self):
+        await self._client.wait_for_client_connection()
+        return await self._client._reader.readline()
+
+    async def write(self, data):
+        await self._client.wait_for_client_connection()
+        self._client._writer.write(data)
+        await self._client._writer.drain()
+
+    class Client(object):
+        def __init__(self):
+            self._connection_accepted = asyncio.Event()
+            self._reader = None
+            self._writer = None
+
+        def accept_connection(self, reader, writer):
+            if self._connection_accepted.is_set():
+                writer.close()
+                return
+            self._reader = reader
+            self._writer = writer
+            self._connection_accepted.set()
+
+        async def wait_for_client_connection(self):
+            await self._connection_accepted.wait()
+
+        async def close(self):
+            if not self._connection_accepted.is_set():
+                return
+            self._writer.close()
+            await self._writer.wait_closed()
+            self._connection_accepted.clear()
+
+
+class SingleConnectionTCPServer(SingleConnectionStreamServer):
+    def __init__(self, port, host=None, ip_protocol_version=socket.AF_INET, ssl=None):
+        super(SingleConnectionTCPServer, self).__init__()
+        self._host = host
+        self._port = port
+        self._family = ip_protocol_version
+        self._ssl = ssl
+
+    async def _start_server(self):
+        logger.info("SingleConnectionTCPServer has been started on host:{}, on port:{}".format(self._host, self._port))
+        server = await asyncio.start_server(self._client_accepted_cb, self._host, self._port, family=self._family, ssl=self._ssl)
+        await server.start_serving()
+        return server
+
+
+class SingleConnectionUnixStreamServer(SingleConnectionStreamServer):
+    def __init__(self, path, ssl=None):
+        super(SingleConnectionUnixStreamServer, self).__init__()
+        self._path = path
+        self._ssl = ssl
+
+    async def _start_server(self):
+        logger.info("SingleConnectionUnixStreamServer has been started on path:{}".format(self._path))
+        server = await asyncio.start_unix_server(self._client_accepted_cb, self._path, ssl=self._ssl)
+        await server.start_serving()
+        return server

--- a/tests/light/src/driver_io/file/file_io.py
+++ b/tests/light/src/driver_io/file/file_io.py
@@ -28,7 +28,7 @@ class FileIO():
         self.__readable_file = File(file_path)
         self.__writeable_file = File(file_path)
 
-    def read_number_of_lines(self, counter):
+    def read_number_of_messages(self, counter):
         if not self.__readable_file.is_opened():
             if not self.__readable_file.wait_for_creation():
                 raise Exception("{} was not created in time.".format(self.__readable_file.path))
@@ -36,7 +36,7 @@ class FileIO():
 
         return self.__readable_file.wait_for_number_of_lines(counter)
 
-    def read_until_lines(self, lines):
+    def read_until_messages(self, lines):
         if not self.__readable_file.is_opened():
             if not self.__readable_file.wait_for_creation():
                 raise Exception("{} was not created in time.".format(self.__readable_file.path))

--- a/tests/light/src/driver_io/file/tests/test_file_io.py
+++ b/tests/light/src/driver_io/file/tests/test_file_io.py
@@ -26,7 +26,7 @@ from src.driver_io.file.file_io import FileIO
 def test_file_io_write_read(temp_file, test_message):
     fileio = FileIO(temp_file)
     fileio.write(test_message)
-    output = fileio.read_number_of_lines(1)
+    output = fileio.read_number_of_messages(1)
     assert [test_message] == output
 
 
@@ -34,5 +34,5 @@ def test_file_io_multiple_write_read(temp_file, test_message):
     fileio = FileIO(temp_file)
     fileio.write(test_message)
     fileio.write(test_message)
-    output = fileio.read_number_of_lines(2)
+    output = fileio.read_number_of_messages(2)
     assert [test_message, test_message] == output

--- a/tests/light/src/driver_io/message_readers.py
+++ b/tests/light/src/driver_io/message_readers.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2022 One Identity
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import asyncio
+
+from src.common.asynchronous import BackgroundEventLoop
+
+
+class SingleLineStreamReader(object):
+    def __init__(self, stream):
+        self._stream = stream
+
+    def wait_for_messages(self, lines, timeout):
+        return BackgroundEventLoop().wait_async_result(self._read_until_lines_found(lines, timeout=timeout))
+
+    def wait_for_number_of_messages(self, number_of_lines, timeout):
+        return BackgroundEventLoop().wait_async_result(self._read_number_of_lines(number_of_lines, timeout=timeout))
+
+    async def _read_until_lines_found(self, lines, timeout):
+        read_lines = []
+        lines_to_find = lines.copy()
+
+        while len(lines_to_find) > 0:
+            try:
+                line = await asyncio.wait_for(self._stream.readline(), timeout=timeout)
+            except (asyncio.TimeoutError) as err:
+                raise Exception("Could not find all lines. Remaining number of lines to find: {} Number of lines found: {}".format(len(lines_to_find), len(read_lines))) from err
+
+            line = line.decode("utf-8")
+            read_lines.append(line)
+            _list_remove_partially_matching_element(lines_to_find, line)
+        return read_lines
+
+    async def _read_number_of_lines(self, number_of_lines, timeout):
+        lines = []
+        for i in range(number_of_lines):
+            try:
+                line = await asyncio.wait_for(self._stream.readline(), timeout=timeout)
+            except (asyncio.TimeoutError) as err:
+                raise Exception("Could not read {} number of lines. Connection closed after {} lines".format(number_of_lines, len(lines))) from err
+
+            lines.append(line.decode("utf-8"))
+        return lines
+
+
+class DatagramReader(object):
+    def __init__(self, datagram_server):
+        self._datagram_server = datagram_server
+
+    def wait_for_messages(self, lines, timeout, maxsize=65536):
+        return BackgroundEventLoop().wait_async_result(self._read_until_dgrams_found(lines, maxsize, timeout=timeout))
+
+    def wait_for_number_of_messages(self, number_of_msgs, timeout, maxsize=65536):
+        return BackgroundEventLoop().wait_async_result(self._read_number_of_dgrams(number_of_msgs, maxsize, timeout=timeout))
+
+    async def _read_until_dgrams_found(self, dgrams, maxsize, timeout):
+        read_dgrams = []
+        dgrams_to_find = dgrams.copy()
+
+        while len(dgrams_to_find) != 0:
+            try:
+                dgram = await asyncio.wait_for(self._datagram_server.read_dgram(maxsize), timeout=timeout)
+            except (asyncio.TimeoutError) as err:
+                raise Exception("Could not find all datagrams. Remaining dgrams to find: {} Lines found: {}".format(len(dgrams_to_find), len(read_dgrams))) from err
+
+            dgram = dgram.decode("utf-8")
+            read_dgrams.append(dgram)
+            _list_remove_partially_matching_element(dgrams_to_find, dgram)
+        return read_dgrams
+
+    async def _read_number_of_dgrams(self, number_of_dgrams, maxsize, timeout):
+        msgs = []
+        for i in range(number_of_dgrams):
+            try:
+                msg = await asyncio.wait_for(self._datagram_server.read_dgram(maxsize), timeout=timeout)
+            except (asyncio.TimeoutError) as err:
+                raise Exception("Could not read {} number of datagrams. Connection closed after {}".format(number_of_dgrams, len(msgs))) from err
+
+            msgs.append(msg.decode("utf-8"))
+        return msgs
+
+
+class FramedStreamReader(object):
+    """RFC6587 message reader for the syslog() driver"""
+    # TODO msg_length = readuntil(' '); msg = readexactly(msg_length)
+    pass
+
+
+# FileIO and this method too operate on partial string matches
+# TODO: LogMessage instances should be used instead, matching the full msg body
+def _list_remove_partially_matching_element(list, elem):
+    for l in list:
+        if l in elem:
+            list.remove(l)
+            return True
+    return False

--- a/tests/light/src/driver_io/network/network_io.py
+++ b/tests/light/src/driver_io/network/network_io.py
@@ -20,7 +20,9 @@
 # COPYING for details.
 #
 #############################################################################
+import socket
 from enum import Enum
+from enum import IntEnum
 
 from pathlib2 import Path
 
@@ -31,10 +33,11 @@ from src.helpers.loggen.loggen import Loggen
 
 
 class NetworkIO():
-    def __init__(self, ip, port, transport):
+    def __init__(self, ip, port, transport, ip_proto_version=None):
         self.__ip = ip
         self.__port = port
         self.__transport = transport
+        self.__ip_proto_version = NetworkIO.IPProtoVersion.V4 if ip_proto_version is None else ip_proto_version
 
     def write(self, content, rate=None):
         loggen_input_file_path = Path(tc_parameters.WORKING_DIR, "loggen_input_{}.txt".format(get_unique_id()))
@@ -45,6 +48,10 @@ class NetworkIO():
         loggen_input_file.close()
 
         Loggen().start(self.__ip, self.__port, read_file=str(loggen_input_file_path), dont_parse=True, permanent=True, rate=rate, **self.__transport.value)
+
+    class IPProtoVersion(IntEnum):
+        V4 = socket.AF_INET
+        V6 = socket.AF_INET6
 
     class Transport(Enum):
         TCP = {"inet": True, "stream": True}

--- a/tests/light/src/driver_io/network/network_io.py
+++ b/tests/light/src/driver_io/network/network_io.py
@@ -20,6 +20,7 @@
 # COPYING for details.
 #
 #############################################################################
+import atexit
 import socket
 from enum import Enum
 from enum import IntEnum
@@ -27,8 +28,13 @@ from enum import IntEnum
 from pathlib2 import Path
 
 import src.testcase_parameters.testcase_parameters as tc_parameters
+from src.common.asynchronous import BackgroundEventLoop
+from src.common.blocking import DEFAULT_TIMEOUT
 from src.common.file import File
+from src.common.network import SingleConnectionTCPServer
+from src.common.network import UDPServer
 from src.common.random_id import get_unique_id
+from src.driver_io import message_readers
 from src.helpers.loggen.loggen import Loggen
 
 
@@ -38,6 +44,10 @@ class NetworkIO():
         self.__port = port
         self.__transport = transport
         self.__ip_proto_version = NetworkIO.IPProtoVersion.V4 if ip_proto_version is None else ip_proto_version
+        self.__server = None
+        self.__message_reader = None
+
+        atexit.register(self.stop_listener)
 
     def write(self, content, rate=None):
         loggen_input_file_path = Path(tc_parameters.WORKING_DIR, "loggen_input_{}.txt".format(get_unique_id()))
@@ -48,6 +58,22 @@ class NetworkIO():
         loggen_input_file.close()
 
         Loggen().start(self.__ip, self.__port, read_file=str(loggen_input_file_path), dont_parse=True, permanent=True, rate=rate, **self.__transport.value)
+
+    def start_listener(self):
+        self.__message_reader, self.__server = self.__transport.construct(self.__port, self.__ip, self.__ip_proto_version)
+        BackgroundEventLoop().wait_async_result(self.__server.start(), timeout=DEFAULT_TIMEOUT)
+
+    def stop_listener(self):
+        if self.__message_reader is not None:
+            BackgroundEventLoop().wait_async_result(self.__server.stop(), timeout=DEFAULT_TIMEOUT)
+            self.__message_reader = None
+            self.__server = None
+
+    def read_number_of_messages(self, counter, timeout=DEFAULT_TIMEOUT):
+        return self.__message_reader.wait_for_number_of_messages(counter, timeout)
+
+    def read_until_messages(self, lines, timeout=DEFAULT_TIMEOUT):
+        return self.__message_reader.wait_for_messages(lines, timeout)
 
     class IPProtoVersion(IntEnum):
         V4 = socket.AF_INET
@@ -60,3 +86,13 @@ class NetworkIO():
         PROXIED_TCP = {"inet": True, "stream": True}
         PROXIED_TLS = {"use_ssl": True}
         PROXIED_TLS_PASSTHROUGH = {"use_ssl": True, "proxied_tls_passthrough": True}
+
+        def construct(self, port, host=None, ip_proto_version=None):
+            def _construct(server, reader_class):
+                return reader_class(server), server
+
+            transport_mapping = {
+                NetworkIO.Transport.TCP: lambda: _construct(SingleConnectionTCPServer(port, host, ip_proto_version), message_readers.SingleLineStreamReader),
+                NetworkIO.Transport.UDP: lambda: _construct(UDPServer(port, host, ip_proto_version), message_readers.DatagramReader),
+            }
+            return transport_mapping[self]()

--- a/tests/light/src/syslog_ng_config/statements/destinations/example_destination.py
+++ b/tests/light/src/syslog_ng_config/statements/destinations/example_destination.py
@@ -41,7 +41,7 @@ class ExampleDestination(DestinationDriver):
         return self.read_logs(1)[0]
 
     def read_logs(self, counter):
-        return self.io.read_number_of_lines(counter)
+        return self.io.read_number_of_messages(counter)
 
     def read_until_logs(self, logs):
-        return self.io.read_until_lines(logs)
+        return self.io.read_until_messages(logs)

--- a/tests/light/src/syslog_ng_config/statements/destinations/file_destination.py
+++ b/tests/light/src/syslog_ng_config/statements/destinations/file_destination.py
@@ -41,7 +41,7 @@ class FileDestination(DestinationDriver):
         return self.read_logs(1)[0]
 
     def read_logs(self, counter):
-        return self.io.read_number_of_lines(counter)
+        return self.io.read_number_of_messages(counter)
 
     def read_until_logs(self, logs):
-        return self.io.read_until_lines(logs)
+        return self.io.read_until_messages(logs)

--- a/tests/light/src/syslog_ng_config/statements/destinations/network_destination.py
+++ b/tests/light/src/syslog_ng_config/statements/destinations/network_destination.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2022 One Identity
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from src.driver_io.network.network_io import NetworkIO
+from src.syslog_ng_config.statements.destinations.destination_driver import DestinationDriver
+
+
+def map_transport(transport):
+    mapping = {
+        "tcp": NetworkIO.Transport.TCP,
+        "udp": NetworkIO.Transport.UDP,
+    }
+    transport = transport.replace("_", "-").replace("'", "").replace('"', "").lower()
+
+    return mapping[transport]
+
+
+def create_io(ip, options):
+    transport = options["transport"] if "transport" in options else "tcp"
+
+    return NetworkIO(ip, options["port"], map_transport(transport))
+
+
+class NetworkDestination(DestinationDriver):
+    def __init__(self, ip, **options):
+        self.driver_name = "network"
+        self.ip = ip
+        self.io = create_io(self.ip, options)
+        super(NetworkDestination, self).__init__([self.ip], options)
+
+    def start_listener(self):
+        self.io.start_listener()
+
+    def stop_listener(self):
+        self.io.stop_listener()
+
+    def read_log(self):
+        return self.read_logs(1)[0]
+
+    def read_logs(self, counter):
+        return self.io.read_number_of_messages(counter)
+
+    def read_until_logs(self, logs):
+        return self.io.read_until_messages(logs)

--- a/tests/light/src/syslog_ng_config/statements/destinations/unix_dgram_destination.py
+++ b/tests/light/src/syslog_ng_config/statements/destinations/unix_dgram_destination.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2022 One Identity
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import atexit
+
+from pathlib2 import Path
+
+from src.common.asynchronous import BackgroundEventLoop
+from src.common.blocking import DEFAULT_TIMEOUT
+from src.common.network import UnixDatagramServer
+from src.driver_io import message_readers
+from src.syslog_ng_config.statements.destinations.destination_driver import DestinationDriver
+
+
+class UnixDgramDestination(DestinationDriver):
+    def __init__(self, file_name, **options):
+        self.driver_name = "unix-dgram"
+        self.path = Path(file_name)
+
+        self.__server = None
+        self.__message_reader = None
+        atexit.register(self.stop_listener)
+
+        super(UnixDgramDestination, self).__init__([self.path], options)
+
+    def start_listener(self):
+        self.__server = UnixDatagramServer(self.path)
+        self.__message_reader = message_readers.DatagramReader(self.__server)
+        BackgroundEventLoop().wait_async_result(self.__server.start(), timeout=DEFAULT_TIMEOUT)
+
+    def stop_listener(self):
+        if self.__message_reader is not None:
+            BackgroundEventLoop().wait_async_result(self.__server.stop(), timeout=DEFAULT_TIMEOUT)
+            self.__message_reader = None
+            self.__server = None
+
+    def read_log(self, timeout=DEFAULT_TIMEOUT):
+        return self.read_logs(1, timeout)[0]
+
+    def read_logs(self, counter, timeout=DEFAULT_TIMEOUT):
+        return self.__message_reader.wait_for_number_of_messages(counter, timeout)
+
+    def read_until_logs(self, logs, timeout=DEFAULT_TIMEOUT):
+        return self.__message_reader.wait_for_messages(logs, timeout)

--- a/tests/light/src/syslog_ng_config/statements/destinations/unix_stream_destination.py
+++ b/tests/light/src/syslog_ng_config/statements/destinations/unix_stream_destination.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2022 One Identity
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import atexit
+
+from pathlib2 import Path
+
+from src.common.asynchronous import BackgroundEventLoop
+from src.common.blocking import DEFAULT_TIMEOUT
+from src.common.network import SingleConnectionUnixStreamServer
+from src.driver_io import message_readers
+from src.syslog_ng_config.statements.destinations.destination_driver import DestinationDriver
+
+
+class UnixStreamDestination(DestinationDriver):
+    def __init__(self, file_name, **options):
+        self.driver_name = "unix-stream"
+        self.path = Path(file_name)
+
+        self.__server = None
+        self.__message_reader = None
+
+        atexit.register(self.stop_listener)
+        super(UnixStreamDestination, self).__init__([self.path], options)
+
+    def start_listener(self):
+        self.__server = SingleConnectionUnixStreamServer(self.path)
+        self.__message_reader = message_readers.SingleLineStreamReader(self.__server)
+        BackgroundEventLoop().wait_async_result(self.__server.start(), timeout=DEFAULT_TIMEOUT)
+
+    def stop_listener(self):
+        if self.__message_reader is not None:
+            BackgroundEventLoop().wait_async_result(self.__server.stop(), timeout=DEFAULT_TIMEOUT)
+            self.__message_reader = None
+            self.__server = None
+
+    def read_log(self, timeout=DEFAULT_TIMEOUT):
+        return self.read_logs(1, timeout)[0]
+
+    def read_logs(self, counter, timeout=DEFAULT_TIMEOUT):
+        return self.__message_reader.wait_for_number_of_messages(counter, timeout)
+
+    def read_until_logs(self, logs, timeout=DEFAULT_TIMEOUT):
+        return self.__message_reader.wait_for_messages(logs, timeout)

--- a/tests/light/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/light/src/syslog_ng_config/syslog_ng_config.py
@@ -28,6 +28,7 @@ from src.syslog_ng_config.renderer import ConfigRenderer
 from src.syslog_ng_config.statement_group import StatementGroup
 from src.syslog_ng_config.statements.destinations.example_destination import ExampleDestination
 from src.syslog_ng_config.statements.destinations.file_destination import FileDestination
+from src.syslog_ng_config.statements.destinations.network_destination import NetworkDestination
 from src.syslog_ng_config.statements.destinations.snmp_destination import SnmpDestination
 from src.syslog_ng_config.statements.filters.filter import Filter
 from src.syslog_ng_config.statements.filters.filter import RateLimit
@@ -140,6 +141,9 @@ class SyslogNgConfig(object):
 
     def create_snmp_destination(self, **options):
         return SnmpDestination(**options)
+
+    def create_network_destination(self, **options):
+        return NetworkDestination(**options)
 
     def create_db_parser(self, config, **options):
         return DBParser(config, **options)

--- a/tests/light/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/light/src/syslog_ng_config/syslog_ng_config.py
@@ -31,6 +31,7 @@ from src.syslog_ng_config.statements.destinations.file_destination import FileDe
 from src.syslog_ng_config.statements.destinations.network_destination import NetworkDestination
 from src.syslog_ng_config.statements.destinations.snmp_destination import SnmpDestination
 from src.syslog_ng_config.statements.destinations.unix_dgram_destination import UnixDgramDestination
+from src.syslog_ng_config.statements.destinations.unix_stream_destination import UnixStreamDestination
 from src.syslog_ng_config.statements.filters.filter import Filter
 from src.syslog_ng_config.statements.filters.filter import RateLimit
 from src.syslog_ng_config.statements.logpath.logpath import LogPath
@@ -44,6 +45,7 @@ from src.syslog_ng_config.statements.sources.example_msg_generator_source import
 from src.syslog_ng_config.statements.sources.file_source import FileSource
 from src.syslog_ng_config.statements.sources.internal_source import InternalSource
 from src.syslog_ng_config.statements.sources.network_source import NetworkSource
+
 
 logger = logging.getLogger(__name__)
 
@@ -148,6 +150,9 @@ class SyslogNgConfig(object):
 
     def create_unix_dgram_destination(self, **options):
         return UnixDgramDestination(**options)
+
+    def create_unix_stream_destination(self, **options):
+        return UnixStreamDestination(**options)
 
     def create_db_parser(self, config, **options):
         return DBParser(config, **options)

--- a/tests/light/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/light/src/syslog_ng_config/syslog_ng_config.py
@@ -30,6 +30,7 @@ from src.syslog_ng_config.statements.destinations.example_destination import Exa
 from src.syslog_ng_config.statements.destinations.file_destination import FileDestination
 from src.syslog_ng_config.statements.destinations.network_destination import NetworkDestination
 from src.syslog_ng_config.statements.destinations.snmp_destination import SnmpDestination
+from src.syslog_ng_config.statements.destinations.unix_dgram_destination import UnixDgramDestination
 from src.syslog_ng_config.statements.filters.filter import Filter
 from src.syslog_ng_config.statements.filters.filter import RateLimit
 from src.syslog_ng_config.statements.logpath.logpath import LogPath
@@ -144,6 +145,9 @@ class SyslogNgConfig(object):
 
     def create_network_destination(self, **options):
         return NetworkDestination(**options)
+
+    def create_unix_dgram_destination(self, **options):
+        return UnixDgramDestination(**options)
 
     def create_db_parser(self, config, **options):
         return DBParser(config, **options)


### PR DESCRIPTION
First of all I would like to give huge thanks to @MrAnno who made the low-level part of this PR

This PR add support to use following network based destination drivers in functional testcases:
- network (with tcp and udp transport support)
- unix-dgram
- unix-stream

In the low-level part this PR introduce an asyncio based communication between the user API (from testcases) and network servers (listeners) API.

class diagramm for low-level API:
![class diagramm for low-level API](https://user-images.githubusercontent.com/2952076/178444397-7e6c993f-22d4-4060-aa98-4b9c04a870b3.svg)
