### PR TITLE
Fix signed/unsigned comparison in `evt_tag_mem()` and add unit tests for it

### DIFF
--- a/lib/eventlog/src/evttags.c
+++ b/lib/eventlog/src/evttags.c
@@ -86,7 +86,7 @@ evt_tag_mem(const char *tag, const void *value, size_t len)
   char *buf = malloc(len + 1);
 
   memcpy(buf, value, len);
-  for (int i = 0; i < len; i++)
+  for (size_t i = 0; i < len; i++)
     {
       if (buf[i] == 0)
         buf[i] = '.';

--- a/lib/eventlog/tests/CMakeLists.txt
+++ b/lib/eventlog/tests/CMakeLists.txt
@@ -6,6 +6,10 @@ add_unit_test(TARGET test_evtfmt
   INCLUDES "${Eventlog_INCLUDE_DIR}"
   SOURCES evtfmt.c)
 
+add_unit_test(CRITERION TARGET test_evt_tag_mem
+  INCLUDES "${Eventlog_INCLUDE_DIR}"
+  SOURCES evt_tag_mem.c)
+
 add_unit_test(TARGET test_evtsyslog
   INCLUDES "${Eventlog_INCLUDE_DIR}"
   SOURCES evtsyslog.c)

--- a/lib/eventlog/tests/Makefile.am
+++ b/lib/eventlog/tests/Makefile.am
@@ -2,7 +2,8 @@ lib_eventlog_tests_TESTS = \
 	lib/eventlog/tests/evtrec \
 	lib/eventlog/tests/evtfmt \
 	lib/eventlog/tests/evtsyslog \
-	lib/eventlog/tests/evtsyslog-macros
+	lib/eventlog/tests/evtsyslog-macros \
+	lib/eventlog/tests/evt_tag_mem
 
 EXTRA_DIST += lib/eventlog/tests/CMakeLists.txt
 
@@ -16,6 +17,9 @@ lib_eventlog_tests_evtfmt_LDADD = $(top_builddir)/lib/eventlog/src/libevtlog.la
 
 lib_eventlog_tests_evtsyslog_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/lib/eventlog/src
 lib_eventlog_tests_evtsyslog_LDADD = $(top_builddir)/lib/eventlog/src/libevtlog.la
+
+lib_eventlog_tests_evt_tag_mem_CFLAGS = $(TEST_CFLAGS)
+lib_eventlog_tests_evt_tag_mem_LDADD = $(TEST_LDADD)
 
 lib_eventlog_tests_evtsyslog_macros_SOURCES = lib/eventlog/tests/evtsyslog.c
 lib_eventlog_tests_evtsyslog_macros_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/lib/eventlog/src -DEVENTLOG_SYSLOG_MACROS=1

--- a/lib/eventlog/tests/evt_tag_mem.c
+++ b/lib/eventlog/tests/evt_tag_mem.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include <evtlog.h>
+#include <criterion/parameterized.h>
+
+struct evt_tag_mem_params
+{
+  gchar *original_value;
+  gsize original_value_len;
+  gchar *new_value;
+};
+
+ParameterizedTestParameters(evt_tag_mem, test)
+{
+  static struct evt_tag_mem_params params[] =
+  {
+    {"", 1, "."},
+    {"\0", 2, ".."},
+    {"foo", 4, "foo."},
+    {"\0\0foo", 6, "..foo."},
+    {"\0a\0b\0c", 7, ".a.b.c."},
+  };
+
+  return cr_make_param_array(struct evt_tag_mem_params, params, sizeof (params) / sizeof(struct evt_tag_mem_params));
+}
+
+ParameterizedTest(struct evt_tag_mem_params *params, evt_tag_mem, test)
+{
+  gchar *key = "test:evt_tag_mem";
+  EVTCONTEXT *ctx = evt_ctx_init("evt_tag_mem", LOG_AUTH);
+  EVTREC *event_rec = evt_rec_init(ctx, LOG_INFO, "");
+
+  evt_rec_add_tag(event_rec, evt_tag_mem(key, params->original_value, params->original_value_len));
+  gchar *formatted_result = evt_format(event_rec);
+
+  GString *expected_result = g_string_sized_new(8);
+  g_string_append_printf(expected_result, "; %s='%s'", key, params->new_value);
+
+  cr_assert_str_eq(formatted_result, expected_result->str);
+
+
+  free(formatted_result);
+  g_string_free(expected_result, TRUE);
+  evt_ctx_free(ctx);
+}

--- a/lib/logproto/logproto-proxied-text-server.c
+++ b/lib/logproto/logproto-proxied-text-server.c
@@ -93,7 +93,7 @@ _parse_unknown_header(LogProtoProxiedTextServer *self, const guchar *msg, gsize 
   if (msg_len == 0)
     return TRUE;
 
-  msg_warning("PROXY UNKNOWN header contains unexpected paramters",
+  msg_warning("PROXY UNKNOWN header contains unexpected parameters",
               evt_tag_mem("parameters", msg, msg_len));
 
   return TRUE;


### PR DESCRIPTION
<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->

This PR adds some unit tests regarding `evt_tag_mem()`.
There is also a fix regarding `signed/unsigned` comparison in `evt_tag_mem()`.
