### PR TITLE
`network`/`syslog`/`http` destination: OCSP stapling support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1372,7 +1372,7 @@ if test "x$enable_http" != "xno" && test "x$with_libcurl" != "xno"; then
         if test "$enable_http" = "yes"; then
            old_CFLAGS=$CFLAGS
            CFLAGS=$LIBCURL_CFLAGS
-           AC_CHECK_DECLS([CURL_SSLVERSION_TLSv1_0, CURL_SSLVERSION_TLSv1_1, CURL_SSLVERSION_TLSv1_2, CURL_SSLVERSION_TLSv1_3, CURLOPT_TLS13_CIPHERS],
+           AC_CHECK_DECLS([CURL_SSLVERSION_TLSv1_0, CURL_SSLVERSION_TLSv1_1, CURL_SSLVERSION_TLSv1_2, CURL_SSLVERSION_TLSv1_3, CURLOPT_TLS13_CIPHERS, CURLOPT_SSL_VERIFYSTATUS],
                           [], [],
                           [[#include <curl/curl.h>]])
            CFLAGS=$old_CFLAGS

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -670,12 +670,19 @@ tls_context_load_pkcs12(TLSContext *self)
 
   PKCS12_free(pkcs12);
 
+  gboolean loaded = FALSE;
   if (ca_list && !tls_context_add_certs(self, ca_list))
-    return FALSE;
+    goto error;
 
-  return SSL_CTX_use_certificate(self->ssl_ctx, cert)
-         && SSL_CTX_use_PrivateKey(self->ssl_ctx, private_key)
-         && SSL_CTX_check_private_key(self->ssl_ctx);
+  loaded = SSL_CTX_use_certificate(self->ssl_ctx, cert)
+           && SSL_CTX_use_PrivateKey(self->ssl_ctx, private_key)
+           && SSL_CTX_check_private_key(self->ssl_ctx);
+
+error:
+  X509_free(cert);
+  EVP_PKEY_free(private_key);
+  sk_X509_pop_free(ca_list, X509_free);
+  return loaded;
 }
 
 static gboolean

--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -99,6 +99,7 @@ GQuark tls_context_error_quark(void);
 enum TLSContextError
 {
   TLSCONTEXT_UNSUPPORTED,
+  TLSCONTEXT_INTERNAL_ERROR,
 };
 
 #define TMI_ALLOW_COMPRESS 0x1
@@ -139,6 +140,7 @@ gboolean tls_context_set_client_sigalgs(TLSContext *self, const gchar *sigalgs, 
 void tls_context_set_ecdh_curve_list(TLSContext *self, const gchar *ecdh_curve_list);
 void tls_context_set_dhparam_file(TLSContext *self, const gchar *dhparam_file);
 void tls_context_set_sni(TLSContext *self, const gchar *sni);
+void tls_context_set_ocsp_stapling_verify(TLSContext *self, gboolean ocsp_stapling_verify);
 const gchar *tls_context_get_key_file(TLSContext *self);
 EVTTAG *tls_context_format_tls_error_tag(TLSContext *self);
 EVTTAG *tls_context_format_location_tag(TLSContext *self);

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -196,6 +196,7 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 %token KW_SNI
 %token KW_ALLOW_COMPRESS
 %token KW_KEYLOG_FILE
+%token KW_OCSP_STAPLING_VERIFY
 
 /* INCLUDE_DECLS */
 
@@ -780,6 +781,10 @@ dest_tls_option
           {
             if ($3)
               tls_context_set_sni(last_tls_context, ((AFInetDestDriver *)last_driver)->primary);
+          }
+        | KW_OCSP_STAPLING_VERIFY '(' yesno ')'
+          {
+            tls_context_set_ocsp_stapling_verify(last_tls_context, $3);
           }
         ;
 

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -65,6 +65,7 @@ static CfgLexerKeyword afsocket_keywords[] =
   { "ssl_options",        KW_SSL_OPTIONS },
   { "sni",                KW_SNI },
   { "allow_compress",     KW_ALLOW_COMPRESS },
+  { "ocsp_stapling_verify", KW_OCSP_STAPLING_VERIFY },
 
   { "localip",            KW_LOCALIP },
   { "ip",                 KW_IP },

--- a/modules/http/CMakeLists.txt
+++ b/modules/http/CMakeLists.txt
@@ -58,6 +58,7 @@ curl_detect_compile_option(CURL_SSLVERSION_TLSv1_1)
 curl_detect_compile_option(CURL_SSLVERSION_TLSv1_2)
 curl_detect_compile_option(CURL_SSLVERSION_TLSv1_3)
 curl_detect_compile_option(CURLOPT_TLS13_CIPHERS)
+curl_detect_compile_option(CURLOPT_SSL_VERIFYSTATUS)
 
 install(FILES ${HTTP_MODULE_DEV_HEADERS} DESTINATION include/syslog-ng/modules/http/)
 

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -71,6 +71,7 @@ HttpResponseHandler last_response_handler;
 %token KW_SSL_VERSION
 %token KW_PEER_VERIFY
 %token KW_TIMEOUT
+%token KW_OCSP_STAPLING_VERIFY
 %token KW_TLS
 %token KW_BATCH_BYTES
 %token KW_BODY_PREFIX
@@ -189,6 +190,11 @@ http_tls_option
           }
       }
     | KW_PEER_VERIFY '(' yesno ')'            { http_dd_set_peer_verify(last_driver, $3); }
+    | KW_OCSP_STAPLING_VERIFY '(' yesno ')'
+      {
+        CHECK_ERROR(http_dd_set_ocsp_stapling_verify(last_driver, $3), @3,
+                    "Error setting ocsp-stapling-verify(), OCSP stapling is not supported with this libcurl version");
+      }
     ;
 
 tls_cipher_suites

--- a/modules/http/http-parser.c
+++ b/modules/http/http-parser.c
@@ -49,6 +49,7 @@ static CfgLexerKeyword http_keywords[] =
   { "use_system_cert_store", KW_USE_SYSTEM_CERT_STORE },
   { "ssl_version",      KW_SSL_VERSION },
   { "peer_verify",      KW_PEER_VERIFY },
+  { "ocsp_stapling_verify", KW_OCSP_STAPLING_VERIFY },
   { "accept_redirects", KW_ACCEPT_REDIRECTS },
   { "response_action",  KW_RESPONSE_ACTION },
   { "success",          KW_SUCCESS },

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -140,6 +140,11 @@ _setup_static_options_in_curl(HTTPDestinationWorker *self)
     curl_easy_setopt(self->curl, CURLOPT_TLS13_CIPHERS, owner->tls13_ciphers);
 #endif
 
+#if SYSLOG_NG_HAVE_DECL_CURLOPT_SSL_VERIFYSTATUS
+  if (owner->ocsp_stapling_verify)
+    curl_easy_setopt(self->curl, CURLOPT_SSL_VERIFYSTATUS, 1L);
+#endif
+
   if (owner->proxy)
     curl_easy_setopt(self->curl, CURLOPT_PROXY, owner->proxy);
 

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -269,6 +269,19 @@ http_dd_set_peer_verify(LogDriver *d, gboolean verify)
   self->peer_verify = verify;
 }
 
+gboolean
+http_dd_set_ocsp_stapling_verify(LogDriver *d, gboolean verify)
+{
+#if SYSLOG_NG_HAVE_DECL_CURLOPT_SSL_VERIFYSTATUS
+  HTTPDestinationDriver *self = (HTTPDestinationDriver *) d;
+
+  self->ocsp_stapling_verify = verify;
+  return TRUE;
+#else
+  return FALSE;
+#endif
+}
+
 void
 http_dd_set_accept_redirects(LogDriver *d, gboolean accept_redirects)
 {

--- a/modules/http/http.h
+++ b/modules/http/http.h
@@ -56,6 +56,7 @@ typedef struct
   GString *delimiter;
   int ssl_version;
   gboolean peer_verify;
+  gboolean ocsp_stapling_verify;
   gboolean accept_redirects;
   short int method_type;
   glong timeout;
@@ -86,6 +87,7 @@ gboolean http_dd_set_tls13_cipher_suite(LogDriver *d, const gchar *tls13_ciphers
 void http_dd_set_proxy(LogDriver *d, const gchar *proxy);
 gboolean http_dd_set_ssl_version(LogDriver *d, const gchar *value);
 void http_dd_set_peer_verify(LogDriver *d, gboolean verify);
+gboolean http_dd_set_ocsp_stapling_verify(LogDriver *d, gboolean verify);
 void http_dd_set_timeout(LogDriver *d, glong timeout);
 void http_dd_set_batch_bytes(LogDriver *d, glong batch_bytes);
 void http_dd_set_body_prefix(LogDriver *d, const gchar *body_prefix);

--- a/news/feature-4082.md
+++ b/news/feature-4082.md
@@ -1,0 +1,24 @@
+`network`/`syslog`/`http` destination: OCSP stapling support
+
+OCSP stapling support for network destinations and for the `http()` module has been added.
+
+When OCSP stapling verification is enabled, the server will be requested to send back OCSP status responses.
+This status response will be verified using the trust store configured by the user (`ca-file()`, `ca-dir()`, `pkcs12-file()`).
+
+Note: RFC 6961 multi-stapling and TLS 1.3-provided multiple responses are currently not validated, only the peer certificate is verified.
+
+Example config:
+```
+destination {
+
+    network("test.tld" transport(tls)
+        tls(
+            pkcs12-file("/path/to/test.p12")
+            peer-verify(yes)
+            ocsp-stapling-verify(yes)
+        )
+    );
+
+    http(url("https://test.tld") method("POST") tls(peer-verify(yes) ocsp-stapling-verify(yes)));
+};
+```


### PR DESCRIPTION
This PR adds OCSP stapling support for network destinations and for the `http()` module.

When OCSP stapling verification is enabled, the server will be requested to send back OCSP status responses.
This status response will be verified using the trust store configured by the user (ca_file, ca_dir, pkcs12_file).

Note: RFC 6961 multi-stapling and TLS 1.3-provided multiple responses are currently not validated, only the peer certificate is verified.

Resolves #4013

More info:
https://www.openssl.org/docs/man1.0.2/man3/SSL_set_tlsext_status_type.html
https://www.openssl.org/docs/man1.1.1/man3/OCSP_resp_find_status.html

All new OpenSSL calls are compatible with OpenSSL 1.0.2 and above (CentOS 7 still uses v1.0.2).
Source (server) side OCSP stapling is not part of this pull request.

TODO:
- [x] verbose/debug logging

----

Example config:
```
destination {

    network("test.tld" transport(tls)
        tls(
            pkcs12-file("/path/to/test.p12")
            peer-verify(yes)
            ocsp-stapling-verify(yes)
        )
    );

    http(url("https://test.tld") method("POST") tls(peer-verify(yes) ocsp-stapling-verify(yes)));
};
```