### PR TITLE
buffered-server: skip invalid characters 

### DIFF
--- a/lib/logproto/logproto-buffered-server.c
+++ b/lib/logproto/logproto-buffered-server.c
@@ -142,10 +142,19 @@ log_proto_buffered_server_convert_from_raw(LogProtoBufferedServer *self, const g
                 }
               break;
             case EILSEQ:
-            default:
-              msg_notice("Invalid byte sequence or other error while converting input, skipping character",
+              msg_notice("Invalid byte sequence, skipping character",
                          evt_tag_str("encoding", self->super.options->encoding),
                          evt_tag_printf("char", "0x%02x", *(guchar *) raw_buffer));
+              raw_buffer++;
+              avail_in--;
+
+              state->pending_buffer_end = state->buffer_size - avail_out;
+              break;
+            default:
+              msg_error("Unknown error while converting input",
+                        evt_tag_error("errno"),
+                        evt_tag_str("encoding", self->super.options->encoding),
+                        evt_tag_printf("char", "0x%02x", *(guchar *) raw_buffer));
               goto error;
             }
         }

--- a/lib/logproto/tests/test-text-server.c
+++ b/lib/logproto/tests/test-text-server.c
@@ -221,6 +221,22 @@ Test(log_proto, test_log_proto_text_server_partial_chars_before_eof)
   log_proto_server_free(proto);
 }
 
+Test(log_proto, test_log_proto_text_server_invalid_char_with_encoding)
+{
+  LogProtoServer *proto;
+
+  log_proto_server_options_set_encoding(&proto_server_options, "GB18030");
+  proto = construct_test_proto(
+            log_transport_mock_stream_new(
+              "foo" "\x80" "bar" "\x80" "baz", -1,
+              LTM_EOF));
+
+  cr_assert(log_proto_server_validate_options(proto),
+            "validate_options() returned failure but it should have succeeded");
+  assert_proto_server_fetch(proto, "foobarbaz", -1);
+  log_proto_server_free(proto);
+}
+
 Test(log_proto, test_log_proto_text_server_not_fixed_encoding)
 {
   LogProtoServer *proto;

--- a/news/bugfix-4084.md
+++ b/news/bugfix-4084.md
@@ -1,0 +1,2 @@
+socket based sources: Fixed a bug, where syslog-ng halted the input instead of skipping a character
+in case of a character conversion error.


### PR DESCRIPTION
### For the reviewers
I think skipping one byte might cause a misalignment in case of wide characters, which could possibly produce jumbled output.
Would it be better to stop processing and return the successfully converted string instead?

---

Fixes #4083

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>