### PR TITLE
contrib: specify DefaultInstance= in systemd template service file

### DIFF
--- a/contrib/systemd/syslog-ng@.service
+++ b/contrib/systemd/syslog-ng@.service
@@ -16,4 +16,5 @@ StandardError=journal
 Restart=on-failure
 
 [Install]
+DefaultInstance=default
 WantedBy=multi-user.target


### PR DESCRIPTION
Per systemd.unit(5) documentation:

  In case of template units listing non template units, the listing unit
  must have DefaultInstance= set, or systemctl enable must be called
  with an instance name.

Since syslog-ng already ships a configuration for syslog-ng@default,
add DefaultInstance=default to the template service file. This means
that the command systemctl enable syslog-ng@.service will create the
appropriate symlink multi-user.target.wants/syslog-ng@default.service to
syslog-ng@.service. Previously it would fail.

Signed-off-by: Alvin Šipraga <alsi@bang-olufsen.dk>