### PR TITLE
news: remove Attila and Zoltan from fixed contributors

### DIFF
--- a/news/create-newsfile.py
+++ b/news/create-newsfile.py
@@ -34,13 +34,11 @@ newsfile = root_dir / 'NEWS.md'
 
 credit_fixed_contributors = [
     "Andras Mitzki",
-    "Attila Szakacs",
     "Balazs Scheidler",
     "Gabor Nagy",
     "László Várady",
     "Parrag Szilárd",
     "Peter Kokai",
-    "Zoltan Pallagi",
 ]
 exclude_contributor_list = [
     "github-actions",


### PR DESCRIPTION
Hopefully the removal of my name will not make any changes in the upcoming actual news files :)

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>