### PR TITLE
Set loglevels from config

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -192,6 +192,7 @@
 %token KW_KEEP_HOSTNAME               10092
 %token KW_CHECK_HOSTNAME              10093
 %token KW_BAD_HOSTNAME                10094
+%token KW_LOG_LEVEL                   10095
 
 %token KW_KEEP_TIMESTAMP              10100
 
@@ -924,6 +925,7 @@ options_item
 	| KW_PROTO_TEMPLATE '(' string ')'	{ configuration->proto_template_name = g_strdup($3); free($3); }
 	| KW_RECV_TIME_ZONE '(' string ')'	{ configuration->recv_time_zone = g_strdup($3); free($3); }
 	| KW_MIN_IW_SIZE_PER_READER '(' positive_integer ')' { configuration->min_iw_size_per_reader = $3; }
+	| KW_LOG_LEVEL '(' string ')'		{ CHECK_ERROR(cfg_set_log_level(configuration, $3), @3, "Unknown log-level() option"); free($3); }
 	| { last_template_options = &configuration->template_options; } template_option
 	| { last_host_resolve_options = &configuration->host_resolve_options; } host_resolve_option
 	| { last_stats_options = &configuration->stats_options; } stat_option

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -130,6 +130,7 @@ static CfgLexerKeyword main_keywords[] =
   { "threaded",           KW_THREADED },
   { "use_rcptid",         KW_USE_RCPTID, KWS_OBSOLETE, "This has been deprecated, try use_uniqid() instead" },
   { "use_uniqid",         KW_USE_UNIQID },
+  { "log_level",          KW_LOG_LEVEL },
 
   { "log_fifo_size",      KW_LOG_FIFO_SIZE },
   { "log_fetch_limit",    KW_LOG_FETCH_LIMIT },

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -143,6 +143,17 @@ cfg_set_mark_mode(GlobalConfig *self, const gchar *mark_mode)
   self->mark_mode = cfg_lookup_mark_mode(mark_mode);
 }
 
+gboolean
+cfg_set_log_level(GlobalConfig *self, const gchar *log_level)
+{
+  gint ll = msg_map_string_to_log_level(log_level);
+
+  if (ll < 0)
+    return FALSE;
+  configuration->log_level = ll;
+  return TRUE;
+}
+
 static void
 _invoke_module_init(gchar *key, ModuleConfig *mc, gpointer *args)
 {
@@ -314,6 +325,7 @@ cfg_init(GlobalConfig *cfg)
 {
   gint regerr;
 
+  msg_apply_config_log_level(cfg->log_level);
   if (cfg->file_template_name && !(cfg->file_template = cfg_tree_lookup_template(&cfg->tree, cfg->file_template_name)))
     msg_error("Error resolving file template",
               evt_tag_str("name", cfg->file_template_name));
@@ -501,6 +513,7 @@ cfg_new(gint version)
 
   self->recv_time_zone = NULL;
   self->keep_timestamp = TRUE;
+  self->log_level = -1;
 
   self->use_uniqid = FALSE;
 

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -91,6 +91,7 @@ struct _GlobalConfig
   gint log_fifo_size;
   gint log_msg_size;
   gboolean trim_large_messages;
+  gint log_level;
 
   gboolean create_dirs;
   FilePermOptions file_perm_options;
@@ -136,6 +137,7 @@ gboolean cfg_allow_config_dups(GlobalConfig *self);
 void cfg_bad_hostname_set(GlobalConfig *self, gchar *bad_hostname_re);
 gint cfg_lookup_mark_mode(const gchar *mark_mode);
 void cfg_set_mark_mode(GlobalConfig *self, const gchar *mark_mode);
+gboolean cfg_set_log_level(GlobalConfig *self, const gchar *log_level);
 
 gint cfg_tz_convert_value(gchar *convert);
 gint cfg_ts_format_value(gchar *format);

--- a/lib/control/tests/test_control_cmds.c
+++ b/lib/control/tests/test_control_cmds.c
@@ -125,55 +125,49 @@ Test(control_cmds, test_log)
   cr_assert(first_line_eq(response, "FAIL Invalid arguments received"),
             "Bad reply: [%s]", response);
 
-  verbose_flag = 0;
-  debug_flag = 1;
-  trace_flag = 1;
+  msg_set_log_level(0);
   _run_command("LOG VERBOSE", &response);
-  cr_assert(first_line_eq(response, "OK VERBOSE=0"),
+  cr_assert(first_line_eq(response, "OK syslog-ng log level set to 0"),
             "Bad reply: [%s]", response);
 
   _run_command("LOG VERBOSE ON", &response);
-  cr_assert(first_line_eq(response, "OK VERBOSE=1"),
+  cr_assert(first_line_eq(response, "OK syslog-ng log level set to 1"),
             "Bad reply: [%s]", response);
   cr_assert_eq(verbose_flag, 1, "Flag isn't changed");
 
   _run_command("LOG VERBOSE OFF", &response);
-  cr_assert(first_line_eq(response, "OK VERBOSE=0"),
+  cr_assert(first_line_eq(response, "OK syslog-ng log level set to 0"),
             "Bad reply: [%s]", response);
   cr_assert_eq(verbose_flag, 0, "Flag isn't changed");
 
 
-  debug_flag = 0;
-  verbose_flag = 1;
-  trace_flag = 1;
+  msg_set_log_level(1);
   _run_command("LOG DEBUG", &response);
-  cr_assert(first_line_eq(response, "OK DEBUG=0"),
+  cr_assert(first_line_eq(response, "OK syslog-ng log level set to 1"),
             "Bad reply: [%s]", response);
 
   _run_command("LOG DEBUG ON", &response);
-  cr_assert(first_line_eq(response, "OK DEBUG=1"),
+  cr_assert(first_line_eq(response, "OK syslog-ng log level set to 2"),
             "Bad reply: [%s]", response);
   cr_assert_eq(debug_flag, 1, "Flag isn't changed");
 
   _run_command("LOG DEBUG OFF", &response);
-  cr_assert(first_line_eq(response, "OK DEBUG=0"),
+  cr_assert(first_line_eq(response, "OK syslog-ng log level set to 1"),
             "Bad reply: [%s]", response);
   cr_assert_eq(debug_flag, 0, "Flag isn't changed");
 
-  debug_flag = 1;
-  verbose_flag = 1;
-  trace_flag = 0;
+  msg_set_log_level(2);
   _run_command("LOG TRACE", &response);
-  cr_assert(first_line_eq(response, "OK TRACE=0"),
+  cr_assert(first_line_eq(response, "OK syslog-ng log level set to 2"),
             "Bad reply: [%s]", response);
 
   _run_command("LOG TRACE ON", &response);
-  cr_assert(first_line_eq(response, "OK TRACE=1"),
+  cr_assert(first_line_eq(response, "OK syslog-ng log level set to 3"),
             "Bad reply: [%s]", response);
   cr_assert_eq(trace_flag, 1, "Flag isn't changed");
 
   _run_command("LOG TRACE OFF", &response);
-  cr_assert(first_line_eq(response, "OK TRACE=0"),
+  cr_assert(first_line_eq(response, "OK syslog-ng log level set to 2"),
             "Bad reply: [%s]", response);
   cr_assert_eq(trace_flag, 0, "Flag isn't changed");
 

--- a/lib/control/tests/test_control_cmds.c
+++ b/lib/control/tests/test_control_cmds.c
@@ -173,6 +173,27 @@ Test(control_cmds, test_log)
 
 }
 
+Test(control_cmds, test_log_level)
+{
+  const gchar *response;
+
+  msg_set_log_level(0);
+  _run_command("LOG LEVEL foo", &response);
+  cr_assert(first_line_eq(response, "FAIL Invalid arguments received"),
+            "Bad reply: [%s]", response);
+
+  msg_set_log_level(0);
+  _run_command("LOG LEVEL debug", &response);
+  cr_assert(first_line_eq(response, "OK syslog-ng log level set to 2"),
+            "Bad reply: [%s]", response);
+
+  msg_set_log_level(1);
+  _run_command("LOG LEVEL", &response);
+  cr_assert(first_line_eq(response, "OK syslog-ng log level set to 1"),
+            "Bad reply: [%s]", response);
+
+}
+
 Test(control_cmds, test_stats)
 {
   StatsCounterItem *counter = NULL;

--- a/lib/mainloop-control.c
+++ b/lib/mainloop-control.c
@@ -35,6 +35,22 @@
 #include <string.h>
 
 static gboolean
+_control_process_log_level(const gchar *level, GString *result)
+{
+  if (!level)
+    {
+      /* query current log level */
+      return TRUE;
+    }
+  gint ll = msg_map_string_to_log_level(level);
+  if (ll < 0)
+    return FALSE;
+
+  msg_set_log_level(ll);
+  return TRUE;
+}
+
+static gboolean
 _control_process_compat_log_command(const gchar *level, const gchar *onoff, GString *result)
 {
   if (!level)
@@ -70,7 +86,10 @@ control_connection_message_log(ControlConnection *cc, GString *command, gpointer
 
   gint orig_log_level = msg_get_log_level();
 
-  success = _control_process_compat_log_command(cmds[1], cmds[2], result);
+  if (g_str_equal(cmds[1], "LEVEL"))
+    success = _control_process_log_level(cmds[2], result);
+  else
+    success = _control_process_compat_log_command(cmds[1], cmds[2], result);
 
   if (orig_log_level != msg_get_log_level())
     msg_info("Verbosity changed",

--- a/lib/messages.h
+++ b/lib/messages.h
@@ -47,6 +47,12 @@ void msg_event_print_event_to_stderr(EVTREC *e);
 
 
 void msg_set_post_func(MsgPostFunc func);
+gint msg_map_string_to_log_level(const gchar *log_level);
+void msg_set_log_level(gint new_log_level);
+gint msg_get_log_level(void);
+void msg_apply_cmdline_log_level(gint new_log_level);
+void msg_apply_config_log_level(gint new_log_level);
+
 void msg_init(gboolean interactive);
 void msg_deinit(void);
 

--- a/lib/tests/test_messages.c
+++ b/lib/tests/test_messages.c
@@ -74,3 +74,67 @@ Test(test_messages, test_errno_capture)
   msg_set_post_func(test_errno_capture_asserter);
   msg_error("test errno capture", (errno=10, evt_tag_error("error")));
 }
+
+Test(test_messages, test_msg_set_log_level_sets_flags_correctly)
+{
+  verbose_flag = FALSE;
+  debug_flag = FALSE;
+  trace_flag = FALSE;
+
+  msg_set_log_level(0);
+  cr_assert_not(verbose_flag);
+  cr_assert_not(debug_flag);
+  cr_assert_not(trace_flag);
+  cr_assert_eq(msg_get_log_level(), 0);
+
+  msg_set_log_level(1);
+  cr_assert(verbose_flag);
+  cr_assert_not(debug_flag);
+  cr_assert_not(trace_flag);
+  cr_assert_eq(msg_get_log_level(), 1);
+
+  msg_set_log_level(2);
+  cr_assert(verbose_flag);
+  cr_assert(debug_flag);
+  cr_assert_not(trace_flag);
+  cr_assert_eq(msg_get_log_level(), 2);
+
+  msg_set_log_level(3);
+  cr_assert(verbose_flag);
+  cr_assert(debug_flag);
+  cr_assert(trace_flag);
+  cr_assert_eq(msg_get_log_level(), 3);
+
+  /* this does nothing */
+  msg_set_log_level(-1);
+  cr_assert(verbose_flag);
+  cr_assert(debug_flag);
+  cr_assert(trace_flag);
+  cr_assert_eq(msg_get_log_level(), 3);
+
+  msg_set_log_level(0);
+  cr_assert_not(verbose_flag);
+  cr_assert_not(debug_flag);
+  cr_assert_not(trace_flag);
+  cr_assert_eq(msg_get_log_level(), 0);
+
+  /* this does nothing */
+  msg_set_log_level(-1);
+  cr_assert_not(verbose_flag);
+  cr_assert_not(debug_flag);
+  cr_assert_not(trace_flag);
+  cr_assert_eq(msg_get_log_level(), 0);
+}
+
+Test(test_messages, test_msg_apply_config_log_level_sets_log_level_if_unset)
+{
+  msg_apply_config_log_level(3);
+  cr_assert_eq(msg_get_log_level(), 3);
+}
+
+Test(test_messages, test_msg_apply_config_log_level_is_ignored_if_already_set)
+{
+  msg_apply_cmdline_log_level(1);
+  msg_apply_config_log_level(3);
+  cr_assert_eq(msg_get_log_level(), 1);
+}

--- a/news/feature-4091.md
+++ b/news/feature-4091.md
@@ -1,0 +1,15 @@
+`log-level()`: added a new global option to control syslog-ng's own internal
+log level.  This augments the existing support for doing the same via the
+command line (via -d, -v and -t options) and via syslog-ng-ctl.  This change
+also causes higher log-levels to include messages from lower log-levels,
+e.g.  "trace" also implies "debug" and "verbose".  By adding this capability
+to the configuration, it becomes easier to control logging in containerized
+environments where changing command line options is more challenging.
+
+`syslog-ng-ctl log-level`: this new subcommand in syslog-ng-ctl allows
+setting the log level in a more intuitive way, compared to the existing
+`syslog-ng-ctl verbose|debug|trace -s` syntax.
+
+`syslog-ng --log-level`: this new command line option for the syslog-ng
+main binary allows you to set the desired log-level similar to how you
+can control it from the configuration or through `syslog-ng-ctl`.

--- a/syslog-ng-ctl/CMakeLists.txt
+++ b/syslog-ng-ctl/CMakeLists.txt
@@ -7,6 +7,8 @@ set(SYSLOG_NG_CTL_SOURCES
     commands/credentials.c
     commands/verbose.h
     commands/verbose.c
+    commands/log-level.h
+    commands/log-level.c
     commands/ctl-stats.h
     commands/ctl-stats.c
     commands/query.h

--- a/syslog-ng-ctl/Makefile.am
+++ b/syslog-ng-ctl/Makefile.am
@@ -12,6 +12,8 @@ syslog_ng_ctl_syslog_ng_ctl_SOURCES		= 	\
 	syslog-ng-ctl/commands/credentials.c		\
 	syslog-ng-ctl/commands/verbose.h		\
 	syslog-ng-ctl/commands/verbose.c		\
+	syslog-ng-ctl/commands/log-level.h		\
+	syslog-ng-ctl/commands/log-level.c		\
 	syslog-ng-ctl/commands/ctl-stats.h		\
 	syslog-ng-ctl/commands/ctl-stats.c		\
 	syslog-ng-ctl/commands/query.h			\

--- a/syslog-ng-ctl/commands/log-level.c
+++ b/syslog-ng-ctl/commands/log-level.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2022 Balazs Scheidler <bazsi77@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "log-level.h"
+#include <strings.h>
+
+static gchar *log_level = NULL;
+
+static gboolean
+_store_log_level(const gchar *option_name,
+                 const gchar *value,
+                 gpointer data,
+                 GError **error)
+{
+  if (!log_level)
+    {
+      log_level = g_strdup(value);
+      return TRUE;
+    }
+  g_set_error(error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED, "You can't specify multiple log-levels at a time.");
+  return FALSE;
+}
+
+GOptionEntry log_level_options[] =
+{
+  {
+    G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_CALLBACK, _store_log_level,
+    "Set log level", "<verbose|debug|trace>"
+  },
+  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL }
+};
+
+gint
+slng_log_level(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
+{
+  gchar buf[256];
+
+  if (log_level)
+    g_snprintf(buf, sizeof(buf), "LOG LEVEL %s\n", log_level);
+  else
+    g_snprintf(buf, sizeof(buf), "LOG LEVEL\n");
+
+  gchar *command = g_ascii_strup(buf, -1);
+
+  gint ret = dispatch_command(command);
+
+  g_free(command);
+  g_free(log_level);
+  return ret;
+}

--- a/syslog-ng-ctl/commands/log-level.h
+++ b/syslog-ng-ctl/commands/log-level.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022 Balazs Scheidler <bazsi77@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SYSLOG_NG_CTL_LOG_LEVEL_H_INCLUDED
+#define SYSLOG_NG_CTL_LOG_LEVEL_H_INCLUDED 1
+
+#include "commands.h"
+
+extern GOptionEntry log_level_options[];
+gint slng_log_level(int argc, char *argv[], const gchar *mode, GOptionContext *ctx);
+
+#endif

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -32,6 +32,7 @@
 #include "commands/config.h"
 #include "commands/credentials.h"
 #include "commands/verbose.h"
+#include "commands/log-level.h"
 #include "commands/ctl-stats.h"
 #include "commands/query.h"
 #include "commands/license.h"
@@ -113,6 +114,7 @@ static CommandDescriptor modes[] =
   { "verbose", verbose_options, "Enable/query verbose messages", slng_verbose, NULL },
   { "debug", verbose_options, "Enable/query debug messages", slng_verbose, NULL },
   { "trace", verbose_options, "Enable/query trace messages", slng_verbose, NULL },
+  { "log-level", log_level_options, "Set syslog-ng loglevel (verbose, debug, trace)", slng_log_level, NULL },
   { "stop", no_options, "Stop syslog-ng process", slng_stop, NULL },
   { "reload", no_options, "Reload syslog-ng", slng_reload, NULL },
   { "reopen", no_options, "Re-open of log destination files", slng_reopen, NULL },

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -85,6 +85,7 @@ lib/logmsg/tests/dump_logmsg\.c
 libtest/mock-logpipe\.[ch]
 lib/generic-number\.[ch]
 lib/tests/test_generic_number\.c
+syslog-ng-ctl/commands/log-level.[ch]
 
 ###########################################################################
 # These tests are GPLd even though they reside under lib/ and are excluded


### PR DESCRIPTION
This patch adds a feature to control the internal verbosity of syslog-ng (e.g. verbose, debug, trace) via the configuration file.
    
Example:

```    
    options {
      log-level(debug);
    };
```
Possible values for log-level:
    - default, just normal log messages
    - verbose, normal + messages that get enabled via -v
    - debug, verbose + messages that get enabled via -d
    - trace, debug + messages that get enabled via -t
    
If the option is unset, we leave the settings as specified on the command line.
    
If we have log-level(default) it would override settings specified via the command line.

Rationale: in containerized environments, it is much easier to override log verbosity settings via the config file than via changing the command line options.