### PR TITLE
Light: Dropping working dir concept

### DIFF
--- a/tests/light/functional_tests/conftest.py
+++ b/tests/light/functional_tests/conftest.py
@@ -26,7 +26,6 @@ import os
 import pytest
 from pathlib2 import Path
 
-import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.common.file import copy_file
 from src.common.pytest_operations import calculate_testcase_name
 
@@ -37,30 +36,22 @@ def calculate_report_file_path(working_dir):
     return Path(working_dir, "testcase.reportlog")
 
 
+def chdir_to_light_base_dir():
+    absolute_light_base_dir = Path(__file__).parents[1]
+    os.chdir(absolute_light_base_dir)
+
+
 def calculate_working_dir(pytest_config_object, testcase_name):
+    chdir_to_light_base_dir()
     report_dir = Path(pytest_config_object.getoption("--reports")).resolve().absolute()
     return Path(report_dir, calculate_testcase_name(testcase_name))
 
 
-def working_dir_and_current_dir_has_common_base(working_dir):
-    return str(working_dir).startswith(str(Path.cwd()))
-
-
 def pytest_runtest_setup(item):
     logging_plugin = item.config.pluginmanager.get_plugin("logging-plugin")
-    tc_parameters.WORKING_DIR = working_dir = calculate_working_dir(item.config, item.name)
+    working_dir = calculate_working_dir(item.config, item.name)
     logging_plugin.set_log_path(calculate_report_file_path(working_dir))
-    item.user_properties.append(("working_dir", working_dir))
-    if working_dir_and_current_dir_has_common_base(working_dir):
-        # relative path for working dir could be calculeted from current directory
-        relative_working_dir = working_dir.relative_to(Path.cwd())
-        item.user_properties.append(("relative_working_dir", relative_working_dir))
-    else:
-        # relative path for working dir could not be calculeted from current directory
-        if len(str(working_dir)) + len("syslog_ng_server.ctl") > 108:
-            # #define UNIX_PATH_MAX	108 (cat /usr/include/linux/un.h | grep "define UNIX_PATH_MAX)"
-            raise ValueError("Working directory lenght is too long, some socket files could not be saved, please make it shorter")
-        item.user_properties.append(("relative_working_dir", working_dir))
+    os.chdir(working_dir)
 
 
 def light_extra_files(target_dir):

--- a/tests/light/functional_tests/conftest.py
+++ b/tests/light/functional_tests/conftest.py
@@ -65,9 +65,9 @@ def light_extra_files(target_dir):
 def setup(request):
     testcase_parameters = request.getfixturevalue("testcase_parameters")
 
-    copy_file(testcase_parameters.get_testcase_file(), testcase_parameters.get_working_dir())
-    light_extra_files(testcase_parameters.get_working_dir())
-    request.addfinalizer(lambda: logger.info("Report file path\n{}\n".format(calculate_report_file_path(testcase_parameters.get_working_dir()))))
+    copy_file(testcase_parameters.get_testcase_file(), Path.cwd())
+    light_extra_files(Path.cwd())
+    request.addfinalizer(lambda: logger.info("Report file path\n{}\n".format(calculate_report_file_path(Path.cwd()))))
 
 
 class PortAllocator():

--- a/tests/light/functional_tests/destination_drivers/unix_dgram_destination/test_unix_dgram_destination.py
+++ b/tests/light/functional_tests/destination_drivers/unix_dgram_destination/test_unix_dgram_destination.py
@@ -20,9 +20,6 @@
 # COPYING for details.
 #
 #############################################################################
-from pathlib2 import Path
-
-import src.testcase_parameters.testcase_parameters as tc_parameters
 
 
 def test_unix_dgram_destination(config, syslog_ng):
@@ -30,9 +27,7 @@ def test_unix_dgram_destination(config, syslog_ng):
     message = "message text"
 
     generator_source = config.create_example_msg_generator_source(num=counter, freq=0.0001, template=config.stringify(message))
-    # NOTE: In this iteration testcase is responsible for generating proper output path (because of socket path length), this will be changed in the future
-    relative_unix_dgram_path = Path(tc_parameters.WORKING_DIR, "output_unix_dgram").relative_to(Path.cwd())
-    unix_dgram_destination = config.create_unix_dgram_destination(file_name=relative_unix_dgram_path)
+    unix_dgram_destination = config.create_unix_dgram_destination(file_name="output_unix_dgram")
     config.create_logpath(statements=[generator_source, unix_dgram_destination])
 
     unix_dgram_destination.start_listener()

--- a/tests/light/functional_tests/destination_drivers/unix_stream_destination/test_unix_stream_destination.py
+++ b/tests/light/functional_tests/destination_drivers/unix_stream_destination/test_unix_stream_destination.py
@@ -20,9 +20,6 @@
 # COPYING for details.
 #
 #############################################################################
-from pathlib2 import Path
-
-import src.testcase_parameters.testcase_parameters as tc_parameters
 
 
 def test_unix_stream_destination(config, syslog_ng):
@@ -30,9 +27,7 @@ def test_unix_stream_destination(config, syslog_ng):
     message = "message text"
 
     generator_source = config.create_example_msg_generator_source(num=counter, freq=0.0001, template=config.stringify(message))
-    # NOTE: In this iteration testcase is responsible for generating proper output path (because of socket path length), this will be changed in the future
-    relative_unix_stream_path = Path(tc_parameters.WORKING_DIR, "output_unix_stream").relative_to(Path.cwd())
-    unix_stream_destination = config.create_unix_stream_destination(file_name=relative_unix_stream_path)
+    unix_stream_destination = config.create_unix_stream_destination(file_name="output_unix_stream")
     config.create_logpath(statements=[generator_source, unix_stream_destination])
 
     unix_stream_destination.start_listener()

--- a/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_tls_passthrough.py
+++ b/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_tls_passthrough.py
@@ -22,7 +22,6 @@
 #############################################################################
 from pathlib2 import Path
 
-import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.common.blocking import wait_until_true
 from src.common.file import copy_shared_file
 from src.common.file import File
@@ -55,7 +54,7 @@ def test_pp_tls_passthrough(config, syslog_ng, port_allocator, loggen, testcase_
 
     syslog_ng.start(config)
 
-    loggen_input_file_path = Path(tc_parameters.WORKING_DIR, "loggen_input_{}.txt".format(get_unique_id()))
+    loggen_input_file_path = Path("loggen_input_{}.txt".format(get_unique_id()))
     loggen_input_file = File(loggen_input_file_path)
     loggen_input_file.open(mode="w")
     loggen_input_file.write(INPUT_MESSAGES)

--- a/tests/light/src/common/file.py
+++ b/tests/light/src/common/file.py
@@ -26,7 +26,6 @@ import shutil
 
 from pathlib2 import Path
 
-import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.common.blocking import DEFAULT_TIMEOUT
 from src.common.blocking import wait_until_true
 from src.common.blocking import wait_until_true_custom
@@ -46,12 +45,12 @@ def copy_file(src_file_path, dst_dir):
 
 def copy_shared_file(testcase_parameters, shared_file_name):
     shared_dir = testcase_parameters.get_shared_dir()
-    copy_file(Path(shared_dir, shared_file_name), testcase_parameters.get_working_dir())
-    return Path(testcase_parameters.get_working_dir(), shared_file_name)
+    copy_file(Path(shared_dir, shared_file_name), Path.cwd())
+    return Path(Path.cwd(), shared_file_name)
 
 
 def delete_session_file(shared_file_name):
-    shared_file_name = Path(tc_parameters.WORKING_DIR, shared_file_name)
+    shared_file_name = Path(shared_file_name)
     shared_file_name.unlink()
 
 

--- a/tests/light/src/conftest.py
+++ b/tests/light/src/conftest.py
@@ -22,9 +22,7 @@
 #
 #############################################################################
 import pytest
-from pathlib2 import Path
 
-import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.testcase_parameters.testcase_parameters import TestcaseParameters
 
 
@@ -37,12 +35,9 @@ def test_message():
 def fake_testcase_parameters(request, tmpdir):
     orig_installdir = request.config.option.installdir
     orig_reportdir = request.config.option.reports
-    tc_parameters.WORKING_DIR = working_dir = Path(tmpdir.join("working_dir"))
     request.config.option.installdir = tmpdir.join("installdir")
     request.config.option.reports = tmpdir.join("reports")
     request.config.option.runundertool = ""
-    request.node.user_properties.append(("working_dir", working_dir))
-    request.node.user_properties.append(("relative_working_dir", working_dir.relative_to(tmpdir.join("working_dir"))))
 
     yield TestcaseParameters(request)
     request.config.option.installdir = orig_installdir

--- a/tests/light/src/driver_io/network/network_io.py
+++ b/tests/light/src/driver_io/network/network_io.py
@@ -27,7 +27,6 @@ from enum import IntEnum
 
 from pathlib2 import Path
 
-import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.common.asynchronous import BackgroundEventLoop
 from src.common.blocking import DEFAULT_TIMEOUT
 from src.common.file import File
@@ -50,7 +49,7 @@ class NetworkIO():
         atexit.register(self.stop_listener)
 
     def write(self, content, rate=None):
-        loggen_input_file_path = Path(tc_parameters.WORKING_DIR, "loggen_input_{}.txt".format(get_unique_id()))
+        loggen_input_file_path = Path("loggen_input_{}.txt".format(get_unique_id()))
 
         loggen_input_file = File(loggen_input_file_path)
         loggen_input_file.open(mode="w")

--- a/tests/light/src/helpers/loggen/loggen.py
+++ b/tests/light/src/helpers/loggen/loggen.py
@@ -151,8 +151,8 @@ class Loggen(object):
             raise Exception("Loggen is already running, you shouldn't call start")
 
         instanceIndex = Loggen.__get_new_instance_index()
-        self.loggen_stdout_path = Path(tc_parameters.WORKING_DIR, "loggen_stdout_{}".format(instanceIndex))
-        self.loggen_stderr_path = Path(tc_parameters.WORKING_DIR, "loggen_stderr_{}".format(instanceIndex))
+        self.loggen_stdout_path = Path("loggen_stdout_{}".format(instanceIndex))
+        self.loggen_stderr_path = Path("loggen_stderr_{}".format(instanceIndex))
 
         self.parameters = self.__decode_start_parameters(
             inet, unix, stream, dgram, use_ssl, dont_parse, read_file, skip_tokens, loop_reading,

--- a/tests/light/src/helpers/secure_logging/conftest.py
+++ b/tests/light/src/helpers/secure_logging/conftest.py
@@ -23,7 +23,6 @@
 import pytest
 from pathlib2 import Path
 
-import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.common.file import copy_file
 from src.executors.command_executor import CommandExecutor
 from src.syslog_ng.syslog_ng_paths import SyslogNgPaths
@@ -43,10 +42,10 @@ class SecureLogging():
         self.create_decryption_key()
 
     def create_master_key(self):
-        slogkey_stdout = Path(tc_parameters.WORKING_DIR, "slogkey_stdout_master")
-        slogkey_stderr = Path(tc_parameters.WORKING_DIR, "slogkey_stderr_master")
+        slogkey_stdout = Path("slogkey_stdout_master")
+        slogkey_stderr = Path("slogkey_stderr_master")
 
-        self.master_key = Path(tc_parameters.WORKING_DIR, "master.key")
+        self.master_key = Path("master.key")
 
         CommandExecutor().run(
             [self.slogkey, "-m", self.master_key],
@@ -55,11 +54,11 @@ class SecureLogging():
         )
 
     def create_derived_key(self):
-        slogkey_stdout = Path(tc_parameters.WORKING_DIR, "slogkey_stdout_derived")
-        slogkey_stderr = Path(tc_parameters.WORKING_DIR, "slogkey_stderr_derived")
+        slogkey_stdout = Path("slogkey_stdout_derived")
+        slogkey_stderr = Path("slogkey_stderr_derived")
 
-        self.derived_key = Path(tc_parameters.WORKING_DIR, "derived.key")
-        self.cmac = Path(tc_parameters.WORKING_DIR, "cmac")
+        self.derived_key = Path("derived.key")
+        self.cmac = Path("cmac")
 
         CommandExecutor().run(
             [self.slogkey, "-d", self.master_key, "foo", "bar", self.derived_key],
@@ -68,14 +67,14 @@ class SecureLogging():
         )
 
     def create_decryption_key(self):
-        self.decryption_key = Path(tc_parameters.WORKING_DIR, "decryption.key")
+        self.decryption_key = Path("decryption.key")
         copy_file(self.derived_key, self.decryption_key)
 
     def decrypt(self, input_file):
-        slogverify_stdout = Path(tc_parameters.WORKING_DIR, "slogverify_stdout")
-        slogverify_stderr = Path(tc_parameters.WORKING_DIR, "slogverify_stderr")
-        encrypted = Path(tc_parameters.WORKING_DIR, input_file)
-        decrypted = Path(tc_parameters.WORKING_DIR, "decrypted.txt")
+        slogverify_stdout = Path("slogverify_stdout")
+        slogverify_stderr = Path("slogverify_stderr")
+        encrypted = Path(input_file)
+        decrypted = Path("decrypted.txt")
 
         CommandExecutor().run(
             [

--- a/tests/light/src/helpers/snmptrapd/conftest.py
+++ b/tests/light/src/helpers/snmptrapd/conftest.py
@@ -27,7 +27,6 @@ import pytest
 from pathlib2 import Path
 from psutil import TimeoutExpired
 
-import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.common.blocking import wait_until_true
 from src.common.file import File
 from src.executors.process_executor import ProcessExecutor
@@ -40,9 +39,9 @@ class SNMPtrapd(object):
         self.snmptrapd_proc = None
         self.port = port
 
-        self.snmptrapd_log = Path(tc_parameters.WORKING_DIR, "snmptrapd_log")
-        self.snmptrapd_stdout_path = Path(tc_parameters.WORKING_DIR, "snmptrapd_stdout")
-        self.snmptrapd_stderr_path = Path(tc_parameters.WORKING_DIR, "snmptrapd_stderr")
+        self.snmptrapd_log = Path("snmptrapd_log")
+        self.snmptrapd_stdout_path = Path("snmptrapd_stdout")
+        self.snmptrapd_stderr_path = Path("snmptrapd_stderr")
 
     def wait_for_snmptrapd_log_creation(self):
         return self.snmptrapd_log.exists()

--- a/tests/light/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/light/src/syslog_ng/syslog_ng_cli.py
@@ -24,7 +24,6 @@ import logging
 
 from pathlib2 import Path
 
-import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.common.blocking import wait_until_false
 from src.common.blocking import wait_until_true
 from src.syslog_ng.console_log_reader import ConsoleLogReader
@@ -166,7 +165,7 @@ class SyslogNgCli(object):
                 core_file_found = True
                 self.__process = None
                 self.__syslog_ng_executor.get_backtrace_from_core(core_file=str(core_file))
-                core_file.replace(Path(tc_parameters.WORKING_DIR, core_file))
+                core_file.replace(Path(core_file))
             if core_file_found:
                 raise Exception("syslog-ng core file was found and processed")
 

--- a/tests/light/src/syslog_ng/syslog_ng_paths.py
+++ b/tests/light/src/syslog_ng/syslog_ng_paths.py
@@ -22,7 +22,6 @@
 #############################################################################
 from pathlib2 import Path
 
-import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.common.random_id import get_unique_id
 
 
@@ -36,8 +35,6 @@ class SyslogNgPaths(object):
         if self.__instance_name is not None:
             raise Exception("Instance already configured")
         self.__instance_name = instance_name
-        working_dir = tc_parameters.WORKING_DIR
-        relative_working_dir = self.__testcase_parameters.get_relative_working_dir()
         install_dir = self.__testcase_parameters.get_install_dir()
         if not install_dir:
             raise ValueError("Missing --installdir start parameter")
@@ -45,12 +42,12 @@ class SyslogNgPaths(object):
         self.__syslog_ng_paths = {
             "dirs": {"install_dir": Path(install_dir)},
             "file_paths": {
-                "config_path": Path(working_dir, "syslog_ng_{}.conf".format(instance_name)),
-                "persist_path": Path(working_dir, "syslog_ng_{}.persist".format(instance_name)),
-                "pid_path": Path(working_dir, "syslog_ng_{}.pid".format(instance_name)),
-                "control_socket_path": Path(relative_working_dir, "syslog_ng_{}.ctl".format(instance_name)),
-                "stderr": Path(working_dir, "syslog_ng_{}_stderr".format(instance_name)),
-                "stdout": Path(working_dir, "syslog_ng_{}_stdout".format(instance_name)),
+                "config_path": Path("syslog_ng_{}.conf".format(instance_name)),
+                "persist_path": Path("syslog_ng_{}.persist".format(instance_name)),
+                "pid_path": Path("syslog_ng_{}.pid".format(instance_name)),
+                "control_socket_path": Path("syslog_ng_{}.ctl".format(instance_name)),
+                "stderr": Path("syslog_ng_{}_stderr".format(instance_name)),
+                "stdout": Path("syslog_ng_{}_stdout".format(instance_name)),
             },
             "binary_file_paths": {
                 "slogkey": Path(install_dir, "bin", "slogkey"),
@@ -110,7 +107,7 @@ class SyslogNgPaths(object):
     def register_external_tool_output_path(self, external_tool):
         self.__syslog_ng_paths['file_paths'].update(
             {
-                external_tool: Path(tc_parameters.WORKING_DIR, "{}_{}.log".format(external_tool, get_unique_id())),
+                external_tool: Path("{}_{}.log".format(external_tool, get_unique_id())),
             },
         )
 

--- a/tests/light/src/syslog_ng_config/statements/destinations/example_destination.py
+++ b/tests/light/src/syslog_ng_config/statements/destinations/example_destination.py
@@ -22,7 +22,6 @@
 #############################################################################
 from pathlib2 import Path
 
-import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.driver_io.file.file_io import FileIO
 from src.syslog_ng_config.statements.destinations.destination_driver import DestinationDriver
 
@@ -30,7 +29,7 @@ from src.syslog_ng_config.statements.destinations.destination_driver import Dest
 class ExampleDestination(DestinationDriver):
     def __init__(self, filename, **options):
         self.driver_name = "example-destination"
-        self.path = Path(tc_parameters.WORKING_DIR, filename)
+        self.path = Path(filename)
         self.io = FileIO(self.path)
         super(ExampleDestination, self).__init__(None, dict({"filename": self.path.resolve()}, **options))
 

--- a/tests/light/src/syslog_ng_config/statements/destinations/file_destination.py
+++ b/tests/light/src/syslog_ng_config/statements/destinations/file_destination.py
@@ -22,7 +22,6 @@
 #############################################################################
 from pathlib2 import Path
 
-import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.driver_io.file.file_io import FileIO
 from src.syslog_ng_config.statements.destinations.destination_driver import DestinationDriver
 
@@ -30,7 +29,7 @@ from src.syslog_ng_config.statements.destinations.destination_driver import Dest
 class FileDestination(DestinationDriver):
     def __init__(self, file_name, **options):
         self.driver_name = "file"
-        self.path = Path(tc_parameters.WORKING_DIR, file_name)
+        self.path = Path(file_name)
         self.io = FileIO(self.path)
         super(FileDestination, self).__init__([self.path], options)
 

--- a/tests/light/src/syslog_ng_config/statements/parsers/db_parser.py
+++ b/tests/light/src/syslog_ng_config/statements/parsers/db_parser.py
@@ -26,7 +26,6 @@ from xml.etree.ElementTree import tostring
 
 from pathlib2 import Path
 
-import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.syslog_ng_config.statements.parsers.parser import Parser
 
 
@@ -59,7 +58,7 @@ class DBParser(Parser):
     index = 0
 
     def __init__(self, config, **options):
-        path = Path(tc_parameters.WORKING_DIR, "patterndb-{}.xml".format(self.index))
+        path = Path("patterndb-{}.xml".format(self.index))
         config.write_to(path)
         self.index += 1
         super(DBParser, self).__init__("db-parser", file=path.resolve(), **options)

--- a/tests/light/src/syslog_ng_config/statements/sources/file_source.py
+++ b/tests/light/src/syslog_ng_config/statements/sources/file_source.py
@@ -24,7 +24,6 @@ import logging
 
 from pathlib2 import Path
 
-import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.driver_io.file.file_io import FileIO
 from src.syslog_ng_config.statements.sources.source_driver import SourceDriver
 
@@ -42,7 +41,7 @@ class FileSource(SourceDriver):
         return self.path
 
     def set_path(self, pathname):
-        self.path = Path(tc_parameters.WORKING_DIR, pathname)
+        self.path = Path(pathname)
 
     def write_log(self, formatted_log, counter=1):
         for _ in range(counter):

--- a/tests/light/src/syslog_ng_ctl/syslog_ng_ctl_executor.py
+++ b/tests/light/src/syslog_ng_ctl/syslog_ng_ctl_executor.py
@@ -24,7 +24,6 @@ from enum import Enum  # noreorder
 
 from pathlib2 import Path
 
-import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.executors.command_executor import CommandExecutor
 
 
@@ -51,7 +50,7 @@ class SyslogNgCtlExecutor(object):
 
     def __construct_std_file_path(self, command_short_name, std_type):
         instance_name = self.__instance_paths.get_instance_name()
-        return Path(tc_parameters.WORKING_DIR, "syslog_ng_ctl_{}_{}_{}".format(instance_name, command_short_name, std_type))
+        return Path("syslog_ng_ctl_{}_{}_{}".format(instance_name, command_short_name, std_type))
 
     def __construct_ctl_command(self, command):
         ctl_command = [self.__syslog_ng_control_tool_path]

--- a/tests/light/src/testcase_parameters/testcase_parameters.py
+++ b/tests/light/src/testcase_parameters/testcase_parameters.py
@@ -25,20 +25,12 @@ from pathlib2 import Path
 from src.common.pytest_operations import calculate_testcase_name
 
 
-WORKING_DIR = None
 INSTANCE_PATH = None
 
 
 class TestcaseParameters(object):
     def __init__(self, pytest_request):
         testcase_name = calculate_testcase_name(pytest_request.node.name)
-        for item in pytest_request.node.user_properties:
-            if item[0] == "working_dir":
-                self.working_dir = None
-                self.set_working_dir(item[1])
-            elif item[0] == "relative_working_dir":
-                self.relative_working_dir = None
-                self.set_relative_working_dir(item[1])
         absolute_framework_dir = Path(__file__).parents[2]
         self.testcase_parameters = {
             "dirs": {
@@ -51,18 +43,6 @@ class TestcaseParameters(object):
             "testcase_name": testcase_name,
             "external_tool": pytest_request.config.getoption("--run-under"),
         }
-
-    def set_working_dir(self, working_dir):
-        self.working_dir = working_dir
-
-    def set_relative_working_dir(self, relative_working_dir):
-        self.relative_working_dir = relative_working_dir
-
-    def get_working_dir(self):
-        return self.working_dir
-
-    def get_relative_working_dir(self):
-        return self.relative_working_dir
 
     def get_install_dir(self):
         return self.testcase_parameters["dirs"]["install_dir"]


### PR DESCRIPTION
Behind the working dir the main concept was the following:
 - we are running Light from the following base dir: tests/light/
 - in setup phase for every testcase working dir has been calculated: tests/light/reports/date/testcase_name/
 - during the testrun Light will collect/write each testcase related files into the working dir
 - the code uses the path reference for these files with their absoulute or relative paths


The problem with working dir concept:
 - basically with the working dir we reference for the files with their absolute path
 - in some cases this path can not be longer than a certain character length (~160 chars for sockets), which makes
 a hard limit for reports dir and testcase file names also 
 - because of this relative working dir path will be introduced 
 -  because there are so many files related with testcases the concept has been leaked in various
    places of the code which was hard to manage and adds some complexity


The original concept will be replaced with the following:
  - in setup phase of each testcase Light will calculate actual working dir as previously
  - after the working dir has been calculated Light will change (chdir) the actual 'running dir' to the
    working dir (this is new)
  - with this we can reference for all testcase related files as it is placed in the actual dir, so
    working dir and relative working dir can be dropped

