### PR TITLE
add support for custom separators in json-parser() and $(format-json)

### DIFF
--- a/lib/value-pairs/cmdline.h
+++ b/lib/value-pairs/cmdline.h
@@ -28,7 +28,7 @@
 
 ValuePairs *value_pairs_new_from_cmdline(GlobalConfig *cfg,
                                          gint *argc, gchar ***argv,
-                                         gboolean ignore_unknown_options,
+                                         GOptionGroup *custom_options,
                                          GError **error);
 
 #endif

--- a/lib/value-pairs/internals.h
+++ b/lib/value-pairs/internals.h
@@ -31,6 +31,7 @@
 struct _ValuePairs
 {
   GAtomicCounter ref_cnt;
+  GlobalConfig *cfg;
   GPtrArray *builtins;
   GPtrArray *patterns;
   GPtrArray *vpairs;

--- a/lib/value-pairs/tests/test_value_pairs_walk.c
+++ b/lib/value-pairs/tests/test_value_pairs_walk.c
@@ -124,7 +124,7 @@ Test(value_pairs_walker, prefix_dat)
   log_msg_set_value_by_name(msg, "root.test.korte", value, strlen(value));
 
   LogTemplateEvalOptions options = {&template_options, LTZ_LOCAL, 0, NULL, LM_VT_STRING};
-  value_pairs_walk(vp, test_vp_obj_start, test_vp_value, test_vp_obj_stop, msg, &options, NULL);
+  value_pairs_walk(vp, test_vp_obj_start, test_vp_value, test_vp_obj_stop, msg, &options, 0, NULL);
   value_pairs_unref(vp);
   log_msg_unref(msg);
 };

--- a/lib/value-pairs/value-pairs.c
+++ b/lib/value-pairs/value-pairs.c
@@ -714,25 +714,43 @@ _extract_and_find_next_token_with_custom_delimiter(vp_walk_state_t *state, const
   *token_end_p = token_end;
 }
 
-static GPtrArray *
-vp_walker_split_name_to_tokens(vp_walk_state_t *state, const gchar *name)
+static void
+_extract_tokens_with_default_delimiter(vp_walk_state_t *state, const gchar *name)
 {
   const gchar *token_start = name;
   const gchar *token_end = name;
 
-  state->tokens = g_ptr_array_sized_new(VP_STACK_INITIAL_SIZE);
-
   while (*token_end)
-    {
-      if (state->key_delimiter == '.')
-        _extract_and_find_next_token(state, &token_start, &token_end);
-      else
-        _extract_and_find_next_token_with_custom_delimiter(state, &token_start, &token_end);
-    }
+    _extract_and_find_next_token(state, &token_start, &token_end);
 
   /* extract last token at the end */
   if (token_start != token_end)
     _extract_token(state, token_start, token_end - token_start);
+}
+
+static void
+_extract_tokens_with_custom_delimiter(vp_walk_state_t *state, const gchar *name)
+{
+  const gchar *token_start = name;
+  const gchar *token_end = name;
+
+  while (*token_end)
+    _extract_and_find_next_token_with_custom_delimiter(state, &token_start, &token_end);
+
+  /* extract last token at the end */
+  if (token_start != token_end)
+    _extract_token(state, token_start, token_end - token_start);
+}
+
+static GPtrArray *
+vp_walker_split_name_to_tokens(vp_walk_state_t *state, const gchar *name)
+{
+  state->tokens = g_ptr_array_sized_new(VP_STACK_INITIAL_SIZE);
+
+  if (state->key_delimiter == '.')
+    _extract_tokens_with_default_delimiter(state, name);
+  else
+    _extract_tokens_with_custom_delimiter(state, name);
 
   if (state->tokens->len == 0)
     {

--- a/lib/value-pairs/value-pairs.c
+++ b/lib/value-pairs/value-pairs.c
@@ -897,6 +897,7 @@ value_pairs_new(GlobalConfig *cfg)
   vp->vpairs = g_ptr_array_new();
   vp->patterns = g_ptr_array_new();
   vp->transforms = g_ptr_array_new();
+  vp->cfg = cfg;
 
   if (cfg_is_config_version_older(cfg, VERSION_VALUE_4_0))
     {

--- a/lib/value-pairs/value-pairs.h
+++ b/lib/value-pairs/value-pairs.h
@@ -70,6 +70,7 @@ gboolean value_pairs_walk(ValuePairs *vp,
                           VPWalkValueCallbackFunc process_value_func,
                           VPWalkCallbackFunc obj_end_func,
                           LogMessage *msg, LogTemplateEvalOptions *options,
+                          gchar key_delimiter,
                           gpointer user_data);
 
 ValuePairs *value_pairs_new(GlobalConfig *cfg);

--- a/modules/afmongodb/afmongodb-worker.c
+++ b/modules/afmongodb/afmongodb-worker.c
@@ -333,6 +333,7 @@ _worker_insert(LogThreadedDestWorker *s, LogMessage *msg)
                              _vp_process_value,
                              _vp_obj_end,
                              msg, &options,
+                             0,
                              self);
 
   if (!success)

--- a/modules/basicfuncs/vp-funcs.c
+++ b/modules/basicfuncs/vp-funcs.c
@@ -56,7 +56,7 @@ tf_value_pairs_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *paren
   else
     g_assert_not_reached();
 
-  state->vp = value_pairs_new_from_cmdline (parent->cfg, &argc, &argv, TRUE, error);
+  state->vp = value_pairs_new_from_cmdline (parent->cfg, &argc, &argv, NULL, error);
   return state->vp != NULL;
 }
 

--- a/modules/cef/format-cef-extension.c
+++ b/modules/cef/format-cef-extension.c
@@ -41,7 +41,7 @@ tf_cef_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
 {
   TFCefState *state = (TFCefState *)s;
 
-  state->vp = value_pairs_new_from_cmdline(parent->cfg, &argc, &argv, FALSE, error);
+  state->vp = value_pairs_new_from_cmdline(parent->cfg, &argc, &argv, NULL, error);
   if (!state->vp)
     return FALSE;
 

--- a/modules/graphite/graphite-output.c
+++ b/modules/graphite/graphite-output.c
@@ -105,7 +105,7 @@ tf_graphite_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
       log_template_compile(state->timestamp_template, "$R_UNIXTIME", NULL);
     }
 
-  state->vp = value_pairs_new_from_cmdline (parent->cfg, &argc, &argv, FALSE, error);
+  state->vp = value_pairs_new_from_cmdline (parent->cfg, &argc, &argv, NULL, error);
   if (!state->vp)
     return FALSE;
 

--- a/modules/json/format-json.c
+++ b/modules/json/format-json.c
@@ -338,7 +338,7 @@ tf_json_append(GString *result, ValuePairs *vp, LogMessage *msg, LogTemplateEval
 
   return value_pairs_walk(vp,
                           tf_json_obj_start, tf_json_value, tf_json_obj_end,
-                          msg, options, &state);
+                          msg, options, 0, &state);
 }
 
 static void
@@ -432,7 +432,7 @@ tf_flat_json_append(GString *result, ValuePairs *vp, LogMessage *msg, LogTemplat
 
   gboolean success = value_pairs_walk(vp,
                                       tf_flat_json_obj_start, tf_flat_json_value, tf_flat_json_obj_end,
-                                      msg, options,
+                                      msg, options, 0,
                                       &state);
 
   g_string_append_c(state.buffer, '}');

--- a/modules/json/json-parser-grammar.ym
+++ b/modules/json/json-parser-grammar.ym
@@ -51,6 +51,7 @@
 %token KW_JSON_PARSER
 %token KW_PREFIX
 %token KW_MARKER
+%token KW_KEY_DELIMITER
 %token KW_EXTRACT_PREFIX
 
 %type	<ptr> parser_expr_json
@@ -79,7 +80,13 @@ parser_json_opts
 parser_json_opt
 	: KW_PREFIX '(' string ')'		{ json_parser_set_prefix(last_parser, $3); free($3); }
 	| KW_MARKER '(' string ')'		{ json_parser_set_marker(last_parser, $3); free($3); }
-	| KW_EXTRACT_PREFIX '(' string  ')'      { json_parser_set_extract_prefix(last_parser, $3); free($3); }
+	| KW_EXTRACT_PREFIX '(' string  ')'     { json_parser_set_extract_prefix(last_parser, $3); free($3); }
+        | KW_KEY_DELIMITER '(' string ')'
+          {
+            CHECK_ERROR(strlen($3) == 1, @3, "key-delimiter() only supports single characters");
+            json_parser_set_key_delimiter(last_parser, $3[0]);
+            free($3);
+          }
 	| parser_opt
 	;
 

--- a/modules/json/json-parser-parser.c
+++ b/modules/json/json-parser-parser.c
@@ -34,6 +34,7 @@ static CfgLexerKeyword json_parser_keywords[] =
   { "prefix",               KW_PREFIX,  },
   { "marker",               KW_MARKER,  },
   { "extract_prefix",       KW_EXTRACT_PREFIX, },
+  { "key_delimiter",        KW_KEY_DELIMITER, },
   { NULL }
 };
 

--- a/modules/json/json-parser.c
+++ b/modules/json/json-parser.c
@@ -43,6 +43,7 @@ typedef struct _JSONParser
   gchar *marker;
   gint marker_len;
   gchar *extract_prefix;
+  gchar key_delimiter;
 } JSONParser;
 
 void
@@ -71,6 +72,14 @@ json_parser_set_extract_prefix(LogParser *s, const gchar *extract_prefix)
 
   g_free(self->extract_prefix);
   self->extract_prefix = g_strdup(extract_prefix);
+}
+
+void
+json_parser_set_key_delimiter(LogParser *s, gchar delimiter)
+{
+  JSONParser *self = (JSONParser *) s;
+
+  self->key_delimiter = delimiter;
 }
 
 static void
@@ -182,8 +191,8 @@ json_parser_extract_values_from_complex_json_object(JSONParser *self,
       if (prefix)
         g_string_assign(key, prefix);
       g_string_append(key, obj_key);
-      g_string_append_c(key, '.');
-      json_parser_process_object(jso, key->str, msg);
+      g_string_append_c(key, self->key_delimiter);
+      json_parser_process_object(self, jso, key->str, msg);
       return TRUE;
     }
     case json_type_array:
@@ -382,6 +391,7 @@ json_parser_clone(LogPipe *s)
   json_parser_set_prefix(cloned, self->prefix);
   json_parser_set_marker(cloned, self->marker);
   json_parser_set_extract_prefix(cloned, self->extract_prefix);
+  json_parser_set_key_delimiter(cloned, self->key_delimiter);
   log_parser_set_template(cloned, log_template_ref(self->super.template));
 
   return &cloned->super;
@@ -407,6 +417,7 @@ json_parser_new(GlobalConfig *cfg)
   self->super.super.free_fn = json_parser_free;
   self->super.super.clone = json_parser_clone;
   self->super.process = json_parser_process;
+  self->key_delimiter = '.';
 
   return &self->super;
 }

--- a/modules/json/json-parser.c
+++ b/modules/json/json-parser.c
@@ -74,7 +74,8 @@ json_parser_set_extract_prefix(LogParser *s, const gchar *extract_prefix)
 }
 
 static void
-json_parser_store_value(const gchar *prefix, const gchar *obj_key,
+json_parser_store_value(JSONParser *self,
+                        const gchar *prefix, const gchar *obj_key,
                         GString *value, LogMessageValueType type,
                         LogMessage *msg)
 {
@@ -92,13 +93,17 @@ json_parser_store_value(const gchar *prefix, const gchar *obj_key,
 }
 
 static void
-json_parser_process_object(struct json_object *jso,
+json_parser_process_object(JSONParser *self,
+                           struct json_object *jso,
                            const gchar *prefix,
                            LogMessage *msg);
 
 
 static gboolean
-json_parser_extract_string_from_simple_json_object(struct json_object *jso, GString *value, LogMessageValueType *type)
+json_parser_extract_string_from_simple_json_object(JSONParser *self,
+                                                   struct json_object *jso,
+                                                   GString *value,
+                                                   LogMessageValueType *type)
 {
   switch (json_object_get_type(jso))
     {
@@ -149,21 +154,23 @@ json_parser_extract_string_from_simple_json_object(struct json_object *jso, GStr
 }
 
 static gboolean
-json_parser_extract_value_from_simple_json_object(struct json_object *jso,
+json_parser_extract_value_from_simple_json_object(JSONParser *self,
+                                                  struct json_object *jso,
                                                   const gchar *prefix, const gchar *obj_key,
                                                   LogMessage *msg)
 {
   GString *value = scratch_buffers_alloc();
   LogMessageValueType type = LM_VT_STRING;
 
-  if (!json_parser_extract_string_from_simple_json_object(jso, value, &type))
+  if (!json_parser_extract_string_from_simple_json_object(self, jso, value, &type))
     return FALSE;
-  json_parser_store_value(prefix, obj_key, value, type, msg);
+  json_parser_store_value(self, prefix, obj_key, value, type, msg);
   return TRUE;
 }
 
 static gboolean
-json_parser_extract_values_from_complex_json_object(struct json_object *jso,
+json_parser_extract_values_from_complex_json_object(JSONParser *self,
+                                                    struct json_object *jso,
                                                     const gchar *prefix, const gchar *obj_key,
                                                     LogMessage *msg)
 {
@@ -192,7 +199,7 @@ json_parser_extract_values_from_complex_json_object(struct json_object *jso,
           GString *element_value = scratch_buffers_alloc();
           LogMessageValueType element_type;
 
-          if (json_parser_extract_string_from_simple_json_object(el, element_value, &element_type))
+          if (json_parser_extract_string_from_simple_json_object(self, el, element_value, &element_type))
             {
               if (i != 0)
                 g_string_append_c(value, ',');
@@ -207,7 +214,7 @@ json_parser_extract_values_from_complex_json_object(struct json_object *jso,
             }
         }
 
-      json_parser_store_value(prefix, obj_key, value, type, msg);
+      json_parser_store_value(self, prefix, obj_key, value, type, msg);
       return TRUE;
     }
     default:
@@ -218,7 +225,8 @@ json_parser_extract_values_from_complex_json_object(struct json_object *jso,
 
 
 static void
-json_parser_process_attribute(struct json_object *jso,
+json_parser_process_attribute(JSONParser *self,
+                              struct json_object *jso,
                               const gchar *prefix,
                               const gchar *obj_key,
                               LogMessage *msg)
@@ -226,8 +234,8 @@ json_parser_process_attribute(struct json_object *jso,
   ScratchBuffersMarker marker;
   scratch_buffers_mark(&marker);
 
-  if (!json_parser_extract_value_from_simple_json_object(jso, prefix, obj_key, msg) &&
-      !json_parser_extract_values_from_complex_json_object(jso, prefix, obj_key, msg))
+  if (!json_parser_extract_value_from_simple_json_object(self, jso, prefix, obj_key, msg) &&
+      !json_parser_extract_values_from_complex_json_object(self, jso, prefix, obj_key, msg))
     {
       msg_debug("JSON parser encountered an unknown type, skipping",
                 evt_tag_str("key", obj_key),
@@ -239,7 +247,8 @@ json_parser_process_attribute(struct json_object *jso,
 }
 
 static void
-json_parser_process_object(struct json_object *jso,
+json_parser_process_object(JSONParser *self,
+                           struct json_object *jso,
                            const gchar *prefix,
                            LogMessage *msg)
 {
@@ -247,12 +256,13 @@ json_parser_process_object(struct json_object *jso,
 
   json_object_object_foreachC(jso, itr)
   {
-    json_parser_process_attribute(itr.val, prefix, itr.key, msg);
+    json_parser_process_attribute(self, itr.val, prefix, itr.key, msg);
   }
 }
 
 static void
-json_parser_process_array(struct json_object *jso,
+json_parser_process_array(JSONParser *self,
+                          struct json_object *jso,
                           const gchar *prefix,
                           LogMessage *msg)
 {
@@ -265,7 +275,7 @@ json_parser_process_array(struct json_object *jso,
       GString *element_value = scratch_buffers_alloc();
       LogMessageValueType element_type;
 
-      if (json_parser_extract_string_from_simple_json_object(el, element_value, &element_type))
+      if (json_parser_extract_string_from_simple_json_object(self, el, element_value, &element_type))
         {
           log_msg_set_match_with_type(msg, i + 1, element_value->str, element_value->len, element_type);
         }
@@ -289,12 +299,12 @@ json_parser_extract(JSONParser *self, struct json_object *jso, LogMessage *msg)
 
   if (json_object_is_type(jso, json_type_object))
     {
-      json_parser_process_object(jso, self->prefix, msg);
+      json_parser_process_object(self, jso, self->prefix, msg);
       return TRUE;
     }
   if (json_object_is_type(jso, json_type_array))
     {
-      json_parser_process_array(jso, self->prefix, msg);
+      json_parser_process_array(self, jso, self->prefix, msg);
       return TRUE;
     }
   return FALSE;

--- a/modules/json/json-parser.h
+++ b/modules/json/json-parser.h
@@ -28,6 +28,7 @@
 void json_parser_set_extract_prefix(LogParser *s, const gchar *extract_prefix);
 void json_parser_set_prefix(LogParser *p, const gchar *prefix);
 void json_parser_set_marker(LogParser *p, const gchar *marker);
+void json_parser_set_key_delimiter(LogParser *p, gchar delimiter);
 LogParser *json_parser_new(GlobalConfig *cfg);
 
 #endif

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -381,6 +381,7 @@ Test(format_json, test_format_flat_json_with_type_hints)
 Test(format_json, test_format_json_performance)
 {
   perftest_template("$(format-json APP.*)\n");
+  perftest_template("$(format-flat-json APP.*)\n");
   perftest_template("<$PRI>1 $ISODATE $LOGHOST @syslog-ng - - ${SDATA:--} $(format-json --scope all-nv-pairs "
                     "--exclude 0* --exclude 1* --exclude 2* --exclude 3* --exclude 4* --exclude 5* "
                     "--exclude 6* --exclude 7* --exclude 8* --exclude 9* "

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -396,3 +396,13 @@ Test(format_json, test_format_json_performance)
                     "..RSTAMP='${R_UNIXTIME}${R_TZ}' "
                     "..TAGS=${TAGS})\n");
 }
+
+Test(format_json, test_format_json_with_key_delimiter)
+{
+  assert_template_format("$(format-json --key-delimiter \"\t\" \".foo\t.b.a.r.\"=\"baz\")",
+                         "{\".foo\":{\".b.a.r.\":\"baz\"}}");
+  assert_template_format("$(format-json --key-delimiter \".\" \".foo.bar\"=\"baz\")",
+                         "{\"_foo\":{\"bar\":\"baz\"}}");
+  assert_template_format("$(format-json \".foo.bar\"=\"baz\")",
+                         "{\"_foo\":{\"bar\":\"baz\"}}");
+}

--- a/modules/json/tests/test_json_parser.c
+++ b/modules/json/tests/test_json_parser.c
@@ -101,6 +101,19 @@ Test(json_parser, test_json_parser_adds_prefix_to_name_value_pairs_when_instruct
   log_pipe_unref(&json_parser->super);
 }
 
+Test(json_parser, test_json_parser_uses_key_delimiter_when_its_specified)
+{
+  LogMessage *msg;
+  LogParser *json_parser = json_parser_new(NULL);
+
+  json_parser_set_key_delimiter(json_parser, '\t');
+  msg = parse_json_into_log_message("{'foo': 'bar', 'embed': {'foo': 'bar'}}", json_parser);
+  assert_log_message_value(msg, log_msg_get_value_handle("foo"), "bar");
+  assert_log_message_value(msg, log_msg_get_value_handle("embed\tfoo"), "bar");
+  log_msg_unref(msg);
+  log_pipe_unref(&json_parser->super);
+}
+
 Test(json_parser, test_json_parser_skips_marker_when_set_in_the_input)
 {
   LogMessage *msg;

--- a/news/feature-4093-2.md
+++ b/news/feature-4093-2.md
@@ -1,0 +1,3 @@
+`$(format-json)`: add --key-delimiter option to reconstruct JSON objects
+using an alternative structure separator, that was created using the
+key-delimiter() option of json-parser().

--- a/news/feature-4093.md
+++ b/news/feature-4093.md
@@ -1,0 +1,17 @@
+`json-parser()`: add key-delimiter() option to extract JSON structure
+members into name-value pairs, so that the names are flattened using the
+character specified, instead of dot.
+
+Example:
+  Input: {"foo":{"key":"value"}}
+
+  Using json-parser() without key-delimiter() this is extracted to:
+
+      foo.key="value"
+
+  Using json-parser(key-delimiter("~")) this is extracted to:
+
+      foo~key="value"
+
+This feature is useful in case the JSON keys contain dots themselves, in
+those cases the syslog-ng representation is ambigious.


### PR DESCRIPTION
Unfortunately, sometimes the input JSON contains keys that have dots in them (e.g. kubernetes labels). In those cases, using
dot notation to represent the input data is ambiguous.

E.g. these JSONs parse to the same representation in syslog-ng:

```
{"foo.bar.baz": "value"}
and
{"foo":{"bar":{"baz": "value"}}}
```

This would not necessarily cause an issue, however, when we $(format-json) this, we would always get the latter even if the input is the former.

The only solution I could come up with was to add support for custom separators, e.g. instead of using dots to represent "levels" of the input, use a special character, which will not clash with other embedded dots.

Here's an example configuration:

```
@version: 3.37

log {
        source { tcp(port(2000) flags(no-parse)); };

        parser { json-parser(key-delimiter("~") prefix("json.")); };

        destination { file("/tmp/foo" template("$(format-json --key-delimiter ~ json.* --shift-levels 1)")); };
};
```

This configuration would use '~' instead of dot to represent the structure.