### PR TITLE
cmake: let CMake handle no-pie flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 
 # use, i.e. don't skip the full RPATH for the build tree
 set(CMAKE_SKIP_BUILD_RPATH  FALSE)
@@ -24,7 +24,6 @@ include(CheckIncludeFiles)
 include(ExternalProject)
 include(external_or_find_package)
 include(add_module)
-include(add_tests)
 include(module_switch)
 
 set(MEMORYCHECK_SUPPRESSIONS_FILE "${PROJECT_SOURCE_DIR}/tests/valgrind/unit-test-leak.supp")
@@ -331,6 +330,8 @@ endif()
 if (BUILD_TESTING AND NOT CRITERION_FOUND)
   message(FATAL_ERROR "BUILD_TESTING enabled without criterion detected!")
 endif()
+
+include(add_tests)
 
 if (CRITERION_FOUND)
   set(CTEST_ENVIRONMENT

--- a/cmake/add_tests.cmake
+++ b/cmake/add_tests.cmake
@@ -24,6 +24,11 @@
 
 include(CMakeParseArguments)
 
+if (BUILD_TESTING)
+  include(CheckPIESupported)
+  check_pie_supported()
+endif()
+
 function (add_unit_test)
 
   if (NOT BUILD_TESTING)
@@ -48,15 +53,6 @@ function (add_unit_test)
     target_link_libraries(${ADD_UNIT_TEST_TARGET} ${CRITERION_LIBRARIES})
     target_include_directories(${ADD_UNIT_TEST_TARGET} PUBLIC ${CRITERION_INCLUDE_DIRS})
     set_property(TARGET ${ADD_UNIT_TEST_TARGET} PROPERTY POSITION_INDEPENDENT_CODE FALSE)
-
-    # https://gitlab.kitware.com/cmake/cmake/issues/16561
-    include(CheckCCompilerFlag)
-    check_c_compiler_flag(-no-pie NO_PIE_AVAILABLE)
-    if (NO_PIE_AVAILABLE)
-      set_property(TARGET ${ADD_UNIT_TEST_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -no-pie")
-    elseif (APPLE)
-      set_property(TARGET ${ADD_UNIT_TEST_TARGET} APPEND_STRING PROPERTY LINK_FLAGS " -Wl,-no_pie")
-    endif()
 
   endif()
 


### PR DESCRIPTION
Our custom no-pie detection is broken due to Wunused-command-line-argument.

https://gitlab.kitware.com/cmake/cmake/-/issues/16561 has been fixed by
CMP0083, so we let CMake handle the necessary linker flags.