### PR TITLE
.github/workflows/devshell: collect test binaries along with corefiles

### DIFF
--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -80,7 +80,7 @@ jobs:
       - name: make check
         id: make_check
         working-directory: ./build
-        run: make V=1 check || (cat test-suite.log && false)
+        run: make V=1 check || (mkdir -p ${COREFILES_DIR} && find . -executable -a -type f | tar -cf ${COREFILES_DIR}/test-binaries.tar  --files-from=- && cat test-suite.log && false)
 
       - name: make install
         working-directory: ./build


### PR DESCRIPTION
This change would collect test binaries along with core files, should the test fail.

This allows me to analyse core files from test programs and avoids the roundtrip of reproducing the test issue locally.