### PR TITLE
secure-logging: fix possible invalid truncation of counters

### DIFF
--- a/modules/secure-logging/slog.h
+++ b/modules/secure-logging/slog.h
@@ -35,7 +35,7 @@
 #define COLON 1
 #define BLANK 1
 #define COUNTER_LENGTH 12 // We use an 8 byte counter resulting in 12 byte BASE64 encoding
-#define CTR_LEN_SIMPLE 16 // This is for 8 byte (=2^64) counters; simple encoding by doubling
+#define CTR_LEN_SIMPLE 20 // This is for the string representation of 8 byte (=2^64) counters
 
 // These are arbitrary constants (with mean) Hamming distance.
 #define IPAD 0x36

--- a/tests/light/functional_tests/template_functions/slog/test_secure_logging.py
+++ b/tests/light/functional_tests/template_functions/slog/test_secure_logging.py
@@ -42,4 +42,4 @@ def test_secure_logging(config, syslog_ng, slog):
     assert not any(map(lambda x: message_base in x, logs))
 
     decrypted = slog.decrypt(output_file_name)
-    assert decrypted == ["{}: {}: {}".format(str(i).zfill(16), message_base, i) for i in range(num_of_messages)]
+    assert decrypted == ["{}: {}: {}".format(str(i).zfill(20), message_base, i) for i in range(num_of_messages)]


### PR DESCRIPTION
```
warning: '%lu' directive output may be truncated writing between 1 and 20 bytes into a region of size 17 [-Wformat-truncation=]
 1190 |           snprintf(key, CTR_LEN_SIMPLE+1, "%"G_GUINT64_FORMAT, i);
      |                                           ^~~
../modules/secure-logging/slog.c:1190:43: note: directive argument in the range [0, 18446744073709551614]
 1190 |           snprintf(key, CTR_LEN_SIMPLE+1, "%"G_GUINT64_FORMAT, i);
```