### PR TITLE
github-actions: add correct docker privileges for `distcheck` step

### DIFF
--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -147,6 +147,7 @@ jobs:
     runs-on: ubuntu-18.04
     container:
       image: ghcr.io/syslog-ng/dbld-devshell:latest
+      options: --security-opt seccomp=unconfined --ulimit core=-1
 
     steps:
       - name: Checkout syslog-ng source


### PR DESCRIPTION
`g_spawn_command_line_sync()` will make a call to `clone()`, which is not available by default.



By default an unprivileged container runs with the default `seccomp` policy, which has an allowlist for syscalls:
https://github.com/moby/moby/blob/master/profiles/seccomp/default.json#L59

The reason why `g_spawn_command_line_sync()` was unable to run succesfully was its call to `clone()`:

sample program
```C
#include <glib.h>

int main () {

  char *stderr_buff = NULL;
  char *stdout_buff = NULL;

  int exit_status;
  g_spawn_command_line_sync("ls -l", &stdout_buff, &stderr_buff, &exit_status, NULL);
}
```
Compile and check it with `strace`
``` shell
gcc `pkg-config --cflags glib-2.0` main.c -o spawn `pkg-config --libs glib-2.0` && strace -o spawn_strace_output.txt ./spawn
```

Looked for syscalls **NOT** in the [allowlist](https://github.com/moby/moby/blob/master/profiles/seccomp/default.json#L59
):
``` shell
$ cat strace_output.txt | grep -v -E "accept|accept4|...|writev" | cut -f 1 -d '(' | sort -u
clone
```

Docker documentation regarding seccomp:
https://docs.docker.com/engine/security/seccomp/#run-without-the-default-seccomp-profile

Signed-off-by: Szilárd Parrag <szilard.parrag@gmail.com>

Fixes #4106

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->
<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->