### PR TITLE
redis: fix no batch mode

### DIFF
--- a/modules/redis/redis-worker.c
+++ b/modules/redis/redis-worker.c
@@ -152,7 +152,7 @@ redis_worker_insert(LogThreadedDestWorker *s, LogMessage *msg)
   RedisDriver *owner = (RedisDriver *) self->super.owner;
   LogThreadedResult status = LTR_ERROR;
 
-  g_assert(owner->super.batch_lines == 0);
+  g_assert(owner->super.batch_lines <= 0);
 
   ScratchBuffersMarker marker;
   scratch_buffers_mark(&marker);

--- a/news/bugfix-4114.md
+++ b/news/bugfix-4114.md
@@ -1,0 +1,1 @@
+Fixed bug where using redis driver without the `batch-lines` option caused program crash.


### PR DESCRIPTION
Fixed problem where Redis driver failed without `batch-line` option in use. 

Signed-off-by: Bálint Horváth <bal.horv.98@gmail.com>

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
