### PR TITLE
readme: use latest Ubuntu LTS (Jammy) as apt repo example

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ syslog-ng packages are released for the following distribution versions (x86-64)
 2. Add the repository containing the latest build of syslog-ng to the APT sources. For example, stable releases on Ubuntu 20.04:
 
     ```
-    echo "deb https://ose-repo.syslog-ng.com/apt/ stable ubuntu-focal" | sudo tee -a /etc/apt/sources.list.d/syslog-ng-ose.list
+    echo "deb https://ose-repo.syslog-ng.com/apt/ stable ubuntu-jammy" | sudo tee -a /etc/apt/sources.list.d/syslog-ng-ose.list
     ```
 
 3. Run `apt update`


### PR DESCRIPTION
Can be merged after publishing v3.38.1 packages.