### PR TITLE
lib: `_free_value()` fix

### DIFF
--- a/lib/persist-state.c
+++ b/lib/persist-state.c
@@ -305,7 +305,8 @@ _free_value(PersistState *self, PersistEntryHandle handle)
       PersistValueHeader *header;
 
       header = _map_header_of_entry_from_handle(self, handle);
-      header->in_use = 0;
+      if (header)
+        header->in_use = 0;
       persist_state_unmap_entry(self, handle);
     }
 }


### PR DESCRIPTION
As `_map_header_of_entry_from_handle()` may fail, the return value
should be checked.

It could cause a crash, if the the handle or the entry was corrupted.


Signed-off-by: Szilárd Parrag <szilard.parrag@gmail.com>

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
