### PR TITLE
sumologic-http() improvements

### DIFF
--- a/news/other-4124.md
+++ b/news/other-4124.md
@@ -1,0 +1,10 @@
+`sumologic-http()` improvements
+
+Breaking change: `sumologic-http()` originally sent incomplete messages (only the `$MESSAGE` part) to Sumo Logic by default.
+The new default is a JSON object, containing all name-value pairs.
+
+To override the new message format, the `template()` option can be used.
+
+`sumologic-http()` now supports batching, which is enabled by default to increase the destination's performance.
+
+The `tls()` became optional, Sumo Logic servers will be verified using the system's certificate store by default.

--- a/scl/sumologic/sumologic.conf
+++ b/scl/sumologic/sumologic.conf
@@ -77,6 +77,8 @@ block destination sumologic-http(
   collector()
   use-system-cert-store(yes)
   tls("")
+  batch-lines(1000)
+  batch-bytes(1MiB)
   ...)
 {
 
@@ -87,6 +89,8 @@ block destination sumologic-http(
     method("POST")
     use-system-cert-store(`use-system-cert-store`)
     tls(`tls`)
+    batch-lines(`batch-lines`)
+    batch-bytes(`batch-bytes`)
     `__VARARGS__`
   );
 };

--- a/scl/sumologic/sumologic.conf
+++ b/scl/sumologic/sumologic.conf
@@ -73,7 +73,6 @@ block destination sumologic-syslog(token()
 };
 
 block destination sumologic-http(
-                         tag("tag")
                          deployment()
                          collector()
                          tls() ...) {

--- a/scl/sumologic/sumologic.conf
+++ b/scl/sumologic/sumologic.conf
@@ -75,6 +75,7 @@ block destination sumologic-syslog(token()
 block destination sumologic-http(
   deployment()
   collector()
+  use-system-cert-store(yes)
   tls()
   ...)
 {
@@ -84,6 +85,7 @@ block destination sumologic-http(
   http(
     url("https://collectors.`deployment`.sumologic.com/receiver/v1/http/`collector`")
     method("POST")
+    use-system-cert-store(`use-system-cert-store`)
     tls(`tls`)
     `__VARARGS__`
   );

--- a/scl/sumologic/sumologic.conf
+++ b/scl/sumologic/sumologic.conf
@@ -76,7 +76,7 @@ block destination sumologic-http(
   deployment()
   collector()
   use-system-cert-store(yes)
-  tls()
+  tls("")
   ...)
 {
 

--- a/scl/sumologic/sumologic.conf
+++ b/scl/sumologic/sumologic.conf
@@ -79,6 +79,7 @@ block destination sumologic-http(
   tls("")
   batch-lines(1000)
   batch-bytes(1MiB)
+  template("$(format-json --scope all-nv-pairs --exclude SOURCE)\n")
   ...)
 {
 
@@ -91,6 +92,7 @@ block destination sumologic-http(
     tls(`tls`)
     batch-lines(`batch-lines`)
     batch-bytes(`batch-bytes`)
+    body(`template`)
     `__VARARGS__`
   );
 };

--- a/scl/sumologic/sumologic.conf
+++ b/scl/sumologic/sumologic.conf
@@ -25,7 +25,7 @@
 # With TLS encryption (make sure you trust the sumologic CA cert by putting it
 # to /etc/ssl, or create a separate CA directory):
 # For endpoint see - https://help.sumologic.com/APIs/General-API-Information/Sumo-Logic-Endpoints-and-Firewall-Security
-# 
+#
 # Send data using syslog:
 #    log {
 #       destination {
@@ -62,7 +62,7 @@ block destination sumologic-syslog(token()
                          port(6514)
                          tls()
                          template("$MSG") ...) {
-						 
+
 @requires json-plugin "The json-plugin is required for sumologic-syslog()"
 
   network("syslog.collection.`deployment`.sumologic.com" port(`port`) transport(tls) tls(`tls`)
@@ -73,13 +73,18 @@ block destination sumologic-syslog(token()
 };
 
 block destination sumologic-http(
-                         deployment()
-                         collector()
-                         tls() ...) {
-						 
+  deployment()
+  collector()
+  tls()
+  ...)
+{
+
 @requires http "The http() driver is required for sumologic-http(), please install syslog-ng-mod-http (Debian) or syslog-ng-http (RHEL) package"
 
-  http(url("https://collectors.`deployment`.sumologic.com/receiver/v1/http/`collector`") tls(`tls`) method("POST")
-          `__VARARGS__`
+  http(
+    url("https://collectors.`deployment`.sumologic.com/receiver/v1/http/`collector`")
+    method("POST")
+    tls(`tls`)
+    `__VARARGS__`
   );
 };


### PR DESCRIPTION
- The `tls()` option is now optional, Sumo Logic servers will be verified using the system's certificate store by default.
- Batching support: default is 1000 messages or 1 MiB of data, whichever comes first
- Breaking change: the default sumologic-http() payload was incomplete, only the `$MESSAGE` was sent. The new default is a JSON object, containing all name-value pairs.

todo:
- [x] NEWS entry