### PR TITLE
db-parser prefix() support

### DIFF
--- a/modules/dbparser/dbparser-grammar.ym
+++ b/modules/dbparser/dbparser-grammar.ym
@@ -165,6 +165,7 @@ grouping_by_opt
             CHECK_ERROR_WITHOUT_MESSAGE(cfg_parser_parse(&filter_expr_parser, lexer, (gpointer *) &filter_expr, NULL), @1);
             grouping_by_set_trigger_condition(last_parser, filter_expr);
           } ')'
+	| KW_PREFIX '(' string ')'				{ grouping_by_set_prefix(last_parser, $3); free($3); };
 	| stateful_parser_opt
 	;
 

--- a/modules/dbparser/dbparser-grammar.ym
+++ b/modules/dbparser/dbparser-grammar.ym
@@ -67,6 +67,7 @@ SyntheticMessage *last_message;
 %token KW_PROGRAM_TEMPLATE
 %token KW_MESSAGE_TEMPLATE
 %token KW_SORT_KEY
+%token KW_PREFIX
 
 %type <num> stateful_parser_inject_mode
 %type <ptr> synthetic_message
@@ -107,6 +108,7 @@ parser_db_opt
              log_db_parser_set_program_template_ref(last_parser, $3);
           }
         | KW_MESSAGE_TEMPLATE '(' template_content ')'    { log_parser_set_template(last_parser, $3); }
+	| KW_PREFIX '(' string ')'				{ log_db_parser_set_prefix(((LogDBParser *) last_parser), $3); free($3); };
 	| stateful_parser_opt
         ;
 

--- a/modules/dbparser/dbparser-parser.c
+++ b/modules/dbparser/dbparser-parser.c
@@ -48,6 +48,7 @@ static CfgLexerKeyword dbparser_keywords[] =
   { "having",             KW_HAVING },
   { "trigger",            KW_TRIGGER },
   { "value",              KW_VALUE },
+  { "prefix",             KW_PREFIX },
   { "program_template",   KW_PROGRAM_TEMPLATE },
   { "message_template",   KW_MESSAGE_TEMPLATE },
   { NULL }

--- a/modules/dbparser/dbparser.c
+++ b/modules/dbparser/dbparser.c
@@ -40,6 +40,7 @@ struct _LogDBParser
   struct iv_timer tick;
   PatternDB *db;
   gchar *db_file;
+  gchar *prefix;
   time_t db_file_last_check;
   ino_t db_file_inode;
   time_t db_file_mtime;
@@ -132,7 +133,7 @@ log_db_parser_init(LogPipe *s)
   self->db = cfg_persist_config_fetch(cfg, log_db_parser_format_persist_name(self));
 
   if (!self->db)
-    self->db = pattern_db_new(NULL);
+    self->db = pattern_db_new(self->prefix);
 
   log_db_parser_reload_database(self);
   if (self->db)
@@ -233,6 +234,13 @@ log_db_parser_set_db_file(LogDBParser *self, const gchar *db_file)
 }
 
 void
+log_db_parser_set_prefix(LogDBParser *self, const gchar *prefix)
+{
+  g_free(self->prefix);
+  self->prefix = g_strdup(prefix);
+}
+
+void
 log_db_parser_set_drop_unmatched(LogDBParser *self, gboolean setting)
 {
   self->drop_unmatched = setting;
@@ -249,6 +257,7 @@ log_db_parser_clone(LogPipe *s)
 
   cloned = (LogDBParser *) log_db_parser_new(s->cfg);
   log_db_parser_set_db_file(cloned, self->db_file);
+  log_db_parser_set_prefix(cloned, self->prefix);
   log_db_parser_set_drop_unmatched(cloned, self->drop_unmatched);
   log_db_parser_set_program_template_ref(&cloned->super.super, log_template_ref(self->program_template));
   log_parser_set_template(&cloned->super.super, log_template_ref(self->super.super.template));
@@ -275,6 +284,7 @@ log_db_parser_free(LogPipe *s)
     pattern_db_free(self->db);
 
   g_free(self->db_file);
+  g_free(self->prefix);
   stateful_parser_free_method(s);
 }
 

--- a/modules/dbparser/dbparser.c
+++ b/modules/dbparser/dbparser.c
@@ -246,8 +246,7 @@ log_db_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
 void
 log_db_parser_set_db_file(LogDBParser *self, const gchar *db_file)
 {
-  if (self->db_file)
-    g_free(self->db_file);
+  g_free(self->db_file);
   self->db_file = g_strdup(db_file);
 }
 
@@ -293,8 +292,7 @@ log_db_parser_free(LogPipe *s)
   if (self->db)
     pattern_db_free(self->db);
 
-  if (self->db_file)
-    g_free(self->db_file);
+  g_free(self->db_file);
   stateful_parser_free_method(s);
 }
 

--- a/modules/dbparser/dbparser.c
+++ b/modules/dbparser/dbparser.c
@@ -132,7 +132,7 @@ log_db_parser_init(LogPipe *s)
   self->db = cfg_persist_config_fetch(cfg, log_db_parser_format_persist_name(self));
 
   if (!self->db)
-    self->db = pattern_db_new();
+    self->db = pattern_db_new(NULL);
 
   log_db_parser_reload_database(self);
   if (self->db)

--- a/modules/dbparser/dbparser.c
+++ b/modules/dbparser/dbparser.c
@@ -130,29 +130,11 @@ log_db_parser_init(LogPipe *s)
   GlobalConfig *cfg = log_pipe_get_config(s);
 
   self->db = cfg_persist_config_fetch(cfg, log_db_parser_format_persist_name(self));
-  if (self->db)
-    {
-      struct stat st;
 
-      if (stat(self->db_file, &st) < 0)
-        {
-          msg_error("Error stating pattern database file, no automatic reload will be performed",
-                    evt_tag_str("file", self->db_file),
-                    evt_tag_str("error", g_strerror(errno)),
-                    log_pipe_location_tag(&self->super.super.super));
-        }
-      else if (self->db_file_inode != st.st_ino || self->db_file_mtime != st.st_mtime)
-        {
-          log_db_parser_reload_database(self);
-          self->db_file_inode = st.st_ino;
-          self->db_file_mtime = st.st_mtime;
-        }
-    }
-  else
-    {
-      self->db = pattern_db_new();
-      log_db_parser_reload_database(self);
-    }
+  if (!self->db)
+    self->db = pattern_db_new();
+
+  log_db_parser_reload_database(self);
   if (self->db)
     {
       pattern_db_set_emit_func(self->db, log_db_parser_emit, self);

--- a/modules/dbparser/dbparser.h
+++ b/modules/dbparser/dbparser.h
@@ -34,6 +34,7 @@ typedef struct _LogDBParser LogDBParser;
 void log_db_parser_set_drop_unmatched(LogDBParser *self, gboolean setting);
 void log_db_parser_set_program_template_ref(LogParser *s, LogTemplate *program_template);
 void log_db_parser_set_db_file(LogDBParser *self, const gchar *db_file);
+void log_db_parser_set_prefix(LogDBParser *self, const gchar *prefix);
 LogParser *log_db_parser_new(GlobalConfig *cfg);
 
 void log_pattern_database_init(void);

--- a/modules/dbparser/groupingby.h
+++ b/modules/dbparser/groupingby.h
@@ -34,6 +34,7 @@ void grouping_by_set_synthetic_message(LogParser *s, SyntheticMessage *message);
 void grouping_by_set_trigger_condition(LogParser *s, FilterExprNode *filter_expr);
 void grouping_by_set_where_condition(LogParser *s, FilterExprNode *filter_expr);
 void grouping_by_set_having_condition(LogParser *s, FilterExprNode *filter_expr);
+void grouping_by_set_prefix(LogParser *s, const gchar *prefix);
 LogParser *grouping_by_new(GlobalConfig *cfg);
 void grouping_by_global_init(void);
 

--- a/modules/dbparser/patterndb.c
+++ b/modules/dbparser/patterndb.c
@@ -68,6 +68,7 @@ struct _PatternDB
   GHashTable *rate_limits;
   PatternDBEmitFunc emit;
   gpointer emit_data;
+  gchar *prefix;
 };
 
 static inline gpointer
@@ -475,7 +476,7 @@ pattern_db_reload_ruleset(PatternDB *self, GlobalConfig *cfg, const gchar *pdb_f
 {
   PDBRuleSet *new_ruleset;
 
-  new_ruleset = pdb_rule_set_new();
+  new_ruleset = pdb_rule_set_new(self->prefix);
   if (!pdb_rule_set_load(new_ruleset, cfg, pdb_file, NULL))
     {
       pdb_rule_set_free(new_ruleset);
@@ -712,11 +713,12 @@ pattern_db_forget_state(PatternDB *self)
 }
 
 PatternDB *
-pattern_db_new(void)
+pattern_db_new(const gchar *prefix)
 {
   PatternDB *self = g_new0(PatternDB, 1);
 
-  self->ruleset = pdb_rule_set_new();
+  self->prefix = g_strdup(prefix);
+  self->ruleset = pdb_rule_set_new(self->prefix);
   g_mutex_init(&self->ruleset_lock);
   _init_state(self);
   return self;
@@ -725,6 +727,7 @@ pattern_db_new(void)
 void
 pattern_db_free(PatternDB *self)
 {
+  g_free(self->prefix);
   log_template_unref(self->program_template);
   if (self->ruleset)
     pdb_rule_set_free(self->ruleset);

--- a/modules/dbparser/patterndb.h
+++ b/modules/dbparser/patterndb.h
@@ -48,7 +48,7 @@ void pattern_db_debug_ruleset(PatternDB *self, LogMessage *msg, GArray *dbg_list
 void pattern_db_expire_state(PatternDB *self);
 void pattern_db_forget_state(PatternDB *self);
 
-PatternDB *pattern_db_new(void);
+PatternDB *pattern_db_new(const gchar *prefix);
 void pattern_db_free(PatternDB *self);
 
 void pattern_db_global_init(void);

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -363,7 +363,8 @@ _populate_ruleset_radix(gpointer key, gpointer value, gpointer user_data)
   gchar *pattern = key;
   PDBProgram *program = (PDBProgram *) value;
 
-  r_insert_node(state->ruleset->programs, pattern, pdb_program_ref(program), NULL, NULL, program->pdb_location);
+  r_insert_node(state->ruleset->programs, pattern, pdb_program_ref(program),
+                state->ruleset->prefix, NULL, program->pdb_location);
 }
 
 static void
@@ -439,7 +440,7 @@ _pdbl_ruleset_end(PDBLoader *state, const gchar *element_name, GError **error)
           r_insert_node(program->rules,
                         program_pattern->pattern,
                         pdb_rule_ref(program_pattern->rule),
-                        NULL,
+                        state->ruleset->prefix,
                         (RNodeGetValueFunc) pdb_rule_get_name,
                         program_pattern->pdb_location);
           pdb_program_pattern_clear(program_pattern);
@@ -538,6 +539,7 @@ _pdbl_rules_start(PDBLoader *state, const gchar *element_name, const gchar **att
         }
 
       state->current_message = &state->current_rule->msg;
+      synthetic_message_set_prefix(state->current_message, state->ruleset->prefix);
       state->action_id = 0;
       _push_state(state, PDBL_RULE);
     }

--- a/modules/dbparser/pdb-load.c
+++ b/modules/dbparser/pdb-load.c
@@ -363,7 +363,7 @@ _populate_ruleset_radix(gpointer key, gpointer value, gpointer user_data)
   gchar *pattern = key;
   PDBProgram *program = (PDBProgram *) value;
 
-  r_insert_node(state->ruleset->programs, pattern, pdb_program_ref(program), NULL, program->pdb_location);
+  r_insert_node(state->ruleset->programs, pattern, pdb_program_ref(program), NULL, NULL, program->pdb_location);
 }
 
 static void
@@ -439,6 +439,7 @@ _pdbl_ruleset_end(PDBLoader *state, const gchar *element_name, GError **error)
           r_insert_node(program->rules,
                         program_pattern->pattern,
                         pdb_rule_ref(program_pattern->rule),
+                        NULL,
                         (RNodeGetValueFunc) pdb_rule_get_name,
                         program_pattern->pdb_location);
           pdb_program_pattern_clear(program_pattern);

--- a/modules/dbparser/pdb-ruleset.c
+++ b/modules/dbparser/pdb-ruleset.c
@@ -174,11 +174,11 @@ pdb_ruleset_lookup(PDBRuleSet *rule_set, PDBLookupParams *lookup, GArray *dbg_li
 
 
 PDBRuleSet *
-pdb_rule_set_new(void)
+pdb_rule_set_new(const gchar *prefix)
 {
   PDBRuleSet *self = g_new0(PDBRuleSet, 1);
   self->is_empty = TRUE;
-
+  self->prefix = g_strdup(prefix);
   return self;
 }
 
@@ -189,7 +189,7 @@ pdb_rule_set_free(PDBRuleSet *self)
     r_free_node(self->programs, (GDestroyNotify) pdb_program_unref);
   g_free(self->version);
   g_free(self->pub_date);
-
+  g_free(self->prefix);
   g_free(self);
 }
 

--- a/modules/dbparser/pdb-ruleset.c
+++ b/modules/dbparser/pdb-ruleset.c
@@ -187,13 +187,8 @@ pdb_rule_set_free(PDBRuleSet *self)
 {
   if (self->programs)
     r_free_node(self->programs, (GDestroyNotify) pdb_program_unref);
-  if (self->version)
-    g_free(self->version);
-  if (self->pub_date)
-    g_free(self->pub_date);
-  self->programs = NULL;
-  self->version = NULL;
-  self->pub_date = NULL;
+  g_free(self->version);
+  g_free(self->pub_date);
 
   g_free(self);
 }

--- a/modules/dbparser/pdb-ruleset.h
+++ b/modules/dbparser/pdb-ruleset.h
@@ -34,11 +34,12 @@ typedef struct _PDBRuleSet
   RNode *programs;
   gchar *version;
   gchar *pub_date;
+  gchar *prefix;
   gboolean is_empty;
 } PDBRuleSet;
 
 PDBRule *pdb_ruleset_lookup(PDBRuleSet *rule_set, PDBLookupParams *lookup, GArray *dbg_list);
-PDBRuleSet *pdb_rule_set_new(void);
+PDBRuleSet *pdb_rule_set_new(const gchar *prefix);
 void pdb_rule_set_free(PDBRuleSet *self);
 
 void pdb_rule_set_global_init(void);

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -459,7 +459,7 @@ pdbtool_match(int argc, char *argv[])
   proto_options.max_msg_size = 65536;
   log_proto_server_options_init(&proto_options, configuration);
 
-  patterndb = pattern_db_new();
+  patterndb = pattern_db_new(NULL);
   if (!pattern_db_reload_ruleset(patterndb, configuration, patterndb_file))
     {
       goto error;
@@ -773,7 +773,7 @@ pdbtool_test(int argc, char *argv[])
             }
         }
 
-      patterndb = pattern_db_new();
+      patterndb = pattern_db_new(NULL);
       if (!pdb_rule_set_load(pattern_db_get_ruleset(patterndb), configuration, argv[arg_pos], &examples))
         {
           failed_to_load = TRUE;
@@ -917,7 +917,7 @@ pdbtool_dump(int argc, char *argv[])
 {
   PatternDB *patterndb;
 
-  patterndb = pattern_db_new();
+  patterndb = pattern_db_new(NULL);
   if (!pattern_db_reload_ruleset(patterndb, configuration, patterndb_file))
     return 1;
 

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -979,15 +979,14 @@ pdbtool_dictionary_walk(RNode *root, const gchar *progname)
       else
         {
           PDBRule *rule = (PDBRule *)root->value;
-          LogTemplate *template;
           guint tag_id;
 
           if (!dictionary_tags && rule->msg.values)
             {
               for (i = 0; i < rule->msg.values->len; i++)
                 {
-                  template = (LogTemplate *)g_ptr_array_index(rule->msg.values, i);
-                  printf("%s\n", template->name);
+                  SyntheticMessageValue *smv = &g_array_index(rule->msg.values, SyntheticMessageValue, i);
+                  printf("%s\n", log_msg_get_value_name(smv->value_handle, NULL));
                 }
             }
 

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -986,7 +986,7 @@ pdbtool_dictionary_walk(RNode *root, const gchar *progname)
               for (i = 0; i < rule->msg.values->len; i++)
                 {
                   SyntheticMessageValue *smv = synthetic_message_values_index(&rule->msg, i);
-                  printf("%s\n", log_msg_get_value_name(smv->value_handle, NULL));
+                  printf("%s\n", smv->name);
                 }
             }
 

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -985,7 +985,7 @@ pdbtool_dictionary_walk(RNode *root, const gchar *progname)
             {
               for (i = 0; i < rule->msg.values->len; i++)
                 {
-                  SyntheticMessageValue *smv = &g_array_index(rule->msg.values, SyntheticMessageValue, i);
+                  SyntheticMessageValue *smv = synthetic_message_values_index(&rule->msg, i);
                   printf("%s\n", log_msg_get_value_name(smv->value_handle, NULL));
                 }
             }
@@ -994,7 +994,7 @@ pdbtool_dictionary_walk(RNode *root, const gchar *progname)
             {
               for (i = 0; i < rule->msg.tags->len; i++)
                 {
-                  tag_id = g_array_index(rule->msg.tags, guint, i);
+                  tag_id = synthetic_message_tags_index(&rule->msg, i);
                   printf("%s\n", log_tags_get_by_id(tag_id));
                 }
             }

--- a/modules/dbparser/radix.h
+++ b/modules/dbparser/radix.h
@@ -155,7 +155,8 @@ r_parser_type_name(guint8 type)
 
 RNode *r_new_node(const gchar *key, gpointer value);
 void r_free_node(RNode *node, void (*free_fn)(gpointer data));
-void r_insert_node(RNode *root, gchar *key, gpointer value, RNodeGetValueFunc value_func, const gchar *location);
+void r_insert_node(RNode *root, gchar *key, gpointer value,
+                   const gchar *capture_prefix, RNodeGetValueFunc value_func, const gchar *location);
 RNode *r_find_node(RNode *root, gchar *key, gint keylen, GArray *matches);
 RNode *r_find_node_dbg(RNode *root, gchar *key, gint keylen, GArray *matches, GArray *dbg_list);
 gchar **r_find_all_applicable_nodes(RNode *root, gchar *key, gint keylen, RNodeGetValueFunc value_func);

--- a/modules/dbparser/synthetic-message.c
+++ b/modules/dbparser/synthetic-message.c
@@ -158,7 +158,7 @@ synthetic_message_apply(SyntheticMessage *self, CorrelationContext *context, Log
   if (self->tags)
     {
       for (i = 0; i < self->tags->len; i++)
-        log_msg_set_tag_by_id(msg, g_array_index(self->tags, LogTagId, i));
+        log_msg_set_tag_by_id(msg, synthetic_message_tags_index(self, i));
     }
 
   if (self->values)
@@ -169,7 +169,7 @@ synthetic_message_apply(SyntheticMessage *self, CorrelationContext *context, Log
         {
           LogMessageValueType type;
           LogTemplateEvalOptions options = {NULL, LTZ_LOCAL, 0, context ? context->key.session_id : NULL, LM_VT_STRING};
-          SyntheticMessageValue *smv = &g_array_index(self->values, SyntheticMessageValue, i);
+          SyntheticMessageValue *smv = synthetic_message_values_index(self, i);
 
           log_template_format_value_and_type_with_context(smv->value_template,
                                                           context ? (LogMessage **) context->messages->pdata : &msg,
@@ -305,7 +305,7 @@ synthetic_message_deinit(SyntheticMessage *self)
     {
       for (i = 0; i < self->values->len; i++)
         {
-          SyntheticMessageValue *smv = &g_array_index(self->values, SyntheticMessageValue, i);
+          SyntheticMessageValue *smv = synthetic_message_values_index(self, i);
           log_template_unref(smv->value_template);
         }
 

--- a/modules/dbparser/synthetic-message.h
+++ b/modules/dbparser/synthetic-message.h
@@ -36,7 +36,8 @@ typedef enum
 
 typedef struct _SyntheticMessageValue
 {
-  NVHandle value_handle;
+  gchar *name;
+  NVHandle handle;
   LogTemplate *value_template;
 } SyntheticMessageValue;
 
@@ -45,6 +46,7 @@ typedef struct _SyntheticMessage
   SyntheticMessageInheritMode inherit_mode;
   GArray *tags;
   GArray *values;
+  gchar *prefix;
 } SyntheticMessage;
 
 LogMessage *synthetic_message_generate_without_context(SyntheticMessage *self, LogMessage *msg);
@@ -61,6 +63,7 @@ gboolean synthetic_message_set_inherit_mode_string(SyntheticMessage *self, const
                                                    GError **error);
 void synthetic_message_add_value_template(SyntheticMessage *self, const gchar *name, LogTemplate *value);
 void synthetic_message_add_tag(SyntheticMessage *self, const gchar *text);
+void synthetic_message_set_prefix(SyntheticMessage *self, const gchar *prefix);
 void synthetic_message_init(SyntheticMessage *self);
 void synthetic_message_deinit(SyntheticMessage *self);
 SyntheticMessage *synthetic_message_new(void);

--- a/modules/dbparser/synthetic-message.h
+++ b/modules/dbparser/synthetic-message.h
@@ -68,4 +68,16 @@ void synthetic_message_free(SyntheticMessage *self);
 
 gint synthetic_message_lookup_inherit_mode(const gchar *inherit_mode);
 
+static inline SyntheticMessageValue *
+synthetic_message_values_index(SyntheticMessage *self, gint index_)
+{
+  return &g_array_index(self->values, SyntheticMessageValue, index_);
+}
+
+static inline guint
+synthetic_message_tags_index(SyntheticMessage *self, gint index_)
+{
+  return g_array_index(self->tags, LogTagId, index_);
+}
+
 #endif

--- a/modules/dbparser/synthetic-message.h
+++ b/modules/dbparser/synthetic-message.h
@@ -34,11 +34,17 @@ typedef enum
   RAC_MSG_INHERIT_CONTEXT
 } SyntheticMessageInheritMode;
 
+typedef struct _SyntheticMessageValue
+{
+  NVHandle value_handle;
+  LogTemplate *value_template;
+} SyntheticMessageValue;
+
 typedef struct _SyntheticMessage
 {
   SyntheticMessageInheritMode inherit_mode;
   GArray *tags;
-  GPtrArray *values;
+  GArray *values;
 } SyntheticMessage;
 
 LogMessage *synthetic_message_generate_without_context(SyntheticMessage *self, LogMessage *msg);

--- a/modules/dbparser/tests/test_parsers_e2e.c
+++ b/modules/dbparser/tests/test_parsers_e2e.c
@@ -79,7 +79,7 @@ _assert_pattern(PatternDB *patterndb, const gchar *pattern, const gchar *rule, g
 static PatternDB *
 _load_pattern_db_from_string(const gchar *pdb, gchar **filename)
 {
-  PatternDB *patterndb = pattern_db_new();
+  PatternDB *patterndb = pattern_db_new(NULL);
 
   g_file_open_tmp("patterndbXXXXXX.xml", filename, NULL);
   g_file_set_contents(*filename, pdb, strlen(pdb), NULL);

--- a/modules/dbparser/tests/test_patterndb.c
+++ b/modules/dbparser/tests/test_patterndb.c
@@ -71,7 +71,7 @@ assert_pdb_file_valid(const gchar *filename_)
 static PatternDB *
 _create_pattern_db(const gchar *pdb, gchar **filename)
 {
-  PatternDB *patterndb = pattern_db_new();
+  PatternDB *patterndb = pattern_db_new(NULL);
   messages = g_ptr_array_new();
 
   pattern_db_set_emit_func(patterndb, _emit_func, NULL);
@@ -678,7 +678,7 @@ ParameterizedTest(PatternDBTestParam *param, pattern_db, test_rules)
 
 Test(pattern_db, test_tag_outside_of_rule_skeleton)
 {
-  PatternDB *patterndb = pattern_db_new();
+  PatternDB *patterndb = pattern_db_new(NULL);
 
   char *filename;
   g_file_open_tmp("patterndbXXXXXX.xml", &filename, NULL);

--- a/modules/dbparser/tests/test_radix.c
+++ b/modules/dbparser/tests/test_radix.c
@@ -54,7 +54,20 @@ insert_node_with_value(RNode *root, const gchar *key, const gpointer value)
    * and it might be a read-only string literal */
 
   dup = g_strdup(key);
-  r_insert_node(root, dup, value ? : (gpointer)key, NULL, NULL);
+  r_insert_node(root, dup, value ? : (gpointer)key, NULL, NULL, NULL);
+  g_free(dup);
+}
+
+void
+insert_node_with_prefix(RNode *root, const gchar *key, const gchar *prefix)
+{
+  gchar *dup;
+
+  /* NOTE: we need to duplicate the key as r_insert_node modifies its input
+   * and it might be a read-only string literal */
+
+  dup = g_strdup(key);
+  r_insert_node(root, dup, (gpointer) key, prefix, NULL, NULL);
   g_free(dup);
 }
 
@@ -1064,6 +1077,17 @@ ParameterizedTest(RadixTestParam *param, dbparser, test_radix_search_matches, .i
     insert_node(root, param->node_to_insert[i]);
 
   test_search_matches(root, param->key, param->expected_pattern);
+  r_free_node(root, NULL);
+}
+
+Test(dbparser, test_radix_prefix, .init = test_setup, .fini = test_teardown)
+{
+  RNode *root = r_new_node("", NULL);
+
+  insert_node_with_prefix(root, "@NLSTRING:value@\n", "prefix.");
+
+  const gchar *expected_pattern[] = { "prefix.value", "string", NULL };
+  test_search_matches(root, "string\n", expected_pattern);
   r_free_node(root, NULL);
 }
 

--- a/news/feature-4133.md
+++ b/news/feature-4133.md
@@ -1,0 +1,4 @@
+`db-parser()` and `grouping-by()`: added a `prefix()` option to both
+`db-parser()` and `grouping-by()` that allows specifying an extra prefix
+to be prepended to all name-value pairs that get extracted from messages
+using patterns or <value> tags.


### PR DESCRIPTION
This intends to fix #4130

@ryanfaircloth the original idea behind db-parser() was to be the "global" parser for any kind of data. For that reason, I kind of expected all name-value pairs to be specified right within the pattern database. It kind of failed in that mission, today I view db-parser() as a useful alternative to regexps, because it is MUCH faster. But in this role you are right, prefix() would make sense.

These are just a few preparatory patches, but I wanted to submit them so 1) you see there's progress, 2) I can get feedback via the automatic tests.

In the meanwhile, could you please describe your use-case how you'd apply db-parser() to it? It would be useful to learn from. Thanks.