### PR TITLE
syslog-ng/main: resolve path templates in --help output

### DIFF
--- a/lib/cache.c
+++ b/lib/cache.c
@@ -29,13 +29,19 @@ struct _Cache
 };
 
 void *
+cache_resolve(Cache *self, const gchar *key)
+{
+  return cache_resolver_resolve_elem(self->resolver, key);
+}
+
+void *
 cache_lookup(Cache *self, const gchar *key)
 {
   gpointer result = g_hash_table_lookup(self->hash_table, key);
 
   if (!result)
     {
-      result = cache_resolver_resolve_elem(self->resolver, key);
+      result = cache_resolve(self, key);
       if (result)
         {
           g_hash_table_insert(self->hash_table, g_strdup(key), result);

--- a/lib/cache.h
+++ b/lib/cache.h
@@ -60,6 +60,7 @@ cache_resolver_free(CacheResolver *self)
   g_free(self);
 }
 
+void *cache_resolve(Cache *self, const gchar *key);
 gpointer cache_lookup(Cache *self, const gchar *key);
 void cache_clear(Cache *self);
 

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -566,8 +566,8 @@ cfg_set_global_paths(GlobalConfig *self)
   cfg_args_set(self->globals, "syslog-ng-include", get_installation_path_for(SYSLOG_NG_PATH_CONFIG_INCLUDEDIR));
   cfg_args_set(self->globals, "syslog-ng-sysconfdir", get_installation_path_for(SYSLOG_NG_PATH_SYSCONFDIR));
   cfg_args_set(self->globals, "scl-root", get_installation_path_for(SYSLOG_NG_PATH_SCLDIR));
-  cfg_args_set(self->globals, "module-path", resolvedConfigurablePaths.initial_module_path);
-  cfg_args_set(self->globals, "module-install-dir", resolvedConfigurablePaths.initial_module_path);
+  cfg_args_set(self->globals, "module-path", resolved_configurable_paths.initial_module_path);
+  cfg_args_set(self->globals, "module-install-dir", resolved_configurable_paths.initial_module_path);
 
   include_path = g_strdup_printf("%s:%s",
                                  get_installation_path_for(SYSLOG_NG_PATH_SYSCONFDIR),

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -328,7 +328,7 @@ main_loop_reload_config_prepare(MainLoop *self, GError **error)
 
   self->old_config = self->current_configuration;
   self->new_config = cfg_new(0);
-  if (!cfg_read_config(self->new_config, resolvedConfigurablePaths.cfgfilename, NULL))
+  if (!cfg_read_config(self->new_config, resolved_configurable_paths.cfgfilename, NULL))
     {
       cfg_free(self->new_config);
       self->new_config = NULL;
@@ -402,7 +402,7 @@ main_loop_get_pending_new_config(MainLoop *self)
 void
 main_loop_verify_config(GString *result, MainLoop *self)
 {
-  const gchar *file_path = resolvedConfigurablePaths.cfgfilename;
+  const gchar *file_path = resolved_configurable_paths.cfgfilename;
   gchar *config_mem = self -> current_configuration -> original_config -> str;
   GError *err = NULL;
   gchar *file_contents;
@@ -615,7 +615,7 @@ main_loop_read_and_init_config(MainLoop *self)
 {
   MainLoopOptions *options = self->options;
 
-  if (!cfg_read_config(self->current_configuration, resolvedConfigurablePaths.cfgfilename, options->preprocess_into))
+  if (!cfg_read_config(self->current_configuration, resolved_configurable_paths.cfgfilename, options->preprocess_into))
     {
       return 1;
     }
@@ -626,11 +626,11 @@ main_loop_read_and_init_config(MainLoop *self)
     }
 
   app_config_stopped();
-  if (!main_loop_initialize_state(self->current_configuration, resolvedConfigurablePaths.persist_file))
+  if (!main_loop_initialize_state(self->current_configuration, resolved_configurable_paths.persist_file))
     {
       return 2;
     }
-  self->control_server = control_init(resolvedConfigurablePaths.ctlfilename);
+  self->control_server = control_init(resolved_configurable_paths.ctlfilename);
   main_loop_register_control_commands(self);
   stats_register_control_commands();
   return 0;

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -574,7 +574,7 @@ void
 plugin_context_init_instance(PluginContext *context)
 {
   memset(context, 0, sizeof(*context));
-  plugin_context_set_module_path(context, resolvedConfigurablePaths.initial_module_path);
+  plugin_context_set_module_path(context, resolved_configurable_paths.initial_module_path);
 }
 
 void
@@ -596,7 +596,7 @@ plugin_list_modules(FILE *out, gboolean verbose)
   gint i, j, k;
   gboolean first = TRUE;
 
-  mod_paths = g_strsplit(resolvedConfigurablePaths.initial_module_path, ":", 0);
+  mod_paths = g_strsplit(resolved_configurable_paths.initial_module_path, ":", 0);
   for (i = 0; mod_paths[i]; i++)
     {
       GDir *dir;

--- a/lib/reloc.c
+++ b/lib/reloc.c
@@ -172,9 +172,22 @@ lookup_sysprefix(void)
 const gchar *
 get_installation_path_for(const gchar *template)
 {
+  reloc_init();
+  return cache_lookup(path_cache, template);
+}
+
+gchar *
+resolve_path_variables_in_text(const gchar *text)
+{
+  reloc_init();
+  return cache_resolve(path_cache, text);
+}
+
+void
+reloc_init(void)
+{
   if (!path_cache)
     path_cache = cache_new(path_resolver_new(lookup_sysprefix()));
-  return cache_lookup(path_cache, template);
 }
 
 void

--- a/lib/reloc.h
+++ b/lib/reloc.h
@@ -30,7 +30,9 @@
 void path_resolver_add_configure_variable(CacheResolver *self, const gchar *name, const gchar *value);
 CacheResolver *path_resolver_new(const gchar *sysprefix);
 
+gchar *resolve_path_variables_in_text(const gchar *text);
 const gchar *get_installation_path_for(const gchar *template);
+void reloc_init(void);
 void reloc_deinit(void);
 
 #endif

--- a/lib/resolved-configurable-paths.c
+++ b/lib/resolved-configurable-paths.c
@@ -25,13 +25,13 @@
 #include "resolved-configurable-paths.h"
 #include "reloc.h"
 
-ResolvedConfigurablePaths resolvedConfigurablePaths;
+ResolvedConfigurablePaths resolved_configurable_paths;
 
 void
 resolved_configurable_paths_init(ResolvedConfigurablePaths *self)
 {
-  resolvedConfigurablePaths.cfgfilename = get_installation_path_for(PATH_SYSLOG_NG_CONF);
-  resolvedConfigurablePaths.persist_file = get_installation_path_for(PATH_PERSIST_CONFIG);
-  resolvedConfigurablePaths.ctlfilename = get_installation_path_for(PATH_CONTROL_SOCKET);
-  resolvedConfigurablePaths.initial_module_path = get_installation_path_for(SYSLOG_NG_MODULE_PATH);
+  resolved_configurable_paths.cfgfilename = get_installation_path_for(PATH_SYSLOG_NG_CONF);
+  resolved_configurable_paths.persist_file = get_installation_path_for(PATH_PERSIST_CONFIG);
+  resolved_configurable_paths.ctlfilename = get_installation_path_for(PATH_CONTROL_SOCKET);
+  resolved_configurable_paths.initial_module_path = get_installation_path_for(SYSLOG_NG_MODULE_PATH);
 }

--- a/lib/resolved-configurable-paths.h
+++ b/lib/resolved-configurable-paths.h
@@ -36,7 +36,7 @@ typedef struct _ResolvedConfigurablePaths
   const gchar *initial_module_path;
 } ResolvedConfigurablePaths;
 
-extern ResolvedConfigurablePaths resolvedConfigurablePaths;
+extern ResolvedConfigurablePaths resolved_configurable_paths;
 void resolved_configurable_paths_init(ResolvedConfigurablePaths *self);
 
 #endif

--- a/lib/tests/test_cache.c
+++ b/lib/tests/test_cache.c
@@ -53,6 +53,20 @@ dummy_cache_resolver(void)
 }
 
 static void
+assert_cache_resolve(Cache *c, const gchar *key)
+{
+  gchar *value;
+  gchar *expected_value = g_strdup_printf("almafa_%s", key);
+
+  value = cache_resolve(c, key);
+  cr_assert_str_eq(value, expected_value, "Lookup key: %s, Expected value: %s, Actual value: %s",
+                   key, value, expected_value);
+
+  g_free(value);
+  g_free(expected_value);
+}
+
+static void
 assert_cache_lookup(Cache *c, const gchar *key)
 {
   gchar *value;
@@ -118,6 +132,17 @@ Test(cache, cache_clear_drops_cached_elements)
   assert_cache_lookup_uncached(c, "key");
   assert_cache_lookup_uncached(c, "key2");
   cache_free(c);
+}
+
+Test(cache, cache_resolve_does_not_store_element)
+{
+  Cache *c;
+
+  c = cache_new(dummy_cache_resolver());
+
+  assert_cache_resolve(c, "key");
+  assert_cache_lookup_uncached(c, "key");
+  assert_cache_lookup_cached(c, "key");
 }
 
 Test(cache, test_free_calls_resolver_free_fn)

--- a/modules/dbparser/pdbtool/pdbtool.c
+++ b/modules/dbparser/pdbtool/pdbtool.c
@@ -1178,7 +1178,7 @@ static GOptionEntry pdbtool_options[] =
     "Load the module specified as parameter", "<module>"
   },
   {
-    "module-path",         0,         0, G_OPTION_ARG_STRING, &resolvedConfigurablePaths.initial_module_path,
+    "module-path",         0,         0, G_OPTION_ARG_STRING, &resolved_configurable_paths.initial_module_path,
     "Set the list of colon separated directories to search for modules, default=" SYSLOG_NG_MODULE_PATH, "<path>"
   },
   { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL }
@@ -1252,7 +1252,7 @@ main(int argc, char *argv[])
 
   main_loop_thread_resource_init();
   msg_init(TRUE);
-  resolved_configurable_paths_init(&resolvedConfigurablePaths);
+  resolved_configurable_paths_init(&resolved_configurable_paths);
   stats_init();
   scratch_buffers_global_init();
   scratch_buffers_allocator_init();

--- a/modules/java/native/java_machine.c
+++ b/modules/java/native/java_machine.c
@@ -193,7 +193,7 @@ _setup_jvm_options_array(JavaVMSingleton *self, const gchar *jvm_options_str)
 
   jvm_options_array = _jvm_options_array_append(jvm_options_array,
                                                 g_strdup_printf("-Djava.library.path=%s",
-                                                    resolvedConfigurablePaths.initial_module_path));
+                                                    resolved_configurable_paths.initial_module_path));
 
   jvm_options_array = _jvm_options_array_append(jvm_options_array,
                                                 g_strdup_printf("-Dlog4j.configurationFactory=org.syslog_ng.logging.CustomConfigurationFactory"));

--- a/news/bugfix-4143.md
+++ b/news/bugfix-4143.md
@@ -1,0 +1,5 @@
+`syslog-ng --help` screen: the output for the --help command line option has
+included sample paths to various files that contained autoconf style
+directory references (e.g. ${prefix}/etc for instance). This is now fixed,
+these paths will contain the expanded path. Fixes Debian Bug report #962839:
+https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=962839

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -71,18 +71,18 @@ extern int cfg_parser_debug;
 static GOptionEntry syslogng_options[] =
 {
   { "version",           'V',         0, G_OPTION_ARG_NONE, &display_version, "Display version number (" SYSLOG_NG_PACKAGE_NAME " " SYSLOG_NG_COMBINED_VERSION ")", NULL },
-  { "module-path",         0,         0, G_OPTION_ARG_STRING, &resolvedConfigurablePaths.initial_module_path, "Set the list of colon separated directories to search for modules, default=" SYSLOG_NG_MODULE_PATH, "<path>" },
+  { "module-path",         0,         0, G_OPTION_ARG_STRING, &resolved_configurable_paths.initial_module_path, "Set the list of colon separated directories to search for modules, default=" SYSLOG_NG_MODULE_PATH, "<path>" },
   { "module-registry",     0,         0, G_OPTION_ARG_NONE, &display_module_registry, "Display module information", NULL },
   { "no-module-discovery", 0,         0, G_OPTION_ARG_NONE, &main_loop_options.disable_module_discovery, "Disable module auto-discovery, all modules need to be loaded explicitly by the configuration", NULL },
   { "seed",              'S',         0, G_OPTION_ARG_NONE, &dummy, "Does nothing, the need to seed the random generator is autodetected", NULL},
 #ifdef YYDEBUG
   { "yydebug",           'y',         0, G_OPTION_ARG_NONE, &cfg_parser_debug, "Enable configuration parser debugging", NULL },
 #endif
-  { "cfgfile",           'f',         0, G_OPTION_ARG_STRING, &resolvedConfigurablePaths.cfgfilename, "Set config file name, default=" PATH_SYSLOG_NG_CONF, "<config>" },
-  { "persist-file",      'R',         0, G_OPTION_ARG_STRING, &resolvedConfigurablePaths.persist_file, "Set the name of the persistent configuration file, default=" PATH_PERSIST_CONFIG, "<fname>" },
+  { "cfgfile",           'f',         0, G_OPTION_ARG_STRING, &resolved_configurable_paths.cfgfilename, "Set config file name, default=" PATH_SYSLOG_NG_CONF, "<config>" },
+  { "persist-file",      'R',         0, G_OPTION_ARG_STRING, &resolved_configurable_paths.persist_file, "Set the name of the persistent configuration file, default=" PATH_PERSIST_CONFIG, "<fname>" },
   { "preprocess-into",     0,         0, G_OPTION_ARG_STRING, &main_loop_options.preprocess_into, "Write the preprocessed configuration file to the file specified and quit", "output" },
   { "syntax-only",       's',         0, G_OPTION_ARG_NONE, &main_loop_options.syntax_only, "Only read and parse config file", NULL},
-  { "control",           'c',         0, G_OPTION_ARG_STRING, &resolvedConfigurablePaths.ctlfilename, "Set syslog-ng control socket, default=" PATH_CONTROL_SOCKET, "<ctlpath>" },
+  { "control",           'c',         0, G_OPTION_ARG_STRING, &resolved_configurable_paths.ctlfilename, "Set syslog-ng control socket, default=" PATH_CONTROL_SOCKET, "<ctlpath>" },
   { "interactive",       'i',         0, G_OPTION_ARG_NONE, &main_loop_options.interactive_mode, "Enable interactive mode" },
   { NULL },
 };
@@ -167,7 +167,7 @@ version(void)
 #endif
 
   printf("Module-Directory: %s\n", get_installation_path_for(SYSLOG_NG_PATH_MODULEDIR));
-  printf("Module-Path: %s\n", resolvedConfigurablePaths.initial_module_path);
+  printf("Module-Path: %s\n", resolved_configurable_paths.initial_module_path);
   printf("Include-Path: %s\n", get_installation_path_for(SYSLOG_NG_PATH_CONFIG_INCLUDEDIR));
   printf("Available-Modules: ");
   plugin_list_modules(stdout, FALSE);
@@ -236,7 +236,7 @@ main(int argc, char *argv[])
   g_process_set_name("syslog-ng");
   g_process_set_argv_space(argc, (gchar **) argv);
 
-  resolved_configurable_paths_init(&resolvedConfigurablePaths);
+  resolved_configurable_paths_init(&resolved_configurable_paths);
   resolve_paths_in_help_texts();
 
   ctx = g_option_context_new("syslog-ng");

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -87,6 +87,26 @@ static GOptionEntry syslogng_options[] =
   { NULL },
 };
 
+
+static void
+resolve_paths_in_help_texts(void)
+{
+  for (GOptionEntry *oe = syslogng_options; oe->long_name; oe++)
+    {
+      oe->description = resolve_path_variables_in_text(oe->description);
+    }
+}
+
+static void
+free_help_texts(void)
+{
+  for (GOptionEntry *oe = syslogng_options; oe->long_name; oe++)
+    {
+      g_free((gpointer) oe->description);
+    }
+}
+
+
 #define INSTALL_DAT_INSTALLER_VERSION "INSTALLER_VERSION"
 
 static void
@@ -217,6 +237,7 @@ main(int argc, char *argv[])
   g_process_set_argv_space(argc, (gchar **) argv);
 
   resolved_configurable_paths_init(&resolvedConfigurablePaths);
+  resolve_paths_in_help_texts();
 
   ctx = g_option_context_new("syslog-ng");
   g_process_add_option_group(ctx);
@@ -231,6 +252,8 @@ main(int argc, char *argv[])
       return 1;
     }
   g_option_context_free(ctx);
+  free_help_texts();
+
   if (argc > 1)
     {
       fprintf(stderr, "Excess number of arguments\n");


### PR DESCRIPTION
This one fixes #4138, which was forwarded by @mochrul from Debian ticket 

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=962839