### PR TITLE
Drop direct access to dpkg internal database for checking package int…

### DIFF
--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -963,7 +963,10 @@ debun_extra_debian () {
 	printf "\nDebian specific checks\n"
 	printf "Check package files integrity\n"
 	cd /
-	md5sum --quiet -c /var/lib/dpkg/info/syslog-ng*.md5sums && printf "Package files are intact\n"
+	for package in $(dpkg -l syslog-ng\* | grep "ii" | awk -F " " '{print $2}')
+	do
+		dpkg --verify ${package} && printf "Package ${package} files are intact\n"
+	done
 	printf "list syslog-related packages\n"
 	dpkg -l |grep syslog > ${tmpdir}/deb.packages
 }


### PR DESCRIPTION
…egrity

Files in /var/lib/dpkg/info/ is dpkg internal files. It can create some issues accessing it directly, but the most important one is that the dpkg developers would like to change the structure.

For this reason, it is better to validate the integrity of the installed syslog-ng packages using the official interface (dpkg --verify).

This patch resolves #4139
