### PR TITLE
Type hinting compat fixes

### DIFF
--- a/lib/versioning.h
+++ b/lib/versioning.h
@@ -200,6 +200,7 @@
 /* version based feature flips */
 #define VERSION_VALUE_NEXT_MAJOR         VERSION_VALUE_4_0
 #define FEATURE_TYPING_MIN_VERSION       VERSION_VALUE_4_0
+#define FEATURE_TYPING_VERSION           "syslog-ng 4.0"
 
 #include "pe-versioning.h"
 #endif

--- a/modules/add-contextual-data/context-info-db.c
+++ b/modules/add-contextual-data/context-info-db.c
@@ -340,6 +340,7 @@ context_info_db_import(ContextInfoDB *self, FILE *fp, const gchar *filename,
       msg_trace("add-contextual-data(): adding database entry",
                 evt_tag_str("selector", next_record->selector->str),
                 evt_tag_str("name", log_msg_get_value_name(next_record->value_handle, NULL)),
+                evt_tag_str("type", log_msg_value_type_to_str(next_record->value->type_hint)),
                 evt_tag_str("value", next_record->value->template));
       context_info_db_insert(self, next_record);
     }

--- a/news/bugfix-4158.md
+++ b/news/bugfix-4158.md
@@ -1,0 +1,7 @@
+`add-contextual-data()`: add compatibility warnings and update advise in
+case of the value field of the add-contextual-data() database contains an
+expression that resembles the new type-hinting syntax: type(value).
+
+`db-parser()`: add compatibility warnings and update advise in case the
+<value>  element in the pattern database contains an expression that
+resembles the new type-hinting syntax: type(value).


### PR DESCRIPTION
This branch adds a couple of new warnings where the new type-hinting functionality causes incompatibilities.

These are db-parser(), grouping-by() and add-contextual-data() where the template strings can now contain type-hints, which were not supported before.

These cause an incompatibility if the previous templates did contain a parenthesis, as encountered by @ryanfaircloth in issue #4155 
