### PR TITLE
Python: make config accessible globally

### DIFF
--- a/modules/python/pylib/syslogng/__init__.py
+++ b/modules/python/pylib/syslogng/__init__.py
@@ -25,7 +25,7 @@ from __future__ import print_function
 try:
     from _syslogng import LogMessage
     from _syslogng import LogSource, LogFetcher
-    from _syslogng import LogTemplate, LogTemplateException
+    from _syslogng import LogTemplate, LogTemplateException, LogTemplateOptions
     from _syslogng import Logger
     from _syslogng import Persist as SlngPersist
     from _syslogng import InstantAckTracker, ConsecutiveAckTracker, BatchedAckTracker

--- a/modules/python/pylib/syslogng/__init__.py
+++ b/modules/python/pylib/syslogng/__init__.py
@@ -25,7 +25,7 @@ from __future__ import print_function
 try:
     from _syslogng import LogMessage
     from _syslogng import LogSource, LogFetcher
-    from _syslogng import LogTemplate, LogTemplateException, LTZ_LOCAL, LTZ_SEND
+    from _syslogng import LogTemplate, LogTemplateException
     from _syslogng import Logger
     from _syslogng import Persist as SlngPersist
     from _syslogng import InstantAckTracker, ConsecutiveAckTracker, BatchedAckTracker
@@ -41,3 +41,7 @@ try:
 
 except ImportError:
     print("The syslogng package can only be used in syslog-ng.")
+
+
+LTZ_LOCAL = 0
+LTZ_SEND = 1

--- a/modules/python/python-ack-tracker.c
+++ b/modules/python/python-ack-tracker.c
@@ -203,7 +203,7 @@ PyTypeObject py_batched_ack_tracker_factory_type =
 };
 
 void
-py_ack_tracker_init(void)
+py_ack_tracker_global_init(void)
 {
   PyType_Ready(&py_ack_tracker_factory_type);
 

--- a/modules/python/python-ack-tracker.h
+++ b/modules/python/python-ack-tracker.h
@@ -40,7 +40,8 @@ extern PyTypeObject py_instant_ack_tracker_factory_type;
 extern PyTypeObject py_consecutive_ack_tracker_factory_type;
 extern PyTypeObject py_batched_ack_tracker_factory_type;
 
-void py_ack_tracker_init(void);
 int py_is_ack_tracker_factory(PyObject *obj);
+
+void py_ack_tracker_global_init(void);
 
 #endif

--- a/modules/python/python-bookmark.c
+++ b/modules/python/python-bookmark.c
@@ -116,7 +116,7 @@ PyTypeObject py_bookmark_type =
 };
 
 void
-py_bookmark_init(void)
+py_bookmark_global_init(void)
 {
   PyType_Ready(&py_bookmark_type);
 }

--- a/modules/python/python-bookmark.h
+++ b/modules/python/python-bookmark.h
@@ -37,12 +37,12 @@ typedef struct _PyBookmark
 
 extern PyTypeObject py_bookmark_type;
 
+int py_is_bookmark(PyObject *obj);
 PyBookmark *py_bookmark_new(PyObject *data, PyObject *save);
 void py_bookmark_fill(Bookmark *bookmark, PyBookmark *py_bookmark);
 
-void py_bookmark_init(void);
-
-int py_is_bookmark(PyObject *obj);
 PyBookmark *bookmark_to_py_bookmark(Bookmark *bookmark);
+
+void py_bookmark_global_init(void);
 
 #endif

--- a/modules/python/python-config.c
+++ b/modules/python/python-config.c
@@ -32,8 +32,6 @@ python_config_init(ModuleConfig *s, GlobalConfig *cfg)
 {
   PythonConfig *self = (PythonConfig *) s;
 
-  propagate_persist_state(cfg);
-
   PyGILState_STATE gstate;
   gstate = PyGILState_Ensure();
   _py_switch_main_module(self);

--- a/modules/python/python-config.c
+++ b/modules/python/python-config.c
@@ -54,12 +54,13 @@ python_config_free(ModuleConfig *s)
 }
 
 PythonConfig *
-python_config_new(void)
+python_config_new(GlobalConfig *cfg)
 {
   PythonConfig *self = g_new0(PythonConfig, 1);
 
   self->super.init = python_config_init;
   self->super.free_fn = python_config_free;
+  self->cfg = cfg;
   return self;
 }
 
@@ -69,7 +70,7 @@ python_config_get(GlobalConfig *cfg)
   PythonConfig *pc = g_hash_table_lookup(cfg->module_config, MODULE_CONFIG_KEY);
   if (!pc)
     {
-      pc = python_config_new();
+      pc = python_config_new(cfg);
       g_hash_table_insert(cfg->module_config, g_strdup(MODULE_CONFIG_KEY), pc);
     }
   return pc;

--- a/modules/python/python-config.h
+++ b/modules/python/python-config.h
@@ -29,6 +29,7 @@
 typedef struct _PythonConfig
 {
   ModuleConfig super;
+  GlobalConfig *cfg;
   PyObject *main_module;
 } PythonConfig;
 

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -341,6 +341,8 @@ py_get_persist_name(PythonDestDriver *self)
 static gboolean
 _py_init_bindings(PythonDestDriver *self)
 {
+  GlobalConfig *cfg = log_pipe_get_config(&self->super.super.super.super);
+
   self->py._refs_to_clean = g_ptr_array_new_with_free_func((GDestroyNotify)_py_clear);
 
   self->py.class = _py_resolve_qualified_name(self->class);
@@ -359,7 +361,7 @@ _py_init_bindings(PythonDestDriver *self)
 
   _inject_worker_insert_result_consts(self);
 
-  PyObject *py_log_template_options = py_log_template_options_new(&self->template_options);
+  PyObject *py_log_template_options = py_log_template_options_new(&self->template_options, cfg);
   PyObject_SetAttrString(self->py.class, "template_options", py_log_template_options);
   Py_DECREF(py_log_template_options);
 
@@ -440,6 +442,7 @@ _py_init_object(PythonDestDriver *self)
 static gboolean
 _py_construct_message(PythonDestDriver *self, LogMessage *msg, PyObject **msg_object)
 {
+  GlobalConfig *cfg = log_pipe_get_config(&self->super.super.super.super);
   gboolean success;
   *msg_object = NULL;
 
@@ -452,7 +455,7 @@ _py_construct_message(PythonDestDriver *self, LogMessage *msg, PyObject **msg_ob
     }
   else
     {
-      *msg_object = py_log_message_new(msg);
+      *msg_object = py_log_message_new(msg, cfg);
     }
 
   return TRUE;

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -453,10 +453,6 @@ _py_construct_message(PythonDestDriver *self, LogMessage *msg, PyObject **msg_ob
   else
     {
       *msg_object = py_log_message_new(msg);
-
-      GlobalConfig *cfg = log_pipe_get_config(&self->super.super.super.super);
-      if (!cfg_is_typing_feature_enabled(cfg))
-        ((PyLogMessage *) *msg_object)->cast_to_strings = TRUE;
     }
 
   return TRUE;

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -684,7 +684,7 @@ static PyTypeObject py_log_fetcher_type =
 };
 
 void
-py_log_fetcher_init(void)
+py_log_fetcher_global_init(void)
 {
   py_log_fetcher_type.tp_dict = PyDict_New();
   PyDict_SetItemString(py_log_fetcher_type.tp_dict, "FETCH_ERROR",

--- a/modules/python/python-fetcher.h
+++ b/modules/python/python-fetcher.h
@@ -32,6 +32,6 @@ void python_fetcher_set_loaders(LogDriver *d, GList *loaders);
 void python_fetcher_set_class(LogDriver *d, gchar *class_name);
 void python_fetcher_set_option(LogDriver *d, gchar *key, gchar *value);
 
-void py_log_fetcher_init(void);
+void py_log_fetcher_global_init(void);
 
 #endif

--- a/modules/python/python-global-code-loader.c
+++ b/modules/python/python-global-code-loader.c
@@ -94,7 +94,7 @@ static PyTypeObject py_global_code_loader_type =
 };
 
 void
-py_global_code_loader_init(void)
+py_global_code_loader_global_init(void)
 {
   PyType_Ready(&py_global_code_loader_type);
 }

--- a/modules/python/python-global-code-loader.h
+++ b/modules/python/python-global-code-loader.h
@@ -28,6 +28,7 @@
 #include "python-module.h"
 
 PyObject *py_global_code_loader_new(const gchar *source);
-void py_global_code_loader_init(void);
+
+void py_global_code_loader_global_init(void);
 
 #endif

--- a/modules/python/python-integerpointer.c
+++ b/modules/python/python-integerpointer.c
@@ -64,7 +64,7 @@ PyTypeObject py_integer_pointer_type =
 };
 
 void
-py_integer_pointer_init(void)
+py_integer_pointer_global_init(void)
 {
   PyType_Ready(&py_integer_pointer_type);
 }

--- a/modules/python/python-integerpointer.h
+++ b/modules/python/python-integerpointer.h
@@ -35,6 +35,7 @@ typedef struct _PyIntegerPointer
 extern PyTypeObject py_integer_pointer_type;
 
 PyObject *py_integer_pointer_new(gpointer ptr);
-void py_integer_pointer_init(void);
+
+void py_integer_pointer_global_init(void);
 
 #endif

--- a/modules/python/python-logger.c
+++ b/modules/python/python-logger.c
@@ -118,7 +118,7 @@ PyTypeObject py_logger_type =
 };
 
 void
-py_logger_init(void)
+py_logger_global_init(void)
 {
   PyType_Ready(&py_logger_type);
   PyModule_AddObject(PyImport_AddModule("_syslogng"), "Logger", (PyObject *) &py_logger_type);

--- a/modules/python/python-logger.h
+++ b/modules/python/python-logger.h
@@ -27,7 +27,6 @@
 
 #include "python-module.h"
 
-
-void py_logger_init(void);
+void py_logger_global_init(void);
 
 #endif

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -137,7 +137,7 @@ py_log_message_free(PyLogMessage *self)
 }
 
 PyObject *
-py_log_message_new(LogMessage *msg)
+py_log_message_new(LogMessage *msg, GlobalConfig *cfg)
 {
   PyLogMessage *self;
 
@@ -148,7 +148,6 @@ py_log_message_new(LogMessage *msg)
   self->msg = log_msg_ref(msg);
   self->bookmark_data = NULL;
 
-  GlobalConfig *cfg = python_get_associated_config();
   if (!cfg_is_typing_feature_enabled(cfg))
     self->cast_to_strings = TRUE;
   else

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -25,6 +25,7 @@
 #include "compat/compat-python.h"
 #include "python-helpers.h"
 #include "python-types.h"
+#include "python-main.h"
 #include "logmsg/logmsg.h"
 #include "messages.h"
 #include "timeutils/cache.h"
@@ -33,6 +34,7 @@
 #include "timeutils/misc.h"
 #include "msg-format.h"
 #include "scratch-buffers.h"
+#include "cfg.h"
 
 #include <datetime.h>
 
@@ -145,7 +147,12 @@ py_log_message_new(LogMessage *msg)
 
   self->msg = log_msg_ref(msg);
   self->bookmark_data = NULL;
-  self->cast_to_strings = FALSE;
+
+  GlobalConfig *cfg = python_get_associated_config();
+  if (!cfg_is_typing_feature_enabled(cfg))
+    self->cast_to_strings = TRUE;
+  else
+    self->cast_to_strings = FALSE;
   return (PyObject *) self;
 }
 

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -430,7 +430,7 @@ PyTypeObject py_log_message_type =
 };
 
 void
-py_log_message_init(void)
+py_log_message_global_init(void)
 {
   PyDateTime_IMPORT;
   PyType_Ready(&py_log_message_type);

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -156,20 +156,17 @@ py_log_message_new(LogMessage *msg)
   return (PyObject *) self;
 }
 
-static PyObject *
-py_log_message_new_empty(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
+static int
+py_log_message_init(PyObject *s, PyObject *args, PyObject *kwds)
 {
+  PyLogMessage *self = (PyLogMessage *) s;
   PyObject *bookmark_data = NULL;
   const gchar *message = NULL;
   Py_ssize_t message_length = 0;
 
   static const gchar *kwlist[] = {"message", "bookmark", NULL};
   if (!PyArg_ParseTupleAndKeywords(args, kwds, "|z#O", (gchar **) kwlist, &message, &message_length, &bookmark_data))
-    return NULL;
-
-  PyLogMessage *self = (PyLogMessage *) subtype->tp_alloc(subtype, 0);
-  if (!self)
-    return NULL;
+    return -1;
 
   self->msg = log_msg_new_empty();
   self->bookmark_data = NULL;
@@ -181,7 +178,7 @@ py_log_message_new_empty(PyTypeObject *subtype, PyObject *args, PyObject *kwds)
   Py_XINCREF(bookmark_data);
   self->bookmark_data = bookmark_data;
 
-  return (PyObject *) self;
+  return 0;
 }
 
 static PyMappingMethods py_log_message_mapping =
@@ -423,7 +420,8 @@ PyTypeObject py_log_message_type =
   .tp_dealloc = (destructor) py_log_message_free,
   .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
   .tp_doc = "LogMessage class encapsulating a syslog-ng log message",
-  .tp_new = py_log_message_new_empty,
+  .tp_new = PyType_GenericNew,
+  .tp_init = py_log_message_init,
   .tp_as_mapping = &py_log_message_mapping,
   .tp_methods = py_log_message_methods,
   0,

--- a/modules/python/python-logmsg.h
+++ b/modules/python/python-logmsg.h
@@ -37,9 +37,10 @@ typedef struct _PyLogMessage
 
 extern PyTypeObject py_log_message_type;
 
-PyObject *py_log_message_new(LogMessage *msg);
-void py_log_message_init(void);
-
 int py_is_log_message(PyObject *obj);
+PyObject *py_log_message_new(LogMessage *msg);
+
+void py_log_message_global_init(void);
+
 
 #endif

--- a/modules/python/python-logmsg.h
+++ b/modules/python/python-logmsg.h
@@ -38,7 +38,7 @@ typedef struct _PyLogMessage
 extern PyTypeObject py_log_message_type;
 
 int py_is_log_message(PyObject *obj);
-PyObject *py_log_message_new(LogMessage *msg);
+PyObject *py_log_message_new(LogMessage *msg, GlobalConfig *cfg);
 
 void py_log_message_global_init(void);
 

--- a/modules/python/python-logparser.c
+++ b/modules/python/python-logparser.c
@@ -191,11 +191,6 @@ python_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
               evt_tag_msg_reference(msg));
 
     PyObject *msg_object = py_log_message_new(msg);
-
-    GlobalConfig *cfg = log_pipe_get_config(&s->super);
-    if (!cfg_is_typing_feature_enabled(cfg))
-      ((PyLogMessage *) msg_object)->cast_to_strings = TRUE;
-
     result = _py_invoke_parser_process(self, msg_object);
     Py_DECREF(msg_object);
   }

--- a/modules/python/python-logparser.c
+++ b/modules/python/python-logparser.c
@@ -177,6 +177,7 @@ python_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
                       gsize input_len)
 {
   PythonParser *self = (PythonParser *)s;
+  GlobalConfig *cfg = log_pipe_get_config(&s->super);
   PyGILState_STATE gstate;
   gboolean result;
 
@@ -190,7 +191,7 @@ python_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *pat
               evt_tag_str("class", self->class),
               evt_tag_msg_reference(msg));
 
-    PyObject *msg_object = py_log_message_new(msg);
+    PyObject *msg_object = py_log_message_new(msg, cfg);
     result = _py_invoke_parser_process(self, msg_object);
     Py_DECREF(msg_object);
   }

--- a/modules/python/python-logtemplate-options.c
+++ b/modules/python/python-logtemplate-options.c
@@ -46,6 +46,24 @@ py_log_template_options_new(LogTemplateOptions *template_options)
   return (PyObject *) self;
 }
 
+PyObject *
+py_log_template_options_pynew(PyTypeObject *type, PyObject *args, PyObject *kwds)
+{
+  PyLogTemplateOptions *self = PyObject_New(PyLogTemplateOptions, &py_log_template_options_type);
+
+  if (!self)
+    return NULL;
+
+  if (!PyArg_ParseTuple(args, ""))
+    return NULL;
+
+  GlobalConfig *cfg = python_get_associated_config();
+  memset(&self->template_options, 0, sizeof(self->template_options));
+  log_template_options_defaults(&self->template_options);
+  log_template_options_init(&self->template_options, cfg);
+
+  return (PyObject *) self;
+}
 
 PyTypeObject py_log_template_options_type =
 {
@@ -55,6 +73,7 @@ PyTypeObject py_log_template_options_type =
   .tp_dealloc = (destructor) PyObject_Del,
   .tp_flags = Py_TPFLAGS_DEFAULT,
   .tp_doc = "LogTemplateOptions class encapsulating a syslog-ng LogTemplateOptions",
+  .tp_new = py_log_template_options_pynew,
   0,
 };
 
@@ -62,4 +81,5 @@ void
 py_log_template_options_global_init(void)
 {
   PyType_Ready(&py_log_template_options_type);
+  PyModule_AddObject(PyImport_AddModule("_syslogng"), "LogTemplateOptions", (PyObject *) &py_log_template_options_type);
 }

--- a/modules/python/python-logtemplate-options.c
+++ b/modules/python/python-logtemplate-options.c
@@ -31,14 +31,13 @@ py_is_log_template_options(PyObject *obj)
 }
 
 PyObject *
-py_log_template_options_new(LogTemplateOptions *template_options)
+py_log_template_options_new(LogTemplateOptions *template_options, GlobalConfig *cfg)
 {
   PyLogTemplateOptions *self = PyObject_New(PyLogTemplateOptions, &py_log_template_options_type);
 
   if (!self)
     return NULL;
 
-  GlobalConfig *cfg = python_get_associated_config();
   memset(&self->template_options, 0, sizeof(self->template_options));
   log_template_options_clone(template_options, &self->template_options);
   log_template_options_init(&self->template_options, cfg);

--- a/modules/python/python-logtemplate-options.c
+++ b/modules/python/python-logtemplate-options.c
@@ -46,23 +46,20 @@ py_log_template_options_new(LogTemplateOptions *template_options)
   return (PyObject *) self;
 }
 
-PyObject *
-py_log_template_options_pynew(PyTypeObject *type, PyObject *args, PyObject *kwds)
+int
+py_log_template_options_init(PyObject *s, PyObject *args, PyObject *kwds)
 {
-  PyLogTemplateOptions *self = PyObject_New(PyLogTemplateOptions, &py_log_template_options_type);
-
-  if (!self)
-    return NULL;
+  PyLogTemplateOptions *self = (PyLogTemplateOptions *) s;
 
   if (!PyArg_ParseTuple(args, ""))
-    return NULL;
+    return -1;
 
   GlobalConfig *cfg = python_get_associated_config();
   memset(&self->template_options, 0, sizeof(self->template_options));
   log_template_options_defaults(&self->template_options);
   log_template_options_init(&self->template_options, cfg);
 
-  return (PyObject *) self;
+  return 0;
 }
 
 PyTypeObject py_log_template_options_type =
@@ -73,7 +70,8 @@ PyTypeObject py_log_template_options_type =
   .tp_dealloc = (destructor) PyObject_Del,
   .tp_flags = Py_TPFLAGS_DEFAULT,
   .tp_doc = "LogTemplateOptions class encapsulating a syslog-ng LogTemplateOptions",
-  .tp_new = py_log_template_options_pynew,
+  .tp_init = py_log_template_options_init,
+  .tp_new = PyType_GenericNew,
   0,
 };
 

--- a/modules/python/python-logtemplate-options.c
+++ b/modules/python/python-logtemplate-options.c
@@ -54,7 +54,7 @@ PyTypeObject py_log_template_options_type =
 };
 
 void
-py_log_template_options_init(void)
+py_log_template_options_global_init(void)
 {
   PyType_Ready(&py_log_template_options_type);
 }

--- a/modules/python/python-logtemplate-options.c
+++ b/modules/python/python-logtemplate-options.c
@@ -22,6 +22,7 @@
  */
 
 #include "python-logtemplate-options.h"
+#include "python-main.h"
 
 int
 py_is_log_template_options(PyObject *obj)
@@ -33,10 +34,14 @@ PyObject *
 py_log_template_options_new(LogTemplateOptions *template_options)
 {
   PyLogTemplateOptions *self = PyObject_New(PyLogTemplateOptions, &py_log_template_options_type);
+
   if (!self)
     return NULL;
 
-  self->template_options = template_options;
+  GlobalConfig *cfg = python_get_associated_config();
+  memset(&self->template_options, 0, sizeof(self->template_options));
+  log_template_options_clone(template_options, &self->template_options);
+  log_template_options_init(&self->template_options, cfg);
 
   return (PyObject *) self;
 }

--- a/modules/python/python-logtemplate-options.h
+++ b/modules/python/python-logtemplate-options.h
@@ -36,7 +36,7 @@ typedef struct _PyLogTemplateOptions
 extern PyTypeObject py_log_template_options_type;
 
 int py_is_log_template_options(PyObject *obj);
-PyObject *py_log_template_options_new(LogTemplateOptions *template_options);
+PyObject *py_log_template_options_new(LogTemplateOptions *template_options, GlobalConfig *cfg);
 
 void py_log_template_options_global_init(void);
 

--- a/modules/python/python-logtemplate-options.h
+++ b/modules/python/python-logtemplate-options.h
@@ -30,7 +30,7 @@
 typedef struct _PyLogTemplateOptions
 {
   PyObject_HEAD
-  LogTemplateOptions *template_options;
+  LogTemplateOptions template_options;
 } PyLogTemplateOptions;
 
 extern PyTypeObject py_log_template_options_type;

--- a/modules/python/python-logtemplate-options.h
+++ b/modules/python/python-logtemplate-options.h
@@ -35,9 +35,9 @@ typedef struct _PyLogTemplateOptions
 
 extern PyTypeObject py_log_template_options_type;
 
-PyObject *py_log_template_options_new(LogTemplateOptions *template_options);
-void py_log_template_options_init(void);
-
 int py_is_log_template_options(PyObject *obj);
+PyObject *py_log_template_options_new(LogTemplateOptions *template_options);
+
+void py_log_template_options_init(void);
 
 #endif

--- a/modules/python/python-logtemplate-options.h
+++ b/modules/python/python-logtemplate-options.h
@@ -38,6 +38,6 @@ extern PyTypeObject py_log_template_options_type;
 int py_is_log_template_options(PyObject *obj);
 PyObject *py_log_template_options_new(LogTemplateOptions *template_options);
 
-void py_log_template_options_init(void);
+void py_log_template_options_global_init(void);
 
 #endif

--- a/modules/python/python-logtemplate.c
+++ b/modules/python/python-logtemplate.c
@@ -151,15 +151,7 @@ py_log_template_init(void)
 
   PyType_Ready(&py_log_template_type);
   PyModule_AddObject(PyImport_AddModule("_syslogng"), "LogTemplate", (PyObject *) &py_log_template_type);
-  PyObject *PY_LTZ_LOCAL = py_long_from_long(0);
-  PyObject *PY_LTZ_SEND = py_long_from_long(1);
-
-  PyObject_SetAttrString(PyImport_AddModule("_syslogng"), "LTZ_LOCAL", PY_LTZ_LOCAL);
-  PyObject_SetAttrString(PyImport_AddModule("_syslogng"), "LTZ_SEND", PY_LTZ_SEND);
-
-  Py_DECREF(PY_LTZ_LOCAL);
-  Py_DECREF(PY_LTZ_SEND);
 
   PyExc_LogTemplate = PyErr_NewException("_syslogng.LogTemplateException", NULL, NULL);
-  PyModule_AddObject(PyImport_AddModule("_syslogng"), "LogTemplateException", (PyObject *)PyExc_LogTemplate);
+  PyModule_AddObject(PyImport_AddModule("_syslogng"), "LogTemplateException", (PyObject *) PyExc_LogTemplate);
 }

--- a/modules/python/python-logtemplate.c
+++ b/modules/python/python-logtemplate.c
@@ -145,9 +145,9 @@ PyTypeObject py_log_template_type =
 };
 
 void
-py_log_template_init(void)
+py_log_template_global_init(void)
 {
-  py_log_template_options_init();
+  py_log_template_options_global_init();
 
   PyType_Ready(&py_log_template_type);
   PyModule_AddObject(PyImport_AddModule("_syslogng"), "LogTemplate", (PyObject *) &py_log_template_type);

--- a/modules/python/python-logtemplate.c
+++ b/modules/python/python-logtemplate.c
@@ -24,6 +24,7 @@
 #include "python-logtemplate-options.h"
 #include "python-logmsg.h"
 #include "python-types.h"
+#include "python-main.h"
 #include "scratch-buffers.h"
 #include "messages.h"
 
@@ -99,7 +100,7 @@ py_log_template_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
       return NULL;
     }
 
-  LogTemplate *template = log_template_new(NULL, NULL);
+  LogTemplate *template = log_template_new(python_get_associated_config(), NULL);
   GError *error = NULL;
   if (!log_template_compile(template, template_string, &error))
     {

--- a/modules/python/python-logtemplate.h
+++ b/modules/python/python-logtemplate.h
@@ -38,9 +38,10 @@ extern PyTypeObject py_log_template_type;
 extern PyObject *PyExc_LogTemplate;
 
 
-void py_log_template_init(void);
 PyObject *py_log_template_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
 void py_log_template_free(PyLogTemplate *self);
 PyObject *py_log_template_format(PyObject *s, PyObject *args, PyObject *kwds);
+
+void py_log_template_global_init(void);
 
 #endif

--- a/modules/python/python-logtemplate.h
+++ b/modules/python/python-logtemplate.h
@@ -25,13 +25,14 @@
 #define _SNG_PYTHON_TEMPLATE_H
 
 #include "python-module.h"
+#include "python-logtemplate-options.h"
 #include "template/templates.h"
 
 typedef struct _PyLogTemplate
 {
   PyObject_HEAD
   LogTemplate *template;
-  LogTemplateOptions *template_options;
+  PyLogTemplateOptions *py_template_options;
 } PyLogTemplate;
 
 extern PyTypeObject py_log_template_type;

--- a/modules/python/python-main.h
+++ b/modules/python/python-main.h
@@ -29,7 +29,7 @@
 PyObject *_py_get_current_main_module(void);
 PyObject *_py_get_main_module(PythonConfig *pc);
 void _py_switch_main_module(PythonConfig *pc);
+GlobalConfig *python_get_associated_config(void);
 gboolean python_evaluate_global_code(GlobalConfig *cfg, const gchar *code, CFG_LTYPE *yylloc);
-void propagate_persist_state(GlobalConfig *cfg);
 
 #endif

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -24,6 +24,7 @@
 #include "persistable-state-header.h"
 #include "python-helpers.h"
 #include "python-types.h"
+#include "python-main.h"
 #include "syslog-ng.h"
 #include "driver.h"
 #include "mainloop.h"
@@ -229,10 +230,11 @@ prepare_master_entry(PersistState *persist_state, const gchar *persist_name)
 static int
 _persist_type_init(PyObject *s, PyObject *args, PyObject *kwds)
 {
-  PyPersist *self =(PyPersist *)s;
-  const gchar *persist_name=NULL;
+  PyPersist *self = (PyPersist *) s;
+  const gchar *persist_name = NULL;
+  GlobalConfig *cfg = python_get_associated_config();
 
-  self->persist_state = PyCapsule_Import("_syslogng.persist_state", FALSE);
+  self->persist_state = cfg->state;
   if (!self->persist_state)
     {
       gchar buf[256];

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -513,7 +513,7 @@ PyTypeObject py_persist_type =
 };
 
 void
-py_persist_init(void)
+py_persist_global_init(void)
 {
   PyType_Ready(&py_persist_type);
   PyModule_AddObject(PyImport_AddModule("_syslogng"), "Persist", (PyObject *) &py_persist_type);

--- a/modules/python/python-persist.h
+++ b/modules/python/python-persist.h
@@ -43,8 +43,9 @@ typedef struct
   const gchar *id;
 } PythonPersistMembers;
 
-void py_persist_init(void);
 const gchar *python_format_stats_instance(LogPipe *p, const gchar *module, PythonPersistMembers *options);
 const gchar *python_format_persist_name(const LogPipe *p, const gchar *module, PythonPersistMembers *options);
+
+void py_persist_global_init(void);
 
 #endif

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -113,16 +113,16 @@ _py_init_interpreter(void)
       py_init_argv();
 
       py_init_threads();
-      py_log_message_init();
-      py_log_template_init();
-      py_integer_pointer_init();
-      py_log_source_init();
-      py_log_fetcher_init();
-      py_persist_init();
-      py_bookmark_init();
-      py_ack_tracker_init();
-      py_global_code_loader_init();
-      py_logger_init();
+      py_log_message_global_init();
+      py_log_template_global_init();
+      py_integer_pointer_global_init();
+      py_log_source_global_init();
+      py_log_fetcher_global_init();
+      py_persist_global_init();
+      py_bookmark_global_init();
+      py_ack_tracker_global_init();
+      py_global_code_loader_global_init();
+      py_logger_global_init();
       PyEval_SaveThread();
 
       interpreter_initialized = TRUE;

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -731,7 +731,7 @@ static PyTypeObject py_log_source_type =
 };
 
 void
-py_log_source_init(void)
+py_log_source_global_init(void)
 {
   PyType_Ready(&py_log_source_type);
   PyModule_AddObject(PyImport_AddModule("_syslogng"), "LogSource", (PyObject *) &py_log_source_type);

--- a/modules/python/python-source.h
+++ b/modules/python/python-source.h
@@ -32,6 +32,6 @@ void python_sd_set_loaders(LogDriver *d, GList *loaders);
 void python_sd_set_class(LogDriver *d, gchar *class_name);
 void python_sd_set_option(LogDriver *d, gchar *key, gchar *value);
 
-void py_log_source_init(void);
+void py_log_source_global_init(void);
 
 #endif

--- a/modules/python/python-tf.c
+++ b/modules/python/python-tf.c
@@ -45,8 +45,6 @@ _py_construct_args_tuple(PythonTfState *state, LogMessage *msg, gint argc, GStri
   args = PyTuple_New(1 + argc - 1);
 
   PyObject *py_msg = py_log_message_new(msg);
-  ((PyLogMessage *) py_msg)->cast_to_strings = !cfg_is_typing_feature_enabled(state->cfg);
-
   PyTuple_SetItem(args, 0, py_msg);
   for (i = 1; i < argc; i++)
     {

--- a/modules/python/python-tf.c
+++ b/modules/python/python-tf.c
@@ -44,7 +44,7 @@ _py_construct_args_tuple(PythonTfState *state, LogMessage *msg, gint argc, GStri
 
   args = PyTuple_New(1 + argc - 1);
 
-  PyObject *py_msg = py_log_message_new(msg);
+  PyObject *py_msg = py_log_message_new(msg, state->cfg);
   PyTuple_SetItem(args, 0, py_msg);
   for (i = 1; i < argc; i++)
     {

--- a/modules/python/tests/test_python_ack_tracker.c
+++ b/modules/python/tests/test_python_ack_tracker.c
@@ -50,8 +50,8 @@ _py_init_interpreter(void)
   py_init_argv();
 
   py_init_threads();
-  py_ack_tracker_init();
-  py_bookmark_init();
+  py_ack_tracker_global_init();
+  py_bookmark_global_init();
   PyEval_SaveThread();
 }
 

--- a/modules/python/tests/test_python_bookmark.c
+++ b/modules/python/tests/test_python_bookmark.c
@@ -45,7 +45,7 @@ _py_init_interpreter(void)
   py_init_argv();
 
   py_init_threads();
-  py_bookmark_init();
+  py_bookmark_global_init();
   PyEval_SaveThread();
 }
 

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -189,7 +189,7 @@ ParameterizedTest(PyLogMessageSetValueTestParams *params, python_log_message, te
   gstate = PyGILState_Ensure();
   {
     cfg_set_version_without_validation(configuration, VERSION_VALUE_4_0);
-    PyObject *msg_object = py_log_message_new(msg);
+    PyObject *msg_object = py_log_message_new(msg, configuration);
 
     PyDict_SetItemString(_python_main_dict, "test_msg", msg_object);
 
@@ -220,7 +220,7 @@ Test(python_log_message, test_python_logmessage_set_value_no_typing_support)
   PyGILState_STATE gstate;
   gstate = PyGILState_Ensure();
   {
-    PyObject *msg_object = py_log_message_new(msg);
+    PyObject *msg_object = py_log_message_new(msg, configuration);
     ((PyLogMessage *) msg_object)->cast_to_strings = TRUE;
 
     PyDict_SetItemString(_python_main_dict, "test_msg", msg_object);
@@ -246,7 +246,7 @@ Test(python_log_message, test_python_logmessage_get_value_no_typing_support)
   PyGILState_STATE gstate;
   gstate = PyGILState_Ensure();
   {
-    PyObject *msg_object = py_log_message_new(msg);
+    PyObject *msg_object = py_log_message_new(msg, configuration);
     ((PyLogMessage *) msg_object)->cast_to_strings = TRUE;
 
     PyDict_SetItemString(_python_main_dict, "test_msg", msg_object);
@@ -277,7 +277,7 @@ Test(python_log_message, test_python_logmessage_set_value_indirect)
   PyGILState_STATE gstate;
   gstate = PyGILState_Ensure();
   {
-    PyObject *msg_object = py_log_message_new(msg);
+    PyObject *msg_object = py_log_message_new(msg, configuration);
 
     PyDict_SetItemString(_python_main_dict, "test_msg", msg_object);
 
@@ -301,7 +301,7 @@ Test(python_log_message, test_py_is_log_message)
   gstate = PyGILState_Ensure();
 
   LogMessage *msg = log_msg_new_empty();
-  PyObject *msg_object = py_log_message_new(msg);
+  PyObject *msg_object = py_log_message_new(msg, configuration);
 
   cr_assert(py_is_log_message(msg_object));
   cr_assert_not(py_is_log_message(_python_main));
@@ -415,7 +415,7 @@ Test(python_log_message, test_python_logmessage_keys)
   log_msg_get_value_handle("unused_value");
 
   PyGILState_STATE gstate = PyGILState_Ensure();
-  PyObject *py_msg = py_log_message_new(msg);
+  PyObject *py_msg = py_log_message_new(msg, configuration);
 
   PyObject *keys = _py_invoke_method_by_name(py_msg, "keys", NULL, "PyLogMessageTest", NULL);
   cr_assert_not_null(keys);

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -47,7 +47,7 @@ _py_init_interpreter(void)
   py_init_argv();
 
   py_init_threads();
-  py_log_message_init();
+  py_log_message_global_init();
   PyEval_SaveThread();
 }
 

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -29,6 +29,7 @@
 #include "python-helpers.h"
 #include "python-types.h"
 #include "python-logmsg.h"
+#include "python-main.h"
 #include "apphook.h"
 #include "logmsg/logmsg.h"
 #include "scratch-buffers.h"
@@ -55,7 +56,8 @@ _init_python_main(void)
 {
   PyGILState_STATE gstate = PyGILState_Ensure();
   {
-    _python_main = PyImport_AddModule("__main__");
+    PythonConfig *pc = python_config_get(configuration);
+    _python_main = _py_get_main_module(pc);
     _python_main_dict = PyModule_GetDict(_python_main);
   }
   PyGILState_Release(gstate);
@@ -186,6 +188,7 @@ ParameterizedTest(PyLogMessageSetValueTestParams *params, python_log_message, te
   PyGILState_STATE gstate;
   gstate = PyGILState_Ensure();
   {
+    cfg_set_version_without_validation(configuration, VERSION_VALUE_4_0);
     PyObject *msg_object = py_log_message_new(msg);
 
     PyDict_SetItemString(_python_main_dict, "test_msg", msg_object);

--- a/modules/python/tests/test_python_persist.c
+++ b/modules/python/tests/test_python_persist.c
@@ -64,8 +64,6 @@ _py_init_interpreter(void)
 static void
 _load_code(const gchar *code)
 {
-  propagate_persist_state(cfg);
-
   PyGILState_STATE gstate;
   gstate = PyGILState_Ensure();
   cr_assert(python_evaluate_global_code(cfg, code, &yyltype));

--- a/modules/python/tests/test_python_persist.c
+++ b/modules/python/tests/test_python_persist.c
@@ -57,7 +57,7 @@ _py_init_interpreter(void)
   py_init_argv();
 
   py_init_threads();
-  py_persist_init();
+  py_persist_global_init();
   PyEval_SaveThread();
 }
 

--- a/modules/python/tests/test_python_persist_name.c
+++ b/modules/python/tests/test_python_persist_name.c
@@ -54,10 +54,10 @@ _py_init_interpreter(void)
   py_init_argv();
 
   py_init_threads();
-  py_log_fetcher_init();
-  py_log_source_init();
-  py_bookmark_init();
-  py_ack_tracker_init();
+  py_log_fetcher_global_init();
+  py_log_source_global_init();
+  py_bookmark_global_init();
+  py_ack_tracker_global_init();
   PyEval_SaveThread();
 }
 

--- a/modules/python/tests/test_python_template.c
+++ b/modules/python/tests/test_python_template.c
@@ -71,7 +71,7 @@ _init_python_main(void)
     _python_main = _py_get_main_module(pc);
     _python_main_dict = PyModule_GetDict(_python_main);
 
-    py_template_options = py_log_template_options_new(&log_template_options);
+    py_template_options = py_log_template_options_new(&log_template_options, configuration);
   }
   PyGILState_Release(gstate);
 }
@@ -116,7 +116,7 @@ create_parsed_message(const gchar *raw_msg)
 {
   LogMessage *msg = msg_format_parse(&parse_options, (const guchar *) raw_msg, strlen(raw_msg));
 
-  PyLogMessage *py_log_msg = (PyLogMessage *)py_log_message_new(msg);
+  PyLogMessage *py_log_msg = (PyLogMessage *)py_log_message_new(msg, configuration);
   log_msg_unref(msg);
 
   return py_log_msg;

--- a/modules/python/tests/test_python_template.c
+++ b/modules/python/tests/test_python_template.c
@@ -29,6 +29,7 @@
 #include "python-logmsg.h"
 #include "python-logtemplate.h"
 #include "python-logtemplate-options.h"
+#include "python-main.h"
 #include "apphook.h"
 #include "logmsg/logmsg.h"
 #include "syslog-format.h"
@@ -72,7 +73,8 @@ _init_python_main(void)
 {
   PyGILState_STATE gstate = PyGILState_Ensure();
   {
-    _python_main = PyImport_AddModule("__main__");
+    PythonConfig *pc = python_config_get(configuration);
+    _python_main = _py_get_main_module(pc);
     _python_main_dict = PyModule_GetDict(_python_main);
   }
   PyGILState_Release(gstate);

--- a/modules/python/tests/test_python_template.c
+++ b/modules/python/tests/test_python_template.c
@@ -62,9 +62,9 @@ _py_init_interpreter(void)
   PyGILState_Release(gstate);
 
   py_init_threads();
-  py_log_message_init();
-  py_log_template_init();
-  py_integer_pointer_init();
+  py_log_message_global_init();
+  py_log_template_global_init();
+  py_integer_pointer_global_init();
   PyEval_SaveThread();
 }
 

--- a/modules/python/tests/test_python_template.c
+++ b/modules/python/tests/test_python_template.c
@@ -127,7 +127,7 @@ create_py_log_template(const gchar *template)
 {
   PyObject *template_str = py_string_from_string(template, -1);
   PyObject *args = PyTuple_Pack(1, template_str);
-  PyLogTemplate *py_template = (PyLogTemplate *)py_log_template_new(&py_log_template_type, args, NULL);
+  PyLogTemplate *py_template = (PyLogTemplate *) PyObject_Call((PyObject *) &py_log_template_type, args, NULL);
   Py_DECREF(template_str);
   Py_DECREF(args);
 
@@ -241,7 +241,7 @@ Test(python_log_logtemplate, test_py_is_log_template_options)
   cr_assert_not(py_is_log_template_options((PyObject *)template_str));
 
   PyObject *args = PyTuple_Pack(2, template_str, Py_None); /* Second argument must be PyLogTemplateOptions */
-  PyLogTemplate *py_template = (PyLogTemplate *)py_log_template_new(&py_log_template_type, args, NULL);
+  PyLogTemplate *py_template = (PyLogTemplate *)PyObject_Call((PyObject *) &py_log_template_type, args, NULL);
   Py_DECREF(template_str);
   Py_DECREF(args);
   cr_assert_null(py_template);

--- a/modules/python/tests/test_python_tf.c
+++ b/modules/python/tests/test_python_tf.c
@@ -32,6 +32,7 @@
 #include "python-logtemplate.h"
 #include "python-logtemplate-options.h"
 #include "python-integerpointer.h"
+#include "python-main.h"
 #include "apphook.h"
 #include "logmsg/logmsg.h"
 #include "scratch-buffers.h"
@@ -46,7 +47,8 @@ _init_python_main(void)
 {
   PyGILState_STATE gstate = PyGILState_Ensure();
   {
-    _python_main = PyImport_AddModule("_syslogng_main");
+    PythonConfig *pc = python_config_get(configuration);
+    _python_main = _py_get_main_module(pc);
     _python_main_dict = PyModule_GetDict(_python_main);
   }
   PyGILState_Release(gstate);


### PR DESCRIPTION
While working on the resolution of #4136 I recognized that Python code is associated to a specific configuration. Whenever we
reload the config, the Python "instance" is reloaded as well.

Sometimes the Python code intends to do something that is related to the current config, make it available in the main module
as _syslogng_main.__config__

This is actually a PyCapsule instance holding a reference to GlobalConfig.

The current change simplifies the initialization of PyLogMessage->cast_to_strings, but can similarly be used to pass the GlobalConfig instance to log_template_new(), so it can actually resolve template functions.
