### PR TITLE
Python: add support for datetime() type

### DIFF
--- a/modules/python/python-debugger.c
+++ b/modules/python/python-debugger.c
@@ -104,11 +104,10 @@ python_fetch_debugger_command(void)
   if (!ret)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error calling debugger fetch_command",
                 evt_tag_str("function", DEBUGGER_FETCH_COMMAND),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
       goto exit;
     }

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -349,12 +349,11 @@ _py_init_bindings(PythonDestDriver *self)
   if (!self->py.class)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error looking Python driver class",
                 evt_tag_str("driver", self->super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
       return FALSE;
     }
@@ -373,12 +372,11 @@ _py_init_bindings(PythonDestDriver *self)
   if (!self->py.instance)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error instantiating Python driver class",
                 evt_tag_str("driver", self->super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
       return FALSE;
     }

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -288,12 +288,11 @@ _py_resolve_class(PythonFetcherDriver *self)
   if (!self->py.class)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error looking Python driver class",
                 evt_tag_str("driver", self->super.super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
       return FALSE;
     }
@@ -309,12 +308,11 @@ _py_init_instance(PythonFetcherDriver *self)
   if (!self->py.instance)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error instantiating Python driver class",
                 evt_tag_str("driver", self->super.super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
       return FALSE;
     }
@@ -415,12 +413,11 @@ _py_parse_options_new(PythonFetcherDriver *self, MsgFormatOptions *parse_options
   if (!py_parse_options)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error creating capsule for message parse options",
                 evt_tag_str("driver", self->super.super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
       return NULL;
     }
@@ -464,12 +461,11 @@ _py_set_parse_options(PythonFetcherDriver *self)
   if (PyObject_SetAttrString(self->py.instance, "parse_options", py_parse_options) == -1)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error setting attribute message parse options",
                 evt_tag_str("driver", self->super.super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
 
       Py_DECREF(py_parse_options);

--- a/modules/python/python-helpers.c
+++ b/modules/python/python-helpers.c
@@ -31,6 +31,10 @@
 const gchar *
 _py_get_callable_name(PyObject *callable, gchar *buf, gsize buf_len)
 {
+  PyObject *exc, *value, *tb;
+
+  PyErr_Fetch(&exc, &value, &tb);
+
   PyObject *name = PyObject_GetAttrString(callable, "__name__");
 
   const gchar *str;
@@ -44,6 +48,8 @@ _py_get_callable_name(PyObject *callable, gchar *buf, gsize buf_len)
       g_strlcpy(buf, "<unknown>", buf_len);
     }
   Py_XDECREF(name);
+
+  PyErr_Restore(exc, value, tb);
   return buf;
 }
 

--- a/modules/python/python-helpers.c
+++ b/modules/python/python-helpers.c
@@ -84,7 +84,7 @@ exit:
   PyErr_Restore(exc, value, tb);
 }
 
-void
+const gchar *
 _py_format_exception_text(gchar *buf, gsize buf_len)
 {
   PyObject *exc, *value, *tb, *str;
@@ -93,7 +93,7 @@ _py_format_exception_text(gchar *buf, gsize buf_len)
   if (!exc)
     {
       g_strlcpy(buf, "None", buf_len);
-      return;
+      return buf;
     }
   PyErr_NormalizeException(&exc, &value, &tb);
 
@@ -112,7 +112,7 @@ _py_format_exception_text(gchar *buf, gsize buf_len)
     }
   Py_XDECREF(str);
   PyErr_Restore(exc, value, tb);
-  return;
+  return buf;
 }
 
 void
@@ -157,11 +157,10 @@ _py_do_import(const gchar *modname)
   if (!modobj)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error loading Python module",
                 evt_tag_str("module", modname),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
       return NULL;
     }
@@ -237,14 +236,13 @@ _py_invoke_function(PyObject *func, PyObject *arg, const gchar *class, const gch
   if (!ret)
     {
       gchar buf1[256], buf2[256];
-      _py_format_exception_text(buf2, sizeof(buf2));
-      _py_get_callable_name(func, buf1, sizeof(buf1));
 
+      _py_get_callable_name(func, buf1, sizeof(buf1));
       msg_error("Exception while calling a Python function",
                 evt_tag_str("caller", caller_context),
                 evt_tag_str("class", class),
                 evt_tag_str("function", buf1),
-                evt_tag_str("exception", buf2));
+                evt_tag_str("exception", _py_format_exception_text(buf2, sizeof(buf2))));
       _py_finish_exception_handling();
       return NULL;
     }
@@ -260,14 +258,13 @@ _py_invoke_function_with_args(PyObject *func, PyObject *args, const gchar *class
   if (!ret)
     {
       gchar buf1[256], buf2[256];
-      _py_format_exception_text(buf2, sizeof(buf2));
       _py_get_callable_name(func, buf1, sizeof(buf1));
 
       msg_error("Exception while calling a Python function",
                 evt_tag_str("caller", caller_context),
                 evt_tag_str("class", class),
                 evt_tag_str("function", buf1),
-                evt_tag_str("exception", buf2));
+                evt_tag_str("exception", _py_format_exception_text(buf2, sizeof(buf2))));
       _py_finish_exception_handling();
       return NULL;
     }

--- a/modules/python/python-helpers.c
+++ b/modules/python/python-helpers.c
@@ -28,7 +28,7 @@
 #include "messages.h"
 #include "reloc.h"
 
-void
+const gchar *
 _py_get_callable_name(PyObject *callable, gchar *buf, gsize buf_len)
 {
   PyObject *name = PyObject_GetAttrString(callable, "__name__");
@@ -44,7 +44,7 @@ _py_get_callable_name(PyObject *callable, gchar *buf, gsize buf_len)
       g_strlcpy(buf, "<unknown>", buf_len);
     }
   Py_XDECREF(name);
-  return;
+  return buf;
 }
 
 void
@@ -237,11 +237,10 @@ _py_invoke_function(PyObject *func, PyObject *arg, const gchar *class, const gch
     {
       gchar buf1[256], buf2[256];
 
-      _py_get_callable_name(func, buf1, sizeof(buf1));
       msg_error("Exception while calling a Python function",
                 evt_tag_str("caller", caller_context),
                 evt_tag_str("class", class),
-                evt_tag_str("function", buf1),
+                evt_tag_str("function", _py_get_callable_name(func, buf1, sizeof(buf1))),
                 evt_tag_str("exception", _py_format_exception_text(buf2, sizeof(buf2))));
       _py_finish_exception_handling();
       return NULL;
@@ -258,12 +257,11 @@ _py_invoke_function_with_args(PyObject *func, PyObject *args, const gchar *class
   if (!ret)
     {
       gchar buf1[256], buf2[256];
-      _py_get_callable_name(func, buf1, sizeof(buf1));
 
       msg_error("Exception while calling a Python function",
                 evt_tag_str("caller", caller_context),
                 evt_tag_str("class", class),
-                evt_tag_str("function", buf1),
+                evt_tag_str("function", _py_get_callable_name(func, buf1, sizeof(buf1))),
                 evt_tag_str("exception", _py_format_exception_text(buf2, sizeof(buf2))));
       _py_finish_exception_handling();
       return NULL;

--- a/modules/python/python-helpers.h
+++ b/modules/python/python-helpers.h
@@ -27,7 +27,7 @@
 #include "python-module.h"
 
 void _py_get_callable_name(PyObject *callable, gchar *buf, gsize buf_len);
-void _py_format_exception_text(gchar *buf, gsize buf_len);
+const gchar *_py_format_exception_text(gchar *buf, gsize buf_len);
 void _py_finish_exception_handling(void);
 PyObject *_py_get_attr_or_null(PyObject *o, const gchar *attr);
 PyObject *_py_do_import(const gchar *modname);

--- a/modules/python/python-helpers.h
+++ b/modules/python/python-helpers.h
@@ -26,7 +26,7 @@
 
 #include "python-module.h"
 
-void _py_get_callable_name(PyObject *callable, gchar *buf, gsize buf_len);
+const gchar *_py_get_callable_name(PyObject *callable, gchar *buf, gsize buf_len);
 const gchar *_py_format_exception_text(gchar *buf, gsize buf_len);
 void _py_finish_exception_handling(void);
 PyObject *_py_get_attr_or_null(PyObject *o, const gchar *attr);

--- a/modules/python/python-http-header.c
+++ b/modules/python/python-http-header.c
@@ -97,10 +97,9 @@ _py_append_str_to_pylist(gconstpointer data, gpointer user_data)
   if (!py_str)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error creating Python String object from C string",
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
 
       goto exit;
@@ -110,10 +109,9 @@ _py_append_str_to_pylist(gconstpointer data, gpointer user_data)
   if (PyList_Append(py_list, py_str) != 0)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error adding new item to Python List",
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
     }
 
@@ -140,11 +138,10 @@ _py_attach_class(PythonHttpHeaderPlugin *self)
   if (!self->py.class)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error looking up Python class",
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
 
       return FALSE;
@@ -160,11 +157,10 @@ _create_arg_dict_from_options(PythonHttpHeaderPlugin *self)
   if (!py_args)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error creating argument dictionary",
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
 
       return NULL;
@@ -185,11 +181,10 @@ _py_instantiate_class(PythonHttpHeaderPlugin *self)
   if (!self->py.instance)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error instantiating Python class",
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
 
       goto exit;
@@ -282,11 +277,10 @@ _append_headers(PythonHttpHeaderPlugin *self, HttpHeaderRequestSignalData *data)
   if (!py_args)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error creating Python arguments",
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
 
       goto cleanup;
@@ -296,12 +290,11 @@ _append_headers(PythonHttpHeaderPlugin *self, HttpHeaderRequestSignalData *data)
   if (!py_ret_list)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Invalid response returned by Python call",
                 evt_tag_str("class", self->class),
                 evt_tag_str("method", "get_headers"),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
 
       goto cleanup;
@@ -315,12 +308,11 @@ _append_headers(PythonHttpHeaderPlugin *self, HttpHeaderRequestSignalData *data)
   if (!_py_append_pylist_to_list(py_ret_list, &headers))
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Converting Python List failed",
                 evt_tag_str("class", self->class),
                 evt_tag_str("method", "get_headers"),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
       goto cleanup;
     }
@@ -354,11 +346,10 @@ _on_http_response_received(PythonHttpHeaderPlugin *self, HttpResponseReceivedSig
     if (!py_arg)
       {
         gchar buf[256];
-        _py_format_exception_text(buf, sizeof(buf));
 
         msg_error("Error creating Python argument",
                   evt_tag_str("class", self->class),
-                  evt_tag_str("exception", buf));
+                  evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
         _py_finish_exception_handling();
         return;
       }

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -248,89 +248,6 @@ py_log_message_set_pri(PyLogMessage *self, PyObject *args, PyObject *kwrds)
 }
 
 static PyObject *
-_datetime_timestamp(PyObject *py_datetime)
-{
-  PyObject *py_tzinfo = _py_get_attr_or_null(py_datetime, "tzinfo");
-  if (!py_tzinfo)
-    {
-      PyErr_Format(PyExc_ValueError, "Error obtaining tzinfo");
-      return NULL;
-    }
-  PyObject *py_epoch = PyDateTimeAPI->DateTime_FromDateAndTime(1970, 1, 1, 0, 0, 0, 0, py_tzinfo,
-                       PyDateTimeAPI->DateTimeType);
-
-  PyObject *py_delta = _py_invoke_method_by_name(py_datetime, "__sub__", py_epoch,
-                                                 "PyDateTime", "py_datetime_to_logstamp");
-  if (!py_delta)
-    {
-      Py_XDECREF(py_tzinfo);
-      Py_XDECREF(py_epoch);
-      PyErr_Format(PyExc_ValueError, "Error calculating POSIX timestamp");
-      return NULL;
-    }
-
-  PyObject *py_posix_timestamp = _py_invoke_method_by_name(py_delta, "total_seconds", NULL,
-                                                           "PyDateTime", "py_datetime_to_logstamp");
-  Py_XDECREF(py_tzinfo);
-  Py_XDECREF(py_delta);
-  Py_XDECREF(py_epoch);
-
-  return py_posix_timestamp;
-}
-
-static gboolean
-_datetime_get_gmtoff(PyObject *py_datetime, gint *utcoffset)
-{
-  *utcoffset = -1;
-  PyObject *py_utcoffset = _py_invoke_method_by_name(py_datetime, "utcoffset", NULL, "PyDateTime",
-                                                     "py_datetime_to_logstamp");
-  if (!py_utcoffset)
-    {
-      PyErr_Format(PyExc_ValueError, "Error obtaining timezone info");
-      return FALSE;
-    }
-
-  if (py_utcoffset != Py_None)
-    {
-      *utcoffset = PyDateTime_DELTA_GET_SECONDS(py_utcoffset);
-    }
-
-  Py_XDECREF(py_utcoffset);
-  return TRUE;
-}
-
-static gboolean
-py_datetime_to_logstamp(PyObject *py_timestamp, UnixTime *logstamp)
-{
-  if (!PyDateTime_Check(py_timestamp))
-    {
-      PyErr_Format(PyExc_TypeError, "datetime expected in the first parameter");
-      return FALSE;
-    }
-
-  PyObject *py_posix_timestamp = _datetime_timestamp(py_timestamp);
-  if (!py_posix_timestamp)
-    return FALSE;
-
-  gdouble posix_timestamp;
-  py_double_to_double(py_posix_timestamp, &posix_timestamp);
-
-  Py_XDECREF(py_posix_timestamp);
-
-  gint local_gmtoff;
-  if (!_datetime_get_gmtoff(py_timestamp, &local_gmtoff))
-    return FALSE;
-  if (local_gmtoff == -1)
-    local_gmtoff = get_local_timezone_ofs((time_t) posix_timestamp);
-
-  logstamp->ut_sec = (gint64) posix_timestamp;
-  logstamp->ut_usec = (guint32) (posix_timestamp * 1000000 - logstamp->ut_sec * 1000000);
-  logstamp->ut_gmtoff = local_gmtoff;
-
-  return TRUE;
-}
-
-static PyObject *
 py_log_message_set_timestamp(PyLogMessage *self, PyObject *args, PyObject *kwrds)
 {
   PyObject *py_timestamp;
@@ -339,8 +256,11 @@ py_log_message_set_timestamp(PyLogMessage *self, PyObject *args, PyObject *kwrds
   if (!PyArg_ParseTupleAndKeywords(args, kwrds, "O", (gchar **) kwlist, &py_timestamp))
     return NULL;
 
-  if (!py_datetime_to_logstamp((PyObject *) py_timestamp, &self->msg->timestamps[LM_TS_STAMP]))
-    return NULL;
+  if (!py_datetime_to_unix_time((PyObject *) py_timestamp, &self->msg->timestamps[LM_TS_STAMP]))
+    {
+      PyErr_Format(PyExc_ValueError, "Error extracting timestamp from value, expected a datetime instance");
+      return NULL;
+    }
 
   Py_RETURN_NONE;
 }

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -248,6 +248,14 @@ py_log_message_set_pri(PyLogMessage *self, PyObject *args, PyObject *kwrds)
 }
 
 static PyObject *
+py_log_message_get_pri(PyLogMessage *self, PyObject *args, PyObject *kwrds)
+{
+  if (!PyArg_ParseTuple(args, ""))
+    return NULL;
+  return PyLong_FromLong(self->msg->pri);
+}
+
+static PyObject *
 py_log_message_set_timestamp(PyLogMessage *self, PyObject *args, PyObject *kwrds)
 {
   PyObject *py_timestamp;
@@ -324,7 +332,8 @@ py_log_message_parse(PyObject *_none, PyObject *args, PyObject *kwrds)
 static PyMethodDef py_log_message_methods[] =
 {
   { "keys", (PyCFunction)_logmessage_get_keys_method, METH_NOARGS, "Return keys." },
-  { "set_pri", (PyCFunction)py_log_message_set_pri, METH_VARARGS | METH_KEYWORDS, "Set priority" },
+  { "set_pri", (PyCFunction)py_log_message_set_pri, METH_VARARGS | METH_KEYWORDS, "Set syslog priority" },
+  { "get_pri", (PyCFunction)py_log_message_get_pri, METH_VARARGS | METH_KEYWORDS, "Get syslog priority" },
   { "set_timestamp", (PyCFunction)py_log_message_set_timestamp, METH_VARARGS | METH_KEYWORDS, "Set timestamp" },
   { "set_bookmark", (PyCFunction)py_log_message_set_bookmark, METH_VARARGS | METH_KEYWORDS, "Set bookmark" },
   { "parse", (PyCFunction)py_log_message_parse, METH_STATIC|METH_VARARGS|METH_KEYWORDS, "Parse and create LogMessage" },

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -274,6 +274,15 @@ py_log_message_set_timestamp(PyLogMessage *self, PyObject *args, PyObject *kwrds
 }
 
 static PyObject *
+py_log_message_get_timestamp(PyLogMessage *self, PyObject *args, PyObject *kwrds)
+{
+  if (!PyArg_ParseTuple(args, ""))
+    return NULL;
+
+  return py_datetime_from_unix_time(&self->msg->timestamps[LM_TS_STAMP]);
+}
+
+static PyObject *
 py_log_message_set_bookmark(PyLogMessage *self, PyObject *args, PyObject *kwrds)
 {
   PyObject *bookmark_data;
@@ -335,6 +344,7 @@ static PyMethodDef py_log_message_methods[] =
   { "set_pri", (PyCFunction)py_log_message_set_pri, METH_VARARGS | METH_KEYWORDS, "Set syslog priority" },
   { "get_pri", (PyCFunction)py_log_message_get_pri, METH_VARARGS | METH_KEYWORDS, "Get syslog priority" },
   { "set_timestamp", (PyCFunction)py_log_message_set_timestamp, METH_VARARGS | METH_KEYWORDS, "Set timestamp" },
+  { "get_timestamp", (PyCFunction)py_log_message_get_timestamp, METH_VARARGS | METH_KEYWORDS, "Get timestamp" },
   { "set_bookmark", (PyCFunction)py_log_message_set_bookmark, METH_VARARGS | METH_KEYWORDS, "Set bookmark" },
   { "parse", (PyCFunction)py_log_message_parse, METH_STATIC|METH_VARARGS|METH_KEYWORDS, "Parse and create LogMessage" },
   {NULL}

--- a/modules/python/python-logparser.c
+++ b/modules/python/python-logparser.c
@@ -116,12 +116,11 @@ _py_init_bindings(PythonParser *self)
   if (!self->py.class)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error looking Python parser class",
                 evt_tag_str("parser", self->super.name),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
       return FALSE;
     }
@@ -130,12 +129,11 @@ _py_init_bindings(PythonParser *self)
   if (!self->py.instance)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error instantiating Python parser class",
                 evt_tag_str("parser", self->super.name),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
       return FALSE;
     }

--- a/modules/python/python-main.c
+++ b/modules/python/python-main.c
@@ -64,10 +64,9 @@ _py_construct_main_module(PythonConfig *pc)
   if (!module)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error creating syslog-ng main module",
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
       return NULL;
     }
@@ -161,10 +160,9 @@ _py_evaluate_global_code(PythonConfig *pc, const gchar *filename, const gchar *c
   if (!code_object)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error compiling Python global code block",
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
       return FALSE;
     }
@@ -174,10 +172,9 @@ _py_evaluate_global_code(PythonConfig *pc, const gchar *filename, const gchar *c
   if (!module)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error evaluating global Python block",
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
       return FALSE;
     }

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -238,10 +238,9 @@ _persist_type_init(PyObject *s, PyObject *args, PyObject *kwds)
   if (!self->persist_state)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error importing persist_state",
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
 
       g_assert_not_reached();

--- a/modules/python/python-plugin.c
+++ b/modules/python/python-plugin.c
@@ -24,6 +24,7 @@
 
 #include "python-module.h"
 #include "python-helpers.h"
+#include "python-types.h"
 #include "python-parser.h"
 #include "python-dest.h"
 #include "python-tf.h"
@@ -113,6 +114,8 @@ _py_init_interpreter(void)
       py_init_argv();
 
       py_init_threads();
+      py_init_types();
+
       py_log_message_global_init();
       py_log_template_global_init();
       py_integer_pointer_global_init();

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -206,12 +206,11 @@ _py_resolve_class(PythonSourceDriver *self)
   if (!self->py.class)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error looking Python driver class",
                 evt_tag_str("driver", self->super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
       return FALSE;
     }
@@ -227,12 +226,11 @@ _py_init_instance(PythonSourceDriver *self)
   if (!self->py.instance)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error instantiating Python driver class",
                 evt_tag_str("driver", self->super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
       return FALSE;
     }
@@ -371,12 +369,11 @@ _py_parse_options_new(PythonSourceDriver *self, MsgFormatOptions *parse_options)
   if (!py_parse_options)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error creating capsule for message parse options",
                 evt_tag_str("driver", self->super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
       return NULL;
     }
@@ -420,12 +417,11 @@ _py_set_parse_options(PythonSourceDriver *self)
   if (PyObject_SetAttrString(self->py.instance, "parse_options", py_parse_options) == -1)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("Error setting attribute message parse options",
                 evt_tag_str("driver", self->super.super.super.id),
                 evt_tag_str("class", self->class),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
 
       Py_DECREF(py_parse_options);

--- a/modules/python/python-tf.c
+++ b/modules/python/python-tf.c
@@ -106,6 +106,7 @@ _py_convert_return_value_to_result(PythonTfState *state, const gchar *function_n
       msg_error("$(python): The current config version does not support returning non-string values from Python "
                 "functions. Please return str or bytes values from your Python function, use an explicit syslog-ng "
                 "level cast to string() or set the config version to post 4.0",
+                evt_tag_str("function", function_name),
                 cfg_format_config_version_tag(state->cfg));
       Py_DECREF(ret);
       return FALSE;
@@ -113,6 +114,14 @@ _py_convert_return_value_to_result(PythonTfState *state, const gchar *function_n
 
   if (!py_obj_to_log_msg_value(ret, result, type))
     {
+      gchar buf[256];
+
+      _py_format_exception_text(buf, sizeof(buf));
+      msg_error("$(python): error converting the return value of a Python template function to a typed name-value pair",
+                evt_tag_str("function", function_name),
+                evt_tag_str("exception", buf));
+      _py_finish_exception_handling();
+
       Py_DECREF(ret);
       return FALSE;
     }

--- a/modules/python/python-tf.c
+++ b/modules/python/python-tf.c
@@ -64,11 +64,10 @@ _py_invoke_template_function(PythonTfState *state, const gchar *function_name, L
   if (!callable)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("$(python): Error looking up Python function",
                 evt_tag_str("function", function_name),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
       return NULL;
     }
@@ -85,11 +84,10 @@ _py_invoke_template_function(PythonTfState *state, const gchar *function_name, L
   if (!ret)
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
 
       msg_error("$(python): Error invoking Python function",
                 evt_tag_str("function", function_name),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
       return NULL;
     }
@@ -116,10 +114,9 @@ _py_convert_return_value_to_result(PythonTfState *state, const gchar *function_n
     {
       gchar buf[256];
 
-      _py_format_exception_text(buf, sizeof(buf));
       msg_error("$(python): error converting the return value of a Python template function to a typed name-value pair",
                 evt_tag_str("function", function_name),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
 
       Py_DECREF(ret);

--- a/modules/python/python-types.c
+++ b/modules/python/python-types.c
@@ -24,7 +24,12 @@
 #include "python-helpers.h"
 #include "scanner/list-scanner/list-scanner.h"
 #include "str-repr/encode.h"
+#include "timeutils/conv.h"
+#include "timeutils/misc.h"
 #include "messages.h"
+
+/* Python datetime API */
+#include <datetime.h>
 
 PyObject *
 py_bytes_from_string(const char *value, gssize len)
@@ -120,6 +125,30 @@ py_list_from_list(const gchar *list, gssize list_len)
 }
 
 PyObject *
+py_datetime_from_unix_time(UnixTime *ut)
+{
+  WallClockTime wct;
+
+  convert_unix_time_to_wall_clock_time(ut, &wct);
+
+  return PyDateTime_FromDateAndTimeAndFold(
+           wct.wct_year + 1900, wct.wct_mon + 1, wct.wct_mday,
+           wct.wct_hour, wct.wct_min, wct.wct_sec,
+           wct.wct_usec, wct.wct_isdst > 0);
+}
+
+PyObject *
+py_datetime_from_msec(gint64 msec)
+{
+  UnixTime ut;
+
+  ut.ut_sec = msec / 1000;
+  ut.ut_usec = (msec % 1000) * 1000;
+  ut.ut_gmtoff = get_local_timezone_ofs(ut.ut_sec);
+  return py_datetime_from_unix_time(&ut);
+}
+
+PyObject *
 py_obj_from_log_msg_value(const gchar *value, gssize value_len, LogMessageValueType type)
 {
   switch (type)
@@ -154,6 +183,14 @@ py_obj_from_log_msg_value(const gchar *value, gssize value_len, LogMessageValueT
     case LM_VT_LIST:
       return py_list_from_list(value, value_len);
 
+    case LM_VT_DATETIME:
+    {
+      gint64 msec = 0;
+
+      if (type_cast_to_datetime_msec(value, &msec, NULL))
+        return py_datetime_from_msec(msec);
+      return NULL;
+    }
     case LM_VT_STRING:
     default:
       return py_bytes_from_string(value, value_len);
@@ -296,6 +333,63 @@ py_list_to_list(PyObject *obj, GString *list)
   return TRUE;
 }
 
+static gboolean
+_datetime_get_gmtoff(PyObject *py_datetime, glong *utcoffset)
+{
+  *utcoffset = -1;
+  PyObject *py_utcoffset = _py_invoke_method_by_name(py_datetime, "utcoffset", NULL, "PyDateTime",
+                                                     "py_datetime_to_datetime");
+  if (!py_utcoffset)
+    return FALSE;
+
+  if (py_utcoffset != Py_None)
+    *utcoffset = PyDateTime_DELTA_GET_SECONDS(py_utcoffset);
+
+  Py_XDECREF(py_utcoffset);
+  return TRUE;
+}
+
+gboolean
+py_datetime_to_unix_time(PyObject *obj, UnixTime *ut)
+{
+  WallClockTime wct = WALL_CLOCK_TIME_INIT;
+
+  if (!PyDateTime_Check(obj))
+    {
+      return FALSE;
+    }
+
+  if (!_datetime_get_gmtoff(obj, &wct.wct_gmtoff))
+    {
+      return FALSE;
+    }
+
+  wct.wct_year = PyDateTime_GET_YEAR(obj) - 1900;
+  wct.wct_mon = PyDateTime_GET_MONTH(obj) - 1;
+  wct.wct_mday = PyDateTime_GET_DAY(obj);
+  wct.wct_hour = PyDateTime_DATE_GET_HOUR(obj);
+  wct.wct_min = PyDateTime_DATE_GET_MINUTE(obj);
+  wct.wct_sec = PyDateTime_DATE_GET_SECOND(obj);
+  wct.wct_usec = PyDateTime_DATE_GET_MICROSECOND(obj);
+  wct.wct_isdst = PyDateTime_DATE_GET_FOLD(obj);
+  convert_wall_clock_time_to_unix_time(&wct, ut);
+
+  if (ut->ut_gmtoff == -1)
+    ut->ut_gmtoff = get_local_timezone_ofs(ut->ut_sec);
+  return TRUE;
+}
+
+gboolean
+py_datetime_to_datetime(PyObject *obj, GString *dt)
+{
+  UnixTime ut;
+
+  if (!py_datetime_to_unix_time(obj, &ut))
+    return FALSE;
+  g_string_printf(dt, "%ld.%03d", ut.ut_sec, ut.ut_usec / 1000);
+  return TRUE;
+}
+
 /* Appends to the end of `value`. */
 gboolean
 py_obj_to_log_msg_value(PyObject *obj, GString *value, LogMessageValueType *type)
@@ -365,8 +459,22 @@ py_obj_to_log_msg_value(PyObject *obj, GString *value, LogMessageValueType *type
       return TRUE;
     }
 
+  if (PyDateTime_Check(obj))
+    {
+      if (!py_datetime_to_datetime(obj, value))
+        return FALSE;
+      *type = LM_VT_DATETIME;
+      return TRUE;
+    }
+
   *type = LM_VT_NONE;
 
   msg_error("Unexpected python object type", evt_tag_str("type", Py_TYPE(obj)->tp_name));
   return FALSE;
+}
+
+void
+py_init_types(void)
+{
+  PyDateTime_IMPORT;
 }

--- a/modules/python/python-types.h
+++ b/modules/python/python-types.h
@@ -33,6 +33,8 @@ PyObject *py_long_from_long(gint64 l);
 PyObject *py_double_from_double(gdouble d);
 PyObject *py_boolean_from_boolean(gboolean b);
 PyObject *py_list_from_list(const gchar *list, gssize list_len);
+PyObject *py_datetime_from_unix_time(UnixTime *ut);
+PyObject *py_datetime_from_msec(gint64 msec);
 PyObject *py_obj_from_log_msg_value(const gchar *value, gssize value_len, LogMessageValueType type);
 
 gboolean is_py_obj_bytes_or_string_type(PyObject *obj);
@@ -42,6 +44,11 @@ gboolean py_long_to_long(PyObject *obj, gint64 *l);
 gboolean py_double_to_double(PyObject *obj, gdouble *d);
 gboolean py_boolean_to_boolean(PyObject *obj, gboolean *b);
 gboolean py_list_to_list(PyObject *obj, GString *list);
+gboolean py_datetime_to_unix_time(PyObject *obj, UnixTime *ut);
+gboolean py_datetime_to_datetime(PyObject *obj, GString *dt);
 gboolean py_obj_to_log_msg_value(PyObject *obj, GString *value, LogMessageValueType *type);
+
+
+void py_init_types(void);
 
 #endif

--- a/modules/python/python-value-pairs.c
+++ b/modules/python/python-value-pairs.c
@@ -42,9 +42,8 @@ python_worker_vp_add_one(const gchar *name,
     {
       gchar buf[256];
 
-      _py_format_exception_text(buf, sizeof(buf));
       msg_error("python-value-pairs: error converting a name-value pair to a Python object",
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
 
       return type_cast_drop_helper(template_options->on_error, value, log_msg_value_type_to_str(type));

--- a/modules/python/python-value-pairs.c
+++ b/modules/python/python-value-pairs.c
@@ -36,16 +36,17 @@ python_worker_vp_add_one(const gchar *name,
 {
   const LogTemplateOptions *template_options = (const LogTemplateOptions *)((gpointer *)user_data)[0];
   PyObject *dict = (PyObject *)((gpointer *)user_data)[1];
-  gboolean fallback = template_options->on_error & ON_ERROR_FALLBACK_TO_STRING;
 
   PyObject *obj = py_obj_from_log_msg_value(value, value_len, type);
-  if (!obj && fallback)
-    {
-      obj = py_obj_from_log_msg_value(value, value_len, LM_VT_STRING);
-    }
-
   if (!obj)
     {
+      gchar buf[256];
+
+      _py_format_exception_text(buf, sizeof(buf));
+      msg_error("python-value-pairs: error converting a name-value pair to a Python object",
+                evt_tag_str("exception", buf));
+      _py_finish_exception_handling();
+
       return type_cast_drop_helper(template_options->on_error, value, log_msg_value_type_to_str(type));
     }
 

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -72,10 +72,10 @@ _assert_python_variable_value(const gchar *variable_name, const gchar *expected_
   if (!PyRun_String(script, Py_file_input, _python_main_dict, _python_main_dict))
     {
       gchar buf[256];
-      _py_format_exception_text(buf, sizeof(buf));
+
       msg_error("Error in _assert_python_variable_value()",
                 evt_tag_str("script", script),
-                evt_tag_str("exception", buf));
+                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
 
       g_free(script);

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -383,6 +383,18 @@ Test(python_log_message, test_py_log_message_set_pri)
 
   cr_assert_eq(py_msg->msg->pri, pri);
 
+  ret = _py_invoke_method_by_name((PyObject *) py_msg, "get_pri", NULL, NULL, NULL);
+  pri = PyLong_AsLong(ret);
+  Py_XDECREF(ret);
+
+  cr_assert_eq(py_msg->msg->pri, pri);
+  py_msg->msg->pri = 55;
+
+  ret = _py_invoke_method_by_name((PyObject *) py_msg, "get_pri", NULL, NULL, NULL);
+  pri = PyLong_AsLong(ret);
+  Py_XDECREF(ret);
+  cr_assert_eq(py_msg->msg->pri, pri);
+
   Py_DECREF(py_msg);
   Py_DECREF(arg);
   PyGILState_Release(gstate);

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -415,6 +415,17 @@ Test(python_log_message, test_py_log_message_set_timestamp)
   cr_assert_eq(py_msg->msg->timestamps[LM_TS_STAMP].ut_sec, 1664890194);
   cr_assert_eq(py_msg->msg->timestamps[LM_TS_STAMP].ut_usec, 123000);
 
+  UnixTime ut;
+
+  py_msg->msg->timestamps[LM_TS_STAMP].ut_sec++;
+  ret = _py_invoke_method_by_name((PyObject *) py_msg, "get_timestamp", NULL, NULL, NULL);
+  cr_assert(ret);
+  py_datetime_to_unix_time(ret, &ut);
+
+  cr_assert_eq(ut.ut_sec, 1664890195);
+  cr_assert_eq(ut.ut_usec, 123000);
+  Py_XDECREF(ret);
+
   Py_DECREF(py_msg);
   Py_DECREF(arg);
   PyGILState_Release(gstate);

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -377,7 +377,6 @@ Test(python_log_message, test_py_log_message_set_pri)
 
   PyObject *arg = Py_BuildValue("i", pri);
   PyLogMessage *py_msg = _construct_py_log_msg(NULL);
-  Py_DECREF(arg);
 
   PyObject *ret = _py_invoke_method_by_name((PyObject *) py_msg, "set_pri", arg, NULL, NULL);
   Py_XDECREF(ret);
@@ -385,6 +384,27 @@ Test(python_log_message, test_py_log_message_set_pri)
   cr_assert_eq(py_msg->msg->pri, pri);
 
   Py_DECREF(py_msg);
+  Py_DECREF(arg);
+  PyGILState_Release(gstate);
+}
+
+Test(python_log_message, test_py_log_message_set_timestamp)
+{
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+
+  PyObject *arg = Py_BuildValue("O", py_datetime_from_msec(1664890194123));
+  PyLogMessage *py_msg = _construct_py_log_msg(NULL);
+
+  PyObject *ret = _py_invoke_method_by_name((PyObject *) py_msg, "set_timestamp", arg, NULL, NULL);
+  cr_assert(ret);
+  Py_XDECREF(ret);
+
+  cr_assert_eq(py_msg->msg->timestamps[LM_TS_STAMP].ut_sec, 1664890194);
+  cr_assert_eq(py_msg->msg->timestamps[LM_TS_STAMP].ut_usec, 123000);
+
+  Py_DECREF(py_msg);
+  Py_DECREF(arg);
   PyGILState_Release(gstate);
 }
 


### PR DESCRIPTION
This PR adds support for handling name-value pairs that have datetime() as type, such name-value pairs would be propagated
to Python as a datetime.datetime instance. 

When setting a name-value pair, if the value is a datetime.datetime instance, it would similarly be converted to a value with syslog-ng's datetime as type.

Example config:

```
@version: 4.0

options {
        ts-format(iso);
};

python {

def foo(msg):
        return msg["dtvalue"].isoformat()

};


log {
        source { tcp(port(2000)); };
        rewrite { set(datetime("1664885832.123") value("dtvalue")); };
        destination { file("foobar" template("$(python foo)\n")); };
};
```

This is how you set the timestamp:
```
        msg.set_timestamp(datetime.datetime(1977, 8, 14, 5, 30))
```

This is how you set a name-value pair with datetime type:

```
        msg['dtvalue'] = datetime.datetime(1977, 8, 14, 5, 30)

```

At the moment timezones other than the local time are not supported for name-value pairs, but that's an easy limitation to lift.
