### PR TITLE
Light: Remove Python 2 compatibility

### DIFF
--- a/dbld/pip_packages.manifest
+++ b/dbld/pip_packages.manifest
@@ -8,7 +8,6 @@ hyrule                  [devshell, kira]                                       [
 requests                [kira]                                                 [python2, python3]
 
 # pip packages for python functional tests
-pathlib2                [centos, fedora, debian, ubuntu, devshell]             [python3]
 psutil                  [centos, fedora, debian, ubuntu, devshell]             [python3]
 pytest                  [centos, fedora, debian, ubuntu, devshell]             [python3]
 virtualenv              [devshell]                                             [python3]

--- a/news/packaging-4174.md
+++ b/news/packaging-4174.md
@@ -1,0 +1,1 @@
+`python`: Python 2 support is now completely removed from Light too. Light will support only Python 3.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ isort==4.3.4
 pylint==1.8.2
 astroid==1.6.1
 logilab-common<=0.63.0
-pathlib2
 psutil
 pytest
 pre-commit

--- a/tests/light/conftest.py
+++ b/tests/light/conftest.py
@@ -24,9 +24,9 @@ import argparse
 import logging
 import subprocess
 from datetime import datetime
+from pathlib import Path
 
 import pytest
-from pathlib import Path
 
 import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.helpers.loggen.loggen import Loggen

--- a/tests/light/conftest.py
+++ b/tests/light/conftest.py
@@ -26,7 +26,7 @@ import subprocess
 from datetime import datetime
 
 import pytest
-from pathlib2 import Path
+from pathlib import Path
 
 import src.testcase_parameters.testcase_parameters as tc_parameters
 from src.helpers.loggen.loggen import Loggen

--- a/tests/light/functional_tests/conftest.py
+++ b/tests/light/functional_tests/conftest.py
@@ -24,7 +24,7 @@ import logging
 import os
 
 import pytest
-from pathlib2 import Path
+from pathlib import Path
 
 from src.common.file import copy_file
 from src.common.pytest_operations import calculate_testcase_name

--- a/tests/light/functional_tests/conftest.py
+++ b/tests/light/functional_tests/conftest.py
@@ -22,9 +22,9 @@
 #############################################################################
 import logging
 import os
+from pathlib import Path
 
 import pytest
-from pathlib import Path
 
 from src.common.file import copy_file
 from src.common.pytest_operations import calculate_testcase_name

--- a/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_tls_passthrough.py
+++ b/tests/light/functional_tests/source_drivers/network_source/proxyprotocol/test_pp_tls_passthrough.py
@@ -20,7 +20,7 @@
 # COPYING for details.
 #
 #############################################################################
-from pathlib2 import Path
+from pathlib import Path
 
 from src.common.blocking import wait_until_true
 from src.common.file import copy_shared_file

--- a/tests/light/src/common/blocking.py
+++ b/tests/light/src/common/blocking.py
@@ -31,9 +31,8 @@ def wait_until_true(func, *args):
 
 
 def wait_until_true_custom(func, args=(), timeout=DEFAULT_TIMEOUT, poll_freq=POLL_FREQ):
-    # Python 2 compatibility note: time.monotonic() is missing
-    t_end = time.time() + timeout
-    while time.time() <= t_end:
+    t_end = time.monotonic() + timeout
+    while time.monotonic() <= t_end:
         result = func(*args)
         if result:
             return result

--- a/tests/light/src/common/file.py
+++ b/tests/light/src/common/file.py
@@ -24,7 +24,7 @@ import atexit
 import logging
 import shutil
 
-from pathlib2 import Path
+from pathlib import Path
 
 from src.common.blocking import DEFAULT_TIMEOUT
 from src.common.blocking import wait_until_true

--- a/tests/light/src/common/file.py
+++ b/tests/light/src/common/file.py
@@ -23,7 +23,6 @@
 import atexit
 import logging
 import shutil
-
 from pathlib import Path
 
 from src.common.blocking import DEFAULT_TIMEOUT

--- a/tests/light/src/common/file.py
+++ b/tests/light/src/common/file.py
@@ -34,13 +34,11 @@ logger = logging.getLogger(__name__)
 
 
 def open_file(file_path, mode):
-    # Python 2 compatibility note: open() can work only with string representation of path
-    return open(str(file_path), mode)
+    return open(file_path, mode)
 
 
 def copy_file(src_file_path, dst_dir):
-    # Python 2 compatibility note: shutil.copy() can work only with string representation of path
-    shutil.copy(str(src_file_path), str(dst_dir))
+    shutil.copy(src_file_path, dst_dir)
 
 
 def copy_shared_file(testcase_parameters, shared_file_name):

--- a/tests/light/src/driver_io/network/network_io.py
+++ b/tests/light/src/driver_io/network/network_io.py
@@ -25,7 +25,7 @@ import socket
 from enum import Enum
 from enum import IntEnum
 
-from pathlib2 import Path
+from pathlib import Path
 
 from src.common.asynchronous import BackgroundEventLoop
 from src.common.blocking import DEFAULT_TIMEOUT

--- a/tests/light/src/driver_io/network/network_io.py
+++ b/tests/light/src/driver_io/network/network_io.py
@@ -24,7 +24,6 @@ import atexit
 import socket
 from enum import Enum
 from enum import IntEnum
-
 from pathlib import Path
 
 from src.common.asynchronous import BackgroundEventLoop

--- a/tests/light/src/helpers/loggen/loggen.py
+++ b/tests/light/src/helpers/loggen/loggen.py
@@ -20,7 +20,7 @@
 # COPYING for details.
 #
 #############################################################################
-from pathlib2 import Path
+from pathlib import Path
 from psutil import TimeoutExpired
 
 import src.testcase_parameters.testcase_parameters as tc_parameters

--- a/tests/light/src/helpers/loggen/loggen.py
+++ b/tests/light/src/helpers/loggen/loggen.py
@@ -21,6 +21,7 @@
 #
 #############################################################################
 from pathlib import Path
+
 from psutil import TimeoutExpired
 
 import src.testcase_parameters.testcase_parameters as tc_parameters

--- a/tests/light/src/helpers/loggen/loggen.py
+++ b/tests/light/src/helpers/loggen/loggen.py
@@ -186,7 +186,7 @@ class Loggen(object):
             return 0
 
         # loggen puts the count= messages to the stderr
-        f = open(str(self.loggen_stderr_path), "r")
+        f = open(self.loggen_stderr_path, "r")
         content = f.read()
         f.close()
 

--- a/tests/light/src/helpers/secure_logging/conftest.py
+++ b/tests/light/src/helpers/secure_logging/conftest.py
@@ -20,8 +20,9 @@
 # COPYING for details.
 #
 #############################################################################
-import pytest
 from pathlib import Path
+
+import pytest
 
 from src.common.file import copy_file
 from src.executors.command_executor import CommandExecutor

--- a/tests/light/src/helpers/secure_logging/conftest.py
+++ b/tests/light/src/helpers/secure_logging/conftest.py
@@ -21,7 +21,7 @@
 #
 #############################################################################
 import pytest
-from pathlib2 import Path
+from pathlib import Path
 
 from src.common.file import copy_file
 from src.executors.command_executor import CommandExecutor

--- a/tests/light/src/helpers/snmptrapd/conftest.py
+++ b/tests/light/src/helpers/snmptrapd/conftest.py
@@ -24,7 +24,7 @@ import os
 import re
 
 import pytest
-from pathlib2 import Path
+from pathlib import Path
 from psutil import TimeoutExpired
 
 from src.common.blocking import wait_until_true

--- a/tests/light/src/helpers/snmptrapd/conftest.py
+++ b/tests/light/src/helpers/snmptrapd/conftest.py
@@ -22,9 +22,9 @@
 #############################################################################
 import os
 import re
+from pathlib import Path
 
 import pytest
-from pathlib import Path
 from psutil import TimeoutExpired
 
 from src.common.blocking import wait_until_true

--- a/tests/light/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/light/src/syslog_ng/syslog_ng_cli.py
@@ -22,7 +22,7 @@
 #############################################################################
 import logging
 
-from pathlib2 import Path
+from pathlib import Path
 
 from src.common.blocking import wait_until_false
 from src.common.blocking import wait_until_true

--- a/tests/light/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/light/src/syslog_ng/syslog_ng_cli.py
@@ -21,7 +21,6 @@
 #
 #############################################################################
 import logging
-
 from pathlib import Path
 
 from src.common.blocking import wait_until_false

--- a/tests/light/src/syslog_ng/syslog_ng_paths.py
+++ b/tests/light/src/syslog_ng/syslog_ng_paths.py
@@ -20,7 +20,7 @@
 # COPYING for details.
 #
 #############################################################################
-from pathlib2 import Path
+from pathlib import Path
 
 from src.common.random_id import get_unique_id
 

--- a/tests/light/src/syslog_ng/tests/test_syslog_ng_paths.py
+++ b/tests/light/src/syslog_ng/tests/test_syslog_ng_paths.py
@@ -21,7 +21,7 @@
 #
 #############################################################################
 import pytest
-from pathlib2 import PosixPath
+from pathlib import PosixPath
 
 from src.syslog_ng.syslog_ng_paths import SyslogNgPaths
 

--- a/tests/light/src/syslog_ng/tests/test_syslog_ng_paths.py
+++ b/tests/light/src/syslog_ng/tests/test_syslog_ng_paths.py
@@ -20,8 +20,9 @@
 # COPYING for details.
 #
 #############################################################################
-import pytest
 from pathlib import PosixPath
+
+import pytest
 
 from src.syslog_ng.syslog_ng_paths import SyslogNgPaths
 

--- a/tests/light/src/syslog_ng_config/statements/destinations/example_destination.py
+++ b/tests/light/src/syslog_ng_config/statements/destinations/example_destination.py
@@ -20,7 +20,7 @@
 # COPYING for details.
 #
 #############################################################################
-from pathlib2 import Path
+from pathlib import Path
 
 from src.driver_io.file.file_io import FileIO
 from src.syslog_ng_config.statements.destinations.destination_driver import DestinationDriver

--- a/tests/light/src/syslog_ng_config/statements/destinations/file_destination.py
+++ b/tests/light/src/syslog_ng_config/statements/destinations/file_destination.py
@@ -20,7 +20,7 @@
 # COPYING for details.
 #
 #############################################################################
-from pathlib2 import Path
+from pathlib import Path
 
 from src.driver_io.file.file_io import FileIO
 from src.syslog_ng_config.statements.destinations.destination_driver import DestinationDriver

--- a/tests/light/src/syslog_ng_config/statements/destinations/unix_dgram_destination.py
+++ b/tests/light/src/syslog_ng_config/statements/destinations/unix_dgram_destination.py
@@ -21,7 +21,6 @@
 #
 #############################################################################
 import atexit
-
 from pathlib import Path
 
 from src.common.asynchronous import BackgroundEventLoop

--- a/tests/light/src/syslog_ng_config/statements/destinations/unix_dgram_destination.py
+++ b/tests/light/src/syslog_ng_config/statements/destinations/unix_dgram_destination.py
@@ -22,7 +22,7 @@
 #############################################################################
 import atexit
 
-from pathlib2 import Path
+from pathlib import Path
 
 from src.common.asynchronous import BackgroundEventLoop
 from src.common.blocking import DEFAULT_TIMEOUT

--- a/tests/light/src/syslog_ng_config/statements/destinations/unix_stream_destination.py
+++ b/tests/light/src/syslog_ng_config/statements/destinations/unix_stream_destination.py
@@ -21,7 +21,6 @@
 #
 #############################################################################
 import atexit
-
 from pathlib import Path
 
 from src.common.asynchronous import BackgroundEventLoop

--- a/tests/light/src/syslog_ng_config/statements/destinations/unix_stream_destination.py
+++ b/tests/light/src/syslog_ng_config/statements/destinations/unix_stream_destination.py
@@ -22,7 +22,7 @@
 #############################################################################
 import atexit
 
-from pathlib2 import Path
+from pathlib import Path
 
 from src.common.asynchronous import BackgroundEventLoop
 from src.common.blocking import DEFAULT_TIMEOUT

--- a/tests/light/src/syslog_ng_config/statements/parsers/db_parser.py
+++ b/tests/light/src/syslog_ng_config/statements/parsers/db_parser.py
@@ -20,11 +20,10 @@
 # COPYING for details.
 #
 #############################################################################
+from pathlib import Path
 from xml.etree.ElementTree import Element
 from xml.etree.ElementTree import SubElement
 from xml.etree.ElementTree import tostring
-
-from pathlib import Path
 
 from src.syslog_ng_config.statements.parsers.parser import Parser
 

--- a/tests/light/src/syslog_ng_config/statements/parsers/db_parser.py
+++ b/tests/light/src/syslog_ng_config/statements/parsers/db_parser.py
@@ -24,7 +24,7 @@ from xml.etree.ElementTree import Element
 from xml.etree.ElementTree import SubElement
 from xml.etree.ElementTree import tostring
 
-from pathlib2 import Path
+from pathlib import Path
 
 from src.syslog_ng_config.statements.parsers.parser import Parser
 

--- a/tests/light/src/syslog_ng_config/statements/sources/file_source.py
+++ b/tests/light/src/syslog_ng_config/statements/sources/file_source.py
@@ -21,7 +21,6 @@
 #
 #############################################################################
 import logging
-
 from pathlib import Path
 
 from src.driver_io.file.file_io import FileIO

--- a/tests/light/src/syslog_ng_config/statements/sources/file_source.py
+++ b/tests/light/src/syslog_ng_config/statements/sources/file_source.py
@@ -22,7 +22,7 @@
 #############################################################################
 import logging
 
-from pathlib2 import Path
+from pathlib import Path
 
 from src.driver_io.file.file_io import FileIO
 from src.syslog_ng_config.statements.sources.source_driver import SourceDriver

--- a/tests/light/src/syslog_ng_ctl/syslog_ng_ctl_executor.py
+++ b/tests/light/src/syslog_ng_ctl/syslog_ng_ctl_executor.py
@@ -22,7 +22,7 @@
 #############################################################################
 from enum import Enum  # noreorder
 
-from pathlib2 import Path
+from pathlib import Path
 
 from src.executors.command_executor import CommandExecutor
 

--- a/tests/light/src/testcase_parameters/testcase_parameters.py
+++ b/tests/light/src/testcase_parameters/testcase_parameters.py
@@ -20,7 +20,7 @@
 # COPYING for details.
 #
 #############################################################################
-from pathlib2 import Path
+from pathlib import Path
 
 from src.common.pytest_operations import calculate_testcase_name
 

--- a/tests/light/tox.ini
+++ b/tests/light/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = py26,py27,py35,py36,py37,py38
+envlist = py35,py36,py37,py38
 skipsdist = True
 
 [testenv]
 deps =
     pytest
     psutil
-    pathlib2
 passenv = INSTALL_DIR
 commands =
     pytest --installdir={env:INSTALL_DIR:} functional_tests/ src/


### PR DESCRIPTION
The main goal of this PR:
- From the early life of Light there was an endeavor to support Python 2 along with Python 3 (which I intended as an additional value)
- Python 2 has been EOL-ed
- In this PR I would like to drop the Python 2 support from Light to focusing on pure Python 3 usage

Additional tasks with this PR:
- [x] Fixup git commit descriptions
- [x] Light related make targets (pytest-check, pytest-self-check) should Pass
- [x] Check a full GitHub Actions pipeline with a new devshell image (related pip package was deleted)

