### PR TITLE
dbparser: fix persist-name() setting from grammar

### DIFF
--- a/modules/dbparser/dbparser-grammar.ym
+++ b/modules/dbparser/dbparser-grammar.ym
@@ -112,7 +112,7 @@ parser_db_opt
 
 stateful_parser_opt
 	: KW_INJECT_MODE '(' stateful_parser_inject_mode ')'	{ stateful_parser_set_inject_mode(((StatefulParser *) last_parser), $3); }
-        | KW_PERSIST_NAME '(' string ')'                        { log_pipe_set_persist_name(&last_driver->super, $3); free($3); }
+        | KW_PERSIST_NAME '(' string ')'                        { log_pipe_set_persist_name(&last_parser->super, $3); free($3); }
 	| parser_opt
 	;
 

--- a/news/bugfix-4180.md
+++ b/news/bugfix-4180.md
@@ -1,0 +1,2 @@
+`grouping-by()` persist-name() option: fixed a segmentation fault in the
+grammar.


### PR DESCRIPTION
This patch fixes #4179, where an incorrect pointer was referenced during parsing when processing the persist-name() option.


