### PR TITLE
.github/workflows/gh-tools: use GITHUB_OUTPUT environment file

### DIFF
--- a/.github/workflows/gh-tools.sh
+++ b/.github/workflows/gh-tools.sh
@@ -16,7 +16,7 @@ gh_path()
 gh_output()
 {
     while [ "x$1" != "x" ]; do
-        echo "::set-output name=$1::$(eval echo \$$1)"
+        echo "$1=$(eval echo \$$1)" >> $GITHUB_OUTPUT
         shift;
     done
 }


### PR DESCRIPTION
The stdout based solution was deprecated.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

no news file needed
