### PR TITLE
Python fix deadlock and a crash

### DIFF
--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -198,7 +198,12 @@ _py_fetcher_fill_bookmark(PythonFetcherDriver *self, PyLogMessage *pymsg)
     }
 
   AckTracker *ack_tracker = _py_fetcher_get_ack_tracker(self);
-  Bookmark *bookmark = ack_tracker_request_bookmark(ack_tracker);
+
+  Bookmark *bookmark;
+
+  Py_BEGIN_ALLOW_THREADS
+  bookmark = ack_tracker_request_bookmark(ack_tracker);
+  Py_END_ALLOW_THREADS
 
   PyBookmark *py_bookmark = py_bookmark_new(pymsg->bookmark_data, self->py.ack_tracker_factory->ack_callback);
   py_bookmark_fill(bookmark, py_bookmark);

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -234,22 +234,21 @@ _persist_type_init(PyObject *s, PyObject *args, PyObject *kwds)
   const gchar *persist_name = NULL;
   GlobalConfig *cfg = python_get_associated_config();
 
-  self->persist_state = cfg->state;
-  if (!self->persist_state)
-    {
-      gchar buf[256];
-
-      msg_error("Error importing persist_state",
-                evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
-      _py_finish_exception_handling();
-
-      g_assert_not_reached();
-    }
-
   static char *kwlist[] = {"persist_name", NULL};
 
   if (! PyArg_ParseTupleAndKeywords(args, kwds, "s", kwlist, &persist_name))
     return -1;
+
+  self->persist_state = cfg->state;
+  if (!self->persist_state)
+    {
+      msg_error("Attempting to use persist_state while the configuration is not yet initialized, please use Persist() in or after the init() method",
+                evt_tag_str("name", persist_name));
+      _py_finish_exception_handling();
+      PyErr_SetString(PyExc_RuntimeError, "persist_state is not yet available");
+      return -1;
+    }
+
 
   if (g_strstr_len(persist_name, -1, SUBKEY_DELIMITER))
     {

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -513,7 +513,11 @@ _py_sd_fill_bookmark(PythonSourceDriver *self, PyLogMessage *pymsg)
     }
 
   AckTracker *ack_tracker = _py_sd_get_ack_tracker(self);
-  Bookmark *bookmark = ack_tracker_request_bookmark(ack_tracker);
+
+  Bookmark *bookmark;
+  Py_BEGIN_ALLOW_THREADS
+  bookmark = ack_tracker_request_bookmark(ack_tracker);
+  Py_END_ALLOW_THREADS;
 
   PyBookmark *py_bookmark = py_bookmark_new(pymsg->bookmark_data, self->py.ack_tracker_factory->ack_callback);
   py_bookmark_fill(bookmark, py_bookmark);


### PR DESCRIPTION
This is chunk #3 of #4165 including two fixes, one for a deadlock in the Python wrapper of our ack tracker functionality, the other an ugly segfault if the Persist class is instantiated before cfg_init(), e.g. in the class body or in global scope.

NOTE: these could potentially be merged separately by rebasing them to master, right now it is part of the sequence as I was splitting up #4165 