### PR TITLE
Python syslogng package improvements

### DIFF
--- a/modules/python/pylib/Makefile.am
+++ b/modules/python/pylib/Makefile.am
@@ -1,5 +1,12 @@
 EXTRA_DIST += \
 	modules/python/pylib/syslogng/__init__.py				\
+	modules/python/pylib/syslogng/dest.py					\
+	modules/python/pylib/syslogng/logger.py					\
+	modules/python/pylib/syslogng/message.py				\
+	modules/python/pylib/syslogng/parser.py					\
+	modules/python/pylib/syslogng/persist.py				\
+	modules/python/pylib/syslogng/source.py					\
+	modules/python/pylib/syslogng/template.py				\
 	modules/python/pylib/syslogng/debuggercli/__init__.py			\
 	modules/python/pylib/syslogng/debuggercli/choicecompleter.py		\
 	modules/python/pylib/syslogng/debuggercli/commandlinelexer.py		\

--- a/modules/python/pylib/syslogng/dest.py
+++ b/modules/python/pylib/syslogng/dest.py
@@ -103,4 +103,4 @@ class LogDestination(LogDestination):
         Returns:
             int: one value from the LogDestinationResult enum
         """
-        return self.SUCCESS
+        raise NotImplementedError

--- a/modules/python/pylib/syslogng/dest.py
+++ b/modules/python/pylib/syslogng/dest.py
@@ -1,0 +1,97 @@
+#############################################################################
+# Copyright (c) 2022 Balazs Scheidler <bazsi77@gmail.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+try:
+    from _syslogng import LogDestination
+
+except ImportError:
+    import warnings
+    warnings.warn("You have imported the syslogng package outside of syslog-ng, thus some of the functionality is not available. Defining fake classes for those exported by the underlying syslog-ng code")
+
+    LogDestination = object
+
+class LogDestination(LogDestination):
+    LTR_DROP = 0
+    LTR_ERROR = 1
+    LTR_EXPLICIT_ACK_MGMT = 2
+    LTR_SUCCESS = 3
+    LTR_QUEUED = 4
+    LTR_NOT_CONNECTED = 5
+    LTR_RETRY = 6
+
+    def open(self):
+        """Open a connection to the target service"""
+        return True
+
+    def close(self):
+        """Close the connection to the target service"""
+        pass
+
+    def is_opened(self):
+        """Check if the connection to the target is able to receive messages"""
+        return True
+
+    def init(self, options):
+        """Initialize this log element
+
+        This method is called when the syslog-ng configuration is
+        initialized.  You can prevent the configuration to be accepted by
+        returning False, in which case you should log why that was the case.
+
+        The same object can be initalized multiple times in case the
+        configuration reload operation fails in syslog-ng:
+          1) init() when the config is first initialized
+          2) deinit() as a preparation for reload
+          3) initialization of the new config fails for some reason (any one
+             object can cause it to fail)
+          4) init() again, as syslog-ng reverts to the old config in such cases.
+
+        Args:
+            options:
+                is a dictionary that contains options passed using the
+                options() parameter of the python() destination
+
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        return True
+
+    def deinit(self):
+        """Deinitialize this log element
+
+        This method is called when the syslog-ng configuration is being shut
+        down.
+        """
+        pass
+
+    def send(self, msg):
+        """Send a message to the target service
+
+        This method is invoked by the underlying C code to dispatch a
+        message to the target service.
+
+        Args:
+            msg (LogMessage): message to be sent
+
+        Returns:
+        """
+        return self.LTR_SUCCESS

--- a/modules/python/pylib/syslogng/dest.py
+++ b/modules/python/pylib/syslogng/dest.py
@@ -21,22 +21,30 @@
 #
 #############################################################################
 try:
-    from _syslogng import LogDestination
+    from _syslogng import LogDestination, LogDestinationResult
 
 except ImportError:
     import warnings
+    from enum import Enum, auto
+
     warnings.warn("You have imported the syslogng package outside of syslog-ng, thus some of the functionality is not available. Defining fake classes for those exported by the underlying syslog-ng code")
 
     LogDestination = object
 
+    class LogDestinationResult(Enum):
+        DROP = auto(),
+        ERROR = auto(),
+        SUCCESS = auto(),
+        QUEUED = auto(),
+        NOT_CONNECTED = auto(),
+
+
 class LogDestination(LogDestination):
-    LTR_DROP = 0
-    LTR_ERROR = 1
-    LTR_EXPLICIT_ACK_MGMT = 2
-    LTR_SUCCESS = 3
-    LTR_QUEUED = 4
-    LTR_NOT_CONNECTED = 5
-    LTR_RETRY = 6
+    DROP = LogDestinationResult.DROP
+    ERROR = LogDestinationResult.ERROR
+    SUCCESS = LogDestinationResult.SUCCESS
+    QUEUED = LogDestinationResult.QUEUED
+    NOT_CONNECTED = LogDestinationResult.NOT_CONNECTED
 
     def open(self):
         """Open a connection to the target service"""
@@ -93,5 +101,6 @@ class LogDestination(LogDestination):
             msg (LogMessage): message to be sent
 
         Returns:
+            int: one value from the LogDestinationResult enum
         """
-        return self.LTR_SUCCESS
+        return self.SUCCESS

--- a/modules/python/pylib/syslogng/logger.py
+++ b/modules/python/pylib/syslogng/logger.py
@@ -1,6 +1,5 @@
 #############################################################################
 # Copyright (c) 2022 Balazs Scheidler <bazsi77@gmail.com>
-# Copyright (c) 2015-2016 Balabit
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -21,11 +20,11 @@
 # COPYING for details.
 #
 #############################################################################
+try:
+    from _syslogng import Logger
 
-from .dest import LogDestination
-from .source import LogSource, LogFetcher, InstantAckTracker, ConsecutiveAckTracker, BatchedAckTracker
-from .parser import LogParser
-from .template import LogTemplate, LogTemplateOptions, LogTemplateException, LTZ_SEND, LTZ_LOCAL
-from .message import LogMessage
-from .logger import Logger
-from .persist import Persist
+except ImportError:
+    import warnings, logging
+    warnings.warn("You have imported the syslogng package outside of syslog-ng, thus some of the functionality is not available. Defining fake classes for those exported by the underlying syslog-ng code")
+
+    Logger = logging.Logger

--- a/modules/python/pylib/syslogng/message.py
+++ b/modules/python/pylib/syslogng/message.py
@@ -27,4 +27,7 @@ except ImportError:
     import warnings
     warnings.warn("You have imported the syslogng package outside of syslog-ng, thus some of the functionality is not available. Defining fake classes for those exported by the underlying syslog-ng code")
 
-    LogMessage = dict
+    class LogMessage(dict):
+        def __init__(self, msg):
+            super().__init__()
+            self['MESSAGE'] = msg

--- a/modules/python/pylib/syslogng/message.py
+++ b/modules/python/pylib/syslogng/message.py
@@ -1,6 +1,5 @@
 #############################################################################
 # Copyright (c) 2022 Balazs Scheidler <bazsi77@gmail.com>
-# Copyright (c) 2015-2016 Balabit
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -21,11 +20,11 @@
 # COPYING for details.
 #
 #############################################################################
+try:
+    from _syslogng import LogMessage
 
-from .dest import LogDestination
-from .source import LogSource, LogFetcher, InstantAckTracker, ConsecutiveAckTracker, BatchedAckTracker
-from .parser import LogParser
-from .template import LogTemplate, LogTemplateOptions, LogTemplateException, LTZ_SEND, LTZ_LOCAL
-from .message import LogMessage
-from .logger import Logger
-from .persist import Persist
+except ImportError:
+    import warnings
+    warnings.warn("You have imported the syslogng package outside of syslog-ng, thus some of the functionality is not available. Defining fake classes for those exported by the underlying syslog-ng code")
+
+    LogMessage = dict

--- a/modules/python/pylib/syslogng/parser.py
+++ b/modules/python/pylib/syslogng/parser.py
@@ -59,4 +59,4 @@ class LogParser(LogParser):
         Returns:
             bool: True if parsing was successful, False to drop the message
         """
-        pass
+        raise NotImplementedError

--- a/modules/python/pylib/syslogng/parser.py
+++ b/modules/python/pylib/syslogng/parser.py
@@ -1,0 +1,62 @@
+#############################################################################
+# Copyright (c) 2022 Balazs Scheidler <bazsi77@gmail.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+try:
+    from _syslogng import LogParser
+
+except ImportError:
+    import warnings
+    warnings.warn("You have imported the syslogng package outside of syslog-ng, thus some of the functionality is not available. Defining fake classes for those exported by the underlying syslog-ng code")
+
+    LogParser = object
+
+
+class LogParser(LogParser):
+    def init(self, options):
+        """This method is called when the configuration is initialized
+
+        Args:
+            options:
+                is a dictionary that contains options passed using the
+                options() parameter of the python() destination
+
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        return True
+
+    def deinit(self):
+        """This method is called when the configuration is deinitialized"""
+        pass
+
+    def parse(self, msg):
+        """This method is called to 'parse' the message
+
+        Args:
+            msg: LogMessage
+                is a syslog-ng message that allows dict-like access to
+                name-value pairs.
+
+        Returns:
+            bool: True if parsing was successful, False to drop the message
+        """
+        pass

--- a/modules/python/pylib/syslogng/persist.py
+++ b/modules/python/pylib/syslogng/persist.py
@@ -21,11 +21,20 @@
 # COPYING for details.
 #
 #############################################################################
+try:
+    from _syslogng import Persist
 
-from .dest import LogDestination
-from .source import LogSource, LogFetcher, InstantAckTracker, ConsecutiveAckTracker, BatchedAckTracker
-from .parser import LogParser
-from .template import LogTemplate, LogTemplateOptions, LogTemplateException, LTZ_SEND, LTZ_LOCAL
-from .message import LogMessage
-from .logger import Logger
-from .persist import Persist
+except ImportError:
+    import warnings
+    warnings.warn("You have imported the syslogng package outside of syslog-ng, thus some of the functionality is not available. Defining fake classes for those exported by the underlying syslog-ng code")
+
+    Persist = object
+
+class Persist(Persist):
+    def __init__(self, persist_name, defaults=None):
+        super(Persist, self).__init__(persist_name)
+
+        if defaults:
+            for key, value in defaults.items():
+                if key not in self:
+                    self[key] = value

--- a/modules/python/pylib/syslogng/persist.py
+++ b/modules/python/pylib/syslogng/persist.py
@@ -28,7 +28,11 @@ except ImportError:
     import warnings
     warnings.warn("You have imported the syslogng package outside of syslog-ng, thus some of the functionality is not available. Defining fake classes for those exported by the underlying syslog-ng code")
 
-    Persist = object
+    # fake Persist class
+    class Persist(dict):
+        def __init__(self, persist_name):
+            self.persist_name = persist_name
+
 
 class Persist(Persist):
     def __init__(self, persist_name, defaults=None):

--- a/modules/python/pylib/syslogng/source.py
+++ b/modules/python/pylib/syslogng/source.py
@@ -82,7 +82,7 @@ class LogSource(LogSource):
         Returns:
             None
         """
-        pass
+        raise NotImplementedError
 
     def post_message(self, msg):
         """Post a message as an output for this source
@@ -117,7 +117,7 @@ class LogSource(LogSource):
         source should stop executing.  The expected result of this function
         is that its run() method returns to its caller.
         """
-        pass
+        raise NotImplementedError
 
 
 class LogFetcher(LogFetcher):
@@ -173,4 +173,4 @@ class LogFetcher(LogFetcher):
                 are defined as members in the LogFetcher class or as values
                 in the LogFetchrResult enum.
         """
-        return self.TRY_AGAIN, None
+        raise NotImplementedError

--- a/modules/python/pylib/syslogng/source.py
+++ b/modules/python/pylib/syslogng/source.py
@@ -21,11 +21,12 @@
 #
 #############################################################################
 try:
-    from _syslogng import LogSource, LogFetcher
+    from _syslogng import LogSource, LogFetcher, LogFetcherResult
     from _syslogng import InstantAckTracker, ConsecutiveAckTracker, BatchedAckTracker
 
 except ImportError:
     import warnings
+    from enum import Enum, auto
 
     warnings.warn("You have imported the syslogng package outside of syslog-ng, thus some of the functionality is not available. Defining fake classes for those exported by the underlying syslog-ng code")
 
@@ -34,6 +35,14 @@ except ImportError:
     InstantAckTracker = object
     ConsecutiveAckTracker = object
     BatchedAckTracker = object
+
+    class LogFetcherResult(Enum):
+        ERROR = auto()
+        NOT_CONNECTED = auto()
+        SUCCESS = auto()
+        TRY_AGAIN = auto()
+        NO_DATA = auto()
+
 
 class LogSource(LogSource):
     """Base class for building an asynchronous source driver
@@ -110,6 +119,7 @@ class LogSource(LogSource):
         """
         pass
 
+
 class LogFetcher(LogFetcher):
     """Base class for building synchronous (blocking) source driver
 
@@ -121,11 +131,12 @@ class LogFetcher(LogFetcher):
     It easily maps to any source mechanism that you need to poll regularly
     for new messages (e.g.  HTTP based log access APIs).
     """
+    ERROR = FETCH_ERROR = LogFetcherResult.ERROR
+    NOT_CONNECTED = FETCH_NOT_CONNECTED = LogFetcherResult.NOT_CONNECTED
+    SUCCESS = FETCH_SUCCESS = LogFetcherResult.SUCCESS
+    TRY_AGAIN = FETCH_TRY_AGAIN = LogFetcherResult.TRY_AGAIN
+    NO_DATA = FETCH_NO_DATA = LogFetcherResult.NO_DATA
 
-    # LogFetcher.FETCH_ERROR,
-    # LogFetcher.FETCH_NOT_CONNECTED,
-    # LogFetcher.FETCH_TRY_AGAIN,
-    # LogFetcher.FETCH_NO_DATA,
     def init(self, options):
         """Initialize this LogFetcher instance
 
@@ -158,6 +169,8 @@ class LogFetcher(LogFetcher):
         Returns:
             (result, message): (LogFetcherResult, LogMessage)
                 the function needs to return a 2-tuple, which comprises of a
-                status code and a message instance.
+                status code and a message instance.  Possible status codes
+                are defined as members in the LogFetcher class or as values
+                in the LogFetchrResult enum.
         """
-        return self.FETCH_TRY_AGAIN
+        return self.TRY_AGAIN, None

--- a/modules/python/pylib/syslogng/source.py
+++ b/modules/python/pylib/syslogng/source.py
@@ -1,0 +1,163 @@
+#############################################################################
+# Copyright (c) 2022 Balazs Scheidler <bazsi77@gmail.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+try:
+    from _syslogng import LogSource, LogFetcher
+    from _syslogng import InstantAckTracker, ConsecutiveAckTracker, BatchedAckTracker
+
+except ImportError:
+    import warnings
+
+    warnings.warn("You have imported the syslogng package outside of syslog-ng, thus some of the functionality is not available. Defining fake classes for those exported by the underlying syslog-ng code")
+
+    LogSource = object
+    LogFetcher = object
+    InstantAckTracker = object
+    ConsecutiveAckTracker = object
+    BatchedAckTracker = object
+
+class LogSource(LogSource):
+    """Base class for building an asynchronous source driver
+
+    A LogSource is a base class that allows the implementation of a
+    syslog-ng source driver.  Derive your source implementation from this
+    class and override the run() method to add your specific behaviour.
+
+    Internally, this class starts a dedicated thread and allows you to
+    use an asynchronous framework such as asyncio to produce messages.
+
+    It easily maps to any source mechanism that pushes messages to syslog-ng
+    (e.g.  queueing protocols such as mqtt or HTTP server implementations)
+    """
+
+    def init(self, options):
+        """Initialize this LogSource instance
+
+        Returns:
+            bool: True to indicate success
+        """
+        return True
+
+    def run(self):
+        """Run the main loop for the source
+
+        This method is invoked by syslog-ng to start producing messages in
+        an asynchronous manner.  This function is executed in a dedicated
+        thread and should run until request_exit() is invoked.
+
+        Usually this would either start polling some API or implement the
+        server side of a push based protocol, using a framework such as asyncio.
+
+        Whenever a new message is available, just call post_message() with
+        the new message.
+
+        Returns:
+            None
+        """
+        pass
+
+    def post_message(self, msg):
+        """Post a message as an output for this source
+
+        post_message() can be called from within run() to post messages to
+        syslog-ng, as the output of the source driver being implemented.
+
+        Flow control is implemented in two ways:
+          - blocking mode: post_message() would block if flow control kicks
+            in (e.g.  there's no room in our output window).  This is simple
+            but your main event loop will be suspended until syslog-ng is
+            able to accept messages again.
+
+          - non-blocking mode: if suspend() and wakeup() methods are
+            implemented in your class, post_message() would not block,
+            rather invoke suspend() to indicate that no further messages
+            is to be produced and wakeup() when it is possible to produce
+            messages again.  This mode allows the continued execution of the
+            async main loop even while syslog-ng is unable to accept
+            messages.
+
+        Arguments:
+            msg: LogMessage
+                the log message to be posted
+        """
+        super().post_message(msg)
+
+    def request_exit(self):
+        """Request the main loop to exit
+
+        This function is invoked by syslog-ng from its main thread when this
+        source should stop executing.  The expected result of this function
+        is that its run() method returns to its caller.
+        """
+        pass
+
+class LogFetcher(LogFetcher):
+    """Base class for building synchronous (blocking) source driver
+
+    A LogFetcher is a base class that allows the implementation of a
+    syslog-ng source driver.  This class starts a dedicated thread and
+    regularly executes the fetch() method in that thread to fetch the next
+    message to be emitted as the output of the log source.
+
+    It easily maps to any source mechanism that you need to poll regularly
+    for new messages (e.g.  HTTP based log access APIs).
+    """
+
+    # LogFetcher.FETCH_ERROR,
+    # LogFetcher.FETCH_NOT_CONNECTED,
+    # LogFetcher.FETCH_TRY_AGAIN,
+    # LogFetcher.FETCH_NO_DATA,
+    def init(self, options):
+        """Initialize this LogFetcher instance
+
+        Returns:
+            bool: True to indicate success
+        """
+        return True
+
+    def open(self):
+        """Open the connection to the target service
+
+        This function is called by syslog-ng to open a connection to the
+        target service.  It should return True to indicate success or False
+        otherwise.  If the connection to the target service fails, syslog-ng
+        will try to reconnect until it succeeds, retrying every
+        time_reopen() seconds.
+        """
+        return True
+
+    def close(self):
+        """Close the connection to the target service"""
+        pass
+
+    def fetch(self):
+        """Function to fetch the next message
+
+        This function is executed from the thread associated with LogFetcher
+        every time syslog-ng is able to consume a new message.
+
+        Returns:
+            (result, message): (LogFetcherResult, LogMessage)
+                the function needs to return a 2-tuple, which comprises of a
+                status code and a message instance.
+        """
+        return self.FETCH_TRY_AGAIN

--- a/modules/python/pylib/syslogng/template.py
+++ b/modules/python/pylib/syslogng/template.py
@@ -1,6 +1,5 @@
 #############################################################################
 # Copyright (c) 2022 Balazs Scheidler <bazsi77@gmail.com>
-# Copyright (c) 2015-2016 Balabit
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -21,11 +20,18 @@
 # COPYING for details.
 #
 #############################################################################
+try:
+    from _syslogng import LogTemplate, LogTemplateException, LogTemplateOptions
 
-from .dest import LogDestination
-from .source import LogSource, LogFetcher, InstantAckTracker, ConsecutiveAckTracker, BatchedAckTracker
-from .parser import LogParser
-from .template import LogTemplate, LogTemplateOptions, LogTemplateException, LTZ_SEND, LTZ_LOCAL
-from .message import LogMessage
-from .logger import Logger
-from .persist import Persist
+except ImportError:
+    import warnings
+    warnings.warn("You have imported the syslogng package outside of syslog-ng, thus some of the functionality is not available. Defining fake classes for those exported by the underlying syslog-ng code")
+
+    LogTemplate = object
+    LogTemplateOptions = object
+
+    class LogTemplateException(Exception):
+        pass
+
+LTZ_LOCAL = 0
+LTZ_SEND = 1

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -701,6 +701,17 @@ static PyTypeObject py_log_destination_type =
 void
 py_log_destination_global_init(void)
 {
+  PyObject *module = PyImport_AddModule("_syslogng");
+  PyObject *enum_seq = PyList_New(6);
+
+  PyList_SetItem(enum_seq, 0, Py_BuildValue("(si)", "DROP", LTR_DROP));
+  PyList_SetItem(enum_seq, 1, Py_BuildValue("(si)", "ERROR", LTR_ERROR));
+  PyList_SetItem(enum_seq, 2, Py_BuildValue("(si)", "EXPLICIT_ACK_MGMT", LTR_EXPLICIT_ACK_MGMT));
+  PyList_SetItem(enum_seq, 3, Py_BuildValue("(si)", "SUCCESS", LTR_SUCCESS));
+  PyList_SetItem(enum_seq, 4, Py_BuildValue("(si)", "QUEUED", LTR_QUEUED));
+  PyList_SetItem(enum_seq, 5, Py_BuildValue("(si)", "NOT_CONNECTED", LTR_NOT_CONNECTED));
+  PyModule_AddObject(module, "LogDestinationResult", _py_construct_enum("LogDestinationResult", enum_seq));
+
   PyType_Ready(&py_log_destination_type);
-  PyModule_AddObject(PyImport_AddModule("_syslogng"), "LogDestination", (PyObject *) &py_log_destination_type);
+  PyModule_AddObject(module, "LogDestination", (PyObject *) &py_log_destination_type);
 }

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -687,18 +687,16 @@ static PyTypeObject py_log_fetcher_type =
 void
 py_log_fetcher_global_init(void)
 {
-  py_log_fetcher_type.tp_dict = PyDict_New();
-  PyDict_SetItemString(py_log_fetcher_type.tp_dict, "FETCH_ERROR",
-                       py_long_from_long(THREADED_FETCH_ERROR));
-  PyDict_SetItemString(py_log_fetcher_type.tp_dict, "FETCH_NOT_CONNECTED",
-                       py_long_from_long(THREADED_FETCH_NOT_CONNECTED));
-  PyDict_SetItemString(py_log_fetcher_type.tp_dict, "FETCH_SUCCESS",
-                       py_long_from_long(THREADED_FETCH_SUCCESS));
-  PyDict_SetItemString(py_log_fetcher_type.tp_dict, "FETCH_TRY_AGAIN",
-                       py_long_from_long(THREADED_FETCH_TRY_AGAIN));
-  PyDict_SetItemString(py_log_fetcher_type.tp_dict, "FETCH_NO_DATA",
-                       py_long_from_long(THREADED_FETCH_NO_DATA));
+  PyObject *module = PyImport_AddModule("_syslogng");
+  PyObject *enum_seq = PyList_New(5);
+
+  PyList_SetItem(enum_seq, 0, Py_BuildValue("(si)", "ERROR", THREADED_FETCH_ERROR));
+  PyList_SetItem(enum_seq, 1, Py_BuildValue("(si)", "NOT_CONNECTED", THREADED_FETCH_NOT_CONNECTED));
+  PyList_SetItem(enum_seq, 2, Py_BuildValue("(si)", "SUCCESS", THREADED_FETCH_SUCCESS));
+  PyList_SetItem(enum_seq, 3, Py_BuildValue("(si)", "TRY_AGAIN", THREADED_FETCH_TRY_AGAIN));
+  PyList_SetItem(enum_seq, 4, Py_BuildValue("(si)", "NO_DATA", THREADED_FETCH_NO_DATA));
+  PyModule_AddObject(module, "LogFetcherResult", _py_construct_enum("LogFetcherResult", enum_seq));
 
   PyType_Ready(&py_log_fetcher_type);
-  PyModule_AddObject(PyImport_AddModule("_syslogng"), "LogFetcher", (PyObject *) &py_log_fetcher_type);
+  PyModule_AddObject(module, "LogFetcher", (PyObject *) &py_log_fetcher_type);
 }

--- a/modules/python/python-helpers.c
+++ b/modules/python/python-helpers.c
@@ -410,6 +410,27 @@ _py_object_repr(PyObject *s, gchar *buf, gsize buflen)
   return buf;
 }
 
+PyObject *
+_py_construct_enum(const gchar *name, PyObject *sequence)
+{
+  PyObject *enum_module = PyImport_ImportModule("enum");
+
+  if (!enum_module)
+    return NULL;
+
+  PyObject *enum_dict = PyModule_GetDict(enum_module);
+  PyObject *enum_new = PyDict_GetItemString(enum_dict, "IntEnum");
+
+  if (!enum_new)
+    return NULL;
+
+  PyObject *result = PyObject_CallFunction(enum_new, "sO", name, sequence);
+  Py_XDECREF(enum_module);
+
+  return result;
+}
+
+
 void
 py_slng_generic_dealloc(PyObject *self)
 {

--- a/modules/python/python-helpers.h
+++ b/modules/python/python-helpers.h
@@ -49,6 +49,7 @@ gboolean _py_invoke_bool_method_by_name(PyObject *instance, const gchar *method_
                                         const gchar *module);
 void _py_perform_imports(GList *imports);
 const gchar *_py_object_repr(PyObject *s, gchar *buf, gsize buflen);
+PyObject *_py_construct_enum(const gchar *name, PyObject *sequence);
 
 void py_slng_generic_dealloc(PyObject *self);
 

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -86,6 +86,12 @@ libtest/mock-logpipe\.[ch]
 lib/generic-number\.[ch]
 lib/tests/test_generic_number\.c
 syslog-ng-ctl/commands/log-level.[ch]
+modules/python/pylib/syslogng/dest\.py
+modules/python/pylib/syslogng/logger\.py
+modules/python/pylib/syslogng/message\.py
+modules/python/pylib/syslogng/parser\.py
+modules/python/pylib/syslogng/source\.py
+modules/python/pylib/syslogng/template\.py
 
 ###########################################################################
 # These tests are GPLd even though they reside under lib/ and are excluded
@@ -122,7 +128,8 @@ modules/native
 modules/http/http-signals.h
 tests/loggen
 persist-tool
-
+modules/python/pylib/syslogng/__init__\.py
+modules/python/pylib/syslogng/persist\.py
 
 ###########################################################################
 # These files are GPLd and non-balabit contributions.


### PR DESCRIPTION
This is the 4th chunk of #4165 adding various improvements to our Python glue layer (e.g. the syslogng package that sits between user code and our C-exported interface).

NOTE: I do have some improvements of the fake classes in this PR (those that let me write unit tests for user-code running outside of syslog-ng), which we might want to pull here. Those are in #4175 and  #4173
