### PR TITLE
Python fix heap corruption in $(python) template function

### DIFF
--- a/libtest/cr_template.c
+++ b/libtest/cr_template.c
@@ -199,8 +199,8 @@ assert_template_format_with_escaping_and_context_msgs(const gchar *template, gbo
                    template, (gint) res->len - prefix_len, res->str + prefix_len, (gint) expected_len, expected);
   if (expected_type != LM_VT_NONE)
     cr_assert_eq(type, expected_type,
-                 "expected type does not match template=%s, type=%d, expected_type=%d",
-                 template, type, expected_type);
+                 "expected type does not match template=%s, type=%d, expected_type=%d (value was %.*s)",
+                 template, type, expected_type, (gint) expected_len, expected);
   log_template_unref(templ);
   g_string_free(res, TRUE);
 }

--- a/modules/python/python-tf.c
+++ b/modules/python/python-tf.c
@@ -162,5 +162,5 @@ tf_python_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArg
   PyGILState_Release(gstate);
 }
 
-TEMPLATE_FUNCTION(TFSimpleFuncState, tf_python, tf_python_prepare, tf_simple_func_eval,
+TEMPLATE_FUNCTION(PythonTfState, tf_python, tf_python_prepare, tf_simple_func_eval,
                   tf_python_call, tf_simple_func_free_state, NULL);


### PR DESCRIPTION
This is chunk 7 from #4165 which fixes a heap corruption issue in the $(python) template function that surfaced on MacOS but then I could reproduce using valgrind locally.

NOTE: this can be integrated separately by rebasing it against master.
