### PR TITLE
Add compat/time.h to timeutils/misc.c

### DIFF
--- a/lib/timeutils/misc.c
+++ b/lib/timeutils/misc.c
@@ -22,6 +22,7 @@
  *
  */
 
+#include "compat/time.h"
 #include "timeutils/misc.h"
 #include "timeutils/cache.h"
 #include "messages.h"


### PR DESCRIPTION
This is needed for compatibility with some macOS versions due to use of `clock_gettime` in `check_nanosleep`.

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
