### PR TITLE
tests/copyright/check.sh: move whether the file is text to after the list was pruned

### DIFF
--- a/tests/copyright/check.sh
+++ b/tests/copyright/check.sh
@@ -109,7 +109,7 @@ main_logged() {
   -iname '.git' -prune \
   -o \
  -type f \
- -exec grep -Iq . {} \; -print |
+ -size +0 -print |
  sed "s~^\./~~" |
  prune_ignored_paths |
  sort |
@@ -121,6 +121,10 @@ main_logged() {
     echo "debug: ignoring $FILE" >&2
    fi
   else
+   if not grep -Iq . {} ; then
+    continue
+   fi
+
    cat "$FILE" |
    escape |
    join_lines |
@@ -480,7 +484,9 @@ prune_ignored_paths() {
    s~$~(/.*)?$~
   " |
   cat > "$IGNORE"
-  echo "*~" >> "$IGNORE"
+  echo "~$" >> "$IGNORE"
+  echo "dbld/((build)|(install)|(release))" >> "$IGNORE"
+  cat $IGNORE >&2
  fi
 
  grep --invert-match --extended-regexp --file "$IGNORE"


### PR DESCRIPTION
There's a "grep" call in the find command line to limit the set of results to text files (as grep defines it). The problem with this is that I have a huge number of files in dbld/ subdirectories, which are all read by grep to determine if they are text files.

Move the grep call inside the loop and add the dbld subdirectories into the IGNORE list. This makes the script usable on my source tree (just barely though)

we don't need a NEWS file for this.