### PR TITLE
modules/timestamp: add $(format-date) template function

### DIFF
--- a/modules/timestamp/CMakeLists.txt
+++ b/modules/timestamp/CMakeLists.txt
@@ -10,6 +10,8 @@ set(TIMESTAMP_SOURCES
     rewrite-set-timezone.h
     rewrite-guess-timezone.c
     rewrite-guess-timezone.h
+    tf-format-date.c
+    tf-format-date.h
 )
 
 add_module(

--- a/modules/timestamp/Makefile.am
+++ b/modules/timestamp/Makefile.am
@@ -17,7 +17,9 @@ modules_timestamp_libtimestamp_la_SOURCES	 = \
 	modules/timestamp/rewrite-guess-timezone.c   \
 	modules/timestamp/rewrite-guess-timezone.h   \
 	modules/timestamp/date-parser.c		   \
-	modules/timestamp/date-parser.h
+	modules/timestamp/date-parser.h	           \
+	modules/timestamp/tf-format-date.h	\
+	modules/timestamp/tf-format-date.c
 
 modules_timestamp_libtimestamp_la_LIBADD = \
 	$(MODULE_DEPS_LIBS)

--- a/modules/timestamp/tests/CMakeLists.txt
+++ b/modules/timestamp/tests/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_unit_test(CRITERION TARGET test_date DEPENDS timestamp)
+add_unit_test(LIBTEST CRITERION TARGET test_format_date DEPENDS timestamp)

--- a/modules/timestamp/tests/Makefile.am
+++ b/modules/timestamp/tests/Makefile.am
@@ -1,5 +1,6 @@
 modules_timestamp_tests_TESTS = \
-	modules/timestamp/tests/test_date
+	modules/timestamp/tests/test_date \
+	modules/timestamp/tests/test_format_date
 
 check_PROGRAMS += \
 	${modules_timestamp_tests_TESTS}
@@ -11,3 +12,9 @@ modules_timestamp_tests_test_date_LDADD = $(TEST_LDADD)
 modules_timestamp_tests_test_date_LDFLAGS = \
 	-dlpreopen $(top_builddir)/modules/timestamp/libtimestamp.la
 modules_timestamp_tests_test_date_DEPENDENCIES = $(top_builddir)/modules/timestamp/libtimestamp.la
+
+modules_timestamp_tests_test_format_date_CFLAGS = $(TEST_CFLAGS) -I$(top_srcdir)/modules/timestamp
+modules_timestamp_tests_test_format_date_LDADD = $(TEST_LDADD)
+modules_timestamp_tests_test_format_date_LDFLAGS = \
+	-dlpreopen $(top_builddir)/modules/timestamp/libtimestamp.la $(PREOPEN_SYSLOGFORMAT)
+modules_timestamp_tests_test_format_date_DEPENDENCIES = $(top_builddir)/modules/timestamp/libtimestamp.la

--- a/modules/timestamp/tests/test_format_date.c
+++ b/modules/timestamp/tests/test_format_date.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022 Balazs Scheidler <bazsi77@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#include <criterion/criterion.h>
+#include "libtest/cr_template.h"
+
+#include "logmsg/logmsg.h"
+#include "timeutils/misc.h"
+#include "apphook.h"
+#include "scratch-buffers.h"
+#include "cfg.h"
+
+void
+setup(void)
+{
+  app_startup();
+  setenv("TZ", "CET", TRUE);
+  tzset();
+  init_template_tests();
+  cfg_load_module(configuration, "timestamp");
+}
+
+void
+teardown(void)
+{
+  deinit_template_tests();
+  scratch_buffers_explicit_gc();
+  app_shutdown();
+}
+
+static void
+_log_msg_set_recvd_time(LogMessage *msg, time_t t)
+{
+  msg->timestamps[LM_TS_STAMP].ut_sec = t;
+  msg->timestamps[LM_TS_STAMP].ut_usec = 0;
+  msg->timestamps[LM_TS_STAMP].ut_gmtoff = get_local_timezone_ofs(t);
+}
+
+TestSuite(format_date, .init = setup, .fini = teardown);
+
+Test(format_date, test_format_date_without_argument_takes_the_timestamp_and_formats_it_using_strftime)
+{
+  LogMessage *msg = log_msg_new_empty();
+
+  _log_msg_set_recvd_time(msg, 1667500613);
+  assert_template_format_msg("$(format-date %Y-%m-%dT%H:%M:%S)", "2022-11-03T19:36:53", msg);
+
+  log_msg_unref(msg);
+}
+
+Test(format_date, test_format_date_with_a_macro_argument_uses_that_value)
+{
+  LogMessage *msg = log_msg_new_empty();
+
+  log_msg_set_value_by_name(msg, "custom_timestamp", "1667500613", -1);
+  assert_template_format_msg("$(format-date %Y-%m-%dT%H:%M:%S ${custom_timestamp})", "2022-11-03T19:36:53", msg);
+
+  log_msg_unref(msg);
+}
+
+Test(format_date, test_format_date_with_timestamp_argument_formats_it_using_strftime)
+{
+  assert_template_format("$(format-date %Y-%m-%dT%H:%M:%S 1667500613)", "2022-11-03T19:36:53");
+}
+
+Test(format_date, test_format_date_with_time_zone_option_overrrides_timezone)
+{
+  assert_template_format("$(format-date --time-zone PST8PDT %Y-%m-%dT%H:%M:%S 1667500613)", "2022-11-03T11:36:53");
+}

--- a/modules/timestamp/tf-format-date.c
+++ b/modules/timestamp/tf-format-date.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2022 Balazs Scheidler <bazsi77@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "tf-format-date.h"
+#include "timeutils/conv.h"
+
+
+/*
+ * $(format-date [options] format-string [timestamp])
+ *
+ * $(format-date) takes a timestamp in the DATETIME representation and
+ * formats it according to an strftime() format string.  The DATETIME
+ * representation in syslog-ng is a UNIX timestamp formatted as a decimal
+ * number, with an optional fractional part, where the seconds and the
+ * fraction of seconds are separated by a dot.
+ *
+ * If the timestamp argument is missing, the timestamp of the message is
+ * used.
+ *
+ * Options:
+ *   --time-zone <TZstring>
+ */
+typedef struct _TFFormatDate
+{
+  TFSimpleFuncState super;
+  TimeZoneInfo *time_zone_info;
+  gchar *format;
+} TFFormatDate;
+
+static gboolean
+tf_format_date_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, gint argc, gchar *argv[],
+                       GError **error)
+{
+  TFFormatDate *state = (TFFormatDate *) s;
+  gchar *time_zone = NULL;
+  GOptionContext *ctx;
+  GOptionEntry format_date_options[] =
+  {
+    { "time-zone", 'Z', 0, G_OPTION_ARG_STRING, &time_zone, NULL, NULL },
+    { NULL }
+  };
+  gboolean result = FALSE;
+
+  ctx = g_option_context_new("format-date");
+  g_option_context_add_main_entries(ctx, format_date_options, NULL);
+
+  if (!g_option_context_parse(ctx, &argc, &argv, error))
+    {
+      g_option_context_free(ctx);
+      goto exit;
+    }
+  g_option_context_free(ctx);
+
+  if (time_zone)
+    {
+      state->time_zone_info = time_zone_info_new(time_zone);
+      if (!state->time_zone_info)
+        {
+          g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
+                      "$(format-date): Error loading timezone information for %s", time_zone);
+          goto exit;
+        }
+    }
+
+  if (argc > 1)
+    {
+      /* take off format string if that our next argument */
+      state->format = g_strdup(argv[1]);
+
+      /* fill up slot in argv array */
+      argv[1] = argv[0];
+      argv++;
+      argc--;
+    }
+
+  /* skip the extracted format argument */
+  if (!tf_simple_func_prepare(self, state, parent, argc, argv, error))
+    {
+      goto exit;
+    }
+  result = TRUE;
+
+exit:
+  /* glib supplies us with duplicated strings that we are responsible for! */
+  g_free(time_zone);
+  return result;
+}
+
+static void
+tf_format_date_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArgs *args, GString *result,
+                    LogMessageValueType *type)
+{
+  TFFormatDate *state = (TFFormatDate *) s;
+  UnixTime ut;
+
+  *type = LM_VT_STRING;
+  gint64 msec;
+
+  if (state->super.argc != 0)
+    {
+      const gchar *ts = args->argv[0]->str;
+      if (!type_cast_to_datetime_msec(ts, &msec, NULL))
+        msec = 0;
+      ut.ut_sec = msec / 1000;
+      ut.ut_usec = (msec % 1000) * 1000;
+      ut.ut_gmtoff = -1;
+    }
+  else
+    {
+      ut = args->messages[0]->timestamps[LM_TS_STAMP];
+    }
+
+  WallClockTime wct;
+
+  gint tz_override = state->time_zone_info ? time_zone_info_get_offset(state->time_zone_info, ut.ut_sec) : -1;
+  convert_unix_time_to_wall_clock_time_with_tz_override(&ut, &wct, tz_override);
+
+  gchar buf[64];
+  gint len = strftime(buf, sizeof(buf), state->format, &wct.tm);
+
+  if (len > 0)
+    g_string_append_len(result, buf, len);
+}
+
+static void
+tf_format_date_free_state(gpointer s)
+{
+  TFFormatDate *state = (TFFormatDate *) s;
+
+  g_free(state->format);
+  if (state->time_zone_info)
+    time_zone_info_free(state->time_zone_info);
+  tf_simple_func_free_state(&state->super);
+}
+
+TEMPLATE_FUNCTION(TFFormatDate, tf_format_date, tf_format_date_prepare, tf_simple_func_eval, tf_format_date_call,
+                  tf_format_date_free_state, NULL);

--- a/modules/timestamp/tf-format-date.h
+++ b/modules/timestamp/tf-format-date.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 Balazs Scheidler <bazsi77@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef TIMESTAMP_FORMAT_TIME_H_INCLUDED
+#define TIMESTAMP_FORMAT_TIME_H_INCLUDED
+
+#include "template/simple-function.h"
+#include "plugin.h"
+
+TEMPLATE_FUNCTION_DECLARE(tf_format_date);
+
+#endif

--- a/modules/timestamp/timestamp-plugin.c
+++ b/modules/timestamp/timestamp-plugin.c
@@ -22,6 +22,7 @@
  */
 
 #include "timestamp-parser.h"
+#include "tf-format-date.h"
 
 #include "plugin.h"
 #include "plugin-types.h"
@@ -50,6 +51,7 @@ static Plugin timestamp_plugins[] =
     .name = "guess-time-zone",
     .parser = &timestamp_parser,
   },
+  TEMPLATE_FUNCTION_PLUGIN(tf_format_date, "format-date"),
 };
 
 gboolean

--- a/news/feature-4202.md
+++ b/news/feature-4202.md
@@ -1,0 +1,15 @@
+`$(format-date)`: add a new template function to format time and date values
+
+    $(format-date [options] format-string [timestamp])
+
+    $(format-date) takes a timestamp in the DATETIME representation and
+    formats it according to an strftime() format string.  The DATETIME
+    representation in syslog-ng is a UNIX timestamp formatted as a decimal
+    number, with an optional fractional part, where the seconds and the
+    fraction of seconds are separated by a dot.
+
+    If the timestamp argument is missing, the timestamp of the message is
+    used.
+
+    Options:
+      --time-zone <TZstring> -- override timezone of the original timestamp

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -139,6 +139,8 @@ modules/python/pylib/syslogng/persist\.py
 modules/http/(http|http-parser|http-plugin|)\.[ch]
 modules/http/http-grammar.ym
 modules/timestamp/rewrite-.*$
+modules/timestamp/tf-format-date.*$
+modules/timestamp/tests/test_format_date.*$
 modules/add-contextual-data/add-contextual-data-glob-selector\.[ch]$
 modules/add-contextual-data/tests/test_glob_selector\.c$
 modules/affile/tests/test_file_writer\.c$


### PR DESCRIPTION
$(format-date [options] format-string [timestamp])

$(format-date) takes a timestamp in the DATETIME representation and formats it according to an strftime() format string.  The DATETIME representation in syslog-ng is a UNIX timestamp formatted as a decimal number, with an optional fractional part, where the seconds and the fraction of seconds are separated by a dot.

If the timestamp argument is missing, the timestamp of the message is used.

Options:
  --time-zone <TZstring> -- override timezone of the original timestamp

Signed-off-by: Balazs Scheidler <bazsi77@gmail.com>
