### PR TITLE
ci: upgrade macOS OpenSSL to v3.0

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -31,7 +31,7 @@ jobs:
           . .github/workflows/gh-tools.sh
 
           PYTHONUSERBASE="${HOME}/python_packages"
-          PKG_CONFIG_PATH="$(brew --prefix)/opt/openssl@1.1/lib/pkgconfig:$PKG_CONFIG_PATH"
+          PKG_CONFIG_PATH="$(brew --prefix)/opt/openssl@3/lib/pkgconfig:$PKG_CONFIG_PATH"
           THREADS="$(sysctl -n hw.physicalcpu)"
           CONFIGURE_FLAGS="
             --with-ivykis=system

--- a/contrib/Brewfile
+++ b/contrib/Brewfile
@@ -10,7 +10,7 @@ brew "pkg-config"
 brew "ivykis"
 brew "rabbitmq-c"
 brew "mongo-c-driver"
-brew "openssl@1.1"
+brew "openssl@3"
 # brew "pcre"
 
 brew "gradle"


### PR DESCRIPTION
This is used as a dependency in the macOS CI job.