### PR TITLE
#3993 support ssl conf cmd

### DIFF
--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -876,6 +876,7 @@ tls_context_setup_cmd_context(TLSContext *self)
                       tls_context_format_location_tag(self));
           result = result && (add_result >= 1);
         }
+      result = result && (SSL_CONF_CTX_finish(ssl_conf_ctx) == 1);
     }
 
   SSL_CONF_CTX_free(ssl_conf_ctx);

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -503,6 +503,7 @@ tls_session_set_trusted_fingerprints(TLSContext *self, GList *fingerprints)
 {
   g_assert(fingerprints);
 
+  g_list_foreach(self->trusted_fingerprint_list, (GFunc) g_free, NULL);
   self->trusted_fingerprint_list = fingerprints;
 }
 
@@ -511,6 +512,7 @@ tls_session_set_trusted_dn(TLSContext *self, GList *dn)
 {
   g_assert(dn);
 
+  g_list_foreach(self->trusted_dn_list, (GFunc) g_free, NULL);
   self->trusted_dn_list = dn;
 }
 

--- a/lib/tlscontext.c
+++ b/lib/tlscontext.c
@@ -66,6 +66,7 @@ struct _TLSContext
   gboolean ocsp_stapling_verify;
 
   SSL_CTX *ssl_ctx;
+  GList *conf_cmds_list;
   GList *trusted_fingerprint_list;
   GList *trusted_dn_list;
   gint ssl_options;
@@ -848,6 +849,39 @@ tls_context_setup_sigalgs(TLSContext *self)
   return TRUE;
 }
 
+static gboolean
+tls_context_setup_cmd_context(TLSContext *self)
+{
+  SSL_CONF_CTX *ssl_conf_ctx = SSL_CONF_CTX_new();
+  const int ctx_flags = SSL_CONF_FLAG_FILE | SSL_CONF_FLAG_CLIENT | SSL_CONF_FLAG_SERVER |
+                        SSL_CONF_FLAG_CERTIFICATE | SSL_CONF_FLAG_SHOW_ERRORS;
+  int set_flags = SSL_CONF_CTX_set_flags(ssl_conf_ctx, ctx_flags);
+
+  gboolean result = (set_flags == ctx_flags);
+  if (result)
+    {
+      SSL_CONF_CTX_set_ssl_ctx(ssl_conf_ctx, self->ssl_ctx);
+
+      for (GList *next_pair = self->conf_cmds_list; next_pair; next_pair = next_pair->next)
+        {
+          gchar *cmd = next_pair->data;
+          next_pair = next_pair->next;
+          gchar *value = next_pair->data;
+
+          int add_result = SSL_CONF_cmd(ssl_conf_ctx, cmd, value);
+          if (add_result < 1)
+            msg_error("Error setting up SSL conf context, invalid cmd or value in config list",
+                      evt_tag_str("cmd", cmd),
+                      evt_tag_str("value", value),
+                      tls_context_format_location_tag(self));
+          result = result && (add_result >= 1);
+        }
+    }
+
+  SSL_CONF_CTX_free(ssl_conf_ctx);
+  return result;
+}
+
 static PKCS12 *
 _load_pkcs12_file(TLSContext *self, const gchar *pkcs12_file)
 {
@@ -1008,11 +1042,7 @@ tls_context_setup_context(TLSContext *self)
 
   tls_context_setup_ssl_options(self);
   if (!tls_context_setup_ecdh(self))
-    {
-      SSL_CTX_free(self->ssl_ctx);
-      self->ssl_ctx = NULL;
-      return TLS_CONTEXT_SETUP_ERROR;
-    }
+    goto error_no_print;
 
   if (!tls_context_setup_dh(self))
     goto error;
@@ -1023,10 +1053,14 @@ tls_context_setup_context(TLSContext *self)
   if (!tls_context_setup_sigalgs(self))
     goto error;
 
+  if (!tls_context_setup_cmd_context(self))
+    goto error;
+
   return TLS_CONTEXT_SETUP_OK;
 
 error:
   _print_and_clear_tls_session_error(self);
+error_no_print:
   if (self->ssl_ctx)
     {
       SSL_CTX_free(self->ssl_ctx);
@@ -1096,6 +1130,7 @@ _tls_context_free(TLSContext *self)
 {
   g_free(self->location);
   SSL_CTX_free(self->ssl_ctx);
+  g_list_foreach(self->conf_cmds_list, (GFunc) g_free, NULL);
   g_list_foreach(self->trusted_fingerprint_list, (GFunc) g_free, NULL);
   g_list_foreach(self->trusted_dn_list, (GFunc) g_free, NULL);
   g_free(self->key_file);
@@ -1375,6 +1410,14 @@ tls_context_set_client_sigalgs(TLSContext *self, const gchar *sigalgs, GError **
               "Setting client sigalgs is not supported with the OpenSSL version syslog-ng was compiled with");
   return FALSE;
 #endif
+}
+
+gboolean
+tls_context_set_conf_cmds(TLSContext *self, GList *cmds, GError **error)
+{
+  g_list_foreach(self->conf_cmds_list, (GFunc) g_free, NULL);
+  self->conf_cmds_list = cmds;
+  return TRUE;
 }
 
 void

--- a/lib/tlscontext.h
+++ b/lib/tlscontext.h
@@ -137,6 +137,7 @@ void tls_context_set_cipher_suite(TLSContext *self, const gchar *cipher_suite);
 gboolean tls_context_set_tls13_cipher_suite(TLSContext *self, const gchar *tls13_cipher_suite, GError **error);
 gboolean tls_context_set_sigalgs(TLSContext *self, const gchar *sigalgs, GError **error);
 gboolean tls_context_set_client_sigalgs(TLSContext *self, const gchar *sigalgs, GError **error);
+gboolean tls_context_set_conf_cmds(TLSContext *self, GList *cmds, GError **error);
 void tls_context_set_ecdh_curve_list(TLSContext *self, const gchar *ecdh_curve_list);
 void tls_context_set_dhparam_file(TLSContext *self, const gchar *dhparam_file);
 void tls_context_set_sni(TLSContext *self, const gchar *sni);

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -197,6 +197,7 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 %token KW_ALLOW_COMPRESS
 %token KW_KEYLOG_FILE
 %token KW_OCSP_STAPLING_VERIFY
+%token KW_CONF_CMDS
 
 /* INCLUDE_DECLS */
 
@@ -236,6 +237,9 @@ systemd_syslog_grammar_set_source_driver(SystemDSyslogSourceDriver *sd)
 
 %type <ptr> dest_failover_options
 %type <ptr> dest_failover_modes_options
+
+%type <ptr> tls_conf_cmds
+%type <ptr> tls_conf_cmd_list_build
 
 %%
 
@@ -890,9 +894,37 @@ tls_option
           {
              transport_mapper_inet_set_allow_compress(last_transport_mapper, $3);
           }
+	| KW_CONF_CMDS '(' tls_conf_cmds ')'
+		{
+			GError *error = NULL;
+			CHECK_ERROR_GERROR(tls_context_set_conf_cmds(last_tls_context, $3, &error), @3, error, "Error setting conf-cmds()");
+		}
         | KW_ENDIF {
 }
         ;
+
+tls_conf_cmds
+	: tls_conf_cmd_list_build
+		{
+			$$ = $1;
+		}
+	;
+
+tls_conf_cmd_list_build
+	: string LL_ARROW string tls_conf_cmd_list_build
+		{
+			/* Revers order is important here as this is inside of a bison right recursion */
+			$$ = g_list_prepend($4, g_strdup($3));
+			$$ = g_list_prepend($$, g_strdup($1));
+
+			free($1);
+			free($3);
+		}
+	|
+		{
+			$$ = NULL;
+		}
+  ;
 
 tls_cipher_suites
         : tls_cipher_suite tls_cipher_suites

--- a/modules/afsocket/afsocket-parser.c
+++ b/modules/afsocket/afsocket-parser.c
@@ -66,6 +66,7 @@ static CfgLexerKeyword afsocket_keywords[] =
   { "sni",                KW_SNI },
   { "allow_compress",     KW_ALLOW_COMPRESS },
   { "ocsp_stapling_verify", KW_OCSP_STAPLING_VERIFY },
+  { "openssl_conf_cmds",  KW_CONF_CMDS},
 
   { "localip",            KW_LOCALIP },
   { "ip",                 KW_IP },

--- a/news/feature-4209.md
+++ b/news/feature-4209.md
@@ -1,0 +1,50 @@
+`network`/`syslog`/`tls` context options: SSL_CONF_cmd support
+
+SSL_CONF_cmd TLS configuration support for `network()` and `syslog()` driver has been added.
+
+OpenSSL offers an alternative, software-independent configuration mechanism through the SSL_CONF_cmd
+interface to support a common solution for setting the so many various SSL_CTX and SSL options that
+can be set earlier via multiple, separated openssl function calls only.
+This update implements that similar to the mod_ssl in Apache.
+
+IMPORTANT:
+The newly introduced `openssl-conf-cmds` always has the highest priority, its content parsed last,
+so it will override any other options can be found in the `tls()` section, does not matter if they
+appear before or after `openssl-conf-cmds`.
+
+Regarding to the other `tls()` options.
+As described in the SSL_CONF_cmd documentation, the order of operations is significant and executed in
+top-down order, basically it means if there are multiple occurrences of setting the same option then the 'last wins'.
+This is also true for options that can be set multiple ways (e.g. used cipher suites and/or protocols).
+
+Example config:
+```
+source source_name {
+    network (
+        ip(0.0.0.0)
+        port(6666)
+        transport("tls")
+        tls(
+            ca-dir("/etc/ca.d")
+            key-file("/etc/cert.d/serverkey.pem")
+            cert-file("/etc/cert.d/servercert.pem")
+            peer-verify(yes)
+
+            openssl-conf-cmds(
+                # For system wide available cipher suites use: /usr/bin/openssl ciphers -v
+                # For formatting rules see: https://www.openssl.org/docs/man1.1.1/man3/SSL_CONF_cmd.html
+                # For quick and dirty testing try: https://github.com/rbsec/sslscan
+                #
+                "CipherString" => "ECDHE-RSA-AES128-SHA",                                   # TLSv1.2 and bellow
+                "CipherSuites" => "TLS_CHACHA20_POLY1305_SHA256:TLS_AES_256_GCM_SHA384",    # TLSv1.3+ (OpenSSl 1.1.1+)
+
+                "Options" => "PrioritizeChaCha",
+                "Protocol" => "-ALL,TLSv1.3",
+            )
+        )
+    );
+};
+
+
+
+```


### PR DESCRIPTION
SSL_CONF_cmd is added to support a common interface for setting the so many various SLL_CTX and SSL options
that can be set earlier via separated openssl function calls (e.g. SSL_CTX_set_options(), SSL_CTX_set_min_proto_version(), SSL_CTX_set_cipher_list(), etc.)

IMPORTANT:
The newly introduced `openssl-conf-cmds` always has the highest priority, its content parsed last,
so it will override any other options can be found in the `tls()` section, does not matter if they
appear before or after `openssl-conf-cmds`.

Regarding to the other `tls()` options.
As described in the SSL_CONF_cmd documentation, the order of operations is significant and executed in
top-down order, basically it means if there are multiple occurrences of setting the same option then the 'last wins'.
This is also true for options that can be set multiple ways (e.g. used cipher suites and/or protocols).
For further info please see: https://www.openssl.org/docs/man1.1.1/man3/SSL_CONF_cmd.html

About the implementation.
It would have been much simpler and cleaner to apply `conf-cmds()` lines immediately during the parsing in afsocket-grammar.y file but (mainly) because of the above (ordering) facts I stayed with the same initialization style that already can be seen e.g. for `trusted_keys()`
Also for simplicity and effectiveness I stayed with the usage of GList (even though it adds a tiny restriction in the afsocket-grammar.y on how the parsed elements must be pushed onto the bison stack about that I've added a comment in the file)

Tests are made manually in two ways.
- I've set up a server/client syslog-ng configuration both with simple and mutual authentication using TLS then set up multiple ciphers setting in many, various ways via `conf-cmds()` (matching, none matching, none existing cipher pairs) to test if the client could establish a TLS connection to the server and send log messages via TLS.
- Using the server instance from the above configuration I've also set up many different kinds of TLS setting via `conf-cmds()` and run sslscan (https://github.com/rbsec/sslscan) then checked/compared the output against my `conf-cmds()` settings.

Fixes #3993
Resolves #3785