### PR TITLE
Add support for PROXY protocol v2

### DIFF
--- a/lib/logproto/logproto-proxied-text-server.c
+++ b/lib/logproto/logproto-proxied-text-server.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 One Identity
+ * Copyright (c) 2022 Balazs Scheidler <bazsi77@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/logproto/logproto-proxied-text-server.c
+++ b/lib/logproto/logproto-proxied-text-server.c
@@ -30,6 +30,38 @@
 #include "transport/transport-factory-tls.h"
 #include "str-utils.h"
 
+#define IP_BUF_SIZE 64
+#define PROXY_PROTO_HDR_MAX_LEN_RFC 108
+#define PROXY_PROTO_HDR_MAX_LEN (PROXY_PROTO_HDR_MAX_LEN_RFC * 2)
+
+struct ProxyProtoInfo
+{
+  gboolean unknown;
+
+  gchar src_ip[IP_BUF_SIZE];
+  gchar dst_ip[IP_BUF_SIZE];
+
+  int ip_version;
+  int src_port;
+  int dst_port;
+};
+
+typedef struct _LogProtoProxiedTextServer
+{
+  LogProtoTextServer super;
+
+  // Info received from the proxied that should be added as LogTransportAuxData to
+  // any message received through this server instance.
+  struct ProxyProtoInfo *info;
+
+  // Flag to only run handshake() once
+  gboolean handshake_done;
+  gboolean has_to_switch_to_tls;
+
+  guchar proxy_header_buff[PROXY_PROTO_HDR_MAX_LEN + 1];
+  gsize proxy_header_buff_len;
+} LogProtoProxiedTextServer;
+
 #define PROXY_HDR_TCP4 "PROXY TCP4 "
 #define PROXY_HDR_TCP6 "PROXY TCP6 "
 #define PROXY_HDR_UNKNOWN "PROXY UNKNOWN"

--- a/lib/logproto/logproto-proxied-text-server.c
+++ b/lib/logproto/logproto-proxied-text-server.c
@@ -64,7 +64,8 @@ typedef struct _LogProtoProxiedTextServer
   gboolean handshake_done;
   gboolean has_to_switch_to_tls;
 
-  enum {
+  enum
+  {
     LPPTS_INITIAL,
     LPPTS_DETERMINE_VERSION,
     LPPTS_PROXY_V1_READ_LINE,
@@ -87,7 +88,8 @@ struct proxy_hdr_v2
   uint16_t len;     /* number of following bytes part of the header */
 };
 
-union proxy_addr {
+union proxy_addr
+{
   struct
   {
     /* for TCP/UDP over IPv4, len = 12 */
@@ -262,7 +264,8 @@ _parse_proxy_v1_header(LogProtoProxiedTextServer *self)
 }
 
 static gboolean
-_parse_proxy_v2_proxy_address(LogProtoProxiedTextServer *self, struct proxy_hdr_v2 *proxy_hdr, union proxy_addr *proxy_addr)
+_parse_proxy_v2_proxy_address(LogProtoProxiedTextServer *self, struct proxy_hdr_v2 *proxy_hdr,
+                              union proxy_addr *proxy_addr)
 {
   gint address_family = (proxy_hdr->fam & 0xF0) >> 4;
   gint proxy_header_len = ntohs(proxy_hdr->len);
@@ -440,7 +443,7 @@ _fetch_into_proxy_buffer(LogProtoProxiedTextServer *self)
     {
     case LPPTS_INITIAL:
       self->header_fetch_state = LPPTS_DETERMINE_VERSION;
-      /* fallthrough */
+    /* fallthrough */
     case LPPTS_DETERMINE_VERSION:
       status = _fetch_chunk(self, 5);
 
@@ -478,7 +481,7 @@ process_proxy_v2:
         return status;
 
       self->header_fetch_state = LPPTS_PROXY_V2_READ_PAYLOAD;
-      /* fallthrough */
+    /* fallthrough */
     case LPPTS_PROXY_V2_READ_PAYLOAD:
       return _fetch_proxy_v2_payload(self);
     default:
@@ -581,7 +584,7 @@ _augment_aux_data(LogProtoProxiedTextServer *self, LogTransportAuxData *aux)
 
 static LogProtoStatus
 log_proto_proxied_text_server_fetch(LogProtoServer *s, const guchar **msg, gsize *msg_len, gboolean *may_read,
-                                     LogTransportAuxData *aux, Bookmark *bookmark)
+                                    LogTransportAuxData *aux, Bookmark *bookmark)
 {
   LogProtoProxiedTextServer *self = (LogProtoProxiedTextServer *) s;
 
@@ -610,7 +613,7 @@ log_proto_proxied_text_server_free(LogProtoServer *s)
 
 static void
 log_proto_proxied_text_server_init(LogProtoProxiedTextServer *self, LogTransport *transport,
-                                    const LogProtoServerOptions *options)
+                                   const LogProtoServerOptions *options)
 {
   msg_info("Initializing PROXY protocol source driver", evt_tag_printf("driver", "%p", self));
 

--- a/lib/logproto/logproto-proxied-text-server.c
+++ b/lib/logproto/logproto-proxied-text-server.c
@@ -508,11 +508,12 @@ log_proto_proxied_text_server_handshake(LogProtoServer *s)
   gboolean parsable = _parse_proxy_header(self);
 
   msg_debug("PROXY protocol header received",
-            evt_tag_mem("line", self->proxy_header_buff, self->proxy_header_buff_len));
+            evt_tag_int("version", self->proxy_header_version),
+            evt_tag_mem("header", self->proxy_header_buff, self->proxy_header_buff_len));
 
   if (parsable)
     {
-      msg_info("PROXY protocol header parsed successfully");
+      msg_trace("PROXY protocol header parsed successfully");
 
       if (self->has_to_switch_to_tls && !_switch_to_tls(self))
         return LPS_ERROR;

--- a/lib/logproto/logproto-proxied-text-server.c
+++ b/lib/logproto/logproto-proxied-text-server.c
@@ -534,7 +534,9 @@ log_proto_proxied_text_server_handshake(LogProtoServer *s)
 
   msg_debug("PROXY protocol header received",
             evt_tag_int("version", self->proxy_header_version),
-            evt_tag_mem("header", self->proxy_header_buff, self->proxy_header_buff_len));
+            self->proxy_header_version == 1
+            ? evt_tag_mem("header", self->proxy_header_buff, self->proxy_header_buff_len)
+            : evt_tag_str("header", "<binary_data>"));
 
   if (parsable)
     {

--- a/lib/logproto/logproto-proxied-text-server.c
+++ b/lib/logproto/logproto-proxied-text-server.c
@@ -480,7 +480,7 @@ process_proxy_v1:
       return _fetch_until_newline(self);
     case LPPTS_PROXY_V2_READ_HEADER:
 process_proxy_v2:
-      status = _fetch_chunk(self, 16);
+      status = _fetch_chunk(self, sizeof(struct proxy_hdr_v2));
       if (status != LPS_SUCCESS)
         return status;
 

--- a/lib/logproto/logproto-proxied-text-server.c
+++ b/lib/logproto/logproto-proxied-text-server.c
@@ -43,6 +43,9 @@
 /* the size of the buffer we use to fetch the PROXY header into */
 #define PROXY_PROTO_HDR_BUFFER_SIZE 1500
 
+/* the amount of bytes we need from the client to detect protocol version */
+#define PROXY_PROTO_HDR_MAGIC_LEN   5
+
 typedef struct _LogProtoProxiedTextServer
 {
   LogProtoTextServer super;
@@ -420,19 +423,19 @@ _fetch_proxy_v2_payload(LogProtoProxiedTextServer *self)
 static gboolean
 _is_proxy_version_v1(LogProtoProxiedTextServer *self)
 {
-  if (self->proxy_header_buff_len < 5)
+  if (self->proxy_header_buff_len < PROXY_PROTO_HDR_MAGIC_LEN)
     return FALSE;
 
-  return memcmp(self->proxy_header_buff, "PROXY", 5) == 0;
+  return memcmp(self->proxy_header_buff, "PROXY", PROXY_PROTO_HDR_MAGIC_LEN) == 0;
 }
 
 static gboolean
 _is_proxy_version_v2(LogProtoProxiedTextServer *self)
 {
-  if (self->proxy_header_buff_len < 5)
+  if (self->proxy_header_buff_len < PROXY_PROTO_HDR_MAGIC_LEN)
     return FALSE;
 
-  return memcmp(self->proxy_header_buff, "\x0D\x0A\x0D\x0A\x00", 5) == 0;
+  return memcmp(self->proxy_header_buff, "\x0D\x0A\x0D\x0A\x00", PROXY_PROTO_HDR_MAGIC_LEN) == 0;
 }
 
 static inline LogProtoStatus
@@ -446,7 +449,7 @@ _fetch_into_proxy_buffer(LogProtoProxiedTextServer *self)
       self->header_fetch_state = LPPTS_DETERMINE_VERSION;
     /* fallthrough */
     case LPPTS_DETERMINE_VERSION:
-      status = _fetch_chunk(self, 5);
+      status = _fetch_chunk(self, PROXY_PROTO_HDR_MAGIC_LEN);
 
       if (status != LPS_SUCCESS)
         return status;

--- a/lib/logproto/logproto-proxied-text-server.h
+++ b/lib/logproto/logproto-proxied-text-server.h
@@ -26,38 +26,6 @@
 
 #include "logproto-text-server.h"
 
-#define IP_BUF_SIZE 64
-#define PROXY_PROTO_HDR_MAX_LEN_RFC 108
-#define PROXY_PROTO_HDR_MAX_LEN (PROXY_PROTO_HDR_MAX_LEN_RFC * 2)
-
-struct ProxyProtoInfo
-{
-  gboolean unknown;
-
-  gchar src_ip[IP_BUF_SIZE];
-  gchar dst_ip[IP_BUF_SIZE];
-
-  int ip_version;
-  int src_port;
-  int dst_port;
-};
-
-typedef struct _LogProtoProxiedTextServer
-{
-  LogProtoTextServer super;
-
-  // Info received from the proxied that should be added as LogTransportAuxData to
-  // any message received through this server instance.
-  struct ProxyProtoInfo *info;
-
-  // Flag to only run handshake() once
-  gboolean handshake_done;
-  gboolean has_to_switch_to_tls;
-
-  guchar proxy_header_buff[PROXY_PROTO_HDR_MAX_LEN + 1];
-  gsize proxy_header_buff_len;
-} LogProtoProxiedTextServer;
-
 LogProtoServer *log_proto_proxied_text_server_new(LogTransport *transport, const LogProtoServerOptions *options);
 LogProtoServer *log_proto_proxied_text_tls_passthrough_server_new(LogTransport *transport,
     const LogProtoServerOptions *options);

--- a/lib/logproto/tests/test-proxy-proto.c
+++ b/lib/logproto/tests/test-proxy-proto.c
@@ -47,8 +47,8 @@ ParameterizedTestParameters(log_proto, test_proxy_protocol_parse_header)
     /* INVALID PROTO */
     { "PROXY UNKNOWN\n",                                      TRUE }, // WRONG TERMINATION
     { "PROXY TCP4 1.1.1.1 2.2.2.2 3333 4444\n",               TRUE }, // WRONG TERMINATION
-    { "PROXY UNKNOWN\r",                                      TRUE }, // WRONG TERMINATION
-    { "PROXY TCP4 1.1.1.1 2.2.2.2 3333 4444\r",               TRUE }, // WRONG TERMINATION
+    { "PROXY UNKNOWN\r",                                      FALSE }, // WRONG TERMINATION
+    { "PROXY TCP4 1.1.1.1 2.2.2.2 3333 4444\r",               FALSE }, // WRONG TERMINATION
     { "PROXY\r\n",                                            FALSE },
     { "PROXY TCP4\r\n",                                       FALSE },
     { "PROXY TCP4 1.1.1.1\r\n",                               FALSE },

--- a/libtest/proto_lib.c
+++ b/libtest/proto_lib.c
@@ -171,7 +171,6 @@ void
 init_proto_tests(void)
 {
   configuration = cfg_new_snippet();
-  cfg_load_module(configuration, "syslogformat");
   log_proto_server_options_defaults(&proto_server_options);
 }
 

--- a/news/feature-4211.md
+++ b/news/feature-4211.md
@@ -1,0 +1,4 @@
+`transport(proxied-tcp)`: added support for PROXY protocol v2, a protocol
+used by network load balancers (for example: AWS ELB and haproxy) to carry
+original source/destination address information, as described in
+https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt

--- a/tests/loggen/loggen.c
+++ b/tests/loggen/loggen.c
@@ -130,7 +130,7 @@ generate_message(char *buffer, int buffer_size, ThreadData *thread_context, unsi
                                       global_plugin_option.proxy_src_ip, global_plugin_option.proxy_dst_ip,
                                       global_plugin_option.proxy_src_port, global_plugin_option.proxy_dst_port);
       thread_context->proxy_header_sent = TRUE;
-      DEBUG("Generated PROXY protocol v1 header; len=%d\n", str_len);
+      DEBUG("Generated PROXY protocol v%d header; len=%d\n", global_plugin_option.proxy_version, str_len);
       return str_len;
     }
 

--- a/tests/loggen/loggen_helper.h
+++ b/tests/loggen/loggen_helper.h
@@ -52,7 +52,7 @@ int connect_ip_socket(int sock_type, const char *target, const char *port, int u
 int connect_unix_domain_socket(int sock_type, const char *path);
 SSL *open_ssl_connection(int sock_fd);
 void close_ssl_connection(SSL *ssl);
-int generate_proxy_header(char *buffer, int buffer_size, int thread_id, const char *proxy_src_ip,
+int generate_proxy_header(char *buffer, int buffer_size, int thread_id, int proxy_version, const char *proxy_src_ip,
                           const char *proxy_dst_ip, const char *proxy_src_port, const char *proxy_dst_port);
 
 #define ERROR(format,...) do {\

--- a/tests/loggen/loggen_plugin.h
+++ b/tests/loggen/loggen_plugin.h
@@ -46,6 +46,7 @@ typedef struct _plugin_option
   int  rate;
   int reconnect;
   gboolean proxied;
+  gint proxy_version;
   char *proxy_src_ip;
   char *proxy_dst_ip;
   char *proxy_src_port;

--- a/tests/loggen/ssl_plugin/ssl_plugin.c
+++ b/tests/loggen/ssl_plugin/ssl_plugin.c
@@ -294,8 +294,10 @@ send_plaintext_proxy_header(ThreadData *thread_context, int sock_fd, char *buf, 
 {
   PluginOption *option = thread_context->option;
 
-  int proxy_header_len = generate_proxy_header(buf, buf_size, thread_context->index, option->proxy_src_ip,
-                                               option->proxy_dst_ip, option->proxy_src_port, option->proxy_dst_port);
+  int proxy_header_len = generate_proxy_header(buf, buf_size, thread_context->index,
+                                               option->proxy_version,
+                                               option->proxy_src_ip, option->proxy_dst_ip,
+                                               option->proxy_src_port, option->proxy_dst_port);
 
   DEBUG("Generated PROXY protocol v1 header; len=%d\n", proxy_header_len);
 

--- a/tests/loggen/ssl_plugin/ssl_plugin.c
+++ b/tests/loggen/ssl_plugin/ssl_plugin.c
@@ -314,6 +314,7 @@ send_plaintext_proxy_header(ThreadData *thread_context, int sock_fd, char *buf, 
       sent += rc;
     }
 
+  thread_context->proxy_header_sent = TRUE;
   DEBUG("Sent PROXY protocol v%d header; len=%d\n", option->proxy_version, proxy_header_len);
 }
 

--- a/tests/loggen/ssl_plugin/ssl_plugin.c
+++ b/tests/loggen/ssl_plugin/ssl_plugin.c
@@ -67,7 +67,7 @@ static int proxied_tls_passthrough = 0;
 static GOptionEntry loggen_options[] =
 {
   { "use-ssl", 'U', 0, G_OPTION_ARG_NONE, &use_ssl,  "Use ssl layer", NULL },
-  { "proxied-tls-passthrough", 0, 0, G_OPTION_ARG_NONE, &proxied_tls_passthrough, "Send the PROXY protocol v1 header before the encrypted payload", NULL },
+  { "proxied-tls-passthrough", 0, 0, G_OPTION_ARG_NONE, &proxied_tls_passthrough, "Send the PROXY protocol header before the encrypted payload", NULL },
   { NULL }
 };
 
@@ -299,7 +299,7 @@ send_plaintext_proxy_header(ThreadData *thread_context, int sock_fd, char *buf, 
                                                option->proxy_src_ip, option->proxy_dst_ip,
                                                option->proxy_src_port, option->proxy_dst_port);
 
-  DEBUG("Generated PROXY protocol v1 header; len=%d\n", proxy_header_len);
+  DEBUG("Generated PROXY protocol v%d header; len=%d\n", option->proxy_version, proxy_header_len);
 
   size_t sent = 0;
   while (sent < proxy_header_len)
@@ -314,7 +314,7 @@ send_plaintext_proxy_header(ThreadData *thread_context, int sock_fd, char *buf, 
       sent += rc;
     }
 
-  DEBUG("Sent PROXY protocol v1 header; len=%d\n", proxy_header_len);
+  DEBUG("Sent PROXY protocol v%d header; len=%d\n", option->proxy_version, proxy_header_len);
 }
 
 gpointer


### PR DESCRIPTION
This PR adds support for PROXY protocol v2 as requested in #4205 

@g-psantos I have tested this blindly, e.g. I wrote my own test program based on the specification, so it might not work in an actual environment, would be great if you could do some manual testing.

NOTE: This does adds some improvement to the existing code, but I feel PROXY v1 should have been done very differently. Instead of a LogProto implementation that combines the PROXY protocol and RFC3164 -like transport over TCP, this should have been a LogTransport implementation that can be combined with any LogProto instances easily. I did NOT address this architectural problem with this PR. I am also not sure that the key-value pairs we are adding to the message (e.g. PROXIED_SRCIP) are the right choice when handling this kind of transport protocol. But I didn't want to extend the scope of this PR too much. This potentially addresses an imminent use-case, hopefully solving it, so I didn't want to complicate things further. I have other things on my plate too :)

@p-gsantos let me know if this indeed solves your use-case. Thanks.
