### PR TITLE
Python kubernetes key separator

### DIFF
--- a/modules/python-modules/syslogng/modules/kubernetes/__init__.py
+++ b/modules/python-modules/syslogng/modules/kubernetes/__init__.py
@@ -34,6 +34,8 @@ class KubernetesAPIEnrichment(LogParser):
         self.__prefix = options["prefix"]
 
         kubernetes.config.load_config()
+        self.key_delimiter = options.get('key_delimiter', '.')
+
         self.__client_api = kubernetes.client.CoreV1Api()
 
         return True
@@ -63,10 +65,10 @@ class KubernetesAPIEnrichment(LogParser):
             self.logger.warning("Error querying pod.metadata.uid for pod {}/{} from the Kubernetes API".format(namespace_name, pod_name))
 
         for name, value in (pod.metadata.labels or {}).items():
-            cached_pod_metadata[self.add_prefix("labels.{}".format(name))] = value
+            cached_pod_metadata[self.add_prefix("labels{}{}".format(self.key_delimiter, name))] = value
 
         for name, value in (pod.metadata.annotations or {}).items():
-            cached_pod_metadata[self.add_prefix("annotations.{}".format(name))] = value
+            cached_pod_metadata[self.add_prefix("annotations{}{}".format(self.key_delimiter, name))] = value
 
         try:
             container_status = pod.status.container_statuses[0]

--- a/modules/python-modules/syslogng/modules/kubernetes/scl/kubernetes.conf
+++ b/modules/python-modules/syslogng/modules/kubernetes/scl/kubernetes.conf
@@ -68,7 +68,7 @@
 # filename format under /var/log/pods
 @define kubernetes-log-pods-regexp '.var.log.pods.(?<namespace_name>[^_]+)_(?<pod_name>[^_]+)_(?<pod_uuid>[a-z0-9-]*).(?<container_name>.+)/[^.]+.log'
 
-block parser kubernetes-metadata-parser (prefix() template("$FILE_NAME")) {
+block parser kubernetes-metadata-parser (prefix() template("$FILE_NAME") key-delimiter()) {
     channel {
 
         parser {
@@ -81,7 +81,8 @@ block parser kubernetes-metadata-parser (prefix() template("$FILE_NAME")) {
             python(
                 class("syslogng.modules.kubernetes.KubernetesAPIEnrichment")
                 options(
-                    "prefix" => "`prefix`"
+                    "prefix" => "`prefix`",
+                    "key_delimiter" => "`key_delimiter`"
                 )
             );
         };
@@ -91,7 +92,7 @@ block parser kubernetes-metadata-parser (prefix() template("$FILE_NAME")) {
      };
 };
 
-block parser kubernetes-file-parser(prefix('.k8s.') cluster-name('k8s')) {
+block parser kubernetes-file-parser(prefix('.k8s.') cluster-name('k8s') key-delimiter()) {
     csv-parser(
 	# time, stream, flags, message
         columns("1", "2", "3", "4")
@@ -115,7 +116,7 @@ block parser kubernetes-file-parser(prefix('.k8s.') cluster-name('k8s')) {
         timeout(10)
     );
 
-    kubernetes-metadata-parser(prefix(`prefix`));
+    kubernetes-metadata-parser(prefix(`prefix`) key-delimiter(`key-delimiter`));
     channel {
         rewrite {
 	    set("`cluster-name`/${`prefix`namespace_name}/${`prefix`pod_name}" value("HOST"));
@@ -125,7 +126,7 @@ block parser kubernetes-file-parser(prefix('.k8s.') cluster-name('k8s')) {
     };
 };
 
-block source kubernetes(prefix('.k8s.') base-dir("/var/log/containers") cluster-name('k8s')) {
+block source kubernetes(prefix('.k8s.') base-dir("/var/log/containers") cluster-name('k8s') key-delimiter('.')) {
     channel {
         source {
             wildcard-file(
@@ -136,6 +137,6 @@ block source kubernetes(prefix('.k8s.') base-dir("/var/log/containers") cluster-
                 flags(no-parse)
             );
         };
-        parser { kubernetes-file-parser(prefix(`prefix`) cluster-name(`cluster-name`)); };
+        parser { kubernetes-file-parser(prefix(`prefix`) cluster-name(`cluster-name`) key-delimiter(`key-delimiter`)); };
     };
 };


### PR DESCRIPTION
This is a work in progress branch to find a good solution for representing kubernetes metadata that contains dots in JSON keys,
causing our name-value representation to become ambiguous

I don't feel the solution in this PR is right, but we can address this post 4.0, so I am splitting this off from #4173 