### PR TITLE
Python based confgen (4.0)

### DIFF
--- a/modules/python-modules/Makefile.am
+++ b/modules/python-modules/Makefile.am
@@ -1,5 +1,6 @@
 EXTRA_DIST += \
 	modules/python-modules/syslogng/__init__.py				\
+	modules/python-modules/syslogng/confgen.py				\
 	modules/python-modules/syslogng/dest.py					\
 	modules/python-modules/syslogng/logger.py				\
 	modules/python-modules/syslogng/message.py				\

--- a/modules/python-modules/syslogng/confgen.py
+++ b/modules/python-modules/syslogng/confgen.py
@@ -1,6 +1,5 @@
 #############################################################################
 # Copyright (c) 2022 Balazs Scheidler <bazsi77@gmail.com>
-# Copyright (c) 2015-2016 Balabit
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -22,11 +21,8 @@
 #
 #############################################################################
 
-from .dest import LogDestination
-from .source import LogSource, LogFetcher, InstantAckTracker, ConsecutiveAckTracker, BatchedAckTracker
-from .parser import LogParser
-from .template import LogTemplate, LogTemplateOptions, LogTemplateException, LTZ_SEND, LTZ_LOCAL
-from .message import LogMessage
-from .logger import Logger
-from .persist import Persist
-from .confgen import register_config_generator
+try:
+    from _syslogng import register_config_generator
+except ImportError:
+    def register_config_generator(context, name, config_generator):
+        pass

--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -11,6 +11,8 @@ set(PYTHON_SOURCES
     python-module.h
     python-config.h
     python-config.c
+    python-confgen.h
+    python-confgen.c
     python-persist.h
     python-persist.c
     python-helpers.h

--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -69,7 +69,9 @@ modules_python_libmod_python_la_SOURCES		= \
 	modules/python/python-ack-tracker.h \
 	modules/python/python-ack-tracker.c \
 	modules/python/python-types.h \
-	modules/python/python-types.c
+	modules/python/python-types.c \
+	modules/python/python-confgen.h \
+	modules/python/python-confgen.c
 
 
 modules_python_libmod_python_la_LDFLAGS		 = \

--- a/modules/python/python-confgen.c
+++ b/modules/python/python-confgen.c
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2022 Balazs Scheidler <bazsi77@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "python-module.h"
+#include "python-helpers.h"
+#include "python-types.h"
+#include "cfg-block-generator.h"
+#include "cfg-lexer.h"
+#include "cfg.h"
+
+typedef struct _PythonConfigGenerator
+{
+  CfgBlockGenerator super;
+  PyObject *py_generator_function;
+} PythonConfigGenerator;
+
+static gboolean
+python_config_generator_generate(CfgBlockGenerator *s,
+                                 GlobalConfig *cfg,
+                                 gpointer a,
+                                 GString *result,
+                                 const gchar *reference)
+{
+  PythonConfigGenerator *self = (PythonConfigGenerator *) s;
+  PyGILState_STATE gstate;
+  CfgArgs *args = (CfgArgs *) a;
+  gboolean success = FALSE;
+
+  gstate = PyGILState_Ensure();
+  PyObject *py_args = _py_construct_cfg_args((CfgArgs *) args);
+  PyObject *res = _py_invoke_function(self->py_generator_function, py_args, NULL, reference);
+  Py_XDECREF(py_args);
+
+  if (res)
+    {
+      const gchar *generated_config;
+      if (py_bytes_or_string_to_string(res, &generated_config))
+        {
+          g_string_assign(result, generated_config);
+          success = TRUE;
+        }
+      else
+        {
+          msg_error("python-confgen: generator function returned a non-string value",
+                    evt_tag_str("reference", reference));
+        }
+      Py_DECREF(res);
+    }
+  PyGILState_Release(gstate);
+  return success;
+}
+
+static void
+python_config_generator_free(CfgBlockGenerator *s)
+{
+  PythonConfigGenerator *self = (PythonConfigGenerator *) s;
+  PyGILState_STATE gstate;
+
+  gstate = PyGILState_Ensure();
+  Py_XDECREF(self->py_generator_function);
+  PyGILState_Release(gstate);
+  cfg_block_generator_free_instance(s);
+}
+
+CfgBlockGenerator *
+python_config_generator_new(gint context, const gchar *name, PyObject *py_generator_function)
+{
+  PythonConfigGenerator *self = g_new0(PythonConfigGenerator, 1);
+
+  cfg_block_generator_init_instance(&self->super, context, name);
+  self->super.generate = python_config_generator_generate;
+  self->super.free_fn = python_config_generator_free;
+  self->py_generator_function = py_generator_function;
+  return &self->super;
+}
+
+void
+python_confgen_register(gint context, const gchar *name, PyObject *py_generator_function)
+{
+  CfgBlockGenerator *confgen;
+
+  confgen = python_config_generator_new(context, name, py_generator_function);
+  cfg_lexer_register_generator_plugin(&configuration->plugin_context, confgen);
+}
+
+static PyObject *
+py_register_config_generator(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+  PyObject *generator_function;
+  gchar *context_name;
+  gchar *name;
+
+  static const gchar *kwlist[] = { "context", "name", "config_generator", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "ssO", (gchar **) kwlist,
+                                   &context_name, &name, &generator_function))
+    return NULL;
+
+  gint context_value = cfg_lexer_lookup_context_type_by_name(context_name);
+  if (!context_value)
+    {
+      PyErr_Format(PyExc_ValueError, "unknown context value %s", context_name);
+      return NULL;
+    }
+
+  python_confgen_register(context_value, name, generator_function);
+
+  Py_RETURN_NONE;
+}
+
+static PyMethodDef py_confgen_methods[] =
+{
+  { "register_config_generator", (PyCFunction) py_register_config_generator, METH_VARARGS | METH_KEYWORDS, "Register a config generator plugin" },
+  { NULL }
+};
+
+void
+py_init_confgen(void)
+{
+  PyObject *module = PyImport_AddModule("_syslogng");
+  PyModule_AddFunctions(module, py_confgen_methods);
+}

--- a/modules/python/python-confgen.h
+++ b/modules/python/python-confgen.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 Balazs Scheidler <bazsi77@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef _SNG_PYTHON_CONFGEN_H
+#define _SNG_PYTHON_CONFGEN_H
+
+#include "python-module.h"
+
+void py_init_confgen(void);
+
+#endif

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -111,12 +111,6 @@ python_dd_set_loaders(LogDriver *d, GList *loaders)
   self->loaders = loaders;
 }
 
-PyObject *
-python_dd_create_arg_dict(PythonDestDriver *self)
-{
-  return _py_create_arg_dict(self->options);
-}
-
 LogTemplateOptions *
 python_dd_get_template_options(LogDriver *d)
 {

--- a/modules/python/python-helpers.c
+++ b/modules/python/python-helpers.c
@@ -261,7 +261,7 @@ _py_invoke_function(PyObject *func, PyObject *arg, const gchar *class, const gch
 
       msg_error("Exception while calling a Python function",
                 evt_tag_str("caller", caller_context),
-                evt_tag_str("class", class),
+                evt_tag_str("class", class ? : "unknown"),
                 evt_tag_str("function", _py_get_callable_name(func, buf1, sizeof(buf1))),
                 evt_tag_str("exception", _py_format_exception_text(buf2, sizeof(buf2))));
       _py_finish_exception_handling();

--- a/modules/python/python-helpers.c
+++ b/modules/python/python-helpers.c
@@ -250,6 +250,14 @@ _py_create_arg_dict(GHashTable *args)
 }
 
 PyObject *
+_py_construct_cfg_args(CfgArgs *args)
+{
+  PyObject *arg_dict = PyDict_New();
+  cfg_args_foreach(args, _insert_to_dict, arg_dict);
+  return arg_dict;
+}
+
+PyObject *
 _py_invoke_function(PyObject *func, PyObject *arg, const gchar *class, const gchar *caller_context)
 {
   PyObject *ret;

--- a/modules/python/python-helpers.h
+++ b/modules/python/python-helpers.h
@@ -25,6 +25,7 @@
 #define PYTHON_HELPERS_H_INCLUDED 1
 
 #include "python-module.h"
+#include "cfg-args.h"
 
 const gchar *_py_get_callable_name(PyObject *callable, gchar *buf, gsize buf_len);
 const gchar *_py_format_exception_text(gchar *buf, gsize buf_len);
@@ -33,6 +34,7 @@ PyObject *_py_get_attr_or_null(PyObject *o, const gchar *attr);
 PyObject *_py_do_import(const gchar *modname);
 PyObject *_py_resolve_qualified_name(const gchar *name);
 PyObject *_py_create_arg_dict(GHashTable *args);
+PyObject *_py_construct_cfg_args(CfgArgs *args);
 PyObject *_py_invoke_function(PyObject *func, PyObject *arg, const gchar *class, const gchar *caller_context);
 PyObject *_py_invoke_function_with_args(PyObject *func, PyObject *args, const gchar *class,
                                         const gchar *caller_context);

--- a/modules/python/python-main.c
+++ b/modules/python/python-main.c
@@ -40,6 +40,7 @@
 #include "python-bookmark.h"
 #include "python-ack-tracker.h"
 #include "python-debugger.h"
+#include "python-confgen.h"
 
 #include "cfg.h"
 #include "messages.h"
@@ -552,6 +553,7 @@ _py_initialize_builtin_modules(void)
 {
   py_init_threads();
   py_init_types();
+  py_init_confgen();
 
   py_log_message_global_init();
   py_log_template_global_init();

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -86,12 +86,14 @@ libtest/mock-logpipe\.[ch]
 lib/generic-number\.[ch]
 lib/tests/test_generic_number\.c
 syslog-ng-ctl/commands/log-level.[ch]
+modules/python-modules/syslogng/confgen\.py
 modules/python-modules/syslogng/dest\.py
 modules/python-modules/syslogng/logger\.py
 modules/python-modules/syslogng/message\.py
 modules/python-modules/syslogng/parser\.py
 modules/python-modules/syslogng/source\.py
 modules/python-modules/syslogng/template\.py
+modules/python/python-confgen\.[ch]
 
 ###########################################################################
 # These tests are GPLd even though they reside under lib/ and are excluded


### PR DESCRIPTION
This PR is split off from #4175 and implements Python based confgen. The original confgen module allows someone to write an external script/program to generate parts of the syslog-ng configuration.

This PR brings this into the syslog-ng process by allowing you to execute a Python function instead of the external script. An example how this can be used is in #4175 or this example:

```
@version: 4.0

python {
from syslogng import register_config_generator

def generate_foobar(args):
	print(args)
	return "tcp(port(2000))"

register_config_generator("source", "foobar", generate_foobar)

};

log {
	source { foobar(this(is) a(value)); };
	destination { file("logfile"); };
};

```

Please notice that the source declaration in the log statements towards the end of the example uses the foobar() source. That same foobar source is a registered in the Python block at the top of the file:

```
register_config_generator("source", "foobar", generate_foobar)
```

This tells syslog-ng that whenever it encounters the "foobar" token in a "source" context, it calls the function specified. That function receives the set of arguments in its "args" parameter (a dict) and can emit whatever config should be inserted in place of the foobar() reference. This is the same infrastructure that blocks use, it's just using program code to generate the resulting output.

Use cases:
- configuration that depends on something external (e.g. environment variable or some file content)
- a complex config that is easier to generate (e.g. load-balancing configs or app-parser())