### PR TITLE
light: use the github repository of flake8

### DIFF
--- a/tests/light/.pre-commit-config.yaml
+++ b/tests/light/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
         files: 'tests/light/'
     -   id: end-of-file-fixer
         files: 'tests/light/'
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.7.7
     hooks:
     -   id: flake8


### PR DESCRIPTION
flake8 has migrated to github from gitlab and the old reference does not work anymore causing the CI to fail. More information here:

  https://github.com/PyCQA/flake8/issues/1290

