### PR TITLE
examples: add missing CMakeLists.txt to tarball

### DIFF
--- a/modules/examples/inner-destinations/http-test-slots/Makefile.am
+++ b/modules/examples/inner-destinations/http-test-slots/Makefile.am
@@ -12,7 +12,9 @@ BUILT_SOURCES += \
   modules/examples/inner-destinations/http-test-slots/http-test-slots-grammar.c \
   modules/examples/inner-destinations/http-test-slots/http-test-slots-grammar.h
 
-EXTRA_DIST += modules/examples/inner-destinations/http-test-slots/http-test-slots-grammar.ym
+EXTRA_DIST += \
+  modules/examples/inner-destinations/http-test-slots/CMakeLists.txt \
+  modules/examples/inner-destinations/http-test-slots/http-test-slots-grammar.ym
 
 modules_examples_inner_destinations_http_test_slots_libhttp_test_slots_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/modules/examples/inner-destinations/http-test-slots -I$(top_builddir)/modules/examples/inner-destinations/http-test-slots
 modules_examples_inner_destinations_http_test_slots_libhttp_test_slots_la_LIBADD = $(MODULE_DEPS_LIBS)


### PR DESCRIPTION
Found when trying to build with cmake from a tarball.

No news file needed.

Signed-off-by: Attila Szakacs <szakacs.attila96@gmail.com>

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
