### PR TITLE
contrib: add pcre dependency to macOS Brewfile

### DIFF
--- a/contrib/Brewfile
+++ b/contrib/Brewfile
@@ -11,7 +11,7 @@ brew "ivykis"
 brew "rabbitmq-c"
 brew "mongo-c-driver"
 brew "openssl@1.1"
-# brew "pcre"
+brew "pcre"
 
 brew "gradle"
 brew "python@3", link: true, force: true


### PR DESCRIPTION
This fixes the macOS CI build.

(pcre was probably fetched transitively until now, but everyone is transitioning to pcre2, so should we: 4140)