### PR TITLE
Enhance make, cmake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,3 +417,6 @@ set(includedir "\${includedir}")
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/syslog-ng.pc.cmake ${CMAKE_CURRENT_BINARY_DIR}/syslog-ng.pc)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/syslog-ng.pc DESTINATION lib/pkgconfig)
+
+include(print_config_summary)
+print_config_summary()

--- a/cmake/Modules/FindRiemannClient.cmake
+++ b/cmake/Modules/FindRiemannClient.cmake
@@ -24,6 +24,9 @@
 include(LibFindMacros)
 
 libfind_pkg_detect(Riemann riemann-client FIND_PATH riemann/event.h FIND_LIBRARY riemann-client)
+if (NOT Riemann_LIBRARY)
+  libfind_pkg_detect(Riemann riemann-client FIND_PATH riemann/event.h FIND_LIBRARY riemann-client-no-tls)
+endif()
 set(Riemann_PROCESS_INCLUDES Riemann_INCLUDE_DIR)
 set(Riemann_PROCESS_LIBS Riemann_LIBRARY)
 

--- a/cmake/print_config_summary.cmake
+++ b/cmake/print_config_summary.cmake
@@ -1,0 +1,56 @@
+# ############################################################################
+# Copyright (c) 2022 One Identity
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+# ############################################################################
+
+# Lists actual module definition results
+# Behaves similar to the cmake -L option but filters out the relevant information and adds some highlighting
+#
+function(print_config_summary)
+  get_cmake_property(_variableNames VARIABLES)
+  list(SORT _variableNames)
+
+  message(STATUS "-----------------------------")
+  message(STATUS "syslog-ng Open Source Edition ${SYSLOG_NG_VERSION} configured")
+  message(STATUS "-----------------------------")
+
+  string(ASCII 27 Esc)
+  set(Red "${Esc}[31m")
+  set(Green "${Esc}[32m")
+
+  foreach(_variableName ${_variableNames})
+    string(REGEX MATCH "^ENABLE_" _match "${_variableName}")
+
+    if(_match)
+      string(LENGTH "${_variableName}" _variableNameLen)
+      math(EXPR _variableNameLen "32 - ${_variableNameLen}")
+      string(REPEAT " " ${_variableNameLen} _spaces)
+      string(REGEX MATCH "^[Oo][Nn]" _on "${${_variableName}}")
+
+      if(_on)
+        message("${_variableName}${_spaces}${Green}On")
+      else()
+        message("${_variableName}${_spaces}${Red}Off")
+      endif()
+    endif()
+  endforeach()
+  
+endfunction ()


### PR DESCRIPTION
- Fixed some automake and cmake issues happened building syslog-ng on macOS (Silicon/Ventura 13.1)
- Added a module enabled state summary to configure end

![image](https://user-images.githubusercontent.com/12213492/204590182-556f1c6a-6c2e-498a-8200-2a69ebad2218.png)
