### PR TITLE
GitHub Actions: fix (some) deprecation warnings

### DIFF
--- a/.github/workflows/comment-on-version-bump-pr.yml
+++ b/.github/workflows/comment-on-version-bump-pr.yml
@@ -21,7 +21,7 @@ jobs:
       COMMIT_URL: https://github.com/${{ github.repository_owner }}/syslog-ng/commit/${{ github.sha }}
     steps:
       - name: Checkout syslog-ng source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check if version bump PR is open
         run: |

--- a/.github/workflows/create-packages.yml
+++ b/.github/workflows/create-packages.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Download source tarball artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.source-tarball-artifact-name }}
 

--- a/.github/workflows/dbld-images.yml
+++ b/.github/workflows/dbld-images.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set container registry
         run: |

--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -101,7 +101,7 @@ jobs:
         run: make VERBOSE=1 func-test
 
       - name: "Artifact: test-suite.log"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always() && steps.make_check.outcome == 'failure'
         with:
           name: test-suite-${{ matrix.build-tool }}-${{ matrix.cc }}
@@ -126,7 +126,7 @@ jobs:
           rm -f `find /tmp/light-reports -type p,s`
 
       - name: "Artifact: light-reports"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always() && steps.prepare-light-reports.outcome == 'success'
         with:
           name: light-reports-${{ matrix.build-tool }}-${{ matrix.cc }}
@@ -140,7 +140,7 @@ jobs:
             gdb --ex="thread apply all bt full" --ex="quit" ${SYSLOG_NG_INSTALL_DIR}/sbin/syslog-ng --core {} \;
 
       - name: "Artifact: corefiles"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: corefiles-${{ matrix.build-tool }}-${{ matrix.cc }}
@@ -226,14 +226,14 @@ jobs:
             (git diff > ../light-style-problems.diff ; git reset --hard HEAD && exit 1)
 
       - name: "Artifact: c-style-problems"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always() && steps.c-style-check.outcome == 'failure'
         with:
           name: c-style-problems
           path: c-style-problems.diff
 
       - name: "Artifact: light-style-problems"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always() && steps.light-style-check.outcome == 'failure'
         with:
           name: light-style-problems

--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout syslog-ng source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup environment
         run: |
@@ -154,7 +154,7 @@ jobs:
 
     steps:
       - name: Checkout syslog-ng source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set ENV variables
         run: |
@@ -194,7 +194,7 @@ jobs:
 
     steps:
       - name: Checkout syslog-ng source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Prepare
         run: |
@@ -248,7 +248,7 @@ jobs:
 
     steps:
       - name: Checkout syslog-ng source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Copyright check
         run: tests/copyright/check.sh . .
@@ -267,7 +267,7 @@ jobs:
 
     steps:
       - name: Checkout syslog-ng source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -254,7 +254,7 @@ jobs:
         run: tests/copyright/check.sh . .
 
       - name: "Artifact: copyright-run.log"
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: copyright-run.log

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -49,7 +49,7 @@ jobs:
             --field body="${COMMENT}"
 
       - name: Checkout syslog-ng source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup environment
         id: setup-environment
@@ -96,7 +96,7 @@ jobs:
     needs: [create-release-tarball, upload-packages]
     steps:
       - name: Checkout syslog-ng source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download release tarball artifact
         uses: actions/download-artifact@v2

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download release tarball artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: release-tarball
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -70,7 +70,7 @@ jobs:
           ./dbld/rules release VERSION=${VERSION}
 
       - name: Store release tarball as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: release-tarball
           path: ${{ env.TARBALL_PATH }}

--- a/.github/workflows/index-packages.yml
+++ b/.github/workflows/index-packages.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Prepare environment
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macOS-latest
     steps:
       - name: Checkout syslog-ng source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Unlinking preinstalled Python 2 (workaround)
         # The python@3 brew package has to be installed and linked system-wide (it's a dependency of glib and syslog-ng)

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -22,7 +22,7 @@ jobs:
         run: ./dbld/rules pkg-tarball
 
       - name: Store source tarball as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: source-tarball
           path: dbld/build/*.tar.gz

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout syslog-ng source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/package-indexer-checks.yml
+++ b/.github/workflows/package-indexer-checks.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build docker image
         run: |

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -22,7 +22,7 @@ jobs:
         run: ./dbld/rules pkg-tarball
 
       - name: Store source tarball as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: source-tarball
           path: dbld/build/*.tar.gz

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout syslog-ng source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout syslog-ng source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v1

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -1,5 +1,8 @@
-name: Stable release
+# Please note that the syslog-ng git repository is not available in this workflow.
+# It means that certain convenience/helper functions are not available (e.g. gh_output).
+# This is intentional as syslog-ng will be acquired from the tarball.
 
+name: Stable release
 
 on:
   workflow_dispatch:

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -42,7 +42,7 @@ jobs:
             false
           fi
 
-          echo "::set-output name=DRAFT_RELEASE_RUN_ID::${DRAFT_RELEASE_RUN_ID}"
+          echo "{DRAFT_RELEASE_RUN_ID}=${DRAFT_RELEASE_RUN_ID}" >> $GITHUB_OUTPUT
 
   index-packages:
     needs: find-draft-release-run

--- a/.github/workflows/test-apt-packages.yml
+++ b/.github/workflows/test-apt-packages.yml
@@ -1,5 +1,8 @@
-name: Run smoke tests on APT packages
+# Please note that the syslog-ng git repository is not available in this workflow.
+# It means that certain convenience/helper functions are not available (e.g. gh_output).
+# This is intentional as syslog-ng will be acquired from the APT repository.
 
+name: Run smoke tests on APT packages
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/test-apt-packages.yml
+++ b/.github/workflows/test-apt-packages.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Get syslog-ng revision
         run: |
           syslog-ng -V
-          echo "::set-output name=REVISION::$(syslog-ng -V | grep Revision | cut -d" " -f2)"
+          echo "{REVISION}={$(syslog-ng -V | grep Revision | cut -d" " -f2)}" >> $GITHUB_OUTPUT
         id: syslog_ng_revision
 
       - name: Check revision

--- a/.github/workflows/upload-packages.yml
+++ b/.github/workflows/upload-packages.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Download package artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: package-${{ matrix.distro }}
           path: package

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -40,7 +40,7 @@ jobs:
       CURRENT_RUN_URL: https://github.com/${{ github.repository_owner }}/syslog-ng/actions/runs/${{ github.run_id }}
     steps:
       - name: Checkout syslog-ng source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -78,7 +78,7 @@ jobs:
           ./dbld/rules release VERSION=${RELEASE_VERSION}
 
       - name: Upload tarball
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: syslog-ng-${{ env.RELEASE_VERSION }}
           path: dbld/release/${{ env.RELEASE_VERSION }}/syslog-ng-${{ env.RELEASE_VERSION }}.tar.gz


### PR DESCRIPTION
<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
Currently there are some warnings in the CI (see https://github.com/syslog-ng/syslog-ng/actions/runs/3608033376 for example).

- [X]  Nodejs 12 deprecation --> simple version bumps should take care of it
- [X]  [GitHub Actions: Deprecating save-state and set-output commands ](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) --> I updated the `set-output` as suggested by the official blog post.
- [ ] [CI @ devshell: .github#L1](https://github.com/syslog-ng/syslog-ng/commit/2debcbe11bc66e70444cf6b0db108d30f472fb18#annotation_6685971219):
> The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002

This PR addresses the first two (as they are straightforward to fix) and I will happily fix the `ubuntu-18.04` environment deprecation as well, just tell me which version it should be bumped to.

No news file needed.