### PR TITLE
Freebsd unit test fixes

### DIFF
--- a/lib/timeutils/cache.c
+++ b/lib/timeutils/cache.c
@@ -138,9 +138,9 @@ _capture_timezone_state_from_variables(void)
    * static, as we are either just starting up or being reloaded.
    **/
 
+  global_state.timezone = _get_system_tzofs();
   global_state.tzname[0] = g_strdup(tzname[0]);
   global_state.tzname[1] = g_strdup(tzname[1]);
-  global_state.timezone = _get_system_tzofs();
 }
 
 /* NOTE: copy the contents of the global cache to thread local variables */

--- a/modules/python/tests/Makefile.am
+++ b/modules/python/tests/Makefile.am
@@ -16,8 +16,7 @@ modules_python_tests_TESTS = \
 modules_python_tests_test_python_logmsg_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) -I$(top_srcdir)/modules/python
 modules_python_tests_test_python_logmsg_LDADD = $(TEST_LDADD) \
 	-dlpreopen $(top_builddir)/modules/python/libmod-python.la \
-	$(PREOPEN_SYSLOGFORMAT) \
-	$(PYTHON_LIBS)
+	$(PYTHON_LIBS) $(PREOPEN_SYSLOGFORMAT)
 
 modules_python_tests_test_python_template_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) \
 	-I$(top_srcdir)/modules/python -I$(top_srcdir)/modules/syslogformat

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -95,6 +95,7 @@ _construct_py_parse_options(void)
 void
 setup(void)
 {
+  setenv("TZ", "UTC", TRUE);
   app_startup();
 
   init_parse_options_and_load_syslogformat(&parse_options);


### PR DESCRIPTION
No NEWS file is needed, especially until the fixes in this branch are confirmed.

@yurivict I couldn't reproduce the test_python_logmsg breakage on my local FreeBSD box (e.g. as you reported it in #4230), but while testing that I've found an unrelated issue that I've fixed in this branch. 

Can you please check if it fixes both issues in your environment? Thanks.
