### PR TITLE
disk-buffer: fix truncate unit test after v4 version bump

### DIFF
--- a/modules/diskq/tests/test_diskq_truncate.c
+++ b/modules/diskq/tests/test_diskq_truncate.c
@@ -313,10 +313,12 @@ _assert_cursors_are_at_start(LogQueue *q)
   cr_assert_eq(qdisk_get_backlog_head(qdisk), QDISK_RESERVED_SPACE, "Backlog head was not reset!");
 }
 
-Test(diskq_truncate, test_diskq_truncate_size_ratio_default)
+Test(diskq_truncate, test_diskq_truncate_size_ratio_default_3_x)
 {
+  cfg_set_version_without_validation(configuration, VERSION_VALUE_3_38);
+
   LogQueue *q;
-  GString *filename = g_string_new("test_dq_truncate_size_ratio_default.rqf");
+  GString *filename = g_string_new("test_dq_truncate_size_ratio_default_3_x.rqf");
 
   DiskQueueOptions options;
   q = _create_reliable_diskqueue(filename->str, &options, TRUE, -1);


### PR DESCRIPTION
The default for `truncate-size-ratio()` changed from `v3.x`'s 0.1 to `v4.x`'s 1.

The `truncate-size-ratio(1)` case is tested in the `test_diskq_truncate_size_ratio_1` unit test case, but we want tests for the v3.x's default 0.1 value, too.

Signed-off-by: Attila Szakacs <szakacs.attila96@gmail.com>

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
