### PR TITLE
riemann: report flush errors with msg_error() instead of trace

### DIFF
--- a/modules/riemann/riemann-worker.c
+++ b/modules/riemann/riemann-worker.c
@@ -351,22 +351,29 @@ riemann_worker_flush(LogThreadedDestWorker *s, LogThreadedFlushMode mode)
       return LTR_ERROR;
     }
 
-  msg_trace("riemann: flushing messages to Riemann server",
-            evt_tag_str("server", owner->server),
-            evt_tag_int("port", owner->port),
-            evt_tag_int("batch_size", self->event.n),
-            evt_tag_int("ok", r->ok),
-            evt_tag_str("error", r->error),
-            evt_tag_str("driver", owner->super.super.super.id),
-            log_pipe_location_tag(&owner->super.super.super.super));
-
   if ((r->error) || (r->has_ok && !r->ok))
     {
+      msg_error("riemann: flushing messages to Riemann server failed",
+                evt_tag_str("server", owner->server),
+                evt_tag_int("port", owner->port),
+                evt_tag_int("batch_size", self->event.n),
+                evt_tag_int("ok", r->ok),
+                evt_tag_str("error", r->error),
+                evt_tag_str("driver", owner->super.super.super.id),
+                log_pipe_location_tag(&owner->super.super.super.super));
       riemann_message_free(r);
       return LTR_ERROR;
     }
   else
     {
+      msg_debug("riemann: flushing messages to Riemann server successful",
+                evt_tag_str("server", owner->server),
+                evt_tag_int("port", owner->port),
+                evt_tag_int("batch_size", self->event.n),
+                evt_tag_int("ok", r->ok),
+                evt_tag_str("error", r->error),
+                evt_tag_str("driver", owner->super.super.super.id),
+                log_pipe_location_tag(&owner->super.super.super.super));
       riemann_message_free(r);
       return LTR_SUCCESS;
     }

--- a/modules/riemann/riemann-worker.c
+++ b/modules/riemann/riemann-worker.c
@@ -348,6 +348,13 @@ riemann_worker_flush(LogThreadedDestWorker *s, LogThreadedFlushMode mode)
                                                  MAX(1, owner->super.batch_lines));
   if (!r)
     {
+      msg_error("riemann: error calling riemann_communicate()",
+                evt_tag_str("server", owner->server),
+                evt_tag_int("port", owner->port),
+                evt_tag_int("batch_size", self->event.n),
+                evt_tag_str("errno", g_strerror(errno)),
+                evt_tag_str("driver", owner->super.super.super.id),
+                log_pipe_location_tag(&owner->super.super.super.super));
       return LTR_ERROR;
     }
 

--- a/news/bugfix-4238.md
+++ b/news/bugfix-4238.md
@@ -1,0 +1,4 @@
+`riemann`: fixed severity levels of Riemann diagnostics messages, the error
+returned by riemann_communicate() was previously only logged at the trace
+level and was even incomplete: not covering the case where
+riemann_communicate() returns NULL.


### PR DESCRIPTION
Signed-off-by: Balazs Scheidler <bazsi77@gmail.com>

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
