### PR TITLE
configure.ac: add --with-python-packages=none

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -348,7 +348,7 @@ AC_ARG_WITH(python,
               ,,with_python="auto")
 
 AC_ARG_WITH(python-packages,
-              [  --with-python-packages=[system|venv]    Use Python packages from the system or a private virtualenv (default: venv)]
+              [  --with-python-packages=[system|venv|none]    Use Python packages from the system or a private virtualenv or skip their installation (default: venv)]
               ,,with_python_packages="venv")
 
 AC_ARG_WITH(python3-home,
@@ -1529,6 +1529,8 @@ if test "x$enable_python" = "xyes"; then
     if test "x$with_python_packages" = "xvenv"; then
         PYTHON_VENV_DIR=`pwd`/venv
         PYTHON_VENV=${PYTHON_VENV_DIR}/bin/python
+    elif test "x$with_python_packages" = "xnone"; then
+        PYTHON_VENV=$PYTHON
     else
         with_python_packages="system"
         PYTHON_VENV=$PYTHON

--- a/modules/python-modules/Makefile.am
+++ b/modules/python-modules/Makefile.am
@@ -85,10 +85,14 @@ pymodules-install: pymodules-install-requirements python-venv
 	$(install_sh_DATA) $(top_srcdir)/requirements.txt "$(PYTHON_ROOT)/$(python_moduledir)/requirements.txt"
 
 pymodules-install-requirements: python-venv
-	(cd $(PYMODULES_SRCDIR) && \
-	 mkdir -p $(PYMODULES_BUILDDIR) && \
-         $(PYTHON_VENV) setup.py egg_info --egg-base="$(PYMODULES_BUILDDIR)"  && \
-         if [ -f $(PYMODULES_BUILDDIR)/$(PYMODULES_ROOT_MODULE).egg-info/requires.txt ]; then $(PYTHON_VENV) -m pip install -r $(PYMODULES_BUILDDIR)/$(PYMODULES_ROOT_MODULE).egg-info/requires.txt; fi)
+	if [ "$(with_python_packages)" != "none" ]; then \
+		(cd $(PYMODULES_SRCDIR) && \
+		 mkdir -p $(PYMODULES_BUILDDIR) && \
+	         $(PYTHON_VENV) setup.py egg_info --egg-base="$(PYMODULES_BUILDDIR)"  && \
+		 if [ -f $(PYMODULES_BUILDDIR)/$(PYMODULES_ROOT_MODULE).egg-info/requires.txt ]; then \
+			$(PYTHON_VENV) -m pip install -r $(PYMODULES_BUILDDIR)/$(PYMODULES_ROOT_MODULE).egg-info/requires.txt; \
+		 fi) \
+	fi
 
 pymodules-uninstall:
 	sed -e 's,^,$(PYTHON_ROOT),g' $(PYMODULES_MANIFEST) | tr '\n' '\0' | xargs -0 rm -f


### PR DESCRIPTION
This change adds a new setting for --with-python-packages: "none" specifies that we should not install dependencies in any way while installing our own modules.  This allows the downstream distributor to include our Python modules without having to deploy their Python dependencies in the build environment.  This will mean that unit tests will not be able to execute, but apart from that the code is installed.

This can then be further customized by culling code that does not apply to a specific target platform.

