### PR TITLE
configure: add python-modules to all-modules

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -383,7 +383,7 @@ if test "x$enable_all_modules" != "xauto"; then
    state="$enable_all_modules"
 
    MODULES="spoof_source sun_streams sql pacct mongodb json amqp stomp \
-            redis systemd geoip2 riemann ipv6 smtp native python java java_modules \
+            redis systemd geoip2 riemann ipv6 smtp native python python_modules java java_modules \
             http afsnmp kafka mqtt"
    for mod in ${MODULES}; do
        modstate=$(eval echo \$enable_${mod})


### PR DESCRIPTION
This makes a bit of a difference when configuring:

`--disable-all-modules --enable-python`

Before: python enabled, python-modules enabled
After:  python enabled, python-modules disabled

I think we want the latter to happen.

Signed-off-by: Attila Szakacs <szakacs.attila96@gmail.com>

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
