### PR TITLE
packaging/debian: add a syslog-ng-scl package

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -48,7 +48,7 @@ Vcs-Browser: https://github.com/gcsideal/syslog-ng-debian
 Package: syslog-ng
 Architecture: all
 Multi-Arch: foreign
-Depends: ${misc:Depends}, syslog-ng-core (>= ${source:Upstream-Version}), ${sng:CoreModules}
+Depends: ${misc:Depends}, syslog-ng-core (>= ${source:Upstream-Version}), syslog-ng-scl (>= ${source:Upstream-Version}), ${sng:CoreModules}
 Recommends: ${sng:Modules}
 Description: Enhanced system logging daemon (metapackage)
  syslog-ng is an enhanced log daemon, supporting a wide range of input
@@ -584,6 +584,29 @@ Description: Enhanced system logging daemon (Kafka destination, based on librdka
  .
  This package provides a native Kafka destination, written entirely in the
  C programming language, based on the librdkafka client library.
+
+Package: syslog-ng-scl
+Architecture: all
+Multi-Arch: foreign
+Depends: ${misc:Depends}, syslog-ng-core (>= ${source:Version}), syslog-ng-core (<< ${source:Version}.1~)
+Description: Enhanced system logging daemon (scl files)
+ syslog-ng is an enhanced log daemon, supporting a wide range of input
+ and output methods: syslog, unstructured text, message queues,
+ databases (SQL and NoSQL alike) and more.
+ .
+ Key features:
+ .
+  * receive and send RFC3164 and RFC5424 style syslog messages
+  * work with any kind of unstructured data
+  * receive and send JSON formatted messages
+  * classify and structure logs with builtin parsers (csv-parser(),
+    db-parser(), etc.)
+  * normalize, crunch and process logs as they flow through the system
+  * hand on messages for further processing using message queues (like
+    AMQP), files or databases (like PostgreSQL or MongoDB).
+ .
+ This package collects scl files, scripts and config sniplets focusing on
+ specific areas, providing help creating more readable configurations.
 
 Package: syslog-ng-mod-examples
 Architecture: any

--- a/packaging/debian/syslog-ng-core.install
+++ b/packaging/debian/syslog-ng-core.install
@@ -35,11 +35,9 @@ usr/lib/syslog-ng/libloggen_helper.so
 usr/lib/syslog-ng/libloggen_plugin.so
 usr/lib/syslog-ng/libloggen_helper-*.so.*
 usr/lib/syslog-ng/libloggen_plugin-*.so.*
-usr/share/syslog-ng/include/scl/*
 usr/share/syslog-ng/xsd/*
 [linux-any] usr/lib/syslog-ng/*/libsdjournal.so
 [linux-any] usr/lib/syslog-ng/*/libpacctformat.so
-[linux-any] usr/share/syslog-ng/include/scl/pacct/*
 
 #[!kfreebsd-any] lib/systemd/system/*
 [!kfreebsd-any] debian/syslog-ng.systemd =>  lib/systemd/system/syslog-ng.service

--- a/packaging/debian/syslog-ng-scl.install
+++ b/packaging/debian/syslog-ng-scl.install
@@ -1,0 +1,1 @@
+usr/share/syslog-ng/include/scl/*


### PR DESCRIPTION
To mimic how syslog-ng is packaged on Debian, supply an "scl" package to contain all our SCL files.

This resolves an issue with updating from Debian installed syslog-ng to our own packages that caused problems in 4.0.0
