### PR TITLE
.github/workflows/test-apt-packages: test against Debian's official packages

### DIFF
--- a/.github/workflows/test-apt-packages.yml
+++ b/.github/workflows/test-apt-packages.yml
@@ -19,6 +19,9 @@ jobs:
           - "ubuntu:bionic"
           - "ubuntu:focal"
           - "ubuntu:jammy"
+        upgrade-from:
+          - "debian-official"
+          - "syslog-ng-last"
       fail-fast: false
     runs-on: ubuntu-latest
     container: ${{ matrix.distro }}
@@ -28,12 +31,19 @@ jobs:
           apt-get update -qq
           apt-get install --yes wget gnupg2 ca-certificates apt-transport-https
 
+      - name: Install the Debian official syslog-ng OSE package
+        if: matrix.upgrade-from == "debian-official"
+        run: |
+          apt-get update -qq
+          DEBIAN_FRONTEND=noninteractive apt-get install --yes syslog-ng
+
       - name: Add OSE repository
         run: |
           wget -qO - https://ose-repo.syslog-ng.com/apt/syslog-ng-ose-pub.asc | gpg --dearmor > /usr/share/keyrings/ose-repo-archive-keyring.gpg
           echo "deb [signed-by=/usr/share/keyrings/ose-repo-archive-keyring.gpg] https://ose-repo.syslog-ng.com/apt/ ${{ inputs.pkg_type }} $(echo ${{ matrix.distro }} | sed 's/:/-/g')" | tee --append /etc/apt/sources.list.d/syslog-ng-ose.list
 
       - name: Install the last but one syslog-ng OSE package
+        if: matrix.upgrade-from == "syslog-ng-last"
         run: |
           apt-get update -qq
           DEBIAN_FRONTEND=noninteractive apt-get install --yes syslog-ng=$(apt-cache madison syslog-ng | sed -n 2p | awk -F"|" '{print $2}' | sed 's/ //g')


### PR DESCRIPTION
This is an emergency PR to help resolve our 4.0.0 release related issue. It adds coverage for smoke testing .deb packages against Debian's official packages, not just against our own, previous version.

The PR does not touch code, except a .github workflow and should cause the nightly to fail (which it should have previously as well).

Once nightly fails, I can resolve that using the packaging fix I have in #4252 