### PR TITLE
Secret-storage no unlock fix

### DIFF
--- a/lib/secret-storage/secret-storage.c
+++ b/lib/secret-storage/secret-storage.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 One Identity LLC
  * Copyright (c) 2018 Balabit
  *
  * This library is free software; you can redistribute it and/or
@@ -79,6 +80,8 @@ void
 secret_storage_deinit(void)
 {
   g_assert(!secret_manager_uninitialized);
+  g_atomic_int_inc(&secret_manager_uninitialized);
+  g_assert(secret_manager_uninitialized == 1);
   g_hash_table_destroy(secret_manager);
   secret_manager = NULL;
 }

--- a/news/bugfix-4276.md
+++ b/news/bugfix-4276.md
@@ -1,0 +1,1 @@
+Fixed issue with secret-storage not unlocking.


### PR DESCRIPTION
<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->
A small bugfix concerning proper shutdown.
the bug concerns the mutex guarding the initialisation of secret-storage, where the mutex has been locked, but no unlock is present.
<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
