### PR TITLE
tlscontext: add ignore-unexpected-eof option for TLS

### DIFF
--- a/lib/transport/tls-context.c
+++ b/lib/transport/tls-context.c
@@ -219,6 +219,13 @@ tls_context_setup_ssl_options(TLSContext *self)
       if(self->ssl_options & TSO_NOTLSv13)
         ssl_options |= SSL_OP_NO_TLSv1_3;
 #endif
+
+#ifdef SSL_OP_IGNORE_UNEXPECTED_EOF
+      if (self->ssl_options & TSO_IGNORE_UNEXPECTED_EOF)
+        ssl_options |= SSL_OP_IGNORE_UNEXPECTED_EOF;
+#endif
+
+
 #ifdef SSL_OP_CIPHER_SERVER_PREFERENCE
       if (self->mode == TM_SERVER)
         ssl_options |= SSL_OP_CIPHER_SERVER_PREFERENCE;
@@ -605,6 +612,10 @@ tls_context_set_ssl_options_by_name(TLSContext *self, GList *options)
 #ifdef SSL_OP_NO_TLSv1_3
       else if (strcasecmp(l->data, "no-tlsv13") == 0 || strcasecmp(l->data, "no_tlsv13") == 0)
         self->ssl_options |= TSO_NOTLSv13;
+#endif
+#ifdef SSL_OP_IGNORE_UNEXPECTED_EOF
+      else if (strcasecmp(l->data, "ignore-unexpected-eof") == 0 || strcasecmp(l->data, "ignore_unexpected_eof") == 0)
+        self->ssl_options |= TSO_IGNORE_UNEXPECTED_EOF;
 #endif
       else
         return FALSE;

--- a/lib/transport/tls-context.h
+++ b/lib/transport/tls-context.h
@@ -53,6 +53,7 @@ typedef enum
   TSO_NOTLSv11=0x0008,
   TSO_NOTLSv12=0x0010,
   TSO_NOTLSv13=0x0020,
+  TSO_IGNORE_UNEXPECTED_EOF=0x0040,
 } TLSSslOptions;
 
 typedef enum


### PR DESCRIPTION
> Some TLS implementations do not send the mandatory close_notify alert on
> shutdown. If the application tries to wait for the close_notify alert but
> the peer closes the connection without sending it, an error is generated.

Error message:
> error:0A000126:SSL routines::unexpected eof while reading

This option disables above error messages but enables the possibility of undetected truncation attacks.

Do not use this option unless you are actively hit by this error message, AND you use an acknowledged protocol type that prevents/detects truncation, AND you have no control over fixing the other side that does not send close_notify as it should.

In any other cases, update/fix the other party that does not send close_notify properly.