### PR TITLE
add sdata-parser() & accept unquoted RFC5424 SD-PARAM-VALUE

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -230,12 +230,11 @@
 
 %token KW_THROTTLE                    10170
 %token KW_THREADED                    10171
-%token KW_PASS_UNIX_CREDENTIALS       10231
 
-%token KW_PERSIST_NAME                10302
-
-%token KW_READ_OLD_RECORDS            10304
-%token KW_USE_SYSLOGNG_PID            10305
+%token KW_PASS_UNIX_CREDENTIALS       10180
+%token KW_PERSIST_NAME                10181
+%token KW_READ_OLD_RECORDS            10182
+%token KW_USE_SYSLOGNG_PID            10183
 
 /* log statement options */
 %token KW_FLAGS                       10190

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -278,6 +278,7 @@
 
 %token KW_DEFAULT_FACILITY            10300
 %token KW_DEFAULT_SEVERITY            10301
+%token KW_SDATA_PREFIX                10302
 
 %token KW_PORT                        10323
 /* misc options */
@@ -1317,6 +1318,11 @@ msg_format_option
 	    if (last_msg_format_options->default_pri == 0xFFFF)
 	      last_msg_format_options->default_pri = LOG_NOTICE;
 	    last_msg_format_options->default_pri = (last_msg_format_options->default_pri & LOG_PRIMASK) | $3;
+          }
+        | KW_SDATA_PREFIX '(' string ')'
+          {
+            msg_format_options_set_sdata_prefix(last_msg_format_options, $3);
+            free($3);
           }
         ;
 

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -132,6 +132,7 @@ static CfgLexerKeyword main_keywords[] =
   { "default_priority",   KW_DEFAULT_SEVERITY },
   { "default_severity",   KW_DEFAULT_SEVERITY },
   { "default_facility",   KW_DEFAULT_FACILITY },
+  { "sdata_prefix",       KW_SDATA_PREFIX },
   { "threaded",           KW_THREADED },
   { "use_rcptid",         KW_USE_RCPTID, KWS_OBSOLETE, "This has been deprecated, try use_uniqid() instead" },
   { "use_uniqid",         KW_USE_UNIQID },

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -189,6 +189,13 @@ msg_format_parse(MsgFormatOptions *options, const guchar *data, gsize length)
 }
 
 void
+msg_format_options_set_sdata_prefix(MsgFormatOptions *options, const gchar *prefix)
+{
+  g_free(options->sdata_prefix);
+  options->sdata_prefix = g_strdup(prefix);
+}
+
+void
 msg_format_options_defaults(MsgFormatOptions *options)
 {
   options->flags = LP_EXPECT_HOSTNAME | LP_STORE_LEGACY_MSGHDR;
@@ -197,6 +204,8 @@ msg_format_options_defaults(MsgFormatOptions *options)
   options->bad_hostname = NULL;
   options->default_pri = 0xFFFF;
   options->sdata_param_value_max = 65535;
+  options->sdata_prefix = NULL;
+  options->sdata_prefix_len = 0;
 }
 
 /* NOTE: _init needs to be idempotent when called multiple times w/o invoking _destroy */
@@ -221,6 +230,10 @@ msg_format_options_init(MsgFormatOptions *options, GlobalConfig *cfg)
   p = cfg_find_plugin(cfg, LL_CONTEXT_FORMAT, options->format);
   if (p)
     options->format_handler = plugin_construct(p);
+
+  if (!options->sdata_prefix)
+    options->sdata_prefix = g_strdup(logmsg_sd_prefix);
+  options->sdata_prefix_len = strlen(options->sdata_prefix);
   options->initialized = TRUE;
 }
 
@@ -234,6 +247,7 @@ msg_format_options_copy(MsgFormatOptions *options, const MsgFormatOptions *sourc
   options->default_pri = source->default_pri;
   options->recv_time_zone = g_strdup(source->recv_time_zone);
   options->sdata_param_value_max = source->sdata_param_value_max;
+  options->sdata_prefix = g_strdup(source->sdata_prefix);
 }
 
 void
@@ -254,6 +268,7 @@ msg_format_options_destroy(MsgFormatOptions *options)
       time_zone_info_free(options->recv_time_zone_info);
       options->recv_time_zone_info = NULL;
     }
+  g_free(options->sdata_prefix);
   options->initialized = FALSE;
 }
 

--- a/lib/msg-format.h
+++ b/lib/msg-format.h
@@ -73,6 +73,8 @@ typedef struct _MsgFormatOptions
   gchar *recv_time_zone;
   TimeZoneInfo *recv_time_zone_info;
   regex_t *bad_hostname;
+  gchar *sdata_prefix;
+  gsize sdata_prefix_len;
   gint sdata_param_value_max;
 } MsgFormatOptions;
 
@@ -97,6 +99,8 @@ void msg_format_parse_into(MsgFormatOptions *options, LogMessage *msg,
 
 LogMessage *msg_format_construct_message(MsgFormatOptions *options, const guchar *data, gsize length);
 LogMessage *msg_format_parse(MsgFormatOptions *options, const guchar *data, gsize length);
+
+void msg_format_options_set_sdata_prefix(MsgFormatOptions *options, const gchar *prefix);
 
 void msg_format_options_defaults(MsgFormatOptions *options);
 void msg_format_options_init(MsgFormatOptions *parse_options, GlobalConfig *cfg);

--- a/modules/correlation/tests/test_patternize.c
+++ b/modules/correlation/tests/test_patternize.c
@@ -87,7 +87,6 @@ _get_logmessages(const gchar *logs)
       g_free(logline);
     }
 
-  msg_format_options_destroy(&parse_options);
   g_strfreev(input_lines);
   return self;
 }

--- a/modules/syslogformat/CMakeLists.txt
+++ b/modules/syslogformat/CMakeLists.txt
@@ -6,6 +6,8 @@ set(SYSLOGFORMAT_SOURCES
     syslog-parser-parser.h
     syslog-parser.c
     syslog-parser.h
+    sdata-parser.c
+    sdata-parser.h
 )
 
 add_module(

--- a/modules/syslogformat/Makefile.am
+++ b/modules/syslogformat/Makefile.am
@@ -7,7 +7,10 @@ modules_syslogformat_libsyslogformat_la_SOURCES	=	\
 	modules/syslogformat/syslog-parser-parser.c	\
 	modules/syslogformat/syslog-parser-parser.h	\
 	modules/syslogformat/syslog-parser.c		\
-	modules/syslogformat/syslog-parser.h
+	modules/syslogformat/syslog-parser.h		\
+	modules/syslogformat/sdata-parser.c		\
+	modules/syslogformat/sdata-parser.h
+
 
 BUILT_SOURCES					+=	\
 	modules/syslogformat/syslog-parser-grammar.c	\

--- a/modules/syslogformat/sdata-parser.c
+++ b/modules/syslogformat/sdata-parser.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2023 Balázs Scheidler <bazsi77@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "sdata-parser.h"
+#include "syslog-format.h"
+
+
+static gboolean
+sdata_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, const gchar *input,
+                     gsize input_len)
+{
+  SDataParser *self = (SDataParser *) s;
+  LogMessage *msg;
+
+  msg = log_msg_make_writable(pmsg, path_options);
+  msg_trace("sdata-parser() message processing started",
+            evt_tag_str("input", input),
+            evt_tag_msg_reference(*pmsg));
+
+  const guchar *data = (const guchar *) input;
+  gint data_len = input_len;
+  return log_msg_parse_sd(msg, &data, &data_len, &self->parse_options);
+}
+
+static gboolean
+sdata_parser_init(LogPipe *s)
+{
+  SDataParser *self = (SDataParser *) s;
+
+  msg_format_options_init(&self->parse_options, log_pipe_get_config(s));
+  return log_parser_init_method(s);
+}
+
+static LogPipe *
+sdata_parser_clone(LogPipe *s)
+{
+  SDataParser *self = (SDataParser *) s;
+  SDataParser *cloned;
+
+  cloned = (SDataParser *) sdata_parser_new(s->cfg);
+  cloned->super.template = log_template_ref(self->super.template);
+  msg_format_options_copy(&cloned->parse_options, &self->parse_options);
+  return &cloned->super.super;
+}
+
+static void
+sdata_parser_free(LogPipe *s)
+{
+  SDataParser *self = (SDataParser *) s;
+
+  msg_format_options_destroy(&self->parse_options);
+  log_parser_free_method(s);
+}
+
+
+LogParser *
+sdata_parser_new(GlobalConfig *cfg)
+{
+  SDataParser *self = g_new0(SDataParser, 1);
+
+  log_parser_init_instance(&self->super, cfg);
+  self->super.super.free_fn = sdata_parser_free;
+  self->super.super.clone = sdata_parser_clone;
+  self->super.super.init = sdata_parser_init;
+  self->super.process = sdata_parser_process;
+  msg_format_options_defaults(&self->parse_options);
+  return &self->super;
+}

--- a/modules/syslogformat/sdata-parser.c
+++ b/modules/syslogformat/sdata-parser.c
@@ -38,7 +38,7 @@ sdata_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path
 
   const guchar *data = (const guchar *) input;
   gint data_len = input_len;
-  return log_msg_parse_sd(msg, &data, &data_len, &self->parse_options);
+  return _syslog_format_parse_sd(msg, &data, &data_len, &self->parse_options);
 }
 
 static gboolean

--- a/modules/syslogformat/sdata-parser.h
+++ b/modules/syslogformat/sdata-parser.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Balázs Scheidler <bazsi77@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef SDATA_PARSER_H_INCLUDED
+#define SDATA_PARSER_H_INCLUDED
+
+#include "parser/parser-expr.h"
+#include "msg-format.h"
+
+typedef struct _SDataParser
+{
+  LogParser super;
+  MsgFormatOptions parse_options;
+} SDataParser;
+
+
+LogParser *sdata_parser_new(GlobalConfig *cfg);
+
+#endif

--- a/modules/syslogformat/syslog-format-plugin.c
+++ b/modules/syslogformat/syslog-format-plugin.c
@@ -49,6 +49,11 @@ static Plugin syslog_format_plugins[] =
     .type = LL_CONTEXT_PARSER,
     .name = "syslog-parser",
     .parser = &syslog_parser_parser,
+  },
+  {
+    .type = LL_CONTEXT_PARSER,
+    .name = "sdata-parser",
+    .parser = &syslog_parser_parser,
   }
 };
 

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -693,6 +693,23 @@ _syslog_format_parse_sd(LogMessage *msg, const guchar **data, gint *length, cons
                   else
                     goto error;
                 }
+              else if (left)
+                {
+                  pos = 0;
+
+                  while (left && (*src != ' ' && *src != ']'))
+                    {
+                      if (pos < sizeof(sd_param_value) - 1)
+                        {
+                          sd_param_value[pos] = *src;
+                          pos++;
+                        }
+                      _skip_char(&src, &left);
+                    }
+                  sd_param_value[pos] = 0;
+                  sd_param_value_len = pos;
+
+                }
               else
                 {
                   goto error;

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -572,7 +572,7 @@ log_msg_parse_sd(LogMessage *self, const guchar **data, gint *length, const MsgF
           while (left && *src != ' ' && *src != ']')
             {
               /* the sd_id_name is max 255, the other chars are only stored in the self->sd_str*/
-              if (pos < sizeof(sd_id_name) - 1 - logmsg_sd_prefix_len)
+              if (pos < sizeof(sd_id_name) - 1 - options->sdata_prefix_len)
                 {
                   if (isascii(*src) && *src != '=' && *src != ' ' && *src != ']' && *src != '"')
                     {
@@ -596,8 +596,8 @@ log_msg_parse_sd(LogMessage *self, const guchar **data, gint *length, const MsgF
 
           sd_id_name[pos] = 0;
           sd_id_len = pos;
-          strcpy(sd_value_name, logmsg_sd_prefix);
-          strncpy(sd_value_name + logmsg_sd_prefix_len, sd_id_name, sizeof(sd_value_name) - logmsg_sd_prefix_len);
+          strcpy(sd_value_name, options->sdata_prefix);
+          strncpy(sd_value_name + options->sdata_prefix_len, sd_id_name, sizeof(sd_value_name) - options->sdata_prefix_len);
 
           if (left && *src == ']')
             {
@@ -605,7 +605,7 @@ log_msg_parse_sd(LogMessage *self, const guchar **data, gint *length, const MsgF
             }
           else
             {
-              sd_value_name[logmsg_sd_prefix_len + pos] = '.';
+              sd_value_name[options->sdata_prefix_len + pos] = '.';
             }
 
           /* read sd-element */
@@ -640,8 +640,8 @@ log_msg_parse_sd(LogMessage *self, const guchar **data, gint *length, const MsgF
                   _process_any_char(&src, &left);
                 }
               sd_param_name[pos] = 0;
-              strncpy(&sd_value_name[logmsg_sd_prefix_len + 1 + sd_id_len], sd_param_name,
-                      sizeof(sd_value_name) - logmsg_sd_prefix_len - 1 - sd_id_len);
+              strncpy(&sd_value_name[options->sdata_prefix_len + 1 + sd_id_len], sd_param_name,
+                      sizeof(sd_value_name) - options->sdata_prefix_len - 1 - sd_id_len);
 
               if (left && *src == '=')
                 _process_any_char(&src, &left);

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -517,7 +517,7 @@ log_msg_parse_hostname(LogMessage *self, const guchar **data, gint *length,
  * message for structured data elements and store the parsed information
  * in @self.values and dup the SD string. Parsing is affected by the bits set @flags argument.
  **/
-static gboolean
+gboolean
 log_msg_parse_sd(LogMessage *self, const guchar **data, gint *length, const MsgFormatOptions *options)
 {
   /*

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -61,7 +61,7 @@ _process_any_char(const guchar **data, gint *left)
 
 
 static gboolean
-log_msg_parse_pri(LogMessage *msg, const guchar **data, gint *length, guint flags, guint16 default_pri)
+_syslog_format_parse_pri(LogMessage *msg, const guchar **data, gint *length, guint flags, guint16 default_pri)
 {
   int pri;
   gboolean success = TRUE;
@@ -102,7 +102,7 @@ log_msg_parse_pri(LogMessage *msg, const guchar **data, gint *length, guint flag
 }
 
 static gint
-log_msg_parse_skip_chars(LogMessage *msg, const guchar **data, gint *length, const gchar *chars, gint max_len)
+_syslog_format_parse_skip_chars(LogMessage *msg, const guchar **data, gint *length, const gchar *chars, gint max_len)
 {
   const guchar *src = *data;
   gint left = *length;
@@ -121,7 +121,7 @@ log_msg_parse_skip_chars(LogMessage *msg, const guchar **data, gint *length, con
 }
 
 static gboolean
-log_msg_parse_skip_space(LogMessage *msg, const guchar **data, gint *length)
+_syslog_format_parse_skip_space(LogMessage *msg, const guchar **data, gint *length)
 {
   const guchar *src = *data;
   gint left = *length;
@@ -141,7 +141,7 @@ log_msg_parse_skip_space(LogMessage *msg, const guchar **data, gint *length)
 }
 
 static gint
-log_msg_parse_skip_chars_until(LogMessage *msg, const guchar **data, gint *length, const gchar *delims)
+_syslog_format_parse_skip_chars_until(LogMessage *msg, const guchar **data, gint *length, const gchar *delims)
 {
   const guchar *src = *data;
   gint left = *length;
@@ -158,7 +158,7 @@ log_msg_parse_skip_chars_until(LogMessage *msg, const guchar **data, gint *lengt
 }
 
 static void
-log_msg_parse_column(LogMessage *msg, NVHandle handle, const guchar **data, gint *length, gint max_length)
+_syslog_format_parse_column(LogMessage *msg, NVHandle handle, const guchar **data, gint *length, gint max_length)
 {
   const guchar *src, *space;
   gint left;
@@ -189,7 +189,7 @@ log_msg_parse_column(LogMessage *msg, NVHandle handle, const guchar **data, gint
 }
 
 static void
-log_msg_parse_cisco_sequence_id(LogMessage *msg, const guchar **data, gint *length)
+_syslog_format_parse_cisco_sequence_id(LogMessage *msg, const guchar **data, gint *length)
 {
   const guchar *src = *data;
   gint left = *length;
@@ -218,7 +218,7 @@ log_msg_parse_cisco_sequence_id(LogMessage *msg, const guchar **data, gint *leng
 }
 
 static void
-log_msg_parse_cisco_timestamp_attributes(LogMessage *msg, const guchar **data, gint *length, gint parse_flags)
+_syslog_format_parse_cisco_timestamp_attributes(LogMessage *msg, const guchar **data, gint *length, gint parse_flags)
 {
   const guchar *src = *data;
   gint left = *length;
@@ -245,7 +245,8 @@ log_msg_parse_cisco_timestamp_attributes(LogMessage *msg, const guchar **data, g
 }
 
 static gboolean
-log_msg_parse_timestamp(UnixTime *stamp, const guchar **data, gint *length, guint parse_flags, glong recv_timezone_ofs)
+_syslog_format_parse_timestamp(UnixTime *stamp, const guchar **data, gint *length, guint parse_flags,
+                               glong recv_timezone_ofs)
 {
   gboolean result;
   WallClockTime wct = WALL_CLOCK_TIME_INIT;
@@ -276,12 +277,13 @@ log_msg_parse_timestamp(UnixTime *stamp, const guchar **data, gint *length, guin
 }
 
 static gboolean
-log_msg_parse_date(LogMessage *msg, const guchar **data, gint *length, guint parse_flags, glong recv_timezone_ofs)
+_syslog_format_parse_date(LogMessage *msg, const guchar **data, gint *length, guint parse_flags,
+                          glong recv_timezone_ofs)
 {
   UnixTime *stamp = &msg->timestamps[LM_TS_STAMP];
 
   unix_time_unset(stamp);
-  if (!log_msg_parse_timestamp(stamp, data, length, parse_flags, recv_timezone_ofs))
+  if (!_syslog_format_parse_timestamp(stamp, data, length, parse_flags, recv_timezone_ofs))
     {
       *stamp = msg->timestamps[LM_TS_RECVD];
       unix_time_set_timezone(stamp, recv_timezone_ofs);
@@ -292,7 +294,7 @@ log_msg_parse_date(LogMessage *msg, const guchar **data, gint *length, guint par
 }
 
 static gboolean
-log_msg_parse_version(LogMessage *msg, const guchar **data, gint *length)
+_syslog_format_parse_version(LogMessage *msg, const guchar **data, gint *length)
 {
   const guchar *src = *data;
   gint left = *length;
@@ -319,7 +321,7 @@ log_msg_parse_version(LogMessage *msg, const guchar **data, gint *length)
 }
 
 static void
-log_msg_parse_legacy_program_name(LogMessage *msg, const guchar **data, gint *length, guint flags)
+_syslog_format_parse_legacy_program_name(LogMessage *msg, const guchar **data, gint *length, guint flags)
 {
   /* the data pointer will not change */
   const guchar *src, *prog_start;
@@ -440,9 +442,9 @@ ipv6_heuristics_feed_gchar(IPv6Heuristics *self, gchar c)
 }
 
 static void
-log_msg_parse_hostname(LogMessage *msg, const guchar **data, gint *length,
-                       const guchar **hostname_start, int *hostname_len,
-                       guint flags, regex_t *bad_hostname)
+_syslog_format_parse_hostname(LogMessage *msg, const guchar **data, gint *length,
+                              const guchar **hostname_start, int *hostname_len,
+                              guint flags, regex_t *bad_hostname)
 {
   /* FIXME: support nil value support  with new protocol*/
   const guchar *src, *oldsrc;
@@ -507,7 +509,7 @@ log_msg_parse_hostname(LogMessage *msg, const guchar **data, gint *length,
 }
 
 /**
- * log_msg_parse:
+ * _syslog_format_parse:
  * @msg: LogMessage instance to store parsed information into
  * @data: message
  * @length: length of the message pointed to by @data
@@ -518,7 +520,7 @@ log_msg_parse_hostname(LogMessage *msg, const guchar **data, gint *length,
  * in @msg.values and dup the SD string. Parsing is affected by the bits set @flags argument.
  **/
 gboolean
-log_msg_parse_sd(LogMessage *msg, const guchar **data, gint *length, const MsgFormatOptions *options)
+_syslog_format_parse_sd(LogMessage *msg, const guchar **data, gint *length, const MsgFormatOptions *options)
 {
   /*
    * STRUCTURED-DATA = NILVALUE / 1*SD-ELEMENT
@@ -733,26 +735,27 @@ error:
 }
 
 static gboolean
-log_msg_parse_legacy_header(LogMessage *msg, const guchar **data, gint *length, const MsgFormatOptions *parse_options)
+_syslog_format_parse_legacy_header(LogMessage *msg, const guchar **data, gint *length,
+                                   const MsgFormatOptions *parse_options)
 {
   const guchar *src = *data;
   gint left = *length;
   GTimeVal now;
 
-  log_msg_parse_cisco_sequence_id(msg, &src, &left);
-  log_msg_parse_skip_chars(msg, &src, &left, " ", -1);
-  log_msg_parse_cisco_timestamp_attributes(msg, &src, &left, parse_options->flags);
+  _syslog_format_parse_cisco_sequence_id(msg, &src, &left);
+  _syslog_format_parse_skip_chars(msg, &src, &left, " ", -1);
+  _syslog_format_parse_cisco_timestamp_attributes(msg, &src, &left, parse_options->flags);
 
   cached_g_current_time(&now);
-  if (log_msg_parse_date(msg, &src, &left, parse_options->flags & ~LP_SYSLOG_PROTOCOL,
-                         time_zone_info_get_offset(parse_options->recv_time_zone_info, (time_t)now.tv_sec)))
+  if (_syslog_format_parse_date(msg, &src, &left, parse_options->flags & ~LP_SYSLOG_PROTOCOL,
+                                time_zone_info_get_offset(parse_options->recv_time_zone_info, (time_t)now.tv_sec)))
     {
       /* Expected format: hostname program[pid]: */
       /* Possibly: Message forwarded from hostname: ... */
       const guchar *hostname_start = NULL;
       int hostname_len = 0;
 
-      log_msg_parse_skip_chars(msg, &src, &left, " ", -1);
+      _syslog_format_parse_skip_chars(msg, &src, &left, " ", -1);
 
       /* Detect funny AIX syslogd forwarded message. */
       if (G_UNLIKELY(left >= (sizeof(aix_fwd_string) - 1) &&
@@ -761,8 +764,8 @@ log_msg_parse_legacy_header(LogMessage *msg, const guchar **data, gint *length, 
           src += sizeof(aix_fwd_string) - 1;
           left -= sizeof(aix_fwd_string) - 1;
           hostname_start = src;
-          hostname_len = log_msg_parse_skip_chars_until(msg, &src, &left, ":");
-          log_msg_parse_skip_chars(msg, &src, &left, " :", -1);
+          hostname_len = _syslog_format_parse_skip_chars_until(msg, &src, &left, ":");
+          _syslog_format_parse_skip_chars(msg, &src, &left, " :", -1);
         }
 
       /* Now, try to tell if it's a "last message repeated" line */
@@ -777,15 +780,15 @@ log_msg_parse_legacy_header(LogMessage *msg, const guchar **data, gint *length, 
             {
               /* Don't parse a hostname if it is local */
               /* It's a regular ol' message. */
-              log_msg_parse_hostname(msg, &src, &left, &hostname_start, &hostname_len, parse_options->flags,
-                                     parse_options->bad_hostname);
+              _syslog_format_parse_hostname(msg, &src, &left, &hostname_start, &hostname_len, parse_options->flags,
+                                            parse_options->bad_hostname);
 
               /* Skip whitespace. */
-              log_msg_parse_skip_chars(msg, &src, &left, " ", -1);
+              _syslog_format_parse_skip_chars(msg, &src, &left, " ", -1);
             }
 
           /* Try to extract a program name */
-          log_msg_parse_legacy_program_name(msg, &src, &left, parse_options->flags);
+          _syslog_format_parse_legacy_program_name(msg, &src, &left, parse_options->flags);
         }
 
       /* If we did manage to find a hostname, store it. */
@@ -808,7 +811,7 @@ log_msg_parse_legacy_header(LogMessage *msg, const guchar **data, gint *length, 
       else
         {
           /* Capture the program name */
-          log_msg_parse_legacy_program_name(msg, &src, &left, parse_options->flags);
+          _syslog_format_parse_legacy_program_name(msg, &src, &left, parse_options->flags);
         }
     }
   *data = src;
@@ -817,7 +820,7 @@ log_msg_parse_legacy_header(LogMessage *msg, const guchar **data, gint *length, 
 }
 
 /**
- * log_msg_parse_legacy:
+ * _syslog_format_parse_legacy:
  * @msg: LogMessage instance to store parsed information into
  * @data: message
  * @length: length of the message pointed to by @data
@@ -827,9 +830,9 @@ log_msg_parse_legacy_header(LogMessage *msg, const guchar **data, gint *length, 
  * in @msg. Parsing is affected by the bits set @flags argument.
  **/
 static gboolean
-log_msg_parse_legacy(const MsgFormatOptions *parse_options,
-                     const guchar *data, gint length,
-                     LogMessage *msg, gsize *position)
+_syslog_format_parse_legacy(const MsgFormatOptions *parse_options,
+                            const guchar *data, gint length,
+                            LogMessage *msg, gsize *position)
 {
   const guchar *src;
   gint left;
@@ -837,13 +840,13 @@ log_msg_parse_legacy(const MsgFormatOptions *parse_options,
   src = (const guchar *) data;
   left = length;
 
-  if (!log_msg_parse_pri(msg, &src, &left, parse_options->flags, parse_options->default_pri))
+  if (!_syslog_format_parse_pri(msg, &src, &left, parse_options->flags, parse_options->default_pri))
     {
       goto error;
     }
 
   if ((parse_options->flags & LP_NO_HEADER) == 0)
-    log_msg_parse_legacy_header(msg, &src, &left, parse_options);
+    _syslog_format_parse_legacy_header(msg, &src, &left, parse_options);
 
   if (parse_options->flags & LP_SANITIZE_UTF8 && !g_utf8_validate((gchar *) src, left, NULL))
     {
@@ -880,13 +883,14 @@ error:
 }
 
 /**
- * log_msg_parse_syslog_proto:
+ * _syslog_format_parse_syslog_proto:
  *
  * Parse a message according to the latest syslog-protocol drafts.
  **/
 static gboolean
-log_msg_parse_syslog_proto(const MsgFormatOptions *parse_options, const guchar *data, gint length, LogMessage *msg,
-                           gsize *position)
+_syslog_format_parse_syslog_proto(const MsgFormatOptions *parse_options, const guchar *data, gint length,
+                                  LogMessage *msg,
+                                  gsize *position)
 {
   /**
    *  SYSLOG-MSG      = HEADER SP STRUCTURED-DATA [SP MSG]
@@ -907,30 +911,30 @@ log_msg_parse_syslog_proto(const MsgFormatOptions *parse_options, const guchar *
   left = length;
 
 
-  if (!log_msg_parse_pri(msg, &src, &left, parse_options->flags, parse_options->default_pri) ||
-      !log_msg_parse_version(msg, &src, &left))
+  if (!_syslog_format_parse_pri(msg, &src, &left, parse_options->flags, parse_options->default_pri) ||
+      !_syslog_format_parse_version(msg, &src, &left))
     {
       if ((parse_options->flags & LP_NO_RFC3164_FALLBACK) == 0)
-        return log_msg_parse_legacy(parse_options, data, length, msg, position);
+        return _syslog_format_parse_legacy(parse_options, data, length, msg, position);
       return FALSE;
     }
 
-  if (!log_msg_parse_skip_space(msg, &src, &left))
+  if (!_syslog_format_parse_skip_space(msg, &src, &left))
     {
       goto error;
     }
 
   /* ISO time format */
-  if (!log_msg_parse_date(msg, &src, &left, parse_options->flags,
-                          time_zone_info_get_offset(parse_options->recv_time_zone_info, time(NULL))))
+  if (!_syslog_format_parse_date(msg, &src, &left, parse_options->flags,
+                                 time_zone_info_get_offset(parse_options->recv_time_zone_info, time(NULL))))
     goto error;
 
-  if (!log_msg_parse_skip_space(msg, &src, &left))
+  if (!_syslog_format_parse_skip_space(msg, &src, &left))
     goto error;
 
   /* hostname 255 ascii */
-  log_msg_parse_hostname(msg, &src, &left, &hostname_start, &hostname_len, parse_options->flags, NULL);
-  if (!log_msg_parse_skip_space(msg, &src, &left))
+  _syslog_format_parse_hostname(msg, &src, &left, &hostname_start, &hostname_len, parse_options->flags, NULL);
+  if (!_syslog_format_parse_skip_space(msg, &src, &left))
     {
       src++;
       goto error;
@@ -944,29 +948,29 @@ log_msg_parse_syslog_proto(const MsgFormatOptions *parse_options, const guchar *
     }
 
   /* application name 48 ascii*/
-  log_msg_parse_column(msg, LM_V_PROGRAM, &src, &left, 48);
-  if (!log_msg_parse_skip_space(msg, &src, &left))
+  _syslog_format_parse_column(msg, LM_V_PROGRAM, &src, &left, 48);
+  if (!_syslog_format_parse_skip_space(msg, &src, &left))
     goto error;
 
   /* process id 128 ascii */
-  log_msg_parse_column(msg, LM_V_PID, &src, &left, 128);
-  if (!log_msg_parse_skip_space(msg, &src, &left))
+  _syslog_format_parse_column(msg, LM_V_PID, &src, &left, 128);
+  if (!_syslog_format_parse_skip_space(msg, &src, &left))
     goto error;
 
   /* message id 32 ascii */
-  log_msg_parse_column(msg, LM_V_MSGID, &src, &left, 32);
-  if (!log_msg_parse_skip_space(msg, &src, &left))
+  _syslog_format_parse_column(msg, LM_V_MSGID, &src, &left, 32);
+  if (!_syslog_format_parse_skip_space(msg, &src, &left))
     goto error;
 
   /* structured data part */
-  if (!log_msg_parse_sd(msg, &src, &left, parse_options))
+  if (!_syslog_format_parse_sd(msg, &src, &left, parse_options))
     goto error;
 
   /* checking if there are remaining data in log message */
   if (left != 0)
     {
       /* optional part of the log message [SP MSG] */
-      if (!log_msg_parse_skip_space(msg, &src, &left))
+      if (!_syslog_format_parse_skip_space(msg, &src, &left))
         {
           goto error;
         }
@@ -1003,9 +1007,9 @@ syslog_format_handler(const MsgFormatOptions *parse_options,
 
   msg->initial_parse = TRUE;
   if (parse_options->flags & LP_SYSLOG_PROTOCOL)
-    success = log_msg_parse_syslog_proto(parse_options, data, length, msg, problem_position);
+    success = _syslog_format_parse_syslog_proto(parse_options, data, length, msg, problem_position);
   else
-    success = log_msg_parse_legacy(parse_options, data, length, msg, problem_position);
+    success = _syslog_format_parse_legacy(parse_options, data, length, msg, problem_position);
   msg->initial_parse = FALSE;
 
   return success;

--- a/modules/syslogformat/syslog-format.h
+++ b/modules/syslogformat/syslog-format.h
@@ -33,4 +33,7 @@ gboolean syslog_format_handler(const MsgFormatOptions *parse_options,
 
 void syslog_format_init(void);
 
+gboolean log_msg_parse_sd(LogMessage *self, const guchar **data, gint *length, const MsgFormatOptions *options);
+
+
 #endif

--- a/modules/syslogformat/syslog-format.h
+++ b/modules/syslogformat/syslog-format.h
@@ -33,7 +33,7 @@ gboolean syslog_format_handler(const MsgFormatOptions *parse_options,
 
 void syslog_format_init(void);
 
-gboolean log_msg_parse_sd(LogMessage *self, const guchar **data, gint *length, const MsgFormatOptions *options);
+gboolean _syslog_format_parse_sd(LogMessage *self, const guchar **data, gint *length, const MsgFormatOptions *options);
 
 
 #endif

--- a/modules/syslogformat/syslog-parser-grammar.ym
+++ b/modules/syslogformat/syslog-parser-grammar.ym
@@ -30,6 +30,7 @@
 %code {
 
 #include "syslog-parser.h"
+#include "sdata-parser.h"
 #include "syslog-names.h"
 #include "cfg-grammar-internal.h"
 
@@ -49,6 +50,8 @@
 
 %token KW_SYSLOG_PARSER
 %token KW_DROP_INVALID
+%token KW_SDATA_PARSER
+%token KW_PREFIX
 
 %type	<ptr> parser_expr_syslog
 
@@ -67,6 +70,13 @@ parser_expr_syslog
             last_msg_format_options = &((SyslogParser *) last_parser)->parse_options;
           }
           parser_syslog_opts
+          ')'					{ $$ = last_parser; }
+        | KW_SDATA_PARSER '('
+          {
+            last_parser = *instance = sdata_parser_new(configuration);
+            last_msg_format_options = &((SDataParser *) last_parser)->parse_options;
+          }
+          parser_sdata_opts
           ')'					{ $$ = last_parser; }
         ;
 
@@ -88,6 +98,21 @@ parser_syslog_opt_flags
         | KW_CHECK_HOSTNAME parser_syslog_opt_flags     { msg_format_options_process_flag(&((SyslogParser *) last_parser)->parse_options, "check-hostname");  }
         |
 	;
+
+parser_sdata_opts
+        : parser_sdata_opt parser_sdata_opts
+        |
+        ;
+
+parser_sdata_opt
+	: parser_opt
+	| KW_PREFIX '(' string ')'
+          {
+            msg_format_options_set_sdata_prefix(last_msg_format_options, $3);
+            free($3);
+          }
+        ;
+
 
 /* INCLUDE_RULES */
 

--- a/modules/syslogformat/syslog-parser-grammar.ym
+++ b/modules/syslogformat/syslog-parser-grammar.ym
@@ -64,6 +64,7 @@ parser_expr_syslog
         : KW_SYSLOG_PARSER '('
           {
             last_parser = *instance = syslog_parser_new(configuration);
+            last_msg_format_options = &((SyslogParser *) last_parser)->parse_options;
           }
           parser_syslog_opts
           ')'					{ $$ = last_parser; }
@@ -79,7 +80,7 @@ parser_syslog_opt
 	: parser_opt
 	| KW_FLAGS '(' parser_syslog_opt_flags ')'
 	| KW_DROP_INVALID '(' yesno ')'			{ syslog_parser_set_drop_invalid(last_parser, $3); }
-	| { last_msg_format_options = &((SyslogParser *) last_parser)->parse_options; } msg_format_option
+	| msg_format_option
         ;
 
 parser_syslog_opt_flags

--- a/modules/syslogformat/syslog-parser-parser.c
+++ b/modules/syslogformat/syslog-parser-parser.c
@@ -32,7 +32,9 @@ int syslog_parser_parse(CfgLexer *lexer, LogParser **instance, gpointer arg);
 static CfgLexerKeyword syslog_parser_keywords[] =
 {
   { "syslog_parser",          KW_SYSLOG_PARSER },
+  { "sdata_parser",           KW_SDATA_PARSER },
   { "drop_invalid",           KW_DROP_INVALID },
+  { "prefix",                 KW_PREFIX },
   { NULL }
 };
 

--- a/modules/syslogformat/tests/CMakeLists.txt
+++ b/modules/syslogformat/tests/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_unit_test(CRITERION TARGET test_syslog_format DEPENDS syslogformat)
+add_unit_test(LIBTEST CRITERION TARGET test_syslog_format DEPENDS syslogformat)

--- a/modules/syslogformat/tests/test_syslog_format.c
+++ b/modules/syslogformat/tests/test_syslog_format.c
@@ -113,7 +113,7 @@ _extract_sdata_into_message(const gchar *sdata, LogMessage **pmsg)
 
   msg_format_options_defaults(&parse_options);
   msg_format_options_init(&parse_options, cfg);
-  gboolean result = log_msg_parse_sd(msg, &data, &data_length, &parse_options);
+  gboolean result = _syslog_format_parse_sd(msg, &data, &data_length, &parse_options);
   msg_format_options_destroy(&parse_options);
 
   if (pmsg)

--- a/modules/syslogformat/tests/test_syslog_format.c
+++ b/modules/syslogformat/tests/test_syslog_format.c
@@ -22,6 +22,7 @@
  */
 
 #include <criterion/criterion.h>
+#include "libtest/msg_parse_lib.h"
 
 #include "apphook.h"
 #include "cfg.h"
@@ -101,4 +102,153 @@ Test(syslog_format, minimal_non_zero_terminated_numeric_message_is_parsed_as_pro
 
   msg_format_options_destroy(&parse_options);
   log_msg_unref(msg);
+}
+
+static gboolean
+_extract_sdata_into_message(const gchar *sdata, LogMessage **pmsg)
+{
+  const guchar *data = (const guchar *) sdata;
+  gint data_length = strlen(sdata);
+  LogMessage *msg = log_msg_new_empty();
+
+  msg_format_options_defaults(&parse_options);
+  msg_format_options_init(&parse_options, cfg);
+  gboolean result = log_msg_parse_sd(msg, &data, &data_length, &parse_options);
+  msg_format_options_destroy(&parse_options);
+
+  if (pmsg)
+    *pmsg = msg;
+  else
+    log_msg_unref(msg);
+
+  return result;
+}
+
+Test(syslog_format, test_sdata_dash_means_there_are_no_sdata_elements)
+{
+  LogMessage *msg;
+
+  cr_assert(_extract_sdata_into_message("-", &msg));
+  assert_log_message_value_by_name(msg, "SDATA", "");
+  log_msg_unref(msg);
+}
+
+Test(syslog_format, test_sdata_parsing_invalid_brackets_are_returned_as_failures)
+{
+  cr_assert_not(_extract_sdata_into_message("<", NULL));
+  cr_assert_not(_extract_sdata_into_message("[", NULL));
+  cr_assert_not(_extract_sdata_into_message("[]", NULL));
+  cr_assert_not(_extract_sdata_into_message("]", NULL));
+  cr_assert_not(_extract_sdata_into_message("[foobar", NULL));
+}
+
+Test(syslog_format, test_sdata_id_without_param_is_accepted_and_represented_in_sdata)
+{
+  LogMessage *msg;
+  cr_assert(_extract_sdata_into_message("[foobar]", &msg));
+  assert_log_message_value_by_name(msg, "SDATA", "[foobar]");
+  assert_log_message_value_by_name(msg, ".SDATA.foobar", "");
+  log_msg_unref(msg);
+}
+
+Test(syslog_format, test_sdata_simple_id_and_param)
+{
+  LogMessage *msg;
+  cr_assert(_extract_sdata_into_message("[foo bar=\"baz\"]", &msg));
+  assert_log_message_value_by_name(msg, "SDATA", "[foo bar=\"baz\"]");
+  assert_log_message_value_by_name(msg, ".SDATA.foo.bar", "baz");
+  log_msg_unref(msg);
+}
+
+Test(syslog_format, test_sdata_invalid_sd_id_and_param)
+{
+  cr_assert_not(_extract_sdata_into_message("[foo= bar=\"baz\"]", NULL));
+  cr_assert_not(_extract_sdata_into_message("[foo\" bar=\"baz\"]", NULL));
+}
+
+Test(syslog_format, test_sdata_invalid_param)
+{
+  cr_assert_not(_extract_sdata_into_message("[foo bar\"=\"baz\"]", NULL));
+  cr_assert_not(_extract_sdata_into_message("[foo bar]", NULL));
+  cr_assert_not(_extract_sdata_into_message("[foo bar baz]", NULL));
+}
+
+Test(syslog_format, test_sdata_invalid_value)
+{
+  cr_assert_not(_extract_sdata_into_message("[foo bar=baz]", NULL));
+  cr_assert_not(_extract_sdata_into_message("[foo bar=\"]", NULL));
+
+}
+
+Test(syslog_format, test_sdata_param_value_invalid_escape)
+{
+  LogMessage *msg;
+  cr_assert(_extract_sdata_into_message("[foo bar=\"\\a\"]", &msg));
+
+  /* non-special character follows a backslash.  We extract as if they were
+   * normal characters (as the spec), however when we reconstruct the SDATA
+   * string, we regenerate it from our internal value, which "fixes" it.
+   * This is against the spec, but our approach is to parse and reconstruct
+   * and there's no way we can encode errors into our internal
+   * representation. There would be not too much value either. */
+  assert_log_message_value_by_name(msg, "SDATA", "[foo bar=\"\\\\a\"]");
+  assert_log_message_value_by_name(msg, ".SDATA.foo.bar", "\\a");
+  log_msg_unref(msg);
+}
+
+Test(syslog_format, test_sdata_param_value_escape_quote)
+{
+  LogMessage *msg;
+  cr_assert(_extract_sdata_into_message("[foo bar=\"\\\"\"]", &msg));
+
+  assert_log_message_value_by_name(msg, "SDATA", "[foo bar=\"\\\"\"]");
+  assert_log_message_value_by_name(msg, ".SDATA.foo.bar", "\"");
+  log_msg_unref(msg);
+}
+
+Test(syslog_format, test_sdata_param_value_escape_bracket)
+{
+  LogMessage *msg;
+  cr_assert(_extract_sdata_into_message("[foo bar=\"\\]\"]", &msg));
+
+  assert_log_message_value_by_name(msg, "SDATA", "[foo bar=\"\\]\"]");
+  assert_log_message_value_by_name(msg, ".SDATA.foo.bar", "]");
+  log_msg_unref(msg);
+}
+
+Test(syslog_format, test_sdata_param_value_escape_backslash)
+{
+  LogMessage *msg;
+  cr_assert(_extract_sdata_into_message("[foo bar=\"\\\\\"]", &msg));
+
+  assert_log_message_value_by_name(msg, "SDATA", "[foo bar=\"\\\\\"]");
+  assert_log_message_value_by_name(msg, ".SDATA.foo.bar", "\\");
+  log_msg_unref(msg);
+}
+
+Test(syslog_format, test_sdata_simple_id_and_multiple_params)
+{
+  LogMessage *msg;
+  cr_assert(_extract_sdata_into_message("[foo bar=\"baz\" chew=\"chow\" peek=\"poke\"]", &msg));
+  assert_log_message_value_by_name(msg, "SDATA", "[foo bar=\"baz\" chew=\"chow\" peek=\"poke\"]");
+  assert_log_message_value_by_name(msg, ".SDATA.foo.bar", "baz");
+  assert_log_message_value_by_name(msg, ".SDATA.foo.chew", "chow");
+  assert_log_message_value_by_name(msg, ".SDATA.foo.peek", "poke");
+  log_msg_unref(msg);
+}
+
+Test(syslog_format, test_sdata_enterprise_qualified_id_with_and_multiple_params)
+{
+  LogMessage *msg;
+  cr_assert(_extract_sdata_into_message("[foo@1.2.3.4 bar=\"baz\" chew=\"chow\" peek=\"poke\"]", &msg));
+  assert_log_message_value_by_name(msg, "SDATA", "[foo@1.2.3.4 bar=\"baz\" chew=\"chow\" peek=\"poke\"]");
+  assert_log_message_value_by_name(msg, ".SDATA.foo@1.2.3.4.bar", "baz");
+  assert_log_message_value_by_name(msg, ".SDATA.foo@1.2.3.4.chew", "chow");
+  assert_log_message_value_by_name(msg, ".SDATA.foo@1.2.3.4.peek", "poke");
+  log_msg_unref(msg);
+}
+
+Test(syslog_format, test_sdata_missing_closing_bracket)
+{
+  cr_assert_not(_extract_sdata_into_message("[foo bar=\"baz\"", NULL));
 }

--- a/news/feature-4281.md
+++ b/news/feature-4281.md
@@ -1,0 +1,6 @@
+`syslog-parser()` and all syslog related sources: accept unquoted RFC5424
+SD-PARAM-VALUEs instead of rejecting them with a parse error.
+
+`sdata-parser()`: this new parser allows you to parse an RFC5424 style
+structured data string. It can be used to parse this relatively complex
+format separately.

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -158,6 +158,7 @@ modules/python-modules/syslogng/modules/example/.*
 modules/python-modules/setup\.py
 scripts/build-python-venv\.sh
 modules/syslogformat/sdata-parser\.[ch]
+tests/light/functional_tests/parsers/sdata-parser/test_sdata_parser\.py
 
 ###########################################################################
 # These files are GPLd with Balabit origin.

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -157,6 +157,7 @@ modules/python-modules/syslogng/modules/kubernetes/.*
 modules/python-modules/syslogng/modules/example/.*
 modules/python-modules/setup\.py
 scripts/build-python-venv\.sh
+modules/syslogformat/sdata-parser\.[ch]
 
 ###########################################################################
 # These files are GPLd with Balabit origin.

--- a/tests/light/functional_tests/parsers/sdata-parser/test_sdata_parser.py
+++ b/tests/light/functional_tests/parsers/sdata-parser/test_sdata_parser.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2023 Balazs Scheidler <bazsi77@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+
+def test_sdata_parser(config, syslog_ng):
+    config.update_global_options(stats_level=1)
+    generator_source = config.create_example_msg_generator_source(num=1, template=config.stringify("[Originator@6876 sub=Vimsvc.ha-eventmgr opID=esxui-13c6-6b16 sid=5214bde6 user=root]"))
+    sdata_parser = config.create_sdata_parser(prefix=config.stringify(".SDATA."))
+
+    file_destination = config.create_file_destination(file_name="output.log", template=config.stringify("$SDATA\n"))
+    config.create_logpath(statements=[generator_source, sdata_parser, file_destination])
+
+    syslog_ng.start(config)
+    assert file_destination.read_log().strip() == '[Originator@6876 sub="Vimsvc.ha-eventmgr" opID="esxui-13c6-6b16" sid="5214bde6" user="root"]'
+    assert sdata_parser.get_query() == {'discarded': 0}

--- a/tests/light/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/light/src/syslog_ng_config/syslog_ng_config.py
@@ -135,6 +135,9 @@ class SyslogNgConfig(object):
     def create_syslog_parser(self, **options):
         return Parser("syslog-parser", **options)
 
+    def create_sdata_parser(self, **options):
+        return Parser("sdata-parser", **options)
+
     def create_cisco_parser(self, **options):
         return Parser("cisco-parser", **options)
 


### PR DESCRIPTION
This allows someone to incrementally parse a malformed RFC5424 message, where the SDATA portion is not at the right spot. The SDATA format is relatively complex, so extracting it as a separate component makes it easier to process this kind of data.

This is WIP, because:
- [x]  no specific tests
- [x] I want to make "prefix" customizable and I am not finished with that yet
- [x] NEWS file

