### PR TITLE
Fix worker warning

### DIFF
--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -28,8 +28,6 @@
 #include "logmsg/logmsg.h"
 #include "stats/stats-registry.h"
 
-extern gint log_queue_max_threads;
-
 typedef void (*LogQueuePushNotifyFunc)(gpointer user_data);
 
 typedef struct _LogQueue LogQueue;
@@ -226,7 +224,5 @@ void log_queue_register_stats_counters(LogQueue *self, gint stats_level, const S
 void log_queue_unregister_stats_counters(LogQueue *self, const StatsClusterKey *sc_key);
 
 void log_queue_free_method(LogQueue *self);
-
-void log_queue_set_max_threads(gint max_threads);
 
 #endif

--- a/lib/mainloop-worker.c
+++ b/lib/mainloop-worker.c
@@ -118,7 +118,7 @@ _allocate_thread_id(void)
                        evt_tag_int("max-worker-threads-hard-limit", MAIN_LOOP_MAX_WORKER_THREADS));
     }
 
-  if (main_loop_worker_id >= main_loop_max_workers)
+  if (main_loop_worker_id > main_loop_max_workers)
     {
       msg_warning_once("The actual number of worker threads exceeds the number of threads "
                        "estimated at startup. This indicates a bug in thread estimation, "

--- a/news/bugfix-4282.md
+++ b/news/bugfix-4282.md
@@ -1,0 +1,2 @@
+Fix a warning message that was displayed incorrectly:
+"The actual number of worker threads exceeds the number of threads estimated at startup."


### PR DESCRIPTION
Reproduction steps:
`--worker-threads=1` and a network source with an active connection