### PR TITLE
ci: fix multiline output issue with tags

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           images: ${{ env.DOCKER_IMAGE_NAME }}
           tags: type=match,pattern=syslog-ng-(.*),group=1
+          sep-tags: ','
 
       - name: Compose Docker image tags
         id: tags


### PR DESCRIPTION
`gh_output` can not export multi-line output, and it is not trivial to do that safely:
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings

(see the warning about script injection).