### PR TITLE
http: fix curl related warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1377,7 +1377,7 @@ if test "x$enable_http" != "xno" && test "x$with_libcurl" != "xno"; then
         if test "$enable_http" = "yes"; then
            old_CFLAGS=$CFLAGS
            CFLAGS=$LIBCURL_CFLAGS
-           AC_CHECK_DECLS([CURL_SSLVERSION_TLSv1_0, CURL_SSLVERSION_TLSv1_1, CURL_SSLVERSION_TLSv1_2, CURL_SSLVERSION_TLSv1_3, CURLOPT_TLS13_CIPHERS, CURLOPT_SSL_VERIFYSTATUS],
+           AC_CHECK_DECLS([CURL_SSLVERSION_TLSv1_0, CURL_SSLVERSION_TLSv1_1, CURL_SSLVERSION_TLSv1_2, CURL_SSLVERSION_TLSv1_3, CURLOPT_TLS13_CIPHERS, CURLOPT_SSL_VERIFYSTATUS, CURLOPT_REDIR_PROTOCOLS_STR],
                           [], [],
                           [[#include <curl/curl.h>]])
            CFLAGS=$old_CFLAGS

--- a/modules/http/CMakeLists.txt
+++ b/modules/http/CMakeLists.txt
@@ -59,6 +59,7 @@ curl_detect_compile_option(CURL_SSLVERSION_TLSv1_2)
 curl_detect_compile_option(CURL_SSLVERSION_TLSv1_3)
 curl_detect_compile_option(CURLOPT_TLS13_CIPHERS)
 curl_detect_compile_option(CURLOPT_SSL_VERIFYSTATUS)
+curl_detect_compile_option(CURLOPT_REDIR_PROTOCOLS_STR)
 
 install(FILES ${HTTP_MODULE_DEV_HEADERS} DESTINATION include/syslog-ng/modules/http/)
 

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -160,7 +160,11 @@ _setup_static_options_in_curl(HTTPDestinationWorker *self)
     {
       curl_easy_setopt(self->curl, CURLOPT_FOLLOWLOCATION, 1);
       curl_easy_setopt(self->curl, CURLOPT_POSTREDIR, CURL_REDIR_POST_ALL);
+#if SYSLOG_NG_HAVE_DECL_CURLOPT_REDIR_PROTOCOLS_STR
+      curl_easy_setopt(self->curl, CURLOPT_REDIR_PROTOCOLS_STR, "http,https");
+#else
       curl_easy_setopt(self->curl, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+#endif
       curl_easy_setopt(self->curl, CURLOPT_MAXREDIRS, 3);
     }
   curl_easy_setopt(self->curl, CURLOPT_TIMEOUT, owner->timeout);


### PR DESCRIPTION
../modules/http/http-worker.c: In function '_setup_static_options_in_curl': ../modules/http/http-worker.c:163:7: warning: 'CURLOPT_REDIR_PROTOCOLS' is deprecated: since 7.85.0. Use CURLOPT_REDIR_PROTOCOLS_STR [-Wdeprecated-declarations]
  163 |       curl_easy_setopt(self->curl, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
      |       ^~~~~~~~~~~~~~~~
In file included from ../modules/http/http-curl-header-list.h:31,
                 from ../modules/http/http-worker.h:30,
                 from ../modules/http/http-worker.c:24:
/usr/include/x86_64-linux-gnu/curl/curl.h:1755:3: note: declared here
 1755 |   CURLOPTDEPRECATED(CURLOPT_REDIR_PROTOCOLS, CURLOPTTYPE_LONG, 182,
      |   ^~~~~~~~~~~~~~~~~
