### PR TITLE
Redeclaration-errors-with-older-gcc-versions-4287

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ TAGS
 GPATH
 GRTAGS
 GTAGS
+modules/python-modules/syslogng.egg-info
+aclocal.m4-e


### PR DESCRIPTION
This PR fixes the broken mock part of journald integration tests when --with-systemd-journal=optional configure option is used

Also added  some builds genereated leftover to the .gitignore

fixes: #4287

Signed-off-by: Hofi <hofione@gmail.com>
