### PR TITLE
python: workaround Python 3.11 PYTHONPATH issue

### DIFF
--- a/modules/python/python-main.c
+++ b/modules/python/python-main.c
@@ -492,8 +492,15 @@ static gboolean
 _py_configure_interpreter(gboolean use_virtualenv)
 {
   PyConfig config;
-  PyConfig_InitIsolatedConfig(&config);
+  PyConfig_InitPythonConfig(&config);
 
+  /* NOTE: to pick up PYTHONPATH, work around https://github.com/python/cpython/issues/101471 */
+  config.configure_c_stdio = 0;
+  config.install_signal_handlers = 0;
+  config.parse_argv = 0;
+  config.pathconfig_warnings = 0;
+  config.user_site_directory = 0;
+  config.use_environment = 1;
   gboolean success = use_virtualenv ? _py_configure_virtualenv_python(&config)
                      : _py_configure_system_python(&config);
   if (success)


### PR DESCRIPTION
Our devshell CI is red on master as long as this is not merged.

This is an attempt to work around
https://github.com/python/cpython/issues/101471 until a more permanent solution is found.

@alltilla @MrAnno @HofiOne could you please review this so I can expedite merging this? Thanks