### PR TITLE
dbld/builddeps: workaround setuptools 66 PEP440 enforcement

### DIFF
--- a/dbld/builddeps
+++ b/dbld/builddeps
@@ -193,8 +193,12 @@ function install_pip_packages {
                 filter_pip_packages_by_platform_and_python_version $DBLD_DIR/pip_packages.manifest $python_executable| xargs $python_executable -m pip install --no-cache-dir --ignore-installed -U
                 ;;
             *)
+                # pip can fail with setuptools>=66 if there are system packages installed which do not comply with PEP440:
+                # https://github.com/pypa/setuptools/issues/3772#issuecomment-1398809718
+                #
+                # As long as our supported distros have invalidly named packages, this will be an issue.
                 $python_executable -m pip install --ignore-installed --no-cache-dir --upgrade pip
-                $python_executable -m pip install --ignore-installed --no-cache-dir --upgrade setuptools
+                $python_executable -m pip install --ignore-installed --no-cache-dir --upgrade "setuptools<66.0"
                 filter_pip_packages_by_platform_and_python_version $DBLD_DIR/pip_packages.manifest $python_executable | xargs $python_executable -m pip install --no-cache-dir --ignore-installed -U
                 ;;
         esac


### PR DESCRIPTION
pip can fail with setuptools>=66 if there are system packages installed which do not comply with PEP440:

https://github.com/pypa/setuptools/issues/3772#issuecomment-1398809718

As long as our supported distros have invalidly named packages, this will be an issue.

Either debian package maintainers start to conform PEP440 versioning, or setuptools loosens this strictness or this workaround sticks for a while.

Either way, we need to see make or CI green, so until one of the above happens I think we should go with this workaround.

Signed-off-by: Attila Szakacs <szakacs.attila96@gmail.com>

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
