### PR TITLE
Apache rawrequest escaping binary characters

### DIFF
--- a/lib/scanner/csv-scanner/tests/test_csv_scanner.c
+++ b/lib/scanner/csv-scanner/tests/test_csv_scanner.c
@@ -359,6 +359,62 @@ Test(csv_scanner, escape_backslash_sequences)
   csv_scanner_deinit(&scanner);
 }
 
+Test(csv_scanner, escape_backslash_x_sequences)
+{
+  const gchar *columns[] = { "foo", "bar", NULL };
+
+  _default_options_with_flags(columns, CSV_SCANNER_STRIP_WHITESPACE);
+
+  csv_scanner_options_set_dialect(&options, CSV_SCANNER_ESCAPE_BACKSLASH_WITH_SEQUENCES);
+  csv_scanner_init(&scanner, &options, "foo,\"\\x41\\x00\\x40\"");
+
+  cr_expect(_column_name_equals("foo"));
+  cr_expect(!_scan_complete());
+
+  cr_expect(_scan_next());
+  cr_expect(_column_name_equals("foo"));
+  cr_expect(!_scan_complete());
+
+  cr_expect(_scan_next());
+  cr_expect(_column_name_equals("bar"));
+  cr_expect(_column_nv_equals("bar", "A\x00@"));
+  cr_expect(!_scan_complete());
+
+  /* go past the last column */
+  cr_expect(!_scan_next());
+  cr_expect(_scan_complete());
+  cr_expect(_column_name_unset());
+  csv_scanner_deinit(&scanner);
+}
+
+Test(csv_scanner, escape_backslash_invalid_x_sequence)
+{
+  const gchar *columns[] = { "foo", "bar", NULL };
+
+  _default_options_with_flags(columns, CSV_SCANNER_STRIP_WHITESPACE);
+
+  csv_scanner_options_set_dialect(&options, CSV_SCANNER_ESCAPE_BACKSLASH_WITH_SEQUENCES);
+  csv_scanner_init(&scanner, &options, "foo,\"\\x4Q\"");
+
+  cr_expect(_column_name_equals("foo"));
+  cr_expect(!_scan_complete());
+
+  cr_expect(_scan_next());
+  cr_expect(_column_name_equals("foo"));
+  cr_expect(!_scan_complete());
+
+  cr_expect(_scan_next());
+  cr_expect(_column_name_equals("bar"));
+  cr_expect(_column_nv_equals("bar", "x4Q"));
+  cr_expect(!_scan_complete());
+
+  /* go past the last column */
+  cr_expect(!_scan_next());
+  cr_expect(_scan_complete());
+  cr_expect(_column_name_unset());
+  csv_scanner_deinit(&scanner);
+}
+
 static void
 setup(void)
 {

--- a/lib/tests/test_utf8utils.c
+++ b/lib/tests/test_utf8utils.c
@@ -84,7 +84,7 @@ ParameterizedTestParameters(test_utf8utils, test_escaped_text)
     {"árvíztűrőtükörfúrógép", "árvíztűrőtükörfúrógép", NULL, -1},
     {"árvíztűrőtükörfúrógép\n", "árvíztűrőtükörfúrógép\\n", NULL, -1},
     {"\x41", "A", NULL, -1},
-    {"\x7", "\\u0007", NULL, -1},
+    {"\x7", "\\x07", NULL, -1},
     {"\xad", "\\\\xad", NULL, -1},
     {"Á\xadÉ", "Á\\\\xadÉ", NULL, -1},
     {"\"text\"", "\\\"text\\\"", "\"", -1},

--- a/lib/utf8utils.c
+++ b/lib/utf8utils.c
@@ -216,7 +216,7 @@ append_unsafe_utf8_as_escaped_text(GString *escaped_string, const gchar *str,
                                    gssize str_len, const gchar *unsafe_chars)
 {
   _append_unsafe_utf8_as_escaped(escaped_string, str, str_len, unsafe_chars,
-                                 "\\u%04x", "\\\\x%02x");
+                                 "\\x%02x", "\\\\x%02x");
 }
 
 gchar *


### PR DESCRIPTION
This branch fixes #4274 by:

1) making sure that apache style escaping in access.logs are parsed properly, even if it contains escaped binary characters
2) on output uses \xXX escaping style for binary characters, instead of \uXXXX, which shouldn't be needed for control characters anyway.

This might still be a change compared to our 3.38 behaviour, I guess in that case these binary characters were considered a single field and then re-escaped as it was sent out in JSON to ElasticSearch.

So it was probably sent to Elastic as: ```"\\x16\\x03\\x01"``` Note the double backslashes.

This patch will make that use binary, e.g. elastic would receive the original: ```"\x16\x03\x01"``` string, which it would de-escape probably. So this is still a change compared to 3.38 but I think this behaviour is better than our previous one, as we are not able to process the binary characters properly.