### PR TITLE
github-actions/macos: temporarily disable amqp

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,6 +44,10 @@ jobs:
             --with-python=3
           "
 
+          # rabbitmq-c 0.12.0 broke the pc file version, which breaks our minimum version check. Once it is fixed, we should reenable amqp.
+          # https://github.com/alanxz/rabbitmq-c/issues/755
+          CONFIGURE_FLAGS="${CONFIGURE_FLAGS} --disable-amqp"
+
           gh_export PYTHONUSERBASE PKG_CONFIG_PATH THREADS CONFIGURE_FLAGS
           gh_path "${HOMEBREW_PREFIX}/opt/bison/bin:${HOMEBREW_PREFIX}/opt/libnet/bin:${PYTHONUSERBASE}/bin:${HOMEBREW_PREFIX}/opt/net-snmp/bin"
 


### PR DESCRIPTION
rabbitmq-c 0.12.0 broke the pc file version, which breaks our minimum version check. Once it is fixed, we should reenable amqp.

https://github.com/alanxz/rabbitmq-c/issues/755

Signed-off-by: Attila Szakacs <szakacs.attila96@gmail.com>

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
