### PR TITLE
diskq: `disk-buf-size()` related fixes: `dqtool cat`, `example-diskq-source()`, changing `disk-buf-size()`

### DIFF
--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -227,14 +227,7 @@ _attach(LogDriverPlugin *s, LogDriver *d)
   LogDestDriver *dd = (LogDestDriver *) d;
   GlobalConfig *cfg = log_pipe_get_config(&d->super);
 
-  if (self->options.disk_buf_size == -1)
-    {
-      msg_error("The required 'disk_buf_size()' parameter of diskq module has not been set.",
-                log_pipe_location_tag(&dd->super.super));
-      return FALSE;
-    }
-
-  if (self->options.disk_buf_size < MIN_DISK_BUF_SIZE && self->options.disk_buf_size != 0)
+  if (self->options.disk_buf_size < MIN_DISK_BUF_SIZE && self->options.disk_buf_size > 0)
     {
       msg_warning("The value of 'disk_buf_size()' is too low, setting to the smallest acceptable value",
                   evt_tag_long("min_space", MIN_DISK_BUF_SIZE),

--- a/modules/diskq/dqtool.c
+++ b/modules/diskq/dqtool.c
@@ -123,13 +123,11 @@ open_queue(char *filename, LogQueue **lq, DiskQueueOptions *options)
 
   if (options->reliable)
     {
-      options->disk_buf_size = 128;
       options->mem_buf_size = 1024 * 1024;
       *lq = log_queue_disk_reliable_new(options, NULL);
     }
   else
     {
-      options->disk_buf_size = 1;
       options->mem_buf_size = 128;
       options->qout_size = 1000;
       *lq = log_queue_disk_non_reliable_new(options, NULL);
@@ -152,6 +150,7 @@ dqtool_cat(int argc, char *argv[])
   GError *error = NULL;
   LogTemplate *template = NULL;
   DiskQueueOptions options = {0};
+  disk_queue_options_set_default_options(&options);
   gint i;
 
   if (template_string)
@@ -211,6 +210,7 @@ dqtool_info(int argc, char *argv[])
     {
       LogQueue *lq;
       DiskQueueOptions options = {0};
+      disk_queue_options_set_default_options(&options);
 
       if (!open_queue(argv[i], &lq, &options))
         continue;

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -135,10 +135,14 @@ log_queue_disk_read_message(LogQueueDisk *self, LogPathOptions *path_options)
         {
           msg_error("Error reading from disk-queue file, dropping disk queue",
                     evt_tag_str("filename", qdisk_get_filename(self->qdisk)));
-          log_queue_disk_restart_corrupted(self);
+
+          if (!qdisk_is_read_only(self->qdisk))
+            log_queue_disk_restart_corrupted(self);
+
           if (msg)
             log_msg_unref(msg);
           msg = NULL;
+
           return NULL;
         }
     }

--- a/modules/examples/sources/threaded-diskq-source/threaded-diskq-source.c
+++ b/modules/examples/sources/threaded-diskq-source/threaded-diskq-source.c
@@ -74,13 +74,11 @@ _load_queue(ThreadedDiskqSourceDriver *self)
 
   if (self->diskq_options.reliable)
     {
-      self->diskq_options.disk_buf_size = 128;
       self->diskq_options.mem_buf_size = 1024 * 1024;
       self->queue = log_queue_disk_reliable_new(&self->diskq_options, NULL);
     }
   else
     {
-      self->diskq_options.disk_buf_size = 1;
       self->diskq_options.mem_buf_size = 128;
       self->diskq_options.qout_size = 1000;
       self->queue = log_queue_disk_non_reliable_new(&self->diskq_options, NULL);
@@ -222,6 +220,8 @@ threaded_diskq_sd_new(GlobalConfig *cfg)
 {
   ThreadedDiskqSourceDriver *self = g_new0(ThreadedDiskqSourceDriver, 1);
   log_threaded_fetcher_driver_init_instance(&self->super, cfg);
+
+  disk_queue_options_set_default_options(&self->diskq_options);
 
   self->super.connect = _open_diskq;
   self->super.disconnect = _close_diskq;

--- a/news/bugfix-4308-1.md
+++ b/news/bugfix-4308-1.md
@@ -1,0 +1,1 @@
+`dqtool`: Fixed `dqtool cat` failing to read the content in some cases.

--- a/news/bugfix-4308-2.md
+++ b/news/bugfix-4308-2.md
@@ -1,0 +1,5 @@
+`disk-buffer`: Fixed disk-queue file becoming corrupt when changing `disk-buf-size()`.
+
+`syslog-ng` now continues with the originally set `disk-buf-size()`.
+Note that changing the `disk-buf-size()` of an existing disk-queue was never supported,
+but could cause errors, which are fixed now.

--- a/news/bugfix-4308-3.md
+++ b/news/bugfix-4308-3.md
@@ -1,0 +1,1 @@
+`example-diskq-source`: Fixed failing to read the disk-queue content in some cases.


### PR DESCRIPTION
There is a bug in `dqtool` which was caused by 2 things:
  1. We changed the condition of the cursor wrapping from file size to `disk-buf-size()`.
  2. We do not store the `disk-buf-size()` in the disk-queue header.

There is no way to tell where we should wrap without knowing the `disk-buf-size()` before loading the disk-queue.

With this patch set we now store the initial `disk-buf-size()` in the header and use that for the wrap condition.

Also we can now detect whether the user tries to change the `disk-buf-size()` of an existing disk-queue file. For now we will reject that change and go with the original `disk-buf-size()`, which is a bugfix itself, as before this patch set we did not realize that with a config change and might have tried to overread/overwrite the disk-queue file.

We can implement the `disk-buf-size()` change in the future in a safe way, however it is not the scope of this patch set.

Signed-off-by: Attila Szakacs <szakacs.attila96@gmail.com>