### PR TITLE
dbld: install criterion from source on Debian testing

### DIFF
--- a/dbld/build.manifest
+++ b/dbld/build.manifest
@@ -30,7 +30,7 @@
 # libcriterion-dev is available starting with bullseye
 debian-buster		python3,nocriterion,nojava,nokafka,nomqtt
 debian-bullseye		python3,nojava
-debian-testing		python3,nojava
+debian-testing		python3,nojava,nocriterion
 debian-sid		python3,nojava
 
 # on ubuntu, we start using Python3 at focal onwards.

--- a/dbld/images/debian-testing.dockerfile
+++ b/dbld/images/debian-testing.dockerfile
@@ -19,6 +19,7 @@ COPY . /dbld/
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps
+RUN /dbld/builddeps install_criterion
 
 VOLUME /source
 VOLUME /build


### PR DESCRIPTION
Criterion was dropped from Debian testing because of an FTBFS (failed to build from source).

Criterion fails to build, as there was a minor change in nanopb command line processing, which causes the criterion.options file to not be found while processing the protobuf declarations.

This is the fix against criterion, which if applied, this entire patch can be reverted.

```
--- criterion-2.4.1/src/protocol/gen-pb.py 2022-04-26 06:51:30.000000000 +0000
+++ criterion-2.4.1.patched/src/protocol/gen-pb.py 2023-02-04 12:51:27.398255067 +0000
@@ -17,7 +17,7 @@

 cmdline = [protoc_path, '--plugin=protoc-gen-nanopb=' + gen_path,
       '-I' + source_dir,
-      '--nanopb_out=' + '-f ' + options_file + ':' + build_dir,
+      '--nanopb_out=' + '-f' + options_file + ':' + build_dir,
       proto_file]

 sys.stderr.write(" ".join(cmdline) + "\n")
```
Signed-off-by: Balazs Scheidler <bazsi77@gmail.com>

