### PR TITLE
package-indexer: add .gz, .xz and .bz2 compression for Packages

### DIFF
--- a/packaging/package-indexer/indexer/deb_indexer.py
+++ b/packaging/package-indexer/indexer/deb_indexer.py
@@ -20,6 +20,9 @@
 #
 #############################################################################
 
+import bz2
+import gzip
+import lzma
 import re
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -88,6 +91,21 @@ class DebIndexer(Indexer):
             with packages_file_path.open("w") as packages_file:
                 self._log_info("Creating `Packages` file.", packages_file_path=str(packages_file_path))
                 utils.execute_command(command, dir=dir, stdout=packages_file)
+
+            packages_gz_file_path = Path(pkg_dir, "Packages.gz")
+            with packages_gz_file_path.open("wb") as packages_gz_file:
+                gz_compressed_data = gzip.compress(packages_file_path.read_bytes())
+                packages_gz_file.write(gz_compressed_data)
+
+            packages_xz_file_path = Path(pkg_dir, "Packages.xz")
+            with packages_xz_file_path.open("wb") as packages_xz_file:
+                xz_compressed_data = lzma.compress(packages_file_path.read_bytes(), lzma.FORMAT_XZ)
+                packages_xz_file.write(xz_compressed_data)
+
+            packages_bz2_file_path = Path(pkg_dir, "Packages.bz2")
+            with packages_bz2_file_path.open("wb") as packages_bz2_file:
+                bz2_compressed_data = bz2.compress(packages_file_path.read_bytes())
+                packages_bz2_file.write(bz2_compressed_data)
 
     def __create_release_file(self, indexed_dir: Path) -> None:
         command = ["apt-ftparchive", "release", "."]


### PR DESCRIPTION
Tested locally:
```
# apt update
Ign:1 http://127.0.0.1:8000/apt nightly InRelease
Get:2 http://127.0.0.1:8000/apt nightly Release [2497 B]                                      
Ign:3 http://127.0.0.1:8000/apt nightly Release.gpg                                           
Get:4 http://127.0.0.1:8000/apt nightly/ubuntu-jammy amd64 Packages [11.7 kB]                 
Hit:5 http://archive.ubuntu.com/ubuntu jammy InRelease                                        
Hit:6 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Get:7 http://archive.ubuntu.com/ubuntu jammy-backports InRelease [107 kB]
Hit:8 http://security.ubuntu.com/ubuntu jammy-security InRelease                              
Fetched 121 kB in 7s (17.4 kB/s)                                                              
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
10 packages can be upgraded. Run 'apt list --upgradable' to see them.
root@alltilla-Precision-5530:/etc/apt/sources.list.d# apt search syslog-ng-core
Sorting... Done
Full Text Search... Done
syslog-ng-core/nightly 4.0.1.116.gfdb88de.dirty-snapshot+20230206T094016 amd64
  Enhanced system logging daemon (core)

```
```
$ python3 -m http.server
Serving HTTP on 0.0.0.0 port 8000 (http://0.0.0.0:8000/) ...
127.0.0.1 - - [06/Feb/2023 11:35:23] code 404, message File not found
127.0.0.1 - - [06/Feb/2023 11:35:23] "GET /apt/dists/nightly/InRelease HTTP/1.1" 404 -
127.0.0.1 - - [06/Feb/2023 11:35:23] "GET /apt/dists/nightly/Release HTTP/1.1" 200 -
127.0.0.1 - - [06/Feb/2023 11:35:23] code 404, message File not found
127.0.0.1 - - [06/Feb/2023 11:35:23] "GET /apt/dists/nightly/Release.gpg HTTP/1.1" 404 -
127.0.0.1 - - [06/Feb/2023 11:35:23] "GET /apt/dists/nightly/ubuntu-jammy/binary-amd64/Packages.gz HTTP/1.1" 200 -
```
Note: The 404 comes from the repo not being signed and the `InRelease` and `Release.gpg` files are missing, which is due to the local testing.

Fixes #4309

Signed-off-by: Attila Szakacs <szakacs.attila96@gmail.com>

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
