### PR TITLE
add value() parameter to date-parser()

### DIFF
--- a/lib/logmsg/tests/test_type_hints.c
+++ b/lib/logmsg/tests/test_type_hints.c
@@ -276,7 +276,9 @@ ParameterizedTestParameters(type_hints, test_datetime_cast)
     {"12345.5", 12345500},
     {"12345.54", 12345540},
     {"12345.543", 12345543},
-    {"12345.54321", 12345543}
+    {"12345.54321", 12345543},
+    {"12345.987654", 12345987},
+    {"12345.987654321", 12345987}
   };
 
   return cr_make_param_array(StringUInt64Pair, string_value_pairs,
@@ -290,20 +292,35 @@ ParameterizedTest(StringUInt64Pair *string_value_pair, type_hints, test_datetime
 
   cr_assert_eq(type_cast_to_datetime_msec(string_value_pair->string, &value, &error), TRUE,
                "Type cast of \"%s\" to msecs failed", string_value_pair->string);
-  cr_assert_eq(value, string_value_pair->value);
+  cr_assert_eq(value, string_value_pair->value, "datetime cast failed %lld != %lld", value, string_value_pair->value);
   cr_assert_null(error);
 }
 
-Test(type_hints, test_invalid_datetime_cast)
+ParameterizedTestParameters(type_hints, test_invalid_datetime_cast)
+{
+  static StringUInt64Pair string_value_pairs[] =
+  {
+    {"invalid", },
+    {"12345T", },
+    {"12345.", },
+    {"12345.1234567890", },
+
+  };
+
+  return cr_make_param_array(StringUInt64Pair, string_value_pairs,
+                             sizeof(string_value_pairs) / sizeof(string_value_pairs[0]));
+}
+
+
+ParameterizedTest(StringUInt64Pair *string_value_pair, type_hints, test_invalid_datetime_cast)
 {
   GError *error = NULL;
   gint64 value;
 
-  cr_assert_eq(type_cast_to_datetime_msec("invalid", &value, &error), FALSE,
-               "Type cast of invalid string to gint64 should be failed");
+  cr_assert_eq(type_cast_to_datetime_msec(string_value_pair->string, &value, &error), FALSE,
+               "Type cast of invalid string to gint64 should have failed %s", string_value_pair->string);
   cr_assert_not_null(error);
   cr_assert_eq(error->domain, TYPE_HINTING_ERROR);
   cr_assert_eq(error->code, TYPE_HINTING_INVALID_CAST);
-
   g_clear_error(&error);
 }

--- a/lib/logmsg/tests/test_type_hints.c
+++ b/lib/logmsg/tests/test_type_hints.c
@@ -278,7 +278,9 @@ ParameterizedTestParameters(type_hints, test_datetime_cast)
     {"12345.543", 12345543},
     {"12345.54321", 12345543},
     {"12345.987654", 12345987},
-    {"12345.987654321", 12345987}
+    {"12345.987654321", 12345987},
+    {"12345+05:00", 12345000},
+    {"12345-05:00", 12345000},
   };
 
   return cr_make_param_array(StringUInt64Pair, string_value_pairs,
@@ -292,7 +294,9 @@ ParameterizedTest(StringUInt64Pair *string_value_pair, type_hints, test_datetime
 
   cr_assert_eq(type_cast_to_datetime_msec(string_value_pair->string, &value, &error), TRUE,
                "Type cast of \"%s\" to msecs failed", string_value_pair->string);
-  cr_assert_eq(value, string_value_pair->value, "datetime cast failed %lld != %lld", value, string_value_pair->value);
+  cr_assert_eq(value, string_value_pair->value,
+               "datetime cast failed %" G_GINT64_FORMAT " != %" G_GINT64_FORMAT,
+               value, string_value_pair->value);
   cr_assert_null(error);
 }
 
@@ -304,6 +308,9 @@ ParameterizedTestParameters(type_hints, test_invalid_datetime_cast)
     {"12345T", },
     {"12345.", },
     {"12345.1234567890", },
+    {"12345+XX:YY", 12345000},
+    {"12345-05", 12345000},
+    {"12345-XX:YY", 12345000}
 
   };
 

--- a/lib/logmsg/type-hinting.h
+++ b/lib/logmsg/type-hinting.h
@@ -48,7 +48,6 @@ gboolean type_cast_to_int32(const gchar *value, gint32 *out, GError **error);
 gboolean type_cast_to_int64(const gchar *value, gint64 *out, GError **error);
 gboolean type_cast_to_double(const gchar *value, gdouble *out, GError **error);
 gboolean type_cast_to_datetime_msec(const gchar *value, gint64 *out, GError **error);
-gboolean type_cast_to_datetime_str(const gchar *value, const char *format,
-                                   gchar **out, GError **error);
+gboolean type_cast_to_datetime_unixtime(const gchar *value, UnixTime *ut, GError **error);
 
 #endif

--- a/lib/timeutils/scan-timestamp.c
+++ b/lib/timeutils/scan-timestamp.c
@@ -382,6 +382,16 @@ __parse_iso_timezone(const guchar **data, gint *length)
   return tz;
 }
 
+gboolean
+scan_iso_timezone(const guchar **data, gint *length, gint *gmtoff)
+{
+  if (__has_iso_timezone(*data, *length))
+    {
+      *gmtoff = __parse_iso_timezone(data, length);
+      return TRUE;
+    }
+  return FALSE;
+}
 
 static gboolean
 __parse_iso_stamp(WallClockTime *wct, const guchar **data, gint *length)

--- a/lib/timeutils/scan-timestamp.h
+++ b/lib/timeutils/scan-timestamp.h
@@ -29,6 +29,8 @@
 #include "timeutils/wallclocktime.h"
 #include "timeutils/unixtime.h"
 
+gboolean scan_iso_timezone(const guchar **buf, gint *length, gint *gmtoff);
+
 gboolean scan_iso_timestamp(const gchar **buf, gint *left, WallClockTime *wct);
 gboolean scan_pix_timestamp(const gchar **buf, gint *left, WallClockTime *wct);
 gboolean scan_linksys_timestamp(const gchar **buf, gint *left, WallClockTime *wct);

--- a/modules/timestamp/date-parser.h
+++ b/modules/timestamp/date-parser.h
@@ -32,6 +32,7 @@ void date_parser_set_offset(LogParser *s, goffset offset);
 void date_parser_set_formats(LogParser *s, GList *formats);
 void date_parser_set_timezone(LogParser *s, gchar *tz);
 void date_parser_set_time_stamp(LogParser *s, LogMessageTimeStamp timestamp);
+void date_parser_set_value(LogParser *s, const gchar *value_name);
 gboolean date_parser_process_flag(LogParser *s, gchar *flag);
 
 #endif

--- a/modules/timestamp/tests/test_format_date.c
+++ b/modules/timestamp/tests/test_format_date.c
@@ -81,6 +81,11 @@ Test(format_date, test_format_date_with_timestamp_argument_formats_it_using_strf
   assert_template_format("$(format-date %Y-%m-%dT%H:%M:%S 1667500613)", "2022-11-03T19:36:53");
 }
 
+Test(format_date, test_format_date_with_timestamp_argument_using_fractions_and_timezone_works)
+{
+  assert_template_format("$(format-date %Y-%m-%dT%H:%M:%S 1667500613.613+05:00)", "2022-11-03T23:36:53");
+}
+
 Test(format_date, test_format_date_with_time_zone_option_overrrides_timezone)
 {
   assert_template_format("$(format-date --time-zone PST8PDT %Y-%m-%dT%H:%M:%S 1667500613)", "2022-11-03T11:36:53");

--- a/modules/timestamp/tf-format-date.c
+++ b/modules/timestamp/tf-format-date.c
@@ -112,16 +112,16 @@ tf_format_date_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvo
   UnixTime ut;
 
   *type = LM_VT_STRING;
-  gint64 msec;
 
   if (state->super.argc != 0)
     {
       const gchar *ts = args->argv[0]->str;
-      if (!type_cast_to_datetime_msec(ts, &msec, NULL))
-        msec = 0;
-      ut.ut_sec = msec / 1000;
-      ut.ut_usec = (msec % 1000) * 1000;
-      ut.ut_gmtoff = -1;
+      if (!type_cast_to_datetime_unixtime(ts, &ut, NULL))
+        {
+          ut.ut_sec = 0;
+          ut.ut_usec = 0;
+          ut.ut_gmtoff = -1;
+        }
     }
   else
     {

--- a/modules/timestamp/timestamp-grammar.ym
+++ b/modules/timestamp/timestamp-grammar.ym
@@ -82,6 +82,7 @@ date_parser_option
         : KW_FORMAT '(' string_list ')'             { date_parser_set_formats(last_parser, $3); }
         | KW_TIME_ZONE '(' string ')'               { date_parser_set_timezone(last_parser, $3); free($3); }
         | KW_TIME_STAMP '(' date_parser_stamp ')'   { date_parser_set_time_stamp(last_parser, $3); }
+	| KW_VALUE '(' string ')'                   { date_parser_set_value(last_parser, $3); free($3); }
         | KW_FLAGS '(' date_parser_flags ')'
         | parser_opt
         ;

--- a/news/feature-4319.md
+++ b/news/feature-4319.md
@@ -1,0 +1,18 @@
+`date-parser()`: add `value()` parameter to instruct `date-parser()` to store
+the resulting timestamp in a name-value pair, instead of changing the
+timestamp value of the LogMessage.
+
+`datetime` type representation: typed values in syslog-ng are represented as
+strings when stored as a part of a log message.  syslog-ng simply remembers
+the type it was stored as.  Whenever the value is used as a specific type in
+a type-aware context where we need the value of the specific type, an
+automatic string parsing takes place.  This parsing happens for instance
+whenever syslog-ng stores a datetime value in MongoDB or when
+`$(format-date)` template function takes a name-value pair as parameter.
+The datetime() type has stored its value as the number of milliseconds since
+the epoch (1970-01-01 00:00:00 GMT).  This has now been enhanced by making
+it possible to store timestamps up to nanosecond resolutions along with an
+optional timezone offset.
+
+`$(format-date)`: when applied to name-value pairs with the `datetime` type,
+use the timezone offset if one is available.


### PR DESCRIPTION
This PR improves 3 things to deliver more complete support for processing non-standard timestamps.

1) type-hinting: improve the format we can use for DATETIME values by allowing usec granularity (instead of msec) and adding timezone offset information.

2) date-parser now allows extracting timestamps into a name-value pair (in addition to storing the extracted time in the message timestamps)

3) $(format-date) now uses the improved datetime format, so the timezone offset is properly handled when formatting the timestamp.


