### PR TITLE
logmsg: remove LF_SIMPLE_HOSTNAME

### DIFF
--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -123,8 +123,6 @@ enum
   LF_STATE_OWN_SDATA   = 0x0100,
   LF_STATE_OWN_MASK    = 0x01F0,
 
-  /* In the log header the hostname shall be printed individually (no group name, no chain hosts)*/
-  LF_SIMPLE_HOSTNAME = 0x0200,
 
   LF_CHAINED_HOSTNAME  = 0x00010000,
 

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -383,12 +383,7 @@ log_source_mangle_hostname(LogSource *self, LogMessage *msg)
       if (G_UNLIKELY(self->options->chain_hostnames))
         {
           msg->flags |= LF_CHAINED_HOSTNAME;
-          if (msg->flags & LF_SIMPLE_HOSTNAME)
-            {
-              /* local without group name */
-              host_len = g_snprintf(host, sizeof(host), "%s", resolved_name);
-            }
-          else if (msg->flags & LF_LOCAL)
+          if (msg->flags & LF_LOCAL)
             {
               /* local */
               host_len = g_snprintf(host, sizeof(host), "%s@%s", self->options->group_name, resolved_name);

--- a/lib/tests/test_logsource.c
+++ b/lib/tests/test_logsource.c
@@ -178,10 +178,6 @@ ParameterizedTestParameters(log_source, test_mangle_hostname)
       .keep_hostname = FALSE, .chain_hostnames = TRUE, "msg-test-host", TEST_SOURCE_GROUP "@resolved-test-host",
       .msg_flags = LF_LOCAL
     },
-    {
-      .keep_hostname = FALSE, .chain_hostnames = TRUE, "msg-test-host", "resolved-test-host",
-      .msg_flags = LF_LOCAL | LF_SIMPLE_HOSTNAME
-    },
   };
 
   return cr_make_param_array(MangleHostnameParams, test_params, G_N_ELEMENTS(test_params));


### PR DESCRIPTION
This flag was unused, even if the functionality has merit, it should have been passed to LogSource through options and not via LogMessage flags.

The flag itself will not survive clones, so not really useful anyway.

@HofiOne this one is probably used by one of your internal modules. An easier alternative to achieve the same is to set LogSourceOptions->chain_hostnames to FALSE. No need to use a LogMessage flag for this purpose.

No NEWS needed.

PS: I am trying to add another LogMessage flag in an alternative branch, that's when I encountered this one.
