### PR TITLE
cfg-lexer refactor and cleanup

### DIFF
--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -453,25 +453,7 @@ cfg_lexer_start_next_include(CfgLexer *self)
       /* we finished with an include statement that included a series of
        * files (e.g.  directory include). */
 
-
-      /* NOTE: this couple of lines should become just a call to
-       * cfg_lexer_clear_include_level(), however this entire function is
-       * playing nasty tricks with the data members within the
-       * CfgIncludeLevel, which I can't decipher right now, so I am leaving
-       * this as is. Memory management in the lexer is clearly messed
-       * up.  */
-
-      g_free(level->name);
-
-      if (level->include_type == CFGI_BUFFER)
-        {
-          g_free(level->buffer.content);
-          g_free(level->buffer.original_content);
-        }
-
-      memset(level, 0, sizeof(*level));
-
-      self->include_depth--;
+      cfg_lexer_drop_include_level(self, &self->include_stack[self->include_depth]);
       cfg_lexer_include_level_resume_from_buffer(self, &self->include_stack[self->include_depth]);
 
       return TRUE;

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -390,7 +390,7 @@ cfg_lexer_include_level_resume_from_buffer(CfgLexer *self, CfgIncludeLevel *leve
 }
 
 void
-cfg_lexer_clear_include_level(CfgLexer *self, CfgIncludeLevel *level)
+cfg_lexer_include_level_clear(CfgLexer *self, CfgIncludeLevel *level)
 {
   g_free(level->name);
   if (level->yybuf)
@@ -430,7 +430,7 @@ void
 cfg_lexer_drop_include_level(CfgLexer *self, CfgIncludeLevel *level)
 {
   g_assert(&self->include_stack[self->include_depth] == level);
-  cfg_lexer_clear_include_level(self, level);
+  cfg_lexer_include_level_clear(self, level);
   self->include_depth--;
 }
 
@@ -1208,7 +1208,7 @@ cfg_lexer_free(CfgLexer *self)
   gint i;
 
   for (i = 0; i <= self->include_depth; i++)
-    cfg_lexer_clear_include_level(self, &self->include_stack[i]);
+    cfg_lexer_include_level_clear(self, &self->include_stack[i]);
 
   self->include_depth = 0;
   _cfg_lexer_lex_destroy(self->state);

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -282,11 +282,12 @@ cfg_lexer_include_level_file_add(CfgLexer *self, CfgIncludeLevel *level, const g
 
 void
 cfg_lexer_init_include_level_buffer(CfgLexer *self, CfgIncludeLevel *level,
+                                    const gchar *name,
                                     const gchar *buffer,
                                     gsize length)
 {
   level->include_type = CFGI_BUFFER;
-
+  level->name = g_strdup(name);
   gint lexer_buffer_len = length + 2;
   gchar *lexer_buffer = g_malloc(lexer_buffer_len);
   memcpy(lexer_buffer, buffer, length);
@@ -722,9 +723,7 @@ cfg_lexer_include_buffer_without_backtick_substitution(CfgLexer *self, const gch
   /* lex requires two NUL characters at the end of the input */
 
   level = cfg_lexer_alloc_include_level(self);
-  cfg_lexer_init_include_level_buffer(self, level, buffer, length);
-
-  level->name = g_strdup(name);
+  cfg_lexer_init_include_level_buffer(self, level, name, buffer, length);
 
   return cfg_lexer_start_next_include(self);
 }
@@ -1157,9 +1156,7 @@ cfg_lexer_new_buffer(GlobalConfig *cfg, const gchar *buffer, gsize length)
   self->ignore_pragma = TRUE;
 
   level = &self->include_stack[0];
-  cfg_lexer_init_include_level_buffer(self, level, buffer, length);
-
-  level->name = g_strdup("<string>");
+  cfg_lexer_init_include_level_buffer(self, level, "<string>", buffer, length);
 
   level->yybuf = _cfg_lexer__scan_buffer(level->buffer.content, level->buffer.content_length, self->state);
   _cfg_lexer__switch_to_buffer(level->yybuf, self->state);

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -1166,10 +1166,9 @@ cfg_lexer_new(GlobalConfig *cfg, FILE *file, const gchar *filename, GString *pre
 
   level = &self->include_stack[0];
   cfg_lexer_init_include_level_file(self, level);
-
-  level->name = g_strdup(filename);
-  level->yybuf = _cfg_lexer__create_buffer(file, YY_BUF_SIZE, self->state);
-  _cfg_lexer__switch_to_buffer(level->yybuf, self->state);
+  cfg_lexer_include_level_file_add(self, level, filename);
+  cfg_lexer_include_level_open_buffer(self, level);
+  cfg_lexer_include_level_resume_from_buffer(self, level);
 
   return self;
 }
@@ -1186,9 +1185,8 @@ cfg_lexer_new_buffer(GlobalConfig *cfg, const gchar *buffer, gsize length)
 
   level = &self->include_stack[0];
   cfg_lexer_init_include_level_buffer(self, level, "<string>", buffer, length);
-
-  level->yybuf = _cfg_lexer__scan_buffer(level->buffer.content, level->buffer.content_length, self->state);
-  _cfg_lexer__switch_to_buffer(level->yybuf, self->state);
+  cfg_lexer_include_level_open_buffer(self, level);
+  cfg_lexer_include_level_resume_from_buffer(self, level);
 
   return self;
 }

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -694,7 +694,15 @@ cfg_lexer_include_file_glob(CfgLexer *self, const gchar *filename_)
       cfg_lexer_drop_include_level(self, level);
       return TRUE;
     }
-  return cfg_lexer_start_next_include(self);
+  if (!cfg_lexer_start_next_include(self))
+    {
+      msg_error("Include file/directory not found",
+                evt_tag_str("filename", filename_),
+                evt_tag_str("include-path", _get_include_path(self)),
+                evt_tag_error("error"));
+      return FALSE;
+    }
+  return TRUE;
 }
 
 gboolean
@@ -721,14 +729,7 @@ cfg_lexer_include_file(CfgLexer *self, const gchar *filename_)
       if (filename)
         g_free(filename);
 
-      if (cfg_lexer_include_file_glob(self, filename_))
-        return TRUE;
-
-      msg_error("Include file/directory not found",
-                evt_tag_str("filename", filename_),
-                evt_tag_str("include-path", _get_include_path(self)),
-                evt_tag_error("error"));
-      return FALSE;
+      return cfg_lexer_include_file_glob(self, filename_);
     }
   else
     {

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -362,6 +362,12 @@ cfg_lexer_include_level_open_buffer(CfgLexer *self, CfgIncludeLevel *level)
 }
 
 void
+cfg_lexer_include_level_resume_from_buffer(CfgLexer *self, CfgIncludeLevel *level)
+{
+  _cfg_lexer__switch_to_buffer(level->yybuf, self->state);
+}
+
+void
 cfg_lexer_clear_include_level(CfgLexer *self, CfgIncludeLevel *level)
 {
   g_free(level->name);
@@ -458,7 +464,7 @@ cfg_lexer_start_next_include(CfgLexer *self)
       memset(level, 0, sizeof(*level));
 
       self->include_depth--;
-      _cfg_lexer__switch_to_buffer(self->include_stack[self->include_depth].yybuf, self->state);
+      cfg_lexer_include_level_resume_from_buffer(self, &self->include_stack[self->include_depth]);
 
       return TRUE;
     }
@@ -468,8 +474,7 @@ cfg_lexer_start_next_include(CfgLexer *self)
   if (!cfg_lexer_include_level_open_buffer(self, level))
     return FALSE;
 
-
-  _cfg_lexer__switch_to_buffer(level->yybuf, self->state);
+  cfg_lexer_include_level_resume_from_buffer(self, level);
   return TRUE;
 }
 


### PR DESCRIPTION
This branch is a preparation for a major overhaul of our "debugger" functionality. As a prep to that I cleaned up the CfgLexer code
and extracted CfgIncludeLevel to be more of a separate class, instead of just being a data structure manipulated in a complicated
way.

The outcome of the branch is that cfg_lexer_start_next_include() became a few lines of code.

No NEWS entry is needed.
