### PR TITLE
Improve debugger source display

### DIFF
--- a/lib/cfg-block.c
+++ b/lib/cfg-block.c
@@ -177,8 +177,10 @@ cfg_block_generate(CfgBlockGenerator *s, GlobalConfig *cfg, gpointer args, GStri
       g_clear_error(&error);
       return FALSE;
     }
-
+  if (cfg->lexer && !cfg->lexer->ignore_pragma)
+    g_string_append_printf(result, "@line \"%s\" %d %d\n", self->filename, self->line, self->column);
   g_string_append_len(result, value, length);
+
   g_free(value);
   return TRUE;
 }

--- a/lib/cfg-block.c
+++ b/lib/cfg-block.c
@@ -212,7 +212,7 @@ cfg_block_new(gint context, const gchar *name, const gchar *content, CfgArgs *ar
   self->super.format_name = cfg_block_format_name;
   self->super.suppress_backticks = TRUE;
   self->content = g_strdup(content);
-  self->filename = g_strdup(lloc->level->name);
+  self->filename = g_strdup(lloc->name);
   self->line = lloc->first_line;
   self->column = lloc->first_column;
   self->arg_defs = arg_defs;

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -65,7 +65,7 @@
   do {                                                                  \
     if (N)                                                              \
       {                                                                 \
-        (Current).level = YYRHSLOC(Rhs, 1).level;                       \
+        (Current).name         = YYRHSLOC(Rhs, 1).name;                 \
         (Current).first_line   = YYRHSLOC (Rhs, 1).first_line;          \
         (Current).first_column = YYRHSLOC (Rhs, 1).first_column;        \
         (Current).last_line    = YYRHSLOC (Rhs, N).last_line;           \
@@ -73,7 +73,7 @@
       }                                                                 \
     else                                                                \
       {                                                                 \
-        (Current).level = YYRHSLOC(Rhs, 0).level;                       \
+        (Current).name         = YYRHSLOC(Rhs, 0).name;                 \
         (Current).first_line   = (Current).last_line   =                \
           YYRHSLOC (Rhs, 0).last_line;                                  \
         (Current).first_column = (Current).last_column =                \

--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -45,7 +45,7 @@ yy_input_run_backtick_substitution(CfgLexer *self, gchar *buf, gsize buf_size, g
     {
       msg_error("Error performing backtick substitution in configuration file",
                 evt_tag_str("error", error->message),
-                evt_tag_str("filename", cur_lloc->level->name),
+                evt_tag_str("filename", cur_lloc->name),
                 evt_tag_printf("line", "%d:%d", cur_lloc->first_line, cur_lloc->first_column));
       g_clear_error(&error);
       goto error;
@@ -56,7 +56,7 @@ yy_input_run_backtick_substitution(CfgLexer *self, gchar *buf, gsize buf_size, g
         {
           msg_error("Error performing backtick substitution in configuration file, the target buffer is too small",
                     evt_tag_int("buf_size", buf_size),
-                    evt_tag_str("filename", cur_lloc->level->name),
+                    evt_tag_str("filename", cur_lloc->name),
                     evt_tag_printf("line", "%d:%d", cur_lloc->first_line, cur_lloc->first_column));
           goto error;
         }
@@ -94,7 +94,7 @@ yy_patch_include_statement(CfgLexer *self, gchar *buf, gsize buf_size, gsize *le
       msg_error("Error parsing old style include statement (e.g. the one without the '@' prefix), "
                 "support for it was removed in " VERSION_3_20 ", just add a '@' in front or revert to @version "
                 VERSION_3_19 " or older",
-                evt_tag_str("filename", cur_lloc->level->name),
+                evt_tag_str("filename", cur_lloc->name),
                 evt_tag_printf("line", "%d:%d", cur_lloc->first_line, cur_lloc->first_column));
 
       return FALSE;
@@ -104,7 +104,7 @@ yy_patch_include_statement(CfgLexer *self, gchar *buf, gsize buf_size, gsize *le
     {
       msg_error("Error performing the `include' patching to @include, the target buffer is too small",
                 evt_tag_int("buf_size", buf_size),
-                evt_tag_str("filename", cur_lloc->level->name),
+                evt_tag_str("filename", cur_lloc->name),
                 evt_tag_printf("line", "%d:%d", cur_lloc->first_line, cur_lloc->first_column));
       return FALSE;
     }
@@ -117,7 +117,7 @@ yy_patch_include_statement(CfgLexer *self, gchar *buf, gsize buf_size, gsize *le
               "character in front) has been removed in " VERSION_3_20 ". Please prepend a '@' "
               "character in front of your include statement while updating your configuration "
               "to match the new version",
-              evt_tag_str("filename", cur_lloc->level->name),
+              evt_tag_str("filename", cur_lloc->name),
               evt_tag_printf("line", "%d:%d", cur_lloc->first_line, cur_lloc->first_column));
   return TRUE;
 }

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -160,7 +160,7 @@ _find_closest_file_inclusion(CfgLexer *self, CFG_LTYPE *yylloc)
 }
 
 const gchar *
-cfg_lexer_format_location(CfgLexer *self, CFG_LTYPE *yylloc, gchar *buf, gsize buf_len)
+cfg_lexer_format_location(CfgLexer *self, const CFG_LTYPE *yylloc, gchar *buf, gsize buf_len)
 {
   CfgIncludeLevel *level;
 
@@ -175,7 +175,7 @@ cfg_lexer_format_location(CfgLexer *self, CFG_LTYPE *yylloc, gchar *buf, gsize b
 }
 
 EVTTAG *
-cfg_lexer_format_location_tag(CfgLexer *self, CFG_LTYPE *yylloc)
+cfg_lexer_format_location_tag(CfgLexer *self, const CFG_LTYPE *yylloc)
 {
   gchar buf[256];
 
@@ -183,7 +183,7 @@ cfg_lexer_format_location_tag(CfgLexer *self, CFG_LTYPE *yylloc)
 }
 
 static int
-cfg_lexer_lookup_keyword(CfgLexer *self, CFG_STYPE *yylval, CFG_LTYPE *yylloc, const char *token)
+cfg_lexer_lookup_keyword(CfgLexer *self, CFG_STYPE *yylval, const CFG_LTYPE *yylloc, const char *token)
 {
   GList *l;
 
@@ -245,7 +245,7 @@ cfg_lexer_lookup_keyword(CfgLexer *self, CFG_STYPE *yylval, CFG_LTYPE *yylloc, c
 }
 
 int
-cfg_lexer_map_word_to_token(CfgLexer *self, CFG_STYPE *yylval, CFG_LTYPE *yylloc, const char *token)
+cfg_lexer_map_word_to_token(CfgLexer *self, CFG_STYPE *yylval, const CFG_LTYPE *yylloc, const char *token)
 {
   int tok = cfg_lexer_lookup_keyword(self, yylval, yylloc, token);
 

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -160,6 +160,17 @@ cfg_lexer_format_location_tag(CfgLexer *self, const CFG_LTYPE *yylloc)
   return evt_tag_str("location", cfg_lexer_format_location(self, yylloc, buf, sizeof(buf)));
 }
 
+void
+cfg_lexer_set_file_location(CfgLexer *self, const gchar *filename, gint line, gint column)
+{
+  CfgIncludeLevel *level = &self->include_stack[self->include_depth];
+
+  level->lloc.name = g_intern_string(filename);
+  level->lloc.first_line = level->lloc.last_line = line;
+  level->lloc.first_column = level->lloc.last_column = column;
+  level->lloc_changed_by_at_line = TRUE;
+}
+
 static int
 cfg_lexer_lookup_keyword(CfgLexer *self, CFG_STYPE *yylval, const CFG_LTYPE *yylloc, const char *token)
 {

--- a/lib/cfg-lexer.h
+++ b/lib/cfg-lexer.h
@@ -83,13 +83,15 @@ typedef struct _CfgTokenBlock CfgTokenBlock;
  */
 
 /* the location type to carry location information from the lexer to the grammar */
+
 typedef struct CFG_LTYPE
 {
   int first_line;
   int first_column;
   int last_line;
   int last_column;
-  CfgIncludeLevel *level;
+
+  const gchar *name;
 } CFG_LTYPE;
 
 /* symbol type that carries token related information to the grammar */
@@ -132,8 +134,6 @@ struct _CfgIncludeLevel
     CFGI_FILE,
     CFGI_BUFFER,
   } include_type;
-  /* include file or block name */
-  gchar *name;
   union
   {
     struct

--- a/lib/cfg-lexer.h
+++ b/lib/cfg-lexer.h
@@ -151,6 +151,10 @@ struct _CfgIncludeLevel
       gsize content_length;
     } buffer;
   };
+
+  /* this value indicates that @line was used which changed lloc relative to
+   * an actual file */
+  gboolean lloc_changed_by_at_line;
   CFG_LTYPE lloc;
   struct yy_buffer_state *yybuf;
 };
@@ -200,6 +204,7 @@ gboolean cfg_lexer_include_buffer(CfgLexer *self, const gchar *name, const gchar
 gboolean cfg_lexer_include_buffer_without_backtick_substitution(CfgLexer *self,
     const gchar *name, const gchar *buffer, gsize length);
 const gchar *cfg_lexer_format_location(CfgLexer *self, const CFG_LTYPE *yylloc, gchar *buf, gsize buf_len);
+void cfg_lexer_set_file_location(CfgLexer *self, const gchar *filename, gint line, gint column);
 EVTTAG *cfg_lexer_format_location_tag(CfgLexer *self, const CFG_LTYPE *yylloc);
 
 /* context tracking */

--- a/lib/cfg-lexer.h
+++ b/lib/cfg-lexer.h
@@ -131,6 +131,7 @@ struct _CfgIncludeLevel
 {
   enum
   {
+    CFGI_NONE,
     CFGI_FILE,
     CFGI_BUFFER,
   } include_type;

--- a/lib/cfg-lexer.h
+++ b/lib/cfg-lexer.h
@@ -190,7 +190,7 @@ void cfg_lexer_append_char(CfgLexer *self, char c);
 /* keyword handling */
 void cfg_lexer_set_current_keywords(CfgLexer *self, CfgLexerKeyword *keywords);
 char *cfg_lexer_get_keyword_string(CfgLexer *self, int kw);
-int cfg_lexer_map_word_to_token(CfgLexer *self, CFG_STYPE *yylval, CFG_LTYPE *yylloc, const char *token);
+int cfg_lexer_map_word_to_token(CfgLexer *self, CFG_STYPE *yylval, const CFG_LTYPE *yylloc, const char *token);
 
 /* include files */
 gboolean cfg_lexer_start_next_include(CfgLexer *self);
@@ -198,8 +198,8 @@ gboolean cfg_lexer_include_file(CfgLexer *self, const gchar *filename);
 gboolean cfg_lexer_include_buffer(CfgLexer *self, const gchar *name, const gchar *buffer, gssize length);
 gboolean cfg_lexer_include_buffer_without_backtick_substitution(CfgLexer *self,
     const gchar *name, const gchar *buffer, gsize length);
-const gchar *cfg_lexer_format_location(CfgLexer *self, CFG_LTYPE *yylloc, gchar *buf, gsize buf_len);
-EVTTAG *cfg_lexer_format_location_tag(CfgLexer *self, CFG_LTYPE *yylloc);
+const gchar *cfg_lexer_format_location(CfgLexer *self, const CFG_LTYPE *yylloc, gchar *buf, gsize buf_len);
+EVTTAG *cfg_lexer_format_location_tag(CfgLexer *self, const CFG_LTYPE *yylloc);
 
 /* context tracking */
 void cfg_lexer_push_context(CfgLexer *self, gint context, CfgLexerKeyword *keywords, const gchar *desc);

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -304,7 +304,8 @@ _report_file_location(const gchar *filename, const CFG_LTYPE *yylloc)
       g_ptr_array_add(context, NULL);
       fclose(f);
     }
-  _print_underlined_source_block(yylloc, (gchar **) context->pdata, error_index);
+  if (context->len > 0)
+    _print_underlined_source_block(yylloc, (gchar **) context->pdata, error_index);
 
 exit:
   g_free(buf);

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -378,7 +378,10 @@ report_syntax_error(CfgLexer *lexer, const CFG_LTYPE *yylloc, const char *what, 
         }
       else if (from->include_type == CFGI_BUFFER)
         {
-          _report_buffer_location(from->buffer.original_content, from_lloc);
+          if (from->lloc_changed_by_at_line)
+            _report_file_location(from_lloc->name, from_lloc);
+          else
+            _report_buffer_location(from->buffer.original_content, from_lloc);
         }
       fprintf(stderr, "\n");
     }

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -339,7 +339,7 @@ void
 report_syntax_error(CfgLexer *lexer, const CFG_LTYPE *yylloc, const char *what, const char *msg,
                     gboolean in_main_grammar)
 {
-  CfgIncludeLevel *level = yylloc->level, *from;
+  CfgIncludeLevel *level = &lexer->include_stack[lexer->include_depth], *from;
 
   for (from = level; from >= lexer->include_stack; from--)
     {
@@ -357,7 +357,7 @@ report_syntax_error(CfgLexer *lexer, const CFG_LTYPE *yylloc, const char *what, 
           fprintf(stderr, "Error parsing %s, %s in %s:%d:%d-%d:%d:\n",
                   what,
                   msg,
-                  from_lloc->level->name,
+                  from_lloc->name,
                   from_lloc->first_line,
                   from_lloc->first_column,
                   from_lloc->last_line,
@@ -366,7 +366,7 @@ report_syntax_error(CfgLexer *lexer, const CFG_LTYPE *yylloc, const char *what, 
       else
         {
           from_lloc = &from->lloc;
-          fprintf(stderr, "Included from %s:%d:%d-%d:%d:\n", from->name,
+          fprintf(stderr, "Included from %s:%d:%d-%d:%d:\n", from_lloc->name,
                   from_lloc->first_line,
                   from_lloc->first_column,
                   from_lloc->last_line,
@@ -374,7 +374,7 @@ report_syntax_error(CfgLexer *lexer, const CFG_LTYPE *yylloc, const char *what, 
         }
       if (from->include_type == CFGI_FILE)
         {
-          _report_file_location(from->name, from_lloc);
+          _report_file_location(from_lloc->name, from_lloc);
         }
       else if (from->include_type == CFGI_BUFFER)
         {

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -268,7 +268,7 @@ log_expr_node_new(gint layout, gint content, const gchar *name, LogExprNode *chi
   self->flags = flags;
   if (yylloc)
     {
-      self->filename = g_strdup(yylloc->level->name);
+      self->filename = g_strdup(yylloc->name);
       self->line = yylloc->first_line;
       self->column = yylloc->first_column;
     }

--- a/lib/pragma-grammar.ym
+++ b/lib/pragma-grammar.ym
@@ -48,6 +48,7 @@
 %token KW_DEFINE
 %token KW_MODULE
 %token KW_REQUIRES
+%token KW_LINE
 
 %code {
 
@@ -110,6 +111,7 @@ stmt_without_eol
 stmt_with_eol
         : include_stmt
         | requires_stmt
+        | line_stmt
         ;
 
 version_stmt
@@ -197,6 +199,13 @@ requires_message
 	: string		{ $$ = $1; }
 	| 			{ $$ = NULL; }
 	;
+
+line_stmt
+	: KW_LINE string positive_integer positive_integer LL_EOL
+          {
+            cfg_lexer_set_file_location(lexer, $2, $3, $4);
+            free($2);
+          }
 
 /* INCLUDE_RULES */
 

--- a/lib/pragma-parser.c
+++ b/lib/pragma-parser.c
@@ -72,6 +72,7 @@ static CfgLexerKeyword pragma_keywords[] =
   { "module",             KW_MODULE, },
   { "define",             KW_DEFINE, },
   { "requires",           KW_REQUIRES, },
+  { "line",               KW_LINE },
   { CFG_KEYWORD_STOP },
 };
 

--- a/lib/tests/test_lexer.c
+++ b/lib/tests/test_lexer.c
@@ -144,7 +144,8 @@ _format_location_tag_message(void)
     char *msg = _format_location_tag_message(); \
     const gchar *tag_repr;        \
     tag_repr = strstr(msg, "; ");                 \
-    cr_assert_str_eq(tag_repr ? tag_repr + 2 : NULL, expected, "Formatted location tag does not match");  \
+    tag_repr = tag_repr ? tag_repr + 2 : NULL;    \
+    cr_assert_str_eq(tag_repr, expected, "Formatted location tag does not match %s <> %s", tag_repr, expected);  \
     free(msg);                    \
                                                                                         \
   })
@@ -385,7 +386,7 @@ Test(lexer, test_location_tracking)
   _next_token();
   assert_location(3, 1);
 
-  assert_location_tag("location='#buffer:3:1'");
+  assert_location_tag("location='#test-buffer:3:1'");
 }
 
 Test(lexer, test_multiline_string_literals)

--- a/lib/tests/test_lexer_block.c
+++ b/lib/tests/test_lexer_block.c
@@ -38,9 +38,9 @@ setup(void)
 {
   result = g_string_sized_new(100);
 
-  CfgIncludeLevel *level = g_new0(CfgIncludeLevel, 1);
-  level->name = "";
-  yyloc.level = level;
+  yyloc.name = "config-file";
+  yyloc.first_line = yyloc.first_column = 1;
+  yyloc.last_line = yyloc.last_column = 1;
 
   configuration = cfg_new_snippet();
   msg_init(TRUE);
@@ -51,7 +51,6 @@ teardown(void)
 {
   msg_deinit();
   cfg_free(configuration);
-  g_free(yyloc.level);
   g_string_free(result, TRUE);
 }
 

--- a/libtest/config_parse_lib.c
+++ b/libtest/config_parse_lib.c
@@ -81,7 +81,6 @@ parse_plugin_config(const gchar *config_to_parse, gint context, gpointer arg)
   yylloc->first_line = 1;
   yylloc->last_column = 1;
   yylloc->last_line = 1;
-  yylloc->level = &lexer->include_stack[0];
 
   plugin = cfg_find_plugin(configuration, context, delimited[0]);
   if (!plugin)

--- a/libtest/mock-cfg-parser.c
+++ b/libtest/mock-cfg-parser.c
@@ -58,7 +58,6 @@ cfg_parser_mock_new(void)
   self->yylloc->last_column = 1;
   self->yylloc->last_line = 1;
   self->lexer = cfg_lexer_new_buffer(configuration, "", 0);
-  self->yylloc->level = &self->lexer->include_stack[0];
 
   return self;
 }


### PR DESCRIPTION
This PR builds on the cfg-lexer refactor and will improve the debugger source display dramatically as we become able to
track code that is inside blocks properly.

It also adds the ability to generate syslog-ng configuration using external tools and mark generated code with "@line" to refer to the original source file, in a similar vein to how C/C++ tracks header files, etc.
