### PR TITLE
Preliminary tracing support in debugger

### DIFF
--- a/lib/debugger/debugger-main.c
+++ b/lib/debugger/debugger-main.c
@@ -33,7 +33,10 @@ _pipe_hook(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
   if ((s->flags & PIF_CONFIG_RELATED) == 0)
     return TRUE;
 
-  return debugger_stop_at_breakpoint(current_debugger, s, msg);
+  if (msg->flags & LF_STATE_TRACING)
+    return debugger_perform_tracing(current_debugger, s, msg);
+  else
+    return debugger_stop_at_breakpoint(current_debugger, s, msg);
 }
 
 void

--- a/lib/debugger/debugger-main.c
+++ b/lib/debugger/debugger-main.c
@@ -30,6 +30,9 @@ static Debugger *current_debugger;
 static gboolean
 _pipe_hook(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
+  if ((s->flags & PIF_CONFIG_RELATED) == 0)
+    return TRUE;
+
   return debugger_stop_at_breakpoint(current_debugger, s, msg);
 }
 

--- a/lib/debugger/debugger.c
+++ b/lib/debugger/debugger.c
@@ -128,6 +128,7 @@ _cmd_help(Debugger *self, gint argc, gchar *argv[])
 {
   printf("syslog-ng interactive console, the following commands are available\n\n"
          "  help, h, or ?            Display this help\n"
+         "  info                     Display information about the current execution state\n"
          "  continue or c            Continue until the next breakpoint\n"
          "  trace                    Display timing information as the message traverses the config\n"
          "  print, p                 Print the current log message\n"
@@ -201,6 +202,31 @@ _cmd_quit(Debugger *self, gint argc, gchar *argv[])
   return FALSE;
 }
 
+static gboolean
+_cmd_info_pipe(Debugger *self, LogPipe *pipe)
+{
+  gchar buf[1024];
+
+  printf("LogPipe %p at %s\n", pipe, log_expr_node_format_location(pipe->expr_node, buf, sizeof(buf)));
+  _display_source_line(pipe->expr_node);
+
+  return TRUE;
+}
+
+static gboolean
+_cmd_info(Debugger *self, gint argc, gchar *argv[])
+{
+  if (argc >= 2)
+    {
+      if (strcmp(argv[1], "pipe") == 0)
+        return _cmd_info_pipe(self, self->current_pipe);
+    }
+
+  printf("info: List of info subcommands\n"
+         "info pipe -- display information about the current pipe\n");
+  return TRUE;
+}
+
 typedef gboolean (*DebuggerCommandFunc)(Debugger *self, gint argc, gchar *argv[]);
 
 struct
@@ -221,6 +247,8 @@ struct
   { "quit",     _cmd_quit },
   { "q",        _cmd_quit },
   { "trace",    _cmd_trace },
+  { "info",     _cmd_info },
+  { "i",        _cmd_info },
   { NULL, NULL }
 };
 

--- a/lib/debugger/debugger.h
+++ b/lib/debugger/debugger.h
@@ -38,6 +38,7 @@ void debugger_free(Debugger *self);
 gchar *debugger_builtin_fetch_command(void);
 void debugger_register_command_fetcher(FetchCommandFunc fetcher);
 void debugger_start_console(Debugger *self);
+gboolean debugger_perform_tracing(Debugger *self, LogPipe *pipe, LogMessage *msg);
 gboolean debugger_stop_at_breakpoint(Debugger *self, LogPipe *pipe, LogMessage *msg);
 
 #endif

--- a/lib/driver.c
+++ b/lib/driver.c
@@ -142,6 +142,7 @@ static void
 log_driver_init_instance(LogDriver *self, GlobalConfig *cfg)
 {
   log_pipe_init_instance(&self->super, cfg);
+  self->super.flags |= PIF_CONFIG_RELATED;
   self->super.free_fn = log_driver_free;
   self->super.pre_init = log_driver_pre_init_method;
   self->super.init = log_driver_init_method;

--- a/lib/filter/filter-pipe.c
+++ b/lib/filter/filter-pipe.c
@@ -124,6 +124,7 @@ log_filter_pipe_new(FilterExprNode *expr, GlobalConfig *cfg)
   LogFilterPipe *self = g_new0(LogFilterPipe, 1);
 
   log_pipe_init_instance(&self->super, cfg);
+  self->super.flags |= PIF_CONFIG_RELATED;
   self->super.init = log_filter_pipe_init;
   self->super.queue = log_filter_pipe_queue;
   self->super.free_fn = log_filter_pipe_free;

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1497,7 +1497,7 @@ log_msg_clone_cow(LogMessage *msg, const LogPathOptions *path_options)
       self->ack_func = log_msg_clone_ack;
     }
 
-  self->flags &= ~LF_STATE_MASK;
+  self->flags &= ~(LF_STATE_MASK - LF_STATE_CLONED_MASK);
 
   if (self->num_tags == 0)
     self->flags |= LF_STATE_OWN_TAGS;

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -113,6 +113,7 @@ enum
   LF_LOCAL             = 0x0004,
   /* message is a MARK mode */
   LF_MARK              = 0x0008,
+
   /* state flags that only matter during syslog-ng runtime and never
    * when a message is serialized */
   LF_STATE_MASK        = 0xFFF0,
@@ -123,6 +124,8 @@ enum
   LF_STATE_OWN_SDATA   = 0x0100,
   LF_STATE_OWN_MASK    = 0x01F0,
 
+  /* part of the state that is kept across clones */
+  LF_STATE_CLONED_MASK = 0xFE00,
 
   LF_CHAINED_HOSTNAME  = 0x00010000,
 

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -126,6 +126,7 @@ enum
 
   /* part of the state that is kept across clones */
   LF_STATE_CLONED_MASK = 0xFE00,
+  LF_STATE_TRACING     = 0x0200,
 
   LF_CHAINED_HOSTNAME  = 0x00010000,
 

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -64,6 +64,9 @@
 
 #define PIF_SOURCE            0x0040
 
+/* node created directly by the user */
+#define PIF_CONFIG_RELATED    0x0080
+
 /* private flags range, to be used by other LogPipe instances for their own purposes */
 
 #define PIF_PRIVATE(x)       ((x) << 16)

--- a/lib/parser/parser-expr.c
+++ b/lib/parser/parser-expr.c
@@ -156,6 +156,7 @@ void
 log_parser_init_instance(LogParser *self, GlobalConfig *cfg)
 {
   log_pipe_init_instance(&self->super, cfg);
+  self->super.flags |= PIF_CONFIG_RELATED;
   self->super.init = log_parser_init_method;
   self->super.deinit = log_parser_deinit_method;
   self->super.free_fn = log_parser_free_method;

--- a/lib/rewrite/rewrite-expr.c
+++ b/lib/rewrite/rewrite-expr.c
@@ -90,6 +90,7 @@ log_rewrite_init_instance(LogRewrite *self, GlobalConfig *cfg)
 {
   log_pipe_init_instance(&self->super, cfg);
   /* indicate that the rewrite rule is changing the message */
+  self->super.flags |= PIF_CONFIG_RELATED;
   self->super.free_fn = log_rewrite_free_method;
   self->super.queue = log_rewrite_queue;
   self->super.init = log_rewrite_init_method;


### PR DESCRIPTION
This is more a proof of concept that improves the interactive debugger of syslog-ng (-i). There are actually two changes in here:

1) the debugger will only stop at user-specified LogPipe instances (and not all of them, which is cumbersome to trace through)
2) a new "trace" command that will display tracing/timing information on how a message traverses the configuration
3) a new "info pipe" command

These three could actually be split. The first two patches implement the 1), the two subsequent patch implement 2) and the new info pipe is the last patch. I just didn't want to bomb you would a lot of PRs. But I can split this easily.

NEWS is still missing, let me see if it's green.
