### PR TITLE
Fix memory leak in timeutils/cache (syslog-ng#4332)

### DIFF
--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -45,6 +45,7 @@
 #include "transport/transport-factory-id.h"
 #include "timeutils/timeutils.h"
 #include "msg-stats.h"
+#include "timeutils/cache.h"
 
 #include <iv.h>
 #include <iv_work.h>
@@ -292,4 +293,5 @@ app_thread_stop(void)
   main_loop_call_thread_deinit();
   dns_caching_thread_deinit();
   scratch_buffers_allocator_deinit();
+  timeutils_cache_deinit();
 }

--- a/lib/timeutils/cache.c
+++ b/lib/timeutils/cache.c
@@ -164,6 +164,11 @@ _clean_timeutils_cache(void)
   memset(&cache.mktime.key, 0, sizeof(cache.mktime.key));
   if (cache.tzinfo.zones)
     cache_clear(cache.tzinfo.zones);
+
+  g_free(state.tzname[0]);
+  state.tzname[0] = NULL;
+  g_free(state.tzname[1]);
+  state.tzname[1] = NULL;
 }
 
 static void
@@ -181,6 +186,12 @@ _validate_timeutils_cache(void)
 
       local_gencounter = gencounter;
     }
+}
+
+void
+timeutils_cache_deinit(void)
+{
+  _clean_timeutils_cache();
 }
 
 void

--- a/lib/timeutils/cache.h
+++ b/lib/timeutils/cache.h
@@ -38,6 +38,7 @@ time_t cached_mktime(struct tm *tm);
 void cached_localtime(time_t *when, struct tm *tm);
 void cached_gmtime(time_t *when, struct tm *tm);
 
+void timeutils_cache_deinit(void);
 
 static inline void
 cached_localtime_wct(time_t *when, WallClockTime *wct)


### PR DESCRIPTION
Each time a worker thread terminates, the 2 allocated tznames are leaked. Solution is to explicitly deinit the cache from the stop function of the thread.

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
