### PR TITLE
qdisk: refactor qdisk_start()

### DIFF
--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1147,6 +1147,31 @@ _close_file(QDisk *self)
     }
 }
 
+static void
+_ensure_header_byte_order(QDisk *self)
+{
+  if ((self->hdr->big_endian && G_BYTE_ORDER == G_LITTLE_ENDIAN) ||
+      (!self->hdr->big_endian && G_BYTE_ORDER == G_BIG_ENDIAN))
+    {
+      self->hdr->read_head = GUINT64_SWAP_LE_BE(self->hdr->read_head);
+      self->hdr->write_head = GUINT64_SWAP_LE_BE(self->hdr->write_head);
+      self->hdr->length = GUINT64_SWAP_LE_BE(self->hdr->length);
+      self->hdr->qout_pos.ofs = GUINT64_SWAP_LE_BE(self->hdr->qout_pos.ofs);
+      self->hdr->qout_pos.len = GUINT32_SWAP_LE_BE(self->hdr->qout_pos.len);
+      self->hdr->qout_pos.count = GUINT32_SWAP_LE_BE(self->hdr->qout_pos.count);
+      self->hdr->qbacklog_pos.ofs = GUINT64_SWAP_LE_BE(self->hdr->qbacklog_pos.ofs);
+      self->hdr->qbacklog_pos.len = GUINT32_SWAP_LE_BE(self->hdr->qbacklog_pos.len);
+      self->hdr->qbacklog_pos.count = GUINT32_SWAP_LE_BE(self->hdr->qbacklog_pos.count);
+      self->hdr->qoverflow_pos.ofs = GUINT64_SWAP_LE_BE(self->hdr->qoverflow_pos.ofs);
+      self->hdr->qoverflow_pos.len = GUINT32_SWAP_LE_BE(self->hdr->qoverflow_pos.len);
+      self->hdr->qoverflow_pos.count = GUINT32_SWAP_LE_BE(self->hdr->qoverflow_pos.count);
+      self->hdr->backlog_head = GUINT64_SWAP_LE_BE(self->hdr->backlog_head);
+      self->hdr->backlog_len = GUINT64_SWAP_LE_BE(self->hdr->backlog_len);
+      self->hdr->disk_buf_size = GUINT64_SWAP_LE_BE(self->hdr->disk_buf_size);
+      self->hdr->big_endian = (G_BYTE_ORDER == G_BIG_ENDIAN);
+    }
+}
+
 static gboolean
 _create_path(const gchar *filename)
 {
@@ -1366,26 +1391,7 @@ qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, 
           _upgrade_header(self);
         }
 
-      if ((self->hdr->big_endian && G_BYTE_ORDER == G_LITTLE_ENDIAN) ||
-          (!self->hdr->big_endian && G_BYTE_ORDER == G_BIG_ENDIAN))
-        {
-          self->hdr->read_head = GUINT64_SWAP_LE_BE(self->hdr->read_head);
-          self->hdr->write_head = GUINT64_SWAP_LE_BE(self->hdr->write_head);
-          self->hdr->length = GUINT64_SWAP_LE_BE(self->hdr->length);
-          self->hdr->qout_pos.ofs = GUINT64_SWAP_LE_BE(self->hdr->qout_pos.ofs);
-          self->hdr->qout_pos.len = GUINT32_SWAP_LE_BE(self->hdr->qout_pos.len);
-          self->hdr->qout_pos.count = GUINT32_SWAP_LE_BE(self->hdr->qout_pos.count);
-          self->hdr->qbacklog_pos.ofs = GUINT64_SWAP_LE_BE(self->hdr->qbacklog_pos.ofs);
-          self->hdr->qbacklog_pos.len = GUINT32_SWAP_LE_BE(self->hdr->qbacklog_pos.len);
-          self->hdr->qbacklog_pos.count = GUINT32_SWAP_LE_BE(self->hdr->qbacklog_pos.count);
-          self->hdr->qoverflow_pos.ofs = GUINT64_SWAP_LE_BE(self->hdr->qoverflow_pos.ofs);
-          self->hdr->qoverflow_pos.len = GUINT32_SWAP_LE_BE(self->hdr->qoverflow_pos.len);
-          self->hdr->qoverflow_pos.count = GUINT32_SWAP_LE_BE(self->hdr->qoverflow_pos.count);
-          self->hdr->backlog_head = GUINT64_SWAP_LE_BE(self->hdr->backlog_head);
-          self->hdr->backlog_len = GUINT64_SWAP_LE_BE(self->hdr->backlog_len);
-          self->hdr->disk_buf_size = GUINT64_SWAP_LE_BE(self->hdr->disk_buf_size);
-          self->hdr->big_endian = (G_BYTE_ORDER == G_BIG_ENDIAN);
-        }
+      _ensure_header_byte_order(self);
       if (!_load_state(self, qout, qbacklog, qoverflow))
         {
           _close_file(self);

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1175,8 +1175,11 @@ _create_file(QDisk *self, const gchar *filename)
   self->fd = fd;
   self->filename = g_strdup(filename);
 
-  if (self->options->prealloc)
-    return _preallocate(self, self->options->disk_buf_size);
+  if (self->options->prealloc && !_preallocate(self, self->options->disk_buf_size))
+    {
+      _close_file(self);
+      return FALSE;
+    }
 
   return TRUE;
 }

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1470,12 +1470,6 @@ qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, 
 
   self->file_size = self->hdr->write_head;
 
-  if (!qdisk_save_state(self, qout, qbacklog, qoverflow))
-    {
-      _close_file(self);
-      return FALSE;
-    }
-
   return TRUE;
 }
 

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1440,8 +1440,13 @@ error:
 static gboolean
 _init_qdisk_file(QDisk *self)
 {
-  self->file_size = QDISK_RESERVED_SPACE;
-  return _create_header(self);
+  if (!_create_header(self))
+    return FALSE;
+
+  if (!self->file_size)
+    self->file_size = QDISK_RESERVED_SPACE;
+
+  return TRUE;
 }
 
 static gboolean

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1037,7 +1037,7 @@ qdisk_save_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
         return FALSE;
     }
 
-  memcpy(self->hdr->magic, self->file_id, 4);
+  memcpy(self->hdr->magic, self->file_id, sizeof(self->hdr->magic));
 
   self->hdr->qout_pos = qout_pos;
   self->hdr->qbacklog_pos = qbacklog_pos;
@@ -1200,6 +1200,8 @@ _create_header(QDisk *self)
                 evt_tag_error("error"));
       return FALSE;
     }
+
+  memcpy(self->hdr->magic, self->file_id, sizeof(self->hdr->magic));
 
   self->hdr->version = QDISK_HDR_VERSION_CURRENT;
   self->hdr->big_endian = (G_BYTE_ORDER == G_BIG_ENDIAN);

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1265,18 +1265,9 @@ _load_header(QDisk *self)
 
   _ensure_header_byte_order(self);
 
-  return TRUE;
-}
-
-static gboolean
-_load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
-{
-  if (!_load_header(self))
-    return FALSE;
-
   if (memcmp(self->hdr->magic, self->file_id, 4) != 0)
     {
-      msg_error("Error reading disk-queue file header",
+      msg_error("Error reading disk-queue file header. Invalid magic",
                 evt_tag_str("filename", self->filename));
       return FALSE;
     }
@@ -1290,6 +1281,15 @@ _load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
                 evt_tag_long("qdisk_length",  self->hdr->length));
       return FALSE;
     }
+
+  return TRUE;
+}
+
+static gboolean
+_load_state(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
+{
+  if (!_load_header(self))
+    return FALSE;
 
   if (!self->options->reliable)
     {

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1457,11 +1457,6 @@ error:
 gboolean
 qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
 {
-  /*
-   * If qdisk_start is called for already initialized qdisk file
-   * it can cause message loosing.
-   * We need this assert to detect programming error as soon as possible.
-   */
   g_assert(!qdisk_started(self));
 
   struct stat st;

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1428,11 +1428,8 @@ qdisk_init_instance(QDisk *self, DiskQueueOptions *options, const gchar *file_id
 void
 qdisk_stop(QDisk *self)
 {
-  if (self->filename)
-    {
-      g_free(self->filename);
-      self->filename = NULL;
-    }
+  g_free(self->filename);
+  self->filename = NULL;
 
   _close_file(self);
 }

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1431,6 +1431,13 @@ error:
   return FALSE;
 }
 
+static gboolean
+_init_qdisk_file(QDisk *self)
+{
+  self->file_size = QDISK_RESERVED_SPACE;
+  return _create_header(self);
+}
+
 gboolean
 qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
 {
@@ -1462,13 +1469,11 @@ qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, 
         }
     }
 
-  if (!_create_header(self))
+  if (!_init_qdisk_file(self))
     {
       _close_file(self);
       return FALSE;
     }
-
-  self->file_size = self->hdr->write_head;
 
   return TRUE;
 }

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1201,8 +1201,8 @@ _open_file(QDisk *self, const gchar *filename)
 static gboolean
 _create_file(QDisk *self, const gchar *filename)
 {
-  if (self->options->read_only)
-    return FALSE;
+  g_assert(!self->options->read_only);
+  g_assert(filename);
 
   if (!_create_path(filename))
     {

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1076,6 +1076,9 @@ _close_file(QDisk *self)
       close(self->fd);
       self->fd = -1;
     }
+
+  g_free(self->filename);
+  self->filename = NULL;
 }
 
 static void
@@ -1488,9 +1491,6 @@ qdisk_init_instance(QDisk *self, DiskQueueOptions *options, const gchar *file_id
 void
 qdisk_stop(QDisk *self)
 {
-  g_free(self->filename);
-  self->filename = NULL;
-
   _close_file(self);
 }
 


### PR DESCRIPTION
This PR refactors the monster `qdisk_start()` function. There are some minor edge case fixes, but no functional change is expected.

No NEWS file needed.

Signed-off-by: Attila Szakacs <szakacs.attila96@gmail.com>