### PR TITLE
#3366 : Added optionality for libexamples module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -289,6 +289,10 @@ AC_ARG_ENABLE(mqtt,
               [  --disable-mqtt          Disable MQTT support (default: auto)]
               ,,enable_mqtt="auto")
 
+AC_ARG_LIB(curl, curl_easy_init, 
+                [have_curl=yes], [have_curl=no])
+
+
 AC_ARG_WITH(libpaho-mqtt,
              AC_HELP_STRING([--with-libpaho-mqtt=DIR],
                             [use libpaho-mqtt library from (prefix) directory DIR]),,)

--- a/modules/examples/Makefile.am
+++ b/modules/examples/Makefile.am
@@ -25,6 +25,12 @@ modules_examples_libexamples_la_LIBADD = $(MODULE_DEPS_LIBS) $(EXAMPLE_PLUGINS)
 modules_examples_libexamples_la_DEPENDENCIES = $(MODULE_DEPS_LIBS) $(EXAMPLE_PLUGINS)
 modules_examples_libexamples_la_LDFLAGS = $(MODULE_LDFLAGS)
 
+if ENABLE_libexamples
+lib_LTLIBRARIES = libexamples.la
+libexamples_la_SOURCES = mymodule.c mymodule.h
+endif
+AM_CPPFLAGS = -DENABLE_MYMODULE
+
 EXTRA_DIST += modules/examples/CMakeLists.txt
 
 modules/examples modules/examples/ mod-examples: modules/examples/libexamples.la


### PR DESCRIPTION
<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
Added optionality for libexamples module
To enable the module, you can define the macro ENABLE_MYMODULE in your build system. For example, you could add the following line to a Makefile.
To disable the module, you can either undefine the ENABLE_MYMODULE macro or comment out the AM_CPPFLAGS line in your Makefile.

by Aryan Sharma 
email :- Sharmaaryan9837@gmail.com
-->
