### PR TITLE
logmpx: fix matched logic

### DIFF
--- a/lib/logmpx.c
+++ b/lib/logmpx.c
@@ -113,25 +113,12 @@ log_multiplexer_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_op
         }
     }
 
-  /* NOTE: non of our multiplexed destinations delivered this message, let's
-   * propagate this result.  But only if we don't have a "next".  If we do,
-   * that would be responsible for doing the same, for instance if it is a
-   * filter.
-   *
-   * In case where this matters most (e.g.  the multiplexer attached to the
-   * source LogPipe), "next" will always be NULL.  I am not sure if there's
-   * ever a case, where a LogMpx has both "next" set, and have branches as
-   * well.
-   *
-   * If there's such a case, then from a conceptual point of view, this Mpx
-   * instance should transfer the responsibility for setting "matched" to
-   * the next pipeline element, which is what we do here.
-   */
+  log_pipe_forward_msg(s, msg, &local_options);
+  if (matched)
+    delivered = TRUE;
 
-  if (!s->pipe_next && !delivered && path_options->matched)
+  if (!delivered && path_options->matched)
     *path_options->matched = FALSE;
-
-  log_pipe_forward_msg(s, msg, path_options);
 }
 
 static void


### PR DESCRIPTION
We can have a multiplexer with both `pipe_next` and `next_hops`.

The `path_options`'s `matched` field must only be set to false if and only if every `next_hop` and also the `pipe_next` failed to deliver. If at least one `next_hop` or at least the `pipe_next` delivered it, it must not be set to false.

With the old logic, if the multiplexer had a `pipe_next`, the `next_hops`' delivery result was ignored completely, which is not the correct behavior.

Signed-off-by: Attila Szakacs <szakacs.attila96@gmail.com>

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
