### PR TITLE
cfg: add named logpaths with counters

### DIFF
--- a/contrib/scripts/config-graph-json-to-dot.py
+++ b/contrib/scripts/config-graph-json-to-dot.py
@@ -15,7 +15,7 @@ arcs = j["arcs"]
 
 print("digraph D {")
 for node in nodes:
-    print("  Node{} [label=\"{} {}\"]".format(node["node"], node["node"], ", ".join(node["info"])))
+    print("  Node{} [label=\"{} {}\", shape=box]".format(node["node"], node["node"], ", ".join(node["info"])))
 for arc in arcs:
     print("  Node{} -> Node{} [label=\"{}\"]".format(arc["from"], arc["to"], arc["type"]))
 print("}")

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,6 +5,7 @@ isort==4.3.4
 pylint==1.8.2
 astroid==1.6.1
 logilab-common<=0.63.0
+prometheus-client
 psutil
 pytest
 pytest-mock

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -112,6 +112,7 @@ set (LIB_HEADERS
     module-config.h
     memtrace.h
     messages.h
+    metrics-pipe.h
     ml-batched-timer.h
     mainloop-control.h
     msg-format.h
@@ -204,6 +205,7 @@ set(LIB_SOURCES
     module-config.c
     memtrace.c
     messages.c
+    metrics-pipe.c
     ml-batched-timer.c
     mainloop-control.c
     msg-format.c

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -139,6 +139,7 @@ pkginclude_HEADERS			+= \
 	lib/module-config.h		\
 	lib/memtrace.h			\
 	lib/messages.h			\
+	lib/metrics-pipe.h			\
 	lib/ml-batched-timer.h		\
 	lib/msg-format.h		\
 	lib/msg-stats.h			\
@@ -229,6 +230,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	lib/module-config.c		\
 	lib/memtrace.c			\
 	lib/messages.c			\
+	lib/metrics-pipe.c			\
 	lib/ml-batched-timer.c		\
 	lib/msg-format.c		\
 	lib/msg-stats.c			\

--- a/lib/cfg-tree.c
+++ b/lib/cfg-tree.c
@@ -241,6 +241,13 @@ log_expr_node_set_aux(LogExprNode *self, gpointer aux, GDestroyNotify destroy)
   self->aux_destroy = destroy;
 }
 
+void
+log_expr_node_set_name(LogExprNode *self, const gchar *name)
+{
+  g_free(self->name);
+  self->name = g_strdup(name);
+}
+
 /**
  * log_expr_node_new:
  * @layout: layout of the children (ENL_*)
@@ -1262,7 +1269,7 @@ cfg_tree_add_object(CfgTree *self, LogExprNode *rule)
 {
   gboolean res = TRUE;
 
-  if (rule->name)
+  if (rule->name && rule->content != ENC_PIPE)
     {
       /* only named rules can be stored as objects to be referenced later */
 

--- a/lib/cfg-tree.h
+++ b/lib/cfg-tree.h
@@ -129,6 +129,7 @@ gint log_expr_node_lookup_flag(const gchar *flag);
 
 LogExprNode *log_expr_node_append_tail(LogExprNode *a, LogExprNode *b);
 void log_expr_node_set_object(LogExprNode *self, gpointer object, GDestroyNotify destroy);
+void log_expr_node_set_name(LogExprNode *self, const gchar *name);
 const gchar *log_expr_node_format_location(LogExprNode *self, gchar *buf, gsize buf_len);
 EVTTAG *log_expr_node_location_tag(LogExprNode *self);
 

--- a/lib/cfg-tree.h
+++ b/lib/cfg-tree.h
@@ -169,6 +169,7 @@ typedef struct _CfgTree
   GPtrArray *rules;
   GHashTable *templates;
   gboolean compiled;
+  GHashTable *log_path_names;
 } CfgTree;
 
 gboolean cfg_tree_add_object(CfgTree *self, LogExprNode *rule);

--- a/lib/metrics-pipe.c
+++ b/lib/metrics-pipe.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2023 Attila Szakacs
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "metrics-pipe.h"
+#include "stats/stats-registry.h"
+#include "stats/stats-cluster-single.h"
+
+static void
+_init_stats_keys(MetricsPipe *self, StatsClusterKey *ingress_sc_key, StatsClusterKey *egress_sc_key)
+{
+  enum { labels_len = 1 };
+  static StatsClusterLabel labels[labels_len];
+
+  labels[0] = stats_cluster_label("id", self->log_path_name);
+  stats_cluster_single_key_set(ingress_sc_key, "log_path_ingress", labels, labels_len);
+  stats_cluster_single_key_set(egress_sc_key, "log_path_egress", labels, labels_len);
+}
+
+static void
+_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
+{
+  MetricsPipe *self = (MetricsPipe *) s;
+
+  stats_counter_inc(self->ingress_counter);
+
+  gboolean matched = TRUE;
+  LogPathOptions local_options = *path_options;
+  local_options.matched = &matched;
+
+  log_pipe_forward_msg(s, msg, &local_options);
+
+  if (*local_options.matched)
+    stats_counter_inc(self->egress_counter);
+
+  if (path_options->matched)
+    *path_options->matched = *local_options.matched;
+}
+
+static gboolean
+_init(LogPipe *s)
+{
+  MetricsPipe *self = (MetricsPipe *) s;
+
+  StatsClusterKey ingress_sc_key;
+  StatsClusterKey egress_sc_key;
+  _init_stats_keys(self, &ingress_sc_key, &egress_sc_key);
+
+  stats_lock();
+  {
+    stats_register_counter(STATS_LEVEL1, &ingress_sc_key, SC_TYPE_SINGLE_VALUE, &self->ingress_counter);
+    stats_register_counter(STATS_LEVEL1, &egress_sc_key, SC_TYPE_SINGLE_VALUE, &self->egress_counter);
+  }
+  stats_unlock();
+
+  return TRUE;
+}
+
+static gboolean
+_deinit(LogPipe *s)
+{
+  MetricsPipe *self = (MetricsPipe *) s;
+
+  StatsClusterKey ingress_sc_key;
+  StatsClusterKey egress_sc_key;
+  _init_stats_keys(self, &ingress_sc_key, &egress_sc_key);
+
+  stats_lock();
+  {
+    stats_unregister_counter(&ingress_sc_key, SC_TYPE_SINGLE_VALUE, &self->ingress_counter);
+    stats_unregister_counter(&egress_sc_key, SC_TYPE_SINGLE_VALUE, &self->egress_counter);
+  }
+  stats_unlock();
+
+  return TRUE;
+}
+
+static void
+_free(LogPipe *s)
+{
+  MetricsPipe *self = (MetricsPipe *) s;
+
+  g_free(self->log_path_name);
+  log_pipe_free_method(s);
+}
+
+MetricsPipe *
+metrics_pipe_new(GlobalConfig *cfg, const gchar *log_path_name)
+{
+  MetricsPipe *self = g_new0(MetricsPipe, 1);
+
+  log_pipe_init_instance(&self->super, cfg);
+  self->super.queue = _queue;
+  self->super.init = _init;
+  self->super.deinit = _deinit;
+  self->super.free_fn = _free;
+
+  self->log_path_name = g_strdup(log_path_name);
+
+  log_pipe_add_info(&self->super, "metrics-pipe");
+  log_pipe_add_info(&self->super, self->log_path_name);
+
+  return self;
+}

--- a/lib/metrics-pipe.h
+++ b/lib/metrics-pipe.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2023 Attila Szakacs
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "syslog-ng.h"
+#include "logpipe.h"
+
+typedef struct _MetricsPipe MetricsPipe;
+struct _MetricsPipe
+{
+  LogPipe super;
+  gchar *log_path_name;
+
+  StatsCounterItem *ingress_counter;
+  StatsCounterItem *egress_counter;
+};
+
+MetricsPipe *metrics_pipe_new(GlobalConfig *cfg, const gchar *log_path_name);

--- a/news/feature-4342.md
+++ b/news/feature-4342.md
@@ -1,0 +1,31 @@
+`log` paths: Added option to create named log paths.
+
+E.g.:
+```
+log top-level {
+    source(s_local);
+
+    log inner-1 {
+        filter(f_inner_1);
+        destination(d_local_1);
+    };
+
+    log inner-2 {
+        filter(f_inner_2);
+        destination(d_local_2);
+    };
+};
+```
+
+Each named log path counts its ingress and egress messages:
+```
+syslogng_log_path_ingress{id="top-level"} 114
+syslogng_log_path_ingress{id="inner-1"} 114
+syslogng_log_path_ingress{id="inner-2"} 114
+syslogng_log_path_egress{id="top-level"} 103
+syslogng_log_path_egress{id="inner-1"} 62
+syslogng_log_path_egress{id="inner-2"} 41
+```
+
+Note that the egress statistics only count the messages which have been have not been filtered out from the related
+log path, it does care about whether there are any destinations in it or that any destination delivers or drops the message.

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -168,6 +168,7 @@ modules/syslogformat/sdata-parser\.[ch]
 tests/light/functional_tests/logpath/__init__.py
 tests/light/functional_tests/logpath/test_named_logpaths.py
 tests/light/functional_tests/logpath/test_named_logpaths_with_catchall_flag.py
+tests/light/functional_tests/logpath/test_named_logpaths_with_fallback_flag.py
 tests/light/functional_tests/parsers/sdata-parser/test_sdata_parser\.py
 tests/light/src/syslog_ng_ctl/prometheus_stats_handler.py
 

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -73,6 +73,7 @@ modules/secure-logging/tests
 modules/secure-logging/slogencrypt
 modules/secure-logging/slogverify
 modules/secure-logging/slogkey
+lib/metrics-pipe\.[ch]
 lib/rewrite/rewrite-set-facility\.h
 lib/rewrite/rewrite-set-matches\.[ch]
 lib/rewrite/rewrite-unset-matches\.[ch]

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -166,6 +166,7 @@ modules/python-modules/setup\.py
 scripts/build-python-venv\.sh
 modules/syslogformat/sdata-parser\.[ch]
 tests/light/functional_tests/parsers/sdata-parser/test_sdata_parser\.py
+tests/light/src/syslog_ng_ctl/prometheus_stats_handler.py
 
 ###########################################################################
 # These files are GPLd with Balabit origin.

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -166,6 +166,7 @@ modules/python-modules/setup\.py
 scripts/build-python-venv\.sh
 modules/syslogformat/sdata-parser\.[ch]
 tests/light/functional_tests/logpath/__init__.py
+tests/light/functional_tests/logpath/test_named_logpaths.py
 tests/light/functional_tests/parsers/sdata-parser/test_sdata_parser\.py
 tests/light/src/syslog_ng_ctl/prometheus_stats_handler.py
 

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -165,6 +165,7 @@ modules/python-modules/syslogng/modules/example/.*
 modules/python-modules/setup\.py
 scripts/build-python-venv\.sh
 modules/syslogformat/sdata-parser\.[ch]
+tests/light/functional_tests/logpath/__init__.py
 tests/light/functional_tests/parsers/sdata-parser/test_sdata_parser\.py
 tests/light/src/syslog_ng_ctl/prometheus_stats_handler.py
 

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -169,6 +169,7 @@ tests/light/functional_tests/logpath/__init__.py
 tests/light/functional_tests/logpath/test_named_logpaths.py
 tests/light/functional_tests/logpath/test_named_logpaths_with_catchall_flag.py
 tests/light/functional_tests/logpath/test_named_logpaths_with_fallback_flag.py
+tests/light/functional_tests/logpath/test_named_logpaths_with_final_flag.py
 tests/light/functional_tests/parsers/sdata-parser/test_sdata_parser\.py
 tests/light/src/syslog_ng_ctl/prometheus_stats_handler.py
 

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -167,6 +167,7 @@ scripts/build-python-venv\.sh
 modules/syslogformat/sdata-parser\.[ch]
 tests/light/functional_tests/logpath/__init__.py
 tests/light/functional_tests/logpath/test_named_logpaths.py
+tests/light/functional_tests/logpath/test_named_logpaths_with_catchall_flag.py
 tests/light/functional_tests/parsers/sdata-parser/test_sdata_parser\.py
 tests/light/src/syslog_ng_ctl/prometheus_stats_handler.py
 

--- a/tests/light/functional_tests/logpath/__init__.py
+++ b/tests/light/functional_tests/logpath/__init__.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2023 Attila Szakacs
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from dataclasses import dataclass
+
+from src.syslog_ng_config.statements.logpath.logpath import LogPath
+
+
+@dataclass
+class ExpectedLogPathStats:
+    logpath: LogPath
+    ingress: int
+    egress: int
+
+
+def assert_logpath_stats(logpath, ingress, egress):
+    stats = logpath.get_prometheus_stats()
+
+    found = False
+    for stat in stats:
+        if stat.name == "syslogng_log_path_ingress" and stat.labels == {"id": logpath.name}:
+            found = True
+            actual_ingress = stat.value
+    assert found, "Did not find ingress stats counter for logpath: %s" % (logpath.name)
+
+    found = False
+    for stat in stats:
+        if stat.name == "syslogng_log_path_egress" and stat.labels == {"id": logpath.name}:
+            found = True
+            actual_egress = stat.value
+    assert found, "Did not find egress stats counter for logpath: %s" % (logpath.name)
+
+    assert actual_ingress == ingress, "Unexpected ingress stat. Logpath: %s Expected: %d Actual: %d" % (logpath.name, ingress, actual_ingress)
+    assert actual_egress == egress, "Unexpected egress stat. Logpath: %s Expected: %d Actual: %d" % (logpath.name, egress, actual_egress)
+
+
+def assert_multiple_logpath_stats(expected_logpath_stats):
+    for _, expected_logpath_stat in expected_logpath_stats.items():
+        assert_logpath_stats(expected_logpath_stat.logpath, expected_logpath_stat.ingress, expected_logpath_stat.egress)

--- a/tests/light/functional_tests/logpath/test_named_logpaths.py
+++ b/tests/light/functional_tests/logpath/test_named_logpaths.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2023 Attila Szakacs
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from . import assert_multiple_logpath_stats
+from . import ExpectedLogPathStats
+
+
+def test_named_logpaths(config, port_allocator, syslog_ng, log_message, bsd_formatter):
+    config.update_global_options(stats_level=1)
+
+    source = config.create_statement_group(statements=[config.create_network_source(port=port_allocator())])
+
+    destination_1 = config.create_statement_group(statements=[config.create_file_destination(file_name="output-1.log")])
+    destination_2 = config.create_statement_group(statements=[config.create_file_destination(file_name="output-2.log")])
+
+    filter_top_level_2 = config.create_statement_group(statements=[config.create_filter(message="'to-top-level-2'")])
+    filter_top_level_3 = config.create_statement_group(statements=[config.create_filter(message="'to-top-level-3'")])
+    filter_inner_1 = config.create_statement_group(statements=[config.create_filter(message="'to-inner-1'")])
+    filter_inner_2 = config.create_statement_group(statements=[config.create_filter(message="'to-inner-2'")])
+    filter_inner_3 = config.create_statement_group(statements=[config.create_filter(message="'to-inner-3'")])
+
+    # log top-level-1 {
+    #     source(s);
+    # };
+    top_level_1 = config.create_logpath(
+        name="top-level-1",
+        statements=[
+            source,
+        ],
+    )
+
+    # log top-level-2 {
+    #     source(s);
+    #     filter(f_t2);
+    #     destination(d_1);
+    # };
+    top_level_2 = config.create_logpath(
+        name="top-level-2",
+        statements=[
+            source,
+            filter_top_level_2,
+            destination_1,
+        ],
+    )
+
+    # log top-level-3 {
+    #     source(s);
+    #     filter(f_t3);
+    #     destination(d_1);
+    #     destination(d_2);
+    # };
+    top_level_3 = config.create_logpath(
+        name="top-level-3",
+        statements=[
+            source,
+            filter_top_level_3,
+            destination_1,
+            destination_2,
+        ],
+    )
+
+    # log top-level-4 {
+    #     source(s);
+    #     log inner-1 { filter(f_i1); destination(d_1); };
+    #     log inner-2 { filter(f_i2); destination(d_2); };
+    # };
+    inner_1 = config.create_inner_logpath(
+        name="inner-1",
+        statements=[
+            filter_inner_1,
+            destination_1,
+        ],
+    )
+    inner_2 = config.create_inner_logpath(
+        name="inner-2",
+        statements=[
+            filter_inner_2,
+            destination_2,
+        ],
+    )
+    top_level_4 = config.create_logpath(
+        name="top-level-4",
+        statements=[
+            source,
+            inner_1,
+            inner_2,
+        ],
+    )
+
+    # log top-level-5 {
+    #     source(s);
+    #     destination(d_1);
+    #     log inner-3 { filter(f_i3); destination(d_2); };
+    # };
+    #
+    # Queueing a message to d_1, but filtering it out from inner-3 will not increase the egress counter of
+    # top-level-5, as the message is not "matched" throughout the whole logpath. This is intended, so we
+    # work logically with parallel log paths and different flags, like final and fallback.
+    #
+    # Here, destination_2 can be thought as a debugging destination. If it is a real one, the config should
+    # be adjusted like this, where the top-level-5 egress will be increased, when it queues to d_1:
+    # log top-level-5 { source(s); log { destination(d_1); }; log inner-3 { filter(f_i3); destination(d_2); }; };
+    inner_3 = config.create_inner_logpath(
+        name="inner-3",
+        statements=[
+            filter_inner_3,
+            destination_2,
+        ],
+    )
+    top_level_5 = config.create_logpath(
+        name="top-level-5",
+        statements=[
+            source,
+            destination_1,
+            inner_3,
+        ],
+    )
+
+    logpaths = {
+        "top-level-1": ExpectedLogPathStats(top_level_1, 0, 0),
+        "top-level-2": ExpectedLogPathStats(top_level_2, 0, 0),
+        "top-level-3": ExpectedLogPathStats(top_level_3, 0, 0),
+        "top-level-4": ExpectedLogPathStats(top_level_4, 0, 0),
+        "inner-1": ExpectedLogPathStats(inner_1, 0, 0),
+        "inner-2": ExpectedLogPathStats(inner_2, 0, 0),
+        "top-level-5": ExpectedLogPathStats(top_level_5, 0, 0),
+        "inner-3": ExpectedLogPathStats(inner_3, 0, 0),
+    }
+
+    syslog_ng.start(config)
+    assert_multiple_logpath_stats(logpaths)
+
+    source[0].write_log(bsd_formatter.format_message(log_message.message("to-top-level-2")))
+    logpaths["top-level-1"].ingress += 1
+    logpaths["top-level-1"].egress += 1
+    logpaths["top-level-2"].ingress += 1
+    logpaths["top-level-2"].egress += 1
+    logpaths["top-level-3"].ingress += 1
+    logpaths["top-level-4"].ingress += 1
+    logpaths["inner-1"].ingress += 1
+    logpaths["inner-2"].ingress += 1
+    logpaths["top-level-5"].ingress += 1
+    logpaths["inner-3"].ingress += 1
+    destination_1[0].read_until_logs(["to-top-level-2"])
+    assert_multiple_logpath_stats(logpaths)
+
+    source[0].write_log(bsd_formatter.format_message(log_message.message("to-top-level-3")))
+    logpaths["top-level-1"].ingress += 1
+    logpaths["top-level-1"].egress += 1
+    logpaths["top-level-2"].ingress += 1
+    logpaths["top-level-3"].ingress += 1
+    logpaths["top-level-3"].egress += 1
+    logpaths["top-level-4"].ingress += 1
+    logpaths["inner-1"].ingress += 1
+    logpaths["inner-2"].ingress += 1
+    logpaths["top-level-5"].ingress += 1
+    logpaths["inner-3"].ingress += 1
+    destination_1[0].read_until_logs(["to-top-level-3"])
+    destination_2[0].read_until_logs(["to-top-level-3"])
+    assert_multiple_logpath_stats(logpaths)
+
+    source[0].write_log(bsd_formatter.format_message(log_message.message("to-inner-1")))
+    logpaths["top-level-1"].ingress += 1
+    logpaths["top-level-1"].egress += 1
+    logpaths["top-level-2"].ingress += 1
+    logpaths["top-level-3"].ingress += 1
+    logpaths["top-level-4"].ingress += 1
+    logpaths["top-level-4"].egress += 1
+    logpaths["inner-1"].ingress += 1
+    logpaths["inner-1"].egress += 1
+    logpaths["inner-2"].ingress += 1
+    logpaths["top-level-5"].ingress += 1
+    logpaths["inner-3"].ingress += 1
+    destination_1[0].read_until_logs(["to-inner-1"])
+    assert_multiple_logpath_stats(logpaths)
+
+    source[0].write_log(bsd_formatter.format_message(log_message.message("to-inner-2")))
+    logpaths["top-level-1"].ingress += 1
+    logpaths["top-level-1"].egress += 1
+    logpaths["top-level-2"].ingress += 1
+    logpaths["top-level-3"].ingress += 1
+    logpaths["top-level-4"].ingress += 1
+    logpaths["top-level-4"].egress += 1
+    logpaths["inner-1"].ingress += 1
+    logpaths["inner-2"].ingress += 1
+    logpaths["inner-2"].egress += 1
+    logpaths["top-level-5"].ingress += 1
+    logpaths["inner-3"].ingress += 1
+    destination_2[0].read_until_logs(["to-inner-2"])
+    assert_multiple_logpath_stats(logpaths)
+
+    source[0].write_log(bsd_formatter.format_message(log_message.message("to-inner-3")))
+    logpaths["top-level-1"].ingress += 1
+    logpaths["top-level-1"].egress += 1
+    logpaths["top-level-2"].ingress += 1
+    logpaths["top-level-3"].ingress += 1
+    logpaths["top-level-4"].ingress += 1
+    logpaths["inner-1"].ingress += 1
+    logpaths["inner-2"].ingress += 1
+    logpaths["top-level-5"].ingress += 1
+    logpaths["top-level-5"].egress += 1
+    logpaths["inner-3"].ingress += 1
+    logpaths["inner-3"].egress += 1
+    destination_1[0].read_until_logs(["to-inner-3"])
+    destination_2[0].read_until_logs(["to-inner-3"])
+    assert_multiple_logpath_stats(logpaths)

--- a/tests/light/functional_tests/logpath/test_named_logpaths_with_catchall_flag.py
+++ b/tests/light/functional_tests/logpath/test_named_logpaths_with_catchall_flag.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2023 Attila Szakacs
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from . import assert_multiple_logpath_stats
+from . import ExpectedLogPathStats
+
+
+def test_named_logpaths_with_catchall_flag(config, port_allocator, syslog_ng, log_message, bsd_formatter):
+    config.update_global_options(stats_level=1)
+
+    source = config.create_statement_group(statements=[config.create_network_source(port=port_allocator())])
+
+    destination = config.create_statement_group(statements=[config.create_file_destination(file_name="output.log")])
+
+    filter_top_level_1 = config.create_statement_group(statements=[config.create_filter(message="'to-top-level-1'")])
+    filter_top_level_2 = config.create_statement_group(statements=[config.create_filter(message="'to-top-level-2'")])
+
+    # log top-level-1 {
+    #     filter(f_t1);
+    #     destination(d);
+    #     flags(catchall);
+    # };
+    top_level_1 = config.create_logpath(
+        name="top-level-1",
+        statements=[
+            filter_top_level_1,
+            destination,
+        ],
+        flags="catchall",
+    )
+
+    # log top-level-2 {
+    #     filter(f_t2);
+    #     destination(d);
+    #     flags(catchall);
+    # };
+    top_level_2 = config.create_logpath(
+        name="top-level-2",
+        statements=[
+            filter_top_level_2,
+            destination,
+        ],
+        flags="catchall",
+    )
+
+    logpaths = {
+        "top-level-1": ExpectedLogPathStats(top_level_1, 0, 0),
+        "top-level-2": ExpectedLogPathStats(top_level_2, 0, 0),
+    }
+
+    syslog_ng.start(config)
+    assert_multiple_logpath_stats(logpaths)
+
+    source[0].write_log(bsd_formatter.format_message(log_message.message("to-top-level-1")))
+    logpaths["top-level-1"].ingress += 1
+    logpaths["top-level-1"].egress += 1
+    logpaths["top-level-2"].ingress += 1
+    destination[0].read_until_logs(["to-top-level-1"])
+    assert_multiple_logpath_stats(logpaths)
+
+    source[0].write_log(bsd_formatter.format_message(log_message.message("to-top-level-2")))
+    logpaths["top-level-1"].ingress += 1
+    logpaths["top-level-2"].ingress += 1
+    logpaths["top-level-2"].egress += 1
+    destination[0].read_until_logs(["to-top-level-2"])
+    assert_multiple_logpath_stats(logpaths)

--- a/tests/light/functional_tests/logpath/test_named_logpaths_with_fallback_flag.py
+++ b/tests/light/functional_tests/logpath/test_named_logpaths_with_fallback_flag.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2023 Attila Szakacs
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from . import assert_multiple_logpath_stats
+from . import ExpectedLogPathStats
+
+
+def test_named_logpaths_with_fallback_flag(config, port_allocator, syslog_ng, log_message, bsd_formatter):
+    config.update_global_options(stats_level=1)
+
+    source = config.create_statement_group(statements=[config.create_network_source(port=port_allocator())])
+
+    destination_1 = config.create_statement_group(statements=[config.create_file_destination(file_name="output-1.log")])
+    destination_2 = config.create_statement_group(statements=[config.create_file_destination(file_name="output-2.log")])
+
+    filter_top_level_1 = config.create_statement_group(statements=[config.create_filter(message="'to-top-level-1'")])
+    filter_top_level_2 = config.create_statement_group(statements=[config.create_filter(message="'to-top-level-2'")])
+    filter_top_level_3 = config.create_statement_group(statements=[config.create_filter(message="'to-top-level-3'")])
+    filter_always_false = config.create_statement_group(statements=[config.create_filter("1 == 2")])
+    filter_always_true = config.create_statement_group(statements=[config.create_filter("1 == 1")])
+
+    # log top-level-1 {
+    #     source(s);
+    #     filter(f_t1);
+    #     log inner-1 { filter(f_false); destination(d_1); };
+    #     log inner-fallback-2 { destination(d_2); flags(fallback); };
+    # };
+    inner_1 = config.create_inner_logpath(
+        name="inner-1",
+        statements=[
+            filter_always_false,
+            destination_1,
+        ],
+    )
+    inner_fallback_2 = config.create_inner_logpath(
+        name="inner-fallback-2",
+        statements=[
+            destination_2,
+        ],
+        flags="fallback",
+    )
+    top_level_1 = config.create_logpath(
+        name="top-level-1",
+        statements=[
+            source,
+            filter_top_level_1,
+            inner_1,
+            inner_fallback_2,
+        ],
+    )
+
+    # log top-level-2 {
+    #     source(s);
+    #     filter(f_t2);
+    #     log inner-3 { filter(f_true); destination(d_1); };
+    #     log inner-fallback-4 { destination(d_2); flags(fallback); };
+    # };
+    inner_3 = config.create_inner_logpath(
+        name="inner-3",
+        statements=[
+            filter_always_true,
+            destination_1,
+        ],
+    )
+    inner_fallback_4 = config.create_inner_logpath(
+        name="inner-fallback-4",
+        statements=[
+            destination_2,
+        ],
+        flags="fallback",
+    )
+    top_level_2 = config.create_logpath(
+        name="top-level-2",
+        statements=[
+            source,
+            filter_top_level_2,
+            inner_3,
+            inner_fallback_4,
+        ],
+    )
+
+    # log top-level-3 {
+    #     source(s);
+    #     filter(f_t3);
+    #     log inner-5 { filter(f_false); destination(d_1); };
+    #     log inner-fallback-6 { destination(d_2); flags(fallback); };
+    # };
+    inner_5 = config.create_inner_logpath(
+        name="inner-5",
+        statements=[
+            filter_always_false,
+            destination_1,
+        ],
+    )
+    inner_fallback_6 = config.create_inner_logpath(
+        name="inner-fallback-6",
+        statements=[
+            destination_2,
+        ],
+        flags="fallback",
+    )
+    top_level_3 = config.create_logpath(
+        name="top-level-3",
+        statements=[
+            source,
+            filter_top_level_3,
+            destination_1,
+            inner_5,
+            inner_fallback_6,
+        ],
+    )
+
+    logpaths = {
+        "top-level-1": ExpectedLogPathStats(top_level_1, 0, 0),
+        "inner-1": ExpectedLogPathStats(inner_1, 0, 0),
+        "inner-fallback-2": ExpectedLogPathStats(inner_fallback_2, 0, 0),
+        "top-level-2": ExpectedLogPathStats(top_level_2, 0, 0),
+        "inner-3": ExpectedLogPathStats(inner_3, 0, 0),
+        "inner-fallback-4": ExpectedLogPathStats(inner_fallback_4, 0, 0),
+        "top-level-3": ExpectedLogPathStats(top_level_3, 0, 0),
+        "inner-5": ExpectedLogPathStats(inner_5, 0, 0),
+        "inner-fallback-6": ExpectedLogPathStats(inner_fallback_6, 0, 0),
+    }
+
+    syslog_ng.start(config)
+    assert_multiple_logpath_stats(logpaths)
+
+    source[0].write_log(bsd_formatter.format_message(log_message.message("to-top-level-1")))
+    logpaths["top-level-1"].ingress += 1
+    logpaths["top-level-1"].egress += 1
+    logpaths["inner-1"].ingress += 1
+    logpaths["top-level-2"].ingress += 1
+    logpaths["inner-fallback-2"].ingress += 1
+    logpaths["inner-fallback-2"].egress += 1
+    logpaths["top-level-3"].ingress += 1
+    destination_2[0].read_until_logs(["to-top-level-1"])
+    assert_multiple_logpath_stats(logpaths)
+
+    source[0].write_log(bsd_formatter.format_message(log_message.message("to-top-level-2")))
+    logpaths["top-level-1"].ingress += 1
+    logpaths["top-level-2"].ingress += 1
+    logpaths["top-level-2"].egress += 1
+    logpaths["inner-3"].ingress += 1
+    logpaths["inner-3"].egress += 1
+    logpaths["top-level-3"].ingress += 1
+    destination_1[0].read_until_logs(["to-top-level-2"])
+    assert_multiple_logpath_stats(logpaths)
+
+    source[0].write_log(bsd_formatter.format_message(log_message.message("to-top-level-3")))
+    logpaths["top-level-1"].ingress += 1
+    logpaths["top-level-2"].ingress += 1
+    logpaths["top-level-3"].ingress += 1
+    logpaths["top-level-3"].egress += 1
+    logpaths["inner-5"].ingress += 1
+    logpaths["inner-fallback-6"].ingress += 1
+    logpaths["inner-fallback-6"].egress += 1
+    destination_1[0].read_until_logs(["to-top-level-3"])
+    assert_multiple_logpath_stats(logpaths)

--- a/tests/light/functional_tests/logpath/test_named_logpaths_with_final_flag.py
+++ b/tests/light/functional_tests/logpath/test_named_logpaths_with_final_flag.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2023 Attila Szakacs
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from . import assert_multiple_logpath_stats
+from . import ExpectedLogPathStats
+
+
+def test_named_logpaths_with_final_flag(config, port_allocator, syslog_ng, log_message, bsd_formatter):
+    config.update_global_options(stats_level=1)
+
+    source = config.create_statement_group(statements=[config.create_network_source(port=port_allocator())])
+
+    destination_1 = config.create_statement_group(statements=[config.create_file_destination(file_name="output-1.log")])
+    destination_2 = config.create_statement_group(statements=[config.create_file_destination(file_name="output-2.log")])
+    destination_3 = config.create_statement_group(statements=[config.create_file_destination(file_name="output-3.log")])
+
+    filter_top_level_1 = config.create_statement_group(statements=[config.create_filter(message="'to-top-level-1'")])
+    filter_top_level_2 = config.create_statement_group(statements=[config.create_filter(message="'to-top-level-2'")])
+
+    # log top-level-1 {
+    #     source(s);
+    #     filter(f_t1);
+    #     log inner-final-1 { destination(d_1); flags(final); };
+    #     log inner-final-2 { destination(d_2); flags(final); };
+    # };
+    inner_final_1 = config.create_inner_logpath(
+        name="inner-final-1",
+        statements=[
+            destination_1,
+        ],
+        flags="final",
+    )
+    inner_final_2 = config.create_inner_logpath(
+        name="inner-final-2",
+        statements=[
+            destination_2,
+        ],
+        flags="final",
+    )
+    top_level_1 = config.create_logpath(
+        name="top-level-1",
+        statements=[
+            source,
+            filter_top_level_1,
+            inner_final_1,
+            inner_final_2,
+        ],
+    )
+
+    # log top-level-2 {
+    #     source(s);
+    #     filter(f_t2);
+    #     destination(d_1);
+    #     log inner-final-3 { destination(d_2); flags(final); };
+    #     log inner-final-4 { destination(d_3); flags(final); };
+    # };
+    inner_final_3 = config.create_inner_logpath(
+        name="inner-final-3",
+        statements=[
+            destination_2,
+        ],
+        flags="final",
+    )
+    inner_final_4 = config.create_inner_logpath(
+        name="inner-final-4",
+        statements=[
+            destination_3,
+        ],
+        flags="final",
+    )
+    top_level_2 = config.create_logpath(
+        name="top-level-2",
+        statements=[
+            source,
+            filter_top_level_2,
+            destination_1,
+            inner_final_3,
+            inner_final_4,
+        ],
+    )
+
+    logpaths = {
+        "top-level-1": ExpectedLogPathStats(top_level_1, 0, 0),
+        "inner-final-1": ExpectedLogPathStats(inner_final_1, 0, 0),
+        "inner-final-2": ExpectedLogPathStats(inner_final_2, 0, 0),
+        "top-level-2": ExpectedLogPathStats(top_level_2, 0, 0),
+        "inner-final-3": ExpectedLogPathStats(inner_final_3, 0, 0),
+        "inner-final-4": ExpectedLogPathStats(inner_final_4, 0, 0),
+    }
+
+    syslog_ng.start(config)
+    assert_multiple_logpath_stats(logpaths)
+
+    source[0].write_log(bsd_formatter.format_message(log_message.message("to-top-level-1")))
+    logpaths["top-level-1"].ingress += 1
+    logpaths["top-level-1"].egress += 1
+    logpaths["inner-final-1"].ingress += 1
+    logpaths["inner-final-1"].egress += 1
+    logpaths["top-level-2"].ingress += 1
+    destination_1[0].read_until_logs(["to-top-level-1"])
+    assert_multiple_logpath_stats(logpaths)
+
+    source[0].write_log(bsd_formatter.format_message(log_message.message("to-top-level-2")))
+    logpaths["top-level-1"].ingress += 1
+    logpaths["top-level-2"].ingress += 1
+    logpaths["top-level-2"].egress += 1
+    logpaths["inner-final-3"].ingress += 1
+    logpaths["inner-final-3"].egress += 1
+    destination_1[0].read_until_logs(["to-top-level-2"])
+    destination_2[0].read_until_logs(["to-top-level-2"])
+    assert_multiple_logpath_stats(logpaths)

--- a/tests/light/src/syslog_ng_config/renderer.py
+++ b/tests/light/src/syslog_ng_config/renderer.py
@@ -130,7 +130,10 @@ def render_logpath_groups(logpath_groups):
     config_snippet = ""
 
     for logpath_group in logpath_groups:
-        config_snippet += "\nlog {\n"
+        if logpath_group.name:
+            config_snippet += "\nlog " + logpath_group.name + " {\n"
+        else:
+            config_snippet += "\nlog {\n"
         for statement_group in logpath_group.logpath:
             if statement_group.group_type == "log":
                 config_snippet += render_logpath_groups(logpath_groups=[statement_group])

--- a/tests/light/src/syslog_ng_config/renderer.py
+++ b/tests/light/src/syslog_ng_config/renderer.py
@@ -126,24 +126,26 @@ def render_statement_groups(statement_groups):
     return config_snippet
 
 
-def render_logpath_groups(logpath_groups):
-    config_snippet = ""
+def _indent(string, depth):
+    return depth * "    " + string
+
+
+def render_logpath_groups(logpath_groups, depth=0):
+    config_snippet = "\n"
 
     for logpath_group in logpath_groups:
         if logpath_group.name:
-            config_snippet += "\nlog " + logpath_group.name + " {\n"
+            config_snippet += _indent("log " + logpath_group.name + " {\n", depth)
         else:
-            config_snippet += "\nlog {\n"
+            config_snippet += _indent("log {\n", depth)
         for statement_group in logpath_group.logpath:
             if statement_group.group_type == "log":
-                config_snippet += render_logpath_groups(logpath_groups=[statement_group])
+                config_snippet += render_logpath_groups(logpath_groups=[statement_group], depth=depth + 1)
             else:
-                config_snippet += "    {}({});\n".format(
-                    statement_group.group_type, statement_group.group_id,
-                )
+                config_snippet += _indent("{}({});\n".format(statement_group.group_type, statement_group.group_id), depth + 1)
         if logpath_group.flags:
-            config_snippet += "    flags({});\n".format("".join(logpath_group.flags))
-        config_snippet += "};\n"
+            config_snippet += _indent("flags({});\n".format("".join(logpath_group.flags)), depth + 1)
+        config_snippet += _indent("};\n", depth)
 
     return config_snippet
 

--- a/tests/light/src/syslog_ng_config/statements/logpath/logpath.py
+++ b/tests/light/src/syslog_ng_config/statements/logpath/logpath.py
@@ -20,6 +20,8 @@
 # COPYING for details.
 #
 #############################################################################
+from src.syslog_ng_ctl.prometheus_stats_handler import MetricFilter
+from src.syslog_ng_ctl.prometheus_stats_handler import PrometheusStatsHandler
 
 
 class LogPath(object):
@@ -28,6 +30,15 @@ class LogPath(object):
         self.__name = name
         self.__logpath = []
         self.__flags = []
+
+        metric_filters = []
+        if name:
+            metric_filters += [
+                MetricFilter("syslogng_log_path_ingress", {"id": name}),
+                MetricFilter("syslogng_log_path_egress", {"id": name}),
+            ]
+
+        self.__prometheus_stats_handler = PrometheusStatsHandler(metric_filters)
 
     @property
     def group_type(self):
@@ -58,3 +69,6 @@ class LogPath(object):
     def add_flags(self, flags):
         for flag in flags:
             self.add_flag(flag)
+
+    def get_prometheus_stats(self):
+        return self.__prometheus_stats_handler.get_samples()

--- a/tests/light/src/syslog_ng_config/statements/logpath/logpath.py
+++ b/tests/light/src/syslog_ng_config/statements/logpath/logpath.py
@@ -23,14 +23,19 @@
 
 
 class LogPath(object):
-    def __init__(self):
+    def __init__(self, name=None):
         self.__group_type = "log"
+        self.__name = name
         self.__logpath = []
         self.__flags = []
 
     @property
     def group_type(self):
         return self.__group_type
+
+    @property
+    def name(self):
+        return self.__name
 
     @property
     def logpath(self):

--- a/tests/light/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/light/src/syslog_ng_config/syslog_ng_config.py
@@ -181,13 +181,13 @@ class SyslogNgConfig(object):
     def create_rewrite_credit_card_hash(self, **options):
         return CreditCardHash(**options)
 
-    def create_logpath(self, statements=None, flags=None):
-        logpath = self.__create_logpath_with_conversion(statements, flags)
+    def create_logpath(self, name=None, statements=None, flags=None):
+        logpath = self.__create_logpath_with_conversion(name, statements, flags)
         self.__syslog_ng_config["logpath_groups"].append(logpath)
         return logpath
 
-    def create_inner_logpath(self, statements=None, flags=None):
-        inner_logpath = self.__create_logpath_with_conversion(statements, flags)
+    def create_inner_logpath(self, name=None, statements=None, flags=None):
+        inner_logpath = self.__create_logpath_with_conversion(name, statements, flags)
         return inner_logpath
 
     def create_statement_group(self, statements):
@@ -201,15 +201,16 @@ class SyslogNgConfig(object):
         else:
             return self.create_statement_group(item)
 
-    def __create_logpath_with_conversion(self, items, flags):
+    def __create_logpath_with_conversion(self, name, items, flags):
         return self.__create_logpath_group(
+            name,
             map(self.__create_statement_group_if_needed, cast_to_list(items)),
             flags,
         )
 
     @staticmethod
-    def __create_logpath_group(statements=None, flags=None):
-        logpath = LogPath()
+    def __create_logpath_group(name=None, statements=None, flags=None):
+        logpath = LogPath(name)
         if statements:
             logpath.add_groups(statements)
         if flags:

--- a/tests/light/src/syslog_ng_ctl/prometheus_stats_handler.py
+++ b/tests/light/src/syslog_ng_ctl/prometheus_stats_handler.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2023 Attila Szakacs
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from typing import Dict
+from typing import NamedTuple
+from typing import Optional
+
+import prometheus_client.parser
+from prometheus_client.samples import Sample
+
+import src.testcase_parameters.testcase_parameters as tc_parameters
+from src.syslog_ng_ctl.syslog_ng_ctl import SyslogNgCtl
+
+__all__ = ["PrometheusStatsHandler", "MetricFilter", "Sample"]
+
+
+class MetricFilter(NamedTuple):
+    name: str
+    labels: Optional[Dict[str, str]] = None
+
+
+class PrometheusStatsHandler(object):
+    def __init__(self, metric_filters):
+        self.__metric_filters = metric_filters
+        self.__syslog_ng_ctl = SyslogNgCtl(tc_parameters.INSTANCE_PATH)
+
+    def __filter_raw_samples(self, raw_samples):
+        samples = []
+
+        for metric_family in prometheus_client.parser.text_string_to_metric_families(raw_samples):
+            for sample in metric_family.samples:
+                for metric_filter in self.__metric_filters:
+                    if metric_filter.name == sample.name and metric_filter.labels.items() <= sample.labels.items():
+                        samples.append(sample)
+
+        return samples
+
+    def get_samples(self):
+        if len(self.__metric_filters) == 0:
+            return []
+
+        ctl_output = self.__syslog_ng_ctl.stats_prometheus()
+        if ctl_output["exit_code"] != 0:
+            return []
+
+        return self.__filter_raw_samples(ctl_output["stdout"])

--- a/tests/light/src/syslog_ng_ctl/syslog_ng_ctl.py
+++ b/tests/light/src/syslog_ng_ctl/syslog_ng_ctl.py
@@ -40,6 +40,9 @@ class SyslogNgCtl(object):
     def stats(self, reset=False):
         return self.__syslog_ng_ctl_cli.stats(reset)
 
+    def stats_prometheus(self):
+        return self.__syslog_ng_ctl_cli.stats_prometheus()
+
     def query(self, pattern="*", query_type=QueryTypes.QUERY_GET):
         return self.__syslog_ng_ctl_cli.query(pattern, query_type)
 

--- a/tests/light/src/syslog_ng_ctl/syslog_ng_ctl_cli.py
+++ b/tests/light/src/syslog_ng_ctl/syslog_ng_ctl_cli.py
@@ -37,6 +37,10 @@ class SyslogNgCtlCli(object):
         ctl_stats_command = self.__syslog_ng_ctl_executor.construct_ctl_stats_command(reset=reset)
         return self.__syslog_ng_ctl_executor.run_command(command_short_name="stats", command=ctl_stats_command)
 
+    def stats_prometheus(self):
+        ctl_stats_prometheus_command = self.__syslog_ng_ctl_executor.construct_ctl_stats_prometheus_command()
+        return self.__syslog_ng_ctl_executor.run_command(command_short_name="stats_prometheus", command=ctl_stats_prometheus_command)
+
     def query(self, pattern, query_type):
         ctl_query_command = self.__syslog_ng_ctl_executor.construct_ctl_query_command(pattern, query_type)
         return self.__syslog_ng_ctl_executor.run_command(command_short_name="query", command=ctl_query_command)

--- a/tests/light/src/syslog_ng_ctl/syslog_ng_ctl_executor.py
+++ b/tests/light/src/syslog_ng_ctl/syslog_ng_ctl_executor.py
@@ -66,6 +66,10 @@ class SyslogNgCtlExecutor(object):
         return stats_command
 
     @staticmethod
+    def construct_ctl_stats_prometheus_command():
+        return ["stats", "prometheus"]
+
+    @staticmethod
     def construct_ctl_credentials_command(credential, secret):
         return ["credentials", "add", credential, secret]
 


### PR DESCRIPTION
E.g.:
```
log top-level {
    source(s_local);

    log inner-1 {
        filter(f_inner_1);
        destination(d_local_1);
    };

    log inner-2 {
        filter(f_inner_2);
        destination(d_local_2);
    };
};
```

Each named log path counts its ingress and egress messages:
```
syslogng_log_path_ingress{id="top-level"} 114
syslogng_log_path_ingress{id="inner-1"} 114
syslogng_log_path_ingress{id="inner-2"} 114
syslogng_log_path_egress{id="top-level"} 103
syslogng_log_path_egress{id="inner-1"} 62
syslogng_log_path_egress{id="inner-2"} 41
```

Note that the egress statistics only count the messages which have been have not been filtered out from the related
log path, it does care about whether there are any destinations in it or that any destination delivers or drops the message.


Depends on #4325 and #4339.

Signed-off-by: Attila Szakacs <szakacs.attila96@gmail.com>