### PR TITLE
dbld: fix externally managed python pip install

### DIFF
--- a/dbld/builddeps
+++ b/dbld/builddeps
@@ -177,31 +177,12 @@ function install_yum_packages {
 }
 
 function install_pip_packages {
-    case "${IMAGE_PLATFORM}" in
-        kira)
-            python_executables="python2 python3"
-            ;;
-        *)
-            python_executables="python3"
-            ;;
-    esac
+    local python_executables="python2 python3"
     for python_executable in ${python_executables}; do
-        case "${IMAGE_PLATFORM}" in
-            fedora-*)
-                # don't update pip/setuptools on Fedora as RPM installed
-                # instances cause an error, at least in Fedora-37
-                filter_pip_packages_by_platform_and_python_version $DBLD_DIR/pip_packages.manifest $python_executable| xargs $python_executable -m pip install --no-cache-dir --ignore-installed -U
-                ;;
-            *)
-                # pip can fail with setuptools>=66 if there are system packages installed which do not comply with PEP440:
-                # https://github.com/pypa/setuptools/issues/3772#issuecomment-1398809718
-                #
-                # As long as our supported distros have invalidly named packages, this will be an issue.
-                $python_executable -m pip install --ignore-installed --no-cache-dir --upgrade pip
-                $python_executable -m pip install --ignore-installed --no-cache-dir --upgrade "setuptools<66.0"
-                filter_pip_packages_by_platform_and_python_version $DBLD_DIR/pip_packages.manifest $python_executable | xargs $python_executable -m pip install --no-cache-dir --ignore-installed -U
-                ;;
-        esac
+        local pip_install="${python_executable} -m pip install --ignore-installed --no-cache-dir --upgrade"
+        ${pip_install} "pip"
+        ${pip_install} "setuptools<66.0"
+        filter_pip_packages_by_platform_and_python_version $DBLD_DIR/pip_packages.manifest ${python_executable} | xargs ${pip_install}
     done
 }
 

--- a/dbld/images/centos-7.dockerfile
+++ b/dbld/images/centos-7.dockerfile
@@ -17,7 +17,6 @@ RUN /dbld/builddeps add_epel_repo
 RUN /dbld/builddeps add_copr_repo
 RUN /dbld/builddeps install_yum_packages
 RUN /dbld/builddeps install_rpm_build_deps
-RUN /dbld/builddeps install_pip_packages
 
 RUN /dbld/builddeps install_criterion
 RUN /dbld/builddeps install_gradle

--- a/dbld/images/debian-buster.dockerfile
+++ b/dbld/images/debian-buster.dockerfile
@@ -19,7 +19,6 @@ COPY . /dbld/
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps
-RUN /dbld/builddeps install_pip_packages
 
 RUN /dbld/builddeps install_criterion
 

--- a/dbld/images/devshell.dockerfile
+++ b/dbld/images/devshell.dockerfile
@@ -11,4 +11,3 @@ RUN /dbld/builddeps enable_dbgsyms
 RUN /dbld/builddeps install_perf
 
 RUN /dbld/builddeps install_apt_packages
-RUN /dbld/builddeps install_pip_packages

--- a/dbld/images/fedora-37.dockerfile
+++ b/dbld/images/fedora-37.dockerfile
@@ -17,7 +17,6 @@ RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps add_copr_repo
 RUN /dbld/builddeps install_yum_packages
 RUN /dbld/builddeps install_rpm_build_deps
-RUN /dbld/builddeps install_pip_packages
 
 RUN /dbld/builddeps install_criterion
 RUN /dbld/builddeps install_gradle

--- a/dbld/images/tarball.dockerfile
+++ b/dbld/images/tarball.dockerfile
@@ -7,4 +7,3 @@ ENV IMAGE_PLATFORM ${ARG_IMAGE_PLATFORM}
 LABEL COMMIT=${COMMIT}
 
 RUN /dbld/builddeps install_apt_packages
-RUN /dbld/builddeps install_pip_packages

--- a/dbld/images/ubuntu-bionic.dockerfile
+++ b/dbld/images/ubuntu-bionic.dockerfile
@@ -19,7 +19,6 @@ COPY . /dbld/
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps
-RUN /dbld/builddeps install_pip_packages
 
 RUN /dbld/builddeps install_criterion
 

--- a/dbld/images/ubuntu-focal.dockerfile
+++ b/dbld/images/ubuntu-focal.dockerfile
@@ -19,7 +19,6 @@ COPY . /dbld/
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps
-RUN /dbld/builddeps install_pip_packages
 
 RUN /dbld/builddeps install_criterion
 

--- a/dbld/images/ubuntu-jammy.dockerfile
+++ b/dbld/images/ubuntu-jammy.dockerfile
@@ -19,7 +19,6 @@ COPY . /dbld/
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps
-RUN /dbld/builddeps install_pip_packages
 
 VOLUME /source
 VOLUME /build

--- a/dbld/pip_packages.manifest
+++ b/dbld/pip_packages.manifest
@@ -3,14 +3,13 @@ ply                     [centos, fedora, debian, ubuntu, devshell, tarball]    [
 
 # pip packages for kira tests
 distro                  [kira]                                                 [python2, python3]
-hy                      [devshell, kira]                                       [python3]
-hyrule                  [devshell, kira]                                       [python3]
+hy                      [kira]                                                 [python3]
+hyrule                  [kira]                                                 [python3]
 requests                [kira]                                                 [python2, python3]
 
 # pip packages for python functional tests
 psutil                  [centos, fedora, debian, ubuntu, devshell]             [python3]
 pytest                  [centos, fedora, debian, ubuntu, devshell]             [python3]
-virtualenv              [devshell]                                             [python3]
 # pytest 4.6.9 has requirement six>=1.10.0, but ubuntu-trusty installs six 1.5.2 which is incompatible
 six>=1.10.0             [ubuntu-trusty]                                        [python3]
 

--- a/dbld/pip_packages.manifest
+++ b/dbld/pip_packages.manifest
@@ -1,20 +1,5 @@
-# pip packages for successful run unit tests
-ply                     [centos, fedora, debian, ubuntu, devshell, tarball]    [python3]
-
 # pip packages for kira tests
 distro                  [kira]                                                 [python2, python3]
 hy                      [kira]                                                 [python3]
 hyrule                  [kira]                                                 [python3]
 requests                [kira]                                                 [python2, python3]
-
-# pip packages for python functional tests
-psutil                  [centos, fedora, debian, ubuntu, devshell]             [python3]
-pytest                  [centos, fedora, debian, ubuntu, devshell]             [python3]
-# pytest 4.6.9 has requirement six>=1.10.0, but ubuntu-trusty installs six 1.5.2 which is incompatible
-six>=1.10.0             [ubuntu-trusty]                                        [python3]
-
-# linters and code formatting
-pep8                    [devshell]                                             [python3]
-pylint                  [devshell]                                             [python3]
-pre-commit              [devshell]                                             [python3]
-pre-commit-hooks        [devshell]                                             [python3]

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,3 +9,4 @@ psutil
 pytest
 pytest-mock
 pre-commit
+virtualenv

--- a/scripts/build-python-venv.sh
+++ b/scripts/build-python-venv.sh
@@ -41,4 +41,6 @@ echo "Building dev virtualenv for syslog-ng at ${PYTHON_VENV_DIR} from ${REQUIRE
 
 rm -rf ${PYTHON_VENV_DIR}
 ${PYTHON} -m venv ${PYTHON_VENV_DIR}
+${PYTHON_VENV_DIR}/bin/python -m pip install --upgrade pip
+${PYTHON_VENV_DIR}/bin/python -m pip install --upgrade setuptools
 ${PYTHON_VENV_DIR}/bin/python -m pip install -r $REQUIREMENTS_FILE

--- a/scripts/syslog-ng-update-virtualenv.in
+++ b/scripts/syslog-ng-update-virtualenv.in
@@ -82,6 +82,8 @@ echo "Running python -m venv..."
 ${SYSTEM_PYTHON} -m venv ${python_venvdir}
 
 echo "Running python -m pip install..."
+${VENV_PYTHON} -m pip install --upgrade pip
+${VENV_PYTHON} -m pip install --upgrade pip setuptools
 ${VENV_PYTHON} -m pip install --upgrade -r "${REQUIREMENTS_FILE}"
 cp "${REQUIREMENTS_FILE}" "${python_venvdir}"
 echo "Finished."


### PR DESCRIPTION
Debian declines to install pip packages to system paths, because of [PEP-668](https://peps.python.org/pep-0668/). The solution to this is to install pip packages to a venv.

At this point I am not sure that we need pip packages installed to the dbld images, as we have build and install time venvs. The only benefit is that we ship these pip packages with the image, and those packages can be used for anything not syslog-ng related even, but I think it is not enough of a reason to keep them there.

With this patchset, we no longer install pip packages during dbld image build, except KIRA, which needs python2 and python3 at the same time and it is not running tests with our prepared build or install venv.

Example devshell CI run: https://github.com/alltilla/syslog-ng/actions/runs/4282919593

Signed-off-by: Attila Szakacs <szakacs.attila96@gmail.com>