### PR TITLE
Fix quick internal tests

### DIFF
--- a/dbld/builddeps
+++ b/dbld/builddeps
@@ -81,8 +81,41 @@ function install_gosu() {
     chmod +x /usr/local/bin/gosu
 }
 
+# NOTE: libjvm.so is not anymore in the java lib dir itself, a better choice could be to use libnio.so to find the real lib dir
+#       for backward compatibility the libjvm.so is kept as the default search base
+function get_jvm_paths() {
+    LIB_FILE=libjvm.so
+    if [ $# -gt 0 ]; then
+        LIB_FILE=$1
+    fi
+    find / -name "${LIB_FILE}" 2>/dev/null | sed "s@/${LIB_FILE}@@g"
+}
+
+function set_jvm_envs() {
+	if [ "${JAVA_HOME}" == "" ]; then
+		JAVA_LIBRARY_PATH=$(get_jvm_paths $@)
+
+		if [ "${JAVA_LIBRARY_PATH}" != "" ]; then
+			OLD_LIB_PATH=${LD_LIBRARY_PATH}
+			if [ "${OLD_LIB_PATH}" != "" ]; then
+				export LD_LIBRARY_PATH=${JAVA_LIBRARY_PATH}:${OLD_LIB_PATH}
+			else
+				export LD_LIBRARY_PATH=${JAVA_LIBRARY_PATH}
+			fi
+
+			for i in {1..4}; do
+				if [ "$(basename $(dirname \"${JAVA_LIBRARY_PATH}\"))" == "jvm" ]; then
+					break
+				fi
+				JAVA_LIBRARY_PATH=$(dirname "${JAVA_LIBRARY_PATH}")
+            done
+            export JAVA_HOME=${JAVA_LIBRARY_PATH}
+		fi
+	fi
+}
+
 function set_jvm_paths() {
-    find / -name 'libjvm.so' | sed 's@/libjvm.so@@g' | tee --append /etc/ld.so.conf.d/openjdk-libjvm.conf
+    get_jvm_paths $@ | tee --append /etc/ld.so.conf.d/openjdk-libjvm.conf
     ldconfig
 }
 
@@ -92,9 +125,9 @@ function install_gradle {
     mkdir -p /opt/gradle
     unzip -d /opt/gradle /tmp/gradle.zip
     rm -rf /tmp/gradle.zip
+    rm -rf /usr/bin/gradle
     ln -s /opt/gradle/gradle-${GRADLE_VERSION}/bin/gradle /usr/bin/gradle
-    find / -name 'libjvm.so' | sed 's@/libjvm.so@@g' | tee --append /etc/ld.so.conf.d/openjdk-libjvm.conf
-    ldconfig
+    set_jvm_paths $@
 }
 
 function install_pip2 {

--- a/dbld/images/hooks/build
+++ b/dbld/images/hooks/build
@@ -10,4 +10,4 @@ DBLD_DIR="./${BUILD_PATH}"
 
 ARG_IMAGE_PLATFORM=$(basename $DOCKERFILE_PATH .dockerfile)
 ${DBLD_DIR}/prepare-image-build $ARG_IMAGE_PLATFORM
-docker build --build-arg=COMMIT=$(git rev-parse --short HEAD) --build-arg=ARG_IMAGE_PLATFORM=${ARG_IMAGE_PLATFORM} -t $IMAGE_NAME -f ${DBLD_DIR}/$DOCKERFILE_PATH ${DBLD_DIR}
+docker build ${DOCKER_BUILD_ARGS} --build-arg=COMMIT=$(git rev-parse --short HEAD) --build-arg=ARG_IMAGE_PLATFORM=${ARG_IMAGE_PLATFORM} -t $IMAGE_NAME -f ${DBLD_DIR}/$DOCKERFILE_PATH ${DBLD_DIR}

--- a/dbld/rules
+++ b/dbld/rules
@@ -39,7 +39,7 @@ DOCKER_RUN_ARGS=-e USER_NAME_ON_HOST=$(shell whoami)	\
 	-e GRADLE_PROJECT_CACHE_DIR=/build/gradle-cache \
 	-e GRADLE_FLAGS=--build-cache \
 	$(if $(wildcard ${HOME}/.gitconfig),-v ${HOME}/.gitconfig:/build/.gitconfig)
-DOCKER_BUILD_ARGS=
+DOCKER_BUILD_ARGS?=
 ROOT_DIR=$(shell pwd)
 DBLD_DIR=$(ROOT_DIR)/dbld
 BUILD_DIR=$(DBLD_DIR)/build


### PR DESCRIPTION
These changes were needed to 

- fix the quick internal tests, as the following issues are found
             - there were many hardcode JVM paths 
             - the automated detection and setup of JVM related environment was broken, as based on hardcoded values and wrong assumptions
             these issues could be found both in the internal test codes and in the dldb scripts (and therefore the docker builds)
             so, I've added
             - a bit more generic detection method
             - some tiny extensions to the already existing JVM env setup
             - a bit more sophisticated env setup to the kira/zts code and test scripts

- prepare support for none amd64 platform docker image usage
           the already existing DOCKER_BUILD_ARGS can be used to pass additional arguments to docker builds (e.g. a different than the default platform), so I just added this arg to the build command line where it was missing, and tried to add support of usage of an already, externally (pre-)defined value too

Signed-off-by: Hofi <hofione@gmail.com>