### PR TITLE
disk-buffer: add disk-buffer related metrics

### DIFF
--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -133,6 +133,7 @@ _ack_backlog(LogQueue *s, gint num_msg_to_ack)
         }
 
       qdisk_ack_backlog(self->super.qdisk);
+      log_queue_disk_update_disk_related_counters(&self->super);
     }
 exit_reliable:
   qdisk_reset_file_if_empty(self->super.qdisk);
@@ -280,6 +281,7 @@ exit:
   if (!s->use_backlog)
     qdisk_empty_backlog(self->super.qdisk);
 
+  log_queue_disk_update_disk_related_counters(&self->super);
   log_queue_queued_messages_dec(s);
 
   if (qdisk_corrupt)
@@ -345,6 +347,8 @@ _push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
       g_mutex_unlock(&s->lock);
       return;
     }
+
+  log_queue_disk_update_disk_related_counters(&self->super);
 
   scratch_buffers_reclaim_marked(marker);
 

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -39,6 +39,18 @@ struct _LogQueueDisk
    * LogQueueDisk should have a separate options class, which should only contain compaction, reliable, etc...
    * Similarly, QDisk should have a separate options class, which should only contain disk_buf_size, mem_buf_size, etc...
    */
+
+  struct
+  {
+    StatsClusterKey *capacity_sc_key;
+    StatsClusterKey *disk_usage_sc_key;
+    StatsClusterKey *disk_allocated_sc_key;
+
+    StatsCounterItem *capacity;
+    StatsCounterItem *disk_usage;
+    StatsCounterItem *disk_allocated;
+  } metrics;
+
   gboolean compaction;
   gboolean (*start)(LogQueueDisk *s);
   gboolean (*stop)(LogQueueDisk *s, gboolean *persistent);
@@ -57,7 +69,7 @@ void log_queue_disk_init_instance(LogQueueDisk *self, DiskQueueOptions *options,
 void log_queue_disk_restart_corrupted(LogQueueDisk *self);
 void log_queue_disk_free_method(LogQueueDisk *self);
 
-
+void log_queue_disk_update_disk_related_counters(LogQueueDisk *self);
 LogMessage *log_queue_disk_read_message(LogQueueDisk *self, LogPathOptions *path_options);
 void log_queue_disk_drop_message(LogQueueDisk *self, LogMessage *msg, const LogPathOptions *path_options);
 gboolean log_queue_disk_serialize_msg(LogQueueDisk *self, LogMessage *msg, GString *serialized);

--- a/modules/diskq/tests/CMakeLists.txt
+++ b/modules/diskq/tests/CMakeLists.txt
@@ -4,3 +4,4 @@ add_unit_test(CRITERION LIBTEST TARGET test_reliable_backlog DEPENDS disk-buffer
 add_unit_test(CRITERION LIBTEST TARGET test_diskq_truncate DEPENDS m disk-buffer)
 add_unit_test(CRITERION LIBTEST TARGET test_qdisk DEPENDS disk-buffer)
 add_unit_test(CRITERION LIBTEST TARGET test_logqueue_disk DEPENDS disk-buffer)
+add_unit_test(CRITERION LIBTEST TARGET test_diskq_counters DEPENDS disk-buffer)

--- a/modules/diskq/tests/Makefile.am
+++ b/modules/diskq/tests/Makefile.am
@@ -8,7 +8,8 @@ modules_diskq_tests_TESTS = \
   modules/diskq/tests/test_diskq_truncate \
   modules/diskq/tests/test_reliable_backlog \
   modules/diskq/tests/test_qdisk \
-  modules/diskq/tests/test_logqueue_disk
+  modules/diskq/tests/test_logqueue_disk \
+  modules/diskq/tests/test_diskq_counters
 
 check_PROGRAMS += ${modules_diskq_tests_TESTS}
 
@@ -66,4 +67,13 @@ modules_diskq_tests_test_logqueue_disk_DEPENDENCIES =	\
 	$(top_builddir)/modules/diskq/libdisk-buffer.la
 modules_diskq_tests_test_logqueue_disk_SOURCES = \
 	modules/diskq/tests/test_logqueue_disk.c \
+	modules/diskq/tests/test_diskq_tools.h
+
+modules_diskq_tests_test_diskq_counters_CFLAGS = $(DISKQ_TEST_C_FLAGS)
+modules_diskq_tests_test_diskq_counters_LDFLAGS = $(DISKQ_TEST_LD_FLAGS)
+modules_diskq_tests_test_diskq_counters_LDADD = $(DISKQ_TEST_LD_ADD)
+modules_diskq_tests_test_diskq_counters_DEPENDENCIES =	\
+	$(top_builddir)/modules/diskq/libdisk-buffer.la
+modules_diskq_tests_test_diskq_counters_SOURCES = \
+	modules/diskq/tests/test_diskq_counters.c \
 	modules/diskq/tests/test_diskq_tools.h

--- a/modules/diskq/tests/test_diskq_counters.c
+++ b/modules/diskq/tests/test_diskq_counters.c
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2023 Attila Szakacs
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <unistd.h>
+
+#include <criterion/criterion.h>
+#include "libtest/queue_utils_lib.h"
+#include "test_diskq_tools.h"
+
+#include "diskq.h"
+#include "logqueue-disk.h"
+#include "apphook.h"
+
+static void
+_setup_with_persist(const gchar *persist_file)
+{
+  app_startup();
+
+  configuration = cfg_new_snippet();
+  configuration->stats_options.level = STATS_LEVEL1;
+  configuration->state = persist_state_new(persist_file);
+  persist_state_start(configuration->state);
+  cfg_init(configuration);
+}
+
+static void
+_teardown_with_persist(const gchar *persist_file)
+{
+  persist_state_cancel(configuration->state);
+  unlink(persist_file);
+  cfg_free(configuration);
+  app_shutdown();
+}
+
+static LogDestDriver *
+_dummy_dd_new(gboolean reliable_disk_buffer, const gchar *dir)
+{
+  LogDestDriver *self = g_new0(LogDestDriver, 1);
+  log_dest_driver_init_instance(self, configuration);
+
+  DiskQDestPlugin *plugin = diskq_dest_plugin_new();
+  DiskQueueOptions *options = diskq_get_options(plugin);
+  disk_queue_options_disk_buf_size_set(options, MIN_DISK_BUF_SIZE);
+  disk_queue_options_qout_size_set(options, 1);
+  disk_queue_options_reliable_set(options, reliable_disk_buffer);
+  disk_queue_options_set_dir(options, dir);
+  cr_assert(log_driver_add_plugin(&self->super, (LogDriverPlugin *) plugin));
+
+  return self;
+}
+
+static gboolean
+_serialize_func(SerializeArchive *sa, gpointer user_data)
+{
+  LogMessage *msg = (LogMessage *) user_data;
+  return log_msg_serialize(msg, sa, 0);
+}
+
+static void
+_push_one_message(LogQueue *q, gssize *memory_size, gssize *serialized_size)
+{
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+  path_options.ack_needed = q->use_backlog;
+  path_options.flow_control_requested = TRUE;
+
+  gchar data[1024] = {0};
+  memset(data, 'x', sizeof(data) - 1);
+
+  LogMessage *msg = log_msg_new_empty();
+  log_msg_set_value(msg, LM_V_MESSAGE, data, sizeof(data));
+  log_msg_add_ack(msg, &path_options);
+
+  log_queue_push_tail(q, msg, &path_options);
+
+  if (memory_size)
+    {
+      *memory_size = log_msg_get_size(msg);
+    }
+
+  if (serialized_size)
+    {
+      GError *error = NULL;
+      GString *buf = g_string_new(NULL);
+      cr_assert(qdisk_serialize(buf, _serialize_func, msg, &error));
+      *serialized_size = buf->len;
+      g_string_free(buf, TRUE);
+      g_error_free(error);
+      /* Some counters have KiB precision, make it larger, so it does not diminish. */
+      cr_assert(*serialized_size > 1024);
+    }
+}
+
+static void
+_assert_counters(LogQueue *queue, gsize queued, gsize memory_usage, gsize capacity, gsize disk_usage,
+                 gsize disk_allocated, guint line)
+{
+  LogQueueDisk *queue_disk = (LogQueueDisk *) queue;
+
+  gsize capacity_kib = capacity / 1024;
+  gsize disk_usage_kib = disk_usage / 1024;
+  gsize disk_allocated_kib = disk_allocated / 1024;
+
+  cr_assert(queue->metrics.owned.queued_messages);
+  cr_assert(queue->metrics.owned.memory_usage);
+  cr_assert(queue_disk->metrics.capacity);
+  cr_assert(queue_disk->metrics.disk_usage);
+  cr_assert(stats_counter_get(queue->metrics.owned.queued_messages) == queued,
+            "line %d: Queued message counter mismatch. Expected: %lu Actual: %lu",
+            line, queued, stats_counter_get(queue->metrics.owned.queued_messages));
+  cr_assert(stats_counter_get(queue->metrics.owned.memory_usage) == memory_usage,
+            "line %d: Memory usage counter mismatch. Expected: %lu Actual: %lu",
+            line, memory_usage, stats_counter_get(queue->metrics.owned.memory_usage));
+  cr_assert(stats_counter_get(queue_disk->metrics.capacity) == capacity_kib,
+            "line %d: Capacity counter mismatch. Expected: %lu Actual: %lu",
+            line, capacity_kib, stats_counter_get(queue_disk->metrics.capacity));
+  cr_assert(stats_counter_get(queue_disk->metrics.disk_usage) == disk_usage_kib,
+            "line %d: Disk usage counter mismatch. Expected: %lu Actual: %lu",
+            line, disk_usage_kib, stats_counter_get(queue_disk->metrics.disk_usage));
+  cr_assert(stats_counter_get(queue_disk->metrics.disk_allocated) == disk_allocated_kib,
+            "line %d: Disk allocated counter mismatch. Expected: %lu Actual: %lu",
+            line, disk_allocated_kib, stats_counter_get(queue_disk->metrics.disk_allocated));
+}
+
+static void
+_test_non_reliable_setup(void)
+{
+  _setup_with_persist("test_non_reliable.persist");
+}
+
+static void
+_test_non_reliable_teardown(void)
+{
+  _teardown_with_persist("test_non_reliable.persist");
+}
+
+Test(diskq_counters, test_non_reliable,
+     .init = _test_non_reliable_setup,
+     .fini = _test_non_reliable_teardown)
+{
+  const gsize expected_capacity = MIN_DISK_BUF_SIZE - QDISK_RESERVED_SPACE;
+  const gchar *queue_persist_name = "test_non_reliable";
+  const gchar *dir_name = "test_diskq_counters_test_non_reliable";
+  const gchar *dirlock_path = "test_diskq_counters_test_non_reliable/syslog-ng-disk-buffer.dirlock";
+
+  StatsClusterKeyBuilder *queue_sck_builder = stats_cluster_key_builder_new();
+  LogDestDriver *driver = _dummy_dd_new(FALSE, dir_name);
+  cr_assert(log_pipe_init(&driver->super.super));
+
+  /* Init empty disk-queue */
+  LogQueue *queue = log_queue_ref(log_dest_driver_acquire_queue(driver, queue_persist_name, STATS_LEVEL0, NULL,
+                                  queue_sck_builder));
+  cr_assert(queue);
+  _assert_counters(queue, 0, 0, expected_capacity, 0, QDISK_RESERVED_SPACE, __LINE__);
+
+  /* First message goes to qout */
+  gssize one_message_memory_size;
+  gssize one_message_serialized_size;
+  _push_one_message(queue, &one_message_memory_size, &one_message_serialized_size);
+  _assert_counters(queue, 1, one_message_memory_size, expected_capacity, 0, QDISK_RESERVED_SPACE, __LINE__);
+
+  /* Second message goes to qdisk */
+  _push_one_message(queue, NULL, NULL);
+  _assert_counters(queue, 2, one_message_memory_size, expected_capacity, one_message_serialized_size,
+                   QDISK_RESERVED_SPACE + one_message_serialized_size, __LINE__);
+
+  /* Release and reacquire queue, same counters are expected */
+  log_dest_driver_release_queue(driver, queue);
+
+  stats_cluster_key_builder_reset(queue_sck_builder);
+  queue = log_queue_ref(log_dest_driver_acquire_queue(driver, queue_persist_name, STATS_LEVEL0, NULL,
+                                                      queue_sck_builder));
+  cr_assert(queue);
+  _assert_counters(queue, 2, one_message_memory_size, expected_capacity, one_message_serialized_size,
+                   QDISK_RESERVED_SPACE + one_message_serialized_size, __LINE__);
+
+  /* Pop one message, disk usage should reduce */
+  send_some_messages(queue, 1);
+  log_queue_ack_backlog(queue, 1);
+  _assert_counters(queue, 1, one_message_memory_size, expected_capacity, 0,
+                   QDISK_RESERVED_SPACE + one_message_serialized_size, __LINE__);
+
+  /* Pop one message, memory usage should reduce */
+  send_some_messages(queue, 1);
+  log_queue_ack_backlog(queue, 1);
+  _assert_counters(queue, 0, 0, expected_capacity, 0, QDISK_RESERVED_SPACE + one_message_serialized_size, __LINE__);
+
+  stats_cluster_key_builder_free(queue_sck_builder);
+  gchar *filename = g_strdup(log_queue_disk_get_filename(queue));
+  log_dest_driver_release_queue(driver, queue);
+  unlink(filename);
+  unlink(dirlock_path);
+  g_free(filename);
+  rmdir(dir_name);
+  cr_assert(log_pipe_unref(&driver->super.super));
+}
+
+static void
+_test_reliable_setup(void)
+{
+  _setup_with_persist("test_reliable.persist");
+}
+
+static void
+_test_reliable_teardown(void)
+{
+  _teardown_with_persist("test_reliable.persist");
+}
+
+Test(diskq_counters, test_reliable,
+     .init = _test_reliable_setup,
+     .fini = _test_reliable_teardown)
+{
+  const gsize expected_capacity = MIN_DISK_BUF_SIZE - QDISK_RESERVED_SPACE;
+  const gchar *queue_persist_name = "test_reliable";
+  const gchar *dir_name = "test_diskq_counters_test_reliable";
+  const gchar *dirlock_path = "test_diskq_counters_test_reliable/syslog-ng-disk-buffer.dirlock";
+
+  StatsClusterKeyBuilder *queue_sck_builder = stats_cluster_key_builder_new();
+  LogDestDriver *driver = _dummy_dd_new(TRUE, dir_name);
+  cr_assert(log_pipe_init(&driver->super.super));
+
+  /* Init empty disk-queue */
+  LogQueue *queue = log_queue_ref(log_dest_driver_acquire_queue(driver, queue_persist_name, STATS_LEVEL0, NULL,
+                                  queue_sck_builder));
+  cr_assert(queue);
+  _assert_counters(queue, 0, 0, expected_capacity, 0, QDISK_RESERVED_SPACE, __LINE__);
+
+  /* The message goes to both qout and qdisk */
+  gssize one_message_memory_size;
+  gssize one_message_serialized_size;
+  _push_one_message(queue, &one_message_memory_size, &one_message_serialized_size);
+  _assert_counters(queue, 1, one_message_memory_size, expected_capacity, one_message_serialized_size,
+                   QDISK_RESERVED_SPACE + one_message_serialized_size, __LINE__);
+
+  /* Release and reacquire queue, only disk usage is expected, as qout is not refilled */
+  log_dest_driver_release_queue(driver, queue);
+
+  stats_cluster_key_builder_reset(queue_sck_builder);
+  queue = log_queue_ref(log_dest_driver_acquire_queue(driver, queue_persist_name, STATS_LEVEL0, NULL,
+                                                      queue_sck_builder));
+  cr_assert(queue);
+  _assert_counters(queue, 1, 0, expected_capacity, one_message_serialized_size,
+                   QDISK_RESERVED_SPACE + one_message_serialized_size, __LINE__);
+
+  /* Pop the message, disk usage should reduce */
+  send_some_messages(queue, 1);
+  log_queue_ack_backlog(queue, 1);
+  _assert_counters(queue, 0, 0, expected_capacity, 0, QDISK_RESERVED_SPACE + one_message_serialized_size, __LINE__);
+
+  stats_cluster_key_builder_free(queue_sck_builder);
+  gchar *filename = g_strdup(log_queue_disk_get_filename(queue));
+  log_dest_driver_release_queue(driver, queue);
+  unlink(filename);
+  unlink(dirlock_path);
+  g_free(filename);
+  rmdir(dir_name);
+  cr_assert(log_pipe_unref(&driver->super.super));
+}
+
+TestSuite(diskq_counters);

--- a/news/feature-4356.md
+++ b/news/feature-4356.md
@@ -1,0 +1,22 @@
+`disk-buffer`: Added capacity, disk_allocated and disk_usage metrics.
+
+  * "capacity_bytes": The theoretical maximal useful size of the disk-buffer.
+                      This is always smaller, than `disk-buf-size()`, as there is some reserved
+                      space for metadata. The actual full disk-buffer file can be larger than this,
+                      as syslog-ng allows to write over this limit once, at the end of the file.
+
+  * "disk_allocated_bytes": The current size of the disk-buffer file on the disk. Please note that
+                            the disk-buffer file size does not strictly correlate with the number
+                            of messages, as it is a ring buffer implementation, and also syslog-ng
+                            optimizes the truncation of the file for performance reasons.
+
+  * "disk_usage_bytes": The serialized size of the queued messages in the disk-buffer file. This counter
+                        is useful for calculating the disk usage percentage (disk_usage_bytes / capacity_bytes)
+                        or the remaining available space (capacity_bytes - disk_usage_bytes).
+
+Example metrics:
+```
+syslogng_disk_queue_capacity_bytes{driver_id="d_network#0",driver_instance="tcp,localhost:1235",path="/var/syslog-ng-00000.rqf",reliable="true"} 104853504
+syslogng_disk_queue_disk_allocated_bytes{driver_id="d_network#0",driver_instance="tcp,localhost:1235",path="/var/syslog-ng-00000.rqf",reliable="true"} 17284
+syslogng_disk_queue_disk_usage_bytes{driver_id="d_network#0",driver_instance="tcp,localhost:1235",path="/var/syslog-ng-00000.rqf",reliable="true"} 13188
+```

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -150,6 +150,7 @@ modules/python-modules/syslogng/persist\.py
 ###########################################################################
                                                  GPLv2+_SSL,non-balabit
 
+modules/diskq/tests/test_diskq_counters\.c
 modules/http/(http|http-parser|http-plugin|)\.[ch]
 modules/http/http-grammar.ym
 modules/timestamp/rewrite-.*$


### PR DESCRIPTION
New metrics:
  * "capacity_bytes": The theoretical maximal useful size of the disk-buffer. This is always smaller, than `disk-buf-size()`, as there is some reserved space for metadata. The actual full disk-buffer file can be larger than this, as syslog-ng allows to write over this limit once, at the end of the file.
  * "disk_allocated_bytes": The current size of the disk-buffer file on the disk. Please note that the disk-buffer file size does not strictly correlate with the number of messages, as it is a ring buffer implementation, and also syslog-ng optimizes the truncation of the file for performance reasons.
  * "disk_usage_bytes": The serialized size of the queued messages in the disk-buffer file. This counter is useful for calculating the disk usage percentage (disk_usage_bytes / capacity_bytes) or the remaining available space (capacity_bytes - disk_usage_bytes).

Example metrics:
```
syslogng_disk_queue_capacity_bytes{driver_id="d_network#0",driver_instance="tcp,localhost:1235",path="/var/syslog-ng-00000.rqf",reliable="true"} 104853504
syslogng_disk_queue_disk_allocated_bytes{driver_id="d_network#0",driver_instance="tcp,localhost:1235",path="/var/syslog-ng-00000.rqf",reliable="true"} 17284
syslogng_disk_queue_disk_usage_bytes{driver_id="d_network#0",driver_instance="tcp,localhost:1235",path="/var/syslog-ng-00000.rqf",reliable="true"} 13188
```

Depends on #4392.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>