### PR TITLE
docker: add metadata label for opencontainers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM debian:testing
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, László Várady <laszlo.varady@balabit.com>"
+LABEL org.opencontainers.image.source="https://github.com/syslog-ng/syslog-ng"
 
 ARG PKG_TYPE=stable
 


### PR DESCRIPTION
Add opencontainers image source label, which is used by external tooling/systems for various purposes.

One example is https://github.com/renovatebot/renovate/blob/main/lib/modules/datasource/docker/readme.md