### PR TITLE
syslog-ng health metrics and `syslog-ng-ctl healthcheck`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,6 +23,6 @@ EXPOSE 514/udp
 EXPOSE 601/tcp
 EXPOSE 6514/tcp
 
-HEALTHCHECK --interval=2m --timeout=3s --start-period=30s CMD /usr/sbin/syslog-ng-ctl stats || exit 1
+HEALTHCHECK --interval=2m --timeout=5s --start-period=30s CMD /usr/sbin/syslog-ng-ctl healthcheck --timeout 5
 ENV LD_PRELOAD /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 ENTRYPOINT ["/usr/sbin/syslog-ng", "-F"]

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -12,6 +12,7 @@ add_flex_bison_dependency(CfgLexer CfgGrammar)
 add_subdirectory(ack-tracker)
 add_subdirectory(compat)
 add_subdirectory(control)
+add_subdirectory(healthcheck)
 add_subdirectory(debugger)
 add_subdirectory(filter)
 add_subdirectory(logmsg)
@@ -36,6 +37,7 @@ set(LIB_SUBDIR_HEADERS
     ${ACK_TRACKER_HEADERS}
     ${COMPAT_HEADERS}
     ${CONTROL_HEADERS}
+    ${HEALTHCHECK_HEADERS}
     ${DEBUGGER_HEADERS}
     ${FILTER_HEADERS}
     ${LOGMSG_HEADERS}
@@ -239,6 +241,7 @@ set(LIB_SOURCES
     ${ACK_TRACKER_SOURCES}
     ${COMPAT_SOURCES}
     ${CONTROL_SOURCES}
+    ${HEALTHCHECK_SOURCES}
     ${DEBUGGER_SOURCES}
     ${FILTER_SOURCES}
     ${LOGMSG_SOURCES}
@@ -355,6 +358,7 @@ install(FILES ${LIB_HEADERS} DESTINATION include/syslog-ng)
 install(FILES ${VALUE_PAIRS_HEADERS} DESTINATION include/syslog-ng/value-pairs)
 install(FILES ${COMPAT_HEADERS} DESTINATION include/syslog-ng/compat)
 install(FILES ${CONTROL_HEADERS} DESTINATION include/syslog-ng/control)
+install(FILES ${HEALTHCHECK_HEADERS} DESTINATION include/syslog-ng/healthcheck)
 install(FILES ${DEBUGGER_HEADERS} DESTINATION include/syslog-ng/debugger)
 install(FILES ${FILTER_HEADERS} DESTINATION include/syslog-ng/filter)
 install(FILES ${LOGMSG_HEADERS} DESTINATION include/syslog-ng/logmsg)

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -12,6 +12,7 @@ include lib/template/Makefile.am
 include lib/value-pairs/Makefile.am
 include lib/stats/Makefile.am
 include lib/control/Makefile.am
+include lib/healthcheck/Makefile.am
 include lib/debugger/Makefile.am
 include lib/compat/Makefile.am
 include lib/logmsg/Makefile.am
@@ -280,6 +281,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	$(value_pairs_sources)		\
 	$(stats_sources)		\
 	$(control_sources)		\
+	$(healthcheck_sources) \
 	$(debugger_sources)		\
 	$(compat_sources)     		\
 	$(logmsg_sources)		\

--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -28,6 +28,7 @@
 #include "dnscache.h"
 #include "alarms.h"
 #include "stats/stats-registry.h"
+#include "healthcheck/healthcheck-stats.h"
 #include "logmsg/logmsg.h"
 #include "logsource.h"
 #include "logwriter.h"
@@ -224,6 +225,7 @@ app_startup(void)
   alarm_init();
   main_loop_thread_resource_init();
   stats_init();
+  healthcheck_stats_global_init();
   tzset();
   log_msg_global_init();
   log_tags_global_init();

--- a/lib/cfg-grammar-internal.c
+++ b/lib/cfg-grammar-internal.c
@@ -43,6 +43,7 @@ ValuePairsTransformSet *last_vp_transset;
 LogMatcherOptions *last_matcher_options;
 HostResolveOptions *last_host_resolve_options;
 StatsOptions *last_stats_options;
+HealthCheckStatsOptions *last_healthcheck_options;
 DNSCacheOptions *last_dns_cache_options;
 LogRewrite *last_rewrite;
 CfgArgs *last_block_args;

--- a/lib/cfg-grammar-internal.h
+++ b/lib/cfg-grammar-internal.h
@@ -51,6 +51,9 @@
 #include "logthrsource/logthrfetcherdrv.h"
 #include "logthrdest/logthrdestdrv.h"
 
+#include "stats/stats.h"
+#include "healthcheck/healthcheck-stats.h"
+
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -77,6 +80,7 @@ extern ValuePairsTransformSet *last_vp_transset;
 extern LogMatcherOptions *last_matcher_options;
 extern HostResolveOptions *last_host_resolve_options;
 extern StatsOptions *last_stats_options;
+extern HealthCheckStatsOptions *last_healthcheck_options;
 extern LogRewrite *last_rewrite;
 extern CfgArgs *last_block_args;
 extern DNSCacheOptions *last_dns_cache_options;

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -192,6 +192,7 @@
 %token KW_LIFETIME                    10403
 %token KW_MAX_DYNAMIC                 10404
 %token KW_SYSLOG_STATS                10405
+%token KW_HEALTHCHECK_FREQ            10406
 
 %token KW_CHAIN_HOSTNAMES             10090
 %token KW_NORMALIZE_HOSTNAMES         10091
@@ -961,7 +962,7 @@ options_item
 	| KW_LOG_LEVEL '(' string ')'		{ CHECK_ERROR(cfg_set_log_level(configuration, $3), @3, "Unknown log-level() option"); free($3); }
 	| { last_template_options = &configuration->template_options; } template_option
 	| { last_host_resolve_options = &configuration->host_resolve_options; } host_resolve_option
-	| { last_stats_options = &configuration->stats_options; } stat_option
+	| { last_stats_options = &configuration->stats_options; last_healthcheck_options = &configuration->healthcheck_options; } stat_option
 	| { last_dns_cache_options = &configuration->dns_cache_options; } dns_cache_option
 	| { last_file_perm_options = &configuration->file_perm_options; } file_perm_option
 	| LL_PLUGIN
@@ -996,6 +997,7 @@ stats_group_option
 	| KW_LIFETIME '(' positive_integer ')'      { last_stats_options->lifetime = $3; }
 	| KW_MAX_DYNAMIC '(' nonnegative_integer ')'   { last_stats_options->max_dynamic = $3; }
 	| KW_SYSLOG_STATS '(' yesnoauto ')'     { last_stats_options->syslog_stats = $3; }
+	| KW_HEALTHCHECK_FREQ '(' nonnegative_integer ')' { last_healthcheck_options->freq = $3; }
 	;
 
 dns_cache_option

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -98,6 +98,7 @@ static CfgLexerKeyword main_keywords[] =
   { "lifetime",           KW_LIFETIME },
   { "max_dynamics",       KW_MAX_DYNAMIC },
   { "syslog_stats",       KW_SYSLOG_STATS },
+  { "healthcheck_freq",   KW_HEALTHCHECK_FREQ},
   { "min_iw_size_per_reader", KW_MIN_IW_SIZE_PER_READER },
   { "flush_lines",        KW_FLUSH_LINES },
   { "flush_timeout",      KW_FLUSH_TIMEOUT, KWS_OBSOLETE, "Some drivers support batch-timeout() instead that you can specify at the destination level." },

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -526,6 +526,7 @@ cfg_new(gint version)
     self->use_uniqid = TRUE;
 
   stats_options_defaults(&self->stats_options);
+  healthcheck_stats_options_defaults(&self->healthcheck_options);
 
   self->min_iw_size_per_reader = 100;
 

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -35,6 +35,7 @@
 #include "host-resolve.h"
 #include "logmsg/type-hinting.h"
 #include "stats/stats.h"
+#include "healthcheck/healthcheck-stats.h"
 #include "dnscache.h"
 #include "file-perms.h"
 
@@ -70,6 +71,7 @@ struct _GlobalConfig
   CfgArgs *globals;
 
   StatsOptions stats_options;
+  HealthCheckStatsOptions healthcheck_options;
   gint mark_freq;
   gint flush_lines;
   gint mark_mode;

--- a/lib/healthcheck/CMakeLists.txt
+++ b/lib/healthcheck/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(HEALTHCHECK_HEADERS
     healthcheck/healthcheck.h
     healthcheck/healthcheck-control.h
+    healthcheck/stopwatch.h
     PARENT_SCOPE)
 
 set(HEALTHCHECK_SOURCES

--- a/lib/healthcheck/CMakeLists.txt
+++ b/lib/healthcheck/CMakeLists.txt
@@ -1,10 +1,12 @@
 set(HEALTHCHECK_HEADERS
     healthcheck/healthcheck.h
     healthcheck/healthcheck-control.h
+    healthcheck/healthcheck-stats.h
     healthcheck/stopwatch.h
     PARENT_SCOPE)
 
 set(HEALTHCHECK_SOURCES
     healthcheck/healthcheck.c
     healthcheck/healthcheck-control.c
+    healthcheck/healthcheck-stats.c
     PARENT_SCOPE)

--- a/lib/healthcheck/CMakeLists.txt
+++ b/lib/healthcheck/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(HEALTHCHECK_HEADERS
+    healthcheck/healthcheck.h
+    healthcheck/healthcheck-control.h
+    PARENT_SCOPE)
+
+set(HEALTHCHECK_SOURCES
+    healthcheck/healthcheck.c
+    healthcheck/healthcheck-control.c
+    PARENT_SCOPE)

--- a/lib/healthcheck/Makefile.am
+++ b/lib/healthcheck/Makefile.am
@@ -5,7 +5,8 @@ EXTRA_DIST += \
 
 healthcheckinclude_HEADERS = \
 	lib/healthcheck/healthcheck.h \
-	lib/healthcheck/healthcheck-control.h
+	lib/healthcheck/healthcheck-control.h \
+	lib/healthcheck/stopwatch.h
 
 healthcheck_sources = \
 	lib/healthcheck/healthcheck.c \

--- a/lib/healthcheck/Makefile.am
+++ b/lib/healthcheck/Makefile.am
@@ -1,0 +1,12 @@
+healthcheckincludedir = ${pkgincludedir}/healthcheck
+
+EXTRA_DIST += \
+	lib/healthcheck/CMakeLists.txt
+
+healthcheckinclude_HEADERS = \
+	lib/healthcheck/healthcheck.h \
+	lib/healthcheck/healthcheck-control.h
+
+healthcheck_sources = \
+	lib/healthcheck/healthcheck.c \
+	lib/healthcheck/healthcheck-control.c

--- a/lib/healthcheck/Makefile.am
+++ b/lib/healthcheck/Makefile.am
@@ -6,8 +6,10 @@ EXTRA_DIST += \
 healthcheckinclude_HEADERS = \
 	lib/healthcheck/healthcheck.h \
 	lib/healthcheck/healthcheck-control.h \
+	lib/healthcheck/healthcheck-stats.h \
 	lib/healthcheck/stopwatch.h
 
 healthcheck_sources = \
 	lib/healthcheck/healthcheck.c \
-	lib/healthcheck/healthcheck-control.c
+	lib/healthcheck/healthcheck-control.c \
+	lib/healthcheck/healthcheck-stats.c

--- a/lib/healthcheck/healthcheck-control.c
+++ b/lib/healthcheck/healthcheck-control.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023 László Várady <laszlo.varady93@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "healthcheck-control.h"
+#include "healthcheck.h"
+
+#include "control/control.h"
+#include "control/control-connection.h"
+#include "control/control-commands.h"
+
+static void
+control_connection_healthcheck(ControlConnection *cc, GString *command, gpointer user_data, gboolean *cancelled)
+{
+
+}
+
+void
+healthcheck_register_control_commands(void)
+{
+  control_register_command("HEALTHCHECK", control_connection_healthcheck, NULL, FALSE);
+}

--- a/lib/healthcheck/healthcheck-control.c
+++ b/lib/healthcheck/healthcheck-control.c
@@ -33,15 +33,19 @@ static void
 _send_healthcheck_reply(HealthCheckResult result, gpointer c)
 {
   ControlConnection *cc = (ControlConnection *) c;
+  gchar double_buf[G_ASCII_DTOSTR_BUF_SIZE];
+
+  gdouble io_worker_latency = result.io_worker_latency / 1e9;
+  gdouble mainloop_io_worker_roundtrip_latency = result.mainloop_io_worker_roundtrip_latency / 1e9;
 
   GString *reply = g_string_new("OK ");
+  g_string_append_printf(reply, PROMETHEUS_METRIC_PREFIX
+                         "io_worker_latency_seconds %s\n",
+                         g_ascii_dtostr(double_buf, G_N_ELEMENTS(double_buf), io_worker_latency));
+  g_string_append_printf(reply, PROMETHEUS_METRIC_PREFIX
+                         "mainloop_io_worker_roundtrip_latency_seconds %s\n",
+                         g_ascii_dtostr(double_buf, G_N_ELEMENTS(double_buf), mainloop_io_worker_roundtrip_latency));
 
-  g_string_append_printf(reply, PROMETHEUS_METRIC_PREFIX
-                         "io_worker_latency_nanoseconds %" G_GUINT64_FORMAT"\n",
-                         result.io_worker_latency);
-  g_string_append_printf(reply, PROMETHEUS_METRIC_PREFIX
-                         "mainloop_io_worker_roundtrip_latency_nanoseconds %" G_GUINT64_FORMAT"\n",
-                         result.mainloop_io_worker_roundtrip_latency);
 
   control_connection_send_reply(cc, reply);
   control_connection_unref(cc);

--- a/lib/healthcheck/healthcheck-control.h
+++ b/lib/healthcheck/healthcheck-control.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 László Várady <laszlo.varady93@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef HEALTHCHECK_CONTROL_H
+#define HEALTHCHECK_CONTROL_H
+
+#include "syslog-ng.h"
+
+void healthcheck_register_control_commands(void);
+
+#endif

--- a/lib/healthcheck/healthcheck-stats.c
+++ b/lib/healthcheck/healthcheck-stats.c
@@ -88,9 +88,11 @@ static void
 _register_counters(HealthCheckStats *self)
 {
   StatsClusterKey sc_key_io_worker_latency, sc_key_mainloop_iow_rt_latency;
-  stats_cluster_single_key_set(&sc_key_io_worker_latency, "io_worker_latency_nanoseconds", NULL, 0);
+  stats_cluster_single_key_set(&sc_key_io_worker_latency, "io_worker_latency_seconds", NULL, 0);
+  stats_cluster_single_key_add_unit(&sc_key_io_worker_latency, SCU_NANOSECONDS);
   stats_cluster_single_key_set(&sc_key_mainloop_iow_rt_latency,
-                               "mainloop_io_worker_roundtrip_latency_nanoseconds", NULL, 0);
+                               "mainloop_io_worker_roundtrip_latency_seconds", NULL, 0);
+  stats_cluster_single_key_add_unit(&sc_key_mainloop_iow_rt_latency, SCU_NANOSECONDS);
 
   stats_lock();
   stats_register_counter(1, &sc_key_io_worker_latency, SC_TYPE_SINGLE_VALUE, &self->io_worker_latency);
@@ -103,9 +105,9 @@ static void
 _unregister_counters(HealthCheckStats *self)
 {
   StatsClusterKey sc_key_io_worker_latency, sc_key_mainloop_iow_rt_latency;
-  stats_cluster_single_key_set(&sc_key_io_worker_latency, "io_worker_latency_nanoseconds", NULL, 0);
+  stats_cluster_single_key_set(&sc_key_io_worker_latency, "io_worker_latency_seconds", NULL, 0);
   stats_cluster_single_key_set(&sc_key_mainloop_iow_rt_latency,
-                               "mainloop_io_worker_roundtrip_latency_nanoseconds", NULL, 0);
+                               "mainloop_io_worker_roundtrip_latency_seconds", NULL, 0);
 
   stats_lock();
   stats_unregister_counter(&sc_key_io_worker_latency, SC_TYPE_SINGLE_VALUE, &self->io_worker_latency);

--- a/lib/healthcheck/healthcheck-stats.c
+++ b/lib/healthcheck/healthcheck-stats.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2023 László Várady <laszlo.varady93@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "healthcheck-stats.h"
+#include "healthcheck.h"
+
+#include "stats/stats-cluster-single.h"
+#include "stats/stats-registry.h"
+#include "stats/stats-counter.h"
+
+#include "apphook.h"
+#include "cfg.h"
+#include "mainloop.h"
+#include "timeutils/misc.h"
+
+#include <iv.h>
+
+typedef struct _HealthCheckStats
+{
+  HealthCheckStatsOptions options;
+  struct iv_timer timer;
+
+  StatsCounterItem *io_worker_latency;
+  StatsCounterItem *mainloop_io_worker_roundtrip_latency;
+} HealthCheckStats;
+
+static HealthCheckStats healthcheck_stats;
+
+static void
+healthcheck_stats_update(HealthCheckResult result, gpointer c)
+{
+  HealthCheckStats *self = (HealthCheckStats *) c;
+
+  stats_counter_set(self->io_worker_latency, result.io_worker_latency);
+  stats_counter_set(self->mainloop_io_worker_roundtrip_latency, result.mainloop_io_worker_roundtrip_latency);
+}
+
+static void
+healthcheck_stats_timer_start(HealthCheckStats *self)
+{
+  if (self->options.freq <= 0)
+    return;
+
+  iv_validate_now();
+  self->timer.expires = iv_now;
+  timespec_add_msec(&self->timer.expires, self->options.freq * 1000);
+  iv_timer_register(&self->timer);
+}
+
+static void
+healthcheck_stats_timer_stop(HealthCheckStats *self)
+{
+  if (self->timer.handler && iv_timer_registered(&self->timer))
+    iv_timer_unregister(&self->timer);
+}
+
+static void
+healthcheck_stats_run(gpointer c)
+{
+  HealthCheckStats *self = (HealthCheckStats *) c;
+
+  HealthCheck *hc = healthcheck_new();
+  healthcheck_run(hc, healthcheck_stats_update, self);
+  healthcheck_unref(hc);
+
+  healthcheck_stats_timer_start(self);
+}
+
+static void
+_register_counters(HealthCheckStats *self)
+{
+  StatsClusterKey sc_key_io_worker_latency, sc_key_mainloop_iow_rt_latency;
+  stats_cluster_single_key_set(&sc_key_io_worker_latency, "io_worker_latency_nanoseconds", NULL, 0);
+  stats_cluster_single_key_set(&sc_key_mainloop_iow_rt_latency,
+                               "mainloop_io_worker_roundtrip_latency_nanoseconds", NULL, 0);
+
+  stats_lock();
+  stats_register_counter(1, &sc_key_io_worker_latency, SC_TYPE_SINGLE_VALUE, &self->io_worker_latency);
+  stats_register_counter(1, &sc_key_mainloop_iow_rt_latency, SC_TYPE_SINGLE_VALUE,
+                         &self->mainloop_io_worker_roundtrip_latency);
+  stats_unlock();
+}
+
+static void
+_unregister_counters(HealthCheckStats *self)
+{
+  StatsClusterKey sc_key_io_worker_latency, sc_key_mainloop_iow_rt_latency;
+  stats_cluster_single_key_set(&sc_key_io_worker_latency, "io_worker_latency_nanoseconds", NULL, 0);
+  stats_cluster_single_key_set(&sc_key_mainloop_iow_rt_latency,
+                               "mainloop_io_worker_roundtrip_latency_nanoseconds", NULL, 0);
+
+  stats_lock();
+  stats_unregister_counter(&sc_key_io_worker_latency, SC_TYPE_SINGLE_VALUE, &self->io_worker_latency);
+  stats_unregister_counter(&sc_key_mainloop_iow_rt_latency, SC_TYPE_SINGLE_VALUE,
+                           &self->mainloop_io_worker_roundtrip_latency);
+  stats_unlock();
+}
+
+void
+healthcheck_stats_init(HealthCheckStatsOptions *options)
+{
+  healthcheck_stats.options = *options;
+
+  _register_counters(&healthcheck_stats);
+
+  healthcheck_stats_timer_stop(&healthcheck_stats);
+  IV_TIMER_INIT(&healthcheck_stats.timer);
+  healthcheck_stats.timer.handler = healthcheck_stats_run;
+  healthcheck_stats.timer.cookie = &healthcheck_stats;
+
+  healthcheck_stats_run(&healthcheck_stats);
+}
+
+void
+healthcheck_stats_deinit(void)
+{
+  healthcheck_stats_timer_stop(&healthcheck_stats);
+  _unregister_counters(&healthcheck_stats);
+}
+
+
+static inline void
+_init(gint type, gpointer c)
+{
+  MainLoop *main_loop = main_loop_get_instance();
+  GlobalConfig *cfg = main_loop_get_current_config(main_loop);
+  if (!cfg)
+    return;
+
+  healthcheck_stats_init(&cfg->healthcheck_options);
+}
+
+static inline void
+_deinit(gint type, gpointer c)
+{
+  healthcheck_stats_deinit();
+}
+
+void
+healthcheck_stats_global_init(void)
+{
+  register_application_hook(AH_CONFIG_CHANGED, _init, NULL, AHM_RUN_REPEAT);
+  register_application_hook(AH_CONFIG_STOPPED, _deinit, NULL, AHM_RUN_REPEAT);
+}

--- a/lib/healthcheck/healthcheck-stats.c
+++ b/lib/healthcheck/healthcheck-stats.c
@@ -58,9 +58,6 @@ healthcheck_stats_update(HealthCheckResult result, gpointer c)
 static void
 healthcheck_stats_timer_start(HealthCheckStats *self)
 {
-  if (self->options.freq <= 0)
-    return;
-
   iv_validate_now();
   self->timer.expires = iv_now;
   timespec_add_msec(&self->timer.expires, self->options.freq * 1000);
@@ -83,7 +80,8 @@ healthcheck_stats_run(gpointer c)
   healthcheck_run(hc, healthcheck_stats_update, self);
   healthcheck_unref(hc);
 
-  healthcheck_stats_timer_start(self);
+  if (self->options.freq > 0)
+    healthcheck_stats_timer_start(self);
 }
 
 static void
@@ -128,7 +126,8 @@ healthcheck_stats_init(HealthCheckStatsOptions *options)
   healthcheck_stats.timer.handler = healthcheck_stats_run;
   healthcheck_stats.timer.cookie = &healthcheck_stats;
 
-  healthcheck_stats_run(&healthcheck_stats);
+  if (healthcheck_stats.mainloop_io_worker_roundtrip_latency)
+    healthcheck_stats_run(&healthcheck_stats);
 }
 
 void

--- a/lib/healthcheck/healthcheck-stats.h
+++ b/lib/healthcheck/healthcheck-stats.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023 László Várady <laszlo.varady93@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef HEALTHCHECK_STATS_H
+#define HEALTHCHECK_STATS_H
+
+#include "syslog-ng.h"
+
+typedef struct _HealthCheckStatsOptions
+{
+  gint freq;
+} HealthCheckStatsOptions;
+
+static inline void
+healthcheck_stats_options_defaults(HealthCheckStatsOptions *options)
+{
+  options->freq = 300;
+}
+
+void healthcheck_stats_init(HealthCheckStatsOptions *options);
+void healthcheck_stats_deinit(void);
+
+void healthcheck_stats_global_init(void);
+
+#endif

--- a/lib/healthcheck/healthcheck.c
+++ b/lib/healthcheck/healthcheck.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023 László Várady <laszlo.varady93@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "healthcheck.h"
+
+#include "atomic.h"
+#include "mainloop-io-worker.h"
+
+struct _HealthCheck
+{
+  GAtomicCounter ref_cnt;
+  gboolean running;
+  HealthCheckResult result;
+
+  HealthCheckCompletionCB completion;
+  gpointer user_data;
+};
+
+gboolean
+healthcheck_run(HealthCheck *self, HealthCheckCompletionCB completion, gpointer user_data)
+{
+  if (self->running || !completion)
+    return FALSE;
+
+  self->completion = completion;
+  self->user_data = user_data;
+  self->result = (HealthCheckResult){0};
+
+  return TRUE;
+}
+
+static void
+healthcheck_free(HealthCheck *self)
+{
+  g_assert(!self->running);
+  g_free(self);
+}
+
+HealthCheck *
+healthcheck_ref(HealthCheck *self)
+{
+  if (!self)
+    return NULL;
+
+  g_atomic_counter_inc(&self->ref_cnt);
+  return self;
+}
+
+void
+healthcheck_unref(HealthCheck *self)
+{
+  if (!self)
+    return;
+
+  if (g_atomic_counter_dec_and_test(&self->ref_cnt))
+    healthcheck_free(self);
+}
+
+HealthCheck *
+healthcheck_new(void)
+{
+  HealthCheck *self = g_new0(HealthCheck, 1);
+  g_atomic_counter_set(&self->ref_cnt, 1);
+
+  self->running = FALSE;
+
+  return self;
+}

--- a/lib/healthcheck/healthcheck.h
+++ b/lib/healthcheck/healthcheck.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 László Várady <laszlo.varady93@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef HEALTHCHECK_H
+#define HEALTHCHECK_H
+
+#include "syslog-ng.h"
+
+typedef struct _HealthCheck HealthCheck;
+
+typedef struct _HealthCheckResult
+{
+} HealthCheckResult;
+
+typedef void(*HealthCheckCompletionCB)(HealthCheckResult, gpointer);
+
+HealthCheck *healthcheck_new(void);
+HealthCheck *healthcheck_ref(HealthCheck *self);
+void healthcheck_unref(HealthCheck *self);
+
+gboolean healthcheck_run(HealthCheck *self, HealthCheckCompletionCB completion, gpointer user_data);
+
+#endif

--- a/lib/healthcheck/healthcheck.h
+++ b/lib/healthcheck/healthcheck.h
@@ -30,6 +30,8 @@ typedef struct _HealthCheck HealthCheck;
 
 typedef struct _HealthCheckResult
 {
+  guint64 io_worker_latency;
+  guint64 mainloop_io_worker_roundtrip_latency;
 } HealthCheckResult;
 
 typedef void(*HealthCheckCompletionCB)(HealthCheckResult, gpointer);

--- a/lib/healthcheck/stopwatch.h
+++ b/lib/healthcheck/stopwatch.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023 László Várady <laszlo.varady93@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef STOPWATCH_H
+#define STOPWATCH_H
+
+#include "syslog-ng.h"
+#include "compat/time.h"
+
+typedef struct _Stopwatch
+{
+  struct timespec start_time;
+} Stopwatch;
+
+static inline void
+stopwatch_start(Stopwatch *self)
+{
+  clock_gettime(CLOCK_MONOTONIC, &self->start_time);
+}
+
+static inline guint64
+stopwatch_get_elapsed_nsec(Stopwatch *self)
+{
+  struct timespec stop_time;
+  clock_gettime(CLOCK_MONOTONIC, &stop_time);
+
+  return (stop_time.tv_sec - self->start_time.tv_sec) * 1000000000
+         + (stop_time.tv_nsec - self->start_time.tv_nsec);
+}
+
+#endif

--- a/lib/mainloop-io-worker.c
+++ b/lib/mainloop-io-worker.c
@@ -48,18 +48,19 @@ _engage(MainLoopIOWorkerJob *self)
 }
 
 /* NOTE: runs in the main thread */
-void
+gboolean
 main_loop_io_worker_job_submit(MainLoopIOWorkerJob *self, GIOCondition cond)
 {
   g_assert(self->working == FALSE);
   if (main_loop_workers_quit)
-    return;
+    return FALSE;
 
   _engage(self);
   main_loop_worker_job_start();
   self->working = TRUE;
   self->cond = cond;
   iv_work_pool_submit_work(&main_loop_io_workers, &self->work_item);
+  return TRUE;
 }
 
 /* NOTE: runs in the actual worker thread spawned by the

--- a/lib/mainloop-io-worker.h
+++ b/lib/mainloop-io-worker.h
@@ -41,7 +41,7 @@ typedef struct _MainLoopIOWorkerJob
 } MainLoopIOWorkerJob;
 
 void main_loop_io_worker_job_init(MainLoopIOWorkerJob *self);
-void main_loop_io_worker_job_submit(MainLoopIOWorkerJob *self, GIOCondition cond);
+gboolean main_loop_io_worker_job_submit(MainLoopIOWorkerJob *self, GIOCondition cond);
 
 void main_loop_io_worker_add_options(GOptionContext *ctx);
 

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -43,6 +43,7 @@
 #include "scratch-buffers.h"
 #include "timeutils/misc.h"
 #include "stats/stats-control.h"
+#include "healthcheck/healthcheck-control.h"
 #include "signal-handler.h"
 
 #include <sys/types.h>
@@ -633,6 +634,7 @@ main_loop_read_and_init_config(MainLoop *self)
   self->control_server = control_init(resolved_configurable_paths.ctlfilename);
   main_loop_register_control_commands(self);
   stats_register_control_commands();
+  healthcheck_register_control_commands();
   return 0;
 }
 

--- a/lib/stats/stats-cluster-single.c
+++ b/lib/stats/stats-cluster-single.c
@@ -141,6 +141,12 @@ stats_cluster_single_key_set(StatsClusterKey *key, const gchar *name, StatsClust
   });
 }
 
+void
+stats_cluster_single_key_add_unit(StatsClusterKey *key, StatsClusterUnit stored_unit)
+{
+  key->stored_unit = stored_unit;
+}
+
 StatsCounterItem *
 stats_cluster_single_get_counter(StatsCluster *self)
 {

--- a/lib/stats/stats-cluster-single.h
+++ b/lib/stats/stats-cluster-single.h
@@ -50,6 +50,8 @@ void stats_cluster_single_key_legacy_set_with_name(StatsClusterKey *key, guint16
 void stats_cluster_single_key_add_legacy_alias_with_name(StatsClusterKey *key, guint16 component, const gchar *id,
                                                          const gchar *instance, const gchar *name);
 
+void stats_cluster_single_key_add_unit(StatsClusterKey *key, StatsClusterUnit stored_unit);
+
 StatsCounterItem *stats_cluster_single_get_counter(StatsCluster *self);
 
 #endif

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -143,6 +143,8 @@ stats_cluster_key_clone(StatsClusterKey *dst, const StatsClusterKey *src)
   dst->labels = stats_cluster_key_labels_clone(src->labels, src->labels_len);
   dst->labels_len = src->labels_len;
 
+  dst->stored_unit = src->stored_unit;
+
   dst->legacy.id = g_strdup(src->legacy.id ? : "");
   dst->legacy.component = src->legacy.component;
   dst->legacy.instance = g_strdup(src->legacy.instance ? : "");

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -46,6 +46,23 @@ enum
   SCS_SOURCE_MASK    = 0xff
 };
 
+typedef enum _StatsClusterUnit
+{
+  SCU_NONE = 0,
+
+  SCU_SECONDS,
+  SCU_MINUTES,
+  SCU_HOURS,
+  SCU_MILLISECONDS,
+  SCU_NANOSECONDS,
+
+  SCU_BYTES,
+  SCU_KIB,
+  SCU_MIB,
+  SCU_GIB,
+
+} StatsClusterUnit;
+
 typedef struct _StatsCounterGroup StatsCounterGroup;
 typedef struct _StatsCounterGroupInit StatsCounterGroupInit;
 
@@ -95,6 +112,8 @@ struct _StatsClusterKey
   const gchar *name;
   StatsClusterLabel *labels;
   gsize labels_len;
+
+  StatsClusterUnit stored_unit;
 
   struct
   {

--- a/lib/stats/stats-prometheus.c
+++ b/lib/stats/stats-prometheus.c
@@ -29,7 +29,7 @@
 #include <string.h>
 
 static gchar *
-stats_format_prometheus_sanitize_value(const gchar *value)
+stats_format_prometheus_sanitize_label_value(const gchar *value)
 {
   GString *sanitized_value = scratch_buffers_alloc();
   append_unsafe_utf8_as_escaped_binary(sanitized_value, value, -1, "\"");
@@ -74,7 +74,7 @@ _append_formatted_label(GString *serialized_labels, const StatsClusterLabel *lab
 
   g_string_append_printf(serialized_labels, "%s=\"%s\"",
                          stats_format_prometheus_sanitize_name(label->name),
-                         stats_format_prometheus_sanitize_value(label->value));
+                         stats_format_prometheus_sanitize_label_value(label->value));
 }
 
 static inline gboolean
@@ -143,14 +143,14 @@ _format_legacy(StatsCluster *sc, gint type, StatsCounterItem *counter)
     {
       gboolean has_id = !_is_str_empty(sc->key.legacy.id);
       if (has_id)
-        g_string_append_printf(labels, "%s=\"%s\"", "id", stats_format_prometheus_sanitize_value(sc->key.legacy.id));
+        g_string_append_printf(labels, "%s=\"%s\"", "id", stats_format_prometheus_sanitize_label_value(sc->key.legacy.id));
 
       if (!_is_str_empty(sc->key.legacy.instance))
         {
           if (has_id)
             g_string_append_c(labels, ',');
           g_string_append_printf(labels, "%s=\"%s\"", "stat_instance",
-                                 stats_format_prometheus_sanitize_value(sc->key.legacy.instance));
+                                 stats_format_prometheus_sanitize_label_value(sc->key.legacy.instance));
         }
     }
 

--- a/lib/stats/stats-prometheus.c
+++ b/lib/stats/stats-prometheus.c
@@ -28,8 +28,6 @@
 
 #include <string.h>
 
-#define PROMETHEUS_METRIC_PREFIX "syslogng"
-
 static gchar *
 stats_format_prometheus_sanitize_value(const gchar *value)
 {
@@ -133,7 +131,7 @@ _format_legacy(StatsCluster *sc, gint type, StatsCounterItem *counter)
 
   gchar component[64];
 
-  g_string_append_printf(record, PROMETHEUS_METRIC_PREFIX"_%s",
+  g_string_append_printf(record, PROMETHEUS_METRIC_PREFIX "%s",
                          stats_format_prometheus_sanitize_name(stats_cluster_get_component_name(sc, component, sizeof(component))));
 
   if (!sc->key.legacy.component || sc->key.legacy.component == SCS_GLOBAL)
@@ -178,7 +176,7 @@ stats_prometheus_format_counter(StatsCluster *sc, gint type, StatsCounterItem *c
     return _format_legacy(sc, type, counter);
 
   GString *record = scratch_buffers_alloc();
-  g_string_append_printf(record, PROMETHEUS_METRIC_PREFIX"_%s", stats_format_prometheus_sanitize_name(sc->key.name));
+  g_string_append_printf(record, PROMETHEUS_METRIC_PREFIX "%s", stats_format_prometheus_sanitize_name(sc->key.name));
 
   const gchar *labels = _format_labels(sc, type);
   if (labels)

--- a/lib/stats/stats-prometheus.h
+++ b/lib/stats/stats-prometheus.h
@@ -26,6 +26,8 @@
 #include "syslog-ng.h"
 #include "stats-cluster.h"
 
+#define PROMETHEUS_METRIC_PREFIX "syslogng_"
+
 typedef void (*StatsPrometheusRecordFunc)(const char *record, gpointer user_data);
 
 GString *stats_prometheus_format_counter(StatsCluster *sc, gint type, StatsCounterItem *counter);

--- a/news/feature-4362.md
+++ b/news/feature-4362.md
@@ -1,0 +1,10 @@
+Health metrics and `syslog-ng-ctl healthcheck`
+
+A new `syslog-ng-ctl` command has been introduced, which can be used to query a healthcheck status from syslog-ng.
+Currently, only 2 basic health values are reported.
+
+`syslog-ng-ctl healthcheck --timeout <seconds>` can be specified to use it as a boolean healthy/unhealthy check.
+
+Health checks are also published as periodically updated metrics.
+The frequency of these checks can be configured with the `stats(healthcheck-freq())` option.
+The default is 5 minutes.

--- a/syslog-ng-ctl/CMakeLists.txt
+++ b/syslog-ng-ctl/CMakeLists.txt
@@ -17,6 +17,8 @@ set(SYSLOG_NG_CTL_SOURCES
     commands/license.c
     commands/config.h
     commands/config.c
+    commands/healthcheck.h
+    commands/healthcheck.c
     control-client.c
 )
 

--- a/syslog-ng-ctl/Makefile.am
+++ b/syslog-ng-ctl/Makefile.am
@@ -20,6 +20,8 @@ syslog_ng_ctl_syslog_ng_ctl_SOURCES		= 	\
 	syslog-ng-ctl/commands/query.c			\
 	syslog-ng-ctl/commands/license.h		\
 	syslog-ng-ctl/commands/license.c		\
+	syslog-ng-ctl/commands/healthcheck.h \
+	syslog-ng-ctl/commands/healthcheck.c \
 	syslog-ng-ctl/control-client.h			\
 	syslog-ng-ctl/control-client.c
 

--- a/syslog-ng-ctl/commands/healthcheck.c
+++ b/syslog-ng-ctl/commands/healthcheck.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023 László Várady <laszlo.varady93@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "healthcheck.h"
+#include "syslog-ng.h"
+
+#include <unistd.h>
+#include <signal.h>
+#include <string.h>
+
+static gint healthcheck_options_timeout = 15;
+
+GOptionEntry healthcheck_options[] =
+{
+  {
+    "timeout", 't', 0, G_OPTION_ARG_INT, &healthcheck_options_timeout,
+    "maximum seconds to wait for healthcheck results (default: 15)"
+  },
+  { NULL }
+};
+
+static void
+_healthcheck_exit(int signo)
+{
+  _exit(1);
+}
+
+static void
+_setup_timeout(gint timeout)
+{
+  struct sigaction sa;
+  memset(&sa, 0, sizeof(sa));
+  sa.sa_handler = _healthcheck_exit;
+  sigaction(SIGALRM, &sa, NULL);
+
+  alarm(timeout);
+}
+
+gint
+slng_healthcheck(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
+{
+  _setup_timeout(healthcheck_options_timeout);
+  return dispatch_command("HEALTHCHECK");
+}

--- a/syslog-ng-ctl/commands/healthcheck.h
+++ b/syslog-ng-ctl/commands/healthcheck.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 László Várady <laszlo.varady93@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SYSLOG_NG_CTL_HEALTHCHECK_H
+#define SYSLOG_NG_CTL_HEALTHCHECK_H
+
+#include "commands.h"
+
+extern GOptionEntry healthcheck_options[];
+gint slng_healthcheck(int argc, char *argv[], const gchar *mode, GOptionContext *ctx);
+
+#endif

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -36,6 +36,7 @@
 #include "commands/ctl-stats.h"
 #include "commands/query.h"
 #include "commands/license.h"
+#include "commands/healthcheck.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -124,6 +125,7 @@ static CommandDescriptor modes[] =
   { "config", config_options, "Print current config", slng_config, NULL },
   { "list-files", no_options, "Print files present in config", slng_listfiles, NULL },
   { "export-config-graph", no_options, "export configuration graph", slng_export_config_graph, NULL },
+  { "healthcheck", healthcheck_options, "Health check", slng_healthcheck, NULL },
   { NULL, NULL },
 };
 

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -95,6 +95,7 @@ lib/generic-number\.[ch]
 lib/tests/test_generic_number\.c
 syslog-ng-ctl/commands/log-level.[ch]
 modules/afsocket/afsocket-signals.h
+syslog-ng-ctl/commands/healthcheck.[ch]
 modules/python-modules/syslogng/confgen\.py
 modules/python-modules/syslogng/dest\.py
 modules/python-modules/syslogng/logger\.py

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -74,6 +74,8 @@ modules/secure-logging/tests
 modules/secure-logging/slogencrypt
 modules/secure-logging/slogverify
 modules/secure-logging/slogkey
+lib/healthcheck
+lib/healthcheck/tests
 lib/metrics-pipe\.[ch]
 lib/rewrite/rewrite-set-facility\.h
 lib/rewrite/rewrite-set-matches\.[ch]


### PR DESCRIPTION
This PR introduces a new syslog-ng-ctl command, which can be used to query a healthcheck status from syslog-ng.
Currently, 2 basic health values are reported:
- `mainloop_io_worker_roundtrip_latency_nanoseconds`: mainloop->io-worker-job->mainloop roundtrip - a basic measure for syslog-ng 
- `io_worker_latency_nanoseconds`: io-worker-job start latency

`syslog-ng-ctl healthcheck --timeout <seconds>` can be specified to use it as a boolean healthy/unhealthy check.

The 2 health checks are published as periodically updated metrics as well.
The frequency of these checks can be configured with the `stats(healthcheck-freq())` option. The default is 5 minutes.