### PR TITLE
logpipe: fix crash for synthetic messages in log_path_options_pop_jun…

### DIFF
--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -231,14 +231,25 @@ log_path_options_push_junction(LogPathOptions *local_path_options, gboolean *mat
 static inline void
 log_path_options_pop_conditional(LogPathOptions *local_path_options)
 {
-  local_path_options->matched = local_path_options->parent->matched;
+  if (local_path_options->parent)
+    local_path_options->matched = local_path_options->parent->matched;
 }
 
+/*
+ * NOTE: we need to be optional about ->parent being set, as synthetic
+ * messages (e.g.  the likes emitted by db-parser/grouping-by() may arrive
+ * at the end of a junction without actually crossing the beginning of the
+ * same junction.  But this is ok, in these cases we don't need to propagate
+ * our matched state to anywhere, we can assume that the synthetic message
+ * will just follow the same route as the one it was created from.
+ */
 static inline void
 log_path_options_pop_junction(LogPathOptions *local_path_options)
 {
   log_path_options_pop_conditional(local_path_options);
-  local_path_options->parent = local_path_options->parent->parent;
+
+  if (local_path_options->parent)
+    local_path_options->parent = local_path_options->parent->parent;
 }
 
 struct _LogPipe


### PR DESCRIPTION
This is a critical fix for a bug reported on gitter

https://matrix.to/#/!JQkTKQPSHHDdacODVM:gitter.im/$tSlHLhOvj4xbOQ6jn11Ut3WA8M4ANZBunGmAT5BfEqI?via=gitter.im&via=matrix.org&via=anno.io

This brings up a separate issue, namely what happens to messages dropped due to correlation (e.g. grouping-by() in aggregate-only). I think those messages should need to be considered "matching" even though we are dropping them as we consume them in our correlation context. But that's not a crasher, so let's do that separately.

If this seems to be a good fix, we probably need to do a 4.1.1, unfortunately.
