### PR TITLE
unit-tests: add 5 min timeout for all tests which did not have any

### DIFF
--- a/lib/ack-tracker/tests/test_batched_ack_tracker.c
+++ b/lib/ack-tracker/tests/test_batched_ack_tracker.c
@@ -140,7 +140,7 @@ _teardown(void)
   cfg_free(cfg);
 }
 
-TestSuite(batched_ack_tracker, .init = _setup, .fini = _teardown);
+TestSuite(batched_ack_tracker, .init = _setup, .fini = _teardown, .timeout = 300);
 
 static void
 _dummy_on_batch_acked(GList *ack_records, gpointer user_data)

--- a/lib/ack-tracker/tests/test_instant_ack_tracker.c
+++ b/lib/ack-tracker/tests/test_instant_ack_tracker.c
@@ -128,7 +128,7 @@ _teardown(void)
   cfg_free(cfg);
 }
 
-TestSuite(instant_ack_tracker_bookmarkless, .init = _setup, .fini = _teardown);
+TestSuite(instant_ack_tracker_bookmarkless, .init = _setup, .fini = _teardown, .timeout = 300);
 
 Test(instant_ack_tracker_bookmarkless, request_bookmark_returns_the_same_bookmark)
 {
@@ -185,7 +185,7 @@ Test(instant_ack_tracker_bookmarkless, same_bookmark_for_all_messages)
 }
 
 
-TestSuite(instant_ack_tracker, .init = _setup, .fini = _teardown);
+TestSuite(instant_ack_tracker, .init = _setup, .fini = _teardown, .timeout = 300);
 
 Test(instant_ack_tracker, request_bookmark_returns_same_bookmarks_until_pending_not_assigned)
 {

--- a/lib/control/tests/test_control_cmds.c
+++ b/lib/control/tests/test_control_cmds.c
@@ -67,7 +67,7 @@ teardown(void)
   reset_control_command_list();
 }
 
-TestSuite(control_cmds, .init = setup, .fini = teardown);
+TestSuite(control_cmds, .init = setup, .fini = teardown, .timeout = 300);
 
 static void
 _send_request(const gchar *request)

--- a/lib/debugger/tests/test-debugger.c
+++ b/lib/debugger/tests/test-debugger.c
@@ -40,7 +40,7 @@ teardown(void)
   cfg_free(configuration);
 }
 
-TestSuite(debugger, .init = setup, .fini = teardown);
+TestSuite(debugger, .init = setup, .fini = teardown, .timeout = 300);
 
 Test(debugger, test_debugger)
 {

--- a/lib/filter/tests/test_filter_call.c
+++ b/lib/filter/tests/test_filter_call.c
@@ -51,5 +51,5 @@ teardown(void)
   cfg_free(configuration);
 }
 
-TestSuite(filter_call, .init = setup, .fini = teardown);
+TestSuite(filter_call, .init = setup, .fini = teardown, .timeout = 300);
 

--- a/lib/filter/tests/test_filters_facility.c
+++ b/lib/filter/tests/test_filters_facility.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-TestSuite(filter, .init = setup, .fini = teardown);
+TestSuite(filter, .init = setup, .fini = teardown, .timeout = 300);
 
 typedef struct _FilterParamBits
 {

--- a/lib/filter/tests/test_filters_fop.c
+++ b/lib/filter/tests/test_filters_fop.c
@@ -104,4 +104,4 @@ Test(filter_op, cloned_filter_with_negation_should_behave_the_same)
   testcase(msg, cloned_filter, TRUE);
 }
 
-TestSuite(filter_op, .init = setup, .fini = teardown);
+TestSuite(filter_op, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/filter/tests/test_filters_fop_cmp.c
+++ b/lib/filter/tests/test_filters_fop_cmp.c
@@ -449,4 +449,4 @@ teardown(void)
   cfg_free(configuration);
 }
 
-TestSuite(filter, .init = setup, .fini = teardown);
+TestSuite(filter, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/filter/tests/test_filters_in_list.c
+++ b/lib/filter/tests/test_filters_in_list.c
@@ -148,4 +148,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(template_filters, .init = setup, .fini = teardown);
+TestSuite(template_filters, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/filter/tests/test_filters_level_new.c
+++ b/lib/filter/tests/test_filters_level_new.c
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-TestSuite(filter, .init = setup, .fini = teardown);
+TestSuite(filter, .init = setup, .fini = teardown, .timeout = 300);
 
 typedef struct _FilterParamRange
 {

--- a/lib/filter/tests/test_filters_netmask.c
+++ b/lib/filter/tests/test_filters_netmask.c
@@ -38,7 +38,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-TestSuite(filter, .init = setup, .fini = teardown);
+TestSuite(filter, .init = setup, .fini = teardown, .timeout = 300);
 
 typedef struct _FilterParamNetmask
 {

--- a/lib/filter/tests/test_filters_regexp.c
+++ b/lib/filter/tests/test_filters_regexp.c
@@ -38,7 +38,7 @@
 #include <stdio.h>
 #include <pcre.h>
 
-TestSuite(filter, .init = setup, .fini = teardown);
+TestSuite(filter, .init = setup, .fini = teardown, .timeout = 300);
 
 typedef struct _FilterParamRegexp
 {

--- a/lib/filter/tests/test_filters_statistics.c
+++ b/lib/filter/tests/test_filters_statistics.c
@@ -82,7 +82,7 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(test_filters_statistics, .init = setup, .fini = teardown);
+TestSuite(test_filters_statistics, .init = setup, .fini = teardown, .timeout = 300);
 
 Test(test_filters_statistics, filter_stastistics)
 {

--- a/lib/logmsg/tests/test_gsockaddr_serialize.c
+++ b/lib/logmsg/tests/test_gsockaddr_serialize.c
@@ -29,7 +29,7 @@
 
 #include <string.h>
 
-TestSuite(gsockaddr_serialize, .init = app_startup, .fini = app_shutdown);
+TestSuite(gsockaddr_serialize, .init = app_startup, .fini = app_shutdown, .timeout = 300);
 
 Test(gsockaddr_serialize, test_empty)
 {

--- a/lib/logmsg/tests/test_log_message.c
+++ b/lib/logmsg/tests/test_log_message.c
@@ -164,7 +164,7 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(log_message, .init = setup, .fini = teardown);
+TestSuite(log_message, .init = setup, .fini = teardown, .timeout = 300);
 
 Test(log_message, test_log_message_can_be_created_and_freed)
 {

--- a/lib/logmsg/tests/test_logmsg_ack.c
+++ b/lib/logmsg/tests/test_logmsg_ack.c
@@ -104,7 +104,7 @@ create_clone(LogMessage *msg, LogPathOptions *path_options)
   return cloned;
 }
 
-TestSuite(msg_ack, .init = setup, .fini = teardown);
+TestSuite(msg_ack, .init = setup, .fini = teardown, .timeout = 300);
 
 Test(msg_ack, normal_ack)
 {

--- a/lib/logmsg/tests/test_logmsg_serialize.c
+++ b/lib/logmsg/tests/test_logmsg_serialize.c
@@ -433,4 +433,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(logmsg_serialize, .init = setup, .fini = teardown);
+TestSuite(logmsg_serialize, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/logmsg/tests/test_nvtable.c
+++ b/lib/logmsg/tests/test_nvtable.c
@@ -56,7 +56,7 @@ assert_nvtable(NVTable *tab, NVHandle handle, gchar *expected_value, gssize expe
 }
 
 
-TestSuite(nvtable, .init = app_startup, .fini = app_shutdown);
+TestSuite(nvtable, .init = app_startup, .fini = app_shutdown, .timeout = 300);
 
 /* NVRegistry */
 /* testcases:

--- a/lib/logmsg/tests/test_tags.c
+++ b/lib/logmsg/tests/test_tags.c
@@ -233,4 +233,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(tags, .init = setup, .fini = teardown);
+TestSuite(tags, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/logmsg/tests/test_timestamp_serialize.c
+++ b/lib/logmsg/tests/test_timestamp_serialize.c
@@ -90,4 +90,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(template_timestamp, .init = setup, .fini = teardown);
+TestSuite(template_timestamp, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/logproto/tests/test_logproto.c
+++ b/lib/logproto/tests/test_logproto.c
@@ -100,4 +100,4 @@ Test(log_proto, test_log_proto, .disabled = true)
    */
 }
 
-TestSuite(log_proto, .init = setup, .fini = teardown);
+TestSuite(log_proto, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/logthrdest/tests/test_logthrdestdrv.c
+++ b/lib/logthrdest/tests/test_logthrdestdrv.c
@@ -829,4 +829,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(logthrdestdrv, .init = setup, .fini = teardown);
+TestSuite(logthrdestdrv, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/rewrite/tests/test_rename.c
+++ b/lib/rewrite/tests/test_rename.c
@@ -135,4 +135,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(rename, .init = setup, .fini = teardown);
+TestSuite(rename, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/rewrite/tests/test_rewrite.c
+++ b/lib/rewrite/tests/test_rewrite.c
@@ -353,5 +353,5 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(rewrite, .init = setup, .fini = teardown);
+TestSuite(rewrite, .init = setup, .fini = teardown, .timeout = 300);
 

--- a/lib/rewrite/tests/test_set_facility.c
+++ b/lib/rewrite/tests/test_set_facility.c
@@ -145,4 +145,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(set_facility, .init = setup, .fini = teardown);
+TestSuite(set_facility, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/rewrite/tests/test_set_matches.c
+++ b/lib/rewrite/tests/test_set_matches.c
@@ -139,4 +139,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(set_matches, .init = setup, .fini = teardown);
+TestSuite(set_matches, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/rewrite/tests/test_set_pri.c
+++ b/lib/rewrite/tests/test_set_pri.c
@@ -152,4 +152,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(set_pri, .init = setup, .fini = teardown);
+TestSuite(set_pri, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/rewrite/tests/test_set_severity.c
+++ b/lib/rewrite/tests/test_set_severity.c
@@ -135,4 +135,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(set_severity, .init = setup, .fini = teardown);
+TestSuite(set_severity, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/rewrite/tests/test_set_tag.c
+++ b/lib/rewrite/tests/test_set_tag.c
@@ -140,4 +140,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(set_tag, .init = setup, .fini = teardown);
+TestSuite(set_tag, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/scanner/csv-scanner/tests/test_csv_scanner.c
+++ b/lib/scanner/csv-scanner/tests/test_csv_scanner.c
@@ -428,4 +428,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(csv_scanner, .init = setup, .fini = teardown);
+TestSuite(csv_scanner, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/scanner/kv-scanner/tests/test_kv_scanner.c
+++ b/lib/scanner/kv-scanner/tests/test_kv_scanner.c
@@ -1024,4 +1024,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(kv_scanner, .init = setup, .fini = teardown);
+TestSuite(kv_scanner, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/scanner/list-scanner/tests/test_list_scanner.c
+++ b/lib/scanner/list-scanner/tests/test_list_scanner.c
@@ -67,7 +67,7 @@ teardown(void)
   list_scanner_free(list_scanner);
 }
 
-TestSuite(list_scanner, .init = setup, .fini = teardown);
+TestSuite(list_scanner, .init = setup, .fini = teardown, .timeout = 300);
 
 Test(list_scanner, individual_items_are_scanned)
 {

--- a/lib/scanner/xml-scanner/tests/test_xml_scanner.c
+++ b/lib/scanner/xml-scanner/tests/test_xml_scanner.c
@@ -110,7 +110,7 @@ _report_possible_parse_error(GError *error, gint line)
     }
 }
 
-TestSuite(xml_scanner, .init = setup, .fini = teardown);
+TestSuite(xml_scanner, .init = setup, .fini = teardown, .timeout = 300);
 
 
 Test(xml_scanner, shouldreverse)

--- a/lib/secret-storage/tests/test_secret_storage.c
+++ b/lib/secret-storage/tests/test_secret_storage.c
@@ -49,7 +49,8 @@ secret_storage_testsuite_deinit(void)
 }
 
 
-TestSuite(secretstorage, .init = secret_storage_testsuite_init, .fini = secret_storage_testsuite_deinit);
+TestSuite(secretstorage, .init = secret_storage_testsuite_init, .fini = secret_storage_testsuite_deinit,
+          .timeout = 300);
 
 Test(secretstorage, simple_store_get)
 {

--- a/lib/stats/tests/test_alias_ctr_reg.c
+++ b/lib/stats/tests/test_alias_ctr_reg.c
@@ -35,7 +35,7 @@
 #include <limits.h>
 #include <time.h>
 
-TestSuite(stats_alias_counter, .init = app_startup, .fini = app_shutdown);
+TestSuite(stats_alias_counter, .init = app_startup, .fini = app_shutdown, .timeout = 300);
 
 Test(stats_alias_counter, register_ctr)
 {

--- a/lib/stats/tests/test_dynamic_ctr_reg.c
+++ b/lib/stats/tests/test_dynamic_ctr_reg.c
@@ -34,7 +34,7 @@
 #include <limits.h>
 #include <time.h>
 
-TestSuite(stats_dynamic_clusters, .init = app_startup, .fini = app_shutdown);
+TestSuite(stats_dynamic_clusters, .init = app_startup, .fini = app_shutdown, .timeout = 300);
 
 Test(stats_dynamic_clusters, unlimited_by_default)
 {

--- a/lib/stats/tests/test_external_ctr_reg.c
+++ b/lib/stats/tests/test_external_ctr_reg.c
@@ -34,7 +34,7 @@
 #include <limits.h>
 #include <time.h>
 
-TestSuite(stats_external_counter, .init = app_startup, .fini = app_shutdown);
+TestSuite(stats_external_counter, .init = app_startup, .fini = app_shutdown, .timeout = 300);
 
 Test(stats_external_counter, register_logpipe_cluster_ctr)
 {

--- a/lib/stats/tests/test_stats_cluster.c
+++ b/lib/stats/tests/test_stats_cluster.c
@@ -363,4 +363,4 @@ Test(stats_cluster, test_register_type)
   cr_assert_eq(first, same);
 }
 
-TestSuite(stats_cluster, .init=setup, .fini = app_shutdown);
+TestSuite(stats_cluster, .init=setup, .fini = app_shutdown, .timeout = 300);

--- a/lib/stats/tests/test_stats_prometheus.c
+++ b/lib/stats/tests/test_stats_prometheus.c
@@ -51,7 +51,7 @@ teardown(void)
   main_loop_thread_resource_deinit();
 }
 
-TestSuite(stats_prometheus, .init = setup, .fini = teardown);
+TestSuite(stats_prometheus, .init = setup, .fini = teardown, .timeout = 300);
 
 static inline StatsCluster *
 test_single_cluster(const gchar *name, StatsClusterLabel *labels, gsize labels_len)

--- a/lib/stats/tests/test_stats_query.c
+++ b/lib/stats/tests/test_stats_query.c
@@ -193,7 +193,7 @@ _test_format_list(StatsCounterItem *ctr, gpointer user_data)
   return TRUE;
 }
 
-TestSuite(cluster_query_key, .init = setup, .fini = app_shutdown);
+TestSuite(cluster_query_key, .init = setup, .fini = app_shutdown, .timeout = 300);
 
 Test(cluster_query_key, test_global_key)
 {
@@ -207,7 +207,7 @@ Test(cluster_query_key, test_global_key)
   stats_cluster_free(sc);
 }
 
-TestSuite(stats_query, .init = _initialize_counter_hash, .fini = app_shutdown);
+TestSuite(stats_query, .init = _initialize_counter_hash, .fini = app_shutdown, .timeout = 300);
 
 ParameterizedTestParameters(stats_query, test_stats_query_get_log_msg_out)
 {

--- a/lib/template/tests/test_macro.c
+++ b/lib/template/tests/test_macro.c
@@ -144,4 +144,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(macro, .init = setup, .fini = teardown);
+TestSuite(macro, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/template/tests/test_template.c
+++ b/lib/template/tests/test_template.c
@@ -136,7 +136,7 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(template, .init = setup, .fini = teardown);
+TestSuite(template, .init = setup, .fini = teardown, .timeout = 300);
 
 
 Test(template, test_macros_v3x)

--- a/lib/template/tests/test_template_compile.c
+++ b/lib/template/tests/test_template_compile.c
@@ -402,4 +402,4 @@ teardown(void)
   stop_grabbing_messages();
 }
 
-TestSuite(template_compile, .init = setup, .fini = teardown);
+TestSuite(template_compile, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/template/tests/test_template_on_error.c
+++ b/lib/template/tests/test_template_on_error.c
@@ -66,4 +66,4 @@ Test(template_on_error, test_fail)
   cr_assert_not(log_template_on_error_parse(pattern, &r), "Parsing '%s' works", pattern);
 }
 
-TestSuite(template_on_error, .init = app_startup, .fini = app_shutdown);
+TestSuite(template_on_error, .init = app_startup, .fini = app_shutdown, .timeout = 300);

--- a/lib/tests/test_cfg_lexer_subst.c
+++ b/lib/tests/test_cfg_lexer_subst.c
@@ -293,4 +293,4 @@ Test(cfg_lexer_subst, test_tracking_string_state)
   cfg_lexer_subst_free(subst);
 }
 
-TestSuite(cfg_lexer_subst, .init = app_startup, .fini = app_shutdown);
+TestSuite(cfg_lexer_subst, .init = app_startup, .fini = app_shutdown, .timeout = 300);

--- a/lib/tests/test_cfg_tree.c
+++ b/lib/tests/test_cfg_tree.c
@@ -206,4 +206,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(cfg_tree, .init = setup, .fini = teardown);
+TestSuite(cfg_tree, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/tests/test_clone_logmsg.c
+++ b/lib/tests/test_clone_logmsg.c
@@ -80,7 +80,7 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(clone_logmsg, .init = setup, .fini = teardown);
+TestSuite(clone_logmsg, .init = setup, .fini = teardown, .timeout = 300);
 
 ParameterizedTestParameters(clone_logmsg, test_cloning_with_log_message)
 {

--- a/lib/tests/test_dnscache.c
+++ b/lib/tests/test_dnscache.c
@@ -158,7 +158,7 @@ assert_forget_all(DNSCache *cache, gint cache_size)
 }
 
 
-TestSuite(dnscache, .init = app_startup, .fini = app_shutdown);
+TestSuite(dnscache, .init = app_startup, .fini = app_shutdown, .timeout = 300);
 
 Test(dnscache, test_expiration)
 {

--- a/lib/tests/test_host_resolve.c
+++ b/lib/tests/test_host_resolve.c
@@ -266,4 +266,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(resolve_hostname, .init = setup, .fini = teardown);
+TestSuite(resolve_hostname, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/tests/test_hostid.c
+++ b/lib/tests/test_hostid.c
@@ -106,7 +106,7 @@ _create_persist_file_with_hostid(const gchar *persist_file, guint32 hostid)
 }
 
 
-TestSuite(hostid, .init = app_startup, .fini = app_shutdown);
+TestSuite(hostid, .init = app_startup, .fini = app_shutdown, .timeout = 300);
 
 #ifndef __hpux
 

--- a/lib/tests/test_lexer.c
+++ b/lib/tests/test_lexer.c
@@ -537,4 +537,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(lexer, .init = setup, .fini = teardown);
+TestSuite(lexer, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/tests/test_lexer_block.c
+++ b/lib/tests/test_lexer_block.c
@@ -54,7 +54,7 @@ teardown(void)
   g_string_free(result, TRUE);
 }
 
-TestSuite(test_block, .init = setup, .fini = teardown);
+TestSuite(test_block, .init = setup, .fini = teardown, .timeout = 300);
 
 Test(test_block, mandatory_arguments)
 {

--- a/lib/tests/test_logqueue.c
+++ b/lib/tests/test_logqueue.c
@@ -171,7 +171,7 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(logqueue, .init = setup, .fini = teardown);
+TestSuite(logqueue, .init = setup, .fini = teardown, .timeout = 300);
 
 Test(logqueue, test_zero_diskbuf_and_normal_acks)
 {

--- a/lib/tests/test_logsource.c
+++ b/lib/tests/test_logsource.c
@@ -499,4 +499,4 @@ Test(log_source, test_dynamic_window_reclaim)
   test_source_destroy(source);
 }
 
-TestSuite(log_source, .init = setup, .fini = teardown);
+TestSuite(log_source, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/tests/test_matcher.c
+++ b/lib/tests/test_matcher.c
@@ -139,7 +139,7 @@ teardown(void)
   cfg_free(configuration);
 }
 
-TestSuite(matcher, .init = setup, .fini = teardown);
+TestSuite(matcher, .init = setup, .fini = teardown, .timeout = 300);
 
 Test(matcher, pcre_regexp, .description = "PCRE regexp")
 {

--- a/lib/tests/test_messages.c
+++ b/lib/tests/test_messages.c
@@ -29,7 +29,7 @@
 
 #include <errno.h>
 
-TestSuite(test_messages, .init = app_startup, .fini = app_shutdown);
+TestSuite(test_messages, .init = app_startup, .fini = app_shutdown, .timeout = 300);
 
 void simple_test_asserter(LogMessage *msg)
 {

--- a/lib/tests/test_msgparse.c
+++ b/lib/tests/test_msgparse.c
@@ -142,7 +142,7 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(msgparse, .init = setup, .fini = teardown);
+TestSuite(msgparse, .init = setup, .fini = teardown, .timeout = 300);
 
 void
 test_log_messages_can_be_parsed(struct msgparse_params *param)

--- a/lib/tests/test_persist_state.c
+++ b/lib/tests/test_persist_state.c
@@ -68,7 +68,7 @@ _foreach_callback_assertions(gchar *name, gint size, gpointer entry, gpointer us
   cr_assert_eq(size, sizeof(TestState), "Size of state does not match!");
 }
 
-TestSuite(persist_state, .init = app_startup, .fini = app_shutdown);
+TestSuite(persist_state, .init = app_startup, .fini = app_shutdown, .timeout = 300);
 
 #ifndef __hpux
 

--- a/lib/tests/test_rcptid.c
+++ b/lib/tests/test_rcptid.c
@@ -59,7 +59,7 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(rcptid, .init = setup, .fini = teardown);
+TestSuite(rcptid, .init = setup, .fini = teardown, .timeout = 300);
 
 Test(rcptid, test_rcptid_is_persistent_across_persist_backend_reinits)
 {

--- a/lib/tests/test_reloc.c
+++ b/lib/tests/test_reloc.c
@@ -72,4 +72,4 @@ teardown(void)
   cache_free(path_cache);
 }
 
-TestSuite(reloc, .init = setup, .fini = teardown);
+TestSuite(reloc, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/tests/test_runid.c
+++ b/lib/tests/test_runid.c
@@ -32,7 +32,7 @@
 
 PersistState *create_persist_state(gchar *persist_file_name);
 
-TestSuite(test_run_id, .init = app_startup, .fini = app_shutdown);
+TestSuite(test_run_id, .init = app_startup, .fini = app_shutdown, .timeout = 300);
 #define RUN_ID_FIRST 1
 
 PersistState *

--- a/lib/tests/test_scratch_buffers.c
+++ b/lib/tests/test_scratch_buffers.c
@@ -208,5 +208,5 @@ stats_test_teardown(void)
   stats_destroy();
 }
 
-TestSuite(scratch_buffers, .init = setup, .fini = teardown);
-TestSuite(scratch_buffers_stats, .init = setup, .fini = stats_test_teardown);
+TestSuite(scratch_buffers, .init = setup, .fini = teardown, .timeout = 300);
+TestSuite(scratch_buffers_stats, .init = setup, .fini = stats_test_teardown, .timeout = 300);

--- a/lib/tests/test_serialize.c
+++ b/lib/tests/test_serialize.c
@@ -24,7 +24,7 @@
 #include "serialize.h"
 #include "apphook.h"
 
-TestSuite(serialize, .init = app_startup, .fini = app_shutdown);
+TestSuite(serialize, .init = app_startup, .fini = app_shutdown, .timeout = 300);
 
 Test(serialize, test_serialize)
 {

--- a/lib/tests/test_zone.c
+++ b/lib/tests/test_zone.c
@@ -127,7 +127,7 @@ assert_timestamp_format(GString *target, UnixTime *stamp, TimestampFormatTestCas
   cr_assert_str_eq(target->str, c.expected_format, "Actual: %s, Expected: %s", target->str, c.expected_format);
 }
 
-TestSuite(zone, .init = app_startup, .fini = app_shutdown);
+TestSuite(zone, .init = app_startup, .fini = app_shutdown, .timeout = 300);
 
 Test(zone, test_time_zone_offset)
 {

--- a/lib/timeutils/tests/test_conv.c
+++ b/lib/timeutils/tests/test_conv.c
@@ -287,4 +287,4 @@ teardown(void)
 {
 }
 
-TestSuite(conv, .init = setup, .fini = teardown);
+TestSuite(conv, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/timeutils/tests/test_scan-timestamp.c
+++ b/lib/timeutils/tests/test_scan-timestamp.c
@@ -589,4 +589,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(parse_timestamp, .init = setup, .fini = teardown);
+TestSuite(parse_timestamp, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/timeutils/tests/test_unixtime.c
+++ b/lib/timeutils/tests/test_unixtime.c
@@ -486,4 +486,4 @@ teardown(void)
 {
 }
 
-TestSuite(unixtime, .init = setup, .fini = teardown);
+TestSuite(unixtime, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/timeutils/tests/test_wallclocktime.c
+++ b/lib/timeutils/tests/test_wallclocktime.c
@@ -406,4 +406,4 @@ teardown(void)
 {
 }
 
-TestSuite(wallclocktime, .init = setup, .fini = teardown);
+TestSuite(wallclocktime, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/transport/tests/test_aux_data.c
+++ b/lib/transport/tests/test_aux_data.c
@@ -160,4 +160,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(aux_data, .init = setup, .fini = teardown);
+TestSuite(aux_data, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/transport/tests/test_multitransport.c
+++ b/lib/transport/tests/test_multitransport.c
@@ -73,7 +73,7 @@
     return &self->super; \
   } \
 
-TestSuite(multitransport, .init = app_startup, .fini = app_shutdown);
+TestSuite(multitransport, .init = app_startup, .fini = app_shutdown, .timeout = 300);
 
 DEFINE_TEST_TRANSPORT_WITH_FACTORY(Fake, fake);
 DEFINE_TEST_TRANSPORT_WITH_FACTORY(Default, default);

--- a/lib/transport/tests/test_transport_factory.c
+++ b/lib/transport/tests/test_transport_factory.c
@@ -90,7 +90,7 @@ _fake_transport_factory_new(void)
   return &instance->super;
 }
 
-TestSuite(transport_factory, .init = app_startup, .fini = app_shutdown);
+TestSuite(transport_factory, .init = app_startup, .fini = app_shutdown, .timeout = 300);
 
 Test(transport_factory, fake_transport_factory)
 {

--- a/lib/transport/tests/test_transport_factory_id.c
+++ b/lib/transport/tests/test_transport_factory_id.c
@@ -26,7 +26,8 @@
 #include "transport/transport-factory-id.h"
 #include "apphook.h"
 
-TestSuite(transport_factory_id, .init = transport_factory_id_global_init, .fini = transport_factory_id_global_deinit);
+TestSuite(transport_factory_id, .init = transport_factory_id_global_init, .fini = transport_factory_id_global_deinit,
+          .timeout = 300);
 
 Test(transport_factory_id_lifecycle, lifecycle)
 {

--- a/lib/transport/tests/test_transport_factory_registry.c
+++ b/lib/transport/tests/test_transport_factory_registry.c
@@ -43,7 +43,7 @@ _test_transport_factory_new(void)
   return instance;
 }
 
-TestSuite(transport_factory_registry, .init = app_startup, .fini = app_shutdown);
+TestSuite(transport_factory_registry, .init = app_startup, .fini = app_shutdown, .timeout = 300);
 
 Test(transport_factory_registry, basic_functionality)
 {

--- a/lib/value-pairs/tests/test_value_pairs.c
+++ b/lib/value-pairs/tests/test_value_pairs.c
@@ -306,4 +306,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(value_pairs, .init = setup, .fini = teardown);
+TestSuite(value_pairs, .init = setup, .fini = teardown, .timeout = 300);

--- a/lib/value-pairs/tests/test_value_pairs_walk.c
+++ b/lib/value-pairs/tests/test_value_pairs_walk.c
@@ -145,4 +145,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(value_pairs_walker, .init = setup, .fini = teardown);
+TestSuite(value_pairs_walker, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/add-contextual-data/tests/test_context_info_db.c
+++ b/modules/add-contextual-data/tests/test_context_info_db.c
@@ -557,4 +557,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(add_contextual_data, .init=setup, .fini=teardown);
+TestSuite(add_contextual_data, .init=setup, .fini=teardown, .timeout = 300);

--- a/modules/add-contextual-data/tests/test_filter_selector.c
+++ b/modules/add-contextual-data/tests/test_filter_selector.c
@@ -85,7 +85,7 @@ teardown(void)
   g_free(test_filter_conf);
 }
 
-TestSuite(add_contextual_data_filter_selector, .init = setup, .fini = teardown);
+TestSuite(add_contextual_data_filter_selector, .init = setup, .fini = teardown, .timeout = 300);
 
 Test(add_contextual_data_filter_selector, test_clone_selector_with_filters)
 {

--- a/modules/add-contextual-data/tests/test_glob_selector.c
+++ b/modules/add-contextual-data/tests/test_glob_selector.c
@@ -119,4 +119,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(add_contextual_data_glob_selector, .init = startup, .fini = teardown);
+TestSuite(add_contextual_data_glob_selector, .init = startup, .fini = teardown, .timeout = 300);

--- a/modules/add-contextual-data/tests/test_template_selector.c
+++ b/modules/add-contextual-data/tests/test_template_selector.c
@@ -29,7 +29,7 @@
 #include "apphook.h"
 #include <unistd.h>
 
-TestSuite(add_contextual_data_template_selector, .init = app_startup, .fini = app_shutdown);
+TestSuite(add_contextual_data_template_selector, .init = app_startup, .fini = app_shutdown, .timeout = 300);
 
 static LogMessage *
 _create_log_msg(const gchar *message, const gchar *host)

--- a/modules/affile/tests/test_directory_monitor.c
+++ b/modules/affile/tests/test_directory_monitor.c
@@ -34,7 +34,7 @@
 #include <glib/gstdio.h>
 #include <unistd.h>
 
-TestSuite(directory_monitor, .init = app_startup, .fini = app_shutdown);
+TestSuite(directory_monitor, .init = app_startup, .fini = app_shutdown, .timeout = 300);
 
 static void
 _callback(const DirectoryMonitorEvent *event, gpointer user_data)
@@ -89,7 +89,7 @@ Test(directory_monitor, non_existing_directory)
   directory_monitor_free(monitor);
 }
 
-TestSuite(directory_monitor_tools, .init = app_startup, .fini = app_shutdown);
+TestSuite(directory_monitor_tools, .init = app_startup, .fini = app_shutdown, .timeout = 300);
 
 Test(directory_monitor_tools, build_filename)
 {
@@ -105,7 +105,7 @@ Test(directory_monitor_tools, build_filename)
   cr_assert_eq(NULL, built_path);
 }
 
-TestSuite(directory_monitor_factory, .init = app_startup, .fini = app_shutdown);
+TestSuite(directory_monitor_factory, .init = app_startup, .fini = app_shutdown, .timeout = 300);
 
 Test(directory_monitor_factory, check_monitor_method)
 {

--- a/modules/affile/tests/test_file_list.c
+++ b/modules/affile/tests/test_file_list.c
@@ -25,7 +25,7 @@
 #include "file-list.h"
 
 
-TestSuite(hashed_queue, .init = NULL, .fini = NULL);
+TestSuite(hashed_queue, .init = NULL, .fini = NULL, .timeout = 300);
 
 
 Test(hashed_queue, normal)

--- a/modules/affile/tests/test_file_opener.c
+++ b/modules/affile/tests/test_file_opener.c
@@ -168,4 +168,4 @@ teardown(void)
 {
 }
 
-TestSuite(file_opener, .init = setup, .fini = teardown);
+TestSuite(file_opener, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/affile/tests/test_file_writer.c
+++ b/modules/affile/tests/test_file_writer.c
@@ -177,4 +177,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(file_writer, .init = startup, .fini = teardown);
+TestSuite(file_writer, .init = startup, .fini = teardown, .timeout = 300);

--- a/modules/affile/tests/test_wildcard_file_reader.c
+++ b/modules/affile/tests/test_wildcard_file_reader.c
@@ -120,7 +120,7 @@ _teardown(void)
   app_shutdown();
 }
 
-TestSuite(test_wildcard_file_reader, .init = _init, .fini = _teardown);
+TestSuite(test_wildcard_file_reader, .init = _init, .fini = _teardown, .timeout = 300);
 
 Test(test_wildcard_file_reader, constructor)
 {

--- a/modules/affile/tests/test_wildcard_source.c
+++ b/modules/affile/tests/test_wildcard_source.c
@@ -68,7 +68,7 @@ _create_wildcard_filesource(const gchar *wildcard_config)
   return driver;
 }
 
-TestSuite(wildcard_source, .init = _init, .fini = _deinit);
+TestSuite(wildcard_source, .init = _init, .fini = _deinit, .timeout = 300);
 
 Test(wildcard_source, initial_test)
 {

--- a/modules/afmongodb/tests/test-mongodb-config.c
+++ b/modules/afmongodb/tests/test-mongodb-config.c
@@ -139,4 +139,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(mongodb_config,  .init = setup, .fini = teardown);
+TestSuite(mongodb_config,  .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/afsnmp/tests/test_afsnmp_dest.c
+++ b/modules/afsnmp/tests/test_afsnmp_dest.c
@@ -48,7 +48,7 @@ _teardown(void)
   cfg_free(cfg);
 }
 
-TestSuite(test_snmp_dest, .init = _init, .fini = _teardown);
+TestSuite(test_snmp_dest, .init = _init, .fini = _teardown, .timeout = 300);
 
 Test(test_snmp_dest, set_version)
 {

--- a/modules/afsnmp/tests/test_snmptrapd_parser.c
+++ b/modules/afsnmp/tests/test_snmptrapd_parser.c
@@ -135,7 +135,7 @@ teardown(void)
   cfg_free(configuration);
 }
 
-TestSuite(snmptrapd_parser, .init = setup, .fini = teardown);
+TestSuite(snmptrapd_parser, .init = setup, .fini = teardown, .timeout = 300);
 
 Test(snmptrapd_parser, test_general_v2_message_with_oids)
 {

--- a/modules/afsnmp/tests/test_varbindlist_scanner.c
+++ b/modules/afsnmp/tests/test_varbindlist_scanner.c
@@ -200,4 +200,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(varbindlist_scanner, .init = setup, .fini = teardown);
+TestSuite(varbindlist_scanner, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/afsocket/tests/test-transport-mapper-inet.c
+++ b/modules/afsocket/tests/test-transport-mapper-inet.c
@@ -359,4 +359,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(transport_mapper_inet, .init = setup, .fini = teardown);
+TestSuite(transport_mapper_inet, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/afsocket/tests/test-transport-mapper-unix.c
+++ b/modules/afsocket/tests/test-transport-mapper-unix.c
@@ -67,4 +67,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(transport_mapper_unix, .init = setup, .fini = teardown);
+TestSuite(transport_mapper_unix, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/afsocket/tests/test-transport-mapper.c
+++ b/modules/afsocket/tests/test-transport-mapper.c
@@ -68,4 +68,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(transport_mapper, .init = setup, .fini = teardown);
+TestSuite(transport_mapper, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/appmodel/tests/test_app_parser_generator.c
+++ b/modules/appmodel/tests/test_app_parser_generator.c
@@ -300,4 +300,4 @@ Test(app_parser_generator, app_parser_includes_and_excludes_apps)
 }
 
 
-TestSuite(app_parser_generator, .init = startup, .fini = teardown);
+TestSuite(app_parser_generator, .init = startup, .fini = teardown, .timeout = 300);

--- a/modules/appmodel/tests/test_appmodel.c
+++ b/modules/appmodel/tests/test_appmodel.c
@@ -114,4 +114,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(appmodel, .init = setup, .fini = teardown);
+TestSuite(appmodel, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/appmodel/tests/test_appmodel_context.c
+++ b/modules/appmodel/tests/test_appmodel_context.c
@@ -83,4 +83,4 @@ Test(appmodel_context, iter_applications_enumerates_apps_in_the_order_of_registr
   g_string_free(result, TRUE);
 }
 
-TestSuite(appmodel_context, .init = startup, .fini = teardown);
+TestSuite(appmodel_context, .init = startup, .fini = teardown, .timeout = 300);

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -124,7 +124,7 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(basicfuncs, .init = setup, .fini = teardown);
+TestSuite(basicfuncs, .init = setup, .fini = teardown, .timeout = 300);
 
 Test(basicfuncs, test_cond_funcs)
 {

--- a/modules/cef/tests/test-format-cef-extension.c
+++ b/modules/cef/tests/test-format-cef-extension.c
@@ -96,7 +96,7 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(format_cef, .init = setup, .fini = teardown);
+TestSuite(format_cef, .init = setup, .fini = teardown, .timeout = 300);
 
 Test(format_cef, test_null_in_value)
 {

--- a/modules/confgen/tests/test_confgen.c
+++ b/modules/confgen/tests/test_confgen.c
@@ -127,4 +127,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(confgen, .init = setup, .fini = teardown);
+TestSuite(confgen, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/correlation/tests/test_grouping_by.c
+++ b/modules/correlation/tests/test_grouping_by.c
@@ -202,4 +202,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(grouping_by, .init = setup, .fini = teardown);
+TestSuite(grouping_by, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/correlation/tests/test_parsers_e2e.c
+++ b/modules/correlation/tests/test_parsers_e2e.c
@@ -203,4 +203,4 @@ void teardown(void)
   app_shutdown();
 }
 
-TestSuite(parsers_e2e, .init = setup, .fini = teardown);
+TestSuite(parsers_e2e, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/correlation/tests/test_patterndb.c
+++ b/modules/correlation/tests/test_patterndb.c
@@ -805,4 +805,4 @@ void teardown(void)
   app_shutdown();
 }
 
-TestSuite(pattern_db, .init = setup, .fini = teardown);
+TestSuite(pattern_db, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/cryptofuncs/tests/test_cryptofuncs.c
+++ b/modules/cryptofuncs/tests/test_cryptofuncs.c
@@ -43,7 +43,7 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(cryptofuncs, .init = setup, .fini = teardown);
+TestSuite(cryptofuncs, .init = setup, .fini = teardown, .timeout = 300);
 
 Test(cryptofuncs, test_hash)
 {

--- a/modules/csvparser/tests/test_csvparser.c
+++ b/modules/csvparser/tests/test_csvparser.c
@@ -911,4 +911,4 @@ void teardown(void)
   app_shutdown();
 }
 
-TestSuite(parser, .init = setup, .fini = teardown);
+TestSuite(parser, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/csvparser/tests/test_csvparser_from_config.c
+++ b/modules/csvparser/tests/test_csvparser_from_config.c
@@ -117,4 +117,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(parser, .init = setup, .fini = teardown);
+TestSuite(parser, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/csvparser/tests/test_csvparser_perf.c
+++ b/modules/csvparser/tests/test_csvparser_perf.c
@@ -145,4 +145,4 @@ Test(csvparser_perf, test_escaped_parsers_performance)
 
 }
 
-TestSuite(csvparser_perf, .init = app_startup, .fini = app_shutdown);
+TestSuite(csvparser_perf, .init = app_startup, .fini = app_shutdown, .timeout = 300);

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -557,4 +557,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(diskq, .init = setup, .fini = teardown);
+TestSuite(diskq, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -112,4 +112,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(diskq_full, .init = setup, .fini = teardown);
+TestSuite(diskq_full, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/diskq/tests/test_diskq_truncate.c
+++ b/modules/diskq/tests/test_diskq_truncate.c
@@ -607,4 +607,4 @@ teardown(void)
   cfg_free(configuration);
 }
 
-TestSuite(diskq_truncate, .init = setup, .fini = teardown);
+TestSuite(diskq_truncate, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/diskq/tests/test_qdisk.c
+++ b/modules/diskq/tests/test_qdisk.c
@@ -367,4 +367,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(qdisk, .init = setup, .fini = teardown);
+TestSuite(qdisk, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/diskq/tests/test_reliable_backlog.c
+++ b/modules/diskq/tests/test_reliable_backlog.c
@@ -394,4 +394,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(diskq_reliable, .init = setup, .fini = teardown);
+TestSuite(diskq_reliable, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/geoip2/tests/test_geoip_parser.c
+++ b/modules/geoip2/tests/test_geoip_parser.c
@@ -134,4 +134,4 @@ Test(geoip2, test_basic)
   log_msg_unref(msg);
 }
 
-TestSuite(geoip2, .init = setup, .fini = teardown);
+TestSuite(geoip2, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/graphite/tests/test_graphite_output.c
+++ b/modules/graphite/tests/test_graphite_output.c
@@ -52,7 +52,7 @@ _log_msg_set_recvd_time(LogMessage *msg, time_t t)
   msg->timestamps[LM_TS_RECVD].ut_gmtoff = get_local_timezone_ofs(t);
 }
 
-TestSuite(graphite_output, .init = setup, .fini = teardown);
+TestSuite(graphite_output, .init = setup, .fini = teardown, .timeout = 300);
 
 Test(graphite_output, test_graphite_plaintext_proto_simple)
 {

--- a/modules/http/tests/test_http-loadbalancer.c
+++ b/modules/http/tests/test_http-loadbalancer.c
@@ -336,4 +336,4 @@ teardown(void)
 {
 }
 
-TestSuite(http_loadbalancer, .init = setup, .fini = teardown);
+TestSuite(http_loadbalancer, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/http/tests/test_http-signal_slot.c
+++ b/modules/http/tests/test_http-signal_slot.c
@@ -58,7 +58,7 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(test_http_signal_slot, .init = setup, .fini = teardown);
+TestSuite(test_http_signal_slot, .init = setup, .fini = teardown, .timeout = 300);
 
 static void
 _generate_message(HTTPDestinationDriver *dd, const gchar *msg_str)

--- a/modules/http/tests/test_http.c
+++ b/modules/http/tests/test_http.c
@@ -30,7 +30,7 @@
 #include "logthrdest/logthrdestdrv.h"
 
 
-TestSuite(http, .init = app_startup, .fini = app_shutdown);
+TestSuite(http, .init = app_startup, .fini = app_shutdown, .timeout = 300);
 
 struct http_action_test_params
 {

--- a/modules/json/tests/test_dot_notation.c
+++ b/modules/json/tests/test_dot_notation.c
@@ -87,7 +87,7 @@ void teardown(void)
   app_shutdown();
 }
 
-TestSuite(json, .init = setup, .fini = teardown);
+TestSuite(json, .init = setup, .fini = teardown, .timeout = 300);
 
 Test(json, test_dot_notation_eval_empty_subscript_returns_the_object)
 {

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -46,7 +46,7 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(format_json, .init = setup, .fini = teardown);
+TestSuite(format_json, .init = setup, .fini = teardown, .timeout = 300);
 
 
 Test(format_json, test_format_json)

--- a/modules/json/tests/test_json_parser.c
+++ b/modules/json/tests/test_json_parser.c
@@ -76,7 +76,7 @@ void teardown(void)
   app_shutdown();
 }
 
-TestSuite(json_parser,  .init = setup, .fini = teardown);
+TestSuite(json_parser,  .init = setup, .fini = teardown, .timeout = 300);
 
 Test(json_parser, test_json_parser_parses_well_formed_json_and_puts_results_in_message)
 {

--- a/modules/kafka/tests/test_kafka-props.c
+++ b/modules/kafka/tests/test_kafka-props.c
@@ -87,4 +87,4 @@ teardown(void)
   msg_deinit();
 }
 
-TestSuite(kafka_props, .init = setup, .fini = teardown);
+TestSuite(kafka_props, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/kafka/tests/test_kafka_config.c
+++ b/modules/kafka/tests/test_kafka_config.c
@@ -159,4 +159,4 @@ teardown(void)
   cfg_free(configuration);
 }
 
-TestSuite(kafka_config, .init = setup, .fini = teardown);
+TestSuite(kafka_config, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/kafka/tests/test_kafka_topic.c
+++ b/modules/kafka/tests/test_kafka_topic.c
@@ -78,7 +78,7 @@ _init_topic_names(LogDriver *driver, const gchar *topic, const gchar *fallback_t
   kafka_dd_set_fallback_topic(driver, fallback_topic);
 }
 
-TestSuite(kafka_topic, .init = setup, .fini = teardown);
+TestSuite(kafka_topic, .init = setup, .fini = teardown, .timeout = 300);
 
 ParameterizedTestParameters(kafka_topic, valid_topic_tests)
 {

--- a/modules/kvformat/tests/test_format_welf.c
+++ b/modules/kvformat/tests/test_format_welf.c
@@ -47,7 +47,7 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(format_welf, .init = setup, .fini = teardown);
+TestSuite(format_welf, .init = setup, .fini = teardown, .timeout = 300);
 
 Test(format_welf, test_format_welf)
 {

--- a/modules/kvformat/tests/test_kv_parser.c
+++ b/modules/kvformat/tests/test_kv_parser.c
@@ -161,4 +161,4 @@ Test(kv_parser, test_extract_stray_words)
 
 }
 
-TestSuite(kv_parser, .init = setup, .fini = teardown);
+TestSuite(kv_parser, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/kvformat/tests/test_linux_audit_scanner.c
+++ b/modules/kvformat/tests/test_linux_audit_scanner.c
@@ -122,4 +122,4 @@ Test(linux_audit_scanner, test_audit_style_hex_dump_is_not_decoded_odd, .descrip
   assert_no_more_tokens();
 }
 
-TestSuite(linux_audit_scanner, .init = setup, .fini = teardown);
+TestSuite(linux_audit_scanner, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
+++ b/modules/linux-kmsg-format/tests/test_linux_format_kmsg.c
@@ -186,4 +186,4 @@ Test(linux_kmsg_format, test_kmsg_device_parsing)
   log_msg_unref(parsed_message);
 }
 
-TestSuite(linux_kmsg_format, .init = setup, .fini = teardown);
+TestSuite(linux_kmsg_format, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/metrics-probe/tests/test_metrics_probe.c
+++ b/modules/metrics-probe/tests/test_metrics_probe.c
@@ -320,4 +320,4 @@ void teardown(void)
   app_shutdown();
 }
 
-TestSuite(metrics_probe, .init = setup, .fini = teardown);
+TestSuite(metrics_probe, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/python/tests/test_python_ack_tracker.c
+++ b/modules/python/tests/test_python_ack_tracker.c
@@ -71,7 +71,7 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(python_ack_tracker, .init = setup, .fini = teardown);
+TestSuite(python_ack_tracker, .init = setup, .fini = teardown, .timeout = 300);
 
 static PyObject *
 ack_callback(PyObject *self, PyObject *args)

--- a/modules/python/tests/test_python_bookmark.c
+++ b/modules/python/tests/test_python_bookmark.c
@@ -63,7 +63,7 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(python_bookmark, .init = setup, .fini = teardown);
+TestSuite(python_bookmark, .init = setup, .fini = teardown, .timeout = 300);
 
 static PyObject *
 test_save_bookmark(PyObject *self, PyObject *args)

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -112,7 +112,7 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(python_log_message, .init = setup, .fini = teardown);
+TestSuite(python_log_message, .init = setup, .fini = teardown, .timeout = 300);
 
 typedef struct _PyLogMessageSetValueTestParams
 {

--- a/modules/python/tests/test_python_persist.c
+++ b/modules/python/tests/test_python_persist.c
@@ -77,7 +77,7 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(python_persist, .init = setup, .fini = teardown);
+TestSuite(python_persist, .init = setup, .fini = teardown, .timeout = 300);
 
 const gchar *simple_persist = "\n\
 from _syslogng import Persist\n\

--- a/modules/python/tests/test_python_persist_name.c
+++ b/modules/python/tests/test_python_persist_name.c
@@ -94,7 +94,7 @@ _load_code(const gchar *code)
   PyGILState_Release(gstate);
 }
 
-TestSuite(python_persist_name, .init = setup, .fini = teardown);
+TestSuite(python_persist_name, .init = setup, .fini = teardown, .timeout = 300);
 
 const gchar *python_destination_code = "\n\
 from _syslogng import LogDestination\n\

--- a/modules/python/tests/test_python_template.c
+++ b/modules/python/tests/test_python_template.c
@@ -95,7 +95,7 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(python_log_logtemplate, .init = setup, .fini = teardown);
+TestSuite(python_log_logtemplate, .init = setup, .fini = teardown, .timeout = 300);
 
 static PyLogMessage *
 create_parsed_message(const gchar *raw_msg)

--- a/modules/python/tests/test_python_tf.c
+++ b/modules/python/tests/test_python_tf.c
@@ -76,7 +76,7 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(python_tf, .init = setup, .fini = teardown);
+TestSuite(python_tf, .init = setup, .fini = teardown, .timeout = 300);
 
 typedef struct _PyTfTestParams
 {

--- a/modules/regexp-parser/tests/test_regexp_parser.c
+++ b/modules/regexp-parser/tests/test_regexp_parser.c
@@ -44,7 +44,7 @@ teardown(void)
   cfg_free(configuration);
 }
 
-TestSuite(regexp_parser, .init = setup, .fini = teardown);
+TestSuite(regexp_parser, .init = setup, .fini = teardown, .timeout = 300);
 
 typedef struct _RegexpParserTestParam
 {

--- a/modules/secure-logging/tests/test_secure_logging.c
+++ b/modules/secure-logging/tests/test_secure_logging.c
@@ -433,7 +433,7 @@ void teardown(void)
 /*************************************************************************/
 /* Test suite                                                            */
 /*************************************************************************/
-TestSuite(secure_logging, .init = setup, .fini = teardown);
+TestSuite(secure_logging, .init = setup, .fini = teardown, .timeout = 300);
 
 void test_slog_template_format(void)
 {

--- a/modules/stardate/tests/test_stardate.c
+++ b/modules/stardate/tests/test_stardate.c
@@ -72,7 +72,7 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(stardate, .init = setup, .fini = teardown);
+TestSuite(stardate, .init = setup, .fini = teardown, .timeout = 300);
 
 Test(stardate, test_stardate)
 {

--- a/modules/syslogformat/tests/test_syslog_format.c
+++ b/modules/syslogformat/tests/test_syslog_format.c
@@ -54,7 +54,7 @@ teardown(void)
   cfg_free(cfg);
 }
 
-TestSuite(syslog_format, .init = setup, .fini = teardown);
+TestSuite(syslog_format, .init = setup, .fini = teardown, .timeout = 300);
 
 Test(syslog_format, parser_should_not_spin_on_non_zero_terminated_input, .timeout = 10)
 {

--- a/modules/systemd-journal/tests/test-journald-mock.c
+++ b/modules/systemd-journal/tests/test-journald-mock.c
@@ -214,4 +214,4 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(journald_mock, .init = setup, .fini = teardown);
+TestSuite(journald_mock, .init = setup, .fini = teardown, .timeout = 300);

--- a/modules/systemd-journal/tests/test_systemd_journal.c
+++ b/modules/systemd-journal/tests/test_systemd_journal.c
@@ -388,4 +388,4 @@ Test(systemd_journal, test_journal_reader)
   _deinit_cfg(persist_file);
 }
 
-TestSuite(systemd_journal, .init = app_startup, .fini = app_shutdown);
+TestSuite(systemd_journal, .init = app_startup, .fini = app_shutdown, .timeout = 300);

--- a/modules/tagsparser/tests/test_tagsparser.c
+++ b/modules/tagsparser/tests/test_tagsparser.c
@@ -42,7 +42,7 @@ teardown(void)
   cfg_free(configuration);
 }
 
-TestSuite(tagsparser, .init = setup, .fini = teardown);
+TestSuite(tagsparser, .init = setup, .fini = teardown, .timeout = 300);
 
 Test(tagsparser, input_list_is_transferred_to_a_list_of_tags)
 {

--- a/modules/timestamp/tests/test_date.c
+++ b/modules/timestamp/tests/test_date.c
@@ -95,7 +95,7 @@ teardown(void)
   app_shutdown();
 }
 
-TestSuite(date, .init = setup, .fini = teardown);
+TestSuite(date, .init = setup, .fini = teardown, .timeout = 300);
 
 ParameterizedTestParameters(date, test_date_parser)
 {

--- a/modules/timestamp/tests/test_format_date.c
+++ b/modules/timestamp/tests/test_format_date.c
@@ -54,7 +54,7 @@ _log_msg_set_recvd_time(LogMessage *msg, time_t t)
   msg->timestamps[LM_TS_STAMP].ut_gmtoff = get_local_timezone_ofs(t);
 }
 
-TestSuite(format_date, .init = setup, .fini = teardown);
+TestSuite(format_date, .init = setup, .fini = teardown, .timeout = 300);
 
 Test(format_date, test_format_date_without_argument_takes_the_timestamp_and_formats_it_using_strftime)
 {

--- a/modules/xml/tests/test_xml_parser.c
+++ b/modules/xml/tests/test_xml_parser.c
@@ -72,7 +72,7 @@ _construct_xml_parser(XMLParserTestOptions options)
   return (LogParser *)cloned;
 }
 
-TestSuite(xmlparser, .init = setup, .fini = teardown);
+TestSuite(xmlparser, .init = setup, .fini = teardown, .timeout = 300);
 
 typedef struct
 {


### PR DESCRIPTION
I faced another stuck unit test in our CI run, and it was a pain to determine which one was it, because there is no "test started" message.

I think it would be a good habit to set a timeout for all of our existing and new unit tests. 5 minutes should be plenty enough, maybe we can even make it 1 minute. There is no reason to make the CI run for 1 hour if a unit test gets stuck.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
