### PR TITLE
fix "matched" logic in case of correlating parsers

### DIFF
--- a/lib/parser/parser-expr.c
+++ b/lib/parser/parser-expr.c
@@ -78,8 +78,8 @@ log_parser_process_message(LogParser *self, LogMessage **pmsg, const LogPathOpti
   return success;
 }
 
-static void
-log_parser_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
+void
+log_parser_queue_method(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
   LogParser *self = (LogParser *) s;
   gboolean success;
@@ -160,5 +160,5 @@ log_parser_init_instance(LogParser *self, GlobalConfig *cfg)
   self->super.init = log_parser_init_method;
   self->super.deinit = log_parser_deinit_method;
   self->super.free_fn = log_parser_free_method;
-  self->super.queue = log_parser_queue;
+  self->super.queue = log_parser_queue_method;
 }

--- a/lib/parser/parser-expr.h
+++ b/lib/parser/parser-expr.h
@@ -53,6 +53,7 @@ log_parser_deinit_method(LogPipe *s)
   return TRUE;
 }
 
+void log_parser_queue_method(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options);
 gboolean log_parser_init_method(LogPipe *s);
 void log_parser_set_template(LogParser *self, LogTemplate *template);
 void log_parser_init_instance(LogParser *self, GlobalConfig *cfg);

--- a/news/bugfix-4370.md
+++ b/news/bugfix-4370.md
@@ -1,0 +1,30 @@
+Consider messages consumed into correlation states "matching": syslog-ng's
+correlation functionality (e.g.  grouping-by() or db-parser() with such
+rules) drop individual messages as they are consumed into a correlation
+contexts and you are using `inject-mode(aggregate-only)`.  This is usually
+happens because you are only interested in the combined message and not in
+those that make up the combination. However, if you are using correlation
+with conditional processing (e.g. if/elif/else or flags(final)), such
+messages were erroneously considered as unmatching, causing syslog-ng to
+take the alternative branch.
+
+Example:
+
+With a configuration similar to this, individual messages are consumed into
+a correlation state and dropped by `grouping-by()`:
+
+```
+log {
+    source(...);
+
+    if {
+        grouping-by(... inject-mode(aggregate-only));
+    } else {
+        # alternative branch
+    };
+};
+```
+
+The bug was that these individual messages also traverse the `else` branch,
+even though they were successfully processed with the inclusion into the
+correlation context. This is not correct. The bugfix changes this behaviour.

--- a/tests/light/Makefile.am
+++ b/tests/light/Makefile.am
@@ -13,12 +13,13 @@ include tests/light/src/Makefile.am
 
 PYTEST_SUBDIR=
 PYTEST_VERBOSE=false
+PYTEST_OPTS=
 
 light-self-check pytest-self-check: python-venv
 	@$(PYTHON_VENV) -m pytest $(top_srcdir)/tests/light/src --showlocals --verbosity=3
 
 light-check pytest-check: python-venv
-	@$(PYTHON_VENV) -m pytest -o log_cli=$(PYTEST_VERBOSE) $(top_srcdir)/tests/light/functional_tests/$(PYTEST_SUBDIR) --installdir=${prefix} --showlocals --verbosity=3 --show-capture=no
+	@$(PYTHON_VENV) -m pytest -o log_cli=$(PYTEST_VERBOSE) $(top_srcdir)/tests/light/functional_tests/$(PYTEST_SUBDIR) $(PYTEST_OPTS) --installdir=${prefix} --showlocals --verbosity=3 --show-capture=no
 
 light-linters pytest-linters: python-venv
 	@find $(top_srcdir)/tests/light/ -name "*.py" \


### PR DESCRIPTION
As a followup to #4366 and #4058, another edge case was identified where syslog-ng evaluation handles matched messages incorrectly.
    
If we are using a correlation while processing the message, the incoming messages are consumed into a context and then the individual messages get dropped, at least when using inject-mode(aggregate-only).
    
In these cases we should not consider dropping of these messages to be unmatching, as dropping happens as a part of correlation.
    
This patch adds a light based testcase to exercise this problem and includes a fix, so that messages consumed into corrlation in `inject-mode(aggregate-only)` mode will not cause those messages to traverse any alternative paths.
