### PR TITLE
qdisk: account for overwriting in get_empty_space()

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -14,6 +14,8 @@ Attila Szakacs <attila.szakacs@balabit.com> <attila.szakacs@quest.com>
 Attila Szakacs <attila.szakacs@balabit.com> <attila.szakacs@balabit.com>
 Attila Szakacs <attila.szakacs@balabit.com> <attila.szakacs@oneidentity.com>
 Attila Szakacs <attila.szakacs@balabit.com> <45236571+alltilla@users.noreply.github.com>
+Attila Szakacs <attila.szakacs@balabit.com> <szakacs.attila96@gmail.com>
+Attila Szakacs <attila.szakacs@balabit.com> <attila.szakacs@axoflow.com>
 Balint Kovacs <balint.kovacs@balasys.hu> <blint@balabit.hu>
 Balint Kovacs <balint.kovacs@balasys.hu> <blint@blint.hu>
 Fabien Wernli <wernli@in2p3.fr> <wernli@in2p3.fr>

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -402,6 +402,11 @@ _maybe_truncate_file_to_minimal(QDisk *self)
   _maybe_truncate_file(self, file_end_offset);
 }
 
+gint64
+qdisk_get_max_useful_space(QDisk *self)
+{
+  return qdisk_get_maximum_size(self) - QDISK_RESERVED_SPACE;
+}
 
 gint64
 qdisk_get_empty_space(QDisk *self)
@@ -515,6 +520,12 @@ qdisk_get_empty_space(QDisk *self)
       /* Not possible by the laws of logic :) */
       g_assert_not_reached();
     }
+}
+
+gint64
+qdisk_get_used_useful_space(QDisk *self)
+{
+  return qdisk_get_max_useful_space(self) - qdisk_get_empty_space(self);
 }
 
 static inline gboolean

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -57,7 +57,9 @@ typedef struct _QDisk QDisk;
 QDisk *qdisk_new(DiskQueueOptions *options, const gchar *file_id);
 
 gboolean qdisk_is_space_avail(QDisk *self, gint at_least);
+gint64 qdisk_get_max_useful_space(QDisk *self);
 gint64 qdisk_get_empty_space(QDisk *self);
+gint64 qdisk_get_used_useful_space(QDisk *self);
 gboolean qdisk_push_tail(QDisk *self, GString *record);
 gboolean qdisk_pop_head(QDisk *self, GString *record);
 gboolean qdisk_remove_head(QDisk *self);


### PR DESCRIPTION
No news file needed.

Related PR #4356.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>