### PR TITLE
logqueue: rename variables of stats counters and cache 

### DIFF
--- a/lib/logqueue-fifo.c
+++ b/lib/logqueue-fifo.c
@@ -190,7 +190,7 @@ log_queue_fifo_drop_messages_from_input_queue(LogQueueFifo *self, InputQueue *in
 
       iv_list_del(&node->list);
       input_queue->len--;
-      stats_counter_inc(self->super.dropped_messages);
+      stats_counter_inc(self->super.metrics.shared.dropped_messages);
       log_msg_free_queue_node(node);
 
       LogMessage *msg = node->msg;
@@ -394,7 +394,7 @@ log_queue_fifo_push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *pat
 
   if (_message_has_to_be_dropped(self, path_options))
     {
-      stats_counter_inc(self->super.dropped_messages);
+      stats_counter_inc(self->super.metrics.shared.dropped_messages);
       g_mutex_unlock(&self->super.lock);
 
       _drop_message(msg, path_options);

--- a/lib/logqueue-fifo.c
+++ b/lib/logqueue-fifo.c
@@ -190,7 +190,7 @@ log_queue_fifo_drop_messages_from_input_queue(LogQueueFifo *self, InputQueue *in
 
       iv_list_del(&node->list);
       input_queue->len--;
-      stats_counter_inc(self->super.metrics.shared.dropped_messages);
+      log_queue_dropped_messages_inc(&self->super);
       log_msg_free_queue_node(node);
 
       LogMessage *msg = node->msg;
@@ -394,7 +394,7 @@ log_queue_fifo_push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *pat
 
   if (_message_has_to_be_dropped(self, path_options))
     {
-      stats_counter_inc(self->super.metrics.shared.dropped_messages);
+      log_queue_dropped_messages_inc(&self->super);
       g_mutex_unlock(&self->super.lock);
 
       _drop_message(msg, path_options);

--- a/lib/logqueue.c
+++ b/lib/logqueue.c
@@ -31,51 +31,51 @@
 void
 log_queue_memory_usage_add(LogQueue *self, gsize value)
 {
-  stats_counter_add(self->memory_usage, value);
-  atomic_gssize_add(&self->stats_cache.memory_usage, value);
+  stats_counter_add(self->metrics.shared.memory_usage, value);
+  atomic_gssize_add(&self->metrics.owned.memory_usage, value);
 }
 
 void
 log_queue_memory_usage_sub(LogQueue *self, gsize value)
 {
-  stats_counter_sub(self->memory_usage, value);
-  atomic_gssize_sub(&self->stats_cache.memory_usage, value);
+  stats_counter_sub(self->metrics.shared.memory_usage, value);
+  atomic_gssize_sub(&self->metrics.owned.memory_usage, value);
 }
 
 void
 log_queue_queued_messages_add(LogQueue *self, gsize value)
 {
-  stats_counter_add(self->queued_messages, value);
-  atomic_gssize_add(&self->stats_cache.queued_messages, value);
+  stats_counter_add(self->metrics.shared.queued_messages, value);
+  atomic_gssize_add(&self->metrics.owned.queued_messages, value);
 }
 
 void
 log_queue_queued_messages_sub(LogQueue *self, gsize value)
 {
-  stats_counter_sub(self->queued_messages, value);
-  atomic_gssize_sub(&self->stats_cache.queued_messages, value);
+  stats_counter_sub(self->metrics.shared.queued_messages, value);
+  atomic_gssize_sub(&self->metrics.owned.queued_messages, value);
 }
 
 void
 log_queue_queued_messages_inc(LogQueue *self)
 {
-  stats_counter_inc(self->queued_messages);
-  atomic_gssize_inc(&self->stats_cache.queued_messages);
+  stats_counter_inc(self->metrics.shared.queued_messages);
+  atomic_gssize_inc(&self->metrics.owned.queued_messages);
 }
 
 void
 log_queue_queued_messages_dec(LogQueue *self)
 {
-  stats_counter_dec(self->queued_messages);
-  atomic_gssize_dec(&self->stats_cache.queued_messages);
+  stats_counter_dec(self->metrics.shared.queued_messages);
+  atomic_gssize_dec(&self->metrics.owned.queued_messages);
 }
 
 void
 log_queue_queued_messages_reset(LogQueue *self)
 {
   const gssize queue_length = log_queue_get_length(self);
-  stats_counter_set(self->queued_messages, queue_length);
-  atomic_gssize_set_and_get(&self->stats_cache.queued_messages, queue_length);
+  stats_counter_set(self->metrics.shared.queued_messages, queue_length);
+  atomic_gssize_set_and_get(&self->metrics.owned.queued_messages, queue_length);
 }
 
 /*
@@ -221,17 +221,18 @@ log_queue_check_items(LogQueue *self, gint *timeout, LogQueuePushNotifyFunc para
 static void
 _register_common_counters(LogQueue *self, gint stats_level, const StatsClusterKey *sc_key)
 {
-  stats_register_counter(stats_level, sc_key, SC_TYPE_QUEUED, &self->queued_messages);
-  stats_register_counter(stats_level, sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
-  atomic_gssize_set(&self->stats_cache.queued_messages, log_queue_get_length(self));
-  stats_counter_add(self->queued_messages, atomic_gssize_get_unsigned(&self->stats_cache.queued_messages));
+  stats_register_counter(stats_level, sc_key, SC_TYPE_QUEUED, &self->metrics.shared.queued_messages);
+  stats_register_counter(stats_level, sc_key, SC_TYPE_DROPPED, &self->metrics.shared.dropped_messages);
+  atomic_gssize_set(&self->metrics.owned.queued_messages, log_queue_get_length(self));
+  stats_counter_add(self->metrics.shared.queued_messages,
+                    atomic_gssize_get_unsigned(&self->metrics.owned.queued_messages));
 
 
   StatsClusterKey sc_mem_key;
   stats_cluster_single_key_legacy_set_with_name(&sc_mem_key, sc_key->legacy.component,
                                                 sc_key->legacy.id, sc_key->legacy.instance, "memory_usage");
-  stats_register_counter_and_index(STATS_LEVEL1, &sc_mem_key, SC_TYPE_SINGLE_VALUE, &self->memory_usage);
-  stats_counter_add(self->memory_usage, atomic_gssize_get_unsigned(&self->stats_cache.memory_usage));
+  stats_register_counter_and_index(STATS_LEVEL1, &sc_mem_key, SC_TYPE_SINGLE_VALUE, &self->metrics.shared.memory_usage);
+  stats_counter_add(self->metrics.shared.memory_usage, atomic_gssize_get_unsigned(&self->metrics.owned.memory_usage));
 }
 
 void
@@ -243,15 +244,15 @@ log_queue_register_stats_counters(LogQueue *self, gint stats_level, const StatsC
 static void
 _unregister_common_counters(LogQueue *self, const StatsClusterKey *sc_key)
 {
-  stats_counter_sub(self->queued_messages, atomic_gssize_get(&self->stats_cache.queued_messages));
-  stats_unregister_counter(sc_key, SC_TYPE_QUEUED, &self->queued_messages);
-  stats_unregister_counter(sc_key, SC_TYPE_DROPPED, &self->dropped_messages);
+  stats_counter_sub(self->metrics.shared.queued_messages, atomic_gssize_get(&self->metrics.owned.queued_messages));
+  stats_unregister_counter(sc_key, SC_TYPE_QUEUED, &self->metrics.shared.queued_messages);
+  stats_unregister_counter(sc_key, SC_TYPE_DROPPED, &self->metrics.shared.dropped_messages);
 
   StatsClusterKey sc_mem_key;
   stats_cluster_single_key_legacy_set_with_name(&sc_mem_key, sc_key->legacy.component,
                                                 sc_key->legacy.id, sc_key->legacy.instance, "memory_usage");
-  stats_counter_sub(self->memory_usage, atomic_gssize_get(&self->stats_cache.memory_usage));
-  stats_unregister_counter(&sc_mem_key, SC_TYPE_SINGLE_VALUE, &self->memory_usage);
+  stats_counter_sub(self->metrics.shared.memory_usage, atomic_gssize_get(&self->metrics.owned.memory_usage));
+  stats_unregister_counter(&sc_mem_key, SC_TYPE_SINGLE_VALUE, &self->metrics.shared.memory_usage);
 }
 
 void

--- a/lib/logqueue.c
+++ b/lib/logqueue.c
@@ -78,6 +78,12 @@ log_queue_queued_messages_reset(LogQueue *self)
   atomic_gssize_set_and_get(&self->metrics.owned.queued_messages, queue_length);
 }
 
+void
+log_queue_dropped_messages_inc(LogQueue *self)
+{
+  stats_counter_inc(self->metrics.shared.dropped_messages);
+}
+
 /*
  * When this is called, it is assumed that the output thread is currently
  * not running (since this is the function that wakes it up), thus we can

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -34,6 +34,22 @@ typedef struct _LogQueue LogQueue;
 
 typedef const char *QueueType;
 
+typedef struct _LogQueueMetrics
+{
+  struct
+  {
+    StatsCounterItem *queued_messages;
+    StatsCounterItem *dropped_messages;
+    StatsCounterItem *memory_usage;
+  } shared;
+
+  struct
+  {
+    atomic_gssize memory_usage;
+    atomic_gssize queued_messages;
+  } owned;
+} LogQueueMetrics;
+
 struct _LogQueue
 {
   QueueType type;
@@ -45,15 +61,8 @@ struct _LogQueue
   GTimeVal last_throttle_check;
 
   gchar *persist_name;
-  StatsCounterItem *queued_messages;
-  StatsCounterItem *dropped_messages;
-  StatsCounterItem *memory_usage;
 
-  struct
-  {
-    atomic_gssize memory_usage;
-    atomic_gssize queued_messages;
-  } stats_cache;
+  LogQueueMetrics metrics;
 
   GMutex lock;
   LogQueuePushNotifyFunc parallel_push_notify;

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -220,6 +220,8 @@ void log_queue_queued_messages_inc(LogQueue *self);
 void log_queue_queued_messages_dec(LogQueue *self);
 void log_queue_queued_messages_reset(LogQueue *self);
 
+void log_queue_dropped_messages_inc(LogQueue *self);
+
 void log_queue_push_notify(LogQueue *self);
 void log_queue_reset_parallel_push(LogQueue *self);
 void log_queue_set_parallel_push(LogQueue *self, LogQueuePushNotifyFunc parallel_push_notify, gpointer user_data,

--- a/lib/logthrdest/tests/test_logthrdestdrv.c
+++ b/lib/logthrdest/tests/test_logthrdestdrv.c
@@ -183,7 +183,7 @@ Test(logthrdestdrv, driver_can_be_instantiated_and_one_message_is_properly_proce
   cr_assert(stats_counter_get(dd->super.processed_messages) == 1);
   cr_assert(stats_counter_get(dd->super.written_messages) == 1);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
-  cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.instance.queue->metrics.shared.memory_usage) == 0);
   cr_assert(dd->super.shared_seq_num == 2,
             "seq_num expected to be 1 larger than the amount of messages generated, found %d", dd->super.shared_seq_num);
 }
@@ -210,7 +210,7 @@ Test(logthrdestdrv, non_local_messages_dont_increment_seq_num)
   cr_assert(stats_counter_get(dd->super.processed_messages) == 1);
   cr_assert(stats_counter_get(dd->super.written_messages) == 1);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
-  cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.instance.queue->metrics.shared.memory_usage) == 0);
   cr_assert(dd->super.shared_seq_num == 1,
             "seq_num expected to be unchanged while non-local messages get derilered, found %d, expected: %d",
             dd->super.shared_seq_num, 1);
@@ -367,7 +367,7 @@ Test(logthrdestdrv, batched_set_of_messages_are_successfully_delivered)
   cr_assert(stats_counter_get(dd->super.processed_messages) == 10);
   cr_assert(stats_counter_get(dd->super.written_messages) == 10);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
-  cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.instance.queue->metrics.shared.memory_usage) == 0);
   cr_assert(dd->super.shared_seq_num == 11,
             "seq_num expected to be 1 larger than the number of insert attempts, found %d", dd->super.shared_seq_num);
 }
@@ -409,7 +409,7 @@ Test(logthrdestdrv, batched_set_of_messages_are_dropped_as_a_whole)
   cr_assert(stats_counter_get(dd->super.processed_messages) == 10);
   cr_assert(stats_counter_get(dd->super.written_messages) == 0);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 10);
-  cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.instance.queue->metrics.shared.memory_usage) == 0);
   cr_assert(dd->super.shared_seq_num == 11, "%d", dd->super.shared_seq_num);
   assert_grabbed_log_contains("dropped while sending message");
 }
@@ -474,7 +474,7 @@ Test(logthrdestdrv,
   cr_assert(stats_counter_get(dd->super.processed_messages) == 10);
   cr_assert(stats_counter_get(dd->super.written_messages) == 0);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 10);
-  cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.instance.queue->metrics.shared.memory_usage) == 0);
   cr_assert(dd->super.shared_seq_num == dd->super.retries_on_error_max * 10 + 1,
             "seq_num needs to be one larger than the number of insert attempts, found %d", dd->super.shared_seq_num);
   assert_grabbed_log_contains("Error occurred while");
@@ -547,7 +547,7 @@ Test(logthrdestdrv,
   cr_assert(stats_counter_get(dd->super.processed_messages) == 10);
   cr_assert(stats_counter_get(dd->super.written_messages) == 10);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
-  cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.instance.queue->metrics.shared.memory_usage) == 0);
   cr_assert(dd->super.shared_seq_num == total_attempts * 10 + 1, "%d", dd->super.shared_seq_num);
   assert_grabbed_log_contains("Error occurred while");
 }
@@ -621,7 +621,7 @@ Test(logthrdestdrv,
   cr_assert(stats_counter_get(dd->super.processed_messages) == 10);
   cr_assert(stats_counter_get(dd->super.written_messages) == 10);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
-  cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.instance.queue->metrics.shared.memory_usage) == 0);
   cr_assert(dd->super.shared_seq_num == total_attempts * 10 + 1, "%d", dd->super.shared_seq_num);
   assert_grabbed_log_contains("Server disconnected");
 }
@@ -649,7 +649,7 @@ Test(logthrdestdrv, throttle_is_applied_to_delivery_and_causes_flush_to_be_calle
   cr_assert(stats_counter_get(dd->super.processed_messages) == 20);
   cr_assert(stats_counter_get(dd->super.written_messages) == 20);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
-  cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.instance.queue->metrics.shared.memory_usage) == 0);
   cr_assert(dd->super.shared_seq_num == 21, "%d", dd->super.shared_seq_num);
 }
 
@@ -799,9 +799,9 @@ Test(logthrdestdrv, test_explicit_ack_accept)
 
   cr_assert(stats_counter_get(dd->super.processed_messages) == 10);
   cr_assert(stats_counter_get(dd->super.written_messages) == 10);
-  cr_assert(stats_counter_get(dd->super.worker.instance.queue->queued_messages) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.instance.queue->metrics.shared.queued_messages) == 0);
   cr_assert(stats_counter_get(dd->super.dropped_messages) == 0);
-  cr_assert(stats_counter_get(dd->super.worker.instance.queue->memory_usage) == 0);
+  cr_assert(stats_counter_get(dd->super.worker.instance.queue->metrics.shared.memory_usage) == 0);
   cr_assert(dd->super.shared_seq_num == 11, "%d", dd->super.shared_seq_num);
 }
 

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -155,7 +155,7 @@ log_queue_disk_read_message(LogQueueDisk *self, LogPathOptions *path_options)
 void
 log_queue_disk_drop_message(LogQueueDisk *self, LogMessage *msg, const LogPathOptions *path_options)
 {
-  stats_counter_inc(self->super.dropped_messages);
+  stats_counter_inc(self->super.metrics.shared.dropped_messages);
 
   if (path_options->flow_control_requested)
     log_msg_drop(msg, path_options, AT_SUSPENDED);

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -155,7 +155,7 @@ log_queue_disk_read_message(LogQueueDisk *self, LogPathOptions *path_options)
 void
 log_queue_disk_drop_message(LogQueueDisk *self, LogMessage *msg, const LogPathOptions *path_options)
 {
-  stats_counter_inc(self->super.metrics.shared.dropped_messages);
+  log_queue_dropped_messages_inc(&self->super);
 
   if (path_options->flow_control_requested)
     log_msg_drop(msg, path_options, AT_SUSPENDED);

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -140,10 +140,10 @@ Test(diskq, testcase_ack_and_rewind_messages)
   StatsClusterKey sc_key;
   stats_cluster_logpipe_key_legacy_set(&sc_key, SCS_DESTINATION, "queued messages", NULL);
   stats_lock();
-  stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &q->queued_messages);
+  stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &q->metrics.shared.queued_messages);
   stats_unlock();
 
-  cr_assert_eq(stats_counter_get(q->queued_messages), 0, "queued messages: %d", __LINE__);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.queued_messages), 0, "queued messages: %d", __LINE__);
 
   filename = g_string_sized_new(32);
   g_string_printf(filename, "test-rewind_and_acks.qf");
@@ -153,22 +153,22 @@ Test(diskq, testcase_ack_and_rewind_messages)
   fed_messages = 0;
   acked_messages = 0;
   feed_some_messages(q, 1000);
-  cr_assert_eq(stats_counter_get(q->queued_messages), 1000, "queued messages: %d", __LINE__);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.queued_messages), 1000, "queued messages: %d", __LINE__);
 
   for (i = 0; i < 10; i++)
     {
       send_some_messages(q, 1);
-      cr_assert_eq(stats_counter_get(q->queued_messages), 999, "queued messages wrong number %d", __LINE__);
+      cr_assert_eq(stats_counter_get(q->metrics.shared.queued_messages), 999, "queued messages wrong number %d", __LINE__);
       log_queue_rewind_backlog(q, 1);
-      cr_assert_eq(stats_counter_get(q->queued_messages), 1000, "queued messages wrong number: %d", __LINE__);
+      cr_assert_eq(stats_counter_get(q->metrics.shared.queued_messages), 1000, "queued messages wrong number: %d", __LINE__);
     }
   send_some_messages(q, 1000);
-  cr_assert_eq(stats_counter_get(q->queued_messages), 0, "queued messages: %d", __LINE__);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.queued_messages), 0, "queued messages: %d", __LINE__);
   log_queue_ack_backlog(q, 500);
   log_queue_rewind_backlog(q, 500);
-  cr_assert_eq(stats_counter_get(q->queued_messages), 500, "queued messages: %d", __LINE__);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.queued_messages), 500, "queued messages: %d", __LINE__);
   send_some_messages(q, 500);
-  cr_assert_eq(stats_counter_get(q->queued_messages), 0, "queued messages: %d", __LINE__);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.queued_messages), 0, "queued messages: %d", __LINE__);
   log_queue_ack_backlog(q, 500);
 
   gboolean persistent;
@@ -424,32 +424,32 @@ init_statistics(LogQueue *q)
   StatsClusterKey sc_key1, sc_key2;
   stats_lock();
   stats_cluster_logpipe_key_legacy_set(&sc_key1, SCS_DESTINATION, "queued messages", NULL);
-  stats_register_counter(0, &sc_key1, SC_TYPE_QUEUED, &q->queued_messages);
+  stats_register_counter(0, &sc_key1, SC_TYPE_QUEUED, &q->metrics.shared.queued_messages);
   stats_cluster_single_key_legacy_set_with_name(&sc_key2, SCS_DESTINATION, "memory usage", NULL, "memory_usage");
-  stats_register_counter(1, &sc_key2, SC_TYPE_SINGLE_VALUE, &q->memory_usage);
+  stats_register_counter(1, &sc_key2, SC_TYPE_SINGLE_VALUE, &q->metrics.shared.memory_usage);
   stats_unlock();
-  stats_counter_set(q->queued_messages, 0);
-  stats_counter_set(q->memory_usage, 0);
+  stats_counter_set(q->metrics.shared.queued_messages, 0);
+  stats_counter_set(q->metrics.shared.memory_usage, 0);
 }
 
 static void
 assert_general_message_flow(LogQueue *q, gssize one_msg_size)
 {
   send_some_messages(q, 1);
-  cr_assert_eq(stats_counter_get(q->queued_messages), 1, "queued messages: line: %d", __LINE__);
-  cr_assert_eq(stats_counter_get(q->memory_usage), one_msg_size, "memory_usage: line: %d", __LINE__);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.queued_messages), 1, "queued messages: line: %d", __LINE__);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.memory_usage), one_msg_size, "memory_usage: line: %d", __LINE__);
 
   send_some_messages(q, 1);
-  cr_assert_eq(stats_counter_get(q->queued_messages), 0, "queued messages: line: %d", __LINE__);
-  cr_assert_eq(stats_counter_get(q->memory_usage), 0, "memory_usage: line: %d", __LINE__);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.queued_messages), 0, "queued messages: line: %d", __LINE__);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.memory_usage), 0, "memory_usage: line: %d", __LINE__);
 
   feed_some_messages(q, 10);
-  cr_assert_eq(stats_counter_get(q->queued_messages), 10, "queued messages: line: %d", __LINE__);
-  cr_assert_eq(stats_counter_get(q->memory_usage), one_msg_size*10, "memory_usage: line: %d", __LINE__);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.queued_messages), 10, "queued messages: line: %d", __LINE__);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.memory_usage), one_msg_size*10, "memory_usage: line: %d", __LINE__);
 
   send_some_messages(q, 5);
-  cr_assert_eq(stats_counter_get(q->queued_messages), 5, "queued messages: line: %d", __LINE__);
-  cr_assert_eq(stats_counter_get(q->memory_usage), one_msg_size*5, "memory_usage: line: %d", __LINE__);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.queued_messages), 5, "queued messages: line: %d", __LINE__);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.memory_usage), one_msg_size*5, "memory_usage: line: %d", __LINE__);
 }
 
 static LogQueue *
@@ -466,8 +466,8 @@ testcase_diskq_prepare(DiskQueueOptions *options, diskq_tester_parameters_t *par
     q = log_queue_disk_non_reliable_new(options, NULL);
 
   init_statistics(q);
-  cr_assert_eq(stats_counter_get(q->queued_messages), 0, "queued messages: line: %d", __LINE__);
-  cr_assert_eq(stats_counter_get(q->memory_usage), 0, "memory_usage: line: %d", __LINE__);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.queued_messages), 0, "queued messages: line: %d", __LINE__);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.memory_usage), 0, "memory_usage: line: %d", __LINE__);
 
   unlink(parameters->filename);
   log_queue_disk_start(q, parameters->filename);
@@ -516,22 +516,22 @@ ParameterizedTest(diskq_tester_parameters_t *parameters, diskq, test_diskq_stati
   q = testcase_diskq_prepare(&options, parameters);
 
   feed_some_messages(q, 1);
-  cr_assert_eq(stats_counter_get(q->queued_messages), 1, "queued messages: line: %d", __LINE__);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.queued_messages), 1, "queued messages: line: %d", __LINE__);
 
   if (parameters->overflow_expected)
     assert_overflow_queue_length(parameters, q, 1);
 
-  guint32 one_msg_size = stats_counter_get(q->memory_usage);
+  guint32 one_msg_size = stats_counter_get(q->metrics.shared.memory_usage);
   if (parameters->overflow_expected)
     /* Only when overflow. If there is no overflow, the first
        msg is put to the output queue so statistics is not increased: one_msg_size == 0 */
     cr_assert(is_valid_msg_size(one_msg_size), "one_msg_size %d: line: %d", one_msg_size, __LINE__);
   else
-    cr_assert_eq(stats_counter_get(q->memory_usage), 0, "queued messages: line: %d", __LINE__);
+    cr_assert_eq(stats_counter_get(q->metrics.shared.memory_usage), 0, "queued messages: line: %d", __LINE__);
 
   feed_some_messages(q, 1);
-  cr_assert_eq(stats_counter_get(q->queued_messages), 2, "queued messages: line: %d", __LINE__);
-  cr_assert_eq(stats_counter_get(q->memory_usage), one_msg_size*2, "memory_usage: line: %d", __LINE__);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.queued_messages), 2, "queued messages: line: %d", __LINE__);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.memory_usage), one_msg_size*2, "memory_usage: line: %d", __LINE__);
 
   if (parameters->overflow_expected)
     assert_overflow_queue_length(parameters, q, 2);

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -72,14 +72,15 @@ test_diskq_become_full(gboolean reliable, const gchar *filename)
   stats_lock();
   StatsClusterKey sc_key;
   stats_cluster_logpipe_key_legacy_set(&sc_key, SCS_DESTINATION, q->persist_name, NULL);
-  stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &q->dropped_messages);
-  stats_counter_set(q->dropped_messages, 0);
+  stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &q->metrics.shared.dropped_messages);
+  stats_counter_set(q->metrics.shared.dropped_messages, 0);
   stats_unlock();
   unlink(filename);
   log_queue_disk_start(q, filename);
   feed_some_messages(q, 1000);
 
-  cr_assert_eq(atomic_gssize_racy_get(&q->dropped_messages->value), 1000, "Bad dropped message number (reliable: %s)",
+  cr_assert_eq(atomic_gssize_racy_get(&q->metrics.shared.dropped_messages->value), 1000,
+               "Bad dropped message number (reliable: %s)",
                reliable ? "TRUE" : "FALSE");
 
   gboolean persistent;

--- a/modules/diskq/tests/test_logqueue_disk.c
+++ b/modules/diskq/tests/test_logqueue_disk.c
@@ -74,13 +74,13 @@ _assert_log_queue_disk_reliable_is_empty(LogQueue *q)
   cr_assert_eq(g_queue_get_length(queue->qbacklog), 0);
   cr_assert_eq(qdisk_get_length(queue->super.qdisk), 0);
 
-  cr_assert(q->memory_usage);
-  cr_assert(q->queued_messages);
+  cr_assert(q->metrics.shared.memory_usage);
+  cr_assert(q->metrics.shared.queued_messages);
 
-  cr_assert_eq(stats_counter_get(q->memory_usage), 0);
-  cr_assert_eq(stats_counter_get(q->queued_messages), 0);
-  cr_assert_eq(atomic_gssize_get_unsigned(&q->stats_cache.memory_usage), 0);
-  cr_assert_eq(atomic_gssize_get_unsigned(&q->stats_cache.queued_messages), 0);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.memory_usage), 0);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.queued_messages), 0);
+  cr_assert_eq(atomic_gssize_get_unsigned(&q->metrics.owned.memory_usage), 0);
+  cr_assert_eq(atomic_gssize_get_unsigned(&q->metrics.owned.queued_messages), 0);
 }
 
 static void
@@ -172,13 +172,13 @@ _assert_log_queue_disk_non_reliable_is_empty(LogQueue *q)
   cr_assert_eq(g_queue_get_length(queue->qbacklog), 0);
   cr_assert_eq(qdisk_get_length(queue->super.qdisk), 0);
 
-  cr_assert(q->memory_usage);
-  cr_assert(q->queued_messages);
+  cr_assert(q->metrics.shared.memory_usage);
+  cr_assert(q->metrics.shared.queued_messages);
 
-  cr_assert_eq(stats_counter_get(q->memory_usage), 0);
-  cr_assert_eq(stats_counter_get(q->queued_messages), 0);
-  cr_assert_eq(atomic_gssize_get_unsigned(&q->stats_cache.memory_usage), 0);
-  cr_assert_eq(atomic_gssize_get_unsigned(&q->stats_cache.queued_messages), 0);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.memory_usage), 0);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.queued_messages), 0);
+  cr_assert_eq(atomic_gssize_get_unsigned(&q->metrics.owned.memory_usage), 0);
+  cr_assert_eq(atomic_gssize_get_unsigned(&q->metrics.owned.queued_messages), 0);
 }
 
 Test(logqueue_disk, restart_corrupted_non_reliable)
@@ -262,13 +262,13 @@ _assert_log_queue_disk_non_reliable_has_messages_in_qout(LogQueue *q, guint num_
   cr_assert_eq(g_queue_get_length(queue->qbacklog), 0);
   cr_assert_eq(qdisk_get_length(queue->super.qdisk), 0);
 
-  cr_assert(q->memory_usage);
-  cr_assert(q->queued_messages);
+  cr_assert(q->metrics.shared.memory_usage);
+  cr_assert(q->metrics.shared.queued_messages);
 
-  cr_assert_eq(stats_counter_get(q->memory_usage), num_of_messages * log_msg_size);
-  cr_assert_eq(stats_counter_get(q->queued_messages), num_of_messages);
-  cr_assert_eq(atomic_gssize_get_unsigned(&q->stats_cache.memory_usage), num_of_messages * log_msg_size);
-  cr_assert_eq(atomic_gssize_get_unsigned(&q->stats_cache.queued_messages), num_of_messages);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.memory_usage), num_of_messages * log_msg_size);
+  cr_assert_eq(stats_counter_get(q->metrics.shared.queued_messages), num_of_messages);
+  cr_assert_eq(atomic_gssize_get_unsigned(&q->metrics.owned.memory_usage), num_of_messages * log_msg_size);
+  cr_assert_eq(atomic_gssize_get_unsigned(&q->metrics.owned.queued_messages), num_of_messages);
 }
 
 Test(logqueue_disk, restart_corrupted_non_reliable_with_qout)


### PR DESCRIPTION
To me `stats_cache` does not tell anything, and the fact that some counters are shared between `LogQueues` are not communicated clearly.

I think the new naming better shows the counters which are shared between `LogQueues`, and counters (`atomic_gssizes`) which are owned by a `LogQueue instance`.

No news file needed.

Related PR #4356.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>

