### PR TITLE
qdisk: preallocate qdisk file after creating header

### DIFF
--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -294,14 +294,7 @@ _maybe_truncate_file(QDisk *self, gint64 expected_size)
             evt_tag_int("fd", self->fd));
 }
 
-#if SYSLOG_NG_HAVE_POSIX_FALLOCATE
-static gint
-_posix_preallocate(QDisk *self, gint64 size)
-{
-  return posix_fallocate(self->fd, 0, (off_t) size);
-}
-
-#else
+#if !SYSLOG_NG_HAVE_POSIX_FALLOCATE
 static gint
 _compat_preallocate(QDisk *self, gint64 size)
 {
@@ -338,7 +331,7 @@ _preallocate_qdisk_file(QDisk *self, off_t size)
   gint result;
 
 #if SYSLOG_NG_HAVE_POSIX_FALLOCATE
-  result = _posix_preallocate(self, size);
+  result = posix_fallocate(self->fd, 0, size);
 #else
   result = _compat_preallocate(self, size);
 #endif

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1170,16 +1170,6 @@ _create_file(QDisk *self, const gchar *filename)
 static gboolean
 _create_header(QDisk *self)
 {
-  self->hdr = (QDiskFileHeader *) mmap(0, sizeof(QDiskFileHeader), (PROT_READ | PROT_WRITE), MAP_SHARED, self->fd, 0);
-
-  if (self->hdr == MAP_FAILED)
-    {
-      msg_error("Error returned by mmap", evt_tag_error("errno"));
-      return FALSE;
-    }
-
-  madvise(self->hdr, sizeof(QDiskFileHeader), MADV_RANDOM);
-
   QDiskFileHeader nulled_hdr;
   memset(&nulled_hdr, 0, sizeof(nulled_hdr));
   if (!pwrite_strict(self->fd, &nulled_hdr, sizeof(nulled_hdr), 0))
@@ -1191,6 +1181,16 @@ _create_header(QDisk *self)
     }
 
   self->cached_file_size = QDISK_RESERVED_SPACE;
+
+  self->hdr = (QDiskFileHeader *) mmap(0, sizeof(QDiskFileHeader), (PROT_READ | PROT_WRITE), MAP_SHARED, self->fd, 0);
+
+  if (self->hdr == MAP_FAILED)
+    {
+      msg_error("Error returned by mmap", evt_tag_error("errno"));
+      return FALSE;
+    }
+
+  madvise(self->hdr, sizeof(QDiskFileHeader), MADV_RANDOM);
 
   memcpy(self->hdr->magic, self->file_id, sizeof(self->hdr->magic));
 

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -329,7 +329,7 @@ _compat_preallocate(QDisk *self, gint64 size)
 #endif
 
 static gboolean
-_preallocate_qdisk_file(QDisk *self, gint64 size)
+_preallocate_qdisk_file(QDisk *self, off_t size)
 {
   msg_debug("Preallocating queue file",
             evt_tag_str("filename", self->filename),

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -356,7 +356,7 @@ _compat_preallocate(QDisk *self, gint64 size)
 #endif
 
 static gboolean
-_preallocate(QDisk *self, gint64 size)
+_preallocate_qdisk_file(QDisk *self, gint64 size)
 {
   msg_debug("Preallocating queue file",
             evt_tag_str("filename", self->filename),
@@ -1185,7 +1185,7 @@ _create_file(QDisk *self, const gchar *filename)
   self->fd = fd;
   self->filename = g_strdup(filename);
 
-  if (self->options->prealloc && !_preallocate(self, self->options->disk_buf_size))
+  if (self->options->prealloc && !_preallocate_qdisk_file(self, self->options->disk_buf_size))
     {
       _close_file(self);
       return FALSE;

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -304,10 +304,6 @@ _posix_preallocate(QDisk *self, gint64 size)
       return TRUE;
     }
 
-  msg_error("Failed to preallocate queue file",
-            evt_tag_str("filename", self->filename),
-            evt_tag_errno("error", result));
-
   return FALSE;
 }
 
@@ -325,22 +321,12 @@ _compat_preallocate(QDisk *self, gint64 size)
   for (gint i = 0; i < buf_write_iterations; i++)
     {
       if (!pwrite_strict(self->fd, buf, buf_size, pos))
-        {
-          msg_error("Failed to preallocate queue file",
-                    evt_tag_str("filename", self->filename),
-                    evt_tag_error("error"));
-          return FALSE;
-        }
+        return FALSE;
       pos += buf_size;
     }
 
   if (!pwrite_strict(self->fd, buf, additional_write_size, pos))
-    {
-      msg_error("Failed to preallocate queue file",
-                evt_tag_str("filename", self->filename),
-                evt_tag_error("error"));
-      return FALSE;
-    }
+    return FALSE;
 
   g_assert(pos + additional_write_size == size);
 
@@ -365,6 +351,9 @@ _preallocate_qdisk_file(QDisk *self, gint64 size)
 
   if (!result)
     {
+      msg_error("Failed to preallocate queue file",
+                evt_tag_str("filename", self->filename),
+                evt_tag_error("error"));
       return FALSE;
     }
 

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -316,15 +316,11 @@ _posix_preallocate(QDisk *self, gint64 size)
 static gboolean
 _compat_preallocate(QDisk *self, gint64 size)
 {
-  const size_t buf_size = QDISK_RESERVED_SPACE;
+  enum { buf_size = QDISK_RESERVED_SPACE };
   gint64 buf_write_iterations = size / buf_size;
   gint64 additional_write_size = size - buf_write_iterations * buf_size;
 
-  gchar buf[buf_size];
-  for (gint i = 0; i < buf_size; i++)
-    {
-      buf[i] = '\0';
-    }
+  gchar buf[buf_size] = { 0 };
   off_t pos = 0;
 
   for (gint i = 0; i < buf_write_iterations; i++)

--- a/modules/diskq/tests/test_diskq_truncate.c
+++ b/modules/diskq/tests/test_diskq_truncate.c
@@ -138,9 +138,9 @@ _assert_diskq_actual_file_size_with_stored(LogQueue *q)
   QDisk *qdisk = ((LogQueueDisk *)q)->qdisk;
 
   gint64 actual_file_size = _get_file_size(q);
-  cr_assert_eq(qdisk->file_size, actual_file_size,
+  cr_assert_eq(qdisk->cached_file_size, actual_file_size,
                "File size does not match with stored size; Actual file size: %ld, Expected file size: %ld\n", actual_file_size,
-               qdisk->file_size);
+               qdisk->cached_file_size);
 }
 
 static void
@@ -506,7 +506,7 @@ Test(diskq_truncate, test_diskq_no_truncate_wrap)
   _feed_one_large_message(q);
   QDisk *qdisk = ((LogQueueDisk *)q)->qdisk;
   cr_assert(qdisk_get_writer_head(qdisk) < qdisk_get_reader_head(qdisk), "write_head should have wrapped");
-  cr_assert(qdisk->file_size > TEST_DISKQ_SIZE, "file_size should be bigger than max size");
+  cr_assert(qdisk->cached_file_size > TEST_DISKQ_SIZE, "file_size should be bigger than max size");
   unprocessed_messages_in_buffer += 1;
 
   // 4. send and ack all messages


### PR DESCRIPTION
Related comment: https://github.com/syslog-ng/syslog-ng/pull/4335#discussion_r1135321974

No news file needed.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>