### PR TITLE
qdisk: fix filename race

### DIFF
--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1545,7 +1545,7 @@ _init_qdisk_file(QDisk *self)
 }
 
 static gboolean
-_create_qdisk_file(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
+_create_qdisk_file(QDisk *self, const gchar *filename)
 {
   if (!_create_file(self, filename))
     goto error;
@@ -1572,11 +1572,11 @@ qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, 
     return _load_qdisk_file(self, filename, qout, qbacklog, qoverflow);
 
   if (filename)
-    return _create_qdisk_file(self, filename, qout, qbacklog, qoverflow);
+    return _create_qdisk_file(self, filename);
 
   gchar next_filename[256];
   if (_next_filename(self, next_filename, sizeof(next_filename)))
-    return _create_qdisk_file(self, next_filename, qout, qbacklog, qoverflow);
+    return _create_qdisk_file(self, next_filename);
 
   return FALSE;
 }

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1229,7 +1229,7 @@ _open_file(QDisk *self, const gchar *filename)
   self->filename = g_strdup(filename);
 
   struct stat st;
-  if (fstat(self->fd, &st) != 0 || st.st_size == 0)
+  if (fstat(self->fd, &st) != 0)
     {
       msg_error("Error loading disk-queue file. Cannot stat",
                 evt_tag_str("filename", self->filename),
@@ -1243,7 +1243,7 @@ _open_file(QDisk *self, const gchar *filename)
 }
 
 static gboolean
-_create_file(QDisk *self, const gchar *filename)
+_create_file(const gchar *filename)
 {
   g_assert(filename);
 
@@ -1264,8 +1264,7 @@ _create_file(QDisk *self, const gchar *filename)
       return FALSE;
     }
 
-  self->fd = fd;
-
+  close(fd);
   return TRUE;
 }
 
@@ -1547,10 +1546,11 @@ _create_qdisk_file(QDisk *self, const gchar *filename)
       return FALSE;
     }
 
-  if (!_create_file(self, filename))
+  if (!_create_file(filename))
     goto error;
 
-  self->filename = g_strdup(filename);
+  if (!_open_file(self, filename))
+    goto error;
 
   if (!_init_qdisk_file(self))
     goto error;

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1242,6 +1242,8 @@ _ensure_header_byte_order(QDisk *self)
 static gboolean
 _open_file(QDisk *self, const gchar *filename)
 {
+  g_assert(filename);
+
   gint fd = open(filename, O_LARGEFILE | (self->options->read_only ? O_RDONLY : O_RDWR), 0600);
   if (fd < 0)
     {

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1245,7 +1245,6 @@ _open_file(QDisk *self, const gchar *filename)
 static gboolean
 _create_file(QDisk *self, const gchar *filename)
 {
-  g_assert(!self->options->read_only);
   g_assert(filename);
 
   if (self->options->disk_buf_size == -1)
@@ -1547,6 +1546,8 @@ _init_qdisk_file(QDisk *self)
 static gboolean
 _create_qdisk_file(QDisk *self, const gchar *filename)
 {
+  g_assert(!self->options->read_only);
+
   if (!_create_file(self, filename))
     goto error;
 

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1265,7 +1265,6 @@ _create_file(QDisk *self, const gchar *filename)
     }
 
   self->fd = fd;
-  self->filename = g_strdup(filename);
 
   return TRUE;
 }
@@ -1550,6 +1549,8 @@ _create_qdisk_file(QDisk *self, const gchar *filename)
 
   if (!_create_file(self, filename))
     goto error;
+
+  self->filename = g_strdup(filename);
 
   if (!_init_qdisk_file(self))
     goto error;

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1247,12 +1247,6 @@ _create_file(QDisk *self, const gchar *filename)
 {
   g_assert(filename);
 
-  if (self->options->disk_buf_size == -1)
-    {
-      msg_error("disk-buf-size for new disk-queue files must be set");
-      return FALSE;
-    }
-
   if (!_create_path(filename))
     {
       msg_error("Error creating dir for disk-queue file",
@@ -1547,6 +1541,12 @@ static gboolean
 _create_qdisk_file(QDisk *self, const gchar *filename)
 {
   g_assert(!self->options->read_only);
+
+  if (self->options->disk_buf_size == -1)
+    {
+      msg_error("disk-buf-size for new disk-queue files must be set");
+      return FALSE;
+    }
 
   if (!_create_file(self, filename))
     goto error;

--- a/news/bugfix-4381.md
+++ b/news/bugfix-4381.md
@@ -1,0 +1,1 @@
+`disk-buffer`: Fixed a rare race condition when calculating disk-buffer filename.


### PR DESCRIPTION
This PR fixes a rare race condition when calculating disk-buffer filename:

As two threads or two syslog-ng instances can run `_next_filename()` simultaneously, and they can get the same filename.

To mitigate this I have introduced an flock, which solves the issue between two syslog-ng instances, but does not solve it for threads in the same syslog-ng instance (man 2 flock):

> If  a  process  uses  open(2)  (or similar) to obtain more than one file descriptor for the same
> file, these file descriptors are treated independently by flock().  An attempt to lock the  file
> using one of these file descriptors may be denied by a lock that the calling process has already
> placed via another file descriptor.

To solve this, I have introduced a static lock, too.

Depends on #4380.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>
