### PR TITLE
Revert "dbld: install criterion from source on Debian testing"

### DIFF
--- a/dbld/build.manifest
+++ b/dbld/build.manifest
@@ -30,7 +30,7 @@
 # libcriterion-dev is available starting with bullseye
 debian-buster		python3,nocriterion,nojava,nokafka,nomqtt
 debian-bullseye		python3,nojava
-debian-testing		python3,nojava,nocriterion
+debian-testing		python3,nojava
 debian-sid		python3,nojava
 
 # on ubuntu, we start using Python3 at focal onwards.

--- a/dbld/images/debian-testing.dockerfile
+++ b/dbld/images/debian-testing.dockerfile
@@ -19,7 +19,6 @@ COPY . /dbld/
 RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps
-RUN /dbld/builddeps install_criterion
 
 VOLUME /source
 VOLUME /build


### PR DESCRIPTION
This reverts commit e423d82b37320ec97128d0adfe7e01b3d2d51602.

Criterion is available again in Debian testing.