### PR TITLE
qdisk: set filename sooner

### DIFF
--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -64,22 +64,14 @@ _acquire_queue(LogDestDriver *dd, const gchar *persist_name)
 {
   DiskQDestPlugin *self = log_driver_get_plugin(&dd->super, DiskQDestPlugin, DISKQ_PLUGIN_NAME);
   GlobalConfig *cfg = log_pipe_get_config(&dd->super.super);
-  LogQueue *queue;
-  gchar *qfile_name;
   gboolean success;
 
   if (persist_name)
-    queue = cfg_persist_config_fetch(cfg, persist_name);
+    log_queue_unref(cfg_persist_config_fetch(cfg, persist_name));
 
-  if (queue)
-    {
-      log_queue_unref(queue);
-      queue = NULL;
-    }
+  LogQueue *queue = _create_disk_queue(self, persist_name);
 
-  queue = _create_disk_queue(self, persist_name);
-
-  qfile_name = persist_state_lookup_string(cfg->state, persist_name, NULL, NULL);
+  gchar *qfile_name = persist_state_lookup_string(cfg->state, persist_name, NULL, NULL);
   if (qfile_name && !log_queue_disk_is_file_in_directory(qfile_name, self->options.dir))
     {
       msg_warning("The disk buffer directory has changed in the configuration, but the disk queue file cannot be moved",

--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -64,7 +64,6 @@ _acquire_queue(LogDestDriver *dd, const gchar *persist_name)
 {
   DiskQDestPlugin *self = log_driver_get_plugin(&dd->super, DiskQDestPlugin, DISKQ_PLUGIN_NAME);
   GlobalConfig *cfg = log_pipe_get_config(&dd->super.super);
-  gboolean success;
 
   if (persist_name)
     log_queue_unref(cfg_persist_config_fetch(cfg, persist_name));
@@ -79,8 +78,7 @@ _acquire_queue(LogDestDriver *dd, const gchar *persist_name)
                   evt_tag_str("dir", self->options.dir));
     }
 
-  success = log_queue_disk_start(queue, qfile_name);
-  if (!success)
+  if (!log_queue_disk_start(queue, qfile_name))
     {
       if (qfile_name && log_queue_disk_start(queue, NULL))
         {

--- a/modules/diskq/dqtool.c
+++ b/modules/diskq/dqtool.c
@@ -124,16 +124,16 @@ open_queue(char *filename, LogQueue **lq, DiskQueueOptions *options)
   if (options->reliable)
     {
       options->mem_buf_size = 1024 * 1024;
-      *lq = log_queue_disk_reliable_new(options, NULL);
+      *lq = log_queue_disk_reliable_new(options, filename, NULL);
     }
   else
     {
       options->mem_buf_size = 128;
       options->qout_size = 1000;
-      *lq = log_queue_disk_non_reliable_new(options, NULL);
+      *lq = log_queue_disk_non_reliable_new(options, filename, NULL);
     }
 
-  if (!log_queue_disk_start(*lq, filename))
+  if (!log_queue_disk_start(*lq))
     {
       fprintf(stderr, "Error restoring disk buffer file.\n");
       return FALSE;

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -44,7 +44,7 @@ _update_memory_usage_during_load(LogQueueDiskNonReliable *s, GQueue *memory_queu
 }
 
 static gboolean
-_start(LogQueueDisk *s, const gchar *filename)
+_start(LogQueueDisk *s)
 {
   LogQueueDiskNonReliable *self = (LogQueueDiskNonReliable *) s;
 
@@ -52,7 +52,7 @@ _start(LogQueueDisk *s, const gchar *filename)
   guint qbacklog_length_before_start = g_queue_get_length(self->qbacklog);
   guint qoverflow_length_before_start = g_queue_get_length(self->qoverflow);
 
-  gboolean retval = qdisk_start(s->qdisk, filename, self->qout, self->qbacklog, self->qoverflow);
+  gboolean retval = qdisk_start(s->qdisk, self->qout, self->qbacklog, self->qoverflow);
 
   _update_memory_usage_during_load(self, self->qout, qout_length_before_start);
   _update_memory_usage_during_load(self, self->qbacklog, qbacklog_length_before_start);
@@ -563,11 +563,11 @@ _set_virtual_functions(LogQueueDiskNonReliable *self)
 }
 
 LogQueue *
-log_queue_disk_non_reliable_new(DiskQueueOptions *options, const gchar *persist_name)
+log_queue_disk_non_reliable_new(DiskQueueOptions *options, const gchar *filename, const gchar *persist_name)
 {
   g_assert(options->reliable == FALSE);
   LogQueueDiskNonReliable *self = g_new0(LogQueueDiskNonReliable, 1);
-  log_queue_disk_init_instance(&self->super, options, "SLQF", persist_name);
+  log_queue_disk_init_instance(&self->super, options, "SLQF", filename, persist_name);
   self->qbacklog = g_queue_new();
   self->qout = g_queue_new();
   self->qoverflow = g_queue_new();

--- a/modules/diskq/logqueue-disk-non-reliable.h
+++ b/modules/diskq/logqueue-disk-non-reliable.h
@@ -36,6 +36,6 @@ typedef struct _LogQueueDiskNonReliable
   gint qout_size;
 } LogQueueDiskNonReliable;
 
-LogQueue *log_queue_disk_non_reliable_new(DiskQueueOptions *options, const gchar *persist_name);
+LogQueue *log_queue_disk_non_reliable_new(DiskQueueOptions *options, const gchar *filename, const gchar *persist_name);
 
 #endif /* LOG_QUEUE_DISK_NON_RELIABLE_H_ */

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -63,9 +63,9 @@ _peek_memory_queue_head_position(GQueue *queue)
 }
 
 static gboolean
-_start(LogQueueDisk *s, const gchar *filename)
+_start(LogQueueDisk *s)
 {
-  return qdisk_start(s->qdisk, filename, NULL, NULL, NULL);
+  return qdisk_start(s->qdisk, NULL, NULL, NULL);
 }
 
 static gboolean
@@ -469,11 +469,11 @@ _set_virtual_functions(LogQueueDiskReliable *self)
 }
 
 LogQueue *
-log_queue_disk_reliable_new(DiskQueueOptions *options, const gchar *persist_name)
+log_queue_disk_reliable_new(DiskQueueOptions *options, const gchar *filename, const gchar *persist_name)
 {
   g_assert(options->reliable == TRUE);
   LogQueueDiskReliable *self = g_new0(LogQueueDiskReliable, 1);
-  log_queue_disk_init_instance(&self->super, options, "SLRQ", persist_name);
+  log_queue_disk_init_instance(&self->super, options, "SLRQ", filename, persist_name);
   if (options->mem_buf_size < 0)
     {
       options->mem_buf_size = PESSIMISTIC_MEM_BUF_SIZE;

--- a/modules/diskq/logqueue-disk-reliable.h
+++ b/modules/diskq/logqueue-disk-reliable.h
@@ -35,6 +35,6 @@ typedef struct _LogQueueDiskReliable
   gint qout_size;
 } LogQueueDiskReliable;
 
-LogQueue *log_queue_disk_reliable_new(DiskQueueOptions *options, const gchar *persist_name);
+LogQueue *log_queue_disk_reliable_new(DiskQueueOptions *options, const gchar *filename, const gchar *persist_name);
 
 #endif /* LOGQUEUE_DISK_RELIABLE_H_ */

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -40,7 +40,7 @@ struct _LogQueueDisk
    * Similarly, QDisk should have a separate options class, which should only contain disk_buf_size, mem_buf_size, etc...
    */
   gboolean compaction;
-  gboolean (*start)(LogQueueDisk *s, const gchar *filename);
+  gboolean (*start)(LogQueueDisk *s);
   gboolean (*stop)(LogQueueDisk *s, gboolean *persistent);
   gboolean (*stop_corrupted)(LogQueueDisk *s);
 };
@@ -49,9 +49,9 @@ extern QueueType log_queue_disk_type;
 
 const gchar *log_queue_disk_get_filename(LogQueue *self);
 gboolean log_queue_disk_stop(LogQueue *self, gboolean *persistent);
-gboolean log_queue_disk_start(LogQueue *self, const gchar *filename);
+gboolean log_queue_disk_start(LogQueue *self);
 void log_queue_disk_init_instance(LogQueueDisk *self, DiskQueueOptions *options, const gchar *qdisk_file_id,
-                                  const gchar *persist_name);
+                                  const gchar *filename, const gchar *persist_name);
 void log_queue_disk_restart_corrupted(LogQueueDisk *self);
 void log_queue_disk_free_method(LogQueueDisk *self);
 

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -240,7 +240,7 @@ qdisk_get_next_filename(const gchar *dir, gboolean reliable)
 {
   gint dirlock_fd = -1;
   if (!_grab_dirlock(dir, &dirlock_fd))
-    return FALSE;
+    return NULL;
 
   gchar *filename = NULL;
   for (gint i = 0; i < 10000; i++)

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1650,29 +1650,18 @@ gboolean
 qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
 {
   g_assert(!qdisk_started(self));
+  g_assert(filename);
 
   struct stat st;
-  gboolean file_exists = filename && stat(filename, &st) != -1;
+  gboolean file_exists = stat(filename, &st) != -1;
 
-  if (file_exists)
-    {
-      if (st.st_size != 0)
-        return _load_qdisk_file(self, filename, qout, qbacklog, qoverflow);
-      return _init_qdisk_file_from_empty_file(self, filename);
-    }
-
-  if (filename)
+  if (!file_exists)
     return _create_qdisk_file(self, filename);
 
-  gchar *next_filename = qdisk_get_next_filename(self->options->dir, self->options->reliable);
-  if (!next_filename || !_init_qdisk_file_from_empty_file(self, next_filename))
-    {
-      g_free(next_filename);
-      return FALSE;
-    }
+  if (st.st_size != 0)
+    return _load_qdisk_file(self, filename, qout, qbacklog, qoverflow);
 
-  g_free(next_filename);
-  return TRUE;
+  return _init_qdisk_file_from_empty_file(self, filename);
 }
 
 static void

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1664,16 +1664,6 @@ qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, 
   return _init_qdisk_file_from_empty_file(self, filename);
 }
 
-static void
-qdisk_init_instance(QDisk *self, DiskQueueOptions *options, const gchar *file_id)
-{
-  self->fd = -1;
-  self->cached_file_size = 0;
-  self->options = options;
-
-  self->file_id = file_id;
-}
-
 gboolean
 qdisk_stop(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
 {
@@ -1777,6 +1767,12 @@ QDisk *
 qdisk_new(DiskQueueOptions *options, const gchar *file_id)
 {
   QDisk *self = g_new0(QDisk, 1);
-  qdisk_init_instance(self, options, file_id);
+
+  self->fd = -1;
+  self->cached_file_size = 0;
+  self->options = options;
+
+  self->file_id = file_id;
+
   return self;
 }

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1274,9 +1274,6 @@ _close_file(QDisk *self)
       self->fd = -1;
     }
 
-  g_free(self->filename);
-  self->filename = NULL;
-
   self->cached_file_size = 0;
 }
 
@@ -1306,21 +1303,20 @@ _ensure_header_byte_order(QDisk *self)
 }
 
 static gboolean
-_open_file(QDisk *self, const gchar *filename)
+_open_file(QDisk *self)
 {
-  g_assert(filename);
+  g_assert(self->filename);
 
-  gint fd = open(filename, O_LARGEFILE | (self->options->read_only ? O_RDONLY : O_RDWR), 0600);
+  gint fd = open(self->filename, O_LARGEFILE | (self->options->read_only ? O_RDONLY : O_RDWR), 0600);
   if (fd < 0)
     {
       msg_error("Error opening disk-queue file",
-                evt_tag_str("filename", filename),
+                evt_tag_str("filename", self->filename),
                 evt_tag_error("error"));
       return FALSE;
     }
 
   self->fd = fd;
-  self->filename = g_strdup(filename);
 
   struct stat st;
   if (fstat(self->fd, &st) != 0)
@@ -1573,9 +1569,9 @@ _ensure_disk_buf_size(QDisk *self)
 }
 
 static gboolean
-_load_qdisk_file(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
+_load_qdisk_file(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
 {
-  if (!_open_file(self, filename))
+  if (!_open_file(self))
     goto error;
 
   if (!_load_state(self, qout, qbacklog, qoverflow))
@@ -1604,7 +1600,7 @@ _init_qdisk_file(QDisk *self)
 }
 
 static gboolean
-_create_qdisk_file(QDisk *self, const gchar *filename)
+_create_qdisk_file(QDisk *self)
 {
   g_assert(!self->options->read_only);
 
@@ -1614,10 +1610,10 @@ _create_qdisk_file(QDisk *self, const gchar *filename)
       return FALSE;
     }
 
-  if (!_create_file(filename))
+  if (!_create_file(self->filename))
     goto error;
 
-  if (!_open_file(self, filename))
+  if (!_open_file(self))
     goto error;
 
   if (!_init_qdisk_file(self))
@@ -1631,9 +1627,9 @@ error:
 }
 
 static gboolean
-_init_qdisk_file_from_empty_file(QDisk *self, const gchar *filename)
+_init_qdisk_file_from_empty_file(QDisk *self)
 {
-  if (!_open_file(self, filename))
+  if (!_open_file(self))
     goto error;
 
   if (!_init_qdisk_file(self))
@@ -1647,21 +1643,21 @@ error:
 }
 
 gboolean
-qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
+qdisk_start(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow)
 {
   g_assert(!qdisk_started(self));
-  g_assert(filename);
+  g_assert(self->filename);
 
   struct stat st;
-  gboolean file_exists = stat(filename, &st) != -1;
+  gboolean file_exists = stat(self->filename, &st) != -1;
 
   if (!file_exists)
-    return _create_qdisk_file(self, filename);
+    return _create_qdisk_file(self);
 
   if (st.st_size != 0)
-    return _load_qdisk_file(self, filename, qout, qbacklog, qoverflow);
+    return _load_qdisk_file(self, qout, qbacklog, qoverflow);
 
-  return _init_qdisk_file_from_empty_file(self, filename);
+  return _init_qdisk_file_from_empty_file(self);
 }
 
 gboolean
@@ -1760,11 +1756,12 @@ void
 qdisk_free(QDisk *self)
 {
   self->options = NULL;
+  g_free(self->filename);
   g_free(self);
 }
 
 QDisk *
-qdisk_new(DiskQueueOptions *options, const gchar *file_id)
+qdisk_new(DiskQueueOptions *options, const gchar *file_id, const gchar *filename)
 {
   QDisk *self = g_new0(QDisk, 1);
 
@@ -1773,6 +1770,7 @@ qdisk_new(DiskQueueOptions *options, const gchar *file_id)
   self->options = options;
 
   self->file_id = file_id;
+  self->filename = g_strdup(filename);
 
   return self;
 }

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -86,7 +86,7 @@ gboolean qdisk_is_read_only(QDisk *self);
 const gchar *qdisk_get_filename(QDisk *self);
 gint64 qdisk_get_file_size(QDisk *self);
 
-gboolean qdisk_get_next_filename(const gchar *dir, gchar *filename, gsize filename_len, gboolean reliable);
+gchar *qdisk_get_next_filename(const gchar *dir, gboolean reliable);
 
 gboolean qdisk_serialize(GString *serialized, QDiskSerializeFunc serialize_func, gpointer user_data, GError **error);
 gboolean qdisk_deserialize(GString *serialized, QDiskDeSerializeFunc deserialize_func, gpointer user_data,

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -54,7 +54,7 @@ QDiskQueuePosition;
 
 typedef struct _QDisk QDisk;
 
-QDisk *qdisk_new(DiskQueueOptions *options, const gchar *file_id);
+QDisk *qdisk_new(DiskQueueOptions *options, const gchar *file_id, const gchar *filename);
 
 gboolean qdisk_is_space_avail(QDisk *self, gint at_least);
 gint64 qdisk_get_max_useful_space(QDisk *self);
@@ -68,7 +68,7 @@ gboolean qdisk_rewind_backlog(QDisk *self, guint rewind_count);
 void qdisk_empty_backlog(QDisk *self);
 gint64 qdisk_get_next_tail_position(QDisk *self);
 gint64 qdisk_get_next_head_position(QDisk *self);
-gboolean qdisk_start(QDisk *self, const gchar *filename, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow);
+gboolean qdisk_start(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow);
 gboolean qdisk_stop(QDisk *self, GQueue *qout, GQueue *qbacklog, GQueue *qoverflow);
 void qdisk_reset_file_if_empty(QDisk *self);
 gboolean qdisk_started(QDisk *self);

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -86,6 +86,8 @@ gboolean qdisk_is_read_only(QDisk *self);
 const gchar *qdisk_get_filename(QDisk *self);
 gint64 qdisk_get_file_size(QDisk *self);
 
+gboolean qdisk_get_next_filename(const gchar *dir, gchar *filename, gsize filename_len, gboolean reliable);
+
 gboolean qdisk_serialize(GString *serialized, QDiskSerializeFunc serialize_func, gpointer user_data, GError **error);
 gboolean qdisk_deserialize(GString *serialized, QDiskDeSerializeFunc deserialize_func, gpointer user_data,
                            GError **error);

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -546,6 +546,35 @@ ParameterizedTest(diskq_tester_parameters_t *parameters, diskq, test_diskq_stati
   disk_queue_options_destroy(&options);
 }
 
+gchar *
+qdisk_get_next_filename(const gchar *dir, gboolean reliable)
+{
+  return NULL;
+}
+
+Test(diskq, test_no_next_filename_in_acquire)
+{
+  const gchar *queue_persist_name = "test_no_next_filename_in_acquire";
+  const gchar *persist_filename = "test_no_next_filename_in_acquire.persist";
+  configuration->state = persist_state_new(persist_filename);
+  persist_state_start(configuration->state);
+
+  LogDestDriver *driver = g_new0(LogDestDriver, 1);
+  log_dest_driver_init_instance(driver, configuration);
+
+  DiskQDestPlugin *plugin = diskq_dest_plugin_new();
+  cr_assert(log_driver_add_plugin(&driver->super, (LogDriverPlugin *) plugin));
+  cr_assert(log_pipe_init(&driver->super.super));
+
+  cr_assert_eq(log_dest_driver_acquire_queue(driver, queue_persist_name), NULL);
+
+  cr_assert(log_pipe_deinit(&driver->super.super));
+  cr_assert(log_pipe_unref(&driver->super.super));
+
+  persist_state_cancel(configuration->state);
+  unlink(persist_filename);
+}
+
 static void
 setup(void)
 {

--- a/modules/diskq/tests/test_diskq.c
+++ b/modules/diskq/tests/test_diskq.c
@@ -62,13 +62,13 @@ Test(diskq, testcase_zero_diskbuf_and_normal_acks)
 
   _construct_options(&options, 10000000, 100000, TRUE);
 
-  q = log_queue_disk_reliable_new(&options, NULL);
-  log_queue_set_use_backlog(q, TRUE);
-
   filename = g_string_sized_new(32);
   g_string_printf(filename, "test-normal_acks.qf");
   unlink(filename->str);
-  log_queue_disk_start(q, filename->str);
+  q = log_queue_disk_reliable_new(&options, filename->str, NULL);
+  log_queue_set_use_backlog(q, TRUE);
+
+  log_queue_disk_start(q);
   fed_messages = 0;
   acked_messages = 0;
   for (i = 0; i < 10; i++)
@@ -97,13 +97,13 @@ Test(diskq, testcase_zero_diskbuf_alternating_send_acks)
 
   _construct_options(&options, 10000000, 100000, TRUE);
 
-  q = log_queue_disk_reliable_new(&options, NULL);
-  log_queue_set_use_backlog(q, TRUE);
-
   filename = g_string_sized_new(32);
   g_string_printf(filename, "test-send_acks.qf");
   unlink(filename->str);
-  log_queue_disk_start(q, filename->str);
+  q = log_queue_disk_reliable_new(&options, filename->str, NULL);
+  log_queue_set_use_backlog(q, TRUE);
+  log_queue_disk_start(q);
+
   fed_messages = 0;
   acked_messages = 0;
   for (i = 0; i < 10; i++)
@@ -134,7 +134,10 @@ Test(diskq, testcase_ack_and_rewind_messages)
 
   _construct_options(&options, 10000000, 100000, TRUE);
 
-  q = log_queue_disk_reliable_new(&options, NULL);
+  filename = g_string_sized_new(32);
+  g_string_printf(filename, "test-rewind_and_acks.qf");
+  unlink(filename->str);
+  q = log_queue_disk_reliable_new(&options, filename->str, NULL);
   log_queue_set_use_backlog(q, TRUE);
 
   StatsClusterKey sc_key;
@@ -145,10 +148,7 @@ Test(diskq, testcase_ack_and_rewind_messages)
 
   cr_assert_eq(stats_counter_get(q->metrics.shared.queued_messages), 0, "queued messages: %d", __LINE__);
 
-  filename = g_string_sized_new(32);
-  g_string_printf(filename, "test-rewind_and_acks.qf");
-  unlink(filename->str);
-  log_queue_disk_start(q, filename->str);
+  log_queue_disk_start(q);
 
   fed_messages = 0;
   acked_messages = 0;
@@ -287,11 +287,11 @@ Test(diskq, testcase_with_threads)
 
       _construct_options(&options, 10000000, 100000, TRUE);
 
-      q = log_queue_disk_reliable_new(&options, NULL);
       filename = g_string_sized_new(32);
       g_string_printf(filename, "test-%04d.qf", i);
       unlink(filename->str);
-      log_queue_disk_start(q, filename->str);
+      q = log_queue_disk_reliable_new(&options, filename->str, NULL);
+      log_queue_disk_start(q);
 
       for (j = 0; j < FEEDERS; j++)
         {
@@ -324,12 +324,12 @@ typedef struct restart_test_parameters
 } restart_test_parameters;
 
 static LogQueue *
-queue_new(gboolean reliable, DiskQueueOptions *options, const gchar *persist_name)
+queue_new(gboolean reliable, DiskQueueOptions *options, const gchar *filename, const gchar *persist_name)
 {
   if (reliable)
-    return log_queue_disk_reliable_new(options, persist_name);
+    return log_queue_disk_reliable_new(options, filename, persist_name);
 
-  return log_queue_disk_non_reliable_new(options, persist_name);
+  return log_queue_disk_non_reliable_new(options, filename, persist_name);
 }
 
 ParameterizedTestParameters(diskq, testcase_diskbuffer_restart_corrupted)
@@ -348,16 +348,16 @@ ParameterizedTest(restart_test_parameters *test_case, diskq, testcase_diskbuffer
   guint64 const original_disk_buf_size = 1000123;
   DiskQueueOptions options;
   _construct_options(&options, original_disk_buf_size, 100000, test_case->reliable);
-  LogQueue *q = queue_new(test_case->reliable, &options, NULL);
+  gchar *filename = test_case->filename;
+  LogQueue *q = queue_new(test_case->reliable, &options, filename, NULL);
   log_queue_set_use_backlog(q, FALSE);
 
-  gchar *filename = test_case->filename;
   gchar filename_corrupted_dq[100];
   g_snprintf(filename_corrupted_dq, 100, "%s.corrupted", filename);
   unlink(filename);
   unlink(filename_corrupted_dq);
 
-  log_queue_disk_start(q, filename);
+  log_queue_disk_start(q);
   fed_messages = 0;
   feed_some_messages(q, 100);
   cr_assert_eq(fed_messages, 100, "Failed to push all messages to the disk-queue!\n");
@@ -461,16 +461,16 @@ testcase_diskq_prepare(DiskQueueOptions *options, diskq_tester_parameters_t *par
   options->qout_size = parameters->qout_size;
 
   if (parameters->reliable)
-    q = log_queue_disk_reliable_new(options, NULL);
+    q = log_queue_disk_reliable_new(options, parameters->filename, NULL);
   else
-    q = log_queue_disk_non_reliable_new(options, NULL);
+    q = log_queue_disk_non_reliable_new(options, parameters->filename, NULL);
 
   init_statistics(q);
   cr_assert_eq(stats_counter_get(q->metrics.shared.queued_messages), 0, "queued messages: line: %d", __LINE__);
   cr_assert_eq(stats_counter_get(q->metrics.shared.memory_usage), 0, "memory_usage: line: %d", __LINE__);
 
   unlink(parameters->filename);
-  log_queue_disk_start(q, parameters->filename);
+  log_queue_disk_start(q);
 
   return q;
 }

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -59,12 +59,12 @@ test_diskq_become_full(gboolean reliable, const gchar *filename)
   if (reliable)
     {
       _construct_options(&options, 1000, 1000, reliable);
-      q = log_queue_disk_reliable_new(&options, persist_name);
+      q = log_queue_disk_reliable_new(&options, filename, persist_name);
     }
   else
     {
       _construct_options(&options, 1000, 0, reliable);
-      q = log_queue_disk_non_reliable_new(&options, persist_name);
+      q = log_queue_disk_non_reliable_new(&options, filename, persist_name);
     }
 
   log_queue_set_use_backlog(q, TRUE);
@@ -76,7 +76,7 @@ test_diskq_become_full(gboolean reliable, const gchar *filename)
   stats_counter_set(q->metrics.shared.dropped_messages, 0);
   stats_unlock();
   unlink(filename);
-  log_queue_disk_start(q, filename);
+  log_queue_disk_start(q);
   feed_some_messages(q, 1000);
 
   cr_assert_eq(atomic_gssize_racy_get(&q->metrics.shared.dropped_messages->value), 1000,

--- a/modules/diskq/tests/test_diskq_truncate.c
+++ b/modules/diskq/tests/test_diskq_truncate.c
@@ -43,9 +43,9 @@
 static LogQueue *
 _get_non_reliable_diskqueue(gchar *filename, DiskQueueOptions *options)
 {
-  LogQueue *q = log_queue_disk_non_reliable_new(options, NULL);
+  LogQueue *q = log_queue_disk_non_reliable_new(options, filename, NULL);
   log_queue_set_use_backlog(q, FALSE);
-  log_queue_disk_start(q, filename);
+  log_queue_disk_start(q);
   return q;
 }
 
@@ -242,9 +242,9 @@ _create_reliable_diskqueue(gchar *filename, DiskQueueOptions *options, gboolean 
     truncate_size_ratio = disk_queue_config_get_truncate_size_ratio(configuration);
   options->truncate_size_ratio = truncate_size_ratio;
 
-  q = log_queue_disk_reliable_new(options, "persist-name");
+  q = log_queue_disk_reliable_new(options, filename, "persist-name");
   log_queue_set_use_backlog(q, use_backlog);
-  log_queue_disk_start(q, filename);
+  log_queue_disk_start(q);
   return q;
 }
 

--- a/modules/diskq/tests/test_logqueue_disk.c
+++ b/modules/diskq/tests/test_logqueue_disk.c
@@ -112,10 +112,10 @@ Test(logqueue_disk, restart_corrupted_reliable)
   disk_queue_options_mem_buf_size_set(&options, 4096);
   disk_queue_options_qout_size_set(&options, 2);
 
-  LogQueue *queue = log_queue_disk_reliable_new(&options, "restart_corrupted_reliable");
+  LogQueue *queue = log_queue_disk_reliable_new(&options, filename, "restart_corrupted_reliable");
   _register_stats_counters(queue);
 
-  cr_assert(log_queue_disk_start(queue, filename));
+  cr_assert(log_queue_disk_start(queue));
   cr_assert_str_eq(log_queue_disk_get_filename(queue), filename);
   _assert_file_exists(filename);
   _assert_log_queue_disk_reliable_is_empty(queue);
@@ -197,10 +197,10 @@ Test(logqueue_disk, restart_corrupted_non_reliable)
   disk_queue_options_mem_buf_size_set(&options, 4096);
   disk_queue_options_qout_size_set(&options, 0);
 
-  LogQueue *queue = log_queue_disk_non_reliable_new(&options, "restart_corrupted_non_reliable");
+  LogQueue *queue = log_queue_disk_non_reliable_new(&options, filename, "restart_corrupted_non_reliable");
   _register_stats_counters(queue);
 
-  cr_assert(log_queue_disk_start(queue, filename));
+  cr_assert(log_queue_disk_start(queue));
   cr_assert_str_eq(log_queue_disk_get_filename(queue), filename);
   _assert_file_exists(filename);
   _assert_log_queue_disk_non_reliable_is_empty(queue);
@@ -285,11 +285,11 @@ Test(logqueue_disk, restart_corrupted_non_reliable_with_qout)
   disk_queue_options_mem_buf_size_set(&options, 4096);
   disk_queue_options_qout_size_set(&options, 1);
 
-  LogQueue *queue = log_queue_disk_non_reliable_new(&options, "restart_corrupted_non_reliable_with_qout");
+  LogQueue *queue = log_queue_disk_non_reliable_new(&options, filename, "restart_corrupted_non_reliable_with_qout");
   LogQueueDiskNonReliable *queue_disk_non_reliable = (LogQueueDiskNonReliable *) queue;
   _register_stats_counters(queue);
 
-  cr_assert(log_queue_disk_start(queue, filename));
+  cr_assert(log_queue_disk_start(queue));
   cr_assert_str_eq(log_queue_disk_get_filename(queue), filename);
   _assert_file_exists(filename);
   _assert_log_queue_disk_non_reliable_is_empty(queue);
@@ -333,14 +333,14 @@ Test(logqueue_disk, restart_corrupted_with_multiple_queues)
   disk_queue_options_disk_buf_size_set(&options, MIN_DISK_BUF_SIZE);
   disk_queue_options_mem_buf_size_set(&options, 4096);
 
-  LogQueue *queue_1 = log_queue_disk_reliable_new(&options, "restart_corrupted_with_multiple_queues_1");
+  LogQueue *queue_1 = log_queue_disk_reliable_new(&options, filename_1, "restart_corrupted_with_multiple_queues_1");
   _register_stats_counters(queue_1);
 
-  LogQueue *queue_2 = log_queue_disk_reliable_new(&options, "restart_corrupted_with_multiple_queues_2");
+  LogQueue *queue_2 = log_queue_disk_reliable_new(&options, filename_2, "restart_corrupted_with_multiple_queues_2");
   _register_stats_counters(queue_2);
 
-  cr_assert(log_queue_disk_start(queue_1, filename_1));
-  cr_assert(log_queue_disk_start(queue_2, filename_2));
+  cr_assert(log_queue_disk_start(queue_1));
+  cr_assert(log_queue_disk_start(queue_2));
 
   LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
 

--- a/modules/diskq/tests/test_qdisk.c
+++ b/modules/diskq/tests/test_qdisk.c
@@ -56,10 +56,10 @@ construct_diskq_options(TestDiskQType dq_type, gint64 disk_buf_size)
 }
 
 static QDisk *
-create_qdisk(TestDiskQType dq_type, gint64 disk_buf_size)
+create_qdisk(TestDiskQType dq_type, const gchar *filename, gint64 disk_buf_size)
 {
   DiskQueueOptions *opts = construct_diskq_options(dq_type, disk_buf_size);
-  QDisk *qdisk = qdisk_new(opts, "TEST");
+  QDisk *qdisk = qdisk_new(opts, "TEST", filename);
 
   return qdisk;
 }
@@ -132,11 +132,11 @@ reliable_pop_record_without_backlog(QDisk *qdisk, GString *record)
 Test(qdisk, test_qdisk_started)
 {
   const gchar *filename = "test_qdisk_started.rqf";
-  QDisk *qdisk = create_qdisk(TDISKQ_RELIABLE, MiB(1));
+  QDisk *qdisk = create_qdisk(TDISKQ_RELIABLE, filename, MiB(1));
 
   cr_assert_not(qdisk_started(qdisk));
 
-  qdisk_start(qdisk, filename, NULL, NULL, NULL);
+  qdisk_start(qdisk, NULL, NULL, NULL);
   cr_assert(qdisk_started(qdisk));
 
   qdisk_stop(qdisk, NULL, NULL, NULL);
@@ -148,8 +148,8 @@ Test(qdisk, test_qdisk_started)
 Test(qdisk, qdisk_basic_push_pop)
 {
   const gchar *filename = "test_qdisk_basic_push_pop.rqf";
-  QDisk *qdisk = create_qdisk(TDISKQ_RELIABLE, MiB(1));
-  qdisk_start(qdisk, filename, NULL, NULL, NULL);
+  QDisk *qdisk = create_qdisk(TDISKQ_RELIABLE, filename, MiB(1));
+  qdisk_start(qdisk, NULL, NULL, NULL);
 
   guint expected_record_len = 128;
   cr_assert(push_dummy_record(qdisk, expected_record_len));
@@ -171,8 +171,8 @@ Test(qdisk, qdisk_is_space_avail)
   const gchar *filename = "test_qdisk_is_space_avail.rqf";
   gsize qdisk_size = MiB(1);
   GString *data = g_string_new(NULL);
-  QDisk *qdisk = create_qdisk(TDISKQ_RELIABLE, qdisk_size);
-  qdisk_start(qdisk, filename, NULL, NULL, NULL);
+  QDisk *qdisk = create_qdisk(TDISKQ_RELIABLE, filename, qdisk_size);
+  qdisk_start(qdisk, NULL, NULL, NULL);
 
   gsize available_space = qdisk_size - QDISK_RESERVED_SPACE;
   cr_assert(qdisk_is_space_avail(qdisk, available_space));
@@ -204,8 +204,8 @@ Test(qdisk, qdisk_is_space_avail)
 Test(qdisk, qdisk_remove_head)
 {
   const gchar *filename = "test_qdisk_remove_head.rqf";
-  QDisk *qdisk = create_qdisk(TDISKQ_RELIABLE, MiB(1));
-  qdisk_start(qdisk, filename, NULL, NULL, NULL);
+  QDisk *qdisk = create_qdisk(TDISKQ_RELIABLE, filename, MiB(1));
+  qdisk_start(qdisk, NULL, NULL, NULL);
 
   push_dummy_record(qdisk, 128);
   cr_assert(qdisk_remove_head(qdisk));
@@ -226,8 +226,8 @@ Test(qdisk, qdisk_remove_head)
 Test(qdisk, qdisk_basic_ack_rewind)
 {
   const gchar *filename = "test_qdisk_basic_ack_rewind.rqf";
-  QDisk *qdisk = create_qdisk(TDISKQ_RELIABLE, MiB(1));
-  qdisk_start(qdisk, filename, NULL, NULL, NULL);
+  QDisk *qdisk = create_qdisk(TDISKQ_RELIABLE, filename, MiB(1));
+  qdisk_start(qdisk, NULL, NULL, NULL);
 
   gsize num_of_records = 100;
 
@@ -264,8 +264,8 @@ Test(qdisk, qdisk_basic_ack_rewind)
 Test(qdisk, qdisk_empty_backlog)
 {
   const gchar *filename = "test_qdisk_empty_backlog.rqf";
-  QDisk *qdisk = create_qdisk(TDISKQ_RELIABLE, MiB(1));
-  qdisk_start(qdisk, filename, NULL, NULL, NULL);
+  QDisk *qdisk = create_qdisk(TDISKQ_RELIABLE, filename, MiB(1));
+  qdisk_start(qdisk, NULL, NULL, NULL);
 
   push_dummy_record(qdisk, 514);
   push_dummy_record(qdisk, 514);
@@ -288,8 +288,8 @@ Test(qdisk, allow_writing_more_than_max_size_when_last_message_does_not_fit)
 {
   const gchar *filename = "test_qdisk_exceed_max_size.rqf";
   gsize qdisk_size = MiB(1);
-  QDisk *qdisk = create_qdisk(TDISKQ_RELIABLE, qdisk_size);
-  qdisk_start(qdisk, filename, NULL, NULL, NULL);
+  QDisk *qdisk = create_qdisk(TDISKQ_RELIABLE, filename, qdisk_size);
+  qdisk_start(qdisk, NULL, NULL, NULL);
 
   push_dummy_record(qdisk, 100);
 
@@ -307,8 +307,8 @@ Test(qdisk, do_not_allow_diskq_to_exceed_max_size_if_last_message_fits)
   const gchar *filename = "test_qdisk_do_not_exceed_max_size_when_msg_fits.rqf";
   gsize qdisk_size = MiB(1);
   GString *data = g_string_new(NULL);
-  QDisk *qdisk = create_qdisk(TDISKQ_RELIABLE, qdisk_size);
-  qdisk_start(qdisk, filename, NULL, NULL, NULL);
+  QDisk *qdisk = create_qdisk(TDISKQ_RELIABLE, filename, qdisk_size);
+  qdisk_start(qdisk, NULL, NULL, NULL);
 
   // fill completely
   push_dummy_record(qdisk, qdisk_size - QDISK_RESERVED_SPACE - FRAME_LENGTH);
@@ -332,8 +332,8 @@ Test(qdisk, completely_full_and_then_emptied_qdisk_should_update_positions_prope
   const gchar *filename = "test_qdisk_completely_full.rqf";
   gsize qdisk_size = MiB(1);
   GString *popped_data = g_string_new(NULL);
-  QDisk *qdisk = create_qdisk(TDISKQ_RELIABLE, qdisk_size);
-  qdisk_start(qdisk, filename, NULL, NULL, NULL);
+  QDisk *qdisk = create_qdisk(TDISKQ_RELIABLE, filename, qdisk_size);
+  qdisk_start(qdisk, NULL, NULL, NULL);
 
   gsize num_of_records = 4;
 
@@ -362,9 +362,9 @@ Test(qdisk, prealloc)
 
   DiskQueueOptions *opts = construct_diskq_options(TDISKQ_RELIABLE, MIN_DISK_BUF_SIZE);
   disk_queue_options_set_prealloc(opts, TRUE);
-  QDisk *qdisk = qdisk_new(opts, "TEST");
+  QDisk *qdisk = qdisk_new(opts, "TEST", filename);
 
-  qdisk_start(qdisk, filename, NULL, NULL, NULL);
+  qdisk_start(qdisk, NULL, NULL, NULL);
 
   struct stat file_stats;
   cr_assert(stat(filename, &file_stats) == 0, "Stat call failed, errno: %d", errno);
@@ -434,8 +434,8 @@ Test(qdisk, get_empty_space_non_wrapped)
   const gchar *filename = "test_get_empty_space_non_wrapped.rqf";
   DiskQueueOptions *opts = construct_diskq_options(TDISKQ_RELIABLE, MIN_DISK_BUF_SIZE);
   disk_queue_options_set_truncate_size_ratio(opts, 1);
-  QDisk *qdisk = qdisk_new(opts, "TEST");
-  cr_assert(qdisk_start(qdisk, filename, NULL, NULL, NULL));
+  QDisk *qdisk = qdisk_new(opts, "TEST", filename);
+  cr_assert(qdisk_start(qdisk, NULL, NULL, NULL));
 
   // 0   RESERVED=B=W              DBS
   // |---|------- ... -------------|
@@ -522,8 +522,8 @@ Test(qdisk, get_empty_space_wrapped)
   const gchar *filename = "test_get_empty_space_wrapped.rqf";
   DiskQueueOptions *opts = construct_diskq_options(TDISKQ_RELIABLE, MIN_DISK_BUF_SIZE);
   disk_queue_options_set_truncate_size_ratio(opts, 1);
-  QDisk *qdisk = qdisk_new(opts, "TEST");
-  cr_assert(qdisk_start(qdisk, filename, NULL, NULL, NULL));
+  QDisk *qdisk = qdisk_new(opts, "TEST", filename);
+  cr_assert(qdisk_start(qdisk, NULL, NULL, NULL));
 
   _push_data_to_qdisk(qdisk, small_amount_of_data * 2);
   _push_data_to_qdisk(qdisk, useful_size);

--- a/modules/diskq/tests/test_reliable_backlog.c
+++ b/modules/diskq/tests/test_reliable_backlog.c
@@ -58,11 +58,11 @@ _init_diskq_for_test(const gchar *filename, gint64 size, gint64 membuf_size)
   LogQueueDiskReliable *dq;
 
   _construct_options(&options, size, membuf_size, TRUE);
-  LogQueue *q = log_queue_disk_reliable_new(&options, NULL);
+  LogQueue *q = log_queue_disk_reliable_new(&options, filename, NULL);
   struct stat st;
   num_of_ack = 0;
   unlink(filename);
-  log_queue_disk_start(q, filename);
+  log_queue_disk_start(q);
   dq = (LogQueueDiskReliable *)q;
   lseek(dq->super.qdisk->fd, size - 1, SEEK_SET);
   ssize_t written = write(dq->super.qdisk->fd, "", 1);

--- a/modules/examples/sources/threaded-diskq-source/threaded-diskq-source.c
+++ b/modules/examples/sources/threaded-diskq-source/threaded-diskq-source.c
@@ -75,16 +75,16 @@ _load_queue(ThreadedDiskqSourceDriver *self)
   if (self->diskq_options.reliable)
     {
       self->diskq_options.mem_buf_size = 1024 * 1024;
-      self->queue = log_queue_disk_reliable_new(&self->diskq_options, NULL);
+      self->queue = log_queue_disk_reliable_new(&self->diskq_options, self->filename, NULL);
     }
   else
     {
       self->diskq_options.mem_buf_size = 128;
       self->diskq_options.qout_size = 1000;
-      self->queue = log_queue_disk_non_reliable_new(&self->diskq_options, NULL);
+      self->queue = log_queue_disk_non_reliable_new(&self->diskq_options, self->filename, NULL);
     }
 
-  if (!log_queue_disk_start(self->queue, self->filename))
+  if (!log_queue_disk_start(self->queue))
     {
       msg_error("Error loading diskq", evt_tag_str("file", self->filename));
       return FALSE;


### PR DESCRIPTION
This PR is a preparation step for #4356.

There, we will need to know the filename when creating a `LogQueueDisk` instance in order to properly setup the `StatsClusterKey` for the metrics.

No news file needed.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>