### PR TITLE
stats-cluster-key-builder: add clone() and reset()

### DIFF
--- a/lib/stats/stats-cluster-key-builder.c
+++ b/lib/stats/stats-cluster-key-builder.c
@@ -83,14 +83,8 @@ stats_cluster_key_builder_clone(const StatsClusterKeyBuilder *self)
 void
 stats_cluster_key_builder_free(StatsClusterKeyBuilder *self)
 {
-  g_free(self->name);
-  g_free(self->name_suffix);
+  stats_cluster_key_builder_reset(self);
   g_array_free(self->labels, TRUE);
-
-  g_free(self->legacy.id);
-  g_free(self->legacy.instance);
-  g_free(self->legacy.name);
-
   g_free(self);
 }
 
@@ -142,6 +136,19 @@ stats_cluster_key_builder_set_legacy_alias_name(StatsClusterKeyBuilder *self, co
 
   g_free(self->legacy.name);
   self->legacy.name = g_strdup(name);
+}
+
+void
+stats_cluster_key_builder_reset(StatsClusterKeyBuilder *self)
+{
+  stats_cluster_key_builder_set_name(self, NULL);
+  stats_cluster_key_builder_set_name_suffix(self, NULL);
+
+  g_array_remove_range(self->labels, 0, self->labels->len);
+
+  stats_cluster_key_builder_set_legacy_alias(self, 0, NULL, NULL);
+  stats_cluster_key_builder_set_legacy_alias_name(self, NULL);
+  self->legacy.set = FALSE;
 }
 
 static gint

--- a/lib/stats/stats-cluster-key-builder.c
+++ b/lib/stats/stats-cluster-key-builder.c
@@ -131,7 +131,7 @@ _labels_sort(const StatsClusterLabel *a, const StatsClusterLabel *b)
 }
 
 static gchar *
-_format_name(StatsClusterKeyBuilder *self)
+_format_name(const StatsClusterKeyBuilder *self)
 {
   if (self->name_suffix)
     return g_strdup_printf("%s%s", self->name, self->name_suffix);
@@ -140,7 +140,7 @@ _format_name(StatsClusterKeyBuilder *self)
 }
 
 StatsClusterKey *
-stats_cluster_key_builder_build_single(StatsClusterKeyBuilder *self)
+stats_cluster_key_builder_build_single(const StatsClusterKeyBuilder *self)
 {
   StatsClusterKey *sc_key = g_new0(StatsClusterKey, 1);
 
@@ -167,7 +167,7 @@ stats_cluster_key_builder_build_single(StatsClusterKeyBuilder *self)
 }
 
 StatsClusterKey *
-stats_cluster_key_builder_build_logpipe(StatsClusterKeyBuilder *self)
+stats_cluster_key_builder_build_logpipe(const StatsClusterKeyBuilder *self)
 {
   StatsClusterKey *sc_key = g_new0(StatsClusterKey, 1);
 

--- a/lib/stats/stats-cluster-key-builder.c
+++ b/lib/stats/stats-cluster-key-builder.c
@@ -60,6 +60,26 @@ stats_cluster_key_builder_new(void)
   return self;
 }
 
+StatsClusterKeyBuilder *
+stats_cluster_key_builder_clone(const StatsClusterKeyBuilder *self)
+{
+  StatsClusterKeyBuilder *cloned = stats_cluster_key_builder_new();
+
+  stats_cluster_key_builder_set_name(cloned, self->name);
+  stats_cluster_key_builder_set_name_suffix(cloned, self->name_suffix);
+  for (gint i = 0; i < self->labels->len; i++)
+    {
+      StatsClusterLabel *label = &g_array_index(self->labels, StatsClusterLabel, i);
+      stats_cluster_key_builder_add_label(cloned, stats_cluster_label(label->name, label->value));
+    }
+  stats_cluster_key_builder_set_unit(cloned, self->unit);
+  stats_cluster_key_builder_set_legacy_alias(cloned, self->legacy.component, self->legacy.id, self->legacy.instance);
+  stats_cluster_key_builder_set_legacy_alias_name(cloned, self->legacy.name);
+  cloned->legacy.set = self->legacy.set;
+
+  return cloned;
+}
+
 void
 stats_cluster_key_builder_free(StatsClusterKeyBuilder *self)
 {

--- a/lib/stats/stats-cluster-key-builder.h
+++ b/lib/stats/stats-cluster-key-builder.h
@@ -41,6 +41,8 @@ void stats_cluster_key_builder_set_legacy_alias(StatsClusterKeyBuilder *self, gu
                                                 const gchar *instance);
 void stats_cluster_key_builder_set_legacy_alias_name(StatsClusterKeyBuilder *self, const gchar *name);
 
+void stats_cluster_key_builder_reset(StatsClusterKeyBuilder *self);
+
 StatsClusterKey *stats_cluster_key_builder_build_single(const StatsClusterKeyBuilder *self);
 StatsClusterKey *stats_cluster_key_builder_build_logpipe(const StatsClusterKeyBuilder *self);
 

--- a/lib/stats/stats-cluster-key-builder.h
+++ b/lib/stats/stats-cluster-key-builder.h
@@ -40,7 +40,7 @@ void stats_cluster_key_builder_set_legacy_alias(StatsClusterKeyBuilder *self, gu
                                                 const gchar *instance);
 void stats_cluster_key_builder_set_legacy_alias_name(StatsClusterKeyBuilder *self, const gchar *name);
 
-StatsClusterKey *stats_cluster_key_builder_build_single(StatsClusterKeyBuilder *self);
-StatsClusterKey *stats_cluster_key_builder_build_logpipe(StatsClusterKeyBuilder *self);
+StatsClusterKey *stats_cluster_key_builder_build_single(const StatsClusterKeyBuilder *self);
+StatsClusterKey *stats_cluster_key_builder_build_logpipe(const StatsClusterKeyBuilder *self);
 
 #endif

--- a/lib/stats/stats-cluster-key-builder.h
+++ b/lib/stats/stats-cluster-key-builder.h
@@ -30,6 +30,7 @@
 typedef struct _StatsClusterKeyBuilder StatsClusterKeyBuilder;
 
 StatsClusterKeyBuilder *stats_cluster_key_builder_new(void);
+StatsClusterKeyBuilder *stats_cluster_key_builder_clone(const StatsClusterKeyBuilder *self);
 void stats_cluster_key_builder_free(StatsClusterKeyBuilder *self);
 
 void stats_cluster_key_builder_set_name(StatsClusterKeyBuilder *self, const gchar *name);

--- a/lib/stats/tests/test_stats_cluster_key_builder.c
+++ b/lib/stats/tests/test_stats_cluster_key_builder.c
@@ -183,6 +183,11 @@ _test_builder(KeyType type)
                                               dummy_legacy_instance, dummy_legacy_name);
     }
 
+  /* Reset */
+  stats_cluster_key_builder_reset(builder);
+  stats_cluster_key_builder_set_name(builder, dummy_name);
+  _assert_built_sc_key_equals(builder, type, dummy_name, empty_labels, G_N_ELEMENTS(empty_labels));
+
   stats_cluster_key_builder_free(builder);
 }
 

--- a/lib/stats/tests/test_stats_cluster_key_builder.c
+++ b/lib/stats/tests/test_stats_cluster_key_builder.c
@@ -40,15 +40,17 @@ _assert_built_sc_key_equals(const StatsClusterKeyBuilder *builder, KeyType type,
   StatsClusterKey expected_sc_key;
   StatsClusterKey *built_key;
 
+  StatsClusterKeyBuilder *cloned_builder = stats_cluster_key_builder_clone(builder);
+
   if (type == TEST_LOGPIPE)
     {
       stats_cluster_logpipe_key_set(&expected_sc_key, name, labels, labels_len);
-      built_key = stats_cluster_key_builder_build_logpipe(builder);
+      built_key = stats_cluster_key_builder_build_logpipe(cloned_builder);
     }
   else if (type == TEST_SINGLE)
     {
       stats_cluster_single_key_set(&expected_sc_key, name, labels, labels_len);
-      built_key = stats_cluster_key_builder_build_single(builder);
+      built_key = stats_cluster_key_builder_build_single(cloned_builder);
     }
   else
     {
@@ -56,18 +58,22 @@ _assert_built_sc_key_equals(const StatsClusterKeyBuilder *builder, KeyType type,
     }
 
   cr_assert(stats_cluster_key_equal(&expected_sc_key, built_key));
+
   stats_cluster_key_free(built_key);
+  stats_cluster_key_builder_free(cloned_builder);
 }
 
 static void
 _assert_built_sc_key_has_unit(const StatsClusterKeyBuilder *builder, KeyType type, StatsClusterUnit unit)
 {
-  StatsClusterKey *built_key = stats_cluster_key_builder_build_single(builder);
+  StatsClusterKeyBuilder *cloned_builder = stats_cluster_key_builder_clone(builder);
+  StatsClusterKey *built_key = stats_cluster_key_builder_build_single(cloned_builder);
 
   if (type == TEST_SINGLE)
     cr_assert(built_key->stored_unit == unit);
 
   stats_cluster_key_free(built_key);
+  stats_cluster_key_builder_free(cloned_builder);
 }
 
 static void
@@ -79,11 +85,13 @@ _assert_built_sc_key_equals_with_legacy(const StatsClusterKeyBuilder *builder, K
   StatsClusterKey expected_sc_key;
   StatsClusterKey *built_key;
 
+  StatsClusterKeyBuilder *cloned_builder = stats_cluster_key_builder_clone(builder);
+
   if (type == TEST_LOGPIPE)
     {
       stats_cluster_logpipe_key_set(&expected_sc_key, name, labels, labels_len);
       stats_cluster_logpipe_key_add_legacy_alias(&expected_sc_key, legacy_component, legacy_id, legacy_instance);
-      built_key = stats_cluster_key_builder_build_logpipe(builder);
+      built_key = stats_cluster_key_builder_build_logpipe(cloned_builder);
     }
   else if (type == TEST_SINGLE)
     {
@@ -97,7 +105,7 @@ _assert_built_sc_key_equals_with_legacy(const StatsClusterKeyBuilder *builder, K
         {
           stats_cluster_single_key_add_legacy_alias(&expected_sc_key, legacy_component, legacy_id, legacy_instance);
         }
-      built_key = stats_cluster_key_builder_build_single(builder);
+      built_key = stats_cluster_key_builder_build_single(cloned_builder);
     }
   else
     {
@@ -105,7 +113,9 @@ _assert_built_sc_key_equals_with_legacy(const StatsClusterKeyBuilder *builder, K
     }
 
   cr_assert(stats_cluster_key_equal(&expected_sc_key, built_key));
+
   stats_cluster_key_free(built_key);
+  stats_cluster_key_builder_free(cloned_builder);
 }
 
 static void

--- a/lib/stats/tests/test_stats_cluster_key_builder.c
+++ b/lib/stats/tests/test_stats_cluster_key_builder.c
@@ -34,7 +34,7 @@ typedef enum
 } KeyType;
 
 static void
-_assert_built_sc_key_equals(StatsClusterKeyBuilder *builder, KeyType type, const gchar *name,
+_assert_built_sc_key_equals(const StatsClusterKeyBuilder *builder, KeyType type, const gchar *name,
                             StatsClusterLabel *labels, gssize labels_len)
 {
   StatsClusterKey expected_sc_key;
@@ -60,7 +60,7 @@ _assert_built_sc_key_equals(StatsClusterKeyBuilder *builder, KeyType type, const
 }
 
 static void
-_assert_built_sc_key_has_unit(StatsClusterKeyBuilder *builder, KeyType type, StatsClusterUnit unit)
+_assert_built_sc_key_has_unit(const StatsClusterKeyBuilder *builder, KeyType type, StatsClusterUnit unit)
 {
   StatsClusterKey *built_key = stats_cluster_key_builder_build_single(builder);
 
@@ -71,7 +71,7 @@ _assert_built_sc_key_has_unit(StatsClusterKeyBuilder *builder, KeyType type, Sta
 }
 
 static void
-_assert_built_sc_key_equals_with_legacy(StatsClusterKeyBuilder *builder, KeyType type, const gchar *name,
+_assert_built_sc_key_equals_with_legacy(const StatsClusterKeyBuilder *builder, KeyType type, const gchar *name,
                                         StatsClusterLabel *labels, gssize labels_len, guint16 legacy_component,
                                         const gchar *legacy_id, const gchar *legacy_instance,
                                         const gchar *legacy_name)


### PR DESCRIPTION
While preparing #4356, a couple more use cases have emerged, which can be solved with these two functions.

No news file needed.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>