### PR TITLE
logqueue: register stats counters in ctor

### DIFF
--- a/lib/driver.c
+++ b/lib/driver.c
@@ -243,7 +243,8 @@ log_src_driver_free(LogPipe *s)
 /* LogDestDriver */
 
 static LogQueue *
-_create_memory_queue(LogDestDriver *self, const gchar *persist_name)
+_create_memory_queue(LogDestDriver *self, const gchar *persist_name, gint stats_level,
+                     const StatsClusterKeyBuilder *driver_sck_builder)
 {
   GlobalConfig *cfg = log_pipe_get_config(&self->super.super);
 
@@ -257,15 +258,16 @@ _create_memory_queue(LogDestDriver *self, const gchar *persist_name)
                        "flags(flow-control) option set.) To enable the new behaviour, update the @version string in "
                        "your configuration and consider lowering the value of log-fifo-size().");
 
-      return log_queue_fifo_legacy_new(log_fifo_size, persist_name);
+      return log_queue_fifo_legacy_new(log_fifo_size, persist_name, stats_level, driver_sck_builder);
     }
 
-  return log_queue_fifo_new(log_fifo_size, persist_name);
+  return log_queue_fifo_new(log_fifo_size, persist_name, stats_level, driver_sck_builder);
 }
 
 /* returns a reference */
 static LogQueue *
-log_dest_driver_acquire_memory_queue(LogDestDriver *self, const gchar *persist_name)
+log_dest_driver_acquire_memory_queue(LogDestDriver *self, const gchar *persist_name, gint stats_level,
+                                     const StatsClusterKeyBuilder *driver_sck_builder)
 {
   GlobalConfig *cfg = log_pipe_get_config(&self->super.super);
   LogQueue *queue = NULL;
@@ -281,7 +283,7 @@ log_dest_driver_acquire_memory_queue(LogDestDriver *self, const gchar *persist_n
 
   if (!queue)
     {
-      queue = _create_memory_queue(self, persist_name);
+      queue = _create_memory_queue(self, persist_name, stats_level, driver_sck_builder);
       log_queue_set_throttle(queue, self->throttle);
     }
   return queue;

--- a/lib/driver.h
+++ b/lib/driver.h
@@ -158,7 +158,8 @@ struct _LogDestDriver
 {
   LogDriver super;
 
-  LogQueue *(*acquire_queue)(LogDestDriver *s, const gchar *persist_name);
+  LogQueue *(*acquire_queue)(LogDestDriver *s, const gchar *persist_name, gint stats_level,
+                             const StatsClusterKeyBuilder *driver_sck_builder);
   void (*release_queue)(LogDestDriver *s, LogQueue *q);
 
   /* queues managed by this LogDestDriver, all constructed queues come
@@ -172,11 +173,12 @@ struct _LogDestDriver
 
 /* returns a reference */
 static inline LogQueue *
-log_dest_driver_acquire_queue(LogDestDriver *self, const gchar *persist_name)
+log_dest_driver_acquire_queue(LogDestDriver *self, const gchar *persist_name, gint stats_level,
+                              const StatsClusterKeyBuilder *driver_sck_builder)
 {
   LogQueue *q;
 
-  q = self->acquire_queue(self, persist_name);
+  q = self->acquire_queue(self, persist_name, stats_level, driver_sck_builder);
   if (q)
     {
       self->queues = g_list_prepend(self->queues, q);

--- a/lib/logqueue-fifo.c
+++ b/lib/logqueue-fifo.c
@@ -655,14 +655,15 @@ log_queue_fifo_free(LogQueue *s)
 }
 
 LogQueue *
-log_queue_fifo_new(gint log_fifo_size, const gchar *persist_name)
+log_queue_fifo_new(gint log_fifo_size, const gchar *persist_name, gint stats_level,
+                   const StatsClusterKeyBuilder *driver_sck_builder)
 {
   LogQueueFifo *self;
 
   gint max_threads = main_loop_worker_get_max_number_of_threads();
   self = g_malloc0(sizeof(LogQueueFifo) + max_threads * sizeof(self->input_queues[0]));
 
-  log_queue_init_instance(&self->super, persist_name);
+  log_queue_init_instance(&self->super, persist_name, stats_level, driver_sck_builder);
   self->super.type = log_queue_fifo_type;
   self->super.use_backlog = FALSE;
   self->super.get_length = log_queue_fifo_get_length;
@@ -694,9 +695,11 @@ log_queue_fifo_new(gint log_fifo_size, const gchar *persist_name)
 }
 
 LogQueue *
-log_queue_fifo_legacy_new(gint log_fifo_size, const gchar *persist_name)
+log_queue_fifo_legacy_new(gint log_fifo_size, const gchar *persist_name, gint stats_level,
+                          const StatsClusterKeyBuilder *driver_sck_builder)
 {
-  LogQueueFifo *self = (LogQueueFifo *) log_queue_fifo_new(log_fifo_size, persist_name);
+  LogQueueFifo *self = (LogQueueFifo *) log_queue_fifo_new(log_fifo_size, persist_name, stats_level,
+                                                           driver_sck_builder);
   self->use_legacy_fifo_size = TRUE;
   return &self->super;
 }

--- a/lib/logqueue-fifo.h
+++ b/lib/logqueue-fifo.h
@@ -27,8 +27,10 @@
 
 #include "logqueue.h"
 
-LogQueue *log_queue_fifo_new(gint log_fifo_size, const gchar *persist_name);
-LogQueue *log_queue_fifo_legacy_new(gint log_fifo_size, const gchar *persist_name);
+LogQueue *log_queue_fifo_new(gint log_fifo_size, const gchar *persist_name, gint stats_level,
+                             const StatsClusterKeyBuilder *driver_sck_builder);
+LogQueue *log_queue_fifo_legacy_new(gint log_fifo_size, const gchar *persist_name, gint stats_level,
+                                    const StatsClusterKeyBuilder *driver_sck_builder);
 
 QueueType log_queue_fifo_get_type(void);
 

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -27,6 +27,7 @@
 
 #include "logmsg/logmsg.h"
 #include "stats/stats-registry.h"
+#include "stats/stats-cluster-key-builder.h"
 
 typedef void (*LogQueuePushNotifyFunc)(gpointer user_data);
 
@@ -38,6 +39,9 @@ typedef struct _LogQueueMetrics
 {
   struct
   {
+    StatsClusterKey *output_events_sc_key;
+    StatsClusterKey *memory_usage_sc_key;
+
     StatsCounterItem *queued_messages;
     StatsCounterItem *dropped_messages;
     StatsCounterItem *memory_usage;
@@ -228,9 +232,8 @@ void log_queue_set_parallel_push(LogQueue *self, LogQueuePushNotifyFunc parallel
                                  GDestroyNotify user_data_destroy);
 gboolean log_queue_check_items(LogQueue *self, gint *timeout, LogQueuePushNotifyFunc parallel_push_notify,
                                gpointer user_data, GDestroyNotify user_data_destroy);
-void log_queue_init_instance(LogQueue *self, const gchar *persist_name);
-void log_queue_register_stats_counters(LogQueue *self, gint stats_level, const StatsClusterKey *sc_key);
-void log_queue_unregister_stats_counters(LogQueue *self, const StatsClusterKey *sc_key);
+void log_queue_init_instance(LogQueue *self, const gchar *persist_name, gint stats_level,
+                             const StatsClusterKeyBuilder *driver_sck_builder);
 
 void log_queue_free_method(LogQueue *self);
 

--- a/lib/logthrdest/logthrdestdrv.h
+++ b/lib/logthrdest/logthrdestdrv.h
@@ -104,6 +104,8 @@ struct _LogThreadedDestDriver
   LogDestDriver super;
   GMutex lock;
 
+  StatsClusterKey *output_events_sc_key;
+  StatsClusterKey *processed_sc_key;
   StatsCounterItem *dropped_messages;
   StatsCounterItem *processed_messages;
   StatsCounterItem *written_messages;

--- a/lib/logwriter.h
+++ b/lib/logwriter.h
@@ -88,6 +88,8 @@ LogQueue *log_writer_get_queue(LogWriter *s);
 LogWriter *log_writer_new(guint32 flags, GlobalConfig *cfg);
 void log_writer_msg_rewind(LogWriter *self);
 
+void log_writer_init_driver_sck_builder(LogWriter *self, StatsClusterKeyBuilder *builder);
+
 void log_writer_options_set_template_escape(LogWriterOptions *options, gboolean enable);
 void log_writer_options_defaults(LogWriterOptions *options);
 void log_writer_options_init(LogWriterOptions *options, GlobalConfig *cfg, guint32 option_flags);

--- a/lib/tests/test_logqueue.c
+++ b/lib/tests/test_logqueue.c
@@ -178,16 +178,9 @@ Test(logqueue, test_zero_diskbuf_and_normal_acks)
   LogQueue *q;
   gint i;
 
-  q = log_queue_fifo_new(OVERFLOW_SIZE, NULL);
-
-  StatsClusterKey sc_key;
-  stats_lock();
-  stats_cluster_logpipe_key_legacy_set(&sc_key, SCS_DESTINATION, q->persist_name, NULL );
-  stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &q->metrics.shared.queued_messages);
-  stats_cluster_single_key_legacy_set_with_name(&sc_key, SCS_DESTINATION, q->persist_name, NULL, "memory_usage");
-  stats_register_counter(1, &sc_key, SC_TYPE_SINGLE_VALUE, &q->metrics.shared.memory_usage);
-  stats_unlock();
-
+  StatsClusterKeyBuilder *driver_sck_builder = stats_cluster_key_builder_new();
+  q = log_queue_fifo_new(OVERFLOW_SIZE, NULL, STATS_LEVEL0, driver_sck_builder);
+  stats_cluster_key_builder_free(driver_sck_builder);
   log_queue_set_use_backlog(q, TRUE);
 
   cr_assert_eq(atomic_gssize_racy_get(&q->metrics.shared.queued_messages->value), 0);
@@ -220,7 +213,7 @@ Test(logqueue, test_zero_diskbuf_alternating_send_acks)
   LogQueue *q;
   gint i;
 
-  q = log_queue_fifo_new(OVERFLOW_SIZE, NULL);
+  q = log_queue_fifo_new(OVERFLOW_SIZE, NULL, STATS_LEVEL0, NULL);
   log_queue_set_use_backlog(q, TRUE);
 
   fed_messages = 0;
@@ -251,7 +244,7 @@ Test(logqueue, test_with_threads)
   for (i = 0; i < TEST_RUNS; i++)
     {
       fprintf(stderr, "starting testrun: %d\n", i);
-      q = log_queue_fifo_new(MESSAGES_SUM, NULL);
+      q = log_queue_fifo_new(MESSAGES_SUM, NULL, STATS_LEVEL0, NULL);
       log_queue_set_use_backlog(q, TRUE);
 
       for (j = 0; j < FEEDERS; j++)
@@ -278,14 +271,10 @@ Test(logqueue, test_with_threads)
 
 Test(logqueue, log_queue_fifo_rewind_all_and_memory_usage)
 {
-  LogQueue *q = log_queue_fifo_new(OVERFLOW_SIZE, NULL);
+  StatsClusterKeyBuilder *driver_sck_builder = stats_cluster_key_builder_new();
+  LogQueue *q = log_queue_fifo_new(OVERFLOW_SIZE, NULL, STATS_LEVEL0, driver_sck_builder);
+  stats_cluster_key_builder_free(driver_sck_builder);
   log_queue_set_use_backlog(q, TRUE);
-
-  StatsClusterKey sc_key;
-  stats_lock();
-  stats_cluster_single_key_legacy_set_with_name(&sc_key, SCS_DESTINATION, q->persist_name, NULL, "memory_usage");
-  stats_register_counter(1, &sc_key, SC_TYPE_SINGLE_VALUE, &q->metrics.shared.memory_usage);
-  stats_unlock();
 
   feed_some_messages(q, 1);
   gint size_when_single_msg = stats_counter_get(q->metrics.shared.memory_usage);
@@ -301,28 +290,6 @@ Test(logqueue, log_queue_fifo_rewind_all_and_memory_usage)
   log_queue_unref(q);
 }
 
-static void
-_register_stats_counters(LogQueue *q)
-{
-  StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_legacy_set(&sc_key, SCS_DESTINATION, q->persist_name, NULL);
-
-  stats_lock();
-  log_queue_register_stats_counters(q, 0, &sc_key);
-  stats_unlock();
-}
-
-static void
-_unregister_stats_counters(LogQueue *q)
-{
-  StatsClusterKey sc_key;
-  stats_cluster_logpipe_key_legacy_set(&sc_key, SCS_DESTINATION, q->persist_name, NULL);
-
-  stats_lock();
-  log_queue_unregister_stats_counters(q, &sc_key);
-  stats_unlock();
-}
-
 Test(logqueue, log_queue_fifo_should_drop_only_non_flow_controlled_messages,
      .description = "Flow-controlled messages should never be dropped")
 {
@@ -333,9 +300,10 @@ Test(logqueue, log_queue_fifo_should_drop_only_non_flow_controlled_messages,
   non_flow_controlled_path.flow_control_requested = FALSE;
 
   gint fifo_size = 5;
-  LogQueue *q = log_queue_fifo_new(fifo_size, NULL);
+  StatsClusterKeyBuilder *driver_sck_builder = stats_cluster_key_builder_new();
+  LogQueue *q = log_queue_fifo_new(fifo_size, NULL, STATS_LEVEL0, driver_sck_builder);
+  stats_cluster_key_builder_free(driver_sck_builder);
   log_queue_set_use_backlog(q, TRUE);
-  _register_stats_counters(q);
 
   fed_messages = 0;
   acked_messages = 0;
@@ -357,7 +325,6 @@ Test(logqueue, log_queue_fifo_should_drop_only_non_flow_controlled_messages,
                "did not receive enough acknowledgements: fed_messages=%d, acked_messages=%d",
                fed_messages, acked_messages);
 
-  _unregister_stats_counters(q);
   log_queue_unref(q);
 }
 
@@ -397,9 +364,10 @@ Test(logqueue, log_queue_fifo_should_drop_only_non_flow_controlled_messages_thre
   main_loop_worker_allocate_thread_space(1);
   main_loop_worker_finalize_thread_space();
 
-  LogQueue *q = log_queue_fifo_new(fifo_size, NULL);
+  StatsClusterKeyBuilder *driver_sck_builder = stats_cluster_key_builder_new();
+  LogQueue *q = log_queue_fifo_new(fifo_size, NULL, STATS_LEVEL0, driver_sck_builder);
+  stats_cluster_key_builder_free(driver_sck_builder);
   log_queue_set_use_backlog(q, TRUE);
-  _register_stats_counters(q);
 
   GThread *thread = g_thread_new(NULL, _flow_control_feed_thread, q);
   g_thread_join(thread);
@@ -414,6 +382,5 @@ Test(logqueue, log_queue_fifo_should_drop_only_non_flow_controlled_messages_thre
                "did not receive enough acknowledgements: fed_messages=%d, acked_messages=%d",
                fed_messages, acked_messages);
 
-  _unregister_stats_counters(q);
   log_queue_unref(q);
 }

--- a/lib/tests/test_logwriter.c
+++ b/lib/tests/test_logwriter.c
@@ -173,7 +173,7 @@ _assert_logwriter_output(LogWriterTestCase c)
       opt.template = templ;
     }
   msg = init_msg(c.msg, c.is_rfc5424);
-  queue = log_queue_fifo_new(1000, NULL);
+  queue = log_queue_fifo_new(1000, NULL, STATS_LEVEL0, NULL);
   writer = log_writer_new(c.writer_flags, configuration);
 
   log_writer_set_options(writer, NULL, &opt, NULL, NULL);

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -197,8 +197,15 @@ affile_dw_init(LogPipe *s)
                          &self->owner->writer_options,
                          self->owner->super.super.id,
                          self->filename);
-  log_writer_set_queue(self->writer, log_dest_driver_acquire_queue(&self->owner->super,
-                       affile_dw_format_persist_name(self)));
+
+  StatsClusterKeyBuilder *driver_sck_builder = stats_cluster_key_builder_new();
+  log_writer_init_driver_sck_builder(self->writer, driver_sck_builder);
+
+  LogQueue *queue = log_dest_driver_acquire_queue(&self->owner->super, affile_dw_format_persist_name(self),
+                                                  self->owner->writer_options.stats_level, driver_sck_builder);
+  log_writer_set_queue(self->writer, queue);
+
+  stats_cluster_key_builder_free(driver_sck_builder);
 
   if (!log_pipe_init((LogPipe *) self->writer))
     {

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -534,8 +534,15 @@ afprogram_dd_init(LogPipe *s)
                          &self->writer_options,
                          self->super.super.id,
                          self->process_info.cmdline->str);
-  log_writer_set_queue(self->writer, log_dest_driver_acquire_queue(&self->super,
-                       afprogram_dd_format_queue_persist_name(self)));
+
+  StatsClusterKeyBuilder *driver_sck_builder = stats_cluster_key_builder_new();
+  log_writer_init_driver_sck_builder(self->writer, driver_sck_builder);
+
+  LogQueue *queue = log_dest_driver_acquire_queue(&self->super, afprogram_dd_format_queue_persist_name(self),
+                                                  self->writer_options.stats_level, driver_sck_builder);
+  log_writer_set_queue(self->writer, queue);
+
+  stats_cluster_key_builder_free(driver_sck_builder);
 
   if (!log_pipe_init((LogPipe *) self->writer))
     {

--- a/modules/diskq/dqtool.c
+++ b/modules/diskq/dqtool.c
@@ -124,13 +124,13 @@ open_queue(char *filename, LogQueue **lq, DiskQueueOptions *options)
   if (options->reliable)
     {
       options->mem_buf_size = 1024 * 1024;
-      *lq = log_queue_disk_reliable_new(options, filename, NULL);
+      *lq = log_queue_disk_reliable_new(options, filename, NULL, STATS_LEVEL0, NULL);
     }
   else
     {
       options->mem_buf_size = 128;
       options->qout_size = 1000;
-      *lq = log_queue_disk_non_reliable_new(options, filename, NULL);
+      *lq = log_queue_disk_non_reliable_new(options, filename, NULL, STATS_LEVEL0, NULL);
     }
 
   if (!log_queue_disk_start(*lq))

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -563,11 +563,13 @@ _set_virtual_functions(LogQueueDiskNonReliable *self)
 }
 
 LogQueue *
-log_queue_disk_non_reliable_new(DiskQueueOptions *options, const gchar *filename, const gchar *persist_name)
+log_queue_disk_non_reliable_new(DiskQueueOptions *options, const gchar *filename, const gchar *persist_name,
+                                gint stats_level, const StatsClusterKeyBuilder *driver_sck_builder)
 {
   g_assert(options->reliable == FALSE);
   LogQueueDiskNonReliable *self = g_new0(LogQueueDiskNonReliable, 1);
-  log_queue_disk_init_instance(&self->super, options, "SLQF", filename, persist_name);
+  log_queue_disk_init_instance(&self->super, options, "SLQF", filename, persist_name, stats_level,
+                               driver_sck_builder);
   self->qbacklog = g_queue_new();
   self->qout = g_queue_new();
   self->qoverflow = g_queue_new();

--- a/modules/diskq/logqueue-disk-non-reliable.h
+++ b/modules/diskq/logqueue-disk-non-reliable.h
@@ -36,6 +36,7 @@ typedef struct _LogQueueDiskNonReliable
   gint qout_size;
 } LogQueueDiskNonReliable;
 
-LogQueue *log_queue_disk_non_reliable_new(DiskQueueOptions *options, const gchar *filename, const gchar *persist_name);
+LogQueue *log_queue_disk_non_reliable_new(DiskQueueOptions *options, const gchar *filename, const gchar *persist_name,
+                                          gint stats_level, const StatsClusterKeyBuilder *driver_sck_builder);
 
 #endif /* LOG_QUEUE_DISK_NON_RELIABLE_H_ */

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -469,11 +469,13 @@ _set_virtual_functions(LogQueueDiskReliable *self)
 }
 
 LogQueue *
-log_queue_disk_reliable_new(DiskQueueOptions *options, const gchar *filename, const gchar *persist_name)
+log_queue_disk_reliable_new(DiskQueueOptions *options, const gchar *filename, const gchar *persist_name,
+                            gint stats_level, const StatsClusterKeyBuilder *driver_sck_builder)
 {
   g_assert(options->reliable == TRUE);
   LogQueueDiskReliable *self = g_new0(LogQueueDiskReliable, 1);
-  log_queue_disk_init_instance(&self->super, options, "SLRQ", filename, persist_name);
+  log_queue_disk_init_instance(&self->super, options, "SLRQ", filename, persist_name, stats_level,
+                               driver_sck_builder);
   if (options->mem_buf_size < 0)
     {
       options->mem_buf_size = PESSIMISTIC_MEM_BUF_SIZE;

--- a/modules/diskq/logqueue-disk-reliable.h
+++ b/modules/diskq/logqueue-disk-reliable.h
@@ -35,6 +35,7 @@ typedef struct _LogQueueDiskReliable
   gint qout_size;
 } LogQueueDiskReliable;
 
-LogQueue *log_queue_disk_reliable_new(DiskQueueOptions *options, const gchar *filename, const gchar *persist_name);
+LogQueue *log_queue_disk_reliable_new(DiskQueueOptions *options, const gchar *filename, const gchar *persist_name,
+                                      gint stats_level, const StatsClusterKeyBuilder *driver_sck_builder);
 
 #endif /* LOGQUEUE_DISK_RELIABLE_H_ */

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -51,7 +51,8 @@ const gchar *log_queue_disk_get_filename(LogQueue *self);
 gboolean log_queue_disk_stop(LogQueue *self, gboolean *persistent);
 gboolean log_queue_disk_start(LogQueue *self);
 void log_queue_disk_init_instance(LogQueueDisk *self, DiskQueueOptions *options, const gchar *qdisk_file_id,
-                                  const gchar *filename, const gchar *persist_name);
+                                  const gchar *filename, const gchar *persist_name, gint stats_level,
+                                  const StatsClusterKeyBuilder *driver_sck_builder);
 void log_queue_disk_restart_corrupted(LogQueueDisk *self);
 void log_queue_disk_free_method(LogQueueDisk *self);
 

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -73,7 +73,6 @@ test_diskq_become_full(gboolean reliable, const gchar *filename)
   StatsClusterKey sc_key;
   stats_cluster_logpipe_key_legacy_set(&sc_key, SCS_DESTINATION, q->persist_name, NULL);
   stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &q->metrics.shared.dropped_messages);
-  stats_counter_set(q->metrics.shared.dropped_messages, 0);
   stats_unlock();
   unlink(filename);
   log_queue_disk_start(q);
@@ -90,9 +89,13 @@ test_diskq_become_full(gboolean reliable, const gchar *filename)
   unlink(filename);
 }
 
-Test(diskq_full, diskq_become_full)
+Test(diskq_full, diskq_become_full_reliable)
 {
   test_diskq_become_full(TRUE, DISKQ_FILENAME_RELIABLE);
+}
+
+Test(diskq_full, diskq_become_full_non_reliable)
+{
   test_diskq_become_full(FALSE, DISKQ_FILENAME_NOT_RELIABLE);
 }
 

--- a/modules/diskq/tests/test_diskq_truncate.c
+++ b/modules/diskq/tests/test_diskq_truncate.c
@@ -43,7 +43,7 @@
 static LogQueue *
 _get_non_reliable_diskqueue(gchar *filename, DiskQueueOptions *options)
 {
-  LogQueue *q = log_queue_disk_non_reliable_new(options, filename, NULL);
+  LogQueue *q = log_queue_disk_non_reliable_new(options, filename, NULL, STATS_LEVEL0, NULL);
   log_queue_set_use_backlog(q, FALSE);
   log_queue_disk_start(q);
   return q;
@@ -242,7 +242,7 @@ _create_reliable_diskqueue(gchar *filename, DiskQueueOptions *options, gboolean 
     truncate_size_ratio = disk_queue_config_get_truncate_size_ratio(configuration);
   options->truncate_size_ratio = truncate_size_ratio;
 
-  q = log_queue_disk_reliable_new(options, filename, "persist-name");
+  q = log_queue_disk_reliable_new(options, filename, "persist-name", STATS_LEVEL0, NULL);
   log_queue_set_use_backlog(q, use_backlog);
   log_queue_disk_start(q);
   return q;

--- a/modules/diskq/tests/test_reliable_backlog.c
+++ b/modules/diskq/tests/test_reliable_backlog.c
@@ -58,7 +58,7 @@ _init_diskq_for_test(const gchar *filename, gint64 size, gint64 membuf_size)
   LogQueueDiskReliable *dq;
 
   _construct_options(&options, size, membuf_size, TRUE);
-  LogQueue *q = log_queue_disk_reliable_new(&options, filename, NULL);
+  LogQueue *q = log_queue_disk_reliable_new(&options, filename, NULL, STATS_LEVEL0, NULL);
   struct stat st;
   num_of_ack = 0;
   unlink(filename);

--- a/modules/examples/sources/threaded-diskq-source/threaded-diskq-source.c
+++ b/modules/examples/sources/threaded-diskq-source/threaded-diskq-source.c
@@ -75,13 +75,13 @@ _load_queue(ThreadedDiskqSourceDriver *self)
   if (self->diskq_options.reliable)
     {
       self->diskq_options.mem_buf_size = 1024 * 1024;
-      self->queue = log_queue_disk_reliable_new(&self->diskq_options, self->filename, NULL);
+      self->queue = log_queue_disk_reliable_new(&self->diskq_options, self->filename, NULL, STATS_LEVEL0, NULL);
     }
   else
     {
       self->diskq_options.mem_buf_size = 128;
       self->diskq_options.qout_size = 1000;
-      self->queue = log_queue_disk_non_reliable_new(&self->diskq_options, self->filename, NULL);
+      self->queue = log_queue_disk_non_reliable_new(&self->diskq_options, self->filename, NULL, STATS_LEVEL0, NULL);
     }
 
   if (!log_queue_disk_start(self->queue))


### PR DESCRIPTION
`LogQueue` currently only has driver level stats counters, the queue level counters are only atomic counters, but do not have `StatsCounterItems` assigned to them.

I am planning to introduce queue level stats counters, which cannot be done because of the following reasons:
  * The counters of `LogQueue`'s (currenlty only driver level ones) are registered in the `log_queue_register_stats_counters()` function. If we registered the owned `StatsCounterItem`s there, we would not be able to set their values between the ctor and the `register_stats_counters()` calls. This is not a problem currently, because we only have atomic counters for the owned counters, which do not have to be registered, but when they become real `StatsCounterItem`s, they would not be modifiable. This applies for new, implementation (e.g. `LogQueueDisk`) specific counters, too.
  * The necessary info for the `StatsClusterKey` of the owned counters are only available in different levels on the call chain. For example `driver_id` and `driver_instance` are available in `LogWriter` and `LogThreadedDestDriver`, an optional `worker_id` is available only in `LogThreadedDestDriver`, the names of the counters ("memory_queue" or "disk_buffer") are available in `LogQueueDisk` and `LogQueueFifo`.

To make our lives easier, I have moved the registration of the counters to the `LogQueue` ctor, and made it to use the `Builder` class. It can be seen, that no one modifies the builder on the call chain (`const`), but the `Builder` for the owned key will be modifiable.

------------------------------------------------------------------------

Although the registration of the counters are now in the ctor, there is still a need to initialize those values after creating the queue, and cleanup the values before freeing the queue. The responsibilities are the following:
  * The counters are registered in the `LogQueue` ctor.
  * If a `LogQueue` implementation does something related to these, they must update them themselves. A new FIFO instance is always empty, so there is nothing to do there. A new disk-buffer instance might start with an existing disk-queue file. In `log_queue_disk_start()` we update the queued counter with `get_length()`, and the non-reliable disk-buffer updates the `memory_usage` counter during its `start()`.
  * The counters are unregistered in the `LogQueue` dtor.
  * The `LogQueue` implementations can reset these values, before they are getting destroyed, for example when they are getting released (`log_queue_disk_stop()` resets these), but in the `LogQueue` dtor we reset these automatically.

With these, now the responsibility is not on the call site (`LogWriter` and `LogThreadedDestDriver`) to call the `unregister()` at the correct time.

Depends on #4383 

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>