### PR TITLE
Fix v3 typing compat

### DIFF
--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -148,7 +148,7 @@ py_log_message_new(LogMessage *msg, GlobalConfig *cfg)
   self->msg = log_msg_ref(msg);
   self->bookmark_data = NULL;
 
-  if (!cfg_is_typing_feature_enabled(cfg))
+  if (cfg_is_config_version_older(cfg, VERSION_VALUE_4_0))
     self->cast_to_strings = TRUE;
   else
     self->cast_to_strings = FALSE;

--- a/modules/python/python-tf.c
+++ b/modules/python/python-tf.c
@@ -99,7 +99,7 @@ static gboolean
 _py_convert_return_value_to_result(PythonTfState *state, const gchar *function_name, PyObject *ret, GString *result,
                                    LogMessageValueType *type)
 {
-  if (!cfg_is_typing_feature_enabled(state->cfg) && !is_py_obj_bytes_or_string_type(ret))
+  if (cfg_is_config_version_older(state->cfg, VERSION_VALUE_4_0) && !is_py_obj_bytes_or_string_type(ret))
     {
       msg_error("$(python): The current config version does not support returning non-string values from Python "
                 "functions. Please return str or bytes values from your Python function, use an explicit syslog-ng "

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -218,13 +218,14 @@ ParameterizedTest(PyLogMessageSetValueTestParams *params, python_log_message, te
 
 Test(python_log_message, test_python_logmessage_set_value_no_typing_support)
 {
+  cfg_set_version_without_validation(configuration, VERSION_VALUE_3_38);
+
   LogMessage *msg = log_msg_new_empty();
 
   PyGILState_STATE gstate;
   gstate = PyGILState_Ensure();
   {
     PyObject *msg_object = py_log_message_new(msg, configuration);
-    ((PyLogMessage *) msg_object)->cast_to_strings = TRUE;
 
     PyDict_SetItemString(_python_main_dict, "test_msg", msg_object);
 
@@ -241,6 +242,8 @@ Test(python_log_message, test_python_logmessage_get_value_no_typing_support)
   const gchar *test_key = "test_field";
   const gchar *test_value = "42";
 
+  cfg_set_version_without_validation(configuration, VERSION_VALUE_3_38);
+
   LogMessage *msg = log_msg_new_empty();
 
   // set from C code as INTEGER
@@ -250,7 +253,6 @@ Test(python_log_message, test_python_logmessage_get_value_no_typing_support)
   gstate = PyGILState_Ensure();
   {
     PyObject *msg_object = py_log_message_new(msg, configuration);
-    ((PyLogMessage *) msg_object)->cast_to_strings = TRUE;
 
     PyDict_SetItemString(_python_main_dict, "test_msg", msg_object);
 

--- a/news/bugfix-4394.md
+++ b/news/bugfix-4394.md
@@ -1,0 +1,1 @@
+`python()`, `db-parser()`, `grouping-by()`, `add-contextual-data()`: fix typing compatibility with <4.0 config versions


### PR DESCRIPTION
Prior to this PR, `python()`, `db-parser()`, `grouping-by()`, and `add-contextual-data()` used the new typing feature regardless of the config version.