### PR TITLE
json-parser: fix parsing non-string arrays 

### DIFF
--- a/modules/json/json-parser.c
+++ b/modules/json/json-parser.c
@@ -205,14 +205,12 @@ json_parser_extract_values_from_complex_json_object(JSONParser *self,
       for (gint i = 0; i < json_object_array_length(jso); i++)
         {
           struct json_object *el = json_object_array_get_idx(jso, i);
-          GString *element_value = scratch_buffers_alloc();
-          LogMessageValueType element_type;
-
-          if (json_parser_extract_string_from_simple_json_object(self, el, element_value, &element_type))
+          if (json_object_get_type(el) == json_type_string)
             {
+              const gchar *element_value = json_object_get_string(el);
               if (i != 0)
                 g_string_append_c(value, ',');
-              str_repr_encode_append(value, element_value->str, element_value->len, NULL);
+              str_repr_encode_append(value, element_value, -1, NULL);
             }
           else
             {

--- a/modules/json/tests/test_json_parser.c
+++ b/modules/json/tests/test_json_parser.c
@@ -147,7 +147,7 @@ Test(json_parser, test_json_parser_validate_type_representation)
   LogParser *json_parser = json_parser_new(NULL);
 
   json_parser_set_prefix(json_parser, ".prefix.");
-  msg = parse_json_into_log_message("{'int': 123, 'booltrue': true, 'boolfalse': false, 'double': 1.23, 'object': {'member1': 'foo', 'member2': 'bar'}, 'array': [1, 2, 3], 'null': null}",
+  msg = parse_json_into_log_message("{'int': 123, 'booltrue': true, 'boolfalse': false, 'double': 1.23, 'object': {'member1': 'foo', 'member2': 'bar'}, 'array': ['1', '2', '3'], 'null': null}",
                                     json_parser);
   assert_log_message_value_and_type_by_name(msg, ".prefix.int", "123", LM_VT_INTEGER);
   assert_log_message_value_and_type_by_name(msg, ".prefix.booltrue", "true", LM_VT_BOOLEAN);
@@ -173,11 +173,11 @@ Test(json_parser, test_json_parser_different_type_arrays)
                                     " 'dblarray': [1.234,1e6,5.6789],"
                                     " 'nullarray': [null,null,null,null]}",
                                     json_parser);
-  assert_log_message_value_and_type_by_name(msg, ".prefix.intarray", "1,2,3", LM_VT_LIST);
+  assert_log_message_value_and_type_by_name(msg, ".prefix.intarray", "[1,2,3]", LM_VT_JSON);
   assert_log_message_value_and_type_by_name(msg, ".prefix.strarray", "foo,bar,baz", LM_VT_LIST);
-  assert_log_message_value_and_type_by_name(msg, ".prefix.boolarray", "true,false,true", LM_VT_LIST);
-  assert_log_message_value_and_type_by_name(msg, ".prefix.dblarray", "1.234000,1000000.000000,5.678900", LM_VT_LIST);
-  assert_log_message_value_and_type_by_name(msg, ".prefix.nullarray", "\"\",\"\",\"\",\"\"", LM_VT_LIST);
+  assert_log_message_value_and_type_by_name(msg, ".prefix.boolarray", "[true,false,true]", LM_VT_JSON);
+  assert_log_message_value_and_type_by_name(msg, ".prefix.dblarray", "[1.234,1e6,5.6789]", LM_VT_JSON);
+  assert_log_message_value_and_type_by_name(msg, ".prefix.nullarray", "[null,null,null,null]", LM_VT_JSON);
   log_msg_unref(msg);
   log_pipe_unref(&json_parser->super);
 }
@@ -251,7 +251,7 @@ Test(json_parser, test_json_parser_extracts_subobjects_if_extract_prefix_is_spec
   log_pipe_unref(&json_parser->super);
 }
 
-Test(json_parser, test_json_parser_extracts_array_elements_into_matches)
+Test(json_parser, test_json_parser_extracts_top_level_array_elements_into_matches)
 {
   LogMessage *msg;
   LogParser *json_parser = json_parser_new(NULL);

--- a/news/bugfix-4396.md
+++ b/news/bugfix-4396.md
@@ -1,0 +1,4 @@
+`json-parser()`: Fixed parsing non-string arrays.
+
+syslog-ng now no longer parses non-string arrays to list of strings, losing the original type
+information of the array's elements.


### PR DESCRIPTION
Fixes #4387.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>