### PR TITLE
disk-buffer: add metrics for abandoned disk-buffer files

### DIFF
--- a/lib/stats/stats-cluster-key-builder.c
+++ b/lib/stats/stats-cluster-key-builder.c
@@ -25,6 +25,9 @@
 #include "stats/stats-cluster-single.h"
 #include "stats/stats-cluster-logpipe.h"
 
+#include <string.h>
+#include <stdio.h>
+
 struct _StatsClusterKeyBuilder
 {
   gchar *name;

--- a/lib/stats/stats-registry.c
+++ b/lib/stats/stats-registry.c
@@ -356,6 +356,31 @@ stats_get_cluster(const StatsClusterKey *sc_key)
 }
 
 gboolean
+stats_remove_cluster(const StatsClusterKey *sc_key)
+{
+  g_assert(stats_locked);
+  StatsCluster *sc;
+
+  sc = g_hash_table_lookup(stats_cluster_container.dynamic_clusters, sc_key);
+  if (sc)
+    {
+      if (stats_cluster_is_orphaned(sc))
+        return g_hash_table_remove(stats_cluster_container.dynamic_clusters, sc_key);
+      return FALSE;
+    }
+
+  sc = g_hash_table_lookup(stats_cluster_container.static_clusters, sc_key);
+  if (sc)
+    {
+      if (stats_cluster_is_orphaned(sc))
+        return g_hash_table_remove(stats_cluster_container.static_clusters, sc_key);
+      return FALSE;
+    }
+
+  return FALSE;
+}
+
+gboolean
 stats_contains_counter(const StatsClusterKey *sc_key, gint type)
 {
   g_assert(stats_locked);

--- a/lib/stats/stats-registry.h
+++ b/lib/stats/stats-registry.h
@@ -56,6 +56,7 @@ void stats_unregister_dynamic_counter(StatsCluster *handle, gint type, StatsCoun
 gboolean stats_contains_counter(const StatsClusterKey *sc_key, gint type);
 StatsCounterItem *stats_get_counter(const StatsClusterKey *sc_key, gint type);
 StatsCluster *stats_get_cluster(const StatsClusterKey *sc_key);
+gboolean stats_remove_cluster(const StatsClusterKey *sc_key);
 
 void stats_foreach_counter(StatsForeachCounterFunc func, gpointer user_data, gboolean *cancelled);
 void stats_foreach_legacy_counter(StatsForeachCounterFunc func, gpointer user_data, gboolean *cancelled);

--- a/modules/diskq/diskq-global-metrics.c
+++ b/modules/diskq/diskq-global-metrics.c
@@ -106,6 +106,29 @@ _is_non_corrupted_disk_buffer_file(const gchar *dir, const gchar *filename)
 }
 
 static void
+_init_abandoned_disk_buffer_sc_keys(StatsClusterKey *queued_sc_key, StatsClusterKey *capacity_sc_key,
+                                    StatsClusterKey *disk_allocated_sc_key, StatsClusterKey *disk_usage_sc_key,
+                                    const gchar *abs_filename, gboolean reliable)
+{
+  enum { labels_len = 3 };
+  static StatsClusterLabel labels[labels_len];
+  labels[0] = stats_cluster_label("abandoned", "true");
+  labels[1] = stats_cluster_label("path", abs_filename);
+  labels[2] = stats_cluster_label("reliable", reliable ? "true" : "false");
+
+  stats_cluster_single_key_set(queued_sc_key, "disk_queue_events", labels, labels_len);
+
+  stats_cluster_single_key_set(capacity_sc_key, "disk_queue_capacity_bytes", labels, labels_len);
+  stats_cluster_single_key_add_unit(capacity_sc_key, SCU_KIB);
+
+  stats_cluster_single_key_set(disk_allocated_sc_key, "disk_queue_disk_allocated_bytes", labels, labels_len);
+  stats_cluster_single_key_add_unit(disk_allocated_sc_key, SCU_KIB);
+
+  stats_cluster_single_key_set(disk_usage_sc_key, "disk_queue_disk_usage_bytes", labels, labels_len);
+  stats_cluster_single_key_add_unit(disk_usage_sc_key, SCU_KIB);
+}
+
+static void
 _track_disk_buffer_files_in_dir(const gchar *dir, GHashTable *tracked_files)
 {
   DIR *dir_stream = opendir(dir);

--- a/modules/diskq/diskq-global-metrics.c
+++ b/modules/diskq/diskq-global-metrics.c
@@ -72,18 +72,21 @@ _dir_watch_timer_start(DiskQGlobalMetrics *self)
   iv_timer_register(&self->dir_watch_timer);
 }
 
+/* Must be called with the lock held. */
 static void
 _track_acquired_file(GHashTable *tracked_files, const gchar *filename)
 {
   g_hash_table_insert(tracked_files, g_strdup(filename), GINT_TO_POINTER((gint) TRUE));
 }
 
+/* Must be called with the lock held. */
 static void
 _track_released_file(GHashTable *tracked_files, const gchar *filename)
 {
   g_hash_table_insert(tracked_files, g_strdup(filename), GINT_TO_POINTER((gint) FALSE));
 }
 
+/* Must be called with the lock held. */
 static gboolean
 _is_file_tracked(GHashTable *tracked_files, const gchar *filename)
 {
@@ -109,6 +112,7 @@ _is_non_corrupted_disk_buffer_file(const gchar *dir, const gchar *filename)
          _file_exists_and_non_empty(dir, filename);
 }
 
+/* Must be called with the lock held. */
 static void
 _init_abandoned_disk_buffer_sc_keys(StatsClusterKey *queued_sc_key, StatsClusterKey *capacity_sc_key,
                                     StatsClusterKey *disk_allocated_sc_key, StatsClusterKey *disk_usage_sc_key,
@@ -150,6 +154,7 @@ _create_log_queue_disk(DiskQueueOptions *options, const gchar *abs_filename)
     return (LogQueueDisk *) log_queue_disk_non_reliable_new(options, abs_filename, NULL, STATS_LEVEL0, NULL, NULL);
 }
 
+/* Must be called with the lock held. */
 static void
 _set_abandoned_disk_buffer_file_metrics(const gchar *dir, const gchar *filename)
 {
@@ -199,6 +204,7 @@ _set_abandoned_disk_buffer_file_metrics(const gchar *dir, const gchar *filename)
   g_free(abs_filename);
 }
 
+/* Must be called with the lock held. */
 static void
 _unset_abandoned_disk_buffer_file_metrics(const gchar *dir, const gchar *filename)
 {
@@ -222,6 +228,7 @@ _unset_abandoned_disk_buffer_file_metrics(const gchar *dir, const gchar *filenam
   g_free(abs_filename);
 }
 
+/* Must be called with the lock held. */
 static void
 _track_disk_buffer_files_in_dir(const gchar *dir, GHashTable *tracked_files)
 {
@@ -268,6 +275,7 @@ _get_available_space_mib_in_dir(const gchar *dir, gint64 *available_space_mib)
   return TRUE;
 }
 
+/* Must be called with the lock held. */
 static void
 _init_dir_sc_keys(StatsClusterKey *available_bytes_sc_key, const gchar *dir)
 {
@@ -280,6 +288,7 @@ _init_dir_sc_keys(StatsClusterKey *available_bytes_sc_key, const gchar *dir)
   stats_cluster_single_key_add_unit(available_bytes_sc_key, SCU_MIB);
 }
 
+/* Must be called with the lock held. */
 static void
 _update_dir_metrics(gpointer key, gpointer value, gpointer user_data)
 {
@@ -317,6 +326,7 @@ _update_all_dir_metrics(gpointer s)
   _dir_watch_timer_start(self);
 }
 
+/* Must be called with the lock held. */
 static void
 _unset_dir_metrics(const gchar *dir)
 {
@@ -330,6 +340,7 @@ _unset_dir_metrics(const gchar *dir)
   stats_unlock();
 }
 
+/* Must be called with the lock held. */
 static void
 _unset_abandoned_disk_buffer_file_metrics_foreach_fn(gpointer key, gpointer value, gpointer user_data)
 {
@@ -343,6 +354,7 @@ _unset_abandoned_disk_buffer_file_metrics_foreach_fn(gpointer key, gpointer valu
   _unset_abandoned_disk_buffer_file_metrics(dir, filename);
 }
 
+/* Must be called with the lock held. */
 static void
 _unset_all_metrics_in_dir(gpointer key, gpointer value, gpointer user_data)
 {

--- a/modules/diskq/diskq-global-metrics.c
+++ b/modules/diskq/diskq-global-metrics.c
@@ -33,6 +33,7 @@
 #include "timeutils/misc.h"
 #include "qdisk.h"
 
+#include <errno.h>
 #include <iv.h>
 #include <dirent.h>
 #include <sys/stat.h>
@@ -235,9 +236,9 @@ _track_disk_buffer_files_in_dir(const gchar *dir, GHashTable *tracked_files)
   DIR *dir_stream = opendir(dir);
   if (!dir_stream)
     {
-      msg_error("disk-buffer: Failed to list files in dir",
+      msg_debug("disk-buffer: Failed to list files in dir",
                 evt_tag_str("dir", dir),
-                evt_tag_error("error"));
+                evt_tag_str("error", g_strerror(errno)));
       return;
     }
 
@@ -264,9 +265,9 @@ _get_available_space_mib_in_dir(const gchar *dir, gint64 *available_space_mib)
   struct statvfs stat;
   if (statvfs(dir, &stat) < 0 )
     {
-      msg_error("disk-buffer: Failed to get filesystem info",
+      msg_debug("disk-buffer: Failed to get filesystem info",
                 evt_tag_str("dir", dir),
-                evt_tag_error("error"));
+                evt_tag_str("error", g_strerror(errno)));
       return FALSE;
     }
 

--- a/modules/diskq/diskq-global-metrics.h
+++ b/modules/diskq/diskq-global-metrics.h
@@ -27,5 +27,7 @@
 
 void diskq_global_metrics_init(void);
 void diskq_global_metrics_watch_dir(const gchar *dir);
+void diskq_global_metrics_file_acquired(const gchar *abs_filename);
+void diskq_global_metrics_file_released(const gchar *abs_filename);
 
 #endif /* DISKQ_GLOBAL_METRICS_H_ */

--- a/modules/diskq/diskq-global-metrics.h
+++ b/modules/diskq/diskq-global-metrics.h
@@ -26,7 +26,6 @@
 #include "syslog-ng.h"
 
 void diskq_global_metrics_init(void);
-void diskq_global_metrics_watch_dir(const gchar *dir);
 void diskq_global_metrics_file_acquired(const gchar *abs_filename);
 void diskq_global_metrics_file_released(const gchar *abs_filename);
 

--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -162,6 +162,7 @@ exit:
       log_queue_set_throttle(queue, dd->throttle);
 
       const gchar *qfile_name = log_queue_disk_get_filename(queue);
+      diskq_global_metrics_file_acquired(qfile_name);
       if (persist_name && qfile_name)
         persist_state_alloc_string(cfg->state, persist_name, qfile_name, -1);
     }
@@ -179,6 +180,8 @@ _release_queue(LogDestDriver *dd, LogQueue *queue)
   gboolean persistent;
 
   log_queue_disk_stop(queue, &persistent);
+  diskq_global_metrics_file_released(log_queue_disk_get_filename(queue));
+
   if (queue->persist_name)
     {
       cfg_persist_config_add(cfg, queue->persist_name, queue, (GDestroyNotify) log_queue_unref);

--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -304,8 +304,6 @@ _attach(LogDriverPlugin *s, LogDriver *d)
   if (!_set_truncate_size_ratio_and_prealloc(self, dd))
     return FALSE;
 
-  diskq_global_metrics_watch_dir(self->options.dir);
-
   dd->acquire_queue = _acquire_queue;
   dd->release_queue = _release_queue;
   return TRUE;

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1665,7 +1665,8 @@ _init_qdisk_file(QDisk *self)
 static gboolean
 _create_qdisk_file(QDisk *self)
 {
-  g_assert(!self->options->read_only);
+  if (self->options->read_only)
+    return FALSE;
 
   if (self->options->disk_buf_size == -1)
     {

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -320,6 +320,29 @@ qdisk_is_file_a_disk_buffer_file(const gchar *filename)
 }
 
 gboolean
+qdisk_is_disk_buffer_file_reliable(const gchar *filename, gboolean *reliable)
+{
+  const gsize extension_start = strlen(QDISK_FILENAME_PREFIX QDISK_FILENAME_IDX_EXAMPLE);
+
+  if (strlen(filename) < extension_start + MIN(strlen(QDISK_FILENAME_REL_EXT), strlen(QDISK_FILENAME_NON_REL_EXT)))
+    return FALSE;
+
+  if (strncmp(&filename[extension_start], QDISK_FILENAME_REL_EXT, strlen(QDISK_FILENAME_REL_EXT)) == 0)
+    {
+      *reliable = TRUE;
+      return TRUE;
+    }
+
+  if (strncmp(&filename[extension_start], QDISK_FILENAME_NON_REL_EXT, strlen(QDISK_FILENAME_NON_REL_EXT)) == 0)
+    {
+      *reliable = FALSE;
+      return TRUE;
+    }
+
+  return FALSE;
+}
+
+gboolean
 qdisk_started(QDisk *self)
 {
   return self->fd >= 0;

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -36,6 +36,8 @@
 #include <sys/mman.h>
 #include <errno.h>
 #include <unistd.h>
+#include <stdio.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/file.h>
 
@@ -50,6 +52,18 @@
 #define PATH_QDISK              PATH_LOCALSTATEDIR
 
 #define QDISK_HDR_VERSION_CURRENT 3
+
+#define QDISK_FILENAME_PREFIX "syslog-ng-"
+#define QDISK_FILENAME_IDX_FMT "%05d"
+#define QDISK_FILENAME_IDX_EXAMPLE "00000"
+
+#define QDISK_FILENAME_REL_EXT ".rqf"
+#define QDISK_FILENAME_REL_FORMAT QDISK_FILENAME_PREFIX QDISK_FILENAME_IDX_FMT QDISK_FILENAME_REL_EXT
+#define QDISK_FILENAME_REL_EXAMPLE QDISK_FILENAME_PREFIX QDISK_FILENAME_IDX_EXAMPLE QDISK_FILENAME_REL_EXT
+
+#define QDISK_FILENAME_NON_REL_EXT ".qf"
+#define QDISK_FILENAME_NON_REL_FMT QDISK_FILENAME_PREFIX QDISK_FILENAME_IDX_FMT QDISK_FILENAME_NON_REL_EXT
+#define QDISK_FILENAME_NON_REL_EXAMPLE QDISK_FILENAME_PREFIX QDISK_FILENAME_IDX_EXAMPLE QDISK_FILENAME_NON_REL_EXT
 
 #define DIRLOCK_FILENAME "syslog-ng-disk-buffer.dirlock"
 
@@ -246,10 +260,8 @@ qdisk_get_next_filename(const gchar *dir, gboolean reliable)
   for (gint i = 0; i < 10000; i++)
     {
       gchar filename_buffer[256];
-      if (reliable)
-        g_snprintf(filename_buffer, sizeof(filename_buffer), "syslog-ng-%05d.rqf", i);
-      else
-        g_snprintf(filename_buffer, sizeof(filename_buffer), "syslog-ng-%05d.qf", i);
+      g_snprintf(filename_buffer, sizeof(filename_buffer),
+                 reliable ? QDISK_FILENAME_REL_FORMAT : QDISK_FILENAME_NON_REL_FMT, i);
 
       filename = g_build_path(G_DIR_SEPARATOR_S, dir, filename_buffer, NULL);
 
@@ -276,6 +288,35 @@ qdisk_get_next_filename(const gchar *dir, gboolean reliable)
 
   _release_dirlock(dirlock_fd);
   return filename;
+}
+
+gboolean
+qdisk_is_file_a_disk_buffer_file(const gchar *filename)
+{
+  const gsize min_len = MIN(strlen(QDISK_FILENAME_REL_EXAMPLE), strlen(QDISK_FILENAME_NON_REL_EXAMPLE));
+  const gsize prefix_len = strlen(QDISK_FILENAME_PREFIX);
+  const gsize extension_start = strlen(QDISK_FILENAME_PREFIX QDISK_FILENAME_IDX_EXAMPLE);
+
+  gsize len = strlen(filename);
+  if (len < min_len)
+    return FALSE;
+
+  if (strncmp(filename, "syslog-ng-", prefix_len) != 0)
+    return FALSE;
+
+  for (gint i = prefix_len; i < extension_start; i++)
+    {
+      if (!g_ascii_isdigit(filename[i]))
+        return FALSE;
+    }
+
+  if (strncmp(&filename[extension_start], QDISK_FILENAME_REL_EXT, strlen(QDISK_FILENAME_REL_EXT)) != 0 &&
+      strncmp(&filename[extension_start], QDISK_FILENAME_NON_REL_EXT, strlen(QDISK_FILENAME_NON_REL_EXT)) != 0)
+    {
+      return FALSE;
+    }
+
+  return TRUE;
 }
 
 gboolean

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -87,6 +87,7 @@ const gchar *qdisk_get_filename(QDisk *self);
 gint64 qdisk_get_file_size(QDisk *self);
 
 gchar *qdisk_get_next_filename(const gchar *dir, gboolean reliable);
+gboolean qdisk_is_file_a_disk_buffer_file(const gchar *filename);
 
 gboolean qdisk_serialize(GString *serialized, QDiskSerializeFunc serialize_func, gpointer user_data, GError **error);
 gboolean qdisk_deserialize(GString *serialized, QDiskDeSerializeFunc deserialize_func, gpointer user_data,

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -88,6 +88,7 @@ gint64 qdisk_get_file_size(QDisk *self);
 
 gchar *qdisk_get_next_filename(const gchar *dir, gboolean reliable);
 gboolean qdisk_is_file_a_disk_buffer_file(const gchar *filename);
+gboolean qdisk_is_disk_buffer_file_reliable(const gchar *filename, gboolean *reliable);
 
 gboolean qdisk_serialize(GString *serialized, QDiskSerializeFunc serialize_func, gpointer user_data, GError **error);
 gboolean qdisk_deserialize(GString *serialized, QDiskDeSerializeFunc deserialize_func, gpointer user_data,

--- a/modules/diskq/tests/test_diskq_counters.c
+++ b/modules/diskq/tests/test_diskq_counters.c
@@ -27,6 +27,7 @@
 #include "test_diskq_tools.h"
 
 #include "diskq.h"
+#include "diskq-global-metrics.h"
 #include "logqueue-disk.h"
 #include "apphook.h"
 
@@ -39,6 +40,7 @@ _setup_with_persist(const gchar *persist_file)
   configuration->stats_options.level = STATS_LEVEL1;
   configuration->state = persist_state_new(persist_file);
   persist_state_start(configuration->state);
+  diskq_global_metrics_init();
   cfg_init(configuration);
 }
 

--- a/news/feature-4402.md
+++ b/news/feature-4402.md
@@ -1,0 +1,11 @@
+`disk-buffer`: Added metrics for abandoned disk-buffer files.
+
+Availability is the same as the `disk_queue_dir_available_bytes` metric.
+
+Example metrics:
+```
+syslogng_disk_queue_capacity_bytes{abandoned="true",path="/var/syslog-ng/syslog-ng-00000.rqf",reliable="true"} 104853504
+syslogng_disk_queue_disk_allocated_bytes{abandoned="true",path="/var/syslog-ng/syslog-ng-00000.rqf",reliable="true"} 273408
+syslogng_disk_queue_disk_usage_bytes{abandoned="true",path="/var/syslog-ng/syslog-ng-00000.rqf",reliable="true"} 269312
+syslogng_disk_queue_events{abandoned="true",path="/var/syslog-ng/syslog-ng-00000.rqf",reliable="true"} 860
+```


### PR DESCRIPTION
Availability is the same as the `disk_queue_dir_available_bytes` metric.

Example metrics:
```
syslogng_disk_queue_capacity_bytes{abandoned="true",path="/var/syslog-ng/syslog-ng-00000.rqf",reliable="true"} 104853504
syslogng_disk_queue_disk_allocated_bytes{abandoned="true",path="/var/syslog-ng/syslog-ng-00000.rqf",reliable="true"} 273408
syslogng_disk_queue_disk_usage_bytes{abandoned="true",path="/var/syslog-ng/syslog-ng-00000.rqf",reliable="true"} 269312
syslogng_disk_queue_events{abandoned="true",path="/var/syslog-ng/syslog-ng-00000.rqf",reliable="true"} 860
```

Depends on #4399 and #4356.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>

Fixes #4400