### PR TITLE
Fix type validation in "pdbtool test"

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -241,7 +241,7 @@ log_msg_value_type_to_str(LogMessageValueType self)
     [LM_VT_JSON] = "json",
     [LM_VT_BOOLEAN] = "boolean",
     [__COMPAT_LM_VT_INT32] = "compat-int32",
-    [LM_VT_INTEGER] = "integer",
+    [LM_VT_INTEGER] = "int",
     [LM_VT_DOUBLE] = "double",
     [LM_VT_DATETIME] = "datetime",
     [LM_VT_LIST] = "list",
@@ -261,7 +261,8 @@ log_msg_value_type_from_str(const gchar *in_str, LogMessageValueType *out_type)
     *out_type = LM_VT_JSON;
   else if (strcmp(in_str, "boolean") == 0)
     *out_type = LM_VT_BOOLEAN;
-  else if (strcmp(in_str, "int32") == 0 || strcmp(in_str, "int") == 0 || strcmp(in_str, "int64") == 0)
+  else if (strcmp(in_str, "int32") == 0 || strcmp(in_str, "int") == 0 || strcmp(in_str, "int64") == 0
+           || strcmp(in_str, "integer") == 0)
     *out_type = LM_VT_INTEGER;
   else if (strcmp(in_str, "double") == 0 || strcmp(in_str, "float") == 0)
     *out_type = LM_VT_DOUBLE;

--- a/modules/correlation/pdbtool/pdbtool.c
+++ b/modules/correlation/pdbtool/pdbtool.c
@@ -682,33 +682,38 @@ static gboolean
 pdbtool_test_value(LogMessage *msg, const gchar *name, const gchar *test_value, const gchar *test_type)
 {
   const gchar *value;
-  const gchar *type;
   gssize value_len;
-  LogMessageValueType t;
+  LogMessageValueType t, test_t;
   gboolean ret = TRUE;
 
   value = log_msg_get_value_by_name_with_type(msg, name, &value_len, &t);
-  type = log_msg_value_type_to_str(t);
+
+  if (!log_msg_value_type_from_str(test_type, &test_t))
+    {
+      printf(" Unknown type name specified in test_value, name='%s', expected_type='%s'\n", name, test_type);
+      return FALSE;
+    }
 
   if (!test_type)
     {
       /* not interested in validating the type */
-      test_type = type;
+      test_t = t;
     }
 
   if (!(value && strncmp(value, test_value, value_len) == 0 && value_len == strlen(test_value)
-        && strcmp(type, test_type) == 0))
+        && t == test_t))
     {
       if (value)
         printf(" Wrong match name='%s', value='%.*s', type='%s', expected='%s', expected_type='%s'\n", name, (gint) value_len,
-               value, type, test_value, test_type);
+               value, log_msg_value_type_to_str(t), test_value, log_msg_value_type_to_str(test_t));
       else
         printf(" No value to match name='%s', expected='%s'\n", name, test_value);
 
       ret = FALSE;
     }
   else if (verbose_flag)
-    printf(" Match name='%s', value='%.*s', type='%s', expected='%s'\n", name, (gint) value_len, value, type, test_value);
+    printf(" Match name='%s', value='%.*s', type='%s', expected='%s'\n", name, (gint) value_len, value,
+           log_msg_value_type_to_str(t), test_value);
 
   return ret;
 }

--- a/modules/correlation/pdbtool/pdbtool.c
+++ b/modules/correlation/pdbtool/pdbtool.c
@@ -688,16 +688,18 @@ pdbtool_test_value(LogMessage *msg, const gchar *name, const gchar *test_value, 
 
   value = log_msg_get_value_by_name_with_type(msg, name, &value_len, &t);
 
-  if (!log_msg_value_type_from_str(test_type, &test_t))
-    {
-      printf(" Unknown type name specified in test_value, name='%s', expected_type='%s'\n", name, test_type);
-      return FALSE;
-    }
-
   if (!test_type)
     {
       /* not interested in validating the type */
       test_t = t;
+    }
+  else
+    {
+      if (!log_msg_value_type_from_str(test_type, &test_t))
+        {
+          printf(" Unknown type name specified in test_value, name='%s', expected_type='%s'\n", name, test_type);
+          return FALSE;
+        }
     }
 
   if (!(value && strncmp(value, test_value, value_len) == 0 && value_len == strlen(test_value)
@@ -840,7 +842,7 @@ pdbtool_test(int argc, char *argv[])
               for (i = 0; example->values && i < example->values->len; i++)
                 {
                   gchar **nv = g_ptr_array_index(example->values, i);
-                  if (!pdbtool_test_value(msg, nv[0], nv[1], nv[2] ? : "string"))
+                  if (!pdbtool_test_value(msg, nv[0], nv[1], nv[2]))
                     failed_to_match = TRUE;
                 }
 

--- a/modules/correlation/pdbtool/pdbtool.c
+++ b/modules/correlation/pdbtool/pdbtool.c
@@ -714,8 +714,8 @@ pdbtool_test_value(LogMessage *msg, const gchar *name, const gchar *test_value, 
       ret = FALSE;
     }
   else if (verbose_flag)
-    printf(" Match name='%s', value='%.*s', type='%s', expected='%s'\n", name, (gint) value_len, value,
-           log_msg_value_type_to_str(t), test_value);
+    printf(" Match name='%s', value='%.*s', type='%s%s', expected='%s'\n", name, (gint) value_len, value,
+           log_msg_value_type_to_str(t), test_type ? "" : "[unchecked]", test_value);
 
   return ret;
 }

--- a/news/bugfix-4405.md
+++ b/news/bugfix-4405.md
@@ -1,0 +1,13 @@
+`pdbtool test`: fix two type validation bugs:
+
+  1) When `pdbtool test` validates the type information associated with a name-value
+     pair, it was using string comparisons, which didn't take type aliases
+     into account. This is now fixed, so that "int", "integer" or "int64"
+     can all be used to mean the same type.
+
+  2) When type information is missing from a `<test_value/>` tag, don't
+     validate it against "string", rather accept any extracted type.
+
+In addition to these fixes, a new alias "integer" was added to mean the same
+as "int", simply because syslog-ng was erroneously using this term when
+reporting type information in its own messages.


### PR DESCRIPTION
`pdbtool test`: fix two type validation bugs:

  1) When `pdbtool test` validates the type information associated with a name-value
     pair, it was using string comparisons, which didn't take type aliases
     into account. This is now fixed, so that "int", "integer" or "int64"
     can all be used to mean the same type.

  2) When type information is missing from a `<test_value/>` tag, don't
     validate it against "string", rather accept any extracted type.

In addition to these fixes, a new alias "integer" was added to mean the same
as "int", simply because syslog-ng was erroneously using this term when
reporting type information in its own messages.
