### PR TITLE
CMake:  Silenced some warnings

### DIFF
--- a/cmake/Modules/LibFindMacros.cmake
+++ b/cmake/Modules/LibFindMacros.cmake
@@ -150,6 +150,13 @@ function (libfind_process PREFIX)
   set(includeopts ${${PREFIX}_PROCESS_INCLUDES})
   set(libraryopts ${${PREFIX}_PROCESS_LIBS})
 
+  # Process optional arguments
+  foreach(arg ${ARGN})
+    if (arg STREQUAL "QUIET")
+      set(quiet TRUE)
+    endif()
+  endforeach()
+
   # Process deps to add to
   foreach (i ${PREFIX} ${${PREFIX}_DEPENDENCIES})
     if (DEFINED ${i}_INCLUDE_OPTS OR DEFINED ${i}_LIBRARY_OPTS)

--- a/modules/afsmtp/CMakeLists.txt
+++ b/modules/afsmtp/CMakeLists.txt
@@ -1,4 +1,6 @@
-find_package(ESMTP)
+if (NOT DEFINED ENABLE_AFSMTP OR ENABLE_AFSMTP)
+  find_package(ESMTP)
+endif()
 
 module_switch(ENABLE_AFSMTP "Enable SMTP destination" ESMTP_FOUND)
 

--- a/modules/afsnmp/CMakeLists.txt
+++ b/modules/afsnmp/CMakeLists.txt
@@ -1,4 +1,6 @@
-find_package(NETSNMP)
+if (NOT DEFINED ENABLE_AFSNMP OR ENABLE_AFSNMP)
+  find_package(NETSNMP)
+endif()
 
 module_switch(ENABLE_AFSNMP "Enable afsnmp module" NETSNMP_FOUND)
 

--- a/modules/afsql/CMakeLists.txt
+++ b/modules/afsql/CMakeLists.txt
@@ -1,5 +1,7 @@
-find_package(LIBDBI)
-find_package(OpenSSL)
+if (NOT DEFINED ENABLE_SQL OR ENABLE_SQL)
+  find_package(LIBDBI)
+  find_package(OpenSSL)
+endif()
 
 module_switch(ENABLE_SQL "Enable SQL plugin" LIBDBI_FOUND)
 if (NOT ENABLE_SQL)

--- a/modules/ebpf/CMakeLists.txt
+++ b/modules/ebpf/CMakeLists.txt
@@ -1,4 +1,6 @@
-find_package(LIBBPF)
+if (NOT DEFINED ENABLE_EBPF OR ENABLE_EBPF)
+  find_package(LIBBPF)
+endif()
 
 module_switch(ENABLE_EBPF "Enable ebpf module (requires ebpf toolchain)" LIBBPF_FOUND)
 

--- a/modules/geoip2/CMakeLists.txt
+++ b/modules/geoip2/CMakeLists.txt
@@ -1,4 +1,6 @@
-find_package(LIBMAXMINDDB)
+if (NOT DEFINED ENABLE_GEOIP2 OR ENABLE_GEOIP2)
+  find_package(LIBMAXMINDDB)
+endif()
 
 module_switch(ENABLE_GEOIP2 "Enable geoip2 parser and template function" LIBMAXMINDDB_FOUND)
 

--- a/modules/http/CMakeLists.txt
+++ b/modules/http/CMakeLists.txt
@@ -1,4 +1,6 @@
-find_package(Curl)
+if (NOT DEFINED ENABLE_CURL OR ENABLE_CURL)
+  find_package(Curl)
+endif()
 
 module_switch(ENABLE_CURL "Enable http destination" Curl_FOUND)
 if (NOT ENABLE_CURL)

--- a/modules/json/CMakeLists.txt
+++ b/modules/json/CMakeLists.txt
@@ -1,4 +1,6 @@
-external_or_find_package(JSONC)
+if (NOT DEFINED ENABLE_JSON OR ENABLE_JSON)
+  external_or_find_package(JSONC)
+endif()
 
 module_switch(ENABLE_JSON "Enable JSON plugin" JSONC_FOUND)
 if (NOT ENABLE_JSON)

--- a/modules/mqtt/CMakeLists.txt
+++ b/modules/mqtt/CMakeLists.txt
@@ -1,4 +1,6 @@
-find_package(eclipse-paho-mqtt-c)
+if (NOT DEFINED ENABLE_MQTT OR ENABLE_MQTT)
+  find_package(eclipse-paho-mqtt-c)
+endif()
 
 module_switch(ENABLE_MQTT "Enable mqtt" eclipse-paho-mqtt-c_FOUND)
 if (NOT ENABLE_MQTT)

--- a/modules/redis/CMakeLists.txt
+++ b/modules/redis/CMakeLists.txt
@@ -1,4 +1,6 @@
-find_package(Hiredis)
+if (NOT DEFINED ENABLE_REDIS OR ENABLE_REDIS)
+  find_package(Hiredis)
+endif()
 
 module_switch(ENABLE_REDIS "Enable redis module" HIREDIS_FOUND)
 if (NOT ENABLE_REDIS)

--- a/modules/riemann/CMakeLists.txt
+++ b/modules/riemann/CMakeLists.txt
@@ -1,4 +1,7 @@
-find_package(RiemannClient)
+if (NOT DEFINED ENABLE_RIEMANN OR ENABLE_RIEMANN)
+  find_package(RiemannClient)
+endif()
+
 if (HAVE_RIEMANN_MICROSECONDS)
   add_definitions("-DSYSLOG_NG_HAVE_RIEMANN_MICROSECONDS")
 endif()


### PR DESCRIPTION
- eliminated package/lib/source detection for modules that were explicitly disabled already (some modules already care about this, but these were not)
- handling now the QUIET option in libfind_process

Signed-off-by: Hofi <hofione@gmail.com>
