### PR TITLE
`python()`: new `LogMessage` methods and bugfixes

### DIFF
--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -66,7 +66,7 @@ _py_log_message_subscript(PyObject *o, PyObject *key)
       return NULL;
     }
 
-  if (py_msg->cast_to_strings)
+  if (py_msg->cast_to_bytes)
     type = LM_VT_STRING;
 
   APPEND_ZERO(value, value, value_len);
@@ -101,7 +101,7 @@ _py_log_message_ass_subscript(PyObject *o, PyObject *key, PyObject *value)
   if (!value)
     return -1;
 
-  if (py_msg->cast_to_strings && !is_py_obj_bytes_or_string_type(value))
+  if (py_msg->cast_to_bytes && !is_py_obj_bytes_or_string_type(value))
     {
       PyErr_Format(PyExc_ValueError,
                    "str or unicode object expected as log message values, got type %s (key %s). "
@@ -149,9 +149,9 @@ py_log_message_new(LogMessage *msg, GlobalConfig *cfg)
   self->bookmark_data = NULL;
 
   if (cfg_is_config_version_older(cfg, VERSION_VALUE_4_0))
-    self->cast_to_strings = TRUE;
+    self->cast_to_bytes = TRUE;
   else
-    self->cast_to_strings = FALSE;
+    self->cast_to_bytes = FALSE;
   return (PyObject *) self;
 }
 

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -104,10 +104,10 @@ _py_log_message_ass_subscript(PyObject *o, PyObject *key, PyObject *value)
   if (py_msg->cast_to_bytes && !is_py_obj_bytes_or_string_type(value))
     {
       PyErr_Format(PyExc_ValueError,
-                   "str or unicode object expected as log message values, got type %s (key %s). "
+                   "str or bytes object expected as log message values, got type %s (key %s). "
                    "Earlier syslog-ng accepted any type, implicitly converting it to a string. "
                    "Later syslog-ng (at least 4.0) will store the value with the correct type. "
-                   "With this version please convert it explicitly to a string using str()",
+                   "With this version please convert it explicitly to string/bytes",
                    value->ob_type->tp_name, name);
       return -1;
     }

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -254,6 +254,33 @@ _logmessage_get_keys_method(PyLogMessage *self)
 }
 
 static PyObject *
+py_log_message_get(PyLogMessage *self, PyObject *args, PyObject *kwrds)
+{
+  const gchar *key = NULL;
+  Py_ssize_t key_len = 0;
+  PyObject *default_value = NULL;
+
+  static const gchar *kwlist[] = {"key", "default", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwrds, "z#|O", (gchar **) kwlist, &key, &key_len, &default_value))
+    return NULL;
+
+  gboolean error;
+  PyObject *value = _get_value(self, key, self->cast_to_bytes, &error);
+
+  if (error)
+    return NULL;
+
+  if (value)
+    return value;
+
+  if (!default_value)
+    Py_RETURN_NONE;
+
+  Py_XINCREF(default_value);
+  return default_value;
+}
+
+static PyObject *
 py_log_message_set_pri(PyLogMessage *self, PyObject *args, PyObject *kwrds)
 {
   guint pri;
@@ -361,6 +388,7 @@ py_log_message_parse(PyObject *_none, PyObject *args, PyObject *kwrds)
 static PyMethodDef py_log_message_methods[] =
 {
   { "keys", (PyCFunction)_logmessage_get_keys_method, METH_NOARGS, "Return keys." },
+  { "get", (PyCFunction)py_log_message_get, METH_VARARGS | METH_KEYWORDS, "Get value" },
   { "set_pri", (PyCFunction)py_log_message_set_pri, METH_VARARGS | METH_KEYWORDS, "Set syslog priority" },
   { "get_pri", (PyCFunction)py_log_message_get_pri, METH_VARARGS | METH_KEYWORDS, "Get syslog priority" },
   { "set_timestamp", (PyCFunction)py_log_message_set_timestamp, METH_VARARGS | METH_KEYWORDS, "Set timestamp" },

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -294,10 +294,11 @@ py_log_message_get_as_str(PyLogMessage *self, PyObject *args, PyObject *kwrds)
   PyObject *default_value = NULL;
   const gchar *encoding = "utf-8";
   const gchar *errors = "strict";
+  const gchar *repr = "internal";
 
-  static const gchar *kwlist[] = {"key", "default", "encoding", "errors", NULL};
-  if (!PyArg_ParseTupleAndKeywords(args, kwrds, "z#|Oss", (gchar **) kwlist, &key, &key_len, &default_value,
-                                   &encoding, &errors))
+  static const gchar *kwlist[] = {"key", "default", "encoding", "errors", "repr", NULL};
+  if (!PyArg_ParseTupleAndKeywords(args, kwrds, "z#|Osss", (gchar **) kwlist, &key, &key_len, &default_value,
+                                   &encoding, &errors, &repr))
     {
       return NULL;
     }

--- a/modules/python/python-logmsg.h
+++ b/modules/python/python-logmsg.h
@@ -32,7 +32,7 @@ typedef struct _PyLogMessage
   PyObject_HEAD
   LogMessage *msg;
   PyObject *bookmark_data;
-  gboolean cast_to_strings;
+  gboolean cast_to_bytes;
 } PyLogMessage;
 
 extern PyTypeObject py_log_message_type;

--- a/modules/python/python-types.c
+++ b/modules/python/python-types.c
@@ -317,10 +317,11 @@ py_boolean_to_boolean(PyObject *obj, gboolean *b)
   return FALSE;
 }
 
-/* Appends to the end of `list`. */
 gboolean
 py_list_to_list(PyObject *obj, GString *list)
 {
+  g_string_truncate(list, 0);
+
   if (!PyList_Check(obj))
     {
       PyErr_Format(PyExc_ValueError, "Error extracting value from list");
@@ -402,9 +403,7 @@ py_datetime_to_datetime(PyObject *obj, GString *dt)
   return TRUE;
 }
 
-/* Appends to the end of `value`. */
 
-/* in case we return FALSE a Python exception needs to be raised */
 gboolean
 py_obj_to_log_msg_value(PyObject *obj, GString *value, LogMessageValueType *type)
 {
@@ -415,7 +414,7 @@ py_obj_to_log_msg_value(PyObject *obj, GString *value, LogMessageValueType *type
         return FALSE;
 
       *type = LM_VT_STRING;
-      g_string_append(value, string);
+      g_string_assign(value, string);
 
       return TRUE;
     }
@@ -427,7 +426,7 @@ py_obj_to_log_msg_value(PyObject *obj, GString *value, LogMessageValueType *type
         return FALSE;
 
       *type = LM_VT_INTEGER;
-      g_string_append_printf(value, "%ld", l);
+      g_string_printf(value, "%ld", l);
 
       return TRUE;
     }
@@ -439,7 +438,7 @@ py_obj_to_log_msg_value(PyObject *obj, GString *value, LogMessageValueType *type
         return FALSE;
 
       *type = LM_VT_DOUBLE;
-      g_string_append_printf(value, "%f", d);
+      g_string_printf(value, "%f", d);
 
       return TRUE;
     }
@@ -451,7 +450,7 @@ py_obj_to_log_msg_value(PyObject *obj, GString *value, LogMessageValueType *type
         return FALSE;
 
       *type = LM_VT_BOOLEAN;
-      g_string_append(value, b ? "true" : "false");
+      g_string_assign(value, b ? "true" : "false");
 
       return TRUE;
     }
@@ -459,7 +458,7 @@ py_obj_to_log_msg_value(PyObject *obj, GString *value, LogMessageValueType *type
   if (obj == Py_None)
     {
       *type = LM_VT_NULL;
-
+      g_string_truncate(value, 0);
       return TRUE;
     }
 

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -193,7 +193,7 @@ ParameterizedTest(PyLogMessageSetValueTestParams *params, python_log_message, te
 
     gchar *script = g_strdup_printf(
                       "test_msg['test_field'] = %s\n"
-                      "result = test_msg['test_field']\n",
+                      "result = test_msg.get('test_field')\n",
                       params->py_value_to_set
                     );
     if (!PyRun_String(script, Py_file_input, _python_main_dict, _python_main_dict))

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -216,6 +216,113 @@ ParameterizedTest(PyLogMessageSetValueTestParams *params, python_log_message, te
   PyGILState_Release(gstate);
 }
 
+static void
+_run_scripts(const gchar *script)
+{
+  if (!PyRun_String(script, Py_file_input, _python_main_dict, _python_main_dict))
+    {
+      PyErr_Print();
+      cr_assert(FALSE, "Error running Python script >>>%s<<<", script);
+    }
+}
+
+typedef struct
+{
+  const gchar *value;
+  LogMessageValueType type;
+  const gchar *expected_value;
+} PyLogMessageGetTestParams;
+
+ParameterizedTestParameters(python_log_message, test_python_logmessage_get)
+{
+  static PyLogMessageGetTestParams test_data_list[] =
+  {
+    {
+      .value = "test",
+      .type = LM_VT_STRING,
+      .expected_value = "b'test'"
+    },
+    {
+      .value = "true",
+      .type = LM_VT_BOOLEAN,
+      .expected_value = "True"
+    },
+    {
+      .value = "14",
+      .type = LM_VT_INTEGER,
+      .expected_value = "14"
+    },
+    {
+      .value = "14",
+      .type = LM_VT_DOUBLE,
+      .expected_value = "14.000"
+    },
+    {
+      .value = "1664894892",
+      .type = LM_VT_DATETIME,
+      .expected_value = "datetime.datetime(2022, 10, 4, 14, 48, 12)"
+    },
+    {
+      .value = "\"a,\",\" b\",c",
+      .type = LM_VT_LIST,
+      .expected_value = "[b'a,', b' b', b'c']"
+    },
+    {
+      .value = "",
+      .type = LM_VT_NULL,
+      .expected_value = "None"
+    },
+  };
+
+  return cr_make_param_array(PyLogMessageGetTestParams, test_data_list, G_N_ELEMENTS(test_data_list));
+}
+
+ParameterizedTest(PyLogMessageGetTestParams *params, python_log_message, test_python_logmessage_get)
+{
+  LogMessage *msg = log_msg_new_empty();
+
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+  {
+    cfg_set_version_without_validation(configuration, VERSION_VALUE_4_0);
+    PyObject *msg_object = py_log_message_new(msg, configuration);
+    PyDict_SetItemString(_python_main_dict, "test_msg", msg_object);
+
+    log_msg_set_value_by_name_with_type(msg, "field", params->value, -1, params->type);
+
+    _run_scripts("result = test_msg.get('field')");
+    _assert_python_variable_value("result", params->expected_value);
+
+    _run_scripts("result = test_msg.get('field', default='def')");
+    _assert_python_variable_value("result", params->expected_value);
+
+    Py_XDECREF(msg_object);
+  }
+  PyGILState_Release(gstate);
+}
+
+Test(python_log_message, test_python_logmessage_get_with_default_value)
+{
+  LogMessage *msg = log_msg_new_empty();
+
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+  {
+    cfg_set_version_without_validation(configuration, VERSION_VALUE_4_0);
+    PyObject *msg_object = py_log_message_new(msg, configuration);
+    PyDict_SetItemString(_python_main_dict, "test_msg", msg_object);
+
+    _run_scripts("result = test_msg.get('nonexistent', default=-1)");
+    _assert_python_variable_value("result", "-1");
+
+    _run_scripts("result = test_msg.get('nonexistent')");
+    _assert_python_variable_value("result", "None");
+
+    Py_XDECREF(msg_object);
+  }
+  PyGILState_Release(gstate);
+}
+
 Test(python_log_message, test_python_logmessage_set_value_no_typing_support)
 {
   cfg_set_version_without_validation(configuration, VERSION_VALUE_3_38);

--- a/modules/python/tests/test_python_logmsg.c
+++ b/modules/python/tests/test_python_logmsg.c
@@ -323,6 +323,96 @@ Test(python_log_message, test_python_logmessage_get_with_default_value)
   PyGILState_Release(gstate);
 }
 
+ParameterizedTestParameters(python_log_message, test_python_logmessage_get_as_str)
+{
+  static PyLogMessageGetTestParams test_data_list[] =
+  {
+    {
+      .value = "test",
+      .type = LM_VT_STRING,
+      .expected_value = "'test'"
+    },
+    {
+      .value = "true",
+      .type = LM_VT_BOOLEAN,
+      .expected_value = "'true'"
+    },
+    {
+      .value = "14",
+      .type = LM_VT_INTEGER,
+      .expected_value = "'14'"
+    },
+    {
+      .value = "14",
+      .type = LM_VT_DOUBLE,
+      .expected_value = "'14'"
+    },
+    {
+      .value = "1664894892",
+      .type = LM_VT_DATETIME,
+      .expected_value = "'1664894892'"
+    },
+    {
+      .value = "\"a,\",\" b\",c",
+      .type = LM_VT_LIST,
+      .expected_value = "'\"a,\",\" b\",c'"
+    },
+    {
+      .value = "",
+      .type = LM_VT_NULL,
+      .expected_value = "''"
+    },
+  };
+
+  return cr_make_param_array(PyLogMessageGetTestParams, test_data_list, G_N_ELEMENTS(test_data_list));
+}
+
+ParameterizedTest(PyLogMessageGetTestParams *params, python_log_message, test_python_logmessage_get_as_str)
+{
+  LogMessage *msg = log_msg_new_empty();
+
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+  {
+    cfg_set_version_without_validation(configuration, VERSION_VALUE_4_0);
+    PyObject *msg_object = py_log_message_new(msg, configuration);
+    PyDict_SetItemString(_python_main_dict, "test_msg", msg_object);
+
+    log_msg_set_value_by_name_with_type(msg, "field", params->value, -1, params->type);
+
+    _run_scripts("result = test_msg.get_as_str('field')");
+    _assert_python_variable_value("result", params->expected_value);
+
+    _run_scripts("result = test_msg.get_as_str('field', default='def')");
+    _assert_python_variable_value("result", params->expected_value);
+
+    Py_XDECREF(msg_object);
+  }
+  PyGILState_Release(gstate);
+}
+
+Test(python_log_message, test_python_logmessage_get_as_str_with_default_value)
+{
+  LogMessage *msg = log_msg_new_empty();
+
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+  {
+    cfg_set_version_without_validation(configuration, VERSION_VALUE_4_0);
+    PyObject *msg_object = py_log_message_new(msg, configuration);
+    PyDict_SetItemString(_python_main_dict, "test_msg", msg_object);
+
+    _run_scripts("result = test_msg.get_as_str('nonexistent', default='default', encoding='utf-8', errors='strict')");
+    _assert_python_variable_value("result", "'default'");
+
+    _run_scripts("result = test_msg.get_as_str('nonexistent')");
+    _assert_python_variable_value("result", "None");
+
+    Py_XDECREF(msg_object);
+  }
+  PyGILState_Release(gstate);
+}
+
 Test(python_log_message, test_python_logmessage_set_value_no_typing_support)
 {
   cfg_set_version_without_validation(configuration, VERSION_VALUE_3_38);

--- a/modules/python/tests/test_python_tf.c
+++ b/modules/python/tests/test_python_tf.c
@@ -81,6 +81,7 @@ TestSuite(python_tf, .init = setup, .fini = teardown);
 typedef struct _PyTfTestParams
 {
   const gchar *value;
+  const gchar *expected_value;
   LogMessageValueType type;
 } PyTfTestParams;
 
@@ -112,6 +113,11 @@ ParameterizedTestParameters(python_tf, test_python_tf)
       .value = "a,b,c",
       .type = LM_VT_LIST
     },
+    {
+      .value = "1680456974",
+      .expected_value = "1680456974.000",
+      .type = LM_VT_DATETIME
+    },
   };
 
   return cr_make_param_array(PyTfTestParams, test_data_list, G_N_ELEMENTS(test_data_list));
@@ -134,8 +140,9 @@ ParameterizedTest(PyTfTestParams *params, python_tf, test_python_tf)
     cfg_set_version_without_validation(configuration, VERSION_VALUE_3_38);
     assert_template_format_value_and_type_msg(template, params->value, LM_VT_STRING, msg);
 
+    const gchar *expected_value = params->expected_value ? params->expected_value : params->value;
     cfg_set_version_without_validation(configuration, VERSION_VALUE_4_0);
-    assert_template_format_value_and_type_msg(template, params->value, params->type, msg);
+    assert_template_format_value_and_type_msg(template, expected_value, params->type, msg);
   }
   PyGILState_Release(gstate);
 

--- a/modules/python/tests/test_python_tf.c
+++ b/modules/python/tests/test_python_tf.c
@@ -126,7 +126,7 @@ ParameterizedTestParameters(python_tf, test_python_tf)
 ParameterizedTest(PyTfTestParams *params, python_tf, test_python_tf)
 {
   const gchar *python_tf_implementation = "def test_python_tf(msg):\n"
-                                          "    return msg['test_key']\n";
+                                          "    return msg.get('test_key')\n";
   const gchar *template = "$(python test_python_tf)";
 
   LogMessage *msg = log_msg_new_empty();

--- a/news/bugfix-4410-2.md
+++ b/news/bugfix-4410-2.md
@@ -1,0 +1,1 @@
+`python()`: fix exception handling when LogMessage value conversion fails

--- a/news/bugfix-4410-3.md
+++ b/news/bugfix-4410-3.md
@@ -1,0 +1,1 @@
+`$(python)`: fix template function prefix being overwritten when using datetime types

--- a/news/bugfix-4410.md
+++ b/news/bugfix-4410.md
@@ -1,0 +1,6 @@
+`python()`: fix LogMessage subscript not raising KeyError on non-existent keys
+
+When message fields were queried (`msg["key"]`) and the given key did not exist,
+`None` or an empty string was returned (depending on the version of the config).
+
+Neither was correct, now a KeyError occurs in such cases.

--- a/news/feature-4410.md
+++ b/news/feature-4410.md
@@ -1,0 +1,15 @@
+`python()`: new LogMessage methods for querying as string and with default values
+
+- `get(key[, default])`
+  Return the value for `key` if `key` exists, else `default`. If `default` is
+  not given, it defaults to `None`, so that this method never raises a
+  `KeyError`.
+
+
+- `get_as_str(key, default=None, encoding='utf-8', errors='strict')`:
+  Return the string value for `key` if `key` exists, else `default`.
+  If `default` is not given, it defaults to `None`, so that this method never
+  raises a `KeyError`.
+
+  The string value is decoded using the codec registered for `encoding`.
+  `errors` may be given to set the desired error handling scheme.

--- a/news/feature-4410.md
+++ b/news/feature-4410.md
@@ -6,10 +6,15 @@
   `KeyError`.
 
 
-- `get_as_str(key, default=None, encoding='utf-8', errors='strict')`:
+- `get_as_str(key, default=None, encoding='utf-8', errors='strict', repr='internal')`:
   Return the string value for `key` if `key` exists, else `default`.
   If `default` is not given, it defaults to `None`, so that this method never
   raises a `KeyError`.
 
   The string value is decoded using the codec registered for `encoding`.
   `errors` may be given to set the desired error handling scheme.
+
+  Note that currently `repr='internal'` is the only available representation.
+  We may implement another more Pythonic representation in the future, so please
+  specify the `repr` argument explicitly if you want to avoid future
+  representation changes in your code.


### PR DESCRIPTION
`python()`: new LogMessage methods for querying as string and with default values

- `get(key[, default])`
  Return the value for `key` if `key` exists, else `default`. If `default` is
  not given, it defaults to `None`, so that this method never raises a
  `KeyError`.


- `get_as_str(key, default=None, encoding='utf-8', errors='strict', repr='internal')`:
  Return the string value for `key` if `key` exists, else `default`.
  If `default` is not given, it defaults to `None`, so that this method never
  raises a `KeyError`.

  The string value is decoded using the codec registered for `encoding`.
  `errors` may be given to set the desired error handling scheme.

  Note that currently `repr='internal'` is the only available representation.
  We may implement another more Pythonic representation in the future, so please
  specify the `repr` argument explicitly if you want to avoid future
  representation changes in your code.


----

`python()`: fix LogMessage subscript not raising KeyError on non-existent keys

When message fields were queried (`msg["key"]`) and the given key did not exist,
`None` or an empty string was returned (depending on the version of the config).

Neither was correct, now a KeyError occurs in such cases.

----

`python()`: fix exception handling when LogMessage value conversion fails

----

`$(python)`: fix template function prefix being overwritten when using datetime types