### PR TITLE
TCP connection metrics and minor improvements

### DIFF
--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -36,9 +36,8 @@ typedef struct _AFInterSource AFInterSource;
 static GMutex internal_msg_lock;
 static GQueue *internal_msg_queue;
 static AFInterSource *current_internal_source;
-static StatsCounterItem *internal_queue_length;
-static StatsCounterItem *internal_queue_dropped;
-static StatsCounterItem *internal_source_processed;
+
+static AFInterMetrics metrics;
 
 /* the expiration timer of the next MARK message */
 static struct timespec next_mark_target = { -1, 0 };
@@ -121,8 +120,8 @@ afinter_source_post(gpointer s)
       if (!msg)
         break;
 
-      stats_counter_dec(internal_queue_length);
-      stats_counter_inc(internal_source_processed);
+      stats_counter_dec(metrics.queued);
+      stats_counter_inc(metrics.processed);
       log_source_post(&self->super, msg);
       main_loop_worker_invoke_batch_callbacks();
     }
@@ -349,6 +348,7 @@ afinter_source_init(LogPipe *s)
 
   g_mutex_lock(&internal_msg_lock);
   current_internal_source = self;
+  metrics.queue_capacity = self->options->queue_capacity;
   g_mutex_unlock(&internal_msg_lock);
 
   return TRUE;
@@ -535,7 +535,7 @@ _release_internal_msg_queue(void)
   LogMessage *internal_message = g_queue_pop_head(internal_msg_queue);
   while (internal_message)
     {
-      stats_counter_dec(internal_queue_length);
+      stats_counter_dec(metrics.queued);
       log_msg_unref(internal_message);
 
       internal_message = g_queue_pop_head(internal_msg_queue);
@@ -586,23 +586,23 @@ afinter_message_posted(LogMessage *msg)
       StatsClusterKey sc_key;
       stats_cluster_logpipe_key_set(&sc_key, "internal_events_total", NULL, 0);
       stats_cluster_logpipe_key_add_legacy_alias(&sc_key, SCS_GLOBAL, "internal_source", NULL );
-      stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &internal_queue_length);
-      stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &internal_queue_dropped);
-      stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &internal_source_processed);
+      stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &metrics.queued);
+      stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &metrics.dropped);
+      stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &metrics.processed);
       stats_unlock();
 
-      _register_obsolete_stats_alias(internal_queue_length);
+      _register_obsolete_stats_alias(metrics.queued);
     }
 
   if (g_queue_get_length(internal_msg_queue) >= current_internal_source->options->queue_capacity)
     {
-      stats_counter_inc(internal_queue_dropped);
+      stats_counter_inc(metrics.dropped);
       log_msg_unref(msg);
       goto exit;
     }
 
   g_queue_push_tail(internal_msg_queue, msg);
-  stats_counter_inc(internal_queue_length);
+  stats_counter_inc(metrics.queued);
 
   if (current_internal_source->free_to_send)
     iv_event_post(&current_internal_source->post);
@@ -627,15 +627,15 @@ afinter_global_deinit(void)
 {
   if (internal_msg_queue)
     {
-      _unregister_obsolete_stats_alias(internal_queue_length);
+      _unregister_obsolete_stats_alias(metrics.queued);
 
       stats_lock();
       StatsClusterKey sc_key;
       stats_cluster_logpipe_key_set(&sc_key, "internal_events_total", NULL, 0);
       stats_cluster_logpipe_key_add_legacy_alias(&sc_key, SCS_GLOBAL, "internal_source", NULL );
-      stats_unregister_counter(&sc_key, SC_TYPE_QUEUED, &internal_queue_length);
-      stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &internal_queue_dropped);
-      stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &internal_source_processed);
+      stats_unregister_counter(&sc_key, SC_TYPE_QUEUED, &metrics.queued);
+      stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &metrics.dropped);
+      stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &metrics.processed);
       stats_unlock();
       g_queue_free_full(internal_msg_queue, (GDestroyNotify)log_msg_unref);
       internal_msg_queue = NULL;

--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -582,7 +582,7 @@ afinter_message_posted(LogMessage *msg)
 
       stats_lock();
       StatsClusterKey sc_key;
-      stats_cluster_logpipe_key_set(&sc_key, "internal_source", NULL, 0);
+      stats_cluster_logpipe_key_set(&sc_key, "internal_events_total", NULL, 0);
       stats_cluster_logpipe_key_add_legacy_alias(&sc_key, SCS_GLOBAL, "internal_source", NULL );
       stats_register_counter(0, &sc_key, SC_TYPE_QUEUED, &internal_queue_length);
       stats_register_counter(0, &sc_key, SC_TYPE_DROPPED, &internal_queue_dropped);
@@ -628,7 +628,7 @@ afinter_global_deinit(void)
 
       stats_lock();
       StatsClusterKey sc_key;
-      stats_cluster_logpipe_key_set(&sc_key, "internal_source", NULL, 0);
+      stats_cluster_logpipe_key_set(&sc_key, "internal_events_total", NULL, 0);
       stats_cluster_logpipe_key_add_legacy_alias(&sc_key, SCS_GLOBAL, "internal_source", NULL );
       stats_unregister_counter(&sc_key, SC_TYPE_QUEUED, &internal_queue_length);
       stats_unregister_counter(&sc_key, SC_TYPE_DROPPED, &internal_queue_dropped);

--- a/lib/afinter.c
+++ b/lib/afinter.c
@@ -629,3 +629,9 @@ afinter_global_deinit(void)
     }
   current_internal_source = NULL;
 }
+
+AFInterMetrics
+afinter_get_metrics(void)
+{
+  return metrics;
+}

--- a/lib/afinter.h
+++ b/lib/afinter.h
@@ -50,7 +50,7 @@ typedef struct _AFInterMetrics
   StatsCounterItem *processed;
   StatsCounterItem *dropped;
   StatsCounterItem *queued;
-  gsize queue_capacity;
+  StatsCounterItem *queue_capacity;
 } AFInterMetrics;
 
 void afinter_postpone_mark(gint mark_freq);

--- a/lib/afinter.h
+++ b/lib/afinter.h
@@ -28,6 +28,7 @@
 #include "driver.h"
 #include "logsource.h"
 #include "mainloop-worker.h"
+#include "stats/stats-counter.h"
 
 typedef struct AFInterSourceOptions
 {
@@ -57,5 +58,7 @@ void afinter_postpone_mark(gint mark_freq);
 LogDriver *afinter_sd_new(GlobalConfig *cfg);
 void afinter_global_init(void);
 void afinter_global_deinit(void);
+
+AFInterMetrics afinter_get_metrics(void);
 
 #endif

--- a/lib/afinter.h
+++ b/lib/afinter.h
@@ -45,6 +45,14 @@ typedef struct _AFInterSourceDriver
   AFInterSourceOptions source_options;
 } AFInterSourceDriver;
 
+typedef struct _AFInterMetrics
+{
+  StatsCounterItem *processed;
+  StatsCounterItem *dropped;
+  StatsCounterItem *queued;
+  gsize queue_capacity;
+} AFInterMetrics;
+
 void afinter_postpone_mark(gint mark_freq);
 LogDriver *afinter_sd_new(GlobalConfig *cfg);
 void afinter_global_init(void);

--- a/lib/metrics-pipe.c
+++ b/lib/metrics-pipe.c
@@ -32,8 +32,8 @@ _init_stats_keys(MetricsPipe *self, StatsClusterKey *ingress_sc_key, StatsCluste
   static StatsClusterLabel labels[labels_len];
 
   labels[0] = stats_cluster_label("id", self->log_path_name);
-  stats_cluster_single_key_set(ingress_sc_key, "log_path_ingress", labels, labels_len);
-  stats_cluster_single_key_set(egress_sc_key, "log_path_egress", labels, labels_len);
+  stats_cluster_single_key_set(ingress_sc_key, "route_ingress_total", labels, labels_len);
+  stats_cluster_single_key_set(egress_sc_key, "route_egress_total", labels, labels_len);
 }
 
 static void

--- a/modules/afsocket/afsocket-source.h
+++ b/modules/afsocket/afsocket-source.h
@@ -43,7 +43,6 @@ struct _AFSocketSourceDriver
           window_size_initialized:1;
   struct iv_fd listen_fd;
   struct iv_timer dynamic_window_timer;
-  struct iv_timer packet_stats_timer;
   gsize dynamic_window_size;
   gsize dynamic_window_timer_tick;
   glong dynamic_window_stats_freq;
@@ -52,9 +51,15 @@ struct _AFSocketSourceDriver
   LogReaderOptions reader_options;
   DynamicWindowPool *dynamic_window_pool;
   LogProtoServerFactory *proto_factory;
-  StatsCounterItem *stat_socket_dropped_packets;
-  StatsCounterItem *stat_socket_receive_buffer_max;
-  StatsCounterItem *stat_socket_receive_buffer_used;
+
+  struct
+  {
+    struct iv_timer packet_stats_timer;
+    StatsCounterItem *socket_dropped_packets;
+    StatsCounterItem *socket_receive_buffer_max;
+    StatsCounterItem *socket_receive_buffer_used;
+  } metrics;
+
   GSockAddr *bind_addr;
   atomic_gssize max_connections;
   atomic_gssize num_connections;

--- a/modules/afsocket/afsocket-source.h
+++ b/modules/afsocket/afsocket-source.h
@@ -56,7 +56,7 @@ struct _AFSocketSourceDriver
   StatsCounterItem *stat_socket_receive_buffer_max;
   StatsCounterItem *stat_socket_receive_buffer_used;
   GSockAddr *bind_addr;
-  gint max_connections;
+  atomic_gssize max_connections;
   atomic_gssize num_connections;
   gint listen_backlog;
   GList *connections;

--- a/modules/afsocket/afsocket-source.h
+++ b/modules/afsocket/afsocket-source.h
@@ -31,6 +31,7 @@
 #include "logreader.h"
 #include "dynamic-window-pool.h"
 #include "atomic-gssize.h"
+#include "stats/stats-counter.h"
 
 #include <iv.h>
 
@@ -58,6 +59,7 @@ struct _AFSocketSourceDriver
     StatsCounterItem *socket_dropped_packets;
     StatsCounterItem *socket_receive_buffer_max;
     StatsCounterItem *socket_receive_buffer_used;
+    StatsCounterItem *rejected_connections;
   } metrics;
 
   GSockAddr *bind_addr;

--- a/modules/afsocket/afunix-source.c
+++ b/modules/afsocket/afunix-source.c
@@ -148,7 +148,7 @@ afunix_sd_new_instance(TransportMapper *transport_mapper, gchar *filename, Globa
   self->super.super.super.super.free_fn = afunix_sd_free;
   self->super.setup_addresses = afunix_sd_setup_addresses;
 
-  self->super.max_connections = 256;
+  atomic_gssize_set(&self->super.max_connections, 256);
 
   self->filename = g_strdup(filename);
   file_perm_options_defaults(&self->file_perm_options);
@@ -184,6 +184,6 @@ afunix_sd_new_stream(gchar *filename, GlobalConfig *cfg)
 {
   AFUnixSourceDriver *self = afunix_sd_new_instance(transport_mapper_unix_stream_new(), filename, cfg);
 
-  self->super.reader_options.super.init_window_size = self->super.max_connections * 100;
+  self->super.reader_options.super.init_window_size = atomic_gssize_get(&self->super.max_connections )* 100;
   return self;
 }

--- a/modules/afsocket/systemd-syslog-source.c
+++ b/modules/afsocket/systemd-syslog-source.c
@@ -138,7 +138,7 @@ systemd_syslog_sd_new(GlobalConfig *cfg, gboolean fallback)
   self->super.super.super.super.init = systemd_syslog_sd_init_method;
 
   self->super.acquire_socket = systemd_syslog_sd_acquire_socket;
-  self->super.max_connections = 256;
+  atomic_gssize_set(&self->super.max_connections, 256);
 
   if (!self->super.bind_addr)
     self->super.bind_addr = g_sockaddr_unix_new(NULL);

--- a/news/feature-4411.md
+++ b/news/feature-4411.md
@@ -1,0 +1,13 @@
+New metrics
+
+`network()`, `syslog()`: TCP connection metrics
+
+```
+syslogng_socket_connections{id="tcp_src#0",driver_instance="afsocket_sd.(stream,AF_INET(0.0.0.0:5555))",direction="input"} 3
+syslogng_socket_max_connections{id="tcp_src#0",driver_instance="afsocket_sd.(stream,AF_INET(0.0.0.0:5555))",direction="input"} 10
+syslogng_socket_rejected_connections_total{id="tcp_src#0",driver_instance="afsocket_sd.(stream,AF_INET(0.0.0.0:5555))",direction="input"} 96
+```
+
+`internal()`: `internal_events_queue_capacity` metric
+
+`syslog-ng-ctl healthcheck`: new healthcheck value `syslogng_internal_events_queue_usage_ratio`

--- a/news/other-4411.md
+++ b/news/other-4411.md
@@ -1,0 +1,7 @@
+The following Prometheus metrics have been renamed:
+
+`log_path_{in,e}gress` -> `route_{in,e}gress_total`
+`internal_source` -> `internal_events_total`
+
+The `internal_queue_length` stats counter has been removed.
+It was deprecated since syslog-ng 3.29.

--- a/tests/light/functional_tests/logpath/__init__.py
+++ b/tests/light/functional_tests/logpath/__init__.py
@@ -37,14 +37,14 @@ def assert_logpath_stats(logpath, ingress, egress):
 
     found = False
     for stat in stats:
-        if stat.name == "syslogng_log_path_ingress" and stat.labels == {"id": logpath.name}:
+        if stat.name == "syslogng_route_ingress_total" and stat.labels == {"id": logpath.name}:
             found = True
             actual_ingress = stat.value
     assert found, "Did not find ingress stats counter for logpath: %s" % (logpath.name)
 
     found = False
     for stat in stats:
-        if stat.name == "syslogng_log_path_egress" and stat.labels == {"id": logpath.name}:
+        if stat.name == "syslogng_route_egress_total" and stat.labels == {"id": logpath.name}:
             found = True
             actual_egress = stat.value
     assert found, "Did not find egress stats counter for logpath: %s" % (logpath.name)

--- a/tests/light/src/syslog_ng_config/statements/logpath/logpath.py
+++ b/tests/light/src/syslog_ng_config/statements/logpath/logpath.py
@@ -34,8 +34,8 @@ class LogPath(object):
         metric_filters = []
         if name:
             metric_filters += [
-                MetricFilter("syslogng_log_path_ingress", {"id": name}),
-                MetricFilter("syslogng_log_path_egress", {"id": name}),
+                MetricFilter("syslogng_route_ingress_total", {"id": name}),
+                MetricFilter("syslogng_route_egress_total", {"id": name}),
             ]
 
         self.__prometheus_stats_handler = PrometheusStatsHandler(metric_filters)


### PR DESCRIPTION
New metrics

`network()`, `syslog()`: TCP connection metrics

```
syslogng_socket_connections{id="tcp_src#0",driver_instance="afsocket_sd.(stream,AF_INET(0.0.0.0:5555))",direction="input"} 3
syslogng_socket_max_connections{id="tcp_src#0",driver_instance="afsocket_sd.(stream,AF_INET(0.0.0.0:5555))",direction="input"} 10
syslogng_socket_rejected_connections_total{id="tcp_src#0",driver_instance="afsocket_sd.(stream,AF_INET(0.0.0.0:5555))",direction="input"} 96
```

`internal()`: `internal_events_queue_capacity` metric

`syslog-ng-ctl healthcheck`: new healthcheck value `syslogng_internal_events_queue_usage_ratio`

The following Prometheus metrics have been renamed:

`log_path_{in,e}gress` -> `route_{in,e}gress_total`
`internal_source` -> `internal_events_total`

The `internal_queue_length` stats counter has been removed.
It was deprecated since syslog-ng 3.29.