### PR TITLE
inputs/tags: get rid of "processed" label in Prometheus metrics 

### DIFF
--- a/lib/logmsg/tags.c
+++ b/lib/logmsg/tags.c
@@ -26,6 +26,7 @@
 #include "tags.h"
 #include "messages.h"
 #include "stats/stats-registry.h"
+#include "stats/stats-cluster-single.h"
 #include "apphook.h"
 
 typedef struct _LogTag
@@ -92,9 +93,9 @@ log_tags_get_by_name(const gchar *name)
           stats_lock();
           StatsClusterKey sc_key;
           StatsClusterLabel labels[] = { stats_cluster_label("id", name) };
-          stats_cluster_logpipe_key_set(&sc_key, "tagged_events_total", labels, G_N_ELEMENTS(labels));
-          stats_cluster_logpipe_key_add_legacy_alias(&sc_key, SCS_TAG, name, NULL );
-          stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &log_tags_list[id].counter);
+          stats_cluster_single_key_set(&sc_key, "tagged_events_total", labels, G_N_ELEMENTS(labels));
+          stats_cluster_single_key_add_legacy_alias_with_name(&sc_key, SCS_TAG, name, NULL, "processed");
+          stats_register_counter(3, &sc_key, SC_TYPE_SINGLE_VALUE, &log_tags_list[id].counter);
           stats_unlock();
 
           g_hash_table_insert(log_tags_hash, log_tags_list[id].name, GUINT_TO_POINTER(log_tags_list[id].id + 1));
@@ -181,13 +182,13 @@ log_tags_reinit_stats(void)
       const gchar *name = log_tags_list[id].name;
       StatsClusterKey sc_key;
       StatsClusterLabel labels[] = { stats_cluster_label("id", name) };
-      stats_cluster_logpipe_key_set(&sc_key, "tagged_events_total", labels, G_N_ELEMENTS(labels));
-      stats_cluster_logpipe_key_add_legacy_alias(&sc_key, SCS_TAG, name, NULL );
+      stats_cluster_single_key_set(&sc_key, "tagged_events_total", labels, G_N_ELEMENTS(labels));
+      stats_cluster_single_key_add_legacy_alias_with_name(&sc_key, SCS_TAG, name, NULL, "processed");
 
       if (stats_check_level(3))
-        stats_register_counter(3, &sc_key, SC_TYPE_PROCESSED, &log_tags_list[id].counter);
+        stats_register_counter(3, &sc_key, SC_TYPE_SINGLE_VALUE, &log_tags_list[id].counter);
       else
-        stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &log_tags_list[id].counter);
+        stats_unregister_counter(&sc_key, SC_TYPE_SINGLE_VALUE, &log_tags_list[id].counter);
     }
 
   stats_unlock();
@@ -225,9 +226,9 @@ log_tags_global_deinit(void)
   for (i = 0; i < log_tags_num; i++)
     {
       StatsClusterLabel labels[] = { stats_cluster_label("id", log_tags_list[i].name) };
-      stats_cluster_logpipe_key_set(&sc_key, "tagged_events_total", labels, G_N_ELEMENTS(labels));
-      stats_cluster_logpipe_key_add_legacy_alias(&sc_key, SCS_TAG, log_tags_list[i].name, NULL );
-      stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &log_tags_list[i].counter);
+      stats_cluster_single_key_set(&sc_key, "tagged_events_total", labels, G_N_ELEMENTS(labels));
+      stats_cluster_single_key_add_legacy_alias_with_name(&sc_key, SCS_TAG, log_tags_list[i].name, NULL, "processed");
+      stats_unregister_counter(&sc_key, SC_TYPE_SINGLE_VALUE, &log_tags_list[i].counter);
       g_free(log_tags_list[i].name);
     }
   stats_unlock();

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -585,9 +585,9 @@ static void
 _register_aggregated_stats(LogReader *self)
 {
   StatsClusterKey sc_key_eps_input;
-  stats_cluster_logpipe_key_legacy_set(&sc_key_eps_input, self->super.options->stats_source | SCS_SOURCE,
-                                       self->super.stats_id,
-                                       self->super.stats_instance);
+  stats_cluster_single_key_legacy_set_with_name(&sc_key_eps_input, self->super.options->stats_source | SCS_SOURCE,
+                                                self->super.stats_id,
+                                                self->super.stats_instance, "processed");
 
   stats_aggregator_lock();
   StatsClusterKey sc_key;
@@ -605,7 +605,8 @@ _register_aggregated_stats(LogReader *self)
   stats_cluster_single_key_legacy_set_with_name(&sc_key, self->super.options->stats_source | SCS_SOURCE,
                                                 self->super.stats_id,
                                                 self->super.stats_instance, "eps");
-  stats_register_aggregator_cps(self->super.options->stats_level, &sc_key, &sc_key_eps_input, SC_TYPE_PROCESSED,
+
+  stats_register_aggregator_cps(self->super.options->stats_level, &sc_key, &sc_key_eps_input, SC_TYPE_SINGLE_VALUE,
                                 &self->CPS);
 
   stats_aggregator_unlock();

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -26,6 +26,7 @@
 #include "messages.h"
 #include "host-resolve.h"
 #include "stats/stats-registry.h"
+#include "stats/stats-cluster-logpipe.h"
 #include "stats/stats-cluster-single.h"
 #include "msg-stats.h"
 #include "logmsg/tags.h"
@@ -473,11 +474,15 @@ log_source_init(LogPipe *s)
     stats_cluster_label("id", self->stats_id),
     stats_cluster_label("driver_instance", self->stats_instance),
   };
-  stats_cluster_logpipe_key_set(&sc_key, "input_events_total", labels, G_N_ELEMENTS(labels));
-  stats_cluster_logpipe_key_add_legacy_alias(&sc_key, self->options->stats_source | SCS_SOURCE, self->stats_id,
-                                             self->stats_instance);
+  stats_cluster_single_key_set(&sc_key, "input_events_total", labels, G_N_ELEMENTS(labels));
+  stats_cluster_single_key_add_legacy_alias_with_name(&sc_key, self->options->stats_source | SCS_SOURCE, self->stats_id,
+                                                      self->stats_instance, "processed");
   stats_register_counter(self->options->stats_level, &sc_key,
-                         SC_TYPE_PROCESSED, &self->recvd_messages);
+                         SC_TYPE_SINGLE_VALUE, &self->recvd_messages);
+
+
+  stats_cluster_logpipe_key_legacy_set(&sc_key, self->options->stats_source | SCS_SOURCE, self->stats_id,
+                                       self->stats_instance);
   stats_register_counter(self->options->stats_level, &sc_key, SC_TYPE_STAMP, &self->last_message_seen);
 
   _register_window_stats(self);
@@ -500,10 +505,13 @@ log_source_deinit(LogPipe *s)
     stats_cluster_label("id", self->stats_id),
     stats_cluster_label("driver_instance", self->stats_instance),
   };
-  stats_cluster_logpipe_key_set(&sc_key, "input_events_total", labels, G_N_ELEMENTS(labels));
-  stats_cluster_logpipe_key_add_legacy_alias(&sc_key, self->options->stats_source | SCS_SOURCE, self->stats_id,
-                                             self->stats_instance);
-  stats_unregister_counter(&sc_key, SC_TYPE_PROCESSED, &self->recvd_messages);
+  stats_cluster_single_key_set(&sc_key, "input_events_total", labels, G_N_ELEMENTS(labels));
+  stats_cluster_single_key_add_legacy_alias_with_name(&sc_key, self->options->stats_source | SCS_SOURCE, self->stats_id,
+                                                      self->stats_instance, "processed");
+  stats_unregister_counter(&sc_key, SC_TYPE_SINGLE_VALUE, &self->recvd_messages);
+
+  stats_cluster_logpipe_key_legacy_set(&sc_key, self->options->stats_source | SCS_SOURCE, self->stats_id,
+                                       self->stats_instance);
   stats_unregister_counter(&sc_key, SC_TYPE_STAMP, &self->last_message_seen);
 
   _unregister_window_stats(self);


### PR DESCRIPTION
```
syslogng_input_events_total{id="#anon-source0#2",driver_instance="tcp,127.0.0.1"} 1
syslogng_tagged_events_total{id=".source.#anon-source0"} 5
```