### PR TITLE
format-json: fix RFC8259 number violation

### DIFF
--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -222,6 +222,12 @@ Test(format_json, test_v40_value_pairs_yields_typed_values)
   /* macro */
   assert_template_format("$(format-json --auto-cast FACILITY_NUM)",
                          "{\"FACILITY_NUM\":19}");
+
+  /* RFC8259 number sanitization */
+  assert_template_format("$(format-json num=int(00014))", "{\"num\":14}");
+  assert_template_format("$(format-json num=int(+14))", "{\"num\":14}");
+  assert_template_format("$(format-json num=int(-025))", "{\"num\":-25}");
+  assert_template_format("$(format-json num=int(+0009223372036854775804))", "{\"num\":9223372036854775804}");
 }
 
 Test(format_json, test_cast_option_always_yields_strings_regardless_of_versions)

--- a/news/bugfix-4415.md
+++ b/news/bugfix-4415.md
@@ -1,0 +1,4 @@
+`$(format-json)`: fix RFC8259 number violation
+
+`$(format-json)` produced invalid JSON output when it contained numeric values with leading zeros or + signs.
+This has been fixed.


### PR DESCRIPTION
RFC8259 does not allow '+' sign and leading zeros in numbers, but these and leading spaces are allowed by type_cast_to_number().

Because syslog-ng should always store the original representation (normalizing the stored value would break other functionality), normalization/sanitization/etc. should be done in formatter functions.