### PR TITLE
format-json: fix escaping control characters

### DIFF
--- a/lib/utf8utils.c
+++ b/lib/utf8utils.c
@@ -137,11 +137,11 @@ _append_unsafe_utf8_as_escaped_nul_terminated(GString *escaped_output, const gch
 /**
  * @see _append_escaped_utf8_character()
  */
-static void
-_append_unsafe_utf8_as_escaped(GString *escaped_output, const gchar *raw,
-                               gssize raw_len, const gchar *unsafe_chars,
-                               const gchar *control_format,
-                               const gchar *invalid_format)
+void
+append_unsafe_utf8_as_escaped(GString *escaped_output, const gchar *raw,
+                              gssize raw_len, const gchar *unsafe_chars,
+                              const gchar *control_format,
+                              const gchar *invalid_format)
 {
   if (raw_len < 0)
     _append_unsafe_utf8_as_escaped_nul_terminated(escaped_output, raw, unsafe_chars, control_format, invalid_format);
@@ -169,14 +169,14 @@ _append_unsafe_utf8_as_escaped(GString *escaped_output, const gchar *raw,
  *
  * This is basically meant to be used when sending data to
  * 8 bit clean receivers, e.g. syslog-ng or WELF.
- * @see _append_unsafe_utf8_as_escaped()
+ * @see append_unsafe_utf8_as_escaped()
  */
 void
 append_unsafe_utf8_as_escaped_binary(GString *escaped_string, const gchar *str,
                                      gssize str_len, const gchar *unsafe_chars)
 {
-  _append_unsafe_utf8_as_escaped(escaped_string, str, str_len, unsafe_chars,
-                                 "\\x%02x", "\\x%02x");
+  append_unsafe_utf8_as_escaped(escaped_string, str, str_len, unsafe_chars,
+                                "\\x%02x", "\\x%02x");
 }
 gchar *
 convert_unsafe_utf8_to_escaped_binary(const gchar *str, gssize str_len,
@@ -201,7 +201,7 @@ convert_unsafe_utf8_to_escaped_binary(const gchar *str, gssize str_len,
  *
  * Here are the rules that the routine follows:
  *   - well-known control characters are escaped (0x0a as \n and so on)
- *   - other control characters as per control_format (\u00XX)
+ *   - other control characters as per control_format (\xXX)
  *   - backslash is escaped as \\
  *   - any additional characters (only ASCII is supported) as \<char>
  *   - invalid utf8 sequences are converted as per invalid_format (\\xXX)
@@ -209,14 +209,14 @@ convert_unsafe_utf8_to_escaped_binary(const gchar *str, gssize str_len,
  *
  * This is basically meant to be used when sending data to
  * utf8 only receivers, e.g. JSON.
- * @see _append_unsafe_utf8_as_escaped()
+ * @see append_unsafe_utf8_as_escaped()
  */
 void
 append_unsafe_utf8_as_escaped_text(GString *escaped_string, const gchar *str,
                                    gssize str_len, const gchar *unsafe_chars)
 {
-  _append_unsafe_utf8_as_escaped(escaped_string, str, str_len, unsafe_chars,
-                                 "\\x%02x", "\\\\x%02x");
+  append_unsafe_utf8_as_escaped(escaped_string, str, str_len, unsafe_chars,
+                                "\\x%02x", "\\\\x%02x");
 }
 
 gchar *

--- a/lib/utf8utils.h
+++ b/lib/utf8utils.h
@@ -36,4 +36,9 @@ void append_unsafe_utf8_as_escaped_text(GString *escaped_string, const gchar *st
 gchar *convert_unsafe_utf8_to_escaped_text(const gchar *str, gssize str_len,
                                            const gchar *unsafe_chars);
 
+
+void append_unsafe_utf8_as_escaped(GString *escaped_output, const gchar *raw,
+                                   gssize raw_len, const gchar *unsafe_chars,
+                                   const gchar *control_format,
+                                   const gchar *invalid_format);
 #endif

--- a/modules/json/format-json.c
+++ b/modules/json/format-json.c
@@ -124,7 +124,8 @@ typedef struct
 static inline void
 tf_json_append_escaped(GString *dest, const gchar *str, gssize str_len)
 {
-  append_unsafe_utf8_as_escaped_text(dest, str, str_len, "\"");
+  /* RFC8259 specifies only \uXXXX escaping */
+  append_unsafe_utf8_as_escaped(dest, str, str_len, "\"", "\\u%04x", "\\\\x%02x");
 }
 
 static gboolean

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -341,10 +341,13 @@ Test(format_json, test_format_json_with_utf8)
   LogMessage *msg = create_empty_message();
   log_msg_set_value_by_name(msg, "UTF8-C2", "\xc2\xbf \xc2\xb6 \xc2\xa9 \xc2\xb1", -1); // ¿ ¶ © ±
   log_msg_set_value_by_name(msg, "UTF8-C3", "\xc3\x88 \xc3\x90", -1); // È Ð
+  log_msg_set_value_by_name(msg, "UTF8-CTRL", "\x07\x09", -1);
 
   assert_template_format_msg("$(format-json MSG=\"${UTF8-C2}\")", "{\"MSG\":\"\xc2\xbf \xc2\xb6 \xc2\xa9 \xc2\xb1\"}",
                              msg);
   assert_template_format_msg("$(format-json MSG=\"${UTF8-C3}\")", "{\"MSG\":\"\xc3\x88 \xc3\x90\"}", msg);
+
+  assert_template_format_msg("$(format-json MSG=\"${UTF8-CTRL}\")", "{\"MSG\":\"\\u0007\\t\"}", msg);
 
   log_msg_unref(msg);
 }

--- a/news/bugfix-4417.md
+++ b/news/bugfix-4417.md
@@ -1,0 +1,3 @@
+`$(format-json)`: fix escaping control characters
+
+`$(format-json)` produced invalid JSON output when a string value contained control characters.


### PR DESCRIPTION
This fixes a regression introduced in 4b416642528de59290642ca2602b7d5040cbd1c7, where the control char escaping of append_unsafe_utf8_as_escaped_text() has been changed from \u to \x.

RFC8259 only allows \uXXXX escaping.