### PR TITLE
mainloop: deinit() configuration when init() fails on startup

### DIFF
--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -199,15 +199,15 @@ main_loop_initialize_state(GlobalConfig *cfg, const gchar *persist_filename)
   if (!host_id_init(cfg->state))
     return FALSE;
 
-  gboolean success = cfg_init(cfg);
-  if (!success)
-    cfg_deinit(cfg);
+  if (!cfg_init(cfg))
+    {
+      cfg_deinit(cfg);
+      persist_state_cancel(cfg->state);
+      return FALSE;
+    }
 
-  if (success)
-    persist_state_commit(cfg->state);
-  else
-    persist_state_cancel(cfg->state);
-  return success;
+  persist_state_commit(cfg->state);
+  return TRUE;
 }
 
 gboolean

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -189,8 +189,6 @@ main_loop_is_server_mode(MainLoop *self)
 gboolean
 main_loop_initialize_state(GlobalConfig *cfg, const gchar *persist_filename)
 {
-  gboolean success;
-
   cfg->state = persist_state_new(persist_filename);
   persist_state_set_global_error_handler(cfg->state, (gpointer)main_loop_exit, (gpointer)main_loop_get_instance());
 
@@ -201,7 +199,9 @@ main_loop_initialize_state(GlobalConfig *cfg, const gchar *persist_filename)
   if (!host_id_init(cfg->state))
     return FALSE;
 
-  success = cfg_init(cfg);
+  gboolean success = cfg_init(cfg);
+  if (!success)
+    cfg_deinit(cfg);
 
   if (success)
     persist_state_commit(cfg->state);

--- a/news/bugfix-4418.md
+++ b/news/bugfix-4418.md
@@ -1,0 +1,1 @@
+`disk-buffer()`: fix deinitialization when starting syslog-ng with invalid configuration


### PR DESCRIPTION
This does the same that syslog-ng does during reload: a partial (failed) initialization should be followed by a deinit() call.

It makes sure that the pipeline is deinitialized before exiting; for example, that disk-buffers are persisted and closed.