### PR TITLE
Extract grouping-parser()

### DIFF
--- a/modules/correlation/CMakeLists.txt
+++ b/modules/correlation/CMakeLists.txt
@@ -64,6 +64,8 @@ set(CORRELATION_SOURCES
     correlation-plugin.c
     groupingby.c
     groupingby.h
+    grouping-parser.c
+    grouping-parser.h
 )
 
 add_module(

--- a/modules/correlation/Makefile.am
+++ b/modules/correlation/Makefile.am
@@ -59,6 +59,8 @@ modules_correlation_libcorrelation_la_SOURCES			=	\
 	modules/correlation/correlation-parser.c		\
 	modules/correlation/correlation-parser.h		\
 	modules/correlation/correlation-plugin.c		\
+	modules/correlation/grouping-parser.c			\
+	modules/correlation/grouping-parser.h			\
 	modules/correlation/groupingby.c			\
 	modules/correlation/groupingby.h			\
 	$(modules_correlation_libsyslog_ng_patterndb_la_SOURCES)

--- a/modules/correlation/correlation-context.c
+++ b/modules/correlation/correlation-context.c
@@ -80,6 +80,8 @@ correlation_context_sort(CorrelationContext *self, LogTemplate *sort_key)
 void
 correlation_context_init(CorrelationContext *self, const CorrelationKey *key)
 {
+  self->clear = correlation_context_clear_method;
+
   self->messages = g_ptr_array_new();
   memcpy(&self->key, key, sizeof(self->key));
 
@@ -94,14 +96,19 @@ correlation_context_init(CorrelationContext *self, const CorrelationKey *key)
 }
 
 void
-correlation_context_free_method(CorrelationContext *self)
+correlation_context_clear_method(CorrelationContext *self)
 {
-  gint i;
-
-  for (i = 0; i < self->messages->len; i++)
+  for (gint i = 0; i < self->messages->len; i++)
     {
       log_msg_unref((LogMessage *) g_ptr_array_index(self->messages, i));
     }
+  g_ptr_array_set_size(self->messages, 0);
+}
+
+void
+correlation_context_free_method(CorrelationContext *self)
+{
+  correlation_context_clear(self);
   g_ptr_array_free(self->messages, TRUE);
 
   if (self->key.host)

--- a/modules/correlation/correlation-context.h
+++ b/modules/correlation/correlation-context.h
@@ -47,6 +47,7 @@ struct _CorrelationContext
 static inline LogMessage *
 correlation_context_get_last_message(CorrelationContext *self)
 {
+  g_assert(self->messages->len > 0);
   return (LogMessage *) g_ptr_array_index(self->messages, self->messages->len - 1);
 }
 

--- a/modules/correlation/correlation-context.h
+++ b/modules/correlation/correlation-context.h
@@ -40,6 +40,7 @@ struct _CorrelationContext
   /* messages belonging to this context */
   GPtrArray *messages;
   gint ref_cnt;
+  void (*clear)(CorrelationContext *s);
   void (*free_fn)(CorrelationContext *s);
 };
 
@@ -49,7 +50,14 @@ correlation_context_get_last_message(CorrelationContext *self)
   return (LogMessage *) g_ptr_array_index(self->messages, self->messages->len - 1);
 }
 
+static inline void
+correlation_context_clear(CorrelationContext *self)
+{
+  self->clear(self);
+}
+
 void correlation_context_init(CorrelationContext *self, const CorrelationKey *key);
+void correlation_context_clear_method(CorrelationContext *self);
 void correlation_context_free_method(CorrelationContext *self);
 void correlation_context_sort(CorrelationContext *self, LogTemplate *sort_key);
 CorrelationContext *correlation_context_new(CorrelationKey *key);

--- a/modules/correlation/correlation-grammar.ym
+++ b/modules/correlation/correlation-grammar.ym
@@ -134,7 +134,7 @@ grouping_parser_opt
         | KW_SCOPE '(' context_scope ')'                        { grouping_parser_set_scope(last_parser, $3); }
 	| KW_TIMEOUT '(' nonnegative_integer ')'
           {
-            CHECK_ERROR($3 >= 1, @1, "timeout() needs to be greater than 1 second");
+            CHECK_ERROR($3 >= 1, @1, "timeout() needs to be greater than zero");
 
             grouping_parser_set_timeout(last_parser, $3);
           }

--- a/modules/correlation/correlation-grammar.ym
+++ b/modules/correlation/correlation-grammar.ym
@@ -134,9 +134,15 @@ grouping_by_opts
 	;
 
 grouping_by_opt
-	: KW_KEY '(' template_content ')'                       { grouping_by_set_key_template(last_parser, $3); log_template_unref($3); }
-        | KW_SORT_KEY '(' template_content ')'			{ grouping_by_set_sort_key_template(last_parser, $3); log_template_unref($3); }
-        | KW_SCOPE '(' context_scope ')'                        { grouping_by_set_scope(last_parser, $3); }
+	: KW_KEY '(' template_content ')'                       { grouping_parser_set_key_template(last_parser, $3); log_template_unref($3); }
+        | KW_SORT_KEY '(' template_content ')'			{ grouping_parser_set_sort_key_template(last_parser, $3); log_template_unref($3); }
+        | KW_SCOPE '(' context_scope ')'                        { grouping_parser_set_scope(last_parser, $3); }
+	| KW_TIMEOUT '(' nonnegative_integer ')'
+          {
+            CHECK_ERROR($3 >= 1, @1, "timeout() needs to be greater than 1 second");
+
+            grouping_parser_set_timeout(last_parser, $3);
+          }
         | KW_WHERE '('
           {
             FilterExprNode *filter_expr;
@@ -151,12 +157,6 @@ grouping_by_opt
             CHECK_ERROR_WITHOUT_MESSAGE(cfg_parser_parse(&filter_expr_parser, lexer, (gpointer *) &filter_expr, NULL), @1);
             grouping_by_set_having_condition(last_parser, filter_expr);
           } ')'
-	| KW_TIMEOUT '(' nonnegative_integer ')'
-          {
-            CHECK_ERROR($3 >= 1, @1, "timeout() needs to be greater than 1 second");
-
-            grouping_by_set_timeout(last_parser, $3);
-          }
 	| KW_AGGREGATE '(' synthetic_message ')'		{ grouping_by_set_synthetic_message(last_parser, $3); }
 	| KW_TRIGGER '('
           {

--- a/modules/correlation/correlation-grammar.ym
+++ b/modules/correlation/correlation-grammar.ym
@@ -128,13 +128,8 @@ stateful_parser_inject_mode
 	| KW_INTERNAL				{ $$ = stateful_parser_lookup_inject_mode("internal"); }
 	;
 
-grouping_by_opts
-	: grouping_by_opt grouping_by_opts
-	|
-	;
-
-grouping_by_opt
-	: KW_KEY '(' template_content ')'                       { grouping_parser_set_key_template(last_parser, $3); log_template_unref($3); }
+grouping_parser_opt
+        : KW_KEY '(' template_content ')'                       { grouping_parser_set_key_template(last_parser, $3); log_template_unref($3); }
         | KW_SORT_KEY '(' template_content ')'			{ grouping_parser_set_sort_key_template(last_parser, $3); log_template_unref($3); }
         | KW_SCOPE '(' context_scope ')'                        { grouping_parser_set_scope(last_parser, $3); }
 	| KW_TIMEOUT '(' nonnegative_integer ')'
@@ -143,7 +138,16 @@ grouping_by_opt
 
             grouping_parser_set_timeout(last_parser, $3);
           }
-        | KW_WHERE '('
+        ;
+
+
+grouping_by_opts
+	: grouping_by_opt grouping_by_opts
+	|
+	;
+
+grouping_by_opt
+        : KW_WHERE '('
           {
             FilterExprNode *filter_expr;
 
@@ -167,6 +171,7 @@ grouping_by_opt
           } ')'
 	| KW_PREFIX '(' string ')'				{ grouping_by_set_prefix(last_parser, $3); free($3); };
 	| stateful_parser_opt
+        | grouping_parser_opt
 	;
 
 synthetic_message

--- a/modules/correlation/correlation-plugin.c
+++ b/modules/correlation/correlation-plugin.c
@@ -47,7 +47,7 @@ gboolean
 correlation_module_init(PluginContext *context, CfgArgs *args)
 {
   pattern_db_global_init();
-  grouping_by_global_init();
+  grouping_parser_global_init();
   plugin_register(context, correlation_plugins, G_N_ELEMENTS(correlation_plugins));
   return TRUE;
 }

--- a/modules/correlation/correlation.h
+++ b/modules/correlation/correlation.h
@@ -35,14 +35,14 @@ typedef struct _CorrelationState
   GMutex lock;
   GHashTable *state;
   TimerWheel *timer_wheel;
+  TWCallbackFunc expire_callback;
   GTimeVal last_tick;
 } CorrelationState;
 
 void correlation_state_tx_begin(CorrelationState *self);
 void correlation_state_tx_end(CorrelationState *self);
 CorrelationContext *correlation_state_tx_lookup_context(CorrelationState *self, const CorrelationKey *key);
-void correlation_state_tx_store_context(CorrelationState *self, CorrelationContext *context, gint timeout,
-                                        TWCallbackFunc expire);
+void correlation_state_tx_store_context(CorrelationState *self, CorrelationContext *context, gint timeout);
 void correlation_state_tx_remove_context(CorrelationState *self, CorrelationContext *context);
 void correlation_state_tx_update_context(CorrelationState *self, CorrelationContext *context, gint timeout);
 
@@ -54,7 +54,7 @@ void correlation_state_advance_time(CorrelationState *self, gint timeout, gpoint
 
 void correlation_state_init_instance(CorrelationState *self);
 void correlation_state_deinit_instance(CorrelationState *self);
-CorrelationState *correlation_state_new(void);
+CorrelationState *correlation_state_new(TWCallbackFunc expire);
 CorrelationState *correlation_state_ref(CorrelationState *self);
 void correlation_state_unref(CorrelationState *self);
 

--- a/modules/correlation/dbparser.c
+++ b/modules/correlation/dbparser.c
@@ -50,17 +50,14 @@ struct _LogDBParser
 };
 
 static void
-log_db_parser_emit(LogMessage *msg, gboolean synthetic, gpointer user_data)
+log_db_parser_emit(LogMessage *msg, gpointer user_data)
 {
   LogDBParser *self = (LogDBParser *) user_data;
 
-  if (synthetic)
-    {
-      stateful_parser_emit_synthetic(&self->super, msg);
-      msg_debug("db-parser: emitting synthetic message",
-                evt_tag_str("msg", log_msg_get_value(msg, LM_V_MESSAGE, NULL)),
-                log_pipe_location_tag(&self->super.super.super));
-    }
+  stateful_parser_emit_synthetic(&self->super, msg);
+  msg_debug("db-parser: emitting synthetic message",
+            evt_tag_str("msg", log_msg_get_value(msg, LM_V_MESSAGE, NULL)),
+            log_pipe_location_tag(&self->super.super.super));
 }
 
 static void

--- a/modules/correlation/grouping-parser.c
+++ b/modules/correlation/grouping-parser.c
@@ -186,7 +186,7 @@ grouping_parser_lookup_or_create_context(GroupingParser *self, LogMessage *msg)
                 log_pipe_location_tag(&self->super.super.super));
 
       context = grouping_parser_construct_context(self, &key);
-      correlation_state_tx_store_context(self->correlation, context, self->timeout, _expire_entry);
+      correlation_state_tx_store_context(self->correlation, context, self->timeout);
       g_string_steal(buffer);
     }
   else
@@ -333,7 +333,7 @@ grouping_parser_init_instance(GroupingParser *self, GlobalConfig *cfg)
   self->super.super.process = grouping_parser_process_method;
   self->scope = RCS_GLOBAL;
   self->timeout = -1;
-  self->correlation = correlation_state_new();
+  self->correlation = correlation_state_new(_expire_entry);
 }
 
 void

--- a/modules/correlation/grouping-parser.c
+++ b/modules/correlation/grouping-parser.c
@@ -129,6 +129,23 @@ _store_data_in_persist(GroupingParser *self, GlobalConfig *cfg)
 }
 
 
+LogMessage *
+grouping_parser_aggregate_context(GroupingParser *self, CorrelationContext *context)
+{
+  if (self->sort_key_template)
+    correlation_context_sort(context, self->sort_key_template);
+
+  LogMessage *msg = self->aggregate_context(self, context);
+
+  correlation_state_tx_remove_context(self->correlation, context);
+
+  /* correlation_context_free is automatically called when returning from
+     this function by the timerwheel code as a destroy notify
+     callback. */
+
+  return msg;
+}
+
 static void
 _expire_entry(TimerWheel *wheel, guint64 now, gpointer user_data, gpointer caller_context)
 {

--- a/modules/correlation/grouping-parser.c
+++ b/modules/correlation/grouping-parser.c
@@ -188,7 +188,7 @@ grouping_parser_lookup_or_create_context(GroupingParser *self, LogMessage *msg)
                 evt_tag_int("expiration", correlation_state_get_time(self->correlation) + self->timeout),
                 log_pipe_location_tag(&self->super.super.super));
 
-      context = correlation_context_new(&key);
+      context = grouping_parser_construct_context(self, &key);
       correlation_state_tx_store_context(self->correlation, context, self->timeout, _expire_entry);
       g_string_steal(buffer);
     }

--- a/modules/correlation/grouping-parser.c
+++ b/modules/correlation/grouping-parser.c
@@ -211,7 +211,8 @@ grouping_parser_perform_grouping(GroupingParser *self, LogMessage *msg)
   correlation_state_tx_begin(self->correlation);
 
   CorrelationContext *context = grouping_parser_lookup_or_create_context(self, msg);
-  g_ptr_array_add(context->messages, log_msg_ref(msg));
+
+  grouping_parser_update_context(self, context, msg);
 
   if (grouping_parser_is_context_complete(self, context))
     {

--- a/modules/correlation/grouping-parser.c
+++ b/modules/correlation/grouping-parser.c
@@ -212,9 +212,7 @@ grouping_parser_perform_grouping(GroupingParser *self, LogMessage *msg)
 
   CorrelationContext *context = grouping_parser_lookup_or_create_context(self, msg);
 
-  grouping_parser_update_context(self, context, msg);
-
-  if (grouping_parser_is_context_complete(self, context))
+  if (grouping_parser_update_context(self, context, msg))
     {
       msg_verbose("Correlation trigger() met, closing state",
                   evt_tag_str("key", context->key.session_id),

--- a/modules/correlation/grouping-parser.c
+++ b/modules/correlation/grouping-parser.c
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2023 Balazs Scheidler <bazsi77@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "grouping-parser.h"
+
+void
+grouping_parser_set_key_template(LogParser *s, LogTemplate *key_template)
+{
+  GroupingParser *self = (GroupingParser *) s;
+
+  log_template_unref(self->key_template);
+  self->key_template = log_template_ref(key_template);
+}
+
+void
+grouping_parser_set_sort_key_template(LogParser *s, LogTemplate *sort_key)
+{
+  GroupingParser *self = (GroupingParser *) s;
+
+  log_template_unref(self->sort_key_template);
+  self->sort_key_template = log_template_ref(sort_key);
+}
+
+void
+grouping_parser_set_scope(LogParser *s, CorrelationScope scope)
+{
+  GroupingParser *self = (GroupingParser *) s;
+
+  self->scope = scope;
+}
+
+void
+grouping_parser_set_timeout(LogParser *s, gint timeout)
+{
+  GroupingParser *self = (GroupingParser *) s;
+
+  self->timeout = timeout;
+}
+
+/*
+ * This function can be called any time when pattern-db is not processing
+ * messages, but we expect the correlation timer to move forward.  It
+ * doesn't need to be called absolutely regularly as it'll use the current
+ * system time to determine how much time has passed since the last
+ * invocation.  See the timing comment at pattern_db_process() for more
+ * information.
+ */
+static void
+_advance_time_by_timer_tick(GroupingParser *self)
+{
+  StatefulParserEmittedMessages emitted_messages = STATEFUL_PARSER_EMITTED_MESSAGES_INIT;
+
+  if (correlation_state_timer_tick(self->correlation, &emitted_messages))
+    {
+      msg_debug("Advancing grouping-by() current time because of timer tick",
+                evt_tag_long("utc", correlation_state_get_time(self->correlation)),
+                log_pipe_location_tag(&self->super.super.super));
+    }
+  stateful_parser_emitted_messages_flush(&emitted_messages, &self->super);
+}
+
+static void
+_timer_tick(gpointer s)
+{
+  GroupingParser *self = (GroupingParser *) s;
+
+  _advance_time_by_timer_tick(self);
+  iv_validate_now();
+  self->tick.expires = iv_now;
+  self->tick.expires.tv_sec++;
+  iv_timer_register(&self->tick);
+}
+
+
+static void
+_load_correlation_state(GroupingParser *self, GlobalConfig *cfg)
+{
+  CorrelationState *persisted_correlation = cfg_persist_config_fetch(cfg,
+                                            log_pipe_get_persist_name(&self->super.super.super));
+  if (persisted_correlation)
+    {
+      correlation_state_unref(self->correlation);
+      self->correlation = persisted_correlation;
+    }
+
+  timer_wheel_set_associated_data(self->correlation->timer_wheel, log_pipe_ref((LogPipe *)self),
+                                  (GDestroyNotify)log_pipe_unref);
+}
+
+static void
+_store_data_in_persist(GroupingParser *self, GlobalConfig *cfg)
+{
+  cfg_persist_config_add(cfg, log_pipe_get_persist_name(&self->super.super.super),
+                         correlation_state_ref(self->correlation),
+                         (GDestroyNotify) correlation_state_unref);
+}
+
+gboolean
+grouping_parser_init_method(LogPipe *s)
+{
+  GroupingParser *self = (GroupingParser *) s;
+  GlobalConfig *cfg = log_pipe_get_config(s);
+
+  if (self->timeout < 1)
+    {
+      msg_error("timeout() needs to be specified explicitly and must be greater than 0 in the grouping-by() parser",
+                log_pipe_location_tag(s));
+      return FALSE;
+    }
+  if (!self->key_template)
+    {
+      msg_error("The key() option is mandatory for the grouping-by() parser",
+                log_pipe_location_tag(s));
+      return FALSE;
+    }
+
+  iv_validate_now();
+  IV_TIMER_INIT(&self->tick);
+  self->tick.cookie = self;
+  self->tick.handler = _timer_tick;
+  self->tick.expires = iv_now;
+  self->tick.expires.tv_sec++;
+  self->tick.expires.tv_nsec = 0;
+  iv_timer_register(&self->tick);
+
+  _load_correlation_state(self, cfg);
+
+  return stateful_parser_init_method(s);
+}
+
+gboolean
+grouping_parser_deinit_method(LogPipe *s)
+{
+  GroupingParser *self = (GroupingParser *) s;
+  GlobalConfig *cfg = log_pipe_get_config(s);
+
+  if (iv_timer_registered(&self->tick))
+    {
+      iv_timer_unregister(&self->tick);
+    }
+
+  _store_data_in_persist(self, cfg);
+  return stateful_parser_deinit_method(s);
+}
+
+void
+grouping_parser_free_method(LogPipe *s)
+{
+  GroupingParser *self = (GroupingParser *) s;
+
+  log_template_unref(self->key_template);
+  log_template_unref(self->sort_key_template);
+  correlation_state_unref(self->correlation);
+
+  stateful_parser_free_method(s);
+}
+
+void
+grouping_parser_init_instance(GroupingParser *self, GlobalConfig *cfg)
+{
+  stateful_parser_init_instance(&self->super, cfg);
+  self->super.super.super.free_fn = grouping_parser_free_method;
+  self->super.super.super.init = grouping_parser_init_method;
+  self->super.super.super.deinit = grouping_parser_deinit_method;
+//  self->super.super.super.clone = _clone;
+//  self->super.super.super.generate_persist_name = _format_persist_name;
+//  self->super.super.process = _process;
+  self->scope = RCS_GLOBAL;
+  self->timeout = -1;
+  self->correlation = correlation_state_new();
+}

--- a/modules/correlation/grouping-parser.c
+++ b/modules/correlation/grouping-parser.c
@@ -115,6 +115,18 @@ _store_data_in_persist(GroupingParser *self, GlobalConfig *cfg)
 }
 
 gboolean
+grouping_parser_process_method(LogParser *s,
+                               LogMessage **pmsg, const LogPathOptions *path_options,
+                               const char *input, gsize input_len)
+{
+  GroupingParser *self = (GroupingParser *) s;
+
+  if (grouping_parser_filter_messages(self, pmsg, path_options))
+    grouping_parser_perform_grouping(self, log_msg_make_writable(pmsg, path_options));
+  return (self->super.inject_mode != LDBP_IM_AGGREGATE_ONLY);
+}
+
+gboolean
 grouping_parser_init_method(LogPipe *s)
 {
   GroupingParser *self = (GroupingParser *) s;
@@ -183,7 +195,7 @@ grouping_parser_init_instance(GroupingParser *self, GlobalConfig *cfg)
   self->super.super.super.deinit = grouping_parser_deinit_method;
 //  self->super.super.super.clone = _clone;
 //  self->super.super.super.generate_persist_name = _format_persist_name;
-//  self->super.super.process = _process;
+  self->super.super.process = grouping_parser_process_method;
   self->scope = RCS_GLOBAL;
   self->timeout = -1;
   self->correlation = correlation_state_new();

--- a/modules/correlation/grouping-parser.c
+++ b/modules/correlation/grouping-parser.c
@@ -268,19 +268,6 @@ grouping_parser_init_method(LogPipe *s)
   GroupingParser *self = (GroupingParser *) s;
   GlobalConfig *cfg = log_pipe_get_config(s);
 
-  if (self->timeout < 1)
-    {
-      msg_error("timeout() needs to be specified explicitly and must be greater than 0 in the grouping-by() parser",
-                log_pipe_location_tag(s));
-      return FALSE;
-    }
-  if (!self->key_template)
-    {
-      msg_error("The key() option is mandatory for the grouping-by() parser",
-                log_pipe_location_tag(s));
-      return FALSE;
-    }
-
   iv_validate_now();
   IV_TIMER_INIT(&self->tick);
   self->tick.cookie = self;

--- a/modules/correlation/grouping-parser.h
+++ b/modules/correlation/grouping-parser.h
@@ -83,7 +83,8 @@ void grouping_parser_set_timeout(LogParser *s, gint timeout);
 
 
 CorrelationContext *grouping_parser_lookup_or_create_context(GroupingParser *self, LogMessage *msg);
-void grouping_parser_perform_grouping(GroupingParser *s, LogMessage *msg);
+void grouping_parser_perform_grouping(GroupingParser *s, LogMessage *msg,
+                                      StatefulParserEmittedMessages *emitted_mesages);
 
 gboolean
 grouping_parser_process_method(LogParser *s,

--- a/modules/correlation/grouping-parser.h
+++ b/modules/correlation/grouping-parser.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2015 BalaBit
+ * Copyright (c) 2023 Balazs Scheidler <bazsi77@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef CORRELATION_GROUPING_PARSER_H_INCLUDED
+#define CORRELATION_GROUPING_PARSER_H_INCLUDED
+
+#include "stateful-parser.h"
+#include "correlation.h"
+#include <iv.h>
+
+typedef struct _GroupingParser GroupingParser;
+
+struct _GroupingParser
+{
+  StatefulParser super;
+  struct iv_timer tick;
+  CorrelationState *correlation;
+  LogTemplate *key_template;
+  LogTemplate *sort_key_template;
+  gint timeout;
+  CorrelationScope scope;
+};
+
+void grouping_parser_set_key_template(LogParser *s, LogTemplate *key_template);
+void grouping_parser_set_sort_key_template(LogParser *s, LogTemplate *sort_key);
+void grouping_parser_set_scope(LogParser *s, CorrelationScope scope);
+void grouping_parser_set_timeout(LogParser *s, gint timeout);
+
+gboolean grouping_parser_init_method(LogPipe *s);
+gboolean grouping_parser_deinit_method(LogPipe *s);
+
+void grouping_parser_free_method(LogPipe *s);
+void grouping_parser_init_instance(GroupingParser *self, GlobalConfig *cfg);
+
+
+
+#endif

--- a/modules/correlation/grouping-parser.h
+++ b/modules/correlation/grouping-parser.h
@@ -29,6 +29,13 @@
 
 typedef struct _GroupingParser GroupingParser;
 
+typedef enum
+{
+  GP_CONTEXT_UPDATED,
+  GP_CONTEXT_COMPLETE,
+  GP_STARTS_NEW_CONTEXT,
+} GroupingParserUpdateContextResult;
+
 struct _GroupingParser
 {
   StatefulParser super;
@@ -40,7 +47,7 @@ struct _GroupingParser
   CorrelationScope scope;
   gboolean (*filter_messages)(GroupingParser *self, LogMessage **pmsg, const LogPathOptions *path_options);
   CorrelationContext *(*construct_context)(GroupingParser *self, CorrelationKey *key);
-  gboolean (*update_context)(GroupingParser *self, CorrelationContext *context, LogMessage *msg);
+  GroupingParserUpdateContextResult (*update_context)(GroupingParser *self, CorrelationContext *context, LogMessage *msg);
   LogMessage *(*aggregate_context)(GroupingParser *self, CorrelationContext *context);
 };
 

--- a/modules/correlation/grouping-parser.h
+++ b/modules/correlation/grouping-parser.h
@@ -39,6 +39,7 @@ struct _GroupingParser
   gint timeout;
   CorrelationScope scope;
   gboolean (*filter_messages)(GroupingParser *self, LogMessage **pmsg, const LogPathOptions *path_options);
+  CorrelationContext *(*construct_context)(GroupingParser *self, CorrelationKey *key);
   gboolean (*is_context_complete)(GroupingParser *self, CorrelationContext *context);
   LogMessage *(*aggregate_context)(GroupingParser *self, CorrelationContext *context);
 };
@@ -57,6 +58,14 @@ grouping_parser_is_context_complete(GroupingParser *self, CorrelationContext *co
   if (self->is_context_complete)
     return self->is_context_complete(self, context);
   return FALSE;
+}
+
+static inline CorrelationContext *
+grouping_parser_construct_context(GroupingParser *self, CorrelationKey *key)
+{
+  if (self->construct_context)
+    return self->construct_context(self, key);
+  return correlation_context_new(key);
 }
 
 LogMessage *grouping_parser_aggregate_context(GroupingParser *self, CorrelationContext *context);

--- a/modules/correlation/grouping-parser.h
+++ b/modules/correlation/grouping-parser.h
@@ -40,8 +40,7 @@ struct _GroupingParser
   CorrelationScope scope;
   gboolean (*filter_messages)(GroupingParser *self, LogMessage **pmsg, const LogPathOptions *path_options);
   CorrelationContext *(*construct_context)(GroupingParser *self, CorrelationKey *key);
-  void (*update_context)(GroupingParser *self, CorrelationContext *context, LogMessage *msg);
-  gboolean (*is_context_complete)(GroupingParser *self, CorrelationContext *context);
+  gboolean (*update_context)(GroupingParser *self, CorrelationContext *context, LogMessage *msg);
   LogMessage *(*aggregate_context)(GroupingParser *self, CorrelationContext *context);
 };
 
@@ -62,21 +61,10 @@ grouping_parser_construct_context(GroupingParser *self, CorrelationKey *key)
   return correlation_context_new(key);
 }
 
-static inline void
+static inline gboolean
 grouping_parser_update_context(GroupingParser *self, CorrelationContext *context, LogMessage *msg)
 {
-  if (self->update_context)
-    self->update_context(self, context, msg);
-  else
-    g_ptr_array_add(context->messages, log_msg_ref(msg));
-}
-
-static inline gboolean
-grouping_parser_is_context_complete(GroupingParser *self, CorrelationContext *context)
-{
-  if (self->is_context_complete)
-    return self->is_context_complete(self, context);
-  return FALSE;
+  return self->update_context(self, context, msg);
 }
 
 LogMessage *grouping_parser_aggregate_context(GroupingParser *self, CorrelationContext *context);

--- a/modules/correlation/grouping-parser.h
+++ b/modules/correlation/grouping-parser.h
@@ -38,13 +38,33 @@ struct _GroupingParser
   LogTemplate *sort_key_template;
   gint timeout;
   CorrelationScope scope;
+  gboolean (*filter_messages)(GroupingParser *self, LogMessage **pmsg, const LogPathOptions *path_options);
+  void (*perform_grouping)(GroupingParser *self, LogMessage *msg);
 };
+
+static inline gboolean
+grouping_parser_filter_messages(GroupingParser *self, LogMessage **pmsg, const LogPathOptions *path_options)
+{
+  if (self->filter_messages)
+    return self->filter_messages(self, pmsg, path_options);
+  return TRUE;
+}
+
+static inline void
+grouping_parser_perform_grouping(GroupingParser *self, LogMessage *msg)
+{
+  return self->perform_grouping(self, msg);
+}
 
 void grouping_parser_set_key_template(LogParser *s, LogTemplate *key_template);
 void grouping_parser_set_sort_key_template(LogParser *s, LogTemplate *sort_key);
 void grouping_parser_set_scope(LogParser *s, CorrelationScope scope);
 void grouping_parser_set_timeout(LogParser *s, gint timeout);
 
+gboolean
+grouping_parser_process_method(LogParser *s,
+                               LogMessage **pmsg, const LogPathOptions *path_options,
+                               const char *input, gsize input_len);
 gboolean grouping_parser_init_method(LogPipe *s);
 gboolean grouping_parser_deinit_method(LogPipe *s);
 

--- a/modules/correlation/grouping-parser.h
+++ b/modules/correlation/grouping-parser.h
@@ -81,6 +81,6 @@ gboolean grouping_parser_deinit_method(LogPipe *s);
 void grouping_parser_free_method(LogPipe *s);
 void grouping_parser_init_instance(GroupingParser *self, GlobalConfig *cfg);
 
-
+void grouping_parser_global_init(void);
 
 #endif

--- a/modules/correlation/grouping-parser.h
+++ b/modules/correlation/grouping-parser.h
@@ -59,7 +59,6 @@ grouping_parser_filter_messages(GroupingParser *self, LogMessage **pmsg, const L
   return TRUE;
 }
 
-
 static inline CorrelationContext *
 grouping_parser_construct_context(GroupingParser *self, CorrelationKey *key)
 {

--- a/modules/correlation/grouping-parser.h
+++ b/modules/correlation/grouping-parser.h
@@ -39,7 +39,7 @@ struct _GroupingParser
   gint timeout;
   CorrelationScope scope;
   gboolean (*filter_messages)(GroupingParser *self, LogMessage **pmsg, const LogPathOptions *path_options);
-  void (*perform_grouping)(GroupingParser *self, LogMessage *msg);
+  gboolean (*is_context_complete)(GroupingParser *self, CorrelationContext *context);
   LogMessage *(*aggregate_context)(GroupingParser *self, CorrelationContext *context);
 };
 
@@ -51,10 +51,12 @@ grouping_parser_filter_messages(GroupingParser *self, LogMessage **pmsg, const L
   return TRUE;
 }
 
-static inline void
-grouping_parser_perform_grouping(GroupingParser *self, LogMessage *msg)
+static inline gboolean
+grouping_parser_is_context_complete(GroupingParser *self, CorrelationContext *context)
 {
-  return self->perform_grouping(self, msg);
+  if (self->is_context_complete)
+    return self->is_context_complete(self, context);
+  return FALSE;
 }
 
 LogMessage *grouping_parser_aggregate_context(GroupingParser *self, CorrelationContext *context);
@@ -66,6 +68,7 @@ void grouping_parser_set_timeout(LogParser *s, gint timeout);
 
 
 CorrelationContext *grouping_parser_lookup_or_create_context(GroupingParser *self, LogMessage *msg);
+void grouping_parser_perform_grouping(GroupingParser *s, LogMessage *msg);
 
 gboolean
 grouping_parser_process_method(LogParser *s,

--- a/modules/correlation/grouping-parser.h
+++ b/modules/correlation/grouping-parser.h
@@ -57,11 +57,7 @@ grouping_parser_perform_grouping(GroupingParser *self, LogMessage *msg)
   return self->perform_grouping(self, msg);
 }
 
-static inline LogMessage *
-grouping_parser_aggregate_context(GroupingParser *self, CorrelationContext *context)
-{
-  return self->aggregate_context(self, context);
-}
+LogMessage *grouping_parser_aggregate_context(GroupingParser *self, CorrelationContext *context);
 
 void grouping_parser_set_key_template(LogParser *s, LogTemplate *key_template);
 void grouping_parser_set_sort_key_template(LogParser *s, LogTemplate *sort_key);

--- a/modules/correlation/grouping-parser.h
+++ b/modules/correlation/grouping-parser.h
@@ -40,6 +40,7 @@ struct _GroupingParser
   CorrelationScope scope;
   gboolean (*filter_messages)(GroupingParser *self, LogMessage **pmsg, const LogPathOptions *path_options);
   void (*perform_grouping)(GroupingParser *self, LogMessage *msg);
+  LogMessage *(*aggregate_context)(GroupingParser *self, CorrelationContext *context);
 };
 
 static inline gboolean
@@ -56,10 +57,19 @@ grouping_parser_perform_grouping(GroupingParser *self, LogMessage *msg)
   return self->perform_grouping(self, msg);
 }
 
+static inline LogMessage *
+grouping_parser_aggregate_context(GroupingParser *self, CorrelationContext *context)
+{
+  return self->aggregate_context(self, context);
+}
+
 void grouping_parser_set_key_template(LogParser *s, LogTemplate *key_template);
 void grouping_parser_set_sort_key_template(LogParser *s, LogTemplate *sort_key);
 void grouping_parser_set_scope(LogParser *s, CorrelationScope scope);
 void grouping_parser_set_timeout(LogParser *s, gint timeout);
+
+
+CorrelationContext *grouping_parser_lookup_or_create_context(GroupingParser *self, LogMessage *msg);
 
 gboolean
 grouping_parser_process_method(LogParser *s,

--- a/modules/correlation/groupingby.c
+++ b/modules/correlation/groupingby.c
@@ -116,8 +116,9 @@ _evaluate_trigger(GroupingBy *self, CorrelationContext *context)
 }
 
 static LogMessage *
-_generate_synthetic_msg(GroupingBy *self, CorrelationContext *context)
+_aggregate_context(GroupingParser *s, CorrelationContext *context)
 {
+  GroupingBy *self = (GroupingBy *) s;
   LogMessage *msg = NULL;
 
   if (!_evaluate_having(self, context))
@@ -129,24 +130,6 @@ _generate_synthetic_msg(GroupingBy *self, CorrelationContext *context)
     }
 
   msg = synthetic_message_generate_with_context(self->synthetic_message, context);
-
-  return msg;
-}
-
-static LogMessage *
-_aggregate_context(GroupingParser *s, CorrelationContext *context)
-{
-  GroupingBy *self = (GroupingBy *) s;
-  if (self->super.sort_key_template)
-    correlation_context_sort(context, self->super.sort_key_template);
-
-  LogMessage *msg = _generate_synthetic_msg(self, context);
-
-  correlation_state_tx_remove_context(self->super.correlation, context);
-
-  /* correlation_context_free is automatically called when returning from
-     this function by the timerwheel code as a destroy notify
-     callback. */
 
   return msg;
 }

--- a/modules/correlation/groupingby.c
+++ b/modules/correlation/groupingby.c
@@ -34,58 +34,18 @@
 
 typedef struct _GroupingBy
 {
-  StatefulParser super;
-  struct iv_timer tick;
-  CorrelationState *correlation;
-  LogTemplate *key_template;
-  LogTemplate *sort_key_template;
-  gint timeout;
-  gint clone_id;
-  CorrelationScope scope;
+  GroupingParser super;
   SyntheticMessage *synthetic_message;
   FilterExprNode *trigger_condition_expr;
   FilterExprNode *where_condition_expr;
   FilterExprNode *having_condition_expr;
   gchar *prefix;
+  gint clone_id;
 } GroupingBy;
 
 static NVHandle context_id_handle = 0;
 
 /* public functions */
-
-void
-grouping_by_set_key_template(LogParser *s, LogTemplate *key_template)
-{
-  GroupingBy *self = (GroupingBy *) s;
-
-  log_template_unref(self->key_template);
-  self->key_template = log_template_ref(key_template);
-}
-
-void
-grouping_by_set_sort_key_template(LogParser *s, LogTemplate *sort_key)
-{
-  GroupingBy *self = (GroupingBy *) s;
-
-  log_template_unref(self->sort_key_template);
-  self->sort_key_template = log_template_ref(sort_key);
-}
-
-void
-grouping_by_set_scope(LogParser *s, CorrelationScope scope)
-{
-  GroupingBy *self = (GroupingBy *) s;
-
-  self->scope = scope;
-}
-
-void
-grouping_by_set_timeout(LogParser *s, gint timeout)
-{
-  GroupingBy *self = (GroupingBy *) s;
-
-  self->timeout = timeout;
-}
 
 void
 grouping_by_set_trigger_condition(LogParser *s, FilterExprNode *filter_expr)
@@ -130,49 +90,14 @@ grouping_by_set_prefix(LogParser *s, const gchar *prefix)
   self->prefix = g_strdup(prefix);
 }
 
-
 /* NOTE: lock should be acquired for writing before calling this function. */
 void
 _advance_time_based_on_message(GroupingBy *self, const UnixTime *ls, StatefulParserEmittedMessages *emitted_messages)
 {
-  correlation_state_set_time(self->correlation, ls->ut_sec, emitted_messages);
+  correlation_state_set_time(self->super.correlation, ls->ut_sec, emitted_messages);
   msg_debug("Advancing grouping-by() current time because of an incoming message",
-            evt_tag_long("utc", correlation_state_get_time(self->correlation)),
-            log_pipe_location_tag(&self->super.super.super));
-}
-
-/*
- * This function can be called any time when pattern-db is not processing
- * messages, but we expect the correlation timer to move forward.  It
- * doesn't need to be called absolutely regularly as it'll use the current
- * system time to determine how much time has passed since the last
- * invocation.  See the timing comment at pattern_db_process() for more
- * information.
- */
-static void
-_advance_time_by_timer_tick(GroupingBy *self)
-{
-  StatefulParserEmittedMessages emitted_messages = STATEFUL_PARSER_EMITTED_MESSAGES_INIT;
-
-  if (correlation_state_timer_tick(self->correlation, &emitted_messages))
-    {
-      msg_debug("Advancing grouping-by() current time because of timer tick",
-                evt_tag_long("utc", correlation_state_get_time(self->correlation)),
-                log_pipe_location_tag(&self->super.super.super));
-    }
-  stateful_parser_emitted_messages_flush(&emitted_messages, &self->super);
-}
-
-static void
-_timer_tick(gpointer s)
-{
-  GroupingBy *self = (GroupingBy *) s;
-
-  _advance_time_by_timer_tick(self);
-  iv_validate_now();
-  self->tick.expires = iv_now;
-  self->tick.expires.tv_sec++;
-  iv_timer_register(&self->tick);
+            evt_tag_long("utc", correlation_state_get_time(self->super.correlation)),
+            log_pipe_location_tag(&self->super.super.super.super));
 }
 
 static gboolean
@@ -210,7 +135,7 @@ _generate_synthetic_msg(GroupingBy *self, CorrelationContext *context)
     {
       msg_debug("groupingby() dropping context, because having() is FALSE",
                 evt_tag_str("key", context->key.session_id),
-                log_pipe_location_tag(&self->super.super.super));
+                log_pipe_location_tag(&self->super.super.super.super));
       return NULL;
     }
 
@@ -222,12 +147,12 @@ _generate_synthetic_msg(GroupingBy *self, CorrelationContext *context)
 static LogMessage *
 _aggregate_context(GroupingBy *self, CorrelationContext *context)
 {
-  if (self->sort_key_template)
-    correlation_context_sort(context, self->sort_key_template);
+  if (self->super.sort_key_template)
+    correlation_context_sort(context, self->super.sort_key_template);
 
   LogMessage *msg = _generate_synthetic_msg(self, context);
 
-  correlation_state_tx_remove_context(self->correlation, context);
+  correlation_state_tx_remove_context(self->super.correlation, context);
 
   /* correlation_context_free is automatically called when returning from
      this function by the timerwheel code as a destroy notify
@@ -244,9 +169,9 @@ _expire_entry(TimerWheel *wheel, guint64 now, gpointer user_data, gpointer calle
   GroupingBy *self = (GroupingBy *) timer_wheel_get_associated_data(wheel);
 
   msg_debug("Expiring grouping-by() correlation context",
-            evt_tag_long("utc", correlation_state_get_time(self->correlation)),
+            evt_tag_long("utc", correlation_state_get_time(self->super.correlation)),
             evt_tag_str("context-id", context->key.session_id),
-            log_pipe_location_tag(&self->super.super.super));
+            log_pipe_location_tag(&self->super.super.super.super));
 
   context->timer = NULL;
   LogMessage *msg = _aggregate_context(self, context);
@@ -265,44 +190,45 @@ _lookup_or_create_context(GroupingBy *self, LogMessage *msg)
   CorrelationKey key;
   GString *buffer = scratch_buffers_alloc();
 
-  log_template_format(self->key_template, msg, &DEFAULT_TEMPLATE_EVAL_OPTIONS, buffer);
+  log_template_format(self->super.key_template, msg, &DEFAULT_TEMPLATE_EVAL_OPTIONS, buffer);
   log_msg_set_value(msg, context_id_handle, buffer->str, -1);
 
-  correlation_key_init(&key, self->scope, msg, buffer->str);
-  context = correlation_state_tx_lookup_context(self->correlation, &key);
+  correlation_key_init(&key, self->super.scope, msg, buffer->str);
+  context = correlation_state_tx_lookup_context(self->super.correlation, &key);
   if (!context)
     {
       msg_debug("Correlation context lookup failure, starting a new context",
                 evt_tag_str("key", key.session_id),
-                evt_tag_int("timeout", self->timeout),
-                evt_tag_int("expiration", correlation_state_get_time(self->correlation) + self->timeout),
-                log_pipe_location_tag(&self->super.super.super));
+                evt_tag_int("timeout", self->super.timeout),
+                evt_tag_int("expiration", correlation_state_get_time(self->super.correlation) + self->super.timeout),
+                log_pipe_location_tag(&self->super.super.super.super));
 
       context = correlation_context_new(&key);
-      correlation_state_tx_store_context(self->correlation, context, self->timeout, _expire_entry);
+      correlation_state_tx_store_context(self->super.correlation, context, self->super.timeout, _expire_entry);
       g_string_steal(buffer);
     }
   else
     {
       msg_debug("Correlation context lookup successful",
                 evt_tag_str("key", key.session_id),
-                evt_tag_int("timeout", self->timeout),
-                evt_tag_int("expiration", correlation_state_get_time(self->correlation) + self->timeout),
+                evt_tag_int("timeout", self->super.timeout),
+                evt_tag_int("expiration", correlation_state_get_time(self->super.correlation) + self->super.timeout),
                 evt_tag_int("num_messages", context->messages->len),
-                log_pipe_location_tag(&self->super.super.super));
+                log_pipe_location_tag(&self->super.super.super.super));
     }
 
   return context;
 }
 
 static void
-_perform_groupby(GroupingBy *self, LogMessage *msg)
+_perform_groupby(GroupingParser *s, LogMessage *msg)
 {
+  GroupingBy *self = (GroupingBy *) s;
   StatefulParserEmittedMessages emitted_messages = STATEFUL_PARSER_EMITTED_MESSAGES_INIT;
 
   _advance_time_based_on_message(self, &msg->timestamps[LM_TS_STAMP], &emitted_messages);
 
-  correlation_state_tx_begin(self->correlation);
+  correlation_state_tx_begin(self->super.correlation);
 
   CorrelationContext *context = _lookup_or_create_context(self, msg);
   g_ptr_array_add(context->messages, log_msg_ref(msg));
@@ -311,19 +237,19 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
     {
       msg_verbose("Correlation trigger() met, closing state",
                   evt_tag_str("key", context->key.session_id),
-                  evt_tag_int("timeout", self->timeout),
+                  evt_tag_int("timeout", self->super.timeout),
                   evt_tag_int("num_messages", context->messages->len),
-                  log_pipe_location_tag(&self->super.super.super));
+                  log_pipe_location_tag(&self->super.super.super.super));
 
       /* close down state */
       LogMessage *genmsg = _aggregate_context(self, context);
 
-      correlation_state_tx_end(self->correlation);
-      stateful_parser_emitted_messages_flush(&emitted_messages, &self->super);
+      correlation_state_tx_end(self->super.correlation);
+      stateful_parser_emitted_messages_flush(&emitted_messages, &self->super.super);
 
       if (genmsg)
         {
-          stateful_parser_emit_synthetic(&self->super, genmsg);
+          stateful_parser_emit_synthetic(&self->super.super, genmsg);
           log_msg_unref(genmsg);
         }
 
@@ -331,17 +257,19 @@ _perform_groupby(GroupingBy *self, LogMessage *msg)
     }
   else
     {
-      correlation_state_tx_update_context(self->correlation, context, self->timeout);
+      correlation_state_tx_update_context(self->super.correlation, context, self->super.timeout);
       log_msg_write_protect(msg);
 
-      correlation_state_tx_end(self->correlation);
-      stateful_parser_emitted_messages_flush(&emitted_messages, &self->super);
+      correlation_state_tx_end(self->super.correlation);
+      stateful_parser_emitted_messages_flush(&emitted_messages, &self->super.super);
     }
 }
 
 static gboolean
-_evaluate_where(GroupingBy *self, LogMessage **pmsg, const LogPathOptions *path_options)
+_evaluate_where(GroupingParser *s, LogMessage **pmsg, const LogPathOptions *path_options)
 {
+  GroupingBy *self = (GroupingBy *) s;
+
   if (!self->where_condition_expr)
     return TRUE;
 
@@ -354,9 +282,9 @@ _process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, co
 {
   GroupingBy *self = (GroupingBy *) s;
 
-  if (_evaluate_where(self, pmsg, path_options))
-    _perform_groupby(self, log_msg_make_writable(pmsg, path_options));
-  return (self->super.inject_mode != LDBP_IM_AGGREGATE_ONLY);
+  if (_evaluate_where(&self->super, pmsg, path_options))
+    _perform_groupby(&self->super, log_msg_make_writable(pmsg, path_options));
+  return (self->super.super.inject_mode != LDBP_IM_AGGREGATE_ONLY);
 }
 
 static const gchar *
@@ -368,33 +296,10 @@ _format_persist_name(const LogPipe *s)
   if (s->persist_name)
     g_snprintf(persist_name, sizeof(persist_name), "grouping-by.%s(clone=%d)", s->persist_name, self->clone_id);
   else
-    g_snprintf(persist_name, sizeof(persist_name), "grouping-by(%s,scope=%d,clone=%d)", self->key_template->template,
-               self->scope, self->clone_id);
+    g_snprintf(persist_name, sizeof(persist_name), "grouping-by(%s,scope=%d,clone=%d)", self->super.key_template->template,
+               self->super.scope, self->clone_id);
 
   return persist_name;
-}
-
-static void
-_load_correlation_state(GroupingBy *self, GlobalConfig *cfg)
-{
-  CorrelationState *persisted_correlation = cfg_persist_config_fetch(cfg,
-                                            log_pipe_get_persist_name(&self->super.super.super));
-  if (persisted_correlation)
-    {
-      correlation_state_unref(self->correlation);
-      self->correlation = persisted_correlation;
-    }
-
-  timer_wheel_set_associated_data(self->correlation->timer_wheel, log_pipe_ref((LogPipe *)self),
-                                  (GDestroyNotify)log_pipe_unref);
-}
-
-static void
-_store_data_in_persist(GroupingBy *self, GlobalConfig *cfg)
-{
-  cfg_persist_config_add(cfg, log_pipe_get_persist_name(&self->super.super.super),
-                         correlation_state_ref(self->correlation),
-                         (GDestroyNotify) correlation_state_unref);
 }
 
 static gboolean
@@ -409,31 +314,8 @@ _init(LogPipe *s)
                 log_pipe_location_tag(s));
       return FALSE;
     }
-  if (self->timeout < 1)
-    {
-      msg_error("timeout() needs to be specified explicitly and must be greater than 0 in the grouping-by() parser",
-                log_pipe_location_tag(s));
-      return FALSE;
-    }
-  if (!self->key_template)
-    {
-      msg_error("The key() option is mandatory for the grouping-by() parser",
-                log_pipe_location_tag(s));
-      return FALSE;
-    }
 
   synthetic_message_set_prefix(self->synthetic_message, self->prefix);
-
-  _load_correlation_state(self, cfg);
-
-  iv_validate_now();
-  IV_TIMER_INIT(&self->tick);
-  self->tick.cookie = self;
-  self->tick.handler = _timer_tick;
-  self->tick.expires = iv_now;
-  self->tick.expires.tv_sec++;
-  self->tick.expires.tv_nsec = 0;
-  iv_timer_register(&self->tick);
 
   if (self->trigger_condition_expr && !filter_expr_init(self->trigger_condition_expr, cfg))
     return FALSE;
@@ -442,24 +324,7 @@ _init(LogPipe *s)
   if (self->having_condition_expr && !filter_expr_init(self->having_condition_expr, cfg))
     return FALSE;
 
-  return stateful_parser_init_method(s);
-}
-
-
-static gboolean
-_deinit(LogPipe *s)
-{
-  GroupingBy *self = (GroupingBy *) s;
-  GlobalConfig *cfg = log_pipe_get_config(s);
-
-  if (iv_timer_registered(&self->tick))
-    {
-      iv_timer_unregister(&self->tick);
-    }
-
-  _store_data_in_persist(self, cfg);
-
-  return stateful_parser_deinit_method(s);
+  return grouping_parser_init_method(s);
 }
 
 static LogPipe *
@@ -469,18 +334,18 @@ _clone(LogPipe *s)
   GroupingBy *cloned;
 
   cloned = (GroupingBy *) grouping_by_new(s->cfg);
-  grouping_by_set_key_template(&cloned->super.super, self->key_template);
-  grouping_by_set_sort_key_template(&cloned->super.super, self->sort_key_template);
-  grouping_by_set_timeout(&cloned->super.super, self->timeout);
-  grouping_by_set_scope(&cloned->super.super, self->scope);
-  grouping_by_set_synthetic_message(&cloned->super.super, self->synthetic_message);
-  grouping_by_set_trigger_condition(&cloned->super.super, filter_expr_clone(self->trigger_condition_expr));
-  grouping_by_set_where_condition(&cloned->super.super, filter_expr_clone(self->where_condition_expr));
-  grouping_by_set_having_condition(&cloned->super.super, filter_expr_clone(self->having_condition_expr));
-  grouping_by_set_prefix(&cloned->super.super, self->prefix);
+  grouping_parser_set_key_template(&cloned->super.super.super, self->super.key_template);
+  grouping_parser_set_sort_key_template(&cloned->super.super.super, self->super.sort_key_template);
+  grouping_parser_set_timeout(&cloned->super.super.super, self->super.timeout);
+  grouping_parser_set_scope(&cloned->super.super.super, self->super.scope);
+  grouping_by_set_synthetic_message(&cloned->super.super.super, self->synthetic_message);
+  grouping_by_set_trigger_condition(&cloned->super.super.super, filter_expr_clone(self->trigger_condition_expr));
+  grouping_by_set_where_condition(&cloned->super.super.super, filter_expr_clone(self->where_condition_expr));
+  grouping_by_set_having_condition(&cloned->super.super.super, filter_expr_clone(self->having_condition_expr));
+  grouping_by_set_prefix(&cloned->super.super.super, self->prefix);
 
   cloned->clone_id = self->clone_id++;
-  return &cloned->super.super.super;
+  return &cloned->super.super.super.super;
 }
 
 static void
@@ -489,16 +354,13 @@ _free(LogPipe *s)
   GroupingBy *self = (GroupingBy *) s;
 
   g_free(self->prefix);
-  log_template_unref(self->key_template);
-  log_template_unref(self->sort_key_template);
   if (self->synthetic_message)
     synthetic_message_free(self->synthetic_message);
-  stateful_parser_free_method(s);
 
   filter_expr_unref(self->trigger_condition_expr);
   filter_expr_unref(self->where_condition_expr);
   filter_expr_unref(self->having_condition_expr);
-  correlation_state_unref(self->correlation);
+  grouping_parser_free_method(s);
 }
 
 LogParser *
@@ -506,17 +368,13 @@ grouping_by_new(GlobalConfig *cfg)
 {
   GroupingBy *self = g_new0(GroupingBy, 1);
 
-  stateful_parser_init_instance(&self->super, cfg);
-  self->super.super.super.free_fn = _free;
-  self->super.super.super.init = _init;
-  self->super.super.super.deinit = _deinit;
-  self->super.super.super.clone = _clone;
-  self->super.super.super.generate_persist_name = _format_persist_name;
-  self->super.super.process = _process;
-  self->scope = RCS_GLOBAL;
-  self->timeout = -1;
-  self->correlation = correlation_state_new();
-  return &self->super.super;
+  grouping_parser_init_instance(&self->super, cfg);
+  self->super.super.super.super.free_fn = _free;
+  self->super.super.super.super.init = _init;
+  self->super.super.super.super.clone = _clone;
+  self->super.super.super.super.generate_persist_name = _format_persist_name;
+  self->super.super.super.process = _process;
+  return &self->super.super.super;
 }
 
 void

--- a/modules/correlation/groupingby.c
+++ b/modules/correlation/groupingby.c
@@ -21,16 +21,6 @@
  */
 
 #include "groupingby.h"
-#include "correlation.h"
-#include "correlation-context.h"
-#include "synthetic-message.h"
-#include "messages.h"
-#include "str-utils.h"
-#include "scratch-buffers.h"
-#include "filter/filter-expr.h"
-#include "timeutils/cache.h"
-#include "timeutils/misc.h"
-#include <iv.h>
 
 typedef struct _GroupingBy
 {

--- a/modules/correlation/groupingby.c
+++ b/modules/correlation/groupingby.c
@@ -106,17 +106,17 @@ _evaluate_having(GroupingBy *self, CorrelationContext *context)
   return _evaluate_filter(self->having_condition_expr, context);
 }
 
-static gboolean
+static GroupingParserUpdateContextResult
 _update_context(GroupingParser *s, CorrelationContext *context, LogMessage *msg)
 {
   GroupingBy *self = (GroupingBy *) s;
 
   g_ptr_array_add(context->messages, log_msg_ref(msg));
 
-  if (!self->trigger_condition_expr)
-    return FALSE;
-
-  return _evaluate_filter(self->trigger_condition_expr, context);
+  if (self->trigger_condition_expr &&
+      _evaluate_filter(self->trigger_condition_expr, context))
+    return GP_CONTEXT_COMPLETE;
+  return GP_CONTEXT_UPDATED;
 }
 
 static LogMessage *

--- a/modules/correlation/groupingby.c
+++ b/modules/correlation/groupingby.c
@@ -276,17 +276,6 @@ _evaluate_where(GroupingParser *s, LogMessage **pmsg, const LogPathOptions *path
   return filter_expr_eval_root(self->where_condition_expr, pmsg, path_options);
 }
 
-static gboolean
-_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_options, const char *input,
-         gsize input_len)
-{
-  GroupingBy *self = (GroupingBy *) s;
-
-  if (_evaluate_where(&self->super, pmsg, path_options))
-    _perform_groupby(&self->super, log_msg_make_writable(pmsg, path_options));
-  return (self->super.super.inject_mode != LDBP_IM_AGGREGATE_ONLY);
-}
-
 static const gchar *
 _format_persist_name(const LogPipe *s)
 {
@@ -373,7 +362,8 @@ grouping_by_new(GlobalConfig *cfg)
   self->super.super.super.super.init = _init;
   self->super.super.super.super.clone = _clone;
   self->super.super.super.super.generate_persist_name = _format_persist_name;
-  self->super.super.super.process = _process;
+  self->super.filter_messages = _evaluate_where;
+  self->super.perform_grouping = _perform_groupby;
   return &self->super.super.super;
 }
 

--- a/modules/correlation/groupingby.c
+++ b/modules/correlation/groupingby.c
@@ -107,9 +107,11 @@ _evaluate_having(GroupingBy *self, CorrelationContext *context)
 }
 
 static gboolean
-_evaluate_trigger(GroupingParser *s, CorrelationContext *context)
+_update_context(GroupingParser *s, CorrelationContext *context, LogMessage *msg)
 {
   GroupingBy *self = (GroupingBy *) s;
+
+  g_ptr_array_add(context->messages, log_msg_ref(msg));
 
   if (!self->trigger_condition_expr)
     return FALSE;
@@ -234,7 +236,7 @@ grouping_by_new(GlobalConfig *cfg)
   self->super.super.super.super.clone = _clone;
   self->super.super.super.super.generate_persist_name = _format_persist_name;
   self->super.filter_messages = _evaluate_where;
-  self->super.is_context_complete = _evaluate_trigger;
+  self->super.update_context = _update_context;
   self->super.aggregate_context = _aggregate_context;
   return &self->super.super.super;
 }

--- a/modules/correlation/groupingby.c
+++ b/modules/correlation/groupingby.c
@@ -160,6 +160,19 @@ _init(LogPipe *s)
   GroupingBy *self = (GroupingBy *) s;
   GlobalConfig *cfg = log_pipe_get_config(s);
 
+  if (self->super.timeout < 1)
+    {
+      msg_error("timeout() needs to be specified explicitly and must be greater than 0 in the grouping-by() parser",
+                log_pipe_location_tag(s));
+      return FALSE;
+    }
+  if (!self->super.key_template)
+    {
+      msg_error("The key() option is mandatory for the grouping-by() parser",
+                log_pipe_location_tag(s));
+      return FALSE;
+    }
+
   if (!self->synthetic_message)
     {
       msg_error("The aggregate() option for grouping-by() is mandatory",

--- a/modules/correlation/groupingby.h
+++ b/modules/correlation/groupingby.h
@@ -22,7 +22,7 @@
 #ifndef PATTERNDB_GROUPING_BY_PARSER_H_INCLUDED
 #define PATTERNDB_GROUPING_BY_PARSER_H_INCLUDED
 
-#include "stateful-parser.h"
+#include "grouping-parser.h"
 #include "synthetic-message.h"
 #include "filter/filter-expr.h"
 

--- a/modules/correlation/groupingby.h
+++ b/modules/correlation/groupingby.h
@@ -36,6 +36,5 @@ void grouping_by_set_where_condition(LogParser *s, FilterExprNode *filter_expr);
 void grouping_by_set_having_condition(LogParser *s, FilterExprNode *filter_expr);
 void grouping_by_set_prefix(LogParser *s, const gchar *prefix);
 LogParser *grouping_by_new(GlobalConfig *cfg);
-void grouping_by_global_init(void);
 
 #endif

--- a/modules/correlation/patterndb.c
+++ b/modules/correlation/patterndb.c
@@ -319,8 +319,7 @@ _execute_action_create_context(PatternDB *db, PDBProcessParams *process_params)
 
   correlation_key_init(&key, syn_context->scope, context_msg, buffer->str);
   new_context = pdb_context_new(&key);
-  correlation_state_tx_store_context(db->correlation, &new_context->super, rule->context.timeout,
-                                     pattern_db_expire_entry);
+  correlation_state_tx_store_context(db->correlation, &new_context->super, rule->context.timeout);
   g_string_free(buffer, FALSE);
 
   g_ptr_array_add(new_context->super.messages, context_msg);
@@ -536,7 +535,7 @@ _pattern_db_process_matching_rule(PatternDB *self, PDBProcessParams *process_par
                     evt_tag_int("context_timeout", rule->context.timeout),
                     evt_tag_int("context_expiration", correlation_state_get_time(self->correlation) + rule->context.timeout));
           context = pdb_context_new(&key);
-          correlation_state_tx_store_context(self->correlation, &context->super, rule->context.timeout, pattern_db_expire_entry);
+          correlation_state_tx_store_context(self->correlation, &context->super, rule->context.timeout);
           g_string_steal(buffer);
         }
       else
@@ -658,7 +657,7 @@ _init_state(PatternDB *self)
 {
   self->rate_limits = g_hash_table_new_full(correlation_key_hash, correlation_key_equal, NULL,
                                             (GDestroyNotify) pdb_rate_limit_free);
-  self->correlation = correlation_state_new();
+  self->correlation = correlation_state_new(pattern_db_expire_entry);
   timer_wheel_set_associated_data(self->correlation->timer_wheel, self, NULL);
 }
 

--- a/modules/correlation/patterndb.h
+++ b/modules/correlation/patterndb.h
@@ -30,7 +30,7 @@
 
 typedef struct _PatternDB PatternDB;
 
-typedef void (*PatternDBEmitFunc)(LogMessage *msg, gboolean synthetic, gpointer user_data);
+typedef void (*PatternDBEmitFunc)(LogMessage *msg, gpointer user_data);
 void pattern_db_set_emit_func(PatternDB *self, PatternDBEmitFunc emit_func, gpointer emit_data);
 void pattern_db_set_program_template(PatternDB *self, LogTemplate *program_template);
 

--- a/modules/correlation/pdbtool/pdbtool.c
+++ b/modules/correlation/pdbtool/pdbtool.c
@@ -351,7 +351,7 @@ pdbtool_match_values(NVHandle handle, const gchar *name,
 }
 
 static void
-pdbtool_pdb_emit(LogMessage *msg, gboolean synthetic, gpointer user_data)
+pdbtool_pdb_emit(LogMessage *msg, gpointer user_data)
 {
   gpointer *args = (gpointer *) user_data;
   FilterExprNode *filter = (FilterExprNode *) args[0];
@@ -599,12 +599,13 @@ pdbtool_match(int argc, char *argv[])
           dbg_info = NULL;
           {
             gpointer nulls[] = { NULL, NULL, &ret, output };
-            pdbtool_pdb_emit(msg, FALSE, nulls);
+            pdbtool_pdb_emit(msg, nulls);
           }
         }
       else
         {
           pattern_db_process(patterndb, msg);
+          pdbtool_pdb_emit(msg, args);
         }
 
       if (G_LIKELY(proto))

--- a/modules/correlation/stateful-parser.c
+++ b/modules/correlation/stateful-parser.c
@@ -24,7 +24,6 @@
 #include "stateful-parser.h"
 #include <string.h>
 
-
 void
 stateful_parser_set_inject_mode(StatefulParser *self, LogDBParserInjectMode inject_mode)
 {
@@ -44,6 +43,17 @@ stateful_parser_emit_synthetic(StatefulParser *self, LogMessage *msg)
   else
     {
       msg_post_message(log_msg_ref(msg));
+    }
+}
+
+void
+stateful_parser_emit_synthetic_list(StatefulParser *self, LogMessage **values, gsize len)
+{
+  for (gint i = 0; i < len; i++)
+    {
+      LogMessage *msg = values[i];
+      stateful_parser_emit_synthetic(self, msg);
+      log_msg_unref(msg);
     }
 }
 

--- a/modules/correlation/stateful-parser.c
+++ b/modules/correlation/stateful-parser.c
@@ -24,6 +24,8 @@
 #include "stateful-parser.h"
 #include <string.h>
 
+
+
 void
 stateful_parser_set_inject_mode(StatefulParser *self, LogDBParserInjectMode inject_mode)
 {
@@ -99,4 +101,46 @@ stateful_parser_lookup_inject_mode(const gchar *inject_mode)
   else if (strcasecmp(inject_mode, "aggregate-only") == 0 || strcasecmp(inject_mode, "aggregate_only") == 0)
     return LDBP_IM_AGGREGATE_ONLY;
   return -1;
+}
+
+/* This function is called to populate the emitted_messages array.  It only
+ * manipulates per-thread data structure so it does not require locks but
+ * does not mind them being locked either.  */
+void
+stateful_parser_emitted_messages_add(StatefulParserEmittedMessages *self, LogMessage *msg)
+{
+  if (self->num_emitted_messages < EXPECTED_NUMBER_OF_MESSAGES_EMITTED)
+    {
+      self->emitted_messages[self->num_emitted_messages++] = log_msg_ref(msg);
+      return;
+    }
+
+  if (!self->emitted_messages_overflow)
+    self->emitted_messages_overflow = g_ptr_array_new();
+
+  g_ptr_array_add(self->emitted_messages_overflow, log_msg_ref(msg));
+}
+
+/* This function is called to flush the accumulated list of messages that
+ * are generated during processing.  We must not hold any locks within
+ * GroupingBy when doing this, as it will cause log_pipe_queue() calls to
+ * subsequent elements in the message pipeline, which in turn may recurse
+ * into PatternDB.  This works as msg_emitter itself is per-thread
+ * (actually an auto variable on the stack), and this is called without
+ * locks held at the end of a process() invocation. */
+void
+stateful_parser_emitted_messages_flush(StatefulParserEmittedMessages *self, StatefulParser *parser)
+{
+  stateful_parser_emit_synthetic_list(parser,
+                                      self->emitted_messages, self->num_emitted_messages);
+  self->num_emitted_messages = 0;
+
+  if (!self->emitted_messages_overflow)
+    return;
+
+  stateful_parser_emit_synthetic_list(parser, (LogMessage **) self->emitted_messages_overflow->pdata,
+                                      self->emitted_messages_overflow->len);
+
+  g_ptr_array_free(self->emitted_messages_overflow, TRUE);
+  self->emitted_messages_overflow = NULL;
 }

--- a/modules/correlation/stateful-parser.h
+++ b/modules/correlation/stateful-parser.h
@@ -53,6 +53,7 @@ stateful_parser_deinit_method(LogPipe *s)
 
 void stateful_parser_set_inject_mode(StatefulParser *self, LogDBParserInjectMode inject_mode);
 void stateful_parser_emit_synthetic(StatefulParser *self, LogMessage *msg);
+void stateful_parser_emit_synthetic_list(StatefulParser *self, LogMessage **values, gsize len);
 void stateful_parser_init_instance(StatefulParser *self, GlobalConfig *cfg);
 void stateful_parser_free_method(LogPipe *s);
 

--- a/modules/correlation/stateful-parser.h
+++ b/modules/correlation/stateful-parser.h
@@ -59,4 +59,26 @@ void stateful_parser_free_method(LogPipe *s);
 
 int stateful_parser_lookup_inject_mode(const gchar *inject_mode);
 
+#define EXPECTED_NUMBER_OF_MESSAGES_EMITTED 32
+
+/* This structure is to be held on the stack to accumulate messages to be
+ * emitted after a single correlation cycle.  We store these messages
+ * temporarily in this struct (instead of sending them along on the log
+ * pipeline), so we can avoid posting them while our locks are held.
+ *
+ * Sending messages along the pipeline with locks held can cause deadlocks,
+ * see the commit a00164c04d for more information.
+ */
+typedef struct _StatefulParserEmittedMessages
+{
+  LogMessage *emitted_messages[EXPECTED_NUMBER_OF_MESSAGES_EMITTED];
+  GPtrArray *emitted_messages_overflow;
+  gint num_emitted_messages;
+} StatefulParserEmittedMessages;
+
+#define STATEFUL_PARSER_EMITTED_MESSAGES_INIT {0}
+
+void stateful_parser_emitted_messages_add(StatefulParserEmittedMessages *self, LogMessage *msg);
+void stateful_parser_emitted_messages_flush(StatefulParserEmittedMessages *self, StatefulParser *parser);
+
 #endif

--- a/news/other-4424.md
+++ b/news/other-4424.md
@@ -1,0 +1,9 @@
+`grouping-by()`: Remove setting of the `${.classifier.context_id}`
+name-value pair in all messages consumed into a correlation context.  This
+functionality is inherited from db-parser() and has never been documented
+for `grouping-by()`, has of limited use, and any uses can be replaced by the
+use of the built-in macro named `$CONTEXT_ID`.  Modifying all consumed
+messages this way has significant performance consequences for
+`grouping-by()` and removing it outweighs the small incompatibility this
+change introduces. The similar functionality in `db-parser()` correlation is
+not removed with this change.


### PR DESCRIPTION
This is the initial set of refactors split off from #4225  Apart from a large amounts of refactoring steps, there's a user
visible change too, as described in this news snippet

`grouping-by()`: Remove setting of the `${.classifier.context_id}`
name-value pair in all messages consumed into a correlation context.  This
functionality is inherited from db-parser() and has never been documented
for `grouping-by()`, has of limited use, and any uses can be replaced by the
use of the built-in macro named `$CONTEXT_ID`.  Modifying all consumed
messages this way has significant performance consequences for
`grouping-by()` and removing it outweighs the small incompatibility this
change introduces. The similar functionality in `db-parser()` correlation is
not removed with this change.
