### PR TITLE
TLS custom certificate validation plugin

### DIFF
--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -57,7 +57,7 @@ typedef struct _AFInetDestDriverTLSVerifyData
 {
   TLSContext *tls_context;
   gchar *hostname;
-  AFInetDestDriver *driver;
+  SignalSlotConnector *signal_connector;
 } AFInetDestDriverTLSVerifyData;
 
 void
@@ -150,7 +150,7 @@ afinet_dd_verify_callback(gint ok, X509_STORE_CTX *ctx, gpointer user_data)
           AFSocketTLSCertificateValidationSignalData signal_data = {0};
           signal_data.ctx = ctx;
 
-          EMIT(self->driver->super.super.super.super.signal_slot_connector, signal_afsocket_tls_certificate_validation,
+          EMIT(self->signal_connector, signal_afsocket_tls_certificate_validation,
                &signal_data);
           ok = !signal_data.failure;
         }
@@ -160,13 +160,13 @@ afinet_dd_verify_callback(gint ok, X509_STORE_CTX *ctx, gpointer user_data)
 }
 
 static AFInetDestDriverTLSVerifyData *
-afinet_dd_tls_verify_data_new(TLSContext *ctx, const gchar *hostname, AFInetDestDriver *driver)
+afinet_dd_tls_verify_data_new(TLSContext *ctx, const gchar *hostname, SignalSlotConnector *signal_connector)
 {
   AFInetDestDriverTLSVerifyData *self = g_new0(AFInetDestDriverTLSVerifyData, 1);
 
   self->tls_context = tls_context_ref(ctx);
   self->hostname = g_strdup(hostname);
-  self->driver = driver;
+  self->signal_connector = signal_connector;
   return self;
 }
 
@@ -221,7 +221,8 @@ afinet_dd_setup_tls_verifier(AFInetDestDriver *self)
   TransportMapperInet *transport_mapper_inet = (TransportMapperInet *) self->super.transport_mapper;
 
   AFInetDestDriverTLSVerifyData *verify_data;
-  verify_data = afinet_dd_tls_verify_data_new(transport_mapper_inet->tls_context, _afinet_dd_get_hostname(self), self);
+  verify_data = afinet_dd_tls_verify_data_new(transport_mapper_inet->tls_context, _afinet_dd_get_hostname(self),
+                                              self->super.super.super.super.signal_slot_connector);
   TLSVerifier *verifier = tls_verifier_new(afinet_dd_verify_callback, verify_data, afinet_dd_tls_verify_data_free);
 
   transport_mapper_inet_set_tls_verifier(transport_mapper_inet, verifier);

--- a/modules/afsocket/afsocket-signals.h
+++ b/modules/afsocket/afsocket-signals.h
@@ -25,6 +25,13 @@
 #define AFSOCKET_SIGNALS_H_INCLUDED
 
 #include "signal-slot-connector/signal-slot-connector.h"
+#include <openssl/x509v3.h>
+
+typedef struct _AFSocketTLSCertificateValidationSignalData
+{
+  X509_STORE_CTX *ctx;
+  gboolean failure;
+} AFSocketTLSCertificateValidationSignalData;
 
 typedef struct _AFSocketSetupSocketSignalData
 {
@@ -35,5 +42,7 @@ typedef struct _AFSocketSetupSocketSignalData
 } AFSocketSetupSocketSignalData;
 
 #define signal_afsocket_setup_socket SIGNAL(afsocket, setup_socket, AFSocketSetupSocketSignalData *)
+
+#define signal_afsocket_tls_certificate_validation SIGNAL(afsocket, tls_certificate_validation, AFSocketTLSCertificateValidationSignalData *)
 
 #endif

--- a/modules/examples/CMakeLists.txt
+++ b/modules/examples/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(sources/threaded-random-generator)
 add_subdirectory(sources/threaded-diskq-source)
 
 add_subdirectory(inner-destinations/http-test-slots)
+add_subdirectory(inner-destinations/tls-test-validation)
 add_subdirectory(destinations/example_destination)
 
 
@@ -14,6 +15,7 @@ target_link_libraries(examples PRIVATE threaded-random-generator)
 target_link_libraries(examples PRIVATE threaded-diskq-source)
 
 target_link_libraries(examples PRIVATE http-test-slots)
+target_link_libraries(examples PRIVATE tls-test-validation)
 target_link_libraries(examples PRIVATE example_destination)
 
 target_link_libraries(examples PRIVATE syslog-ng)

--- a/modules/examples/Makefile.am
+++ b/modules/examples/Makefile.am
@@ -2,6 +2,7 @@ include modules/examples/sources/msg-generator/Makefile.am
 include modules/examples/sources/threaded-diskq-source/Makefile.am
 include modules/examples/sources/threaded-random-generator/Makefile.am
 include modules/examples/inner-destinations/http-test-slots/Makefile.am
+include modules/examples/inner-destinations/tls-test-validation/Makefile.am
 include modules/examples/destinations/example_destination/Makefile.am
 
 
@@ -9,6 +10,7 @@ EXAMPLE_PLUGINS = \
   $(top_builddir)/modules/examples/sources/libmsg-generator.la \
   $(top_builddir)/modules/examples/sources/libthreaded-diskq-source.la \
   $(top_builddir)/modules/examples/inner-destinations/http-test-slots/libhttp-test-slots.la \
+  $(top_builddir)/modules/examples/inner-destinations/tls-test-validation/libtls-test-validation.la \
   $(top_builddir)/modules/examples/destinations/example_destination/libexample_destination.la
 
 if HAVE_GETRANDOM

--- a/modules/examples/example-plugins.c
+++ b/modules/examples/example-plugins.c
@@ -35,6 +35,8 @@ extern CfgParser threaded_diskq_source_parser;
 
 extern CfgParser http_test_slots_parser;
 
+extern CfgParser tls_test_validation_parser;
+
 extern CfgParser example_destination_parser;
 
 static Plugin example_plugins[] =
@@ -60,6 +62,11 @@ static Plugin example_plugins[] =
     .type = LL_CONTEXT_INNER_DEST,
     .name = "http_test_slots",
     .parser = &http_test_slots_parser
+  },
+  {
+    .type = LL_CONTEXT_INNER_DEST,
+    .name = "tls_test_validation",
+    .parser = &tls_test_validation_parser
   },
   {
     .type = LL_CONTEXT_DESTINATION,

--- a/modules/examples/inner-destinations/tls-test-validation/CMakeLists.txt
+++ b/modules/examples/inner-destinations/tls-test-validation/CMakeLists.txt
@@ -1,0 +1,29 @@
+set(TLS_TEST_VALIDATION_HEADERS
+    "${CMAKE_CURRENT_BINARY_DIR}/tls-test-validation-grammar.h"
+    "tls-test-validation-parser.h"
+    "tls-test-validation.h"
+)
+
+set(TLS_TEST_VALIDATION_SOURCES
+    "${CMAKE_CURRENT_BINARY_DIR}/tls-test-validation-grammar.c"
+    "tls-test-validation-parser.c"
+    "tls-test-validation.c"
+)
+
+generate_y_from_ym(modules/examples/inner-destinations/tls-test-validation/tls-test-validation-grammar)
+
+bison_target(HttpTestSlotsGrammar
+      ${CMAKE_CURRENT_BINARY_DIR}/tls-test-validation-grammar.y
+      ${CMAKE_CURRENT_BINARY_DIR}/tls-test-validation-grammar.c
+      COMPILE_FLAGS ${BISON_FLAGS})
+
+add_library(tls-test-validation STATIC ${TLS_TEST_VALIDATION_SOURCES})
+
+target_include_directories(tls-test-validation
+  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+  PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+  PUBLIC ${PROJECT_SOURCE_DIR}
+)
+
+target_link_libraries(tls-test-validation PUBLIC syslog-ng)
+

--- a/modules/examples/inner-destinations/tls-test-validation/Makefile.am
+++ b/modules/examples/inner-destinations/tls-test-validation/Makefile.am
@@ -1,0 +1,24 @@
+noinst_LTLIBRARIES += modules/examples/inner-destinations/tls-test-validation/libtls-test-validation.la
+
+modules_examples_inner_destinations_tls_test_validation_libtls_test_validation_la_SOURCES = \
+  modules/examples/inner-destinations/tls-test-validation/tls-test-validation.c \
+  modules/examples/inner-destinations/tls-test-validation/tls-test-validation.h \
+  modules/examples/inner-destinations/tls-test-validation/tls-test-validation-grammar.y \
+  modules/examples/inner-destinations/tls-test-validation/tls-test-validation-parser.c \
+  modules/examples/inner-destinations/tls-test-validation/tls-test-validation-parser.h
+
+BUILT_SOURCES += \
+  modules/examples/inner-destinations/tls-test-validation/tls-test-validation-grammar.y \
+  modules/examples/inner-destinations/tls-test-validation/tls-test-validation-grammar.c \
+  modules/examples/inner-destinations/tls-test-validation/tls-test-validation-grammar.h
+
+EXTRA_DIST += \
+  modules/examples/inner-destinations/tls-test-validation/CMakeLists.txt \
+  modules/examples/inner-destinations/tls-test-validation/tls-test-validation-grammar.ym
+
+modules_examples_inner_destinations_tls_test_validation_libtls_test_validation_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/modules/examples/inner-destinations/tls-test-validation -I$(top_builddir)/modules/examples/inner-destinations/tls-test-validation
+modules_examples_inner_destinations_tls_test_validation_libtls_test_validation_la_LIBADD = $(MODULE_DEPS_LIBS)
+modules_examples_inner_destinations_tls_test_validation_libtls_test_validation_la_LDFLAGS = $(MODULE_LDFLAGS)
+modules_examples_inner_destinations_tls_test_validation_libtls_test_validation_la_DEPENDENCIES = $(MODULE_DEPS_LIBS)
+
+PHONY: modules/examples/inner-destinations/tls-test-validation/ mod-tls-test-validation

--- a/modules/examples/inner-destinations/tls-test-validation/tls-test-validation-grammar.ym
+++ b/modules/examples/inner-destinations/tls-test-validation/tls-test-validation-grammar.ym
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2020 One Identity
+ * Copyright (c) 2020 Laszlo Budai <laszlo.budai@outlook.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+%code top {
+#include "driver.h"
+#include "cfg-lexer.h"
+#include "tls-test-validation-parser.h"
+}
+
+%code {
+
+#pragma GCC diagnostic ignored "-Wswitch-default"
+
+#include "tls-test-validation.h"
+
+TlsTestValidationPlugin *last_tls_test_validation;
+
+}
+
+%define api.prefix {tls_test_validation_}
+
+/* this parameter is needed in order to instruct bison to use a complete
+ * argument list for yylex/yyerror */
+
+%lex-param {CfgLexer *lexer}
+%parse-param {CfgLexer *lexer}
+%parse-param {LogDriverPlugin **instance}
+%parse-param {gpointer arg}
+
+/* INCLUDE_DECLS */
+
+%token KW_TLS_TEST_VALIDATION
+%token KW_IDENTITY
+
+%%
+
+start
+  : LL_CONTEXT_INNER_DEST tls_test_validation_start { YYACCEPT; }
+  ;
+
+tls_test_validation_start
+  : KW_TLS_TEST_VALIDATION '('
+  {
+    last_tls_test_validation = tls_test_validation_plugin_new();
+    *instance = (LogDriverPlugin *) last_tls_test_validation;
+    }
+    tls_test_validation_options
+  ')'
+  ;
+
+tls_test_validation_options
+	: tls_test_validation_option tls_test_validation_options
+	|
+	;
+
+
+tls_test_validation_option
+  : KW_IDENTITY '(' string ')'		{ tls_test_validation_plugin_set_identity(last_tls_test_validation, $3); free($3); }
+
+  ;
+
+/* INCLUDE_RULES */
+
+%%

--- a/modules/examples/inner-destinations/tls-test-validation/tls-test-validation-grammar.ym
+++ b/modules/examples/inner-destinations/tls-test-validation/tls-test-validation-grammar.ym
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2020 One Identity
- * Copyright (c) 2020 Laszlo Budai <laszlo.budai@outlook.com>
+ * Copyright (c) 2023 Ricardo Filipe <ricardo.l.filipe@tecnico.ulisboa.pt>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/examples/inner-destinations/tls-test-validation/tls-test-validation-parser.c
+++ b/modules/examples/inner-destinations/tls-test-validation/tls-test-validation-parser.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 One Identity
+ * Copyright (c) 2020 Laszlo Budai <laszlo.budai@outlook.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "tls-test-validation.h"
+#include "cfg-parser.h"
+#include "tls-test-validation-grammar.h"
+
+extern int tls_test_validation_debug;
+int tls_test_validation_parse(CfgLexer *lexer, LogDriverPlugin **instance, gpointer arg);
+
+static CfgLexerKeyword tls_test_validation_keywords[] =
+{
+  { "tls_test_validation",  KW_TLS_TEST_VALIDATION },
+  { "identity", KW_IDENTITY },
+  { NULL }
+};
+
+CfgParser tls_test_validation_parser =
+{
+#if SYSLOG_NG_ENABLE_DEBUG
+  .debug_flag = &tls_test_validation_debug,
+#endif
+  .name = "tls_test_validation",
+  .keywords = tls_test_validation_keywords,
+  .parse = (int (*)(CfgLexer *lexer, gpointer *instance, gpointer arg)) tls_test_validation_parse,
+  .cleanup = (void (*)(gpointer)) log_driver_plugin_free
+};
+
+CFG_PARSER_IMPLEMENT_LEXER_BINDING(tls_test_validation_, TLS_TEST_VALIDATION_, LogDriverPlugin **)

--- a/modules/examples/inner-destinations/tls-test-validation/tls-test-validation-parser.c
+++ b/modules/examples/inner-destinations/tls-test-validation/tls-test-validation-parser.c
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2020 One Identity
- * Copyright (c) 2020 Laszlo Budai <laszlo.budai@outlook.com>
+ * Copyright (c) 2023 Ricardo Filipe <ricardo.l.filipe@tecnico.ulisboa.pt>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/examples/inner-destinations/tls-test-validation/tls-test-validation-parser.h
+++ b/modules/examples/inner-destinations/tls-test-validation/tls-test-validation-parser.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 One Identity
+ * Copyright (c) 2020 Laszlo Budai <laszlo.budai@outlook.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef TLS_TEST_VALIDATION_PARSER_H_INCLUDED
+#define TLS_TEST_VALIDATION_PARSER_H_INCLUDED
+
+#include "cfg-parser.h"
+#include "driver.h"
+
+extern CfgParser tls_test_validation_parser;
+
+CFG_PARSER_DECLARE_LEXER_BINDING(tls_test_validation_, TLS_TEST_VALIDATION_, LogDriverPlugin **);
+
+#endif

--- a/modules/examples/inner-destinations/tls-test-validation/tls-test-validation-parser.h
+++ b/modules/examples/inner-destinations/tls-test-validation/tls-test-validation-parser.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2020 One Identity
- * Copyright (c) 2020 Laszlo Budai <laszlo.budai@outlook.com>
+ * Copyright (c) 2023 Ricardo Filipe <ricardo.l.filipe@tecnico.ulisboa.pt>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/examples/inner-destinations/tls-test-validation/tls-test-validation.c
+++ b/modules/examples/inner-destinations/tls-test-validation/tls-test-validation.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2020 One Identity
+ * Copyright (c) 2020 Laszlo Budai <laszlo.budai@outlook.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "tls-test-validation.h"
+#include "modules/afsocket/afsocket-signals.h"
+#include "transport/tls-verifier.h"
+
+#define TLS_TEST_VALIDATION_PLUGIN "tls-test-validation"
+
+struct _TlsTestValidationPlugin
+{
+  LogDriverPlugin super;
+  gchar *identity;
+};
+
+void
+tls_test_validation_plugin_set_identity(TlsTestValidationPlugin *self, const gchar *identity)
+{
+  g_free(self->identity);
+  self->identity = g_strdup(identity);
+}
+
+static void
+_slot_append_test_identity(TlsTestValidationPlugin *self, AFSocketTLSCertificateValidationSignalData *data)
+{
+  X509 *cert = X509_STORE_CTX_get0_cert(data->ctx);
+  data->failure = !tls_verify_certificate_name(cert, self->identity);
+
+  msg_debug("TlsTestValidationPlugin validated");
+}
+
+static gboolean
+_attach(LogDriverPlugin *s, LogDriver *driver)
+{
+  SignalSlotConnector *ssc = driver->super.signal_slot_connector;
+
+  msg_debug("TlsTestValidationPlugin::attach()",
+            evt_tag_printf("SignalSlotConnector", "%p", ssc));
+
+  /* DISCONNECT: the whole SignalSlotConnector is destroyed when the owner LogDriver is freed up, so DISCONNECT is not required */
+  CONNECT(ssc, signal_afsocket_tls_certificate_validation, _slot_append_test_identity, s);
+
+  return TRUE;
+}
+
+static void
+_free(LogDriverPlugin *s)
+{
+  msg_debug("TlsTestValidationPlugin::free");
+  TlsTestValidationPlugin *self = (TlsTestValidationPlugin *)s;
+  g_free(self->identity);
+  log_driver_plugin_free_method(s);
+}
+
+TlsTestValidationPlugin *
+tls_test_validation_plugin_new(void)
+{
+  TlsTestValidationPlugin *self = g_new0(TlsTestValidationPlugin, 1);
+
+  log_driver_plugin_init_instance(&self->super, TLS_TEST_VALIDATION_PLUGIN);
+
+  self->super.attach = _attach;
+  self->super.free_fn = _free;
+
+  return self;
+}

--- a/modules/examples/inner-destinations/tls-test-validation/tls-test-validation.c
+++ b/modules/examples/inner-destinations/tls-test-validation/tls-test-validation.c
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2020 One Identity
- * Copyright (c) 2020 Laszlo Budai <laszlo.budai@outlook.com>
+ * Copyright (c) 2023 Ricardo Filipe <ricardo.l.filipe@tecnico.ulisboa.pt>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/modules/examples/inner-destinations/tls-test-validation/tls-test-validation.h
+++ b/modules/examples/inner-destinations/tls-test-validation/tls-test-validation.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020 One Identity
+ * Copyright (c) 2020 Laszlo Budai <laszlo.budai@outlook.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef TLS_TEST_VALIDATION_H_INCLUDED
+#define TLS_TEST_VALIDATION_H_INCLUDED
+
+#include "driver.h"
+
+typedef struct _TlsTestValidationPlugin TlsTestValidationPlugin;
+
+TlsTestValidationPlugin *tls_test_validation_plugin_new(void);
+
+void tls_test_validation_plugin_set_identity(TlsTestValidationPlugin *self, const gchar *identity);
+
+#endif

--- a/modules/examples/inner-destinations/tls-test-validation/tls-test-validation.h
+++ b/modules/examples/inner-destinations/tls-test-validation/tls-test-validation.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2020 One Identity
- * Copyright (c) 2020 Laszlo Budai <laszlo.budai@outlook.com>
+ * Copyright (c) 2023 Ricardo Filipe <ricardo.l.filipe@tecnico.ulisboa.pt>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 as published

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -166,6 +166,7 @@ modules/diskq/tests/test_logqueue_disk\.c$
 modules/metrics-probe/metrics-probe(|-parser|-plugin|-grammar)\.(c|h|ym)$
 modules/metrics-probe/label-template\.(c|h)$
 modules/metrics-probe/tests/test_metrics_probe\.c$
+modules/examples/inner-destinations/tls-test-validation
 scl/fortigate/.*\.conf$
 scl/cee/.*\.conf$
 scl/mariadb/.*\.conf$


### PR DESCRIPTION
As discussed in #4219, currently there is no OCSP/CRL validation for remote peer certificates.
In this PR, a hook is added for a custom certificate validation for remote certificate. The hook is only called when the remote certificate is being verified. The hook will call the plugin with SSL_CONTEXT which allows the custom validation.

A plugin example, called tls-test-validation,  was added that verifies if a certificate has an expected identifier.

```
destination test {
    syslog("172.16.17.4" transport("tls") ip-protocol(4) port(6514) keep-alive(no)
        suppress(5)
        tls(
            ca-dir("/path/to/ca/")
            peer-verify(yes)
        )
        tls-test-validation(identity("test"))
        disk-buffer(
            mem-buf-length(2000)
            disk-buf-size(8388608)
            dir("/tmp")
        )
    );
```

Let me know if any changes are needed