### PR TITLE
`syslog-ng`: add `--config-id` command line option

### DIFF
--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -694,6 +694,15 @@ main_loop_read_and_init_config(MainLoop *self)
       return 1;
     }
 
+  if (options->config_id)
+    {
+      GString *config_id = g_string_sized_new(128);
+      cfg_format_id(self->current_configuration, config_id);
+      fprintf(stdout, "%s\n", config_id->str);
+      g_string_free(config_id, TRUE);
+      return 0;
+    }
+
   if (options->syntax_only || options->preprocess_into)
     {
       return 0;

--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -35,6 +35,7 @@ typedef struct _MainLoopOptions
 {
   gchar *preprocess_into;
   gboolean syntax_only;
+  gboolean config_id;
   gboolean interactive_mode;
   gboolean server_mode;
   gboolean disable_module_discovery;

--- a/news/feature-4435.md
+++ b/news/feature-4435.md
@@ -1,0 +1,7 @@
+`syslog-ng`: add `--config-id` command line option
+
+Similarly to `--syntax-only`, this command line option parses the configuration
+and then prints its ID before exiting.
+
+It can be used to query the ID of the current configuration persisted on
+disk.

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -82,6 +82,7 @@ static GOptionEntry syslogng_options[] =
   { "persist-file",      'R',         0, G_OPTION_ARG_STRING, &resolved_configurable_paths.persist_file, "Set the name of the persistent configuration file, default=" PATH_PERSIST_CONFIG, "<fname>" },
   { "preprocess-into",     0,         0, G_OPTION_ARG_STRING, &main_loop_options.preprocess_into, "Write the preprocessed configuration file to the file specified and quit", "output" },
   { "syntax-only",       's',         0, G_OPTION_ARG_NONE, &main_loop_options.syntax_only, "Only read and parse config file", NULL},
+  { "config-id",           0,         0, G_OPTION_ARG_NONE, &main_loop_options.config_id, "Parse config file, print configuration ID, and quit", NULL},
   { "control",           'c',         0, G_OPTION_ARG_STRING, &resolved_configurable_paths.ctlfilename, "Set syslog-ng control socket, default=" PATH_CONTROL_SOCKET, "<ctlpath>" },
   { "interactive",       'i',         0, G_OPTION_ARG_NONE, &main_loop_options.interactive_mode, "Enable interactive mode" },
   { NULL },
@@ -290,7 +291,10 @@ main(int argc, char *argv[])
       g_process_message("The -d/--debug option no longer implies -e/--stderr, if you want to redirect internal() source to stderr please also include -e/--stderr option");
     }
 
-  gboolean exit_before_main_loop_run = main_loop_options.syntax_only || main_loop_options.preprocess_into;
+  gboolean exit_before_main_loop_run = main_loop_options.syntax_only
+                                       || main_loop_options.preprocess_into
+                                       || main_loop_options.config_id;
+
   if (debug_flag || exit_before_main_loop_run)
     {
       g_process_set_mode(G_PM_FOREGROUND);


### PR DESCRIPTION
Similarly to `--syntax-only`, this command line option parses the configuration
and then prints its ID before exiting.

It can be used to query the ID of the current configuration persisted on
disk.

Note:
`--syntax-only` could have been used for the same functionality.
In that case, `--config-id` would just be an alias.