### PR TITLE
afprog: Fixed possible freezing on some OSes

### DIFF
--- a/news/bugfix-4438.md
+++ b/news/bugfix-4438.md
@@ -1,0 +1,1 @@
+`afprog`: Fixed possible freezing on some OSes


### PR DESCRIPTION
There were 2 issues in the `_close_all_fd` implementation

- iterating through the file handler numbers used an `int` though the init value is an `rlim_t` (that can be an `unsigned long long`) that can have an `RLIM_INFINITY` value, so an overflow could happen, therefore no file handlers were closed at all that led to a freeze in `_wait_for_child_closing_fds`
- as the `rlp.rlim_max` can be `RLIM_INFINITY` that is an extremely large number in that case, calling close() for such a huge number of handlers could take an extremely long time.