### PR TITLE
Retrieve packet timestamp from the kernel

### DIFF
--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -464,6 +464,13 @@ log_reader_handle_line(LogReader *self, const guchar *line, gint length, LogTran
     {
       log_msg_set_saddr(m, aux->peer_addr ? : self->peer_addr);
       log_msg_set_daddr(m, aux->local_addr ? : self->local_addr);
+      if (aux->timestamp.tv_sec)
+        {
+          /* accurate timestamp was received from the transport layer, use
+           * that instead of the one we generated */
+          m->timestamps[LM_TS_RECVD].ut_sec = aux->timestamp.tv_sec;
+          m->timestamps[LM_TS_RECVD].ut_usec = aux->timestamp.tv_nsec / 1000;
+        }
       m->proto = aux->proto;
     }
   log_msg_refcache_start_producer(m);

--- a/lib/transport/transport-aux-data.h
+++ b/lib/transport/transport-aux-data.h
@@ -30,6 +30,7 @@ typedef struct _LogTransportAuxData
 {
   GSockAddr *peer_addr;
   GSockAddr *local_addr;
+  struct timespec timestamp;
   gint proto;
   gchar data[1536];
   gsize end_ptr;
@@ -44,6 +45,8 @@ log_transport_aux_data_init(LogTransportAuxData *self)
       self->local_addr = NULL;
       self->end_ptr = 0;
       self->data[0] = 0;
+      self->timestamp.tv_sec = 0;
+      self->timestamp.tv_nsec = 0;
     }
 }
 
@@ -97,6 +100,13 @@ log_transport_aux_data_set_local_addr_ref(LogTransportAuxData *self, GSockAddr *
         g_sockaddr_unref(self->local_addr);
       self->local_addr = local_addr;
     }
+}
+
+static inline void
+log_transport_aux_data_set_timestamp(LogTransportAuxData *self, const struct timespec *timestamp)
+{
+  if (self)
+    self->timestamp = *timestamp;
 }
 
 void log_transport_aux_data_add_nv_pair(LogTransportAuxData *self, const gchar *name, const gchar *value);

--- a/lib/transport/transport-socket.c
+++ b/lib/transport/transport-socket.c
@@ -97,21 +97,20 @@ log_transport_socket_init_instance(LogTransportSocket *self, gint fd)
 static gssize
 _extract_from_msghdr_method(LogTransportSocket *self, gint rc, struct msghdr *msg, LogTransportAuxData *aux)
 {
-  if (rc != -1)
-    {
-      if (msg->msg_namelen && aux)
-        log_transport_aux_data_set_peer_addr_ref(aux, g_sockaddr_new((struct sockaddr *) msg->msg_name, msg->msg_namelen));
-      if (aux)
-        aux->proto = self->proto;
-    }
   if (rc == 0)
     {
       /* DGRAM sockets should never return EOF, they just need to be read again */
       rc = -1;
       errno = EAGAIN;
     }
+  else if (rc > 0)
+    {
+      if (msg->msg_namelen && aux)
+        log_transport_aux_data_set_peer_addr_ref(aux, g_sockaddr_new((struct sockaddr *) msg->msg_name, msg->msg_namelen));
+      if (aux)
+        aux->proto = self->proto;
+    }
   return rc;
-
 }
 
 static gssize

--- a/lib/transport/transport-socket.h
+++ b/lib/transport/transport-socket.h
@@ -33,7 +33,10 @@ struct _LogTransportSocket
   LogTransport super;
   gint address_family;
   gint proto;
+  void (*parse_cmsg)(LogTransportSocket *self, struct cmsghdr *cmsg, LogTransportAuxData *aux);
 };
+
+void log_transport_socket_parse_cmsg_method(LogTransportSocket *s, struct cmsghdr *cmsg, LogTransportAuxData *aux);
 
 void log_transport_dgram_socket_init_instance(LogTransportSocket *self, gint fd);
 LogTransport *log_transport_dgram_socket_new(gint fd);

--- a/lib/transport/transport-udp-socket.c
+++ b/lib/transport/transport-udp-socket.c
@@ -127,7 +127,7 @@ log_transport_udp_parse_cmsg(LogTransportSocket *s, struct cmsghdr *cmsg, LogTra
 }
 
 static void
-log_transport_udp_setup_fd(LogTransportUDP *self, gint fd)
+_setup_fd(LogTransportUDP *self, gint fd)
 {
   gint on = 1;
 
@@ -167,6 +167,6 @@ log_transport_udp_socket_new(gint fd)
   self->super.super.free_fn = log_transport_udp_socket_free;
   self->super.parse_cmsg = log_transport_udp_parse_cmsg;
 
-  log_transport_udp_setup_fd(self, fd);
+  _setup_fd(self, fd);
   return &self->super.super;
 }

--- a/modules/afsocket/compat-unix-creds.h
+++ b/modules/afsocket/compat-unix-creds.h
@@ -33,14 +33,14 @@
 # if SYSLOG_NG_HAVE_STRUCT_UCRED && SYSLOG_NG_HAVE_CTRLBUF_IN_MSGHDR
 # define CRED_PASS_SUPPORTED
 # define cred_t struct ucred
-# define cred_get(c,x) (c->x)
+# define cred_get(c,x) ((c)->x)
 # endif
 #elif defined(__FreeBSD__)
 # if SYSLOG_NG_HAVE_STRUCT_CMSGCRED && SYSLOG_NG_HAVE_CTRLBUF_IN_MSGHDR
 #  define CRED_PASS_SUPPORTED
 #  define SCM_CREDENTIALS SCM_CREDS
 #  define cred_t struct cmsgcred
-#  define cred_get(c,x) (c->cmcred_##x)
+#  define cred_get(c,x) ((c)->cmcred_##x)
 # endif
 #endif
 

--- a/modules/afsocket/transport-unix-socket.c
+++ b/modules/afsocket/transport-unix-socket.c
@@ -32,6 +32,7 @@
 #include <sys/socket.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <string.h>
 #include <unistd.h>
 
 static void G_GNUC_UNUSED
@@ -188,15 +189,16 @@ _feed_credentials_from_cmsg(LogTransportAuxData *aux, struct msghdr *msg)
 {
 #if defined(CRED_PASS_SUPPORTED)
   struct cmsghdr *cmsg;
+  cred_t uc;
 
   for (cmsg = CMSG_FIRSTHDR(msg); cmsg != NULL; cmsg = CMSG_NXTHDR(msg, cmsg))
     {
       if (cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_CREDENTIALS)
         {
-          cred_t *uc = (cred_t *) CMSG_DATA(cmsg);
+          memcpy(&uc, CMSG_DATA(cmsg), sizeof(uc));
 
-          _feed_aux_from_procfs(aux, cred_get(uc, pid));
-          _feed_aux_from_ucred(aux, uc);
+          _feed_aux_from_procfs(aux, cred_get(&uc, pid));
+          _feed_aux_from_ucred(aux, &uc);
           break;
         }
     }


### PR DESCRIPTION
This PR adds support for SO_TIMESTAMPNS getsockopt to retrieve an accurate timestamp from the kernel to retain packet ordering.
