### PR TITLE
Fix memory use of add contextual data

### DIFF
--- a/lib/template/templates.c
+++ b/lib/template/templates.c
@@ -211,6 +211,13 @@ log_template_compile(LogTemplate *self, const gchar *template, GError **error)
   return result;
 }
 
+void
+log_template_forget_template_string(LogTemplate *self)
+{
+  g_free(self->template);
+  self->template = NULL;
+}
+
 static void
 _split_type_and_template(gchar *spec, gchar **value, gchar **type)
 {

--- a/lib/template/templates.h
+++ b/lib/template/templates.h
@@ -80,6 +80,7 @@ void log_template_set_escape(LogTemplate *self, gboolean enable);
 gboolean log_template_set_type_hint(LogTemplate *self, const gchar *hint, GError **error);
 gboolean log_template_compile(LogTemplate *self, const gchar *template, GError **error);
 gboolean log_template_compile_with_type_hint(LogTemplate *self, const gchar *template_and_typehint, GError **error);
+void log_template_forget_template_string(LogTemplate *self);
 void log_template_compile_literal_string(LogTemplate *self, const gchar *literal);
 gboolean log_template_is_literal_string(const LogTemplate *self);
 const gchar *log_template_get_literal_value(const LogTemplate *self, gssize *value_len);

--- a/modules/add-contextual-data/context-info-db.c
+++ b/modules/add-contextual-data/context-info-db.c
@@ -52,7 +52,7 @@ _contextual_data_record_cmp(gconstpointer k1, gconstpointer k2)
   ContextualDataRecord *r1 = (ContextualDataRecord *) k1;
   ContextualDataRecord *r2 = (ContextualDataRecord *) k2;
 
-  return strcmp(r1->selector->str, r2->selector->str);
+  return strcmp(r1->selector, r2->selector);
 }
 
 static gint
@@ -75,7 +75,7 @@ _contextual_data_record_case_cmp(gconstpointer k1, gconstpointer k2)
   ContextualDataRecord *r1 = (ContextualDataRecord *) k1;
   ContextualDataRecord *r2 = (ContextualDataRecord *) k2;
 
-  return _g_strcasecmp(r1->selector->str, r2->selector->str);
+  return _g_strcasecmp(r1->selector, r2->selector);
 }
 
 void
@@ -113,7 +113,7 @@ context_info_db_index(ContextInfoDB *self)
               current_range->offset = range_start;
               current_range->length = i - range_start;
 
-              g_hash_table_insert(self->index, range_start_record->selector->str,
+              g_hash_table_insert(self->index, range_start_record->selector,
                                   current_range);
 
               range_start_record = current_record;
@@ -125,7 +125,7 @@ context_info_db_index(ContextInfoDB *self)
         element_range *last_range = g_new(element_range, 1);
         last_range->offset = range_start;
         last_range->length = self->data->len - range_start;
-        g_hash_table_insert(self->index, range_start_record->selector->str,
+        g_hash_table_insert(self->index, range_start_record->selector,
                             last_range);
       }
       self->is_data_indexed = TRUE;
@@ -222,8 +222,8 @@ context_info_db_insert(ContextInfoDB *self,
 {
   g_array_append_val(self->data, *record);
   self->is_data_indexed = FALSE;
-  if (self->is_ordering_enabled && !g_list_find_custom(self->ordered_selectors, record->selector->str, _g_strcmp))
-    self->ordered_selectors = g_list_append(self->ordered_selectors, record->selector->str);
+  if (self->is_ordering_enabled && !g_list_find_custom(self->ordered_selectors, record->selector, _g_strcmp))
+    self->ordered_selectors = g_list_append(self->ordered_selectors, record->selector);
 }
 
 gboolean
@@ -338,7 +338,7 @@ context_info_db_import(ContextInfoDB *self, FILE *fp, const gchar *filename,
           return FALSE;
         }
       msg_trace("add-contextual-data(): adding database entry",
-                evt_tag_str("selector", next_record->selector->str),
+                evt_tag_str("selector", next_record->selector),
                 evt_tag_str("name", log_msg_get_value_name(next_record->value_handle, NULL)),
                 evt_tag_str("type", log_msg_value_type_to_str(next_record->value->type_hint)),
                 evt_tag_str("value", next_record->value->template));

--- a/modules/add-contextual-data/contextual-data-record-scanner.c
+++ b/modules/add-contextual-data/contextual-data-record-scanner.c
@@ -67,7 +67,7 @@ _fetch_selector(ContextualDataRecordScanner *self, ContextualDataRecord *record)
 {
   if (!_fetch_next(self))
     return FALSE;
-  record->selector = g_string_new(csv_scanner_get_current_value(&self->scanner));
+  record->selector = g_strdup(csv_scanner_get_current_value(&self->scanner));
   return TRUE;
 }
 
@@ -108,7 +108,7 @@ _fetch_value(ContextualDataRecordScanner *self, ContextualDataRecord *record)
                   "configuration. This message means that this string is now assumed to be a "
                   "literal (non-template) string for compatibility",
                   cfg_format_config_version_tag(self->cfg),
-                  evt_tag_str("selector", record->selector->str),
+                  evt_tag_str("selector", record->selector),
                   evt_tag_str("name", log_msg_get_value_name(record->value_handle, NULL)),
                   evt_tag_str("value", value_template));
       log_template_compile_literal_string(record->value, value_template);
@@ -135,7 +135,7 @@ _fetch_value(ContextualDataRecordScanner *self, ContextualDataRecord *record)
                               "or remove the parenthesis. The value column will be processed as a 'string' "
                               "expression",
                               cfg_format_config_version_tag(self->cfg),
-                              evt_tag_str("selector", record->selector->str),
+                              evt_tag_str("selector", record->selector),
                               evt_tag_str("name", log_msg_get_value_name(record->value_handle, NULL)),
                               evt_tag_str("value", value_template),
                               evt_tag_printf("fixed-value", "string(%s)", value_template));
@@ -163,7 +163,7 @@ _fetch_value(ContextualDataRecordScanner *self, ContextualDataRecord *record)
   if (!success)
     {
       msg_error("add-contextual-data(): error compiling template",
-                evt_tag_str("selector", record->selector->str),
+                evt_tag_str("selector", record->selector),
                 evt_tag_str("name", log_msg_get_value_name(record->value_handle, NULL)),
                 evt_tag_str("value", value_template),
                 evt_tag_str("error", error->message));

--- a/modules/add-contextual-data/contextual-data-record-scanner.c
+++ b/modules/add-contextual-data/contextual-data-record-scanner.c
@@ -170,7 +170,7 @@ _fetch_value(ContextualDataRecordScanner *self, ContextualDataRecord *record)
       g_clear_error(&error);
       return FALSE;
     }
-
+  log_template_forget_template_string(record->value);
   return TRUE;
 }
 

--- a/modules/add-contextual-data/contextual-data-record.c
+++ b/modules/add-contextual-data/contextual-data-record.c
@@ -33,10 +33,7 @@ contextual_data_record_init(ContextualDataRecord *record)
 void
 contextual_data_record_clean(ContextualDataRecord *record)
 {
-  if (record->selector)
-    g_string_free(record->selector, TRUE);
-
+  g_free(record->selector);
   log_template_unref(record->value);
-
   contextual_data_record_init(record);
 }

--- a/modules/add-contextual-data/contextual-data-record.h
+++ b/modules/add-contextual-data/contextual-data-record.h
@@ -29,7 +29,7 @@
 
 typedef struct _ContextualDataRecord
 {
-  GString *selector;
+  gchar *selector;
   NVHandle value_handle;
   LogTemplate *value;
 } ContextualDataRecord;

--- a/modules/add-contextual-data/tests/test_context_info_db.c
+++ b/modules/add-contextual-data/tests/test_context_info_db.c
@@ -104,7 +104,7 @@ _fill_context_info_db(ContextInfoDB *context_info_db,
           ContextualDataRecord record;
 
           g_snprintf(buf, sizeof(buf), "%s-%d", selector_base, i);
-          record.selector = g_string_new(buf);
+          record.selector = g_strdup(buf);
 
           g_snprintf(buf, sizeof(buf), "%s-%d.%d", name_base, i, j);
           record.value_handle = log_msg_get_value_handle(buf);

--- a/news/feature-4444.md
+++ b/news/feature-4444.md
@@ -1,0 +1,2 @@
+`add-contextual-data()`: significantly reduce memory usage for large CSV
+files.


### PR DESCRIPTION
The PR significantly decreases the memory use for add-contextual-data() (e.g. 40%) as reported in #4439 

I'd appreciate some testing with your original CSV database, so testing would absolutely be welcome. 

Note that add-contextual-data()'s data representation is not really optimized for memory usage, I could easily slash it almost half, but anything more would seems more complicated. 

db-parser() is difficult to use but it's performance/memory use is difficult to beat. If you are interested I could help you on Axoflow's discord server for a more interactive chat, https://discord.gg/E65kP9aZGm

Depending on how you deploy syslog-ng, you could use the PR specific binaries produced by github or compile from source, etc.
