### PR TITLE
Update the sample Debian config to not throw warning

### DIFF
--- a/packaging/debian/syslog-ng.conf
+++ b/packaging/debian/syslog-ng.conf
@@ -7,7 +7,7 @@
 # First, set some global options.
 options { chain_hostnames(off); flush_lines(0); use_dns(no); use_fqdn(no);
 	  dns_cache(no); owner("root"); group("adm"); perm(0640);
-	  stats_freq(0); bad_hostname("^gconfd$");
+	  stats(freq(0)); bad_hostname("^gconfd$");
 };
 
 ########################


### PR DESCRIPTION
When installing the Debian package, the installed sample configuration
file include some legacy settings that cause a warning:

> WARNING: Your configuration file uses an obsoleted keyword, please update your configuration; keyword='stats_freq', change='Use the stats() block. E.g. stats(freq(1));', location='/etc/syslog-ng/syslog-ng.conf:10:4'

Adjust the sample configuration to use the updated syntax instead.
