### PR TITLE
Value pairs upper and lower transforms

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -342,6 +342,8 @@
 %token KW_ADD_PREFIX                  10509
 %token KW_REPLACE_PREFIX              10510
 %token KW_CAST                        10511
+%token KW_UPPER                       10512
+%token KW_LOWER                       10513
 
 %token KW_ON_ERROR                    10520
 
@@ -1499,6 +1501,8 @@ vp_rekey_option
 	| KW_SHIFT_LEVELS '(' positive_integer ')' { value_pairs_transform_set_add_func(last_vp_transset, value_pairs_new_transform_shift_levels($3)); }
 	| KW_ADD_PREFIX '(' string ')' { value_pairs_transform_set_add_func(last_vp_transset, value_pairs_new_transform_add_prefix($3)); free($3); }
 	| KW_REPLACE_PREFIX '(' string string ')' { value_pairs_transform_set_add_func(last_vp_transset, value_pairs_new_transform_replace_prefix($3, $4)); free($3); free($4); }
+	| KW_UPPER '(' ')' { value_pairs_transform_set_add_func(last_vp_transset, value_pairs_new_transform_upper()); }
+	| KW_LOWER '(' ')' { value_pairs_transform_set_add_func(last_vp_transset, value_pairs_new_transform_lower()); }
 	;
 
 rewrite_expr_opt

--- a/lib/value-pairs/cmdline.c
+++ b/lib/value-pairs/cmdline.c
@@ -287,6 +287,48 @@ vp_cmdline_parse_rekey_add_prefix (const gchar *option_name, const gchar *value,
 }
 
 static gboolean
+vp_cmdline_parse_rekey_upper (const gchar *option_name, const gchar *value,
+                              gpointer data, GError **error)
+{
+  gpointer *args = (gpointer *) data;
+  ValuePairsTransformSet *vpts = (ValuePairsTransformSet *) args[2];
+  gchar *key = (gchar *) args[3];
+
+  vpts = vp_cmdline_rekey_verify (key, vpts, data);
+  if (!vpts)
+    {
+      g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
+                   "Error parsing value-pairs: --upper used without --key or --rekey");
+      return FALSE;
+    }
+
+  value_pairs_transform_set_add_func(vpts,
+                                     value_pairs_new_transform_upper ());
+  return TRUE;
+}
+
+static gboolean
+vp_cmdline_parse_rekey_lower (const gchar *option_name, const gchar *value,
+                              gpointer data, GError **error)
+{
+  gpointer *args = (gpointer *) data;
+  ValuePairsTransformSet *vpts = (ValuePairsTransformSet *) args[2];
+  gchar *key = (gchar *) args[3];
+
+  vpts = vp_cmdline_rekey_verify (key, vpts, data);
+  if (!vpts)
+    {
+      g_set_error (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
+                   "Error parsing value-pairs: --lower used without --key or --rekey");
+      return FALSE;
+    }
+
+  value_pairs_transform_set_add_func(vpts,
+                                     value_pairs_new_transform_lower ());
+  return TRUE;
+}
+
+static gboolean
 vp_cmdline_parse_rekey_shift (const gchar *option_name, const gchar *value,
                               gpointer data, GError **error)
 {
@@ -391,6 +433,14 @@ value_pairs_parse_command_line(ValuePairs *vp,
     },
     {
       "pair", 'p', 0, G_OPTION_ARG_CALLBACK, vp_cmdline_parse_pair,
+      NULL, NULL
+    },
+    {
+      "upper", 0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, vp_cmdline_parse_rekey_upper,
+      NULL, NULL
+    },
+    {
+      "lower", 0, G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK, vp_cmdline_parse_rekey_lower,
       NULL, NULL
     },
     {

--- a/lib/value-pairs/tests/test_value_pairs.c
+++ b/lib/value-pairs/tests/test_value_pairs.c
@@ -285,6 +285,30 @@ Test(value_pairs, test_transformer_shift_levels)
   g_ptr_array_free(transformers, TRUE);
 }
 
+Test(value_pairs, test_transformer_lower)
+{
+  /* test the value-pair transformators */
+  GPtrArray *transformers = g_ptr_array_new();
+  g_ptr_array_add(transformers, value_pairs_new_transform_lower());
+
+  transformers_testcase("sdata", ".SDATA.meta.sequenceId",
+                        ".SDATA.EventData@18372.4.Data,.SDATA.Keywords@18372.4.Keyword,.SDATA.meta.sysUpTime,.SDATA.origin.ip,.sdata.meta.sequenceid",
+                        transformers);
+  g_ptr_array_free(transformers, TRUE);
+}
+
+Test(value_pairs, test_transformer_upper)
+{
+  /* test the value-pair transformators */
+  GPtrArray *transformers = g_ptr_array_new();
+  g_ptr_array_add(transformers, value_pairs_new_transform_upper());
+
+  transformers_testcase("sdata", ".SDATA.meta.sequenceId",
+                        ".SDATA.EventData@18372.4.Data,.SDATA.Keywords@18372.4.Keyword,.SDATA.META.SEQUENCEID,.SDATA.meta.sysUpTime,.SDATA.origin.ip",
+                        transformers);
+  g_ptr_array_free(transformers, TRUE);
+}
+
 void
 setup(void)
 {

--- a/lib/value-pairs/transforms.c
+++ b/lib/value-pairs/transforms.c
@@ -127,6 +127,42 @@ value_pairs_new_transform_add_prefix (const gchar *prefix)
   return (ValuePairsTransform *)vpt;
 }
 
+/* upper() */
+
+static void
+vp_trans_upper(ValuePairsTransform *self, GString *key)
+{
+  g_string_ascii_up(key);
+}
+
+ValuePairsTransform *
+value_pairs_new_transform_upper (void)
+{
+  ValuePairsTransform *vpt = g_new0(ValuePairsTransform, 1);
+
+  vp_trans_init(vpt, vp_trans_upper, NULL);
+
+  return vpt;
+}
+
+/* lower() */
+
+static void
+vp_trans_lower(ValuePairsTransform *self, GString *key)
+{
+  g_string_ascii_down(key);
+}
+
+ValuePairsTransform *
+value_pairs_new_transform_lower (void)
+{
+  ValuePairsTransform *vpt = g_new0(ValuePairsTransform, 1);
+
+  vp_trans_init(vpt, vp_trans_lower, NULL);
+
+  return vpt;
+}
+
 /* shift() */
 
 static void

--- a/lib/value-pairs/transforms.h
+++ b/lib/value-pairs/transforms.h
@@ -31,6 +31,8 @@ typedef struct _ValuePairsTransform ValuePairsTransform;
 typedef struct _ValuePairsTransformSet ValuePairsTransformSet;
 
 ValuePairsTransform *value_pairs_new_transform_add_prefix (const gchar *prefix);
+ValuePairsTransform *value_pairs_new_transform_lower (void);
+ValuePairsTransform *value_pairs_new_transform_upper (void);
 ValuePairsTransform *value_pairs_new_transform_shift (gint amount);
 ValuePairsTransform *value_pairs_new_transform_replace_prefix(const gchar *prefix, const gchar *new_prefix);
 ValuePairsTransform *value_pairs_new_transform_shift_levels(gint amount);

--- a/news/feature-4452.md
+++ b/news/feature-4452.md
@@ -1,0 +1,8 @@
+`$(format-json)` and template functions which support value-pairs
+expressions: new key transformations upper() and lower() have been added to
+translate the caps of keys while formatting the output template. For
+example:
+
+    template("$(format-json test.* --upper)\n")
+
+Would convert all keys to uppercase. Only supports US ASCII.

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -186,6 +186,7 @@ tests/light/functional_tests/logpath/test_named_logpaths_with_final_flag.py
 tests/light/functional_tests/parsers/sdata-parser/test_sdata_parser\.py
 tests/light/functional_tests/logpath/test_conditionals\.py
 tests/light/functional_tests/logpath/test_midpoint_destinations\.py
+tests/light/functional_tests/value-pairs/test_value_pairs\.py
 tests/light/src/syslog_ng_ctl/prometheus_stats_handler.py
 
 ###########################################################################

--- a/tests/light/functional_tests/Makefile.am
+++ b/tests/light/functional_tests/Makefile.am
@@ -61,4 +61,5 @@ EXTRA_DIST += \
 	tests/light/functional_tests/source_options/test_use_syslogng_pid.py \
 	tests/light/functional_tests/template_functions/graphite-output/test_graphite_output.py \
 	tests/light/functional_tests/template_functions/slog/test_secure_logging.py \
+	tests/light/functional_tests/value-pairs/test_value_pairs.py \
 	tests/light/functional_tests/tools/loggen/test_loggen_with_reconnect.py

--- a/tests/light/functional_tests/value-pairs/test_value_pairs.py
+++ b/tests/light/functional_tests/value-pairs/test_value_pairs.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2023 Balazs Scheidler <balazs.scheidler@axoflow.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import pytest
+
+
+test_parameters = [
+    ("$(format-json test.*)\n", """{"test":{"key2":"value2","key1":"value1"}}\n"""),
+    # transformations
+    ("$(format-json test.* --add-prefix foo.)\n", """{"foo":{"test":{"key2":"value2","key1":"value1"}}}\n"""),
+    ("$(format-json test.* --replace-prefix test=foobar)\n", """{"foobar":{"key2":"value2","key1":"value1"}}\n"""),
+    ("$(format-json test.* --shift-levels 1)\n", """{"key2":"value2","key1":"value1"}\n"""),
+    ("$(format-json test.* --shift 2)\n", """{"st":{"key2":"value2","key1":"value1"}}\n"""),
+    ("$(format-json test.* --upper)\n", """{"TEST":{"KEY2":"value2","KEY1":"value1"}}\n"""),
+    ("$(format-json MESSAGE --lower)\n", """{"message":"-- Generated message. --"}\n"""),
+]
+
+
+@pytest.mark.parametrize(
+    "template, expected_value", test_parameters,
+    ids=list(map(lambda x: x[0], test_parameters)),
+)
+def test_value_pairs(config, syslog_ng, template, expected_value):
+
+    generator_source = config.create_example_msg_generator_source(num=1, values="test.key1 => value1 test.key2 => value2")
+    file_destination = config.create_file_destination(file_name="output.log", template=config.stringify(template))
+
+    config.create_logpath(statements=[generator_source, file_destination])
+    syslog_ng.start(config)
+    log = file_destination.read_log()
+    assert log == expected_value


### PR DESCRIPTION

This is an attempt to add support for lower/upper transformations in value-pairs expressions as discussed in #4422 

This is how to use it:

```file("logfile" template("$(format-json * --lower)\n")); ```

Or, a slightly different example:

```file("logfile" template("$(format-json * foo.bar=value --rekey foo.* --upper)\n"))```

