### PR TITLE
kubernetes: make SCL drivers internal

### DIFF
--- a/modules/metrics-probe/metrics-probe-grammar.ym
+++ b/modules/metrics-probe/metrics-probe-grammar.ym
@@ -78,6 +78,7 @@ metrics_probe_opt
         : KW_KEY '(' string ')' { metrics_probe_set_key(last_parser, $3); g_free($3); }
         | KW_LABELS '(' metrics_probe_label_templates ')'
         | KW_INCREMENT '(' template_content ')' { metrics_probe_set_increment_template(last_parser, $3); log_template_unref($3); }
+        | KW_LEVEL '(' nonnegative_integer ')' { metrics_probe_set_level(last_parser, $3); }
         | { last_template_options = metrics_probe_get_template_options(last_parser); } template_option
         | parser_opt
         ;

--- a/modules/metrics-probe/metrics-probe-parser.c
+++ b/modules/metrics-probe/metrics-probe-parser.c
@@ -34,6 +34,7 @@ static CfgLexerKeyword metrics_probe_keywords[] =
   { "key",                         KW_KEY },
   { "labels",                      KW_LABELS },
   { "increment",                   KW_INCREMENT },
+  { "level",                       KW_LEVEL },
   { NULL }
 };
 

--- a/modules/metrics-probe/metrics-probe.h
+++ b/modules/metrics-probe/metrics-probe.h
@@ -31,6 +31,7 @@ LogParser *metrics_probe_new(GlobalConfig *cfg);
 void metrics_probe_set_key(LogParser *s, const gchar *key);
 gboolean metrics_probe_add_label_template(LogParser *s, const gchar *label, LogTemplate *value_template);
 void metrics_probe_set_increment_template(LogParser *s, LogTemplate *increment_template);
+void metrics_probe_set_level(LogParser *s, gint level);
 
 LogTemplateOptions *metrics_probe_get_template_options(LogParser *s);
 

--- a/modules/python-modules/syslogng/modules/kubernetes/scl/kubernetes.conf
+++ b/modules/python-modules/syslogng/modules/kubernetes/scl/kubernetes.conf
@@ -170,6 +170,7 @@ block source kubernetes(prefix('.k8s.') base-dir("/var/log/containers") cluster-
         };
         parser {
             metrics-probe(
+                level(1)
                 key("input_events_total")
                 labels(
                     "cluster" => "`cluster-name`"
@@ -180,6 +181,7 @@ block source kubernetes(prefix('.k8s.') base-dir("/var/log/containers") cluster-
                 )
             );
             metrics-probe(
+                level(1)
                 key("input_event_bytes_total")
                 labels(
                     "cluster" => "`cluster-name`"

--- a/modules/python-modules/syslogng/modules/kubernetes/scl/kubernetes.conf
+++ b/modules/python-modules/syslogng/modules/kubernetes/scl/kubernetes.conf
@@ -80,12 +80,14 @@ block parser kubernetes-metadata-parser (prefix() template("$FILE_NAME") key-del
 
         parser {
 	    regexp-parser(
+                internal(yes)
                 patterns("`kubernetes-log-containers-regexp`",
                          "`kubernetes-log-pods-regexp`")
                 template(`template`)
                 prefix(`prefix`)
             );
             python(
+                internal(yes)
                 class("syslogng.modules.kubernetes.KubernetesAPIEnrichment")
                 options(
                     "prefix" => "`prefix`",
@@ -95,40 +97,42 @@ block parser kubernetes-metadata-parser (prefix() template("$FILE_NAME") key-del
         };
 
         # make the container-id of 12 characters long as usual in cli
-	rewrite { set("$(substr ${`prefix`container_id} 0 12)" value("`prefix`container_id")); };
+	rewrite { set("$(substr ${`prefix`container_id} 0 12)" value("`prefix`container_id") internal(yes)); };
      };
 };
 
 block parser kubernetes-json-file-parser(prefix('.k8s.') cluster-name('k8s') key-delimiter()) {
-    json-parser(prefix(`prefix`));
+    json-parser(internal(yes) prefix(`prefix`));
     channel {
       rewrite {
-        set("${`prefix`log}" value(MESSAGE));
+        set("${`prefix`log}" value(MESSAGE) internal(yes));
       };
     };
-    date-parser(format("%FT%H:%M:%S.%f%Z") template("${`prefix`time}"));
+    date-parser(internal(yes) format("%FT%H:%M:%S.%f%Z") template("${`prefix`time}"));
 
     kubernetes-metadata-parser(prefix(`prefix`) key-delimiter(`key-delimiter`));
     channel {
         rewrite {
-            set("`cluster-name`/${`prefix`namespace_name}/${`prefix`pod_name}" value("HOST"));
-            set("${`prefix`container_name}" value("PROGRAM"));
-            set("$(if ('${`prefix`pod_uuid}' ne '') ${`prefix`pod_uuid} ${`prefix`container_id})/${`prefix`stream}" value("PID"));
+            set("`cluster-name`/${`prefix`namespace_name}/${`prefix`pod_name}" value("HOST") internal(yes));
+            set("${`prefix`container_name}" value("PROGRAM") internal(yes));
+            set("$(if ('${`prefix`pod_uuid}' ne '') ${`prefix`pod_uuid} ${`prefix`container_id})/${`prefix`stream}" value("PID") internal(yes));
         };
     };
 };
 
 block parser kubernetes-file-parser(prefix('.k8s.') cluster-name('k8s') key-delimiter()) {
     csv-parser(
+        internal(yes)
 	# time, stream, flags, message
         columns("1", "2", "3", "4")
         delimiters(" ")
         flags(greedy)
     );
-    date-parser(format("%FT%H:%M:%S.%f%Z") template("$1"));
+    date-parser(format("%FT%H:%M:%S.%f%Z") template("$1") internal(yes));
 
     # decode multiline
     grouping-by(
+        internal(yes)
         key("$FILE_NAME|$2")
         scope(global)
         trigger("$3" eq "F")
@@ -145,9 +149,9 @@ block parser kubernetes-file-parser(prefix('.k8s.') cluster-name('k8s') key-deli
     kubernetes-metadata-parser(prefix(`prefix`) key-delimiter(`key-delimiter`));
     channel {
         rewrite {
-	    set("`cluster-name`/${`prefix`namespace_name}/${`prefix`pod_name}" value("HOST"));
-            set("${`prefix`container_name}" value("PROGRAM"));
-            set("$(if ('${`prefix`pod_uuid}' ne '') ${`prefix`pod_uuid} ${`prefix`container_id})/${`prefix`stream}" value("PID"));
+	    set("`cluster-name`/${`prefix`namespace_name}/${`prefix`pod_name}" value("HOST") internal(yes));
+            set("${`prefix`container_name}" value("PROGRAM") internal(yes));
+            set("$(if ('${`prefix`pod_uuid}' ne '') ${`prefix`pod_uuid} ${`prefix`container_id})/${`prefix`stream}" value("PID") internal(yes));
         };
     };
 };
@@ -156,6 +160,7 @@ block source kubernetes(prefix('.k8s.') base-dir("/var/log/containers") cluster-
     channel {
         source {
             wildcard-file(
+                internal(yes)
                 base-dir(`base-dir`)
                 filename-pattern("*.log")
                 recursive(yes)
@@ -170,6 +175,7 @@ block source kubernetes(prefix('.k8s.') base-dir("/var/log/containers") cluster-
         };
         parser {
             metrics-probe(
+                internal(yes)
                 level(1)
                 key("input_events_total")
                 labels(
@@ -181,6 +187,7 @@ block source kubernetes(prefix('.k8s.') base-dir("/var/log/containers") cluster-
                 )
             );
             metrics-probe(
+                internal(yes)
                 level(1)
                 key("input_event_bytes_total")
                 labels(

--- a/news/feature-4453.md
+++ b/news/feature-4453.md
@@ -1,0 +1,1 @@
+`metrics-probe()`: Added `level()` option to set the stats level of the generated metrics.


### PR DESCRIPTION
### On stats level 0

```
syslogng_last_config_file_modification_timestamp_seconds 1683030288
syslogng_last_config_reload_timestamp_seconds 1683030289
syslogng_last_successful_config_reload_timestamp_seconds 1683030289
syslogng_scratch_buffers_bytes 43008
syslogng_scratch_buffers_count 179
```

### On stats level 1
```
syslogng_events_allocated_bytes 1189424
syslogng_filtered_events_total{id="#anon-filter0",result="matched"} 2302
syslogng_filtered_events_total{id="#anon-filter0",result="not_matched"} 0
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="default",pod="log-generator-1682517834-7797487dcc-49hqc"} 67460
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="default",pod="opensearch-cluster-master-0"} 84974
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="default",pod="opensearch-cluster-master-1"} 80128
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="default",pod="opensearch-cluster-master-2"} 82457
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="default",pod="syslog-ng-collector-1682510155-bhf88"} 3063
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="coredns-787d4945fb-tfr6d"} 6279
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="etcd-minikube"} 49047
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="kube-apiserver-minikube"} 44990
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="kube-controller-manager-minikube"} 61778
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="kube-proxy-xb7db"} 6661
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="kube-scheduler-minikube"} 6866
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="storage-provisioner"} 3229
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="default",pod="log-generator-1682517834-7797487dcc-49hqc"} 264
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="default",pod="opensearch-cluster-master-0"} 374
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="default",pod="opensearch-cluster-master-1"} 364
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="default",pod="opensearch-cluster-master-2"} 361
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="default",pod="syslog-ng-collector-1682510155-bhf88"} 28
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="coredns-787d4945fb-tfr6d"} 34
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="etcd-minikube"} 164
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="kube-apiserver-minikube"} 269
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="kube-controller-manager-minikube"} 362
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="kube-proxy-xb7db"} 38
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="kube-scheduler-minikube"} 33
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="storage-provisioner"} 14
syslogng_io_worker_latency_seconds 0.00088225300000000005
syslogng_last_config_file_modification_timestamp_seconds 1683030311
syslogng_last_config_reload_timestamp_seconds 1683030313
syslogng_last_successful_config_reload_timestamp_seconds 1683030313
syslogng_mainloop_io_worker_roundtrip_latency_seconds 0.00090662800000000003
syslogng_memory_queue_events{driver_instance="/dev/stdout",id="d_stdout#0"} 0
syslogng_memory_queue_memory_usage_bytes{driver_instance="/dev/stdout",id="d_stdout#0"} 0
syslogng_output_event_bytes_total{id="d_stdout#0",driver_instance="/dev/stdout"} 533474
syslogng_output_events_total{driver_instance="/dev/stdout",id="d_stdout#0",result="delivered"} 2245
syslogng_output_events_total{driver_instance="/dev/stdout",id="d_stdout#0",result="dropped"} 0
syslogng_output_events_total{driver_instance="/dev/stdout",id="d_stdout#0",result="queued"} 0
syslogng_scratch_buffers_bytes 48640
syslogng_scratch_buffers_count 232
```

### On stats level 3
```
syslogng_events_allocated_bytes 709560
syslogng_filtered_events_total{id="#anon-filter0",result="matched"} 3872
syslogng_filtered_events_total{id="#anon-filter0",result="not_matched"} 0
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="default",pod="log-generator-1682517834-7797487dcc-49hqc"} 189373
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="default",pod="opensearch-cluster-master-0"} 136863
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="default",pod="opensearch-cluster-master-1"} 148839
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="default",pod="opensearch-cluster-master-2"} 122014
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="default",pod="syslog-ng-collector-1682510155-bhf88"} 3063
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="coredns-787d4945fb-tfr6d"} 6279
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="etcd-minikube"} 49047
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="kube-apiserver-minikube"} 93598
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="kube-controller-manager-minikube"} 71053
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="kube-proxy-xb7db"} 6661
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="kube-scheduler-minikube"} 6866
syslogng_input_event_bytes_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="storage-provisioner"} 3229
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/coredns-787d4945fb-tfr6d_kube-system_coredns-b611ef18ed36f5b1ff954072cefc98766f9490c51b2f19410dbab5a10d771d90.log"} 1636
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/coredns-787d4945fb-tfr6d_kube-system_coredns-f59e752c5d3279c7d67d389c00b57e3a814cfee60fef62472f58eb9921896744.log"} 4643
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/etcd-minikube_kube-system_etcd-a0cc3a3621a901eef7b4f5f68f3c7efc39d9ec8b5200fd5296e11f4227840545.log"} 17179
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/etcd-minikube_kube-system_etcd-b9645297a66640879a9b598434e739c479ff36de7bb2801709a9088af2c9678c.log"} 31868
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/kube-apiserver-minikube_kube-system_kube-apiserver-15e2499083826617d516ed9b78a079ae41bca26ce5b4704cc06045884d662eb8.log"} 16816
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/kube-apiserver-minikube_kube-system_kube-apiserver-87062d9e7a1a2ffe49cb3266ab5edd2ee5a8869805b6b7837612ead4fcad57af.log"} 76782
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/kube-controller-manager-minikube_kube-system_kube-controller-manager-2cf72b89bc2c87c900d367a19e5d156e1e8f488fb3900ab8d2de3783ced8885f.log"} 35955
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/kube-controller-manager-minikube_kube-system_kube-controller-manager-d240c95cff0bf9837f9c7befcbe67d32c4181960b1db348a7dc3e527f453dfc1.log"} 35098
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/kube-proxy-xb7db_kube-system_kube-proxy-16c2163765075da1078fa2e622b10b3477177e560387311c9babd2faf1768457.log"} 3331
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/kube-proxy-xb7db_kube-system_kube-proxy-a3a64481dec732de458f4bd351621f93758d4339814c7322d0d6e9197e93056f.log"} 3330
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/kube-scheduler-minikube_kube-system_kube-scheduler-0ef76e33eaaa9ac6d92f4931041c16099f7405084f930405f028bcc91a5ba829.log"} 4185
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/kube-scheduler-minikube_kube-system_kube-scheduler-1f20b2d98586dec893505e33a27d394cf92d71e32b7cdd1a62f766bf78d1e79d.log"} 2681
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/log-generator-1682517834-7797487dcc-49hqc_default_log-generator-28f6ba19755a4e4e5f6bf91a510790f9ef68888ca0c75f9c0113cdc7835ed082.log"} 20731
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/log-generator-1682517834-7797487dcc-49hqc_default_log-generator-92ee167325e39847306da28657782776e663a47684106bec71c7e35d4c3633c4.log"} 168642
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/opensearch-cluster-master-0_default_fsgroup-volume-2bf32bf91070fcdb353b97e8fc7915f57ed3a3f6f8bef43870f3aaef151a0463.log"} 0
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/opensearch-cluster-master-0_default_opensearch-470f19ea38b40594739bfdb83d25b9a7a6d96f7fb6cdd8a5c95387b837a9af64.log"} 76634
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/opensearch-cluster-master-0_default_opensearch-8d9d4f6c1ed7203ffbaf992cef1e7b25efe0df92611faef0f71dfcf65f7a5b69.log"} 60229
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/opensearch-cluster-master-1_default_fsgroup-volume-782a0aae97b7c801d315e6538b207f68a5022261ed8ca0c01331e686c9aa859b.log"} 0
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/opensearch-cluster-master-1_default_opensearch-26df5ba12968aaefa10de1c03a3b9e1a09df3003a1688eca119b72f95f1f0f33.log"} 76095
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/opensearch-cluster-master-1_default_opensearch-87a78ed3a0d5a1960b9162075db6665041657d0451632b3f68bf26a62e8f4563.log"} 72744
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/opensearch-cluster-master-2_default_fsgroup-volume-d7fe8f322e5829b579c844c34a73961744243b01c1e2a9f42effe5ffcdb3328e.log"} 0
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/opensearch-cluster-master-2_default_opensearch-7003abc6b3f7eca2f125a24c33df9b416fc520a48a27fa28e65fed6a511aaa03.log"} 67685
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/opensearch-cluster-master-2_default_opensearch-cb78f945291ded6b6c194b524a7e3e27d2e31084e7a3504cd1e3111ee3eeb409.log"} 54329
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/storage-provisioner_kube-system_storage-provisioner-65b95e13ce3230f77d3921215037732cb7c27145008f6d79406283c13c511ca2.log"} 1614
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/storage-provisioner_kube-system_storage-provisioner-e2f61e433e402ca422c2b6ec9703fcc59bbb971c482bf84aa70bdc53231131b6.log"} 1615
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/syslog-ng-collector-1682510155-bhf88_default_syslog-ng-collector-40ca4e10dd2e301ab114ade597124545835e5422a0989a2017006d882bd5bb92.log"} 3063
syslogng_input_event_bytes_total{id="s_kubernetes#0",driver_instance="/var/log/containers/syslog-ng-collector-1682510155-bhf88_default_syslog-ng-collector-e45001b5a5561e9ff4bd88e22a08bde2d530d81f926f92c51c2db2bbfc5d41d9.log"} 0
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="default",pod="log-generator-1682517834-7797487dcc-49hqc"} 705
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="default",pod="opensearch-cluster-master-0"} 592
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="default",pod="opensearch-cluster-master-1"} 648
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="default",pod="opensearch-cluster-master-2"} 532
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="default",pod="syslog-ng-collector-1682510155-bhf88"} 28
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="coredns-787d4945fb-tfr6d"} 34
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="etcd-minikube"} 164
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="kube-apiserver-minikube"} 672
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="kube-controller-manager-minikube"} 412
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="kube-proxy-xb7db"} 38
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="kube-scheduler-minikube"} 33
syslogng_input_events_total{cluster="k8s",driver="kubernetes",id="s_kubernetes",namespace="kube-system",pod="storage-provisioner"} 14
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/coredns-787d4945fb-tfr6d_kube-system_coredns-b611ef18ed36f5b1ff954072cefc98766f9490c51b2f19410dbab5a10d771d90.log"} 10
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/coredns-787d4945fb-tfr6d_kube-system_coredns-f59e752c5d3279c7d67d389c00b57e3a814cfee60fef62472f58eb9921896744.log"} 24
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/etcd-minikube_kube-system_etcd-a0cc3a3621a901eef7b4f5f68f3c7efc39d9ec8b5200fd5296e11f4227840545.log"} 52
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/etcd-minikube_kube-system_etcd-b9645297a66640879a9b598434e739c479ff36de7bb2801709a9088af2c9678c.log"} 112
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/kube-apiserver-minikube_kube-system_kube-apiserver-15e2499083826617d516ed9b78a079ae41bca26ce5b4704cc06045884d662eb8.log"} 89
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/kube-apiserver-minikube_kube-system_kube-apiserver-87062d9e7a1a2ffe49cb3266ab5edd2ee5a8869805b6b7837612ead4fcad57af.log"} 583
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/kube-controller-manager-minikube_kube-system_kube-controller-manager-2cf72b89bc2c87c900d367a19e5d156e1e8f488fb3900ab8d2de3783ced8885f.log"} 207
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/kube-controller-manager-minikube_kube-system_kube-controller-manager-d240c95cff0bf9837f9c7befcbe67d32c4181960b1db348a7dc3e527f453dfc1.log"} 205
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/kube-proxy-xb7db_kube-system_kube-proxy-16c2163765075da1078fa2e622b10b3477177e560387311c9babd2faf1768457.log"} 19
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/kube-proxy-xb7db_kube-system_kube-proxy-a3a64481dec732de458f4bd351621f93758d4339814c7322d0d6e9197e93056f.log"} 19
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/kube-scheduler-minikube_kube-system_kube-scheduler-0ef76e33eaaa9ac6d92f4931041c16099f7405084f930405f028bcc91a5ba829.log"} 21
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/kube-scheduler-minikube_kube-system_kube-scheduler-1f20b2d98586dec893505e33a27d394cf92d71e32b7cdd1a62f766bf78d1e79d.log"} 12
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/log-generator-1682517834-7797487dcc-49hqc_default_log-generator-28f6ba19755a4e4e5f6bf91a510790f9ef68888ca0c75f9c0113cdc7835ed082.log"} 85
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/log-generator-1682517834-7797487dcc-49hqc_default_log-generator-92ee167325e39847306da28657782776e663a47684106bec71c7e35d4c3633c4.log"} 620
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/opensearch-cluster-master-0_default_fsgroup-volume-2bf32bf91070fcdb353b97e8fc7915f57ed3a3f6f8bef43870f3aaef151a0463.log"} 0
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/opensearch-cluster-master-0_default_opensearch-470f19ea38b40594739bfdb83d25b9a7a6d96f7fb6cdd8a5c95387b837a9af64.log"} 332
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/opensearch-cluster-master-0_default_opensearch-8d9d4f6c1ed7203ffbaf992cef1e7b25efe0df92611faef0f71dfcf65f7a5b69.log"} 260
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/opensearch-cluster-master-1_default_fsgroup-volume-782a0aae97b7c801d315e6538b207f68a5022261ed8ca0c01331e686c9aa859b.log"} 0
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/opensearch-cluster-master-1_default_opensearch-26df5ba12968aaefa10de1c03a3b9e1a09df3003a1688eca119b72f95f1f0f33.log"} 342
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/opensearch-cluster-master-1_default_opensearch-87a78ed3a0d5a1960b9162075db6665041657d0451632b3f68bf26a62e8f4563.log"} 306
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/opensearch-cluster-master-2_default_fsgroup-volume-d7fe8f322e5829b579c844c34a73961744243b01c1e2a9f42effe5ffcdb3328e.log"} 0
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/opensearch-cluster-master-2_default_opensearch-7003abc6b3f7eca2f125a24c33df9b416fc520a48a27fa28e65fed6a511aaa03.log"} 296
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/opensearch-cluster-master-2_default_opensearch-cb78f945291ded6b6c194b524a7e3e27d2e31084e7a3504cd1e3111ee3eeb409.log"} 236
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/storage-provisioner_kube-system_storage-provisioner-65b95e13ce3230f77d3921215037732cb7c27145008f6d79406283c13c511ca2.log"} 7
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/storage-provisioner_kube-system_storage-provisioner-e2f61e433e402ca422c2b6ec9703fcc59bbb971c482bf84aa70bdc53231131b6.log"} 7
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/syslog-ng-collector-1682510155-bhf88_default_syslog-ng-collector-40ca4e10dd2e301ab114ade597124545835e5422a0989a2017006d882bd5bb92.log"} 28
syslogng_input_events_total{id="s_kubernetes#0",driver_instance="/var/log/containers/syslog-ng-collector-1682510155-bhf88_default_syslog-ng-collector-e45001b5a5561e9ff4bd88e22a08bde2d530d81f926f92c51c2db2bbfc5d41d9.log"} 0
syslogng_io_worker_latency_seconds 0.00054582000000000003
syslogng_last_config_file_modification_timestamp_seconds 1683030346
syslogng_last_config_reload_timestamp_seconds 1683030347
syslogng_last_successful_config_reload_timestamp_seconds 1683030347
syslogng_mainloop_io_worker_roundtrip_latency_seconds 0.0012328619999999999
syslogng_memory_queue_events{driver_instance="/dev/stdout",id="d_stdout#0"} 0
syslogng_memory_queue_memory_usage_bytes{driver_instance="/dev/stdout",id="d_stdout#0"} 0
syslogng_output_event_bytes_total{id="d_stdout#0",driver_instance="/dev/stdout"} 927691
syslogng_output_events_total{driver_instance="/dev/stdout",id="d_stdout#0",result="delivered"} 3872
syslogng_output_events_total{driver_instance="/dev/stdout",id="d_stdout#0",result="dropped"} 0
syslogng_output_events_total{driver_instance="/dev/stdout",id="d_stdout#0",result="queued"} 0
syslogng_parsed_events_total{id="#anon-parser0",result="discarded"} 0
syslogng_parsed_events_total{id="#anon-parser0",result="processed"} 15488
syslogng_parsed_events_total{id="#anon-parser1",result="discarded"} 0
syslogng_parsed_events_total{id="#anon-parser1",result="processed"} 0
syslogng_parsed_events_total{id="#anon-parser2",result="discarded"} 0
syslogng_parsed_events_total{id="#anon-parser2",result="processed"} 7744
syslogng_scratch_buffers_bytes 0
syslogng_scratch_buffers_count 8
syslogng_tagged_events_total{id=".classifier.system"} 0
syslogng_tagged_events_total{id=".classifier.unknown"} 0
syslogng_tagged_events_total{id=".source.s_kubernetes"} 3872
syslogng_tagged_events_total{id=".tmp.k8s"} 0
```

Depends on #4451

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>