### PR TITLE
python: fix reference counting of generator function 

### DIFF
--- a/modules/python/python-confgen.c
+++ b/modules/python/python-confgen.c
@@ -121,6 +121,7 @@ py_register_config_generator(PyObject *self, PyObject *args, PyObject *kwargs)
       return NULL;
     }
 
+  Py_XINCREF(generator_function);
   python_confgen_register(context_value, name, generator_function);
 
   Py_RETURN_NONE;

--- a/news/bugfix-4459.md
+++ b/news/bugfix-4459.md
@@ -1,0 +1,1 @@
+`python`: Fixed a crash which occurred at reloading after registering a confgen plugin.


### PR DESCRIPTION
We are parsing the function pointer a couple lines above with "O".

> O (object) [PyObject *]
> Store a Python object (without any conversion) in a C object pointer. The C program thus receives the actual object that was passed. The object’s reference count is not increased. The pointer stored is not NULL.

Its reference count is not increased with the parsing, however we decrease its reference in `python_config_generator_free()`.
This causes a problem, when we are reloading and re-registering the same function.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>