### PR TITLE
splunk: add splunk-hec-raw() and splunk-hec-event() drivers

### DIFF
--- a/news/feature-4462.md
+++ b/news/feature-4462.md
@@ -1,0 +1,61 @@
+splunk: Added support for sending messages to Splunk HEC.
+
+The `splunk-hec-event()` destination feeds Splunk via the [HEC events API](https://docs.splunk.com/Documentation/Splunk/9.0.4/RESTREF/RESTinput#services.2Fcollector.2Fevent.2F1.0).
+
+Minimal config:
+```
+destination d_splunk_hec_event {
+  splunk-hec-event(
+    url("https://localhost:8088")
+    token("70b6ae71-76b3-4c38-9597-0c5b37ad9630")
+  );
+};
+```
+
+Additional options include:
+  * `event()`
+  * `index()`
+  * `source()`
+  * `sourcetype()`
+  * `host()`
+  * `time()`
+  * `default-index()`
+  * `default-source()`
+  * `default-sourcetype()`
+  * `fields()`
+  * `extra-headers()`
+  * `extra-queries()`
+  * `content-type()`
+
+`event()` accepts a template, which declares the content of the log message sent to Splunk.
+By default we send the `${MSG}` value.
+
+`index()`, `source()`, `host()` and `time()` accepts templates, which declare the respective field
+of each log message based on the set template.
+
+`default-index()`, `default-source()` and `default-sourcetype()` accepts literal strings, which
+will be used for fallback values if a log message does not set these fields. These values are
+passed to the URL as query parameters, so they do not inflate the body of the HTTP request
+for each message in the batch, which saves bandwidth.
+
+`fields()` accepts template, which is passed as additional indexing metadata to Splunk.
+
+`extra-headers()`, `extra-queries()` and `content-type()` are additional HTTP request options.
+
+The `splunk-hec-raw()` destination feeds Splunk via the [HEC raw API](https://docs.splunk.com/Documentation/Splunk/9.0.4/RESTREF/RESTinput#services.2Fcollector.2Fraw.2F1.0).
+
+Regarding its options, it is similar to the `splunk-hec-event()` destination with the addition
+of the mandatory `channel()` option, which accepts a GUID as a literal string that differentiates
+data from different clients. Another difference is that instead of `event()`, here the `template()`
+option sets the template which will represent the log message in Splunk.
+
+Minimal config:
+```
+destination d_splunk_hec_raw {
+  splunk-hec-raw(
+    url("https://localhost:8088")
+    token("70b6ae71-76b3-4c38-9597-0c5b37ad9630")
+    channel("05ed4617-f186-4ccd-b4e7-08847094c8fd")
+  );
+};
+```

--- a/scl/CMakeLists.txt
+++ b/scl/CMakeLists.txt
@@ -32,6 +32,7 @@ set(SCL_DIRS
     slack
     snmptrap
     solaris
+    splunk
     sudo
     sumologic
     syslogconf

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -32,6 +32,7 @@ SCL_SUBDIRS	= \
 	slack \
 	snmptrap	\
 	solaris	\
+	splunk \
 	sudo		\
 	sumologic	\
 	syslogconf	\

--- a/scl/splunk/splunk.conf
+++ b/scl/splunk/splunk.conf
@@ -1,0 +1,129 @@
+#############################################################################
+# Copyright (c) 2023 Attila Szakacs
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+@requires json-plugin
+
+# https://docs.splunk.com/Documentation/Splunk/9.0.4/RESTREF/RESTinput#services.2Fcollector.2Fraw.2F1.0
+block destination splunk_hec_raw(
+  url()
+  token()
+  channel()
+
+  default_index("main")
+  default_source("syslog-ng")
+  default_sourcetype("syslog")
+
+  template("${S_ISODATE} ${HOST} ${MSGHDR}${MSG}\n")
+
+  batch_lines(5000)
+  batch_bytes(4096kB)
+  batch_timeout(300)
+  workers(8)
+  timeout(10)
+
+  content_type("text/plain")
+  extra_headers("")
+  extra_queries("")
+  use_system_cert_store(yes)
+  ...)
+{
+
+@requires http "The splunk-hec-raw() driver depends on the syslog-ng http module, please install the syslog-ng-mod-http (Debian & derivatives) or the syslog-ng-http (RHEL & co) package"
+
+  http(
+    url("`url`/services/collector/raw/1.0?channel=`channel`&index=`default_index`&source=`default_source`&sourcetype=`default_sourcetype``extra_queries`")
+    headers(
+      "Authorization: Splunk `token`"
+      "Content-Type: `content_type`"
+      "Connection: keep-alive"
+      `extra_headers`
+    )
+    body(`template`)
+    batch-lines(`batch_lines`)
+    batch-bytes(`batch_bytes`)
+    batch-timeout(`batch_timeout`)
+    workers(`workers`)
+    timeout(`timeout`)
+    use_system_cert_store(`use_system_cert_store`)
+    `__VARARGS__`
+  );
+};
+
+# https://docs.splunk.com/Documentation/Splunk/9.0.4/RESTREF/RESTinput#services.2Fcollector.2Fevent.2F1.0
+block destination splunk_hec_event(
+  url()
+  token()
+
+  default_index("main")
+  default_source("syslog-ng")
+  default_sourcetype("nix:syslog")
+
+  index("")
+  source("")
+  sourcetype("")
+  host("${HOST}")
+  time("${S_UNIXTIME}.${S_MSEC}")
+  fields("")
+
+  event("${MSG}")
+
+  batch_lines(5000)
+  batch_bytes(4096kB)
+  batch_timeout(300)
+  workers(8)
+  timeout(10)
+
+  content_type("application/json")
+  extra_headers("")
+  extra_queries("")
+  use_system_cert_store(yes)
+  ...)
+{
+
+@requires http "The splunk-hec-event() driver depends on the syslog-ng http module, please install the syslog-ng-mod-http (Debian & derivatives) or the syslog-ng-http (RHEL & co) package"
+
+  http(
+    url("`url`/services/collector/event/1.0?index=`default_index`&source=`default_source`&sourcetype=`default_sourcetype``extra_queries`")
+    headers(
+      "Authorization: Splunk `token`"
+      "Content-Type: `content_type`"
+      "Connection: keep-alive"
+      `extra_headers`
+    )
+    body('$(format-json --scope none --omit-empty-values
+              index="`index`"
+              source="`source`"
+              sourcetype="`sourcetype`"
+              host="`host`"
+              time="`time`"
+              event="`event`"
+              fields=$(if ("`fields`" ne "") $(format-flat-json --scope none `fields`) ""))'
+    )
+    batch-lines(`batch_lines`)
+    batch-bytes(`batch_bytes`)
+    batch-timeout(`batch_timeout`)
+    timeout(`timeout`)
+    workers(`workers`)
+    use_system_cert_store(`use_system_cert_store`)
+    `__VARARGS__`
+  );
+};

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -179,6 +179,7 @@ scl/fortigate/.*\.conf$
 scl/cee/.*\.conf$
 scl/mariadb/.*\.conf$
 scl/python/python-modules\.conf$
+scl/splunk/splunk\.conf$
 modules/python-modules/syslogng/modules/kubernetes/.*
 modules/ebpf/.*
 modules/python-modules/syslogng/modules/hypr/.*


### PR DESCRIPTION
splunk: Added support for sending messages to Splunk HEC.

The `splunk-hec-event()` destination feeds Splunk via the [HEC events API](https://docs.splunk.com/Documentation/Splunk/9.0.4/RESTREF/RESTinput#services.2Fcollector.2Fevent.2F1.0).

Minimal config:
```
destination d_splunk_hec_event {
  splunk-hec-event(
    url("https://localhost:8088")
    token("70b6ae71-76b3-4c38-9597-0c5b37ad9630")
  );
};
```

Additional options include:
  * `event()`
  * `index()`
  * `source()`
  * `sourcetype()`
  * `host()`
  * `time()`
  * `default-index()`
  * `default-source()`
  * `default-sourcetype()`
  * `fields()`
  * `extra-headers()`
  * `extra-queries()`
  * `content-type()`

`event()` accepts a template, which declares the content of the log message sent to Splunk.
By default we send the `${MSG}` value.

`index()`, `source()`, `host()` and `time()` accepts templates, which declare the respective field
of each log message based on the set template.

`default-index()`, `default-source()` and `default-sourcetype()` accepts literal strings, which
will be used for fallback values if a log message does not set these fields. These values are
passed to the URL as query parameters, so they do not inflate the body of the HTTP request
for each message in the batch, which saves bandwidth.

`fields()` accepts template, which is passed as additional indexing metadata to Splunk.

`extra-headers()`, `extra-queries()` and `content-type()` are additional HTTP request options.

The `splunk-hec-raw()` destination feeds Splunk via the [HEC raw API](https://docs.splunk.com/Documentation/Splunk/9.0.4/RESTREF/RESTinput#services.2Fcollector.2Fraw.2F1.0).

Regarding its options, it is similar to the `splunk-hec-event()` destination with the addition
of the mandatory `channel()` option, which accepts a GUID as a literal string that differentiates
data from different clients. Another difference is that instead of `event()`, here the `template()`
option sets the template which will represent the log message in Splunk.

Minimal config:
```
destination d_splunk_hec_raw {
  splunk-hec-raw(
    url("https://localhost:8088")
    token("70b6ae71-76b3-4c38-9597-0c5b37ad9630")
    channel("05ed4617-f186-4ccd-b4e7-08847094c8fd")
  );
};
```

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>