### PR TITLE
examples: fix memory leak

### DIFF
--- a/modules/examples/destinations/example_destination/example_destination_worker.c
+++ b/modules/examples/destinations/example_destination/example_destination_worker.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2023 One Identity LLC.
  * Copyright (c) 2020 Balabit
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -35,7 +36,10 @@ _dw_insert(LogThreadedDestWorker *s, LogMessage *msg)
                   self->thread_id, log_msg_get_value(msg, LM_V_MESSAGE, NULL));
 
   size_t retval = fwrite(string_to_write->str, 1, string_to_write->len, self->file);
-  if (retval != string_to_write->len)
+  gsize string_to_write_len = string_to_write->len;
+  g_string_free(string_to_write, TRUE);
+
+  if (retval != string_to_write_len)
     {
       msg_error("Error while reading file");
       return LTR_NOT_CONNECTED;
@@ -46,8 +50,6 @@ _dw_insert(LogThreadedDestWorker *s, LogMessage *msg)
       msg_error("Error while flushing file");
       return LTR_NOT_CONNECTED;
     }
-
-  g_string_free(string_to_write, TRUE);
 
   return LTR_SUCCESS;
   /*


### PR DESCRIPTION
This patch fixes a memory leak in case the destination worker fails in the _dw_insert method.

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
