### PR TITLE
python-modules: fix signature of BatchedAckTracker fake class

### DIFF
--- a/modules/python-modules/syslogng/source.py
+++ b/modules/python-modules/syslogng/source.py
@@ -212,5 +212,7 @@ class ConsecutiveAckTracker(ConsecutiveAckTracker):
 
 
 class BatchedAckTracker(BatchedAckTracker):
-    def __init__(self, ack_callback):
-        self.ack_callback = ack_callback
+    def __init__(self, timeout, batch_size, batched_ack_callback):
+        self.timeout = timeout
+        self.batch_size = batch_size
+        self.ack_callback = batched_ack_callback


### PR DESCRIPTION
Fixes a bug introduced in #4175.

No news file needed because this has not been released yet.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>