### PR TITLE
python-modules: add register_jinja_config_generator convenience fn

### DIFF
--- a/modules/python-modules/syslogng/__init__.py
+++ b/modules/python-modules/syslogng/__init__.py
@@ -29,4 +29,4 @@ from .template import LogTemplate, LogTemplateOptions, LogTemplateException, LTZ
 from .message import LogMessage
 from .logger import Logger
 from .persist import Persist
-from .confgen import register_config_generator
+from .confgen import register_config_generator, register_jinja_config_generator

--- a/modules/python-modules/syslogng/confgen.py
+++ b/modules/python-modules/syslogng/confgen.py
@@ -20,10 +20,22 @@
 # COPYING for details.
 #
 #############################################################################
-# pylint: disable=unused-import
 
 try:
     from _syslogng import register_config_generator
 except ImportError:
     def register_config_generator(context, name, config_generator):
+        pass
+
+try:
+    import jinja2
+
+    def register_jinja_config_generator(context, name, template):
+        def jinja_confgen_fn(args):
+            jinja2_env = jinja2.Environment()
+            jinja2_template = jinja2_env.from_string(template)
+            return jinja2_template.render(args=args)
+        register_config_generator(context, name, jinja_confgen_fn)
+except ImportError:
+    def register_jinja_config_generator(context, name, template):
         pass

--- a/news/feature-4467.md
+++ b/news/feature-4467.md
@@ -1,0 +1,18 @@
+`python`: Added a convenience function to register jinja templated config generators.
+
+Example usage:
+```
+python {
+import syslogng
+
+syslogng.register_jinja_config_generator(context="destination", name="my_dest", template=r"""
+
+file({{ args.path }});
+
+""")
+};
+
+destination d_my_dest{
+  my-dest(path("/dev/stdout"));
+};
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ six==1.16.0
 urllib3==1.26.12
 websocket-client==1.3.1
 ply==3.11
+MarkupSafe==2.1.2
+Jinja2==3.1.2


### PR DESCRIPTION
Example usage:
```
python {
import syslogng

syslogng.register_jinja_config_generator(context="destination", name="my_dest", template=r"""

file({{ args.path }});

""")
};

destination d_my_dest{
  my-dest(path("/dev/stdout"));
};
```

TODO: make it possible to load `.jinja` file.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>