### PR TITLE
Fix syslog-ng-cfg-db.py

### DIFF
--- a/contrib/config_option_database/utils/OptionParser.py
+++ b/contrib/config_option_database/utils/OptionParser.py
@@ -100,7 +100,7 @@ def _get_resolve_db():
     root_dir = Path(__file__).parents[3]
     if not resolve_db:
         resolve_db = {}
-        struct_regex = re.compile(r'CfgLexerKeyword[^;]*')
+        struct_regex = re.compile(r'CfgLexerKeyword.*?};')
         entry_regex = re.compile(r'{[^{}]+,[^{}]+}')
         for f in root_dir.rglob('*-parser.c'):
             for struct_match in struct_regex.finditer(f.read_text(encoding='UTF-8').replace('\n', '')):

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -80,6 +80,8 @@ static CfgLexerKeyword main_keywords[] =
   { "replace",            KW_REPLACE_PREFIX, KWS_OBSOLETE, "replace_prefix" },
   { "replace_prefix",     KW_REPLACE_PREFIX },
   { "cast",               KW_CAST },
+  { "upper",              KW_UPPER },
+  { "lower",              KW_LOWER },
 
   /* option items */
   { "flags",              KW_FLAGS },


### PR DESCRIPTION
I just read about `./contrib/config_option_database/syslog-ng-cfg-db.py` which I was not aware of and tried to use it on the master `branch` to have some insights on the new parsers of syslog-ng 4.2.0 but encountered errors (and this makes me think we can improve the vim syntax maintenance using this).

Once the data has been generated and cached, it seems not to be refreshed, so you have to `git clean -fdx` between tests to trigger the errors.

While the first commit is a quick workaround due to the fact the script tries to parse C code in a too quick way, the second makes me more skeptical, so Cc @bazsi who may have not added this code on purpose and may want to raise a point.
