### PR TITLE
logscale: add logscale() destination

### DIFF
--- a/news/feature-4472.md
+++ b/news/feature-4472.md
@@ -1,0 +1,23 @@
+Sending messages to CrowdStrike Falcon LogScale (Humio)
+
+The `logscale()` destination feeds LogScale via the [Ingest API](https://library.humio.com/falcon-logscale/api-ingest.html#api-ingest-structured-data).
+
+Minimal config:
+```
+destination d_logscale {
+  logscale(
+    token("my-token")
+  );
+};
+```
+Additional options include:
+  * `url()`
+  * `rawstring()`
+  * `timestamp()`
+  * `timezone()`
+  * `attributes()`
+  * `extra-headers()`
+  * `content-type()`
+
+
+__TODO: Add Andreas Friedmann and Ryan Faircloth to Contributors!!!!!__

--- a/scl/CMakeLists.txt
+++ b/scl/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SCL_DIRS
     loadbalancer
     loggly
     logmatic
+    logscale
     mariadb
     mbox
     netskope

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -20,6 +20,7 @@ SCL_SUBDIRS	= \
 	loadbalancer	\
 	loggly		\
 	logmatic	\
+	logscale	\
 	mariadb		\
 	mbox		\
 	netskope	\

--- a/scl/logscale/logscale.conf
+++ b/scl/logscale/logscale.conf
@@ -1,0 +1,76 @@
+#############################################################################
+# Copyright (c) 2023 Attila Szakacs
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+# Batching best practices: https://library.humio.com/falcon-logscale/api-ingest.html#api-ingest-best-practices
+
+@requires json-plugin
+
+
+# https://library.humio.com/falcon-logscale/api-ingest.html#api-ingest-structured-data
+block destination logscale(
+  url("https://cloud.humio.com")
+  token()
+
+  rawstring("${MESSAGE}")
+  timestamp("${S_ISODATE}")
+  timezone("")
+  attributes("--scope rfc5424 --exclude MESSAGE --exclude DATE --leave-initial-dot")
+
+  batch_lines(1000)
+  batch_bytes(1024kB)
+  batch_timeout(1)
+  workers(8)
+  timeout(10)
+
+  content_type("application/json")
+  extra_headers("")
+  use_system_cert_store(yes)
+  ...)
+{
+
+@requires http "The logscale() driver depends on the syslog-ng http module, please install the syslog-ng-mod-http (Debian & derivatives) or the syslog-ng-http (RHEL & co) package"
+
+  http(
+    url("`url`/api/v1/ingest/humio-structured")
+    headers(
+      "Authorization: Bearer `token`"
+      "Content-Type: `content_type`"
+      `extra_headers`
+    )
+    delimiter(",")
+    body-prefix('[{"events":[')
+    body('$(format-json --scope none --omit-empty-values
+              rawstring=`rawstring`
+              timestamp=`timestamp`
+              timezone=`timezone`
+              attributes=$(if ("`attributes`" ne "") $(format-json --scope none `attributes`) ""))'
+    )
+    body-suffix(']}]')
+    batch-lines(`batch_lines`)
+    batch-bytes(`batch_bytes`)
+    batch-timeout(`batch_timeout`)
+    timeout(`timeout`)
+    workers(`workers`)
+    use_system_cert_store(`use_system_cert_store`)
+    `__VARARGS__`
+  );
+};

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -177,6 +177,7 @@ modules/python/python-flags.(c|h)$
 modules/python/tests/test_python_options.c$
 scl/fortigate/.*\.conf$
 scl/cee/.*\.conf$
+scl/logscale/logscale\.conf$
 scl/mariadb/.*\.conf$
 scl/python/python-modules\.conf$
 scl/splunk/splunk\.conf$


### PR DESCRIPTION
The `logscale()` destination feeds LogScale via the [Ingest API](https://library.humio.com/falcon-logscale/api-ingest.html#api-ingest-structured-data).

Minimal config:
```
destination d_logscale {
  logscale(
    token("my-token")
  );
};
```
Additional options include:
  * `url()`
  * `rawstring()`
  * `timestamp()`
  * `timezone()`
  * `attributes()`
  * `extra-headers()`
  * `content-type()`

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>