### PR TITLE
Keep python core while disabling python modules

### DIFF
--- a/Mk/python-venv.am
+++ b/Mk/python-venv.am
@@ -1,7 +1,7 @@
 
 PYTHON_VENV_TOUCHFILE=$(abs_builddir)/.python-venv-built
 
-$(PYTHON_VENV_TOUCHFILE): Makefile
+$(PYTHON_VENV_TOUCHFILE): dev-requirements.txt
 	if [ "$(with_python_packages)" = "venv" ]; then \
 	    $(top_srcdir)/scripts/build-python-venv.sh "$(PYTHON)" "$(PYTHON_VENV_DIR)" "$(top_srcdir)"; \
 	fi

--- a/configure.ac
+++ b/configure.ac
@@ -350,7 +350,7 @@ AC_ARG_ENABLE(python,
               ,,enable_python="auto")
 
 AC_ARG_ENABLE(python-modules,
-              [  --disable-python-modules  Disable Python based syslog-ng modules]
+              [  --disable-python-modules  Disable Python based syslog-ng addons while installing the core Python modules]
               ,,enable_python_modules="auto")
 
 AC_ARG_WITH(python,

--- a/modules/python-modules/Makefile.am
+++ b/modules/python-modules/Makefile.am
@@ -57,7 +57,7 @@ EXTRA_DIST += \
 	modules/python-modules/setup.py						\
 	modules/python-modules/README.md
 
-if ENABLE_PYTHON_MODULES
+if ENABLE_PYTHON
 
 python_sysconf_module_DATA = modules/python-modules/README.md
 
@@ -66,6 +66,14 @@ PYMODULES_BUILDDIR = $(abs_builddir)/$(PYMODULES_PATH)
 PYMODULES_SRCDIR = $(top_srcdir)/modules/python-modules
 PYMODULES_MANIFEST = $(PYMODULES_BUILDDIR)/install-manifest.txt
 PYMODULES_ROOT_MODULE = syslogng
+
+if ENABLE_PYTHON_MODULES
+PYMODULES_BUILTINS_ONLY=0
+else
+PYMODULES_BUILTINS_ONLY=1
+endif
+export PYMODULES_BUILTINS_ONLY
+
 PYTHON_ROOT = $(if $(DESTDIR),$(DESTDIR),/)
 
 INSTALL_EXEC_HOOKS += pymodules-install

--- a/modules/python-modules/setup.py
+++ b/modules/python-modules/setup.py
@@ -22,6 +22,34 @@
 #############################################################################
 
 from setuptools import setup
+import os
+
+install_addons=int(os.getenv('PYMODULES_BUILTINS_ONLY', '0')) == 0
+
+packages_builtin=[
+  "syslogng",
+  "syslogng.debuggercli",
+]
+requires_builtin=[]
+
+packages_addons=[
+  "syslogng.modules.example",
+  "syslogng.modules.kubernetes",
+  "syslogng.modules.hypr",
+]
+
+requires_addons=[
+  # kubernetes
+  "kubernetes",
+  # hypr
+  "requests",
+]
+
+packages = packages_builtin
+requires = []
+if install_addons:
+  packages = packages + packages_addons
+  requires = requires + requires_addons
 
 setup(name='syslogng',
       version='1.0',
@@ -31,16 +59,5 @@ setup(name='syslogng',
       url='https://www.syslog-ng.org',
       package_data={"": ["scl/*"]},
       exclude_package_data={"": ["*~"]},
-      packages=[
-        "syslogng",
-        "syslogng.debuggercli",
-        "syslogng.modules.example",
-        "syslogng.modules.kubernetes",
-        "syslogng.modules.hypr",
-      ],
-      install_requires=[
-          # kubernetes
-          "kubernetes",
-          # hypr
-          "requests",
-      ])
+      packages=packages,
+      install_requires=requires)


### PR DESCRIPTION
This should fix #4486 by installing the core syslog-ng Python modules even if --disable-python-modules is used.

@czanik can you please test if this fixes your issue?
