### PR TITLE
logmsg: add bytes and protobuf types

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -349,6 +349,7 @@
 %token KW_CAST                        10511
 %token KW_UPPER                       10512
 %token KW_LOWER                       10513
+%token KW_INCLUDE_BYTES               10514
 
 %token KW_ON_ERROR                    10520
 
@@ -1496,6 +1497,7 @@ vp_option
         | KW_EXCLUDE '(' string_list ')'                 { value_pairs_add_glob_patterns(last_value_pairs, $3, FALSE); }
 	| KW_SCOPE '(' vp_scope_list ')'
 	| KW_CAST '(' yesno ')'                          { value_pairs_set_cast_to_strings(last_value_pairs, $3); }
+	| KW_INCLUDE_BYTES '(' yesno ')'                 { value_pairs_set_include_bytes(last_value_pairs, $3); }
 	;
 
 vp_scope_list

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -82,6 +82,7 @@ static CfgLexerKeyword main_keywords[] =
   { "cast",               KW_CAST },
   { "upper",              KW_UPPER },
   { "lower",              KW_LOWER },
+  { "include_bytes",      KW_INCLUDE_BYTES },
 
   /* option items */
   { "flags",              KW_FLAGS },

--- a/lib/debugger/debugger.c
+++ b/lib/debugger/debugger.c
@@ -51,6 +51,17 @@ _format_nvpair(NVHandle handle,
                const gchar *value, gssize length,
                LogMessageValueType type, gpointer user_data)
 {
+  if (type == LM_VT_BYTES || type == LM_VT_PROTOBUF)
+    {
+      printf("%s=", name);
+      for (gssize i = 0; i < length; i++)
+        {
+          const guchar b = (const guchar) value[i];
+          printf("%02hhx", b);
+        }
+      printf("\n");
+      return FALSE;
+    }
   printf("%s=%.*s\n", name, (gint) length, value);
   return FALSE;
 }

--- a/lib/filter/tests/test_filters_fop_cmp.c
+++ b/lib/filter/tests/test_filters_fop_cmp.c
@@ -49,6 +49,8 @@ _construct_sample_message(void)
   log_msg_set_value_by_name_with_type(msg, "datevalue", "1653246684.123", -1, LM_VT_DATETIME);
   log_msg_set_value_by_name_with_type(msg, "listvalue", "foo,bar,baz", -1, LM_VT_LIST);
   log_msg_set_value_by_name_with_type(msg, "nullvalue", "", -1, LM_VT_NULL);
+  log_msg_set_value_by_name_with_type(msg, "bytesvalue", "\0\1\2\3", 4, LM_VT_BYTES);
+  log_msg_set_value_by_name_with_type(msg, "protobufvalue", "\4\5\6\7", 4, LM_VT_PROTOBUF);
   return msg;
 }
 
@@ -290,6 +292,12 @@ Test(filter, test_type_aware_comparisons_strings_to_strings_are_compared_as_stri
   cr_assert(evaluate("'$strvalue' == 'string'"));
   cr_assert(evaluate("'$strvalue' == '$strvalue'"));
   cr_assert_not(evaluate("'$strvalue' != '$strvalue'"));
+
+  /* bytes values */
+  cr_assert(evaluate("'$bytesvalue' == '$bytesvalue'"));
+  cr_assert_not(evaluate("'$bytesvalue' != '$bytesvalue'"));
+  cr_assert(evaluate("'$protobufvalue' == '$protobufvalue'"));
+  cr_assert_not(evaluate("'$protobufvalue' != '$protobufvalue'"));
 }
 
 Test(filter, test_type_aware_comparison_objects_are_compared_as_strings_if_types_match)
@@ -390,6 +398,20 @@ Test(filter, test_type_aware_comparisons_mixed_types_or_numbers_are_compared_as_
   cr_assert_not(evaluate("'$jsonvalue' < 01234"));
   cr_assert_not(evaluate("'$jsonvalue' > 01234"));
   cr_assert_not(evaluate("'$jsonvalue' == 01234"));
+
+  /* bytes and protobuf types are behaving as they were unset (return NULL values) if not explicitly cast to bytes() */
+  cr_assert(evaluate("'$bytesvalue' < 1"));
+  cr_assert(evaluate("'$bytesvalue' > -1"));
+  cr_assert(evaluate("'$protobufvalue' < 1"));
+  cr_assert(evaluate("'$protobufvalue' > -1"));
+
+  /* bytes and protobuf types are NaN values if explicitly cast to bytes() */
+  cr_assert_not(evaluate("bytes('$bytesvalue') < 01234"));
+  cr_assert_not(evaluate("bytes('$bytesvalue') > 01234"));
+  cr_assert_not(evaluate("bytes('$bytesvalue') == 01234"));
+  cr_assert_not(evaluate("protobuf('$protobufvalue') < 01234"));
+  cr_assert_not(evaluate("protobuf('$protobufvalue') > 01234"));
+  cr_assert_not(evaluate("protobuf('$protobufvalue') == 01234"));
 }
 
 Test(filter, test_type_aware_comparison_nan_is_always_different_from_anything)

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -246,6 +246,8 @@ log_msg_value_type_to_str(LogMessageValueType self)
     [LM_VT_DATETIME] = "datetime",
     [LM_VT_LIST] = "list",
     [LM_VT_NULL] = "null",
+    [LM_VT_BYTES] = "bytes",
+    [LM_VT_PROTOBUF] = "protobuf",
     [LM_VT_NONE] = "none",
   };
 
@@ -272,6 +274,10 @@ log_msg_value_type_from_str(const gchar *in_str, LogMessageValueType *out_type)
     *out_type = LM_VT_LIST;
   else if (strcmp(in_str, "null") == 0)
     *out_type = LM_VT_NULL;
+  else if (strcmp(in_str, "bytes") == 0)
+    *out_type = LM_VT_BYTES;
+  else if (strcmp(in_str, "protobuf") == 0)
+    *out_type = LM_VT_PROTOBUF;
   else if (strcmp(in_str, "none") == 0)
     *out_type = LM_VT_NONE;
   else

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -164,6 +164,8 @@ enum _LogMessageValueType
   LM_VT_DATETIME = 6,
   LM_VT_LIST = 7,
   LM_VT_NULL = 8,
+  LM_VT_BYTES = 9,
+  LM_VT_PROTOBUF = 10,
 
   /* extremal value to indicate "unset" state.
    *

--- a/lib/logmsg/tests/test_type_hints.c
+++ b/lib/logmsg/tests/test_type_hints.c
@@ -71,6 +71,10 @@ ParameterizedTestParameters(type_hints, test_type_hint_parse)
     {"float",     LM_VT_DOUBLE},
     {"double",    LM_VT_DOUBLE},
     {"datetime",  LM_VT_DATETIME},
+    {"list",      LM_VT_LIST},
+    {"null",      LM_VT_NULL},
+    {"bytes",     LM_VT_BYTES},
+    {"protobuf",  LM_VT_PROTOBUF},
   };
 
   return cr_make_param_array(StringHintPair, string_value_pairs,

--- a/lib/value-pairs/cmdline.h
+++ b/lib/value-pairs/cmdline.h
@@ -26,8 +26,14 @@
 
 #include "value-pairs/value-pairs.h"
 
+typedef struct ValuePairsOptionalOptions_
+{
+  gboolean enable_include_bytes;
+} ValuePairsOptionalOptions;
+
 ValuePairs *value_pairs_new_from_cmdline(GlobalConfig *cfg,
                                          gint *argc, gchar ***argv,
+                                         const ValuePairsOptionalOptions *optional_options,
                                          GOptionGroup *custom_options,
                                          GError **error);
 

--- a/lib/value-pairs/internals.h
+++ b/lib/value-pairs/internals.h
@@ -38,6 +38,7 @@ struct _ValuePairs
   GPtrArray *transforms;
 
   gboolean omit_empty_values;
+  gboolean include_bytes;
 
   /* guint32 as CfgFlagHandler only supports 32 bit integers */
   guint32 scopes;

--- a/lib/value-pairs/tests/test_value_pairs.c
+++ b/lib/value-pairs/tests/test_value_pairs.c
@@ -309,6 +309,120 @@ Test(value_pairs, test_transformer_upper)
   g_ptr_array_free(transformers, TRUE);
 }
 
+gboolean
+asserts_for_no_include_bytes(const gchar *name, LogMessageValueType type, const gchar *value,
+                             gsize value_len, gpointer user_data)
+{
+  if (strcmp(name, "custom_bytes") == 0)
+    {
+      cr_assert_eq(type, LM_VT_NULL);
+      cr_assert_eq(value_len, 0);
+    }
+  else if (strcmp(name, "custom_protobuf") == 0)
+    {
+      cr_assert_eq(type, LM_VT_NULL);
+      cr_assert_eq(value_len, 0);
+    }
+  else if (strcmp(name, "custom_explicit_bytes") == 0)
+    {
+      cr_assert_eq(type, LM_VT_BYTES);
+      cr_assert_eq(value_len, 4);
+      cr_assert_eq(memcmp(value, "\0\1\2\3", 4), 0);
+    }
+  else if (strcmp(name, "custom_explicit_protobuf") == 0)
+    {
+      cr_assert_eq(type, LM_VT_PROTOBUF);
+      cr_assert_eq(value_len, 4);
+      cr_assert_eq(memcmp(value, "\4\5\6\7", 4), 0);
+    }
+  else
+    {
+      cr_assert(FALSE, "%s not expected", name);
+    }
+
+  return FALSE;
+}
+
+gboolean
+asserts_for_include_bytes(const gchar *name, LogMessageValueType type, const gchar *value,
+                          gsize value_len, gpointer user_data)
+{
+  if (strcmp(name, "bytes") == 0)
+    {
+      cr_assert_eq(type, LM_VT_BYTES);
+      cr_assert_eq(value_len, 4);
+      cr_assert_eq(memcmp(value, "\0\1\2\3", 4), 0);
+    }
+  else if (strcmp(name, "protobuf") == 0)
+    {
+      cr_assert_eq(type, LM_VT_PROTOBUF);
+      cr_assert_eq(value_len, 4);
+      cr_assert_eq(memcmp(value, "\4\5\6\7", 4), 0);
+    }
+  else if (strcmp(name, "custom_bytes") == 0)
+    {
+      cr_assert_eq(type, LM_VT_NULL);
+      cr_assert_eq(value_len, 0);
+    }
+  else if (strcmp(name, "custom_protobuf") == 0)
+    {
+      cr_assert_eq(type, LM_VT_NULL);
+      cr_assert_eq(value_len, 0);
+    }
+  else if (strcmp(name, "custom_explicit_bytes") == 0)
+    {
+      cr_assert_eq(type, LM_VT_BYTES);
+      cr_assert_eq(value_len, 4);
+      cr_assert_eq(memcmp(value, "\0\1\2\3", 4), 0);
+    }
+  else if (strcmp(name, "custom_explicit_protobuf") == 0)
+    {
+      cr_assert_eq(type, LM_VT_PROTOBUF);
+      cr_assert_eq(value_len, 4);
+      cr_assert_eq(memcmp(value, "\4\5\6\7", 4), 0);
+    }
+  else
+    {
+      cr_assert(FALSE, "%s not expected", name);
+    }
+
+  return FALSE;
+}
+
+Test(value_pairs, test_include_bytes)
+{
+  LogTemplateEvalOptions options = {&template_options, LTZ_LOCAL, 11, NULL, LM_VT_STRING};
+
+  ValuePairs *vp = value_pairs_new(configuration);
+  value_pairs_add_scope(vp, "nv-pairs");
+
+  LogTemplate *template;
+  template = create_template(NULL, "$bytes");
+  value_pairs_add_pair(vp, "custom_bytes", template);
+  log_template_unref(template);
+  template = create_template(NULL, "$protobuf");
+  value_pairs_add_pair(vp, "custom_protobuf", template);
+  log_template_unref(template);
+  template = create_template("bytes", "$bytes");
+  value_pairs_add_pair(vp, "custom_explicit_bytes", template);
+  log_template_unref(template);
+  template = create_template("protobuf", "$protobuf");
+  value_pairs_add_pair(vp, "custom_explicit_protobuf", template);
+  log_template_unref(template);
+
+  LogMessage *msg = log_msg_new_empty();
+  log_msg_set_value_by_name_with_type(msg, "bytes", "\0\1\2\3", 4, LM_VT_BYTES);
+  log_msg_set_value_by_name_with_type(msg, "protobuf", "\4\5\6\7", 4, LM_VT_PROTOBUF);
+
+  value_pairs_foreach(vp, asserts_for_no_include_bytes, msg, &options, NULL);
+
+  value_pairs_set_include_bytes(vp, TRUE);
+  value_pairs_foreach(vp, asserts_for_include_bytes, msg, &options, NULL);
+
+  log_msg_unref(msg);
+  value_pairs_unref(vp);
+}
+
 void
 setup(void)
 {

--- a/lib/value-pairs/value-pairs.c
+++ b/lib/value-pairs/value-pairs.c
@@ -973,6 +973,12 @@ value_pairs_is_cast_to_strings_explicit(ValuePairs *vp)
   return vp->explicit_cast_to_strings;
 }
 
+void
+value_pairs_set_include_bytes(ValuePairs *vp, gboolean enable)
+{
+  vp->include_bytes = enable;
+}
+
 ValuePairs *
 value_pairs_new(GlobalConfig *cfg)
 {

--- a/lib/value-pairs/value-pairs.c
+++ b/lib/value-pairs/value-pairs.c
@@ -273,6 +273,9 @@ vp_msg_nvpairs_foreach(NVHandle handle, const gchar *name,
   if (vp->omit_empty_values && value_len == 0)
     return FALSE;
 
+  if ((type == LM_VT_BYTES || type == LM_VT_PROTOBUF) && !vp->include_bytes)
+    return FALSE;
+
   inc = (name[0] == '.' && (vp->scopes & VPS_DOT_NV_PAIRS)) ||
         (name[0] != '.' && (vp->scopes & VPS_NV_PAIRS)) ||
         (log_msg_is_handle_sdata(handle) && (vp->scopes & (VPS_SDATA + VPS_RFC5424)));

--- a/lib/value-pairs/value-pairs.h
+++ b/lib/value-pairs/value-pairs.h
@@ -57,6 +57,8 @@ void value_pairs_set_cast_to_strings(ValuePairs *vp, gboolean enable);
 void value_pairs_set_auto_cast(ValuePairs *vp);
 gboolean value_pairs_is_cast_to_strings_explicit(ValuePairs *vp);
 
+void value_pairs_set_include_bytes(ValuePairs *vp, gboolean enable);
+
 gboolean value_pairs_foreach_sorted(ValuePairs *vp, VPForeachFunc func,
                                     GCompareFunc compare_func,
                                     LogMessage *msg, LogTemplateEvalOptions *options,

--- a/libtest/cr_template.c
+++ b/libtest/cr_template.c
@@ -134,6 +134,8 @@ create_sample_message(void)
   log_msg_set_value_by_name(msg, "template_name", "dummy", -1);
   log_msg_set_value_by_name_with_type(msg, "number1", "123", -1, LM_VT_INTEGER);
   log_msg_set_value_by_name_with_type(msg, "number2", "456", -1, LM_VT_INTEGER);
+  log_msg_set_value_by_name_with_type(msg, "bytes", "\0\1\2\3", 4, LM_VT_BYTES);
+  log_msg_set_value_by_name_with_type(msg, "protobuf", "\4\5\6\7", 4, LM_VT_PROTOBUF);
 
   return msg;
 }

--- a/modules/afmongodb/afmongodb-worker.c
+++ b/modules/afmongodb/afmongodb-worker.c
@@ -408,6 +408,12 @@ _vp_process_value(const gchar *name, const gchar *prefix, LogMessageValueType ty
       bson_append_null(o, name, -1);
       break;
     }
+    case LM_VT_BYTES:
+    case LM_VT_PROTOBUF:
+    {
+      bson_append_binary(o, name, -1, BSON_SUBTYPE_BINARY, (const uint8_t *) value, value_len);
+      break;
+    }
     default:
       return TRUE;
     }

--- a/modules/afmongodb/afmongodb.c
+++ b/modules/afmongodb/afmongodb.c
@@ -374,7 +374,9 @@ afmongodb_dd_new(GlobalConfig *cfg)
   afmongodb_dd_set_collection(&self->super.super.super, template);
 
   log_template_options_defaults(&self->template_options);
-  afmongodb_dd_set_value_pairs(&self->super.super.super, value_pairs_new_default(cfg));
+  ValuePairs *vp = value_pairs_new_default(cfg);
+  value_pairs_set_include_bytes(vp, TRUE);
+  afmongodb_dd_set_value_pairs(&self->super.super.super, vp);
 
   self->use_bulk = TRUE;
   self->bulk_unordered = FALSE;

--- a/modules/basicfuncs/vp-funcs.c
+++ b/modules/basicfuncs/vp-funcs.c
@@ -56,7 +56,7 @@ tf_value_pairs_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *paren
   else
     g_assert_not_reached();
 
-  state->vp = value_pairs_new_from_cmdline (parent->cfg, &argc, &argv, NULL, error);
+  state->vp = value_pairs_new_from_cmdline (parent->cfg, &argc, &argv, NULL, NULL, error);
   return state->vp != NULL;
 }
 

--- a/modules/cef/format-cef-extension.c
+++ b/modules/cef/format-cef-extension.c
@@ -41,7 +41,7 @@ tf_cef_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
 {
   TFCefState *state = (TFCefState *)s;
 
-  state->vp = value_pairs_new_from_cmdline(parent->cfg, &argc, &argv, NULL, error);
+  state->vp = value_pairs_new_from_cmdline(parent->cfg, &argc, &argv, NULL, NULL, error);
   if (!state->vp)
     return FALSE;
 

--- a/modules/graphite/graphite-output.c
+++ b/modules/graphite/graphite-output.c
@@ -105,7 +105,7 @@ tf_graphite_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
       log_template_compile(state->timestamp_template, "$R_UNIXTIME", NULL);
     }
 
-  state->vp = value_pairs_new_from_cmdline (parent->cfg, &argc, &argv, NULL, error);
+  state->vp = value_pairs_new_from_cmdline (parent->cfg, &argc, &argv, NULL, NULL, error);
   if (!state->vp)
     return FALSE;
 

--- a/modules/json/format-json.c
+++ b/modules/json/format-json.c
@@ -80,7 +80,7 @@ tf_json_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
   GOptionGroup *og = g_option_group_new("format-json", "", "", state, NULL);
   g_option_group_add_entries(og, format_json_options);
 
-  state->vp = value_pairs_new_from_cmdline(parent->cfg, &argc, &argv, og, error);
+  state->vp = value_pairs_new_from_cmdline(parent->cfg, &argc, &argv, NULL, og, error);
   if (!state->vp)
     return FALSE;
 

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -354,6 +354,19 @@ Test(format_json, test_format_json_with_utf8)
   log_msg_unref(msg);
 }
 
+Test(format_json, test_format_json_with_bytes)
+{
+  LogMessage *msg = log_msg_new_empty();
+  log_msg_set_value_by_name_with_type(msg, "bytes", "\0\1\2\3", 4, LM_VT_BYTES);
+  log_msg_set_value_by_name_with_type(msg, "protobuf", "\4\5\6\7", 4, LM_VT_PROTOBUF);
+
+  assert_template_format_msg("$(format-json --scope nv-pairs)", "{}", msg);
+  assert_template_format_msg("$(format-json --include-bytes --scope nv-pairs)",
+                             "{\"protobuf\":\"BAUGBw==\",\"bytes\":\"AAECAw==\"}", msg);
+
+  log_msg_unref(msg);
+}
+
 Test(format_json, test_format_flat_json)
 {
   LogMessage *msg = create_empty_message();

--- a/modules/kvformat/format-welf.c
+++ b/modules/kvformat/format-welf.c
@@ -43,7 +43,7 @@ tf_format_welf_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *paren
 {
   TFWelfState *state = (TFWelfState *) s;
 
-  state->vp = value_pairs_new_from_cmdline (parent->cfg, &argc, &argv, FALSE, error);
+  state->vp = value_pairs_new_from_cmdline (parent->cfg, &argc, &argv, NULL, NULL, error);
   if (!state->vp)
     return FALSE;
 

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -219,6 +219,9 @@ _collect_nvpair_names_from_logmsg(NVHandle handle, const gchar *name, const gcha
 {
   PyObject *list = (PyObject *)user_data;
 
+  if (type == LM_VT_BYTES || type == LM_VT_PROTOBUF)
+    return FALSE;
+
   PyObject *py_name = PyBytes_FromString(name);
   PyList_Append(list, py_name);
   Py_XDECREF(py_name);

--- a/modules/python/python-logmsg.c
+++ b/modules/python/python-logmsg.c
@@ -53,7 +53,7 @@ _get_value(PyLogMessage *self, const gchar *name, gboolean cast_to_bytes, gboole
   LogMessageValueType type;
   const gchar *value = log_msg_get_value_if_set_with_type(self->msg, handle, &value_len, &type);
 
-  if (!value)
+  if (!value || type == LM_VT_BYTES || type == LM_VT_PROTOBUF)
     return NULL;
 
   if (cast_to_bytes)
@@ -306,12 +306,12 @@ py_log_message_get_as_str(PyLogMessage *self, PyObject *args, PyObject *kwrds)
       return NULL;
     }
 
-
   NVHandle handle = log_msg_get_value_handle(key);
   gssize value_len = 0;
-  const gchar *value = log_msg_get_value_if_set(self->msg, handle, &value_len);
+  LogMessageValueType type;
+  const gchar *value = log_msg_get_value_if_set_with_type(self->msg, handle, &value_len, &type);
 
-  if (value)
+  if (value && type != LM_VT_BYTES && type != LM_VT_PROTOBUF)
     {
       APPEND_ZERO(value, value, value_len);
       return PyUnicode_Decode(value, value_len, encoding, errors);

--- a/modules/python/python-types.c
+++ b/modules/python/python-types.c
@@ -217,6 +217,17 @@ py_obj_from_log_msg_value(const gchar *value, gssize value_len, LogMessageValueT
         return py_datetime_from_msec(msec);
       goto type_cast_error;
     }
+
+    case LM_VT_BYTES:
+    case LM_VT_PROTOBUF:
+      /*
+      * Dedicated python class is needed to differentiate LM_VT_STRING <-> bytes and LM_VT_BYTES <-> bytes.
+      * Until then we should not be converting, and we should mimic that the key does not exist.
+      * We should not end up here by default, only if the user explicitly set their value-pairs() in the config
+      * with include-bytes().
+      */
+      return NULL;
+
     case LM_VT_STRING:
     default:
       return py_bytes_from_string(value, value_len);


### PR DESCRIPTION
We are implementing these with the following behavior:
  * LogMessage API: `log_msg_get_value()` and `log_msg_values_foreach()`, etc returns them with the proper value and type.
  * Template evaluation:
      * Accessing the NVPair simply (e.g. `$bytes_value`) behaves if like they were unset.
      * Accessing the NVPair with explicit type cast (e.g. `bytes($bytes_value)` or `protobuf($protobuf_value)`) returns them with the proper value and type.
  * Value Pairs API: By default it behaves like it was unset, but an optional `--include-bytes` option can be added, which returns them with the proper value and type. This is opt-in, and the call site must be prepared to handle the values.
  * Python binding: They behave as they were unset, as we cannot differentiate between `LM_VT_STRING` <-> `bytes` and `LM_VT_BYTES` <-> `bytes` without a proper encapsulating class.
  * Destination specific APIs:
      * Accessed with `log_msg_get_value()`, etc: The destination can send it if its transport supports it.
      * Accessed with Value Pairs API: The destination can opt-in for include-bytes, and can handle it like in the prev point.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>