### PR TITLE
Fix CI python3 update issues

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,6 +13,14 @@ jobs:
       - name: Checkout syslog-ng source
         uses: actions/checkout@v3
 
+      - name: Unlinking preinstalled Python (workaround)
+              # The python@3 brew package has to be installed and linked system-wide (it's a dependency of glib and syslog-ng)
+              # The macos-latest GitHub runner has Python preinstalled as a pkg, this prevents linking the python@3
+              # brew package, even when linking is forced. `brew "python@3", link: true, force: true`
+              # also, brew cannot update the links even these cretated by itself for an earlier python version
+        run : |
+          find /usr/local/bin/ -lname "*Python.framework*" -delete
+
       - name: Install dependencies
         run: |
           brew update --preinstall


### PR DESCRIPTION
Put back earlier pyhon 2<->3 workaround that will also fix later brew python3 update issues
Removed existing symlinks that normally should have been overwritten by link: true, force: true

Signed-off-by: Hofi [hofione@gmail.com](mailto:hofione@gmail.com)