### PR TITLE
value-pairs: add v3 unit tests for bytes types & fix no --include-bytes with explicit cast

### DIFF
--- a/lib/value-pairs/tests/test_value_pairs.c
+++ b/lib/value-pairs/tests/test_value_pairs.c
@@ -346,18 +346,6 @@ asserts_for_no_include_bytes_v4(const gchar *name, LogMessageValueType type, con
       cr_assert_eq(type, LM_VT_NULL);
       cr_assert_eq(value_len, 0);
     }
-  else if (strcmp(name, "custom_explicit_bytes") == 0)
-    {
-      cr_assert_eq(type, LM_VT_BYTES);
-      cr_assert_eq(value_len, 4);
-      cr_assert_eq(memcmp(value, "\0\1\2\3", 4), 0);
-    }
-  else if (strcmp(name, "custom_explicit_protobuf") == 0)
-    {
-      cr_assert_eq(type, LM_VT_PROTOBUF);
-      cr_assert_eq(value_len, 4);
-      cr_assert_eq(memcmp(value, "\4\5\6\7", 4), 0);
-    }
   else
     {
       cr_assert(FALSE, "%s not expected", name);
@@ -446,18 +434,6 @@ asserts_for_no_include_bytes_v3(const gchar *name, LogMessageValueType type, con
     {
       cr_assert_eq(type, LM_VT_STRING);
       cr_assert_eq(value_len, 0);
-    }
-  else if (strcmp(name, "custom_explicit_bytes") == 0)
-    {
-      cr_assert_eq(type, LM_VT_BYTES);
-      cr_assert_eq(value_len, 4);
-      cr_assert_eq(memcmp(value, "\0\1\2\3", 4), 0);
-    }
-  else if (strcmp(name, "custom_explicit_protobuf") == 0)
-    {
-      cr_assert_eq(type, LM_VT_PROTOBUF);
-      cr_assert_eq(value_len, 4);
-      cr_assert_eq(memcmp(value, "\4\5\6\7", 4), 0);
     }
   else
     {

--- a/lib/value-pairs/tests/test_value_pairs.c
+++ b/lib/value-pairs/tests/test_value_pairs.c
@@ -309,9 +309,32 @@ Test(value_pairs, test_transformer_upper)
   g_ptr_array_free(transformers, TRUE);
 }
 
-gboolean
-asserts_for_no_include_bytes(const gchar *name, LogMessageValueType type, const gchar *value,
-                             gsize value_len, gpointer user_data)
+static ValuePairs *
+_create_value_pairs_for_include_bytes_tc(void)
+{
+  ValuePairs *vp = value_pairs_new(configuration);
+  value_pairs_add_scope(vp, "nv-pairs");
+
+  LogTemplate *template;
+  template = create_template(NULL, "$bytes");
+  value_pairs_add_pair(vp, "custom_bytes", template);
+  log_template_unref(template);
+  template = create_template(NULL, "$protobuf");
+  value_pairs_add_pair(vp, "custom_protobuf", template);
+  log_template_unref(template);
+  template = create_template("bytes", "$bytes");
+  value_pairs_add_pair(vp, "custom_explicit_bytes", template);
+  log_template_unref(template);
+  template = create_template("protobuf", "$protobuf");
+  value_pairs_add_pair(vp, "custom_explicit_protobuf", template);
+  log_template_unref(template);
+
+  return vp;
+}
+
+static gboolean
+asserts_for_no_include_bytes_v4(const gchar *name, LogMessageValueType type, const gchar *value,
+                                gsize value_len, gpointer user_data)
 {
   if (strcmp(name, "custom_bytes") == 0)
     {
@@ -343,9 +366,9 @@ asserts_for_no_include_bytes(const gchar *name, LogMessageValueType type, const 
   return FALSE;
 }
 
-gboolean
-asserts_for_include_bytes(const gchar *name, LogMessageValueType type, const gchar *value,
-                          gsize value_len, gpointer user_data)
+static gboolean
+asserts_for_include_bytes_v4(const gchar *name, LogMessageValueType type, const gchar *value,
+                             gsize value_len, gpointer user_data)
 {
   if (strcmp(name, "bytes") == 0)
     {
@@ -389,35 +412,123 @@ asserts_for_include_bytes(const gchar *name, LogMessageValueType type, const gch
   return FALSE;
 }
 
-Test(value_pairs, test_include_bytes)
+Test(value_pairs, test_include_bytes_v4)
 {
-  LogTemplateEvalOptions options = {&template_options, LTZ_LOCAL, 11, NULL, LM_VT_STRING};
+  cfg_set_version_without_validation(configuration, VERSION_VALUE_4_0);
 
-  ValuePairs *vp = value_pairs_new(configuration);
-  value_pairs_add_scope(vp, "nv-pairs");
-
-  LogTemplate *template;
-  template = create_template(NULL, "$bytes");
-  value_pairs_add_pair(vp, "custom_bytes", template);
-  log_template_unref(template);
-  template = create_template(NULL, "$protobuf");
-  value_pairs_add_pair(vp, "custom_protobuf", template);
-  log_template_unref(template);
-  template = create_template("bytes", "$bytes");
-  value_pairs_add_pair(vp, "custom_explicit_bytes", template);
-  log_template_unref(template);
-  template = create_template("protobuf", "$protobuf");
-  value_pairs_add_pair(vp, "custom_explicit_protobuf", template);
-  log_template_unref(template);
+  ValuePairs *vp = _create_value_pairs_for_include_bytes_tc();
 
   LogMessage *msg = log_msg_new_empty();
   log_msg_set_value_by_name_with_type(msg, "bytes", "\0\1\2\3", 4, LM_VT_BYTES);
   log_msg_set_value_by_name_with_type(msg, "protobuf", "\4\5\6\7", 4, LM_VT_PROTOBUF);
 
-  value_pairs_foreach(vp, asserts_for_no_include_bytes, msg, &options, NULL);
+  LogTemplateEvalOptions options = {&template_options, LTZ_LOCAL, 11, NULL, LM_VT_STRING};
+
+  value_pairs_foreach(vp, asserts_for_no_include_bytes_v4, msg, &options, NULL);
 
   value_pairs_set_include_bytes(vp, TRUE);
-  value_pairs_foreach(vp, asserts_for_include_bytes, msg, &options, NULL);
+  value_pairs_foreach(vp, asserts_for_include_bytes_v4, msg, &options, NULL);
+
+  log_msg_unref(msg);
+  value_pairs_unref(vp);
+}
+
+static gboolean
+asserts_for_no_include_bytes_v3(const gchar *name, LogMessageValueType type, const gchar *value,
+                                gsize value_len, gpointer user_data)
+{
+  if (strcmp(name, "custom_bytes") == 0)
+    {
+      cr_assert_eq(type, LM_VT_STRING);
+      cr_assert_eq(value_len, 0);
+    }
+  else if (strcmp(name, "custom_protobuf") == 0)
+    {
+      cr_assert_eq(type, LM_VT_STRING);
+      cr_assert_eq(value_len, 0);
+    }
+  else if (strcmp(name, "custom_explicit_bytes") == 0)
+    {
+      cr_assert_eq(type, LM_VT_BYTES);
+      cr_assert_eq(value_len, 4);
+      cr_assert_eq(memcmp(value, "\0\1\2\3", 4), 0);
+    }
+  else if (strcmp(name, "custom_explicit_protobuf") == 0)
+    {
+      cr_assert_eq(type, LM_VT_PROTOBUF);
+      cr_assert_eq(value_len, 4);
+      cr_assert_eq(memcmp(value, "\4\5\6\7", 4), 0);
+    }
+  else
+    {
+      cr_assert(FALSE, "%s not expected", name);
+    }
+
+  return FALSE;
+}
+
+static gboolean
+asserts_for_include_bytes_v3(const gchar *name, LogMessageValueType type, const gchar *value,
+                             gsize value_len, gpointer user_data)
+{
+  if (strcmp(name, "bytes") == 0)
+    {
+      cr_assert_eq(type, LM_VT_STRING);
+      cr_assert_eq(value_len, 4);
+      cr_assert_eq(memcmp(value, "\0\1\2\3", 4), 0);
+    }
+  else if (strcmp(name, "protobuf") == 0)
+    {
+      cr_assert_eq(type, LM_VT_STRING);
+      cr_assert_eq(value_len, 4);
+      cr_assert_eq(memcmp(value, "\4\5\6\7", 4), 0);
+    }
+  else if (strcmp(name, "custom_bytes") == 0)
+    {
+      cr_assert_eq(type, LM_VT_STRING);
+      cr_assert_eq(value_len, 0);
+    }
+  else if (strcmp(name, "custom_protobuf") == 0)
+    {
+      cr_assert_eq(type, LM_VT_STRING);
+      cr_assert_eq(value_len, 0);
+    }
+  else if (strcmp(name, "custom_explicit_bytes") == 0)
+    {
+      cr_assert_eq(type, LM_VT_BYTES);
+      cr_assert_eq(value_len, 4);
+      cr_assert_eq(memcmp(value, "\0\1\2\3", 4), 0);
+    }
+  else if (strcmp(name, "custom_explicit_protobuf") == 0)
+    {
+      cr_assert_eq(type, LM_VT_PROTOBUF);
+      cr_assert_eq(value_len, 4);
+      cr_assert_eq(memcmp(value, "\4\5\6\7", 4), 0);
+    }
+  else
+    {
+      cr_assert(FALSE, "%s not expected", name);
+    }
+
+  return FALSE;
+}
+
+Test(value_pairs, test_include_bytes_v3)
+{
+  cfg_set_version_without_validation(configuration, VERSION_VALUE_3_38);
+
+  ValuePairs *vp = _create_value_pairs_for_include_bytes_tc();
+
+  LogMessage *msg = log_msg_new_empty();
+  log_msg_set_value_by_name_with_type(msg, "bytes", "\0\1\2\3", 4, LM_VT_BYTES);
+  log_msg_set_value_by_name_with_type(msg, "protobuf", "\4\5\6\7", 4, LM_VT_PROTOBUF);
+
+  LogTemplateEvalOptions options = {&template_options, LTZ_LOCAL, 11, NULL, LM_VT_STRING};
+
+  value_pairs_foreach(vp, asserts_for_no_include_bytes_v3, msg, &options, NULL);
+
+  value_pairs_set_include_bytes(vp, TRUE);
+  value_pairs_foreach(vp, asserts_for_include_bytes_v3, msg, &options, NULL);
 
   log_msg_unref(msg);
   value_pairs_unref(vp);

--- a/lib/value-pairs/value-pairs.c
+++ b/lib/value-pairs/value-pairs.c
@@ -253,6 +253,8 @@ vp_pairs_foreach(gpointer data, gpointer user_data)
 
   if (vp->omit_empty_values && sb->len == 0)
     return;
+  if (!vp->include_bytes && (type == LM_VT_BYTES || type == LM_VT_PROTOBUF))
+    return;
   if (vp->cast_to_strings && vpc->template->explicit_type_hint == LM_VT_NONE)
     type = LM_VT_STRING;
   vp_results_insert(results, vp_transform_apply(vp, vpc->name), type, sb);


### PR DESCRIPTION
<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
