### PR TITLE
mainloop-call: fix hang caused by the previous fix for pending mainloop-calls

### DIFF
--- a/lib/mainloop-call.c
+++ b/lib/mainloop-call.c
@@ -40,13 +40,14 @@ struct _MainLoopTaskCallSite
   gpointer result;
   gboolean pending;
   gboolean wait;
+  gboolean mainfree;
   GCond cond;
   GMutex lock;
 };
 
 TLS_BLOCK_START
 {
-  MainLoopTaskCallSite call_info;
+  MainLoopTaskCallSite *call_info;
 }
 TLS_BLOCK_END;
 
@@ -57,24 +58,32 @@ static struct iv_list_head main_task_queue = IV_LIST_HEAD_INIT(main_task_queue);
 static struct iv_event main_task_posted;
 
 static void
+main_loop_call_free(MainLoopTaskCallSite *site)
+{
+  g_cond_clear(&site->cond);
+  g_mutex_clear(&site->lock);
+  g_free(site);
+}
+
+static void
 main_loop_wait_for_pending_call_to_finish(void)
 {
   g_mutex_lock(&main_task_lock);
 
   /* check if a previous call is being executed */
-  g_mutex_lock(&call_info.lock);
-  if (call_info.pending)
+  g_mutex_lock(&call_info->lock);
+  if (call_info->pending)
     {
       /* yes, it is still running, indicate that we need to be woken up */
-      call_info.wait = TRUE;
-      g_mutex_unlock(&call_info.lock);
+      call_info->wait = TRUE;
+      g_mutex_unlock(&call_info->lock);
 
-      while (call_info.pending)
-        g_cond_wait(&call_info.cond, &main_task_lock);
+      while (call_info->pending)
+        g_cond_wait(&call_info->cond, &main_task_lock);
     }
   else
     {
-      g_mutex_unlock(&call_info.lock);
+      g_mutex_unlock(&call_info->lock);
     }
   g_mutex_unlock(&main_task_lock);
 }
@@ -87,27 +96,29 @@ main_loop_call(MainLoopTaskFunc func, gpointer user_data, gboolean wait)
 
   main_loop_wait_for_pending_call_to_finish();
 
-  /* call_info.lock is no longer needed, since we're the only ones using call_info now */
-  INIT_IV_LIST_HEAD(&call_info.list);
-  call_info.pending = TRUE;
-  call_info.func = func;
-  call_info.user_data = user_data;
-  call_info.wait = wait;
+  /* call_info->lock is no longer needed, since we're the only ones using call_info now */
+  INIT_IV_LIST_HEAD(&call_info->list);
+  call_info->pending = TRUE;
+  call_info->func = func;
+  call_info->user_data = user_data;
+  call_info->wait = wait;
   g_mutex_lock(&main_task_lock);
-  iv_list_add(&call_info.list, &main_task_queue);
+  iv_list_add(&call_info->list, &main_task_queue);
   iv_event_post(&main_task_posted);
   if (wait)
     {
-      while (call_info.pending)
-        g_cond_wait(&call_info.cond, &main_task_lock);
+      while (call_info->pending)
+        g_cond_wait(&call_info->cond, &main_task_lock);
     }
   g_mutex_unlock(&main_task_lock);
-  return call_info.result;
+  return call_info->result;
 }
 
 static void
 main_loop_call_handler(gpointer user_data)
 {
+  gboolean dofree, dowakeup;
+
   g_mutex_lock(&main_task_lock);
   while (!iv_list_empty(&main_task_queue))
     {
@@ -123,10 +134,14 @@ main_loop_call_handler(gpointer user_data)
       g_mutex_lock(&site->lock);
       site->result = result;
       site->pending = FALSE;
+      dowakeup = site->wait;
+      dofree = site->mainfree;
       g_mutex_unlock(&site->lock);
 
       g_mutex_lock(&main_task_lock);
-      if (site->wait)
+      if (dofree)
+        main_loop_call_free(site);
+      else if (dowakeup)
         g_cond_signal(&site->cond);
     }
   g_mutex_unlock(&main_task_lock);
@@ -135,17 +150,26 @@ main_loop_call_handler(gpointer user_data)
 void
 main_loop_call_thread_init(void)
 {
-  g_cond_init(&call_info.cond);
-  g_mutex_init(&call_info.lock);
+  call_info = g_malloc(sizeof (MainLoopTaskCallSite));
+  g_cond_init(&call_info->cond);
+  g_mutex_init(&call_info->lock);
+  call_info->mainfree = FALSE;
 }
 
 void
 main_loop_call_thread_deinit(void)
 {
-  main_loop_wait_for_pending_call_to_finish();
+  MainLoopTaskCallSite *site = call_info;
 
-  g_cond_clear(&call_info.cond);
-  g_mutex_clear(&call_info.lock);
+  g_mutex_lock(&site->lock);
+  if (site->pending) {
+    site->mainfree = TRUE;
+    call_info = NULL;
+  }
+  g_mutex_unlock(&site->lock);
+
+  if (call_info)
+     main_loop_call_free(call_info);
 }
 
 void

--- a/lib/mainloop-call.c
+++ b/lib/mainloop-call.c
@@ -150,10 +150,9 @@ main_loop_call_handler(gpointer user_data)
 void
 main_loop_call_thread_init(void)
 {
-  call_info = g_malloc(sizeof (MainLoopTaskCallSite));
+  call_info = g_new0(MainLoopTaskCallSite, 1);
   g_cond_init(&call_info->cond);
   g_mutex_init(&call_info->lock);
-  call_info->mainfree = FALSE;
 }
 
 void
@@ -162,14 +161,15 @@ main_loop_call_thread_deinit(void)
   MainLoopTaskCallSite *site = call_info;
 
   g_mutex_lock(&site->lock);
-  if (site->pending) {
-    site->mainfree = TRUE;
-    call_info = NULL;
-  }
+  if (site->pending)
+    {
+      site->mainfree = TRUE;
+      call_info = NULL;
+    }
   g_mutex_unlock(&site->lock);
 
   if (call_info)
-     main_loop_call_free(call_info);
+    main_loop_call_free(call_info);
 }
 
 void


### PR DESCRIPTION

Now that we've had the previous fix from #4258 in production for a while, we've started to see that syslog-ng is now occasionally hanging, and the hangs are unfortunately caused by that previous fix.  

Here are the stack traces of the two threads that cause the hang:


```
(gdb) i thr
  Id   Target Id                  Frame 
* 1    LWP 101322 of process 1003 _umtx_op_err ()
    at /usr/src/lib/libthr/arch/amd64/amd64/_umtx_op_err.S:40
  2    LWP 101323 of process 1003 _kevent () at _kevent.S:4
  3    LWP 976246 of process 1003 _umtx_op_err ()
    at /usr/src/lib/libthr/arch/amd64/amd64/_umtx_op_err.S:40


(gdb) bt
#0  _umtx_op_err ()
    at /usr/src/lib/libthr/arch/amd64/amd64/_umtx_op_err.S:40
#1  0x000015e1cb8f324c in __thr_umutex_lock (mtx=0x15e1d480a688, id=0x18bca)
    at /usr/src/lib/libthr/thread/thr_umtx.c:82
#2  0x000015e1cb8eba7b in mutex_lock_sleep (curthread=0x15e1d21a6000, m=0x15e1d480a688, abstime=<optimized out>)
    at /usr/src/lib/libthr/thread/thr_mutex.c:702
#3  mutex_lock_common (m=0x15e1d480a688, abstime=abstime@entry=0x0, cvattach=0x0, rb_onlist=0x0)
    at /usr/src/lib/libthr/thread/thr_mutex.c:736
#4  0x000015e1cb8eae16 in __Tthr_mutex_lock (mutex=mutex@entry=0x15e1d21df000)
    at /usr/src/lib/libthr/thread/thr_mutex.c:755
#5  0x000015e1c5dcbc22 in ___mutex_lock (mutex=0x15e1d21df000) at ./mutex.h:53
#6  iv_work_submit_pool (this=0x15e1c5de3548 <main_loop_io_workers>, work=0x15e1d229db70) at iv_work.c:315
#7  iv_work_pool_submit_work (this=0x15e1c5de3548 <main_loop_io_workers>, work=0x15e1d229db70) at iv_work.c:394
#8  0x000015e1c5dcaf2a in iv_run_tasks (st=st@entry=0x15e1d21e4000) at iv_task.c:48
#9  0x000015e1c5dcda77 in iv_main () at iv_main_posix.c:99
#10 0x000015e1c5d756f4 in main_loop_run (self=0x15e1c5de2ae8 <main_loop>) at lib/mainloop.c:677
#11 0x000015d9a4a657bd in main (argc=<optimized out>, argv=0x15e1c4e510b8) at syslog-ng/main.c:335


(gdb) bt
#0  _umtx_op_err ()
    at /usr/src/lib/libthr/arch/amd64/amd64/_umtx_op_err.S:40
#1  0x000015e1cb8f3621 in _thr_umtx_timedwait_uint (mtx=0x15e1db0220e0, id=0x0, clockid=<optimized out>, 
    abstime=<optimized out>, shared=<optimized out>)
    at /usr/src/lib/libthr/thread/thr_umtx.c:236
#2  0x000015e1cb8e5b7f in cond_wait_user (cvp=0x15e1f5737060, mp=0x15e1d481cc88, abstime=0x0, cancel=0x1)
    at /usr/src/lib/libthr/thread/thr_cond.c:320
#3  cond_wait_common (cond=cond@entry=0x15e1e0e03008, mutex=<optimized out>, abstime=abstime@entry=0x0, 
    cancel=cancel@entry=0x1)
    at /usr/src/lib/libthr/thread/thr_cond.c:380
#4  0x000015e1cb8e5e01 in __thr_cond_wait (cond=0x15e1db0220e0, cond@entry=0x15e1e0e03008, mutex=0xf)
    at /usr/src/lib/libthr/thread/thr_cond.c:395
#5  0x000015e1caafb855 in g_cond_wait (cond=<optimized out>, mutex=mutex@entry=0x15e1c5de3470 <main_task_lock>)
    at ../glib/gthread-posix.c:794
#6  0x000015e1c5d75c85 in main_loop_wait_for_pending_call_to_finish () at lib/mainloop-call.c:73
#7  0x000015e1c5d75d0b in main_loop_call_thread_deinit () at lib/mainloop-call.c:145
#8  0x000015e1c5d5aa67 in app_thread_stop () at lib/apphook.c:347
#9  0x000015e1c5d760ab in main_loop_worker_thread_stop () at lib/mainloop-worker.c:205
#10 0x000015e1c5dcc1b1 in __iv_work_thread_die (thr=0x15e1e59991c0) at iv_work.c:75
#11 0x000015e1c5dcc14e in iv_work_thread_idle_timeout (_thr=0x15e1e59991c0) at iv_work.c:154
#12 0x000015e1c5dcb309 in iv_run_timers (st=st@entry=0x15e1e0e0b000) at iv_timer.c:124
#13 0x000015e1c5dcda6f in iv_main () at iv_main_posix.c:98
#14 0x000015e1c5dcbea7 in iv_work_thread (_thr=0x15e1e59991c0) at iv_work.c:185
#15 0x000015e1c5dcf04a in iv_thread_handler (_thr=0x15e1d2385a20) at iv_thread_posix.c:112
#16 0x000015e1cb8e6cf8 in thread_start (curthread=0x15e1d232d400)
    at /usr/src/lib/libthr/thread/thr_create.c:292
```

Here is the mutex that the main-loop thread is blocked on:

```
(gdb) frame 5
#5  0x000015e1c5dcbc22 in ___mutex_lock (mutex=0x15e1d21df000) at ./mutex.h:53
53	./mutex.h: No such file or directory.
(gdb) p mutex
$4 = (___mutex_t *) 0x15e1d21df000
(gdb) p *mutex
$5 = (___mutex_t) 0x15e1d480a688
(gdb) p **mutex
$6 = {
  m_lock = {
    m_owner = 0x800ee576,
    m_flags = 0x0,
    m_ceilings = {0x0, 0x0},
    m_rb_lnk = 0x0,
    m_spare = {0x0, 0x0}
  },
  m_flags = 0x1,
  m_count = 0x0,
  m_spinloops = 0x0,
  m_yieldloops = 0x0,
  m_ps = 0x0,
  m_qe = {
    tqe_next = 0x0,
    tqe_prev = 0x15e1d232d5a8
  },
  m_pqe = {
    tqe_next = 0x0,
    tqe_prev = 0x15e1d232d5b8
  },
  m_rb_prev = 0x0
}
(gdb) p/d 0xee576
$7 = 976246
```

So here we see that the main-loop thread is blocked waiting for a mutex owned by the worker thread, and the worker thread is blocked waiting for the main-loop thread to be done processing the mainloop-call.  The mutex in question is the iv_work_pool's lock:

```
(gdb) p this
$10 = (struct iv_work_pool *) 0x15e1c5de3548 <main_loop_io_workers>
(gdb) p pool
$11 = (struct work_pool_priv *) 0x15e1d21df000
(gdb) p pool->lock
$12 = (___mutex_t) 0x15e1d480a688
```

and this mutex is taken by the dying worker thread a couple frames up in the stack in iv_work_thread_idle_timeout:

```
static void iv_work_thread_idle_timeout(void *_thr)
{
        struct work_pool_thread *thr = _thr;
        struct work_pool_priv *pool = thr->pool;

        ___mutex_lock(&pool->lock);
        
        if (thr->kicked) {
                thr->idle_timer.expires = iv_now;
                thr->idle_timer.expires.tv_sec += 10;
                iv_timer_register(&thr->idle_timer);
        } else {
                iv_list_del_init(&thr->list);
                __iv_work_thread_die(thr);
        }

        ___mutex_unlock(&pool->lock);
}
```

This pull request fixes this hang by moving the mainloop-call TLS state from the worker's TLS structure to a separate structure that the worker's TLS points to. Then rather than waiting for a pending mainloop-call to complete when a worker thread wants to exit, just hand off responsibility for freeing the separate mainloop-call structure when the mainloop-call is complete from the exiting worker thread to the mainloop thread itself.