### PR TITLE
macos: install openssl 3

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,7 +32,7 @@ jobs:
 
           HOMEBREW_PREFIX="$(brew --prefix)"
           PYTHONUSERBASE="${HOME}/python_packages"
-          PKG_CONFIG_PATH="${HOMEBREW_PREFIX}/opt/openssl@1.1/lib/pkgconfig:${HOMEBREW_PREFIX}/opt/net-snmp/lib/pkgconfig:${PKG_CONFIG_PATH}"
+          PKG_CONFIG_PATH="${HOMEBREW_PREFIX}/opt/openssl@3/lib/pkgconfig:${HOMEBREW_PREFIX}/opt/net-snmp/lib/pkgconfig:${PKG_CONFIG_PATH}"
           CFLAGS="-I${HOMEBREW_PREFIX}/include/ ${CFLAGS}"
           LDFLAGS="-L${HOMEBREW_PREFIX}/lib ${LDFLAGS}"
           THREADS="$(sysctl -n hw.physicalcpu)"

--- a/contrib/Brewfile
+++ b/contrib/Brewfile
@@ -9,7 +9,7 @@ brew "glib"
 brew "ivykis"
 brew "json-c"
 brew "libtool"
-brew "openssl@1.1"
+brew "openssl@3"
 brew "pcre"
 brew "pkg-config"
 


### PR DESCRIPTION
A problem appeared overnight with macos and openssl@1.1:

```
Undefined symbols for architecture x86_64:
  "_SSL_get_peer_certificate", referenced from:
      _tls_session_info_callback in libsyslog_ng_la-tls-session.o
      _tls_session_ocsp_client_verify_callback in libsyslog_ng_la-tls-session.o
ld: symbol(s) not found for architecture x86_64
collect2: error: ld returned 1 exit status
```

I have not investigated the issue thoroughly, just tried to upgrade to 3.0, and it works.
We can investigate it if we are concerned, but we have other platforms with openssl 1.1, and they seem to work, so I guessed it is something macos related, but not sure.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>