### PR TITLE
Fix flow-control when `fetch-limit()` is set higher than 64K

### DIFF
--- a/lib/logqueue-fifo.c
+++ b/lib/logqueue-fifo.c
@@ -75,8 +75,8 @@ typedef struct _InputQueue
 {
   struct iv_list_head items;
   WorkerBatchCallback cb;
-  guint16 len;
-  guint16 non_flow_controlled_len;
+  guint32 len;
+  guint32 non_flow_controlled_len;
   guint16 finish_cb_registered;
 } InputQueue;
 

--- a/news/bugfix-4528.md
+++ b/news/bugfix-4528.md
@@ -1,0 +1,6 @@
+Fix flow-control when `fetch-limit()` is set higher than 64K
+
+In high-performance use cases, users may configure log-iw-size() and
+fetch-limit() to be higher than 2^16, which caused flow-control issues,
+such as messages stuck in the queue forever or log sources not receiving
+messages.


### PR DESCRIPTION
In high-performance use cases, users may configure log-iw-size() and
fetch-limit() to be higher than 2^16, which caused flow-control issues,
such as messages stuck in the queue forever or log sources not receiving
messages.