### PR TITLE
WIP: python: use requirements.txt to install runtime dependencies instead of setup.py

### DIFF
--- a/Mk/python-venv.am
+++ b/Mk/python-venv.am
@@ -1,4 +1,22 @@
-
+#
+# Makefile snippet to build the build-time Python venv, which is used during
+# the building of syslog-ng.
+#
+# The functionality depends on the value of ${with_python_packages}
+#
+#    none -- we don't do anything, just assume the packager/system installer
+#            already deployed our packages.
+#
+#    venv -- in this case we have a dedicated Python venv, we bootstrap
+#            everything in dev-requirements.txt, which includes both our
+#            Python based build tools and the runtime requirements for
+#            syslog-ng Python modules
+#
+#    system -- we don't do anything, just assume the packager/system
+#              installer already deployed our build tools.  syslog-ng
+#              runtime requirements are installed by python-modules if those
+#              are enabled.
+#
 PYTHON_VENV_TOUCHFILE=$(abs_builddir)/.python-venv-built
 
 $(PYTHON_VENV_TOUCHFILE): dev-requirements.txt

--- a/modules/python-modules/Makefile.am
+++ b/modules/python-modules/Makefile.am
@@ -96,14 +96,34 @@ pymodules-install: pymodules-install-requirements python-venv
 		install --record=$(PYMODULES_MANIFEST) ${PYMODULES_SETUP_OPTIONS})
 	$(install_sh_DATA) $(top_srcdir)/requirements.txt "$(PYTHON_ROOT)/$(python_moduledir)/requirements.txt"
 
+#
+# This rule installs our runtime Python dependencies (but not our build
+# tools, such as pylint).  Please contrast this implementation with the
+# python-venv rule in Mk/python-venv.mk, which will take care of the build
+# tools instead.
+#
+# The functionality depends on the value of ${with_python_packages}
+#
+#    none -- we don't do anything, just assume the packager/system installer
+#            already deployed or is deploying our dependencies.  If
+#            syslog-ng Python support is not enabled, this might be an empty
+#            set anyway (which is probably the reason anyone would use this
+#            setting).
+#
+#    venv -- in this case we have a dedicated Python venv for building.
+#            That venv is already bootstrapped by python-venv, based on
+#            dev-requirements.txt.  This file does include requirements.txt
+#            too, e.g.  all our runtime dependencies.  This way we don't do
+#            anything.
+#
+#    system -- in this case we are using the system Python, python-venv is
+#              not creating a dedicated virtualenv, thus our runtime
+#              dependencies are not installed.  We install packages in
+#              requirements.txt to the system.
+#
 pymodules-install-requirements: python-venv
-	if [ "$(with_python_packages)" != "none" ]; then \
-		(cd $(PYMODULES_SRCDIR) && \
-		 mkdir -p $(PYMODULES_BUILDDIR) && \
-	         $(PYTHON_VENV) setup.py egg_info --egg-base="$(PYMODULES_BUILDDIR)"  && \
-		 if [ -f $(PYMODULES_BUILDDIR)/$(PYMODULES_ROOT_MODULE).egg-info/requires.txt ]; then \
-			$(PYTHON_VENV) -m pip install -r $(PYMODULES_BUILDDIR)/$(PYMODULES_ROOT_MODULE).egg-info/requires.txt; \
-		 fi) \
+	if [ "$(with_python_packages)" = "system" ]; then \
+		$(PYTHON_VENV) -m pip install -r $(top_srcdir)/requirements.txt; \
 	fi
 
 pymodules-uninstall:

--- a/modules/python-modules/setup.py
+++ b/modules/python-modules/setup.py
@@ -30,7 +30,6 @@ packages_builtin=[
   "syslogng",
   "syslogng.debuggercli",
 ]
-requires_builtin=[]
 
 packages_addons=[
   "syslogng.modules.example",
@@ -38,18 +37,9 @@ packages_addons=[
   "syslogng.modules.hypr",
 ]
 
-requires_addons=[
-  # kubernetes
-  "kubernetes",
-  # hypr
-  "requests",
-]
-
 packages = packages_builtin
-requires = []
 if install_addons:
   packages = packages + packages_addons
-  requires = requires + requires_addons
 
 setup(name='syslogng',
       version='1.0',
@@ -59,5 +49,4 @@ setup(name='syslogng',
       url='https://www.syslog-ng.org',
       package_data={"": ["scl/*"]},
       exclude_package_data={"": ["*~"]},
-      packages=packages,
-      install_requires=requires)
+      packages=packages)


### PR DESCRIPTION
This should fix #4530 

@czanik Can you try this if this fixes the Tumbleweed problem?

btw: the combination of --with-python-packages=system is now being refused on Debian. This is considered a dangerous combination where pip is changing system installed libraries, so a virtualenv is the only way to go (which is the default for --with-python-packages).