### PR TITLE
scl: move scl.conf to ${config_includedir} 

### DIFF
--- a/news/packaging-4534.md
+++ b/news/packaging-4534.md
@@ -1,0 +1,1 @@
+scl.conf: The scl.conf file has been moved to /share/syslog-ng/include/scl.conf

--- a/packaging/debian/syslog-ng-scl.install
+++ b/packaging/debian/syslog-ng-scl.install
@@ -1,1 +1,2 @@
 usr/share/syslog-ng/include/scl/*
+usr/share/syslog-ng/include/scl.conf

--- a/packaging/rhel/syslog-ng.spec
+++ b/packaging/rhel/syslog-ng.spec
@@ -446,7 +446,7 @@ fi
 %dir %{_sysconfdir}/%{name}/conf.d
 %dir %{_sysconfdir}/%{name}/patterndb.d
 %config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
-%config(noreplace) %{_sysconfdir}/%{name}/scl.conf
+%config(noreplace) %{_datadir}/%{name}/include/scl.conf
 %if 0%{?rhel} == 7
 %config(noreplace) %{_sysconfdir}/logrotate.d/syslog
 %endif

--- a/scl/CMakeLists.txt
+++ b/scl/CMakeLists.txt
@@ -44,7 +44,7 @@ set(SCL_DIRS
 )
 
 install(DIRECTORY ${SCL_DIRS} DESTINATION share/syslog-ng/include/scl)
-install(FILES scl.conf DESTINATION etc)
+install(FILES scl.conf DESTINATION share/syslog-ng/include)
 
 if (NOT EXISTS ${CMAKE_INSTALL_PREFIX}/etc/syslog-ng.conf)
     install(FILES syslog-ng.conf DESTINATION etc)

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -48,21 +48,23 @@ SCL_CONFIGS	= scl.conf syslog-ng.conf
 EXTRA_DIST	+= $(addprefix scl/,$(SCL_CONFIGS) $(SCL_SUBDIRS)) scl/CMakeLists.txt
 
 scl-install-data-local:
-	for cfg in $(SCL_CONFIGS); do \
-		if [ -f $(DESTDIR)/$(sysconfdir)/$${cfg} ]; then \
-			echo "Not overwriting existing configuration file, you might want to upgrade manually: $${cfg}"; \
-		else \
-			$(install_sh_DATA) $(srcdir)/scl/$${cfg}  $(DESTDIR)/$(sysconfdir)/$${cfg}; \
-		fi; \
-	done
+	if [ -f $(DESTDIR)/$(sysconfdir)/syslog-ng.conf ]; then \
+		echo "Not overwriting existing configuration file, you might want to upgrade manually: syslog-ng.conf"; \
+	else \
+		$(install_sh_DATA) $(srcdir)/scl/syslog-ng.conf  $(DESTDIR)/$(sysconfdir)/syslog-ng.conf; \
+	fi
 	$(mkinstalldirs) $(DESTDIR)/$(scldir)
+	if [ -f $(DESTDIR)/$(config_includedir)/scl.conf ]; then \
+		echo "Not overwriting existing configuration file, you might want to upgrade manually: scl.conf"; \
+	else \
+		$(install_sh_DATA) $(srcdir)/scl/scl.conf  $(DESTDIR)/$(config_includedir)/scl.conf; \
+	fi
 	(cd $(srcdir)/scl; tar cf - $(SCL_SUBDIRS)) | (cd $(DESTDIR)/$(scldir) && tar xf - --no-same-owner)
 	chmod -R u+rwX $(DESTDIR)/$(scldir)
 
 scl-uninstall-local:
-	for cfg in $(SCL_CONFIGS); do \
-		rm -f $(DESTDIR)/$(sysconfdir)/$${cfg}; \
-	done
+	rm -f $(DESTDIR)/$(sysconfdir)/syslog-ng.conf
+	rm -f $(DESTDIR)/$(config_includedir)/scl.conf
 	rm -rf $(DESTDIR)/$(scldir)
 
 scl-install: scl-install-data-local


### PR DESCRIPTION
It helps to run syslog-ng in containers, with minimizing the content of the etc/ dir, which is mounted usually.

Because of our file include logic, if `etc/scl.conf` exists, it is loaded and `share/syslog-ng/include/scl.conf` is ignored.
This is suitable for an upgrade path, as with an upgrade the old one will be used, but with new installments the new one will be used.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>