### PR TITLE
type-hints: accept hex values as integers

### DIFF
--- a/lib/logmsg/tests/test_type_hints.c
+++ b/lib/logmsg/tests/test_type_hints.c
@@ -158,6 +158,14 @@ Test(type_hints, test_int32_cast)
   cr_assert_eq(value, 12345);
   cr_assert_null(error);
 
+  cr_assert(type_cast_to_int32("0x1000", &value, &error), "Type cast of \"0x1000\" to gint32 failed");
+  cr_assert_eq(value, 0x1000);
+  cr_assert_null(error);
+
+  cr_assert(type_cast_to_int32("0111", &value, &error), "Type cast of \"0111\" to gint32 failed");
+  cr_assert_eq(value, 111);
+  cr_assert_null(error);
+
   /* test for invalid string */
   cr_assert_not(type_cast_to_int32("12345a", &value, &error),
                 "Type cast of invalid string to gint32 should be failed");
@@ -184,6 +192,15 @@ Test(type_hints, test_int64_cast)
   cr_assert(type_cast_to_int64("12345", &value, &error), "Type cast of \"12345\" to gint64 failed");
   cr_assert_eq(value, 12345);
   cr_assert_null(error);
+
+  cr_assert(type_cast_to_int64("0x1000", &value, &error), "Type cast of \"0x1000\" to gint64 failed");
+  cr_assert_eq(value, 0x1000);
+  cr_assert_null(error);
+
+  cr_assert(type_cast_to_int64("0111", &value, &error), "Type cast of \"0111\" to gint64 failed");
+  cr_assert_eq(value, 111);
+  cr_assert_null(error);
+
 
   /* test for invalid string */
   cr_assert_not(type_cast_to_int64("12345a", &value, &error),

--- a/lib/logmsg/type-hinting.c
+++ b/lib/logmsg/type-hinting.c
@@ -82,12 +82,23 @@ type_cast_to_boolean(const gchar *value, gboolean *out, GError **error)
   return TRUE;
 }
 
+static gboolean
+_is_value_hex(const gchar *value)
+{
+  if (value[0] == '+' || value[0] == '-')
+    value++;
+  return (value[0] == '0' && (value[1] == 'x' || value[1] == 'X'));
+}
+
 gboolean
 type_cast_to_int32(const gchar *value, gint32 *out, GError **error)
 {
   gchar *endptr;
 
-  *out = (gint32)strtol(value, &endptr, 10);
+  if (_is_value_hex(value))
+    *out = (gint32)strtol(value, &endptr, 16);
+  else
+    *out = (gint32)strtol(value, &endptr, 10);
 
   if (value[0] == 0 || endptr[0] != '\0')
     {
@@ -104,7 +115,10 @@ type_cast_to_int64(const gchar *value, gint64 *out, GError **error)
 {
   gchar *endptr;
 
-  *out = (gint64)strtoll(value, &endptr, 10);
+  if (_is_value_hex(value))
+    *out = (gint64)strtoll(value, &endptr, 16);
+  else
+    *out = (gint64)strtoll(value, &endptr, 10);
 
   if (value[0] == 0 || endptr[0] != '\0')
     {

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -224,10 +224,17 @@ Test(format_json, test_v40_value_pairs_yields_typed_values)
                          "{\"FACILITY_NUM\":19}");
 
   /* RFC8259 number sanitization */
-  assert_template_format("$(format-json num=int(00014))", "{\"num\":14}");
+  assert_template_format("$(format-json num=int(+00014))", "{\"num\":14}");
+  assert_template_format("$(format-json num=int(014))", "{\"num\":14}");
+  assert_template_format("$(format-json num=int(000014))", "{\"num\":14}");
+  assert_template_format("$(format-json num=int(+0x0014))", "{\"num\":20}");
+  assert_template_format("$(format-json num=int(0x14))", "{\"num\":20}");
+  assert_template_format("$(format-json num=int(-0x14))", "{\"num\":-20}");
+  assert_template_format("$(format-json num=int(0x00014))", "{\"num\":20}");
   assert_template_format("$(format-json num=int(+14))", "{\"num\":14}");
-  assert_template_format("$(format-json num=int(-025))", "{\"num\":-25}");
-  assert_template_format("$(format-json num=int(+0009223372036854775804))", "{\"num\":9223372036854775804}");
+  assert_template_format("$(format-json num=int(-14))", "{\"num\":-14}");
+  assert_template_format("$(format-json num=int(-021))", "{\"num\":-21}");
+  assert_template_format("$(format-json num=int(+9223372036854775804))", "{\"num\":9223372036854775804}");
 }
 
 Test(format_json, test_cast_option_always_yields_strings_regardless_of_versions)

--- a/news/bugfix-4535.md
+++ b/news/bugfix-4535.md
@@ -1,0 +1,6 @@
+`int32()` and `int64()` type casts: accept hex numbers as proper
+number representations just as the @NUMBER@ parser within db-parser().
+Supporting octal numbers were considered and then rejected as the canonical
+octal representation for numbers in C would be ambigious: a zero padded
+decimal number could be erroneously considered octal. I find that log
+messages contain zero padded decimals more often than octals.


### PR DESCRIPTION
db-parser()'s @NUMBER@ extractor allows hex numbers and then marks up the value as integer, so we should accept it in type casts too.

fixes: #4532

