### PR TITLE
python: Create proper fake classes for LogSource, LogFetcher, InstantAckTracker, ConsecutiveAckTracker and BatchedAckTracker

### DIFF
--- a/modules/python-modules/syslogng/source.py
+++ b/modules/python-modules/syslogng/source.py
@@ -1,4 +1,5 @@
 #############################################################################
+# Copyright (c) 2023 One Identity LLC.
 # Copyright (c) 2022 Balazs Scheidler <bazsi77@gmail.com>
 #
 # This library is free software; you can redistribute it and/or
@@ -36,9 +37,6 @@ except ImportError:
 
     LogSource = object
     LogFetcher = object
-    InstantAckTracker = object
-    ConsecutiveAckTracker = object
-    BatchedAckTracker = object
 
     class LogFetcherResult(Enum):
         ERROR = auto()
@@ -46,6 +44,23 @@ except ImportError:
         SUCCESS = auto()
         TRY_AGAIN = auto()
         NO_DATA = auto()
+
+    # Fake InstantAckTracker
+    class InstantAckTracker(dict):
+        def __init__(self, ack_callback):
+            self.ack_callback = ack_callback
+
+    # Fake ConsecutiveAckTracker
+    class ConsecutiveAckTracker(dict):
+        def __init__(self, ack_callback):
+            self.ack_callback = ack_callback
+
+    # Fake BatchedAckTracker
+    class BatchedAckTracker(dict):
+        def __init__(self, timeout, batch_size, batched_ack_callback):
+            self.timeout = timeout
+            self.batch_size = batch_size
+            self.batched_ack_callback = batched_ack_callback
 
 
 class LogSource(LogSource):
@@ -203,16 +218,14 @@ class LogFetcher(LogFetcher):
 
 class InstantAckTracker(InstantAckTracker):
     def __init__(self, ack_callback):
-        self.ack_callback = ack_callback
+        super().__init__(ack_callback=ack_callback)
 
 
 class ConsecutiveAckTracker(ConsecutiveAckTracker):
     def __init__(self, ack_callback):
-        self.ack_callback = ack_callback
+        super().__init__(ack_callback=ack_callback)
 
 
 class BatchedAckTracker(BatchedAckTracker):
     def __init__(self, timeout, batch_size, batched_ack_callback):
-        self.timeout = timeout
-        self.batch_size = batch_size
-        self.ack_callback = batched_ack_callback
+        super().__init__(timeout=timeout, batch_size=batch_size, batched_ack_callback=batched_ack_callback)

--- a/modules/python-modules/syslogng/source.py
+++ b/modules/python-modules/syslogng/source.py
@@ -35,8 +35,15 @@ except ImportError:
                   "thus some of the functionality is not available. "
                   "Defining fake classes for those exported by the underlying syslog-ng code")
 
-    LogSource = object
-    LogFetcher = object
+    # Fake LogSource
+    class LogSource(dict):
+        def __init__(self):
+            pass
+
+    # Fake LogFetcher
+    class LogFetcher(dict):
+        def __init__(self):
+            pass
 
     class LogFetcherResult(Enum):
         ERROR = auto()
@@ -78,6 +85,11 @@ class LogSource(LogSource):
     """
     flags = {}
     parse_options = None
+
+    def __init__(self):
+        """Constructs this LogSource instance
+        """
+        super().__init__()
 
     def init(self, options):
         """Initialize this LogSource instance
@@ -164,6 +176,11 @@ class LogFetcher(LogFetcher):
 
     flags = {}
     parse_options = None
+
+    def __init__(self):
+        """Constructs this LogFetcher instance
+        """
+        super().__init__()
 
     def init(self, options):
         """Initialize this LogFetcher instance

--- a/news/bugfix-4549.md
+++ b/news/bugfix-4549.md
@@ -1,0 +1,4 @@
+`python`: `InstantAckTracker`, `ConsecutiveAckTracker` and `BatchedAckTracker` are now called properly.
+
+Added proper fake classes for the `InstantAckTracker`, `ConsecutiveAckTracker` and `BatchedAckTracker` classes, and the wapper now calls the super class' constructor. 
+Previusly the super class' constructor was not called which caused the python API to never call into the C API, which's result was that that the callback was never called.

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -110,7 +110,6 @@ modules/python-modules/syslogng/dest\.py
 modules/python-modules/syslogng/logger\.py
 modules/python-modules/syslogng/message\.py
 modules/python-modules/syslogng/parser\.py
-modules/python-modules/syslogng/source\.py
 modules/python-modules/syslogng/template\.py
 modules/python/python-confgen\.[ch]
 lib/tests/test_logscheduler\.c
@@ -152,6 +151,7 @@ tests/loggen
 persist-tool
 modules/python-modules/syslogng/__init__\.py
 modules/python-modules/syslogng/persist\.py
+modules/python-modules/syslogng/source\.py
 
 ###########################################################################
 # These files are GPLd and non-balabit contributions.


### PR DESCRIPTION
Fix InstantAckTracker, ConsecutiveAckTracker and BatchedAckTracker calling the C init function, currently the parent constructor (imported from C) is never called, meaning that the callbacks are never called making them non functional