### PR TITLE
Replace `stats_instance` with metric labels

### DIFF
--- a/lib/ack-tracker/tests/test_batched_ack_tracker.c
+++ b/lib/ack-tracker/tests/test_batched_ack_tracker.c
@@ -43,7 +43,7 @@ _init_log_source(AckTrackerFactory *factory)
   options->init_window_size = 10;
   log_source_init_instance(src, cfg);
   log_source_options_init(options, cfg, "testgroup");
-  log_source_set_options(src, options, "test_stats_id", "test_stats_instance", TRUE, NULL);
+  log_source_set_options(src, options, "test_stats_id", NULL, TRUE, NULL);
   log_source_set_ack_tracker_factory(src, factory);
 
   cr_assert(log_pipe_init(&src->super));

--- a/lib/ack-tracker/tests/test_instant_ack_tracker.c
+++ b/lib/ack-tracker/tests/test_instant_ack_tracker.c
@@ -98,7 +98,7 @@ _init_log_source(AckTrackerFactory *factory)
   options->init_window_size = 10;
   log_source_init_instance(src, cfg);
   log_source_options_init(options, cfg, "testgroup");
-  log_source_set_options(src, options, "test_stats_id", "test_stats_instance", TRUE, NULL);
+  log_source_set_options(src, options, "test_stats_id", NULL, TRUE, NULL);
   log_source_set_ack_tracker_factory(src, factory);
 
   cr_assert(log_pipe_init(&src->super));

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -92,7 +92,7 @@ struct _LogReader
 };
 
 void log_reader_set_options(LogReader *s, LogPipe *control, LogReaderOptions *options, const gchar *stats_id,
-                            const gchar *stats_instance);
+                            StatsClusterKeyBuilder *kb);
 void log_reader_set_follow_filename(LogReader *self, const gchar *follow_filename);
 void log_reader_set_name(LogReader *s, const gchar *name);
 void log_reader_set_peer_addr(LogReader *s, GSockAddr *peer_addr);

--- a/lib/logsource.h
+++ b/lib/logsource.h
@@ -28,6 +28,7 @@
 #include "logpipe.h"
 #include "stats/stats-registry.h"
 #include "stats/stats-compat.h"
+#include "stats/stats-cluster-key-builder.h"
 #include "window-size-counter.h"
 #include "dynamic-window.h"
 
@@ -69,7 +70,6 @@ struct _LogSource
   gboolean threaded;
   gchar *name;
   gchar *stats_id;
-  gchar *stats_instance;
   WindowSizeCounter window_size;
   DynamicWindow dynamic_window;
   gboolean window_initialized;
@@ -81,12 +81,17 @@ struct _LogSource
 
   struct
   {
+    StatsClusterKeyBuilder *stats_kb;
+
     StatsCounterItem *stat_window_size;
     StatsCounterItem *stat_full_window;
     StatsCounterItem *last_message_seen;
+
+    StatsClusterKey *recvd_messages_key;
     StatsCounterItem *recvd_messages;
 
     gboolean raw_bytes_enabled;
+    StatsClusterKey *recvd_bytes_key;
     StatsByteCounter recvd_bytes;
 
     StatsCluster *stat_window_size_cluster;
@@ -130,7 +135,7 @@ gboolean log_source_deinit(LogPipe *s);
 void log_source_post(LogSource *self, LogMessage *msg);
 
 void log_source_set_options(LogSource *self, LogSourceOptions *options, const gchar *stats_id,
-                            const gchar *stats_instance, gboolean threaded, LogExprNode *expr_node);
+                            StatsClusterKeyBuilder *kb, gboolean threaded, LogExprNode *expr_node);
 void log_source_set_ack_tracker_factory(LogSource *self, AckTrackerFactory *factory);
 void log_source_set_name(LogSource *self, const gchar *name);
 void log_source_mangle_hostname(LogSource *self, LogMessage *msg);

--- a/lib/logthrdest/logthrdestdrv.h
+++ b/lib/logthrdest/logthrdestdrv.h
@@ -30,6 +30,7 @@
 #include "stats/stats-registry.h"
 #include "stats/aggregator/stats-aggregator.h"
 #include "stats/stats-compat.h"
+#include "stats/stats-cluster-key-builder.h"
 #include "logqueue.h"
 #include "seqnum.h"
 #include "mainloop-threaded-worker.h"
@@ -91,6 +92,8 @@ struct _LogThreadedDestWorker
 
   struct
   {
+    StatsClusterKey *output_event_bytes_sc_key;
+
     StatsByteCounter written_bytes;
   } metrics;
 
@@ -166,7 +169,7 @@ struct _LogThreadedDestDriver
 
   gint32 shared_seq_num;
 
-  const gchar *(*format_stats_instance)(LogThreadedDestDriver *s);
+  const gchar *(*format_stats_key)(LogThreadedDestDriver *s, StatsClusterKeyBuilder *kb);
 };
 
 static inline gboolean

--- a/lib/logthrdest/tests/test_logthrdestdrv.c
+++ b/lib/logthrdest/tests/test_logthrdestdrv.c
@@ -48,9 +48,10 @@ _generate_persist_name(const LogPipe *s)
 }
 
 static const gchar *
-_format_stats_instance(LogThreadedDestDriver *s)
+_format_stats_key(LogThreadedDestDriver *s, StatsClusterKeyBuilder *kb)
 {
-  return "stats-name";
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "stats-name"));
+  return NULL;
 }
 
 static gboolean
@@ -68,7 +69,7 @@ test_threaded_dd_new(GlobalConfig *cfg)
   TestThreadedDestDriver *self = g_new0(TestThreadedDestDriver, 1);
   log_threaded_dest_driver_init_instance(&self->super, cfg);
   self->super.super.super.super.generate_persist_name = _generate_persist_name;
-  self->super.format_stats_instance = _format_stats_instance;
+  self->super.format_stats_key = _format_stats_key;
 
   self->super.worker.connect = _connect_success;
   /* the insert function will be initialized explicitly in testcases */

--- a/lib/logthrsource/logthrsourcedrv.h
+++ b/lib/logthrsource/logthrsourcedrv.h
@@ -68,7 +68,7 @@ struct _LogThreadedSourceDriver
   LogThreadedSourceWorker *worker;
   gboolean auto_close_batches;
 
-  const gchar *(*format_stats_key)(LogThreadedSourceDriver *self, StatsClusterKeyBuilder *kb);
+  void (*format_stats_key)(LogThreadedSourceDriver *self, StatsClusterKeyBuilder *kb);
   gboolean (*thread_init)(LogThreadedSourceDriver *self);
   void (*thread_deinit)(LogThreadedSourceDriver *self);
   void (*run)(LogThreadedSourceDriver *self);

--- a/lib/logthrsource/logthrsourcedrv.h
+++ b/lib/logthrsource/logthrsourcedrv.h
@@ -33,6 +33,7 @@
 #include "logmsg/logmsg.h"
 #include "msg-format.h"
 #include "mainloop-threaded-worker.h"
+#include "stats/stats-cluster-key-builder.h"
 
 typedef struct _LogThreadedSourceDriver LogThreadedSourceDriver;
 typedef struct _LogThreadedSourceWorker LogThreadedSourceWorker;
@@ -67,7 +68,7 @@ struct _LogThreadedSourceDriver
   LogThreadedSourceWorker *worker;
   gboolean auto_close_batches;
 
-  const gchar *(*format_stats_instance)(LogThreadedSourceDriver *self);
+  const gchar *(*format_stats_key)(LogThreadedSourceDriver *self, StatsClusterKeyBuilder *kb);
   gboolean (*thread_init)(LogThreadedSourceDriver *self);
   void (*thread_deinit)(LogThreadedSourceDriver *self);
   void (*run)(LogThreadedSourceDriver *self);

--- a/lib/logthrsource/tests/test_logthrfetcherdrv.c
+++ b/lib/logthrsource/tests/test_logthrfetcherdrv.c
@@ -56,11 +56,10 @@ _generate_persist_name(const LogPipe *s)
   return "test_threaded_fetcher_driver";
 }
 
-static const gchar *
+static void
 _format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuilder *kb)
 {
   stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "test_threaded_fetcher_driver_stats"));
-  return NULL;
 }
 
 static void _source_queue_mock(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)

--- a/lib/logthrsource/tests/test_logthrfetcherdrv.c
+++ b/lib/logthrsource/tests/test_logthrfetcherdrv.c
@@ -57,9 +57,10 @@ _generate_persist_name(const LogPipe *s)
 }
 
 static const gchar *
-_format_stats_instance(LogThreadedSourceDriver *s)
+_format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuilder *kb)
 {
-  return "test_threaded_fetcher_driver_stats";
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "test_threaded_fetcher_driver_stats"));
+  return NULL;
 }
 
 static void _source_queue_mock(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
@@ -113,7 +114,7 @@ test_threaded_fetcher_new(GlobalConfig *cfg)
 
   self->super.super.super.super.super.init = test_threaded_fetcher_driver_init_method;
 
-  self->super.super.format_stats_instance = _format_stats_instance;
+  self->super.super.format_stats_key = _format_stats_key;
   self->super.super.super.super.super.generate_persist_name = _generate_persist_name;
   self->super.super.super.super.super.free_fn = test_threaded_fetcher_free;
 

--- a/lib/logthrsource/tests/test_logthrsourcedrv.c
+++ b/lib/logthrsource/tests/test_logthrsourcedrv.c
@@ -54,11 +54,10 @@ _generate_persist_name(const LogPipe *s)
   return "test_threaded_source_driver";
 }
 
-static const gchar *
+static void
 _format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuilder *kb)
 {
   stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "test_threaded_source_driver_stats"));
-  return NULL;
 }
 
 static void

--- a/lib/logthrsource/tests/test_logthrsourcedrv.c
+++ b/lib/logthrsource/tests/test_logthrsourcedrv.c
@@ -55,9 +55,10 @@ _generate_persist_name(const LogPipe *s)
 }
 
 static const gchar *
-_format_stats_instance(LogThreadedSourceDriver *s)
+_format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuilder *kb)
 {
-  return "test_threaded_source_driver_stats";
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "test_threaded_source_driver_stats"));
+  return NULL;
 }
 
 static void
@@ -99,7 +100,7 @@ test_threaded_sd_new(GlobalConfig *cfg, gboolean blocking_post)
   log_threaded_source_driver_init_instance(&self->super, cfg);
 
   self->super.super.super.super.init = test_threaded_source_driver_init_method;
-  self->super.format_stats_instance = _format_stats_instance;
+  self->super.format_stats_key = _format_stats_key;
   self->super.super.super.super.generate_persist_name = _generate_persist_name;
 
   self->super.request_exit = _request_exit;

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1791,22 +1791,6 @@ log_writer_reopen(LogWriter *s, LogProtoClient *proto)
 }
 
 void
-log_writer_init_driver_sck_builder(LogWriter *self, StatsClusterKeyBuilder *builder)
-{
-  stats_cluster_key_builder_add_label(builder, stats_cluster_label("id", self->stats_id));
-  stats_cluster_key_builder_add_label(builder, stats_cluster_label("driver_instance", self->stats_instance));
-  stats_cluster_key_builder_set_legacy_alias(builder, self->options->stats_source | SCS_DESTINATION, self->stats_id,
-                                             self->stats_instance);
-}
-
-void
-log_writer_init_queue_sck_builder(LogWriter *self, StatsClusterKeyBuilder *builder)
-{
-  stats_cluster_key_builder_add_label(builder, stats_cluster_label("id", self->stats_id));
-  stats_cluster_key_builder_add_label(builder, stats_cluster_label("driver_instance", self->stats_instance));
-}
-
-void
 log_writer_set_options(LogWriter *self, LogPipe *control, LogWriterOptions *options,
                        const gchar *stats_id, const gchar *stats_instance)
 {

--- a/lib/logwriter.h
+++ b/lib/logwriter.h
@@ -29,6 +29,7 @@
 #include "template/templates.h"
 #include "logqueue.h"
 #include "logproto/logproto-client.h"
+#include "stats/stats-cluster-key-builder.h"
 
 /* writer constructor flags */
 #define LW_DETECT_EOF        0x0001
@@ -77,7 +78,7 @@ typedef struct _LogWriter LogWriter;
 void log_writer_set_flags(LogWriter *self, guint32 flags);
 guint32 log_writer_get_flags(LogWriter *self);
 void log_writer_set_options(LogWriter *self, LogPipe *control, LogWriterOptions *options, const gchar *stats_id,
-                            const gchar *stats_instance);
+                            StatsClusterKeyBuilder *kb);
 void log_writer_format_log(LogWriter *self, LogMessage *lm, GString *result);
 gboolean log_writer_has_pending_writes(LogWriter *self);
 gboolean log_writer_opened(LogWriter *self);

--- a/lib/logwriter.h
+++ b/lib/logwriter.h
@@ -88,9 +88,6 @@ LogQueue *log_writer_get_queue(LogWriter *s);
 LogWriter *log_writer_new(guint32 flags, GlobalConfig *cfg);
 void log_writer_msg_rewind(LogWriter *self);
 
-void log_writer_init_driver_sck_builder(LogWriter *self, StatsClusterKeyBuilder *builder);
-void log_writer_init_queue_sck_builder(LogWriter *self, StatsClusterKeyBuilder *builder);
-
 void log_writer_options_set_template_escape(LogWriterOptions *options, gboolean enable);
 void log_writer_options_defaults(LogWriterOptions *options);
 void log_writer_options_init(LogWriterOptions *options, GlobalConfig *cfg, guint32 option_flags);

--- a/lib/stats/stats-cluster-key-builder.h
+++ b/lib/stats/stats-cluster-key-builder.h
@@ -47,4 +47,10 @@ void stats_cluster_key_builder_reset(StatsClusterKeyBuilder *self);
 StatsClusterKey *stats_cluster_key_builder_build_single(const StatsClusterKeyBuilder *self);
 StatsClusterKey *stats_cluster_key_builder_build_logpipe(const StatsClusterKeyBuilder *self);
 
+/* Compatibility functions for reproducing stats_instance names based on unsorted labels */
+void stats_cluster_key_builder_add_legacy_label(StatsClusterKeyBuilder *self, const StatsClusterLabel label);
+void stats_cluster_key_builder_clear_legacy_labels(StatsClusterKeyBuilder *self);
+const gchar *stats_cluster_key_builder_format_legacy_stats_instance(StatsClusterKeyBuilder *self,
+    gchar *buf, gsize buf_size);
+
 #endif

--- a/lib/tests/test_logsource.c
+++ b/lib/tests/test_logsource.c
@@ -37,7 +37,6 @@
 
 #define TEST_SOURCE_GROUP "test_source_group"
 #define TEST_STATS_ID "test_stats_id"
-#define TEST_STATS_INSTANCE "test_stats_instance"
 
 GlobalConfig *cfg;
 LogSourceOptions source_options;
@@ -79,7 +78,7 @@ test_source_init(LogSourceOptions *options)
   source->super.wakeup = test_source_wakeup;
 
   log_source_options_init(options, cfg, TEST_SOURCE_GROUP);
-  log_source_set_options(&source->super, options, TEST_STATS_ID, TEST_STATS_INSTANCE, TRUE, NULL);
+  log_source_set_options(&source->super, options, TEST_STATS_ID, NULL, TRUE, NULL);
   cr_assert(log_pipe_init(&source->super.super));
   return &source->super;
 }

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -182,15 +182,20 @@ affile_dw_reopen(AFFileDestWriter *self)
 }
 
 static void
-_init_stats_key_builders(AFFileDestWriter *self, StatsClusterKeyBuilder *driver_sck_builder,
-                         StatsClusterKeyBuilder *queue_sck_builder)
+_init_stats_key_builders(AFFileDestWriter *self, StatsClusterKeyBuilder **writer_sck_builder,
+                         StatsClusterKeyBuilder **driver_sck_builder, StatsClusterKeyBuilder **queue_sck_builder)
 {
-  stats_cluster_key_builder_add_label(driver_sck_builder, stats_cluster_label("id", self->owner->super.super.id));
-  stats_cluster_key_builder_set_legacy_alias(driver_sck_builder,
+  *writer_sck_builder = stats_cluster_key_builder_new();
+  stats_cluster_key_builder_add_legacy_label(*writer_sck_builder, stats_cluster_label("filename", self->filename));
+
+  *driver_sck_builder = stats_cluster_key_builder_clone(*writer_sck_builder);
+  stats_cluster_key_builder_add_label(*driver_sck_builder, stats_cluster_label("id", self->owner->super.super.id));
+  stats_cluster_key_builder_set_legacy_alias(*driver_sck_builder,
                                              self->owner->writer_options.stats_source | SCS_DESTINATION,
                                              self->owner->super.super.id, self->filename);
 
-  stats_cluster_key_builder_add_label(queue_sck_builder, stats_cluster_label("id", self->owner->super.super.id));
+  *queue_sck_builder = stats_cluster_key_builder_clone(*writer_sck_builder);
+  stats_cluster_key_builder_add_label(*queue_sck_builder, stats_cluster_label("id", self->owner->super.super.id));
 }
 
 static gboolean
@@ -204,16 +209,18 @@ affile_dw_init(LogPipe *s)
       self->writer = log_writer_new(self->owner->writer_flags, cfg);
     }
 
+  StatsClusterKeyBuilder *writer_sck_builder;
+  StatsClusterKeyBuilder *driver_sck_builder;
+  StatsClusterKeyBuilder *queue_sck_builder;
+  _init_stats_key_builders(self, &writer_sck_builder, &driver_sck_builder, &queue_sck_builder);
+
   log_pipe_set_options((LogPipe *) self->writer, &s->options);
   log_writer_set_options(self->writer,
                          s,
                          &self->owner->writer_options,
                          self->owner->super.super.id,
-                         self->filename);
+                         writer_sck_builder);
 
-  StatsClusterKeyBuilder *driver_sck_builder = stats_cluster_key_builder_new();
-  StatsClusterKeyBuilder *queue_sck_builder = stats_cluster_key_builder_new();
-  _init_stats_key_builders(self, driver_sck_builder, queue_sck_builder);
 
   gint stats_level = log_pipe_is_internal(&self->super) ? STATS_LEVEL3 : self->owner->writer_options.stats_level;
   LogQueue *queue = log_dest_driver_acquire_queue(&self->owner->super, affile_dw_format_persist_name(self),
@@ -314,12 +321,15 @@ affile_dw_set_owner(AFFileDestWriter *self, AFFileDestDriver *owner)
   log_pipe_set_config(&self->super, cfg);
   if (self->writer)
     {
+      StatsClusterKeyBuilder *writer_sck_builder = stats_cluster_key_builder_new();
+      stats_cluster_key_builder_add_legacy_label(writer_sck_builder, stats_cluster_label("filename", self->filename));
+
       log_pipe_set_config((LogPipe *) self->writer, cfg);
       log_writer_set_options(self->writer,
                              &self->super,
                              &owner->writer_options,
                              self->owner->super.super.id,
-                             self->filename);
+                             writer_sck_builder);
     }
 }
 

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -186,6 +186,7 @@ _init_stats_key_builders(AFFileDestWriter *self, StatsClusterKeyBuilder **writer
                          StatsClusterKeyBuilder **driver_sck_builder, StatsClusterKeyBuilder **queue_sck_builder)
 {
   *writer_sck_builder = stats_cluster_key_builder_new();
+  stats_cluster_key_builder_add_label(*writer_sck_builder, stats_cluster_label("driver", "file"));
   stats_cluster_key_builder_add_legacy_label(*writer_sck_builder, stats_cluster_label("filename", self->filename));
 
   *driver_sck_builder = stats_cluster_key_builder_clone(*writer_sck_builder);
@@ -322,6 +323,7 @@ affile_dw_set_owner(AFFileDestWriter *self, AFFileDestDriver *owner)
   if (self->writer)
     {
       StatsClusterKeyBuilder *writer_sck_builder = stats_cluster_key_builder_new();
+      stats_cluster_key_builder_add_label(writer_sck_builder, stats_cluster_label("driver", "file"));
       stats_cluster_key_builder_add_legacy_label(writer_sck_builder, stats_cluster_label("filename", self->filename));
 
       log_pipe_set_config((LogPipe *) self->writer, cfg);

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -34,6 +34,7 @@
 #include "poll-file-changes.h"
 #include "poll-multiline-file-changes.h"
 #include "ack-tracker/ack_tracker_factory.h"
+#include "stats/stats-cluster-key-builder.h"
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -161,11 +162,14 @@ _setup_logreader(LogPipe *s, PollEvents *poll_events, LogProtoServer *proto, gbo
   self->reader = log_reader_new(log_pipe_get_config(s));
   log_pipe_set_options(&self->reader->super.super, &self->super.options);
   log_reader_open(self->reader, proto, poll_events);
+
+  StatsClusterKeyBuilder *kb = stats_cluster_key_builder_new();
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("filename", self->filename->str));
   log_reader_set_options(self->reader,
                          s,
                          &self->options->reader_options,
                          self->owner->super.id,
-                         self->filename->str);
+                         kb);
 
   if (check_immediately)
     log_reader_set_immediate_check(self->reader);

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -164,6 +164,7 @@ _setup_logreader(LogPipe *s, PollEvents *poll_events, LogProtoServer *proto, gbo
   log_reader_open(self->reader, proto, poll_events);
 
   StatsClusterKeyBuilder *kb = stats_cluster_key_builder_new();
+  stats_cluster_key_builder_add_label(kb, stats_cluster_label("driver", "file"));
   stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("filename", self->filename->str));
   log_reader_set_options(self->reader,
                          s,

--- a/modules/afmongodb/tests/test-mongodb-config.c
+++ b/modules/afmongodb/tests/test-mongodb-config.c
@@ -62,7 +62,7 @@ Test(mongodb_config, test_stats_name)
   cr_assert(afmongodb_dd_private_uri_init(mongodb));
 
   LogThreadedDestDriver *self = (LogThreadedDestDriver *)mongodb;
-  const gchar *name = self->format_stats_instance(self);
+  const gchar *name = self->format_stats_key(self, NULL);
   cr_assert(name, "mongodb,127.0.0.2:27018,syslog,x,messages");
 }
 

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -28,6 +28,7 @@
 #include "children.h"
 #include "fdhelpers.h"
 #include "stats/stats-registry.h"
+#include "stats/stats-cluster-key-builder.h"
 #include "transport/transport-pipe.h"
 #include "logproto/logproto-text-server.h"
 #include "logproto/logproto-text-client.h"
@@ -292,11 +293,14 @@ afprogram_sd_init(LogPipe *s)
       self->reader = log_reader_new(s->cfg);
       log_pipe_set_options(&self->reader->super.super, &self->super.super.super.options);
       log_reader_open(self->reader, proto, poll_fd_events_new(fd));
+
+      StatsClusterKeyBuilder *kb = stats_cluster_key_builder_new();
+      stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("command", self->process_info.cmdline->str));
       log_reader_set_options(self->reader,
                              s,
                              &self->reader_options,
                              self->super.super.id,
-                             self->process_info.cmdline->str);
+                             kb);
     }
   log_pipe_append((LogPipe *) self->reader, &self->super.super.super);
   if (!log_pipe_init((LogPipe *) self->reader))

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -295,6 +295,7 @@ afprogram_sd_init(LogPipe *s)
       log_reader_open(self->reader, proto, poll_fd_events_new(fd));
 
       StatsClusterKeyBuilder *kb = stats_cluster_key_builder_new();
+      stats_cluster_key_builder_add_label(kb, stats_cluster_label("driver", "program"));
       stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("command", self->process_info.cmdline->str));
       log_reader_set_options(self->reader,
                              s,
@@ -530,6 +531,7 @@ _init_stats_key_builders(AFProgramDestDriver *self, StatsClusterKeyBuilder **wri
                          StatsClusterKeyBuilder **driver_sck_builder, StatsClusterKeyBuilder **queue_sck_builder)
 {
   *writer_sck_builder = stats_cluster_key_builder_new();
+  stats_cluster_key_builder_add_label(*writer_sck_builder, stats_cluster_label("driver", "program"));
   stats_cluster_key_builder_add_legacy_label(*writer_sck_builder, stats_cluster_label("command",
                                              self->process_info.cmdline->str));
 

--- a/modules/afsnmp/afsnmpdest.c
+++ b/modules/afsnmp/afsnmpdest.c
@@ -461,14 +461,18 @@ snmpdest_dd_format_persist_name(const LogPipe *s)
 }
 
 static const gchar *
-snmpdest_dd_format_stats_instance(LogThreadedDestDriver *s)
+snmpdest_dd_format_stats_key(LogThreadedDestDriver *s, StatsClusterKeyBuilder *kb)
 {
   SNMPDestDriver *self = (SNMPDestDriver *)s;
 
-  static gchar persist_name[1024];
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "snmpdest"));
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("host", self->host));
 
-  g_snprintf(persist_name, sizeof(persist_name), "snmpdest,%s,%u", self->host, self->port);
-  return persist_name;
+  gchar num[64];
+  g_snprintf(num, sizeof(num), "%u", self->port);
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("port", num));
+
+  return NULL;
 }
 
 static gboolean
@@ -739,7 +743,7 @@ snmpdest_dd_new(GlobalConfig *cfg)
   self->super.worker.thread_deinit = snmpdest_worker_thread_deinit;
   self->super.worker.insert = snmpdest_worker_insert;
 
-  self->super.format_stats_instance = snmpdest_dd_format_stats_instance;
+  self->super.format_stats_key = snmpdest_dd_format_stats_key;
   self->super.stats_source = stats_register_type("snmp");
 
   if (snmp_dest_counter == 0)

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -496,6 +496,7 @@ _init_stats_key_builders(AFSocketDestDriver *self, StatsClusterKeyBuilder **writ
                          StatsClusterKeyBuilder **driver_sck_builder, StatsClusterKeyBuilder **queue_sck_builder)
 {
   *writer_sck_builder = stats_cluster_key_builder_new();
+  stats_cluster_key_builder_add_label(*writer_sck_builder, stats_cluster_label("driver", "afsocket"));
   stats_cluster_key_builder_add_legacy_label(*writer_sck_builder, stats_cluster_label("transport",
                                              self->transport_mapper->transport));
   stats_cluster_key_builder_add_legacy_label(*writer_sck_builder, stats_cluster_label("address",

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -118,6 +118,8 @@ afsocket_sc_format_stats_key(AFSocketSourceConnection *self, StatsClusterKeyBuil
 {
   gchar addr[256];
 
+  stats_cluster_key_builder_add_label(kb, stats_cluster_label("driver", "afsocket"));
+
   if (!self->peer_addr)
     {
       /* dgram connection, which means we have no peer, use the bind address */

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -1098,15 +1098,17 @@ error:
 }
 
 static const gchar *
-afsql_dd_format_stats_instance(LogThreadedDestDriver *s)
+afsql_dd_format_stats_key(LogThreadedDestDriver *s, StatsClusterKeyBuilder *kb)
 {
   AFSqlDestDriver *self = (AFSqlDestDriver *) s;
-  static gchar persist_name[64];
 
-  g_snprintf(persist_name, sizeof(persist_name),
-             "%s,%s,%s,%s,%s",
-             self->type, self->host, self->port, self->database, self->table->template_str);
-  return persist_name;
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", self->type));
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("host", self->host));
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("port", self->port));
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("database", self->database));
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("table", self->table->template_str));
+
+  return NULL;
 }
 
 static const gchar *
@@ -1329,7 +1331,7 @@ afsql_dd_new(GlobalConfig *cfg)
   self->super.super.super.super.init = afsql_dd_init;
   self->super.super.super.super.free_fn = afsql_dd_free;
   self->super.super.super.super.generate_persist_name = afsql_dd_format_persist_name;
-  self->super.format_stats_instance = afsql_dd_format_stats_instance;
+  self->super.format_stats_key = afsql_dd_format_stats_key;
   self->super.worker.connect = afsql_dd_connect;
   self->super.worker.disconnect = afsql_dd_disconnect;
   self->super.worker.insert = afsql_dd_insert;

--- a/modules/afstreams/afstreams.c
+++ b/modules/afstreams/afstreams.c
@@ -29,6 +29,7 @@
 #include "stats/stats-registry.h"
 #include "poll-fd-events.h"
 #include "logproto/logproto-dgram-server.h"
+#include "stats/stats-cluster-key-builder.h"
 
 typedef struct _AFStreamsSourceDriver
 {
@@ -188,11 +189,14 @@ afstreams_sd_init(LogPipe *s)
       log_pipe_set_options(&self->reader->super.super, &self->super.super.super.options);
       log_reader_open(self->reader, log_proto_dgram_server_new(log_transport_streams_new(fd),
                                                                &self->reader_options.proto_options.super), poll_fd_events_new(fd));
+
+      StatsClusterKeyBuilder *kb = stats_cluster_key_builder_new();
+      stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("filename", self->dev_filename->str));
       log_reader_set_options(self->reader,
                              s,
                              &self->reader_options,
                              self->super.super.id,
-                             self->dev_filename->str);
+                             kb);
       log_pipe_append((LogPipe *) self->reader, s);
 
       if (self->door_filename)

--- a/modules/afstreams/afstreams.c
+++ b/modules/afstreams/afstreams.c
@@ -191,6 +191,7 @@ afstreams_sd_init(LogPipe *s)
                                                                &self->reader_options.proto_options.super), poll_fd_events_new(fd));
 
       StatsClusterKeyBuilder *kb = stats_cluster_key_builder_new();
+      stats_cluster_key_builder_add_label(kb, stats_cluster_label("driver", "sun-streams"));
       stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("filename", self->dev_filename->str));
       log_reader_set_options(self->reader,
                              s,

--- a/modules/examples/destinations/example_destination/example_destination.c
+++ b/modules/examples/destinations/example_destination/example_destination.c
@@ -51,14 +51,14 @@ example_destination_dd_set_filename(LogDriver *d, const gchar *filename)
  */
 
 static const gchar *
-_format_stats_instance(LogThreadedDestDriver *d)
+_format_stats_key(LogThreadedDestDriver *d, StatsClusterKeyBuilder *kb)
 {
   ExampleDestinationDriver *self = (ExampleDestinationDriver *)d;
-  static gchar persist_name[1024];
 
-  g_snprintf(persist_name, sizeof(persist_name),
-             "example-destination,%s", self->filename->str);
-  return persist_name;
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "example-destination"));
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("filename", self->filename->str));
+
+  return NULL;
 }
 
 static const gchar *
@@ -121,7 +121,7 @@ example_destination_dd_new(GlobalConfig *cfg)
   self->super.super.super.super.deinit = _dd_deinit;
   self->super.super.super.super.free_fn = _dd_free;
 
-  self->super.format_stats_instance = _format_stats_instance;
+  self->super.format_stats_key = _format_stats_key;
   self->super.super.super.super.generate_persist_name = _format_persist_name;
   self->super.stats_source = stats_register_type("example-destination");
   self->super.worker.construct = example_destination_dw_new;

--- a/modules/examples/sources/msg-generator/msg-generator-source.c
+++ b/modules/examples/sources/msg-generator/msg-generator-source.c
@@ -170,10 +170,10 @@ msg_generator_source_free(MsgGeneratorSource *self)
 
 void
 msg_generator_source_set_options(MsgGeneratorSource *self, MsgGeneratorSourceOptions *options,
-                                 const gchar *stats_id, const gchar *stats_instance, gboolean threaded,
+                                 const gchar *stats_id, StatsClusterKeyBuilder *kb, gboolean threaded,
                                  gboolean pos_tracked, LogExprNode *expr_node)
 {
-  log_source_set_options(&self->super, &options->super, stats_id, stats_instance, threaded, expr_node);
+  log_source_set_options(&self->super, &options->super, stats_id, kb, threaded, expr_node);
 
   AckTrackerFactory *factory = pos_tracked ? consecutive_ack_tracker_factory_new() :
                                instant_ack_tracker_bookmarkless_factory_new();

--- a/modules/examples/sources/msg-generator/msg-generator-source.h
+++ b/modules/examples/sources/msg-generator/msg-generator-source.h
@@ -26,6 +26,7 @@
 
 #include "cfg.h"
 #include "msg-generator-source-options.h"
+#include "stats/stats-cluster-key-builder.h"
 
 typedef struct MsgGeneratorSource MsgGeneratorSource;
 
@@ -35,7 +36,7 @@ gboolean msg_generator_source_deinit(MsgGeneratorSource *self);
 void msg_generator_source_free(MsgGeneratorSource *self);
 
 void msg_generator_source_set_options(MsgGeneratorSource *self, MsgGeneratorSourceOptions *options,
-                                      const gchar *stats_id, const gchar *stats_instance, gboolean threaded,
+                                      const gchar *stats_id, StatsClusterKeyBuilder *kb, gboolean threaded,
                                       gboolean pos_tracked, LogExprNode *expr_node);
 
 

--- a/modules/examples/sources/random-choice-generator/random-choice-generator.cpp
+++ b/modules/examples/sources/random-choice-generator/random-choice-generator.cpp
@@ -79,17 +79,10 @@ RandomChoiceGeneratorCpp::request_exit()
 }
 
 const gchar *
-RandomChoiceGeneratorCpp::format_stats_instance()
+RandomChoiceGeneratorCpp::format_stats_key(StatsClusterKeyBuilder *kb)
 {
-  static gchar persist_name[1024];
-
-  if (super->super.super.super.super.persist_name)
-    g_snprintf(persist_name, sizeof(persist_name), "random_choice_generator,%s",
-               super->super.super.super.super.persist_name);
-  else
-    g_snprintf(persist_name, sizeof(persist_name), "random_choice_generator");
-
-  return persist_name;
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "random-choice-generator"));
+  return NULL;
 }
 
 gboolean
@@ -138,9 +131,9 @@ _request_exit(LogThreadedSourceDriver *s)
 }
 
 static const gchar *
-_format_stats_instance(LogThreadedSourceDriver *s)
+_format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuilder *kb)
 {
-  return get_RandomChoiceGeneratorCpp(s)->format_stats_instance();
+  return get_RandomChoiceGeneratorCpp(s)->format_stats_key(kb);
 }
 
 static gboolean
@@ -174,7 +167,7 @@ random_choice_generator_sd_new(GlobalConfig *cfg)
   s->super.super.super.super.deinit = _deinit;
   s->super.super.super.super.free_fn = _free;
 
-  s->super.format_stats_instance = _format_stats_instance;
+  s->super.format_stats_key = _format_stats_key;
   s->super.run = _run;
   s->super.request_exit = _request_exit;
 

--- a/modules/examples/sources/random-choice-generator/random-choice-generator.cpp
+++ b/modules/examples/sources/random-choice-generator/random-choice-generator.cpp
@@ -78,11 +78,10 @@ RandomChoiceGeneratorCpp::request_exit()
   exit_requested = true;
 }
 
-const gchar *
+void
 RandomChoiceGeneratorCpp::format_stats_key(StatsClusterKeyBuilder *kb)
 {
   stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "random-choice-generator"));
-  return NULL;
 }
 
 gboolean
@@ -130,10 +129,10 @@ _request_exit(LogThreadedSourceDriver *s)
   get_RandomChoiceGeneratorCpp(s)->request_exit();
 }
 
-static const gchar *
+static void
 _format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuilder *kb)
 {
-  return get_RandomChoiceGeneratorCpp(s)->format_stats_key(kb);
+  get_RandomChoiceGeneratorCpp(s)->format_stats_key(kb);
 }
 
 static gboolean

--- a/modules/examples/sources/random-choice-generator/random-choice-generator.hpp
+++ b/modules/examples/sources/random-choice-generator/random-choice-generator.hpp
@@ -42,7 +42,7 @@ public:
   void set_choices(GList *choices);
   void set_freq(gdouble freq);
   void request_exit();
-  const gchar *format_stats_instance();
+  const gchar *format_stats_key(StatsClusterKeyBuilder *kb);
   gboolean init();
   gboolean deinit();
 

--- a/modules/examples/sources/random-choice-generator/random-choice-generator.hpp
+++ b/modules/examples/sources/random-choice-generator/random-choice-generator.hpp
@@ -42,7 +42,7 @@ public:
   void set_choices(GList *choices);
   void set_freq(gdouble freq);
   void request_exit();
-  const gchar *format_stats_key(StatsClusterKeyBuilder *kb);
+  void format_stats_key(StatsClusterKeyBuilder *kb);
   gboolean init();
   gboolean deinit();
 

--- a/modules/examples/sources/threaded-diskq-source/threaded-diskq-source.c
+++ b/modules/examples/sources/threaded-diskq-source/threaded-diskq-source.c
@@ -171,15 +171,13 @@ _fetch(LogThreadedFetcherDriver *s)
   return result;
 }
 
-static const gchar *
+static void
 _format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuilder *kb)
 {
   ThreadedDiskqSourceDriver *self = (ThreadedDiskqSourceDriver *) s;
 
   stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "diskq-source"));
   stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("filename", self->filename));
-
-  return NULL;
 }
 
 static gboolean

--- a/modules/examples/sources/threaded-random-generator/threaded-random-generator.c
+++ b/modules/examples/sources/threaded-random-generator/threaded-random-generator.c
@@ -119,7 +119,7 @@ _init(LogPipe *s)
   return TRUE;
 }
 
-static const gchar *
+static void
 _format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuilder *kb)
 {
   ThreadedRandomGeneratorSourceDriver *self = (ThreadedRandomGeneratorSourceDriver *) s;
@@ -135,8 +135,6 @@ _format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuilder *kb)
 
   g_snprintf(num, sizeof(num), "%u", self->flags);
   stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("flags", num));
-
-  return NULL;
 }
 
 void

--- a/modules/examples/sources/threaded-random-generator/threaded-random-generator.c
+++ b/modules/examples/sources/threaded-random-generator/threaded-random-generator.c
@@ -120,17 +120,23 @@ _init(LogPipe *s)
 }
 
 static const gchar *
-_format_stats_instance(LogThreadedSourceDriver *s)
+_format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuilder *kb)
 {
   ThreadedRandomGeneratorSourceDriver *self = (ThreadedRandomGeneratorSourceDriver *) s;
-  static gchar persist_name[1024];
 
-  if (s->super.super.super.persist_name)
-    g_snprintf(persist_name, sizeof(persist_name), "random-generator,%s", s->super.super.super.persist_name);
-  else
-    g_snprintf(persist_name, sizeof(persist_name), "random-generator,%u,%u,%u", self->bytes, self->freq, self->flags);
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "random-generator"));
 
-  return persist_name;
+  gchar num[64];
+  g_snprintf(num, sizeof(num), "%u", self->bytes);
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("bytes", num));
+
+  g_snprintf(num, sizeof(num), "%u", self->freq);
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("freq", num));
+
+  g_snprintf(num, sizeof(num), "%u", self->flags);
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("flags", num));
+
+  return NULL;
 }
 
 void
@@ -173,7 +179,7 @@ threaded_random_generator_sd_new(GlobalConfig *cfg)
   g_atomic_counter_set(&self->exit_requested, FALSE);
 
   self->super.super.super.super.init = _init;
-  self->super.format_stats_instance = _format_stats_instance;
+  self->super.format_stats_key = _format_stats_key;
 
   self->super.run = _run;
   self->super.request_exit = _request_exit;

--- a/modules/grpc/otel/otel-source.cpp
+++ b/modules/grpc/otel/otel-source.cpp
@@ -93,18 +93,15 @@ syslogng::grpc::otel::SourceDriver::request_exit()
 }
 
 const gchar *
-syslogng::grpc::otel::SourceDriver::format_stats_instance()
+syslogng::grpc::otel::SourceDriver::format_stats_key(StatsClusterKeyBuilder *kb)
 {
-  static gchar persist_name[1024];
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "opentelemetry"));
 
-  if (super->super.super.super.super.persist_name)
-    g_snprintf(persist_name, sizeof(persist_name), "opentelemetry,%s",
-               super->super.super.super.super.persist_name);
-  else
-    g_snprintf(persist_name, sizeof(persist_name), "opentelemetry,%lu",
-               port);
+  gchar num[64];
+  g_snprintf(num, sizeof(num), "%" G_GUINT64_FORMAT, port);
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("port", num));
 
-  return persist_name;
+  return NULL;
 }
 
 gboolean
@@ -167,9 +164,9 @@ _request_exit(LogThreadedSourceDriver *s)
 }
 
 static const gchar *
-_format_stats_instance(LogThreadedSourceDriver *s)
+_format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuilder *kb)
 {
-  return get_SourceDriver(s)->format_stats_instance();
+  return get_SourceDriver(s)->format_stats_key(kb);
 }
 
 static gboolean
@@ -203,7 +200,7 @@ otel_sd_new(GlobalConfig *cfg)
   s->super.super.super.super.deinit = _deinit;
   s->super.super.super.super.free_fn = _free;
 
-  s->super.format_stats_instance = _format_stats_instance;
+  s->super.format_stats_key = _format_stats_key;
   s->super.run = _run;
   s->super.request_exit = _request_exit;
 

--- a/modules/grpc/otel/otel-source.cpp
+++ b/modules/grpc/otel/otel-source.cpp
@@ -92,7 +92,7 @@ syslogng::grpc::otel::SourceDriver::request_exit()
   cq->Shutdown();
 }
 
-const gchar *
+void
 syslogng::grpc::otel::SourceDriver::format_stats_key(StatsClusterKeyBuilder *kb)
 {
   stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "opentelemetry"));
@@ -100,8 +100,6 @@ syslogng::grpc::otel::SourceDriver::format_stats_key(StatsClusterKeyBuilder *kb)
   gchar num[64];
   g_snprintf(num, sizeof(num), "%" G_GUINT64_FORMAT, port);
   stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("port", num));
-
-  return NULL;
 }
 
 gboolean
@@ -163,10 +161,10 @@ _request_exit(LogThreadedSourceDriver *s)
   get_SourceDriver(s)->request_exit();
 }
 
-static const gchar *
+static void
 _format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuilder *kb)
 {
-  return get_SourceDriver(s)->format_stats_key(kb);
+  get_SourceDriver(s)->format_stats_key(kb);
 }
 
 static gboolean

--- a/modules/grpc/otel/otel-source.hpp
+++ b/modules/grpc/otel/otel-source.hpp
@@ -45,7 +45,7 @@ public:
 
   void run();
   void request_exit();
-  const gchar *format_stats_instance();
+  const gchar *format_stats_key(StatsClusterKeyBuilder *kb);
   gboolean init();
   gboolean deinit();
 

--- a/modules/grpc/otel/otel-source.hpp
+++ b/modules/grpc/otel/otel-source.hpp
@@ -45,7 +45,7 @@ public:
 
   void run();
   void request_exit();
-  const gchar *format_stats_key(StatsClusterKeyBuilder *kb);
+  void format_stats_key(StatsClusterKeyBuilder *kb);
   gboolean init();
   gboolean deinit();
 

--- a/modules/grpc/otel/tests/test-otel-protobuf-parser.cpp
+++ b/modules/grpc/otel/tests/test-otel-protobuf-parser.cpp
@@ -20,8 +20,6 @@
  *
  */
 
-#include <criterion/criterion.h>
-
 #include "opentelemetry/proto/logs/v1/logs.pb.h"
 #include "opentelemetry/proto/metrics/v1/metrics.pb.h"
 #include "opentelemetry/proto/trace/v1/trace.pb.h"
@@ -31,6 +29,8 @@
 #include "compat/cpp-start.h"
 #include "apphook.h"
 #include "compat/cpp-end.h"
+
+#include <criterion/criterion.h>
 
 using namespace syslogng::grpc::otel;
 using namespace opentelemetry::proto::resource::v1;

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -337,15 +337,14 @@ _format_persist_name(const LogPipe *s)
 }
 
 static const gchar *
-_format_stats_instance(LogThreadedDestDriver *s)
+_format_stats_key(LogThreadedDestDriver *s, StatsClusterKeyBuilder *kb)
 {
-  static gchar stats[1024];
-
   HTTPDestinationDriver *self = (HTTPDestinationDriver *) s;
 
-  g_snprintf(stats, sizeof(stats), "http,%s", self->url);
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "http"));
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("url", self->url));
 
-  return stats;
+  return NULL;
 }
 
 gboolean
@@ -440,7 +439,7 @@ http_dd_new(GlobalConfig *cfg)
   self->super.super.super.super.deinit = http_dd_deinit;
   self->super.super.super.super.free_fn = http_dd_free;
   self->super.super.super.super.generate_persist_name = _format_persist_name;
-  self->super.format_stats_instance = _format_stats_instance;
+  self->super.format_stats_key = _format_stats_key;
   self->super.metrics.raw_bytes_enabled = TRUE;
   self->super.stats_source = stats_register_type("http");
   self->super.worker.construct = http_dw_new;

--- a/modules/java/native/java-destination.c
+++ b/modules/java/native/java-destination.c
@@ -252,19 +252,15 @@ java_dd_format_persist_name(const LogPipe *s)
 }
 
 static const gchar *
-java_dd_format_stats_instance(LogThreadedDestDriver *d)
+java_dd_format_stats_key(LogThreadedDestDriver *d, StatsClusterKeyBuilder *kb)
 {
   JavaDestDriver *self = (JavaDestDriver *)d;
-  static gchar persist_name[1024];
 
-  if (d->super.super.super.persist_name)
-    g_snprintf(persist_name, sizeof(persist_name), "java_dst,%s",
-               d->super.super.super.persist_name);
-  else
-    g_snprintf(persist_name, sizeof(persist_name), "java_dst,%s",
-               java_destination_proxy_get_name_by_uniq_options(self->proxy));
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "java_dst"));
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("name",
+                                             java_destination_proxy_get_name_by_uniq_options(self->proxy)));
 
-  return persist_name;
+  return NULL;
 }
 
 void
@@ -310,7 +306,7 @@ java_dd_new(GlobalConfig *cfg)
   self->super.worker.insert = java_worker_insert;
   self->super.worker.flush = java_worker_flush;
 
-  self->super.format_stats_instance = java_dd_format_stats_instance;
+  self->super.format_stats_key = java_dd_format_stats_key;
   self->super.stats_source = stats_register_type("java");
 
   self->template = log_template_new(cfg, NULL);

--- a/modules/kafka/kafka-dest-driver.c
+++ b/modules/kafka/kafka-dest-driver.c
@@ -140,13 +140,14 @@ kafka_dd_is_topic_name_a_template(KafkaDestDriver *self)
 /* methods */
 
 static const gchar *
-_format_stats_instance(LogThreadedDestDriver *d)
+_format_stats_key(LogThreadedDestDriver *d, StatsClusterKeyBuilder *kb)
 {
   KafkaDestDriver *self = (KafkaDestDriver *)d;
-  static gchar stats_name[1024];
 
-  g_snprintf(stats_name, sizeof(stats_name), "kafka,%s", self->topic_name->template_str);
-  return stats_name;
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "kafka"));
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("topic", self->topic_name->template_str));
+
+  return NULL;
 }
 
 static const gchar *
@@ -708,7 +709,7 @@ kafka_dd_new(GlobalConfig *cfg)
   self->super.super.super.super.free_fn = kafka_dd_free;
   self->super.super.super.super.generate_persist_name = _format_persist_name;
 
-  self->super.format_stats_instance = _format_stats_instance;
+  self->super.format_stats_key = _format_stats_key;
   self->super.stats_source = stats_register_type("kafka");
   self->super.worker.construct = _construct_worker;
   /* one minute */

--- a/modules/mqtt/destination/mqtt-destination.c
+++ b/modules/mqtt/destination/mqtt-destination.c
@@ -77,18 +77,16 @@ mqtt_dd_set_message_template_ref(LogDriver *d, LogTemplate *message)
  * Utilities
  */
 static const gchar *
-_format_stats_instance(LogThreadedDestDriver *d)
+_format_stats_key(LogThreadedDestDriver *d, StatsClusterKeyBuilder *kb)
 {
   MQTTDestinationDriver *self = (MQTTDestinationDriver *)d;
-  static gchar stats_instance[1024];
 
-  if (((LogPipe *)d)->persist_name)
-    g_snprintf(stats_instance, sizeof(stats_instance), "%s", ((LogPipe *)d)->persist_name);
-  else
-    g_snprintf(stats_instance, sizeof(stats_instance), "mqtt,%s,%s", mqtt_client_options_get_address(&self->options),
-               self->topic_name->template_str);
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "mqtt"));
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("address",
+                                             mqtt_client_options_get_address(&self->options)));
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("topic", self->topic_name->template_str));
 
-  return stats_instance;
+  return NULL;
 }
 
 static const gchar *
@@ -231,7 +229,7 @@ mqtt_dd_new(GlobalConfig *cfg)
   self->super.super.super.super.init = _init;
   self->super.super.super.super.free_fn = _free;
 
-  self->super.format_stats_instance = _format_stats_instance;
+  self->super.format_stats_key = _format_stats_key;
   self->super.super.super.super.generate_persist_name = _format_persist_name;
   self->super.stats_source = stats_register_type("mqtt-destination");
   self->super.worker.construct = mqtt_dw_new;

--- a/modules/mqtt/source/mqtt-source.c
+++ b/modules/mqtt/source/mqtt-source.c
@@ -49,7 +49,7 @@ _format_persist_name(const LogPipe *s)
   return stats_instance;
 }
 
-static const gchar *
+static void
 _format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuilder *kb)
 {
   MQTTSourceDriver *self = (MQTTSourceDriver *) s;
@@ -58,8 +58,6 @@ _format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuilder *kb)
   stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("address",
                                              mqtt_client_options_get_address(&self->options)));
   stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("topic", self->topic));
-
-  return NULL;
 }
 
 static LogMessage *

--- a/modules/mqtt/source/mqtt-source.c
+++ b/modules/mqtt/source/mqtt-source.c
@@ -50,19 +50,16 @@ _format_persist_name(const LogPipe *s)
 }
 
 static const gchar *
-_format_stats_instance(LogThreadedSourceDriver *s)
+_format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuilder *kb)
 {
   MQTTSourceDriver *self = (MQTTSourceDriver *) s;
-  LogPipe *p = &s->super.super.super;
-  static gchar persist_name[1024];
 
-  if (p->persist_name)
-    g_snprintf(persist_name, sizeof(persist_name), "mqtt-source.%s", p->persist_name);
-  else
-    g_snprintf(persist_name, sizeof(persist_name), "mqtt-source.(%s,%s)", mqtt_client_options_get_address(&self->options),
-               self->topic);
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "mqtt-source"));
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("address",
+                                             mqtt_client_options_get_address(&self->options)));
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("topic", self->topic));
 
-  return persist_name;
+  return NULL;
 }
 
 static LogMessage *
@@ -289,7 +286,7 @@ mqtt_sd_new(GlobalConfig *cfg)
   self->super.thread_deinit = _thread_deinit;
 
   self->super.super.super.super.super.generate_persist_name = _format_persist_name;
-  self->super.super.format_stats_instance = _format_stats_instance;
+  self->super.super.format_stats_key = _format_stats_key;
   return &self->super.super.super.super;
 }
 

--- a/modules/openbsd/openbsd-driver.c
+++ b/modules/openbsd/openbsd-driver.c
@@ -34,6 +34,7 @@
 #include "poll-fd-events.h"
 #include "logproto/logproto-dgram-server.h"
 #include "transport/transport-socket.h"
+#include "stats/stats-cluster-key-builder.h"
 
 #define OPENBSD_LOG_DEV  "/dev/klog"
 
@@ -126,11 +127,13 @@ _openbsd_sd_init(LogPipe *s)
                                                            &self->reader_options.proto_options.super),
                   poll_fd_events_new(syslog_fd));
 
+  StatsClusterKeyBuilder *kb = stats_cluster_key_builder_new();
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("filename", OPENBSD_LOG_DEV));
   log_reader_set_options(self->reader,
                          s,
                          &self->reader_options,
                          self->super.super.id,
-                         OPENBSD_LOG_DEV);
+                         kb);
   log_pipe_append((LogPipe *) self->reader, s);
 
   if (!log_pipe_init((LogPipe *) self->reader))

--- a/modules/openbsd/openbsd-driver.c
+++ b/modules/openbsd/openbsd-driver.c
@@ -128,6 +128,7 @@ _openbsd_sd_init(LogPipe *s)
                   poll_fd_events_new(syslog_fd));
 
   StatsClusterKeyBuilder *kb = stats_cluster_key_builder_new();
+  stats_cluster_key_builder_add_label(kb, stats_cluster_label("driver", "openbsd"));
   stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("filename", OPENBSD_LOG_DEV));
   log_reader_set_options(self->reader,
                          s,

--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -122,7 +122,7 @@ python_dd_get_template_options(LogDriver *d)
 /** Helpers for stats & persist_name formatting **/
 
 static const gchar *
-python_dd_format_stats_instance(LogThreadedDestDriver *d)
+python_dd_format_stats_key(LogThreadedDestDriver *d, StatsClusterKeyBuilder *kb)
 {
   PythonDestDriver *self = (PythonDestDriver *)d;
 
@@ -134,7 +134,7 @@ python_dd_format_stats_instance(LogThreadedDestDriver *d)
     .id = self->super.super.super.id
   };
 
-  return python_format_stats_instance((LogPipe *)d, "python", &options);
+  return python_format_stats_key((LogPipe *)d, kb, "python", &options);
 }
 
 static const gchar *
@@ -664,7 +664,7 @@ python_dd_new(GlobalConfig *cfg)
   self->super.worker.insert = python_dd_insert;
   self->super.worker.flush = python_dd_flush;
 
-  self->super.format_stats_instance = python_dd_format_stats_instance;
+  self->super.format_stats_key = python_dd_format_stats_key;
   self->super.stats_source = stats_register_type("python");
 
   self->options = python_options_new();

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -92,7 +92,7 @@ python_fetcher_set_loaders(LogDriver *s, GList *loaders)
   self->loaders = loaders;
 }
 
-static const gchar *
+static void
 python_fetcher_format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuilder *kb)
 {
   PythonFetcherDriver *self = (PythonFetcherDriver *) s;
@@ -105,7 +105,7 @@ python_fetcher_format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuild
     .id = self->super.super.super.super.id
   };
 
-  return python_format_stats_key((LogPipe *)s, kb, "python-fetcher", &options);
+  python_format_stats_key((LogPipe *)s, kb, "python-fetcher", &options);
 }
 
 static void

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -93,7 +93,7 @@ python_fetcher_set_loaders(LogDriver *s, GList *loaders)
 }
 
 static const gchar *
-python_fetcher_format_stats_instance(LogThreadedSourceDriver *s)
+python_fetcher_format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuilder *kb)
 {
   PythonFetcherDriver *self = (PythonFetcherDriver *) s;
 
@@ -105,7 +105,7 @@ python_fetcher_format_stats_instance(LogThreadedSourceDriver *s)
     .id = self->super.super.super.super.id
   };
 
-  return python_format_stats_instance((LogPipe *)s, "python-fetcher", &options);
+  return python_format_stats_key((LogPipe *)s, kb, "python-fetcher", &options);
 }
 
 static void
@@ -686,7 +686,7 @@ python_fetcher_new(GlobalConfig *cfg)
   self->super.super.super.super.super.free_fn = python_fetcher_free;
   self->super.super.super.super.super.generate_persist_name = python_fetcher_format_persist_name;
 
-  self->super.super.format_stats_instance = python_fetcher_format_stats_instance;
+  self->super.super.format_stats_key = python_fetcher_format_stats_key;
   self->super.super.worker_options.super.stats_level = STATS_LEVEL0;
   self->super.super.worker_options.super.stats_source = stats_register_type("python");
 

--- a/modules/python/python-persist.c
+++ b/modules/python/python-persist.c
@@ -114,9 +114,19 @@ copy_stats_instance(const LogPipe *self, const gchar *module, PythonPersistMembe
 }
 
 const gchar *
-python_format_stats_instance(LogPipe *p, const gchar *module, PythonPersistMembers *options)
+python_format_stats_key(LogPipe *p, StatsClusterKeyBuilder *kb, const gchar *module, PythonPersistMembers *options)
 {
   static gchar persist_name[1024];
+
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", module));
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("class", options->class));
+
+  if (options->generate_persist_name_method)
+    {
+      copy_stats_instance(p, module, options, persist_name, sizeof(persist_name));
+      stats_cluster_key_builder_add_label(kb, stats_cluster_label("instance", persist_name));
+    }
+
 
   if (p->persist_name)
     format_default_stats_instance(persist_name, sizeof(persist_name), module, p->persist_name);

--- a/modules/python/python-persist.h
+++ b/modules/python/python-persist.h
@@ -26,6 +26,7 @@
 #include "python-module.h"
 #include "python-options.h"
 #include "logpipe.h"
+#include "stats/stats-cluster-key-builder.h"
 
 typedef struct
 {
@@ -44,7 +45,8 @@ typedef struct
   const gchar *id;
 } PythonPersistMembers;
 
-const gchar *python_format_stats_instance(LogPipe *p, const gchar *module, PythonPersistMembers *options);
+const gchar *python_format_stats_key(LogPipe *p, StatsClusterKeyBuilder *kb, const gchar *module,
+                                     PythonPersistMembers *options);
 const gchar *python_format_persist_name(const LogPipe *p, const gchar *module, PythonPersistMembers *options);
 
 void py_persist_global_init(void);

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -99,7 +99,7 @@ python_sd_set_loaders(LogDriver *s, GList *loaders)
   self->loaders = loaders;
 }
 
-static const gchar *
+static void
 python_sd_format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuilder *kb)
 {
   PythonSourceDriver *self = (PythonSourceDriver *) s;
@@ -112,7 +112,7 @@ python_sd_format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuilder *k
     .id = self->super.super.super.id
   };
 
-  return python_format_stats_key((LogPipe *)s, kb, "python", &options);
+  python_format_stats_key((LogPipe *)s, kb, "python", &options);
 }
 
 static void

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -100,7 +100,7 @@ python_sd_set_loaders(LogDriver *s, GList *loaders)
 }
 
 static const gchar *
-python_sd_format_stats_instance(LogThreadedSourceDriver *s)
+python_sd_format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuilder *kb)
 {
   PythonSourceDriver *self = (PythonSourceDriver *) s;
 
@@ -112,7 +112,7 @@ python_sd_format_stats_instance(LogThreadedSourceDriver *s)
     .id = self->super.super.super.id
   };
 
-  return python_format_stats_instance((LogPipe *)s, "python", &options);
+  return python_format_stats_key((LogPipe *)s, kb, "python", &options);
 }
 
 static void
@@ -756,7 +756,7 @@ python_sd_new(GlobalConfig *cfg)
   self->super.super.super.super.free_fn = python_sd_free;
   self->super.super.super.super.generate_persist_name = python_source_format_persist_name;
 
-  self->super.format_stats_instance = python_sd_format_stats_instance;
+  self->super.format_stats_key = python_sd_format_stats_key;
   self->super.worker_options.super.stats_level = STATS_LEVEL0;
   self->super.worker_options.super.stats_source = stats_register_type("python");
 

--- a/modules/python/tests/test_python_persist_name.c
+++ b/modules/python/tests/test_python_persist_name.c
@@ -36,6 +36,7 @@
 #include "mainloop-worker.h"
 #include "mainloop.h"
 #include "python-persist.h"
+#include "stats/stats-cluster-key-builder.h"
 
 
 MainLoop *main_loop;
@@ -220,7 +221,10 @@ Test(python_persist_name, test_python_exception_in_generate_persist_name)
     .generate_persist_name_method = persist_generator_stats,
     .class = "class",
   };
-  cr_assert_str_eq(python_format_stats_instance(p, "module", &options_stats), "module,class");
+
+  StatsClusterKeyBuilder *kb = stats_cluster_key_builder_new();
+  cr_assert_str_eq(python_format_stats_key(p, kb, "module", &options_stats), "module,class");
+  stats_cluster_key_builder_free(kb);
 
   PythonPersistMembers options_persist =
   {

--- a/modules/redis/redis.c
+++ b/modules/redis/redis.c
@@ -105,17 +105,18 @@ redis_dd_get_template_options(LogDriver *d)
  */
 
 static const gchar *
-redis_dd_format_stats_instance(LogThreadedDestDriver *d)
+redis_dd_format_stats_key(LogThreadedDestDriver *d, StatsClusterKeyBuilder *kb)
 {
   RedisDriver *self = (RedisDriver *)d;
-  static gchar persist_name[1024];
 
-  if (d->super.super.super.persist_name)
-    g_snprintf(persist_name, sizeof(persist_name), "redis,%s", d->super.super.super.persist_name);
-  else
-    g_snprintf(persist_name, sizeof(persist_name), "redis,%s,%u", self->host, self->port);
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "redis"));
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("host", self->host));
 
-  return persist_name;
+  gchar num[64];
+  g_snprintf(num, sizeof(num), "%u", self->port);
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("port", num));
+
+  return NULL;
 }
 
 static const gchar *
@@ -196,7 +197,7 @@ redis_dd_new(GlobalConfig *cfg)
 
   self->super.worker.construct = redis_worker_new;
 
-  self->super.format_stats_instance = redis_dd_format_stats_instance;
+  self->super.format_stats_key = redis_dd_format_stats_key;
   self->super.stats_source = stats_register_type("redis");
 
   redis_dd_set_host((LogDriver *)self, "127.0.0.1");

--- a/modules/riemann/riemann.c
+++ b/modules/riemann/riemann.c
@@ -206,17 +206,18 @@ riemann_dd_get_template_options(LogDriver *d)
  */
 
 static const gchar *
-riemann_dd_format_stats_instance(LogThreadedDestDriver *s)
+riemann_dd_format_stats_key(LogThreadedDestDriver *s, StatsClusterKeyBuilder *kb)
 {
   RiemannDestDriver *self = (RiemannDestDriver *)s;
-  static gchar persist_name[1024];
 
-  if (s->super.super.super.persist_name)
-    g_snprintf(persist_name, sizeof(persist_name), "riemann,%s", s->super.super.super.persist_name);
-  else
-    g_snprintf(persist_name, sizeof(persist_name), "riemann,%s,%u", self->server, self->port);
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "riemann"));
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("host", self->server));
 
-  return persist_name;
+  gchar num[64];
+  g_snprintf(num, sizeof(num), "%u", self->port);
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("port", num));
+
+  return NULL;
 }
 
 static const gchar *
@@ -334,7 +335,7 @@ riemann_dd_new(GlobalConfig *cfg)
   self->super.super.super.super.generate_persist_name = riemann_dd_format_persist_name;
   self->super.worker.construct = riemann_dw_new;
 
-  self->super.format_stats_instance = riemann_dd_format_stats_instance;
+  self->super.format_stats_key = riemann_dd_format_stats_key;
   self->super.stats_source = stats_register_type("riemann");
 
   self->port = -1;

--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -809,11 +809,11 @@ journal_reader_get_sd_journal(JournalReader *self)
 
 void
 journal_reader_set_options(LogPipe *s, LogPipe *control, JournalReaderOptions *options,
-                           const gchar *stats_id, const gchar *stats_instance)
+                           const gchar *stats_id, StatsClusterKeyBuilder *kb)
 {
   JournalReader *self = (JournalReader *) s;
 
-  log_source_set_options(&self->super, &options->super, stats_id, stats_instance,
+  log_source_set_options(&self->super, &options->super, stats_id, kb,
                          (options->flags & JR_THREADED), control->expr_node);
   log_source_set_ack_tracker_factory(&self->super, consecutive_ack_tracker_factory_new());
 

--- a/modules/systemd-journal/journal-reader.h
+++ b/modules/systemd-journal/journal-reader.h
@@ -27,6 +27,7 @@
 #include "logsource.h"
 #include "journald-subsystem.h"
 #include "journald-helper.h"
+#include "stats/stats-cluster-key-builder.h"
 
 typedef struct _JournalReader JournalReader;
 
@@ -48,7 +49,7 @@ typedef struct _JournalReaderOptions
 
 JournalReader *journal_reader_new(GlobalConfig *cfg);
 void journal_reader_set_options(LogPipe *s, LogPipe *control, JournalReaderOptions *options, const gchar *stats_id,
-                                const gchar *stats_instance);
+                                StatsClusterKeyBuilder *kb);
 
 void journal_reader_options_init(JournalReaderOptions *options, GlobalConfig *cfg, const gchar *group_name);
 void journal_reader_options_set_default_severity(JournalReaderOptions *self, gint severity);

--- a/modules/systemd-journal/systemd-journal.c
+++ b/modules/systemd-journal/systemd-journal.c
@@ -54,8 +54,10 @@ __init(LogPipe *s)
 
   journal_reader_options_init(&self->reader_options, cfg, self->super.super.group);
 
+  StatsClusterKeyBuilder *kb = stats_cluster_key_builder_new();
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "journal"));
   journal_reader_set_options((LogPipe *)self->reader, &self->super.super.super,  &self->reader_options,
-                             self->super.super.id, "journal");
+                             self->super.super.id, kb);
 
   log_pipe_append((LogPipe *)self->reader, &self->super.super.super);
   if (!log_pipe_init((LogPipe *)self->reader))

--- a/modules/systemd-journal/tests/test-source.c
+++ b/modules/systemd-journal/tests/test-source.c
@@ -53,7 +53,7 @@ __init(LogPipe *s)
       self->current_test_case->init(self->current_test_case, self, self->reader, &self->options);
     }
   journal_reader_options_init(&self->options, cfg, "test");
-  journal_reader_set_options((LogPipe *)self->reader, &self->super, &self->options, "test", "1");
+  journal_reader_set_options((LogPipe *)self->reader, &self->super, &self->options, "test", NULL);
   log_pipe_append((LogPipe *)self->reader, &self->super);
   cr_assert(log_pipe_init((LogPipe *)self->reader), "%s", "Can't initialize reader");
   return TRUE;
@@ -155,5 +155,3 @@ test_source_finish_tc(TestSource *self)
     }
   iv_task_register(&self->stop);
 }
-
-

--- a/news/bugfix-4551.md
+++ b/news/bugfix-4551.md
@@ -1,0 +1,1 @@
+`mqtt()`: fix the name of the stats instance (`mqtt-source`) to conform to the standard comma-separated format

--- a/news/other-4551.md
+++ b/news/other-4551.md
@@ -1,0 +1,18 @@
+metrics: replace `driver_instance` (`stats_instance`) with metric labels
+
+The new metric system had a label inherited from legacy: `driver_instance`.
+
+This non-structured label has been removed and different driver-specific labels have been added instead, for example:
+
+Before:
+```
+syslogng_output_events_total{driver_instance="mongodb,localhost:27017,defaultdb,,coll",id="#anon-destination1#1",result="queued"} 4
+```
+
+After:
+```
+syslogng_output_events_total{driver="mongodb",host="localhost:27017",database="defaultdb",collection="coll",id="#anon-destination1#1",result="queued"} 4
+```
+
+This change may affect legacy stats outputs (`syslog-ng-ctl stats`), for example, `persist-name()`-based naming
+is no longer supported in this old format.


### PR DESCRIPTION
This PR replaces all occurrences of `stats_instance` with a more structured modern approach: metric labels.

For backward-compatibility reasons, the legacy `stats_instance` name is still reproducible through the old API or by recreating it based on new-style labels.
