### PR TITLE
python: avoid consuming the argument in python_XX_set_options()

### DIFF
--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -86,12 +86,11 @@ python_dd_set_class(LogDriver *d, gchar *class_name)
 }
 
 void
-python_dd_set_options(LogDriver *d, PythonOptions *options)
+python_dd_add_options(LogDriver *d, PythonOptions *options)
 {
   PythonDestDriver *self = (PythonDestDriver *)d;
 
   python_options_add_options(self->options, options);
-  python_options_release(options);
 }
 
 void

--- a/modules/python/python-dest.h
+++ b/modules/python/python-dest.h
@@ -35,7 +35,7 @@ LogDriver *python_dd_new(GlobalConfig *cfg);
 void python_dd_set_loaders(LogDriver *d, GList *loaders);
 void python_dd_set_class(LogDriver *d, gchar *class_name);
 void python_dd_set_value_pairs(LogDriver *d, ValuePairs *vp);
-void python_dd_set_options(LogDriver *d, PythonOptions *options);
+void python_dd_add_options(LogDriver *d, PythonOptions *options);
 LogTemplateOptions *python_dd_get_template_options(LogDriver *d);
 
 void py_log_destination_global_init(void);

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -76,12 +76,11 @@ python_fetcher_set_class(LogDriver *s, gchar *filename)
 }
 
 void
-python_fetcher_set_options(LogDriver *s, PythonOptions *options)
+python_fetcher_add_options(LogDriver *s, PythonOptions *options)
 {
   PythonFetcherDriver *self = (PythonFetcherDriver *) s;
 
   python_options_add_options(self->options, options);
-  python_options_release(options);
 }
 
 void

--- a/modules/python/python-fetcher.h
+++ b/modules/python/python-fetcher.h
@@ -31,7 +31,7 @@
 LogDriver *python_fetcher_new(GlobalConfig *cfg);
 void python_fetcher_set_loaders(LogDriver *d, GList *loaders);
 void python_fetcher_set_class(LogDriver *d, gchar *class_name);
-void python_fetcher_set_options(LogDriver *d, PythonOptions *options);
+void python_fetcher_add_options(LogDriver *d, PythonOptions *options);
 
 void py_log_fetcher_global_init(void);
 

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -141,7 +141,8 @@ python_dd_option
         | KW_IMPORTS python_dd_loaders
         | python_options_block
           {
-            python_dd_set_options(last_driver, $1);
+            python_dd_add_options(last_driver, $1);
+            python_options_release($1);
           }
         | threaded_dest_driver_general_option
         | threaded_dest_driver_batch_option
@@ -167,7 +168,8 @@ python_sd_option
         | KW_LOADERS python_sd_loaders
         | python_options_block
           {
-            python_sd_set_options(last_driver, $1);
+            python_sd_add_options(last_driver, $1);
+            python_options_release($1);
           }
         | threaded_source_driver_option
         ;
@@ -187,7 +189,8 @@ python_fetcher_option
         | KW_LOADERS python_fetcher_loaders
         | python_options_block
           {
-            python_fetcher_set_options(last_driver, $1);
+            python_fetcher_add_options(last_driver, $1);
+            python_options_release($1);
           }
         | threaded_source_driver_option
         | threaded_fetcher_driver_option
@@ -209,7 +212,8 @@ python_parser_option
         | KW_IMPORTS python_parser_loaders
         | python_options_block
           {
-            python_parser_set_options(last_parser, $1);
+            python_parser_add_options(last_parser, $1);
+            python_options_release($1);
           }
         | parser_opt
         ;
@@ -229,7 +233,8 @@ python_http_header_option
         | KW_LOADERS python_http_header_loaders
         | python_options_block
           {
-            python_http_header_set_options(last_header, $1);
+            python_http_header_add_options(last_header, $1);
+            python_options_release($1);
           }
         | KW_MARK_ERRORS_AS_CRITICAL '(' yesno ')'
           {

--- a/modules/python/python-http-header.c
+++ b/modules/python/python-http-header.c
@@ -455,10 +455,9 @@ python_http_header_set_class(PythonHttpHeaderPlugin *self, gchar *class)
 }
 
 void
-python_http_header_set_options(PythonHttpHeaderPlugin *self, PythonOptions *options)
+python_http_header_add_options(PythonHttpHeaderPlugin *self, PythonOptions *options)
 {
   python_options_add_options(self->options, options);
-  python_options_release(options);
 }
 
 void

--- a/modules/python/python-http-header.h
+++ b/modules/python/python-http-header.h
@@ -32,7 +32,7 @@ PythonHttpHeaderPlugin *python_http_header_new(void);
 
 void python_http_header_set_loaders(PythonHttpHeaderPlugin *self, GList *loaders);
 void python_http_header_set_class(PythonHttpHeaderPlugin *self, gchar *class);
-void python_http_header_set_options(PythonHttpHeaderPlugin *self, PythonOptions *options);
+void python_http_header_add_options(PythonHttpHeaderPlugin *self, PythonOptions *options);
 void python_http_header_set_mark_errors_as_critical(PythonHttpHeaderPlugin *self, gboolean enable);
 
 #endif

--- a/modules/python/python-logparser.c
+++ b/modules/python/python-logparser.c
@@ -67,12 +67,11 @@ python_parser_set_class(LogParser *d, gchar *class)
 }
 
 void
-python_parser_set_options(LogParser *d, PythonOptions *options)
+python_parser_add_options(LogParser *d, PythonOptions *options)
 {
   PythonParser *self = (PythonParser *)d;
 
   python_options_add_options(self->options, options);
-  python_options_release(options);
 }
 
 void
@@ -310,7 +309,7 @@ python_parser_clone(LogPipe *s)
   log_parser_clone_settings(&self->super, &cloned->super);
   python_parser_set_class(&cloned->super, self->class);
   cloned->loaders = string_list_clone(self->loaders);
-  python_parser_set_options(&cloned->super, self->options);
+  python_parser_add_options(&cloned->super, self->options);
 
   return &cloned->super.super;
 }

--- a/modules/python/python-logparser.h
+++ b/modules/python/python-logparser.h
@@ -31,7 +31,7 @@
 LogParser *python_parser_new(GlobalConfig *cfg);
 void python_parser_set_loaders(LogParser *s, GList *loaders);
 void python_parser_set_class(LogParser *s, gchar *class_name);
-void python_parser_set_options(LogParser  *s, PythonOptions *options);
+void python_parser_add_options(LogParser  *s, PythonOptions *options);
 
 void py_log_parser_global_init(void);
 

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -83,12 +83,11 @@ python_sd_set_class(LogDriver *s, gchar *filename)
 }
 
 void
-python_sd_set_options(LogDriver *s, PythonOptions *options)
+python_sd_add_options(LogDriver *s, PythonOptions *options)
 {
   PythonSourceDriver *self = (PythonSourceDriver *) s;
 
   python_options_add_options(self->options, options);
-  python_options_release(options);
 }
 
 void

--- a/modules/python/python-source.h
+++ b/modules/python/python-source.h
@@ -31,7 +31,7 @@
 LogDriver *python_sd_new(GlobalConfig *cfg);
 void python_sd_set_loaders(LogDriver *d, GList *loaders);
 void python_sd_set_class(LogDriver *d, gchar *class_name);
-void python_sd_set_options(LogDriver *d, PythonOptions *options);
+void python_sd_add_options(LogDriver *d, PythonOptions *options);
 
 void py_log_source_global_init(void);
 

--- a/modules/python/tests/test_python_persist_name.c
+++ b/modules/python/tests/test_python_persist_name.c
@@ -119,7 +119,10 @@ Test(python_persist_name, test_python_dest)
 
   LogDriver *d = python_dd_new(empty_cfg);
   python_dd_set_class(d, "Dest");
-  python_dd_set_options(d, _create_custom_options_with_dummy_option());
+
+  PythonOptions *options = _create_custom_options_with_dummy_option();
+  python_dd_add_options(d, options);
+  python_options_release(options);
 
   cr_assert(log_pipe_init((LogPipe *)d));
 
@@ -145,7 +148,10 @@ Test(python_persist_name, test_python_fetcher)
 
   LogDriver *d = python_fetcher_new(empty_cfg);
   python_fetcher_set_class(d, "Fetcher");
-  python_fetcher_set_options(d, _create_custom_options_with_dummy_option());
+
+  PythonOptions *options = _create_custom_options_with_dummy_option();
+  python_fetcher_add_options(d, options);
+  python_options_release(options);
 
   cr_assert(log_pipe_init((LogPipe *)d));
 
@@ -173,7 +179,10 @@ Test(python_persist_name, test_python_source)
 
   LogDriver *d = python_sd_new(empty_cfg);
   python_sd_set_class(d, "Source");
-  python_sd_set_options(d, _create_custom_options_with_dummy_option());
+
+  PythonOptions *options = _create_custom_options_with_dummy_option();
+  python_sd_add_options(d, options);
+  python_options_release(options);
 
   cr_assert(log_pipe_init((LogPipe *)d));
 
@@ -242,7 +251,10 @@ Test(python_persist_name, test_python_fetcher_no_generate_persist_name)
 
   LogDriver *d = python_fetcher_new(empty_cfg);
   python_fetcher_set_class(d, "Fetcher");
-  python_fetcher_set_options(d, _create_custom_options_with_dummy_option());
+
+  PythonOptions *options = _create_custom_options_with_dummy_option();
+  python_fetcher_add_options(d, options);
+  python_options_release(options);
 
   log_pipe_set_persist_name((LogPipe *)d, "test_persist_name");
   cr_assert(log_pipe_init((LogPipe *)d));
@@ -268,7 +280,10 @@ Test(python_persist_name, test_python_source_no_generate_persist_name)
 
   LogDriver *d = python_sd_new(empty_cfg);
   python_sd_set_class(d, "Source");
-  python_sd_set_options(d, _create_custom_options_with_dummy_option());
+
+  PythonOptions *options = _create_custom_options_with_dummy_option();
+  python_sd_add_options(d, options);
+  python_options_release(options);
 
   log_pipe_set_persist_name((LogPipe *)d, "test_persist_name");
   cr_assert(log_pipe_init((LogPipe *)d));
@@ -353,7 +368,10 @@ Test(python_persist_name, test_python_fetcher_persist_preference)
   LogDriver *d = python_fetcher_new(empty_cfg);
   log_pipe_set_persist_name(&d->super, "test_persist_name");
   python_fetcher_set_class(d, "Fetcher");
-  python_fetcher_set_options(d, _create_custom_options_with_dummy_option());
+
+  PythonOptions *options = _create_custom_options_with_dummy_option();
+  python_fetcher_add_options(d, options);
+  python_options_release(options);
 
   cr_assert(log_pipe_init((LogPipe *)d));
 
@@ -372,7 +390,10 @@ Test(python_persist_name, test_python_source_persist_preference)
   LogDriver *d = python_sd_new(empty_cfg);
   log_pipe_set_persist_name(&d->super, "test_persist_name");
   python_sd_set_class(d, "Source");
-  python_sd_set_options(d, _create_custom_options_with_dummy_option());
+
+  PythonOptions *options = _create_custom_options_with_dummy_option();
+  python_sd_add_options(d, options);
+  python_options_release(options);
 
   cr_assert(log_pipe_init((LogPipe *)d));
 


### PR DESCRIPTION
This should fix a crash in case a Python parser is added as a part of a parser {} statement and not referenced in-line.


Program received signal SIGSEGV, Segmentation fault.
python_options_create_py_dict (self=self@entry=0x55555571b890) at /source/modules/python/python-options.c:325
325	        const PythonOption *option = (const PythonOption *) elem->data;
(gdb) up
#1  0x00007ffff70cb217 in _py_invoke_bool_method_by_name_with_options (instance=<optimized out>, method_name=method_name@entry=0x7ffff70de5bb "init", 
    options=0x55555571b890, class=0x5555556e07b0 "MyParser", module=0x5555556b9500 "p_foo") at /source/modules/python/python-helpers.c:389
389	      PyObject *py_options_dict = options ? python_options_create_py_dict(options) : NULL;
(gdb) up
#2  0x00007ffff70d1f7a in _pp_py_invoke_bool_method_by_name_with_options (method_name=0x7ffff70de5bb "init", instance=<optimized out>, self=0x5555556c4bd0)
    at /source/modules/python/python-logparser.c:102
102	  return _py_invoke_bool_method_by_name_with_options(instance, method_name, self->options, self->class, self->super.name);
(gdb) p self->options
$1 = (PythonOptions *) 0x55555571b890
(gdb) p *self->options
$2 = {options = 0x656c7069746c756d = {<error reading variable: Cannot access memory at address 0x656c7069746c756d>
(gdb) q
