### PR TITLE
systemd-journal: enable multiple systemd-journal sources

### DIFF
--- a/modules/systemd-journal/tests/test-source.c
+++ b/modules/systemd-journal/tests/test-source.c
@@ -63,9 +63,9 @@ static gboolean
 __deinit(LogPipe *s)
 {
   TestSource *self = (TestSource *)s;
-  journal_reader_options_destroy(&self->options);
   log_pipe_deinit((LogPipe *)self->reader);
   log_pipe_unref((LogPipe *)self->reader);
+  journal_reader_options_destroy(&self->options);
   return TRUE;
 }
 

--- a/modules/systemd-journal/tests/test-source.h
+++ b/modules/systemd-journal/tests/test-source.h
@@ -47,5 +47,8 @@ void test_source_add_test_case(TestSource *s, TestCase *tc);
 void test_source_run_tests(TestSource *s);
 void test_source_finish_tc(TestSource *s);
 
+void *journal_reader_test_prepare_with_namespace(const gchar *namespace, GlobalConfig *cfg);
+gboolean journal_reader_test_allocate_namespace(void *test);
+void journal_reader_test_destroy(void *test);
 
 #endif /* TEST_SOURCE_H_ */

--- a/modules/systemd-journal/tests/test_systemd_journal.c
+++ b/modules/systemd-journal/tests/test_systemd_journal.c
@@ -388,4 +388,24 @@ Test(systemd_journal, test_journal_reader)
   _deinit_cfg(persist_file);
 }
 
+#if SYSLOG_NG_HAVE_JOURNAL_NAMESPACES
+Test(systemd_journal, test_journal_reader_namespace_init_same_twice)
+{
+  const gchar *persist_file = "test_systemd_journal_namespace_init.persist";
+  _init_cfg_with_persist_file(persist_file);
+
+  void *test_1 = journal_reader_test_prepare_with_namespace("asd", cfg);
+  cr_assert(journal_reader_test_allocate_namespace(test_1), "%s", "Can't initialize first reader");
+
+  void *test_2 = journal_reader_test_prepare_with_namespace("asd", cfg);
+  cr_assert_not(journal_reader_test_allocate_namespace(test_2), "%s",
+                "Multiple readers with the same namespace initialized");
+
+  journal_reader_test_destroy(test_1);
+  journal_reader_test_destroy(test_2);
+
+  _deinit_cfg(persist_file);
+}
+#endif
+
 TestSuite(systemd_journal, .init = app_startup, .fini = app_shutdown);

--- a/news/feature-4553.md
+++ b/news/feature-4553.md
@@ -1,0 +1,3 @@
+#### Enable multiple systemd-journal() sources
+
+Using multiple systemd-journal() sources are now possible as long as each source uses a unique systemd namespace. The namespace can be configured with the namespace() option, which has a default value of "*".


### PR DESCRIPTION
<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
Resolves #3417 

This PR enables using multiple systemd-journal() sources as long as they use different namespaces.

The persist names were already configured to use the systemd-journal namespace as part of the string, so no changes were needed with creating persist names.