### PR TITLE
requirements.txt: install PyYAML 6.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ oauthlib==3.2.2
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 python-dateutil==2.8.2
-PyYAML==6.0
+PyYAML==6.0.1
 requests==2.27.1
 requests-oauthlib==1.3.1
 rsa==4.9


### PR DESCRIPTION
This fixes installing with certain versions of cython: https://github.com/yaml/pyyaml/commit/ae08bdc82b4ddfcd2b93c8aedcd1963766c3307d

```
  error: subprocess-exited-with-error                                                                                                                                                                                
                                                                                                                                                                                                                     
  × Getting requirements to build wheel did not run successfully.                                                                                                                                                    
  │ exit code: 1                                                                                                                                                                                                     
  ╰─> [54 lines of output]                                                                                                                                                                                           
      running egg_info                                                                                                                                                                                               
      writing lib/PyYAML.egg-info/PKG-INFO                                                                                                                                                                           
      writing dependency_links to lib/PyYAML.egg-info/dependency_links.txt                                                                                                                                           
      writing top-level names to lib/PyYAML.egg-info/top_level.txt                                                                                                                                                   
      Traceback (most recent call last):                                                                                                                                                                             
        File "/tmp/syslog-ng-4.2.0.167.g17c697d/build/venv/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>                                               
          main()                                                                                                                                                                                                     
        File "/tmp/syslog-ng-4.2.0.167.g17c697d/build/venv/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main                                                   
          json_out['return_val'] = hook(**hook_input['kwargs'])                                                                                                                                                      
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                      
        File "/tmp/syslog-ng-4.2.0.167.g17c697d/build/venv/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel                           
          return hook(config_settings)                                                                                                                                                                               
                 ^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                               
        File "/tmp/pip-build-env-1wm5iv0h/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 341, in get_requires_for_build_wheel                                                                  
          return self._get_build_requires(config_settings, requirements=['wheel'])                                                                                                                                   
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-1wm5iv0h/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 323, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-1wm5iv0h/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 338, in run_setup
          exec(code, locals())
        File "<string>", line 288, in <module>
        File "/tmp/pip-build-env-1wm5iv0h/overlay/lib/python3.11/site-packages/setuptools/__init__.py", line 107, in setup
          return distutils.core.setup(**attrs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-1wm5iv0h/overlay/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 185, in setup
          return run_commands(dist)
                 ^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-1wm5iv0h/overlay/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
          dist.run_commands()
        File "/tmp/pip-build-env-1wm5iv0h/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
          self.run_command(cmd)
        File "/tmp/pip-build-env-1wm5iv0h/overlay/lib/python3.11/site-packages/setuptools/dist.py", line 1234, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-1wm5iv0h/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-1wm5iv0h/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 314, in run
          self.find_sources()
        File "/tmp/pip-build-env-1wm5iv0h/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 322, in find_sources
          mm.run()
        File "/tmp/pip-build-env-1wm5iv0h/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 551, in run
          self.add_defaults()
        File "/tmp/pip-build-env-1wm5iv0h/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 589, in add_defaults
          sdist.add_defaults(self)
        File "/tmp/pip-build-env-1wm5iv0h/overlay/lib/python3.11/site-packages/setuptools/command/sdist.py", line 104, in add_defaults
          super().add_defaults()
        File "/tmp/pip-build-env-1wm5iv0h/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/sdist.py", line 251, in add_defaults
          self._add_defaults_ext()
        File "/tmp/pip-build-env-1wm5iv0h/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/sdist.py", line 336, in _add_defaults_ext
          self.filelist.extend(build_ext.get_source_files())
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "<string>", line 204, in get_source_files
        File "/tmp/pip-build-env-1wm5iv0h/overlay/lib/python3.11/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
          raise AttributeError(attr)
      AttributeError: cython_sources
      [end of output]
   
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
```