### PR TITLE
github-actions: skip debian:testing official package test

### DIFF
--- a/.github/workflows/test-apt-packages.yml
+++ b/.github/workflows/test-apt-packages.yml
@@ -25,6 +25,11 @@ jobs:
         upgrade-from:
           - "debian-official"
           - "syslog-ng-last"
+        exclude:
+          # The official syslog-ng got removed from debian:testing because of pcre:
+          # https://tracker.debian.org/news/1445295/syslog-ng-removed-from-testing/
+          - distro: "debian:testing"
+            upgrade-from: "debian-official"
       fail-fast: false
     runs-on: ubuntu-latest
     container: ${{ matrix.distro }}


### PR DESCRIPTION
The official syslog-ng got removed from debian:testing because of pcre: https://tracker.debian.org/news/1445295/syslog-ng-removed-from-testing/

Hopefully this fixes the nightly release.

GitHub Actions reference: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#excluding-matrix-configurations

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
