### PR TITLE
`network()` destination: fix TCP keepalive

### DIFF
--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -357,6 +357,9 @@ afsocket_dd_start_connect(AFSocketDestDriver *self)
       return FALSE;
     }
 
+  if (!socket_options_setup_peer_socket(self->socket_options, sock, self->dest_addr))
+    return FALSE;
+
   rc = g_connect(sock, self->dest_addr);
   if (rc == G_IO_STATUS_NORMAL)
     {

--- a/modules/afsocket/socket-options.c
+++ b/modules/afsocket/socket-options.c
@@ -135,7 +135,7 @@ socket_options_setup_socket_method(SocketOptions *self, gint fd, GSockAddr *bind
 }
 
 gboolean
-socket_options_setup_peer_socket_method(SocketOptions *self, gint fd, GSockAddr *bind_addr)
+socket_options_setup_peer_socket_method(SocketOptions *self, gint fd, GSockAddr *peer_addr)
 {
   if (self->so_keepalive && !_setup_keepalive(fd))
     return FALSE;

--- a/modules/afsocket/socket-options.h
+++ b/modules/afsocket/socket-options.h
@@ -42,7 +42,7 @@ struct _SocketOptions
   gint so_keepalive;
   gboolean so_reuseport;
   gboolean (*setup_socket)(SocketOptions *s, gint sock, GSockAddr *bind_addr, AFSocketDirection dir);
-  gboolean (*setup_peer_socket)(SocketOptions *s, gint sock, GSockAddr *bind_addr);
+  gboolean (*setup_peer_socket)(SocketOptions *s, gint sock, GSockAddr *peer_addr);
   void (*free)(gpointer s);
 };
 
@@ -58,9 +58,9 @@ socket_options_setup_socket(SocketOptions *s, gint sock, GSockAddr *bind_addr, A
 }
 
 static inline gboolean
-socket_options_setup_peer_socket(SocketOptions *s, gint sock, GSockAddr *bind_addr)
+socket_options_setup_peer_socket(SocketOptions *s, gint sock, GSockAddr *peer_addr)
 {
-  return s->setup_peer_socket(s, sock, bind_addr);
+  return s->setup_peer_socket(s, sock, peer_addr);
 }
 
 static inline void

--- a/news/bugfix-4559.md
+++ b/news/bugfix-4559.md
@@ -1,0 +1,3 @@
+`network()`,`syslog()`,`tcp()` destination: fix TCP keepalive
+
+`tcp-keepalive-*()` options were broken on the destination side since v3.34.1.


### PR DESCRIPTION
`tcp-keepalive-*()` options were broken on the destination side since v3.34.1.

Fixes #4546