### PR TITLE
scl: add opensearch 

### DIFF
--- a/news/feature-4560.md
+++ b/news/feature-4560.md
@@ -1,0 +1,4 @@
+`opensearch`: Added a new destination.
+
+It is similar to `elasticsearch-http()`, with the difference that it does not have the `type()`
+option, which is deprecated and advised not to use.

--- a/scl/CMakeLists.txt
+++ b/scl/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SCL_DIRS
     mbox
     netskope
     nodejs
+    opensearch
     osquery
     pacct
     paloalto

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -25,6 +25,7 @@ SCL_SUBDIRS	= \
 	mbox		\
 	netskope	\
 	nodejs		\
+	opensearch	\
 	osquery	\
 	pacct		\
 	paloalto 	\

--- a/scl/opensearch/opensearch.conf
+++ b/scl/opensearch/opensearch.conf
@@ -1,0 +1,52 @@
+#############################################################################
+# Copyright (c) 2019 Balabit
+# Copyright (c) 2023 One Identity LLC.
+# Copyright (c) 2023 Attila Szakacs
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+@requires json-plugin
+
+block destination opensearch(
+  url()
+  index()
+  custom_id("")
+  workers(4)
+  batch_lines(100)
+  timeout(10)
+  template("$(format-json --scope rfc5424 --exclude DATE --key ISODATE @timestamp=${ISODATE})")
+  headers("Content-Type: application/x-ndjson")
+  body_suffix("\n")
+  ...)
+{
+
+@requires http "The opensearch() driver depends on the syslog-ng http module, please install the syslog-ng-mod-http (Debian & derivatives) or the syslog-ng-http (RHEL & co) package"
+
+    http(
+        url(`url`)
+        headers(`headers`)
+        workers(`workers`)
+        batch_lines(`batch_lines`)
+        timeout(`timeout`)
+        body_suffix(`body_suffix`)
+        body("$(format-json --scope none --omit-empty-values index._index=`index` index._id=`custom_id`)\n`template`")
+        `__VARARGS__`
+    );
+};


### PR DESCRIPTION
It is similar to `elasticsearch-http()`, with the difference that it does not have the `type()` option, which is deprecated and advised not to use.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>