### PR TITLE
mainloop: don't reload plugin candidates at reload

### DIFF
--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -347,6 +347,7 @@ main_loop_reload_config_prepare(MainLoop *self, GError **error)
 
   self->old_config = self->current_configuration;
   self->new_config = cfg_new(0);
+  plugin_context_copy_candidates(&self->new_config->plugin_context, &self->old_config->plugin_context);
   if (!cfg_read_config(self->new_config, resolved_configurable_paths.cfgfilename, NULL))
     {
       cfg_free(self->new_config);

--- a/lib/plugin.c
+++ b/lib/plugin.c
@@ -553,6 +553,7 @@ plugin_context_copy_candidates(PluginContext *context, PluginContext *from)
 {
   GList *l;
 
+  _free_candidate_plugins(context);
   for (l = from->candidate_plugins; l; l = l->next)
     {
       PluginCandidate *pc = (PluginCandidate *) l->data;


### PR DESCRIPTION
There was an effort made in plugin.c to avoid rescanning plugins multiple times (for instance at SIGHUP), but this was broken sometime along the way.

This patch restores that behaviour so that even if plugins are removed from the disk we would happily continue at SIGHUP. This also makes reloads cheaper (as we won't have to load potentially heavyweight shared objects from disk).
