### PR TITLE
otel: add syslog-ng <-> syslog-ng communication via OTLP

### DIFF
--- a/lib/rewrite/rewrite-set-pri.c
+++ b/lib/rewrite/rewrite-set-pri.c
@@ -36,15 +36,15 @@ struct _LogRewriteSetPri
   LogTemplate *pri;
 };
 
-static gint
-_convert_pri(GString *pri_text)
+gint
+log_rewrite_set_pri_convert_pri(const gchar *pri_text)
 {
   char *endptr;
-  long int pri = strtol(pri_text->str, &endptr, 10);
+  long int pri = strtol(pri_text, &endptr, 10);
   if (!endptr)
     return -1;
 
-  if (endptr[0] != '\0' || pri_text->str == endptr)
+  if (endptr[0] != '\0' || pri_text == endptr)
     return -1;
 
   /* the maximum facility code is 127 in set-facility() */
@@ -64,7 +64,7 @@ log_rewrite_set_pri_process(LogRewrite *s, LogMessage **pmsg, const LogPathOptio
 
   log_template_format(self->pri, *pmsg, &DEFAULT_TEMPLATE_EVAL_OPTIONS, result);
 
-  const gint pri = _convert_pri(result);
+  const gint pri = log_rewrite_set_pri_convert_pri(result->str);
   if (pri < 0)
     {
       msg_debug("Warning: invalid value passed to set-pri()",

--- a/lib/rewrite/rewrite-set-pri.h
+++ b/lib/rewrite/rewrite-set-pri.h
@@ -27,5 +27,6 @@
 #include "rewrite-expr.h"
 
 LogRewrite *log_rewrite_set_pri_new(LogTemplate *severity, GlobalConfig *cfg);
+gint log_rewrite_set_pri_convert_pri(const gchar *pri_text);
 
 #endif

--- a/modules/grpc/otel/CMakeLists.txt
+++ b/modules/grpc/otel/CMakeLists.txt
@@ -16,7 +16,12 @@ set(OTEL_CPP_SOURCES
   otel-dest.cpp
   otel-dest.h
   otel-dest-worker.hpp
-  otel-dest-worker.cpp)
+  otel-dest-worker.cpp
+  syslog-ng-otlp-dest.hpp
+  syslog-ng-otlp-dest.cpp
+  syslog-ng-otlp-dest.h
+  syslog-ng-otlp-dest-worker.hpp
+  syslog-ng-otlp-dest-worker.cpp)
 
 set(OTEL_SOURCES
   otel-plugin.c

--- a/modules/grpc/otel/Makefile.am
+++ b/modules/grpc/otel/Makefile.am
@@ -20,7 +20,12 @@ modules_grpc_otel_libotel_cpp_la_SOURCES = \
   modules/grpc/otel/otel-dest.hpp \
   modules/grpc/otel/otel-dest.cpp \
   modules/grpc/otel/otel-dest-worker.hpp \
-  modules/grpc/otel/otel-dest-worker.cpp
+  modules/grpc/otel/otel-dest-worker.cpp \
+  modules/grpc/otel/syslog-ng-otlp-dest.h \
+  modules/grpc/otel/syslog-ng-otlp-dest.hpp \
+  modules/grpc/otel/syslog-ng-otlp-dest.cpp \
+  modules/grpc/otel/syslog-ng-otlp-dest-worker.hpp \
+  modules/grpc/otel/syslog-ng-otlp-dest-worker.cpp
 
 modules_grpc_otel_libotel_cpp_la_CXXFLAGS = \
   $(AM_CXXFLAGS) \

--- a/modules/grpc/otel/otel-dest-worker.cpp
+++ b/modules/grpc/otel/otel-dest-worker.cpp
@@ -440,22 +440,27 @@ _free(LogThreadedDestWorker *s)
   log_threaded_dest_worker_free_method(s);
 }
 
+void
+otel_dw_init_super(LogThreadedDestWorker *s, LogThreadedDestDriver *o, gint worker_index)
+{
+  log_threaded_dest_worker_init_instance(s, o, worker_index);
+
+  s->init = _init;
+  s->deinit = _deinit;
+  s->connect = _connect;
+  s->disconnect = _disconnect;
+  s->insert = _insert;
+  s->flush = _flush;
+  s->free_fn = _free;
+}
+
 LogThreadedDestWorker *
 DestWorker::construct(LogThreadedDestDriver *o, gint worker_index)
 {
   OtelDestWorker *self = g_new0(OtelDestWorker, 1);
 
-  log_threaded_dest_worker_init_instance(&self->super, o, worker_index);
-
+  otel_dw_init_super(&self->super, o, worker_index);
   self->cpp = new DestWorker(self);
-
-  self->super.init = _init;
-  self->super.deinit = _deinit;
-  self->super.connect = _connect;
-  self->super.disconnect = _disconnect;
-  self->super.insert = _insert;
-  self->super.flush = _flush;
-  self->super.free_fn = _free;
 
   return &self->super;
 }

--- a/modules/grpc/otel/otel-dest-worker.cpp
+++ b/modules/grpc/otel/otel-dest-worker.cpp
@@ -441,7 +441,7 @@ _free(LogThreadedDestWorker *s)
 }
 
 LogThreadedDestWorker *
-otel_dest_worker_new(LogThreadedDestDriver *o, gint worker_index)
+DestWorker::construct(LogThreadedDestDriver *o, gint worker_index)
 {
   OtelDestWorker *self = g_new0(OtelDestWorker, 1);
 

--- a/modules/grpc/otel/otel-dest-worker.hpp
+++ b/modules/grpc/otel/otel-dest-worker.hpp
@@ -123,4 +123,6 @@ struct OtelDestWorker_
   syslogng::grpc::otel::DestWorker *cpp;
 };
 
+void otel_dw_init_super(LogThreadedDestWorker *s, LogThreadedDestDriver *o, gint worker_index);
+
 #endif

--- a/modules/grpc/otel/otel-dest-worker.hpp
+++ b/modules/grpc/otel/otel-dest-worker.hpp
@@ -67,7 +67,7 @@ public:
   LogThreadedResult insert(LogMessage *msg);
   LogThreadedResult flush(LogThreadedFlushMode mode);
 
-private:
+protected:
   void clear_current_msg_metadata();
   void get_metadata_for_current_msg(LogMessage *msg);
 
@@ -84,7 +84,7 @@ private:
   LogThreadedResult flush_metrics();
   LogThreadedResult flush_spans();
 
-private:
+protected:
   OtelDestWorker *super;
   const DestDriver &owner;
 

--- a/modules/grpc/otel/otel-dest-worker.hpp
+++ b/modules/grpc/otel/otel-dest-worker.hpp
@@ -59,22 +59,23 @@ class DestWorker
 {
 public:
   DestWorker(OtelDestWorker *s);
+  virtual ~DestWorker();
   static LogThreadedDestWorker *construct(LogThreadedDestDriver *o, gint worker_index);
 
-  bool init();
-  void deinit();
-  bool connect();
-  void disconnect();
-  LogThreadedResult insert(LogMessage *msg);
-  LogThreadedResult flush(LogThreadedFlushMode mode);
+  virtual bool init();
+  virtual void deinit();
+  virtual bool connect();
+  virtual void disconnect();
+  virtual LogThreadedResult insert(LogMessage *msg);
+  virtual LogThreadedResult flush(LogThreadedFlushMode mode);
 
 protected:
   void clear_current_msg_metadata();
   void get_metadata_for_current_msg(LogMessage *msg);
 
-  ScopeLogs *lookup_scope_logs(LogMessage *msg);
-  ScopeMetrics *lookup_scope_metrics(LogMessage *msg);
-  ScopeSpans *lookup_scope_spans(LogMessage *msg);
+  virtual ScopeLogs *lookup_scope_logs(LogMessage *msg);
+  virtual ScopeMetrics *lookup_scope_metrics(LogMessage *msg);
+  virtual ScopeSpans *lookup_scope_spans(LogMessage *msg);
 
   bool insert_log_record_from_log_msg(LogMessage *msg);
   void insert_fallback_log_record_from_log_msg(LogMessage *msg);

--- a/modules/grpc/otel/otel-dest-worker.hpp
+++ b/modules/grpc/otel/otel-dest-worker.hpp
@@ -59,6 +59,7 @@ class DestWorker
 {
 public:
   DestWorker(OtelDestWorker *s);
+  static LogThreadedDestWorker *construct(LogThreadedDestDriver *o, gint worker_index);
 
   bool init();
   void deinit();
@@ -120,7 +121,5 @@ struct OtelDestWorker_
   LogThreadedDestWorker super;
   syslogng::grpc::otel::DestWorker *cpp;
 };
-
-LogThreadedDestWorker *otel_dest_worker_new(LogThreadedDestDriver *o, gint worker_index);
 
 #endif

--- a/modules/grpc/otel/otel-dest.cpp
+++ b/modules/grpc/otel/otel-dest.cpp
@@ -56,7 +56,8 @@ DestDriver::generate_persist_name()
     g_snprintf(persist_name, sizeof(persist_name), "opentelemetry.%s",
                super->super.super.super.super.persist_name);
   else
-    g_snprintf(persist_name, sizeof(persist_name), "opentelemetry");
+    g_snprintf(persist_name, sizeof(persist_name), "opentelemetry(%s)",
+               url.c_str());
 
   return persist_name;
 }

--- a/modules/grpc/otel/otel-dest.cpp
+++ b/modules/grpc/otel/otel-dest.cpp
@@ -71,6 +71,12 @@ DestDriver::format_stats_key(StatsClusterKeyBuilder *kb)
   return NULL;
 }
 
+LogThreadedDestWorker *
+DestDriver::construct_worker(int worker_index)
+{
+  return DestWorker::construct(&super->super, worker_index);
+}
+
 bool
 DestDriver::init()
 {
@@ -142,7 +148,7 @@ _deinit(LogPipe *s)
 static LogThreadedDestWorker *
 _construct_worker(LogThreadedDestDriver *s, gint worker_index)
 {
-  return otel_dest_worker_new(s, worker_index);
+  return get_DestDriver(s)->construct_worker(worker_index);
 }
 
 static void

--- a/modules/grpc/otel/otel-dest.hpp
+++ b/modules/grpc/otel/otel-dest.hpp
@@ -49,9 +49,9 @@ public:
   bool deinit();
   const char *format_stats_key(StatsClusterKeyBuilder *kb);
   const char *generate_persist_name();
+  LogThreadedDestWorker *construct_worker(int worker_index);
 
   GrpcClientCredentialsBuilderW *get_credentials_builder_wrapper();
-
 public:
   syslogng::grpc::ClientCredentialsBuilder credentials_builder;
 

--- a/modules/grpc/otel/otel-dest.hpp
+++ b/modules/grpc/otel/otel-dest.hpp
@@ -55,7 +55,7 @@ public:
 public:
   syslogng::grpc::ClientCredentialsBuilder credentials_builder;
 
-private:
+protected:
   friend class DestWorker;
   OtelDestDriver *super;
   std::string url;

--- a/modules/grpc/otel/otel-dest.hpp
+++ b/modules/grpc/otel/otel-dest.hpp
@@ -41,15 +41,16 @@ class DestDriver
 {
 public:
   DestDriver(OtelDestDriver *s);
+  virtual ~DestDriver();
 
   void set_url(const char *url);
   const std::string &get_url() const;
 
-  bool init();
-  bool deinit();
-  const char *format_stats_key(StatsClusterKeyBuilder *kb);
-  const char *generate_persist_name();
-  LogThreadedDestWorker *construct_worker(int worker_index);
+  virtual bool init();
+  virtual bool deinit();
+  virtual const char *format_stats_key(StatsClusterKeyBuilder *kb);
+  virtual const char *generate_persist_name();
+  virtual LogThreadedDestWorker *construct_worker(int worker_index);
 
   GrpcClientCredentialsBuilderW *get_credentials_builder_wrapper();
 public:

--- a/modules/grpc/otel/otel-dest.hpp
+++ b/modules/grpc/otel/otel-dest.hpp
@@ -73,4 +73,6 @@ struct OtelDestDriver_
   syslogng::grpc::otel::DestDriver *cpp;
 };
 
+void otel_dd_init_super(LogThreadedDestDriver *s, GlobalConfig *cfg);
+
 #endif

--- a/modules/grpc/otel/otel-grammar.ym
+++ b/modules/grpc/otel/otel-grammar.ym
@@ -71,7 +71,7 @@ GrpcClientCredentialsBuilderW *last_grpc_client_credentials_builder;
 
 %type <ptr> source_otel
 %type <ptr> parser_otel
-%type <num> source_otel_auth_tls_peer_verify
+%type <num> grpc_server_credentials_builder_tls_peer_verify
 %type <ptr> destination_otel
 
 %%
@@ -97,48 +97,8 @@ source_otel_options
 
 source_otel_option
   : KW_PORT '(' positive_integer ')' { otel_sd_set_port(last_driver, $3); }
-  | KW_AUTH { last_grpc_server_credentials_builder = otel_sd_get_credentials_builder(last_driver); } '(' source_otel_auth_option ')'
+  | KW_AUTH { last_grpc_server_credentials_builder = otel_sd_get_credentials_builder(last_driver); } '(' grpc_server_credentials_builder_option ')'
   | threaded_source_driver_option
-  ;
-
-source_otel_auth_option
-  : KW_INSECURE { grpc_server_credentials_builder_set_mode(last_grpc_server_credentials_builder, GSAM_INSECURE); } '(' ')'
-  | KW_TLS { grpc_server_credentials_builder_set_mode(last_grpc_server_credentials_builder, GSAM_TLS); } '(' source_otel_auth_tls_options ')'
-  | KW_ALTS { grpc_server_credentials_builder_set_mode(last_grpc_server_credentials_builder, GSAM_ALTS); } '(' ')'
-  ;
-
-source_otel_auth_tls_options
-  : source_otel_auth_tls_option source_otel_auth_tls_options
-  |
-  ;
-
-source_otel_auth_tls_option
-  : KW_KEY_FILE '(' string ')'
-      {
-        CHECK_ERROR(grpc_server_credentials_builder_set_tls_key_path(last_grpc_server_credentials_builder, $3), @1, "Failed to set key-file()");
-        free($3);
-      }
-  | KW_CERT_FILE '(' string ')'
-      {
-        CHECK_ERROR(grpc_server_credentials_builder_set_tls_cert_path(last_grpc_server_credentials_builder, $3), @1, "Failed to set cert-file()");
-        free($3);
-      }
-  | KW_CA_FILE '(' string ')'
-      {
-        CHECK_ERROR(grpc_server_credentials_builder_set_tls_ca_path(last_grpc_server_credentials_builder, $3), @1, "Failed to set ca-file()");
-        free($3);
-      }
-  | KW_PEER_VERIFY '(' source_otel_auth_tls_peer_verify ')'
-      {
-        grpc_server_credentials_builder_set_tls_peer_verify(last_grpc_server_credentials_builder, $3);
-      }
-  ;
-
-source_otel_auth_tls_peer_verify
-  : KW_OPTIONAL_UNTRUSTED { $$ = GSTPV_OPTIONAL_UNTRUSTED; }
-  | KW_OPTIONAL_TRUSTED { $$ = GSTPV_OPTIONAL_TRUSTED; }
-  | KW_REQUIRED_UNTRUSTED { $$ = GSTPV_REQUIRED_UNTRUSTED; }
-  | KW_REQUIRED_TRUSTED { $$ = GSTPV_REQUIRED_TRUSTED; }
   ;
 
 parser_otel
@@ -173,25 +133,71 @@ destination_otel_options
 
 destination_otel_option
   : KW_URL '(' string ')' { otel_dd_set_url(last_driver, $3); free($3); }
-  | KW_AUTH { last_grpc_client_credentials_builder = otel_dd_get_credentials_builder(last_driver); } '(' destination_otel_auth_option ')'
+  | KW_AUTH { last_grpc_client_credentials_builder = otel_dd_get_credentials_builder(last_driver); } '(' grpc_client_credentials_option ')'
   | threaded_dest_driver_general_option
   | threaded_dest_driver_batch_option
   | threaded_dest_driver_workers_option
   ;
 
-destination_otel_auth_option
-  : KW_INSECURE { grpc_client_credentials_builder_set_mode(last_grpc_client_credentials_builder, GCAM_INSECURE); } '(' ')'
-  | KW_TLS { grpc_client_credentials_builder_set_mode(last_grpc_client_credentials_builder, GCAM_TLS); } '(' destination_otel_auth_tls_options ')'
-  | KW_ALTS { grpc_client_credentials_builder_set_mode(last_grpc_client_credentials_builder, GCAM_ALTS); } '(' destination_otel_auth_alts_options ')'
-  | KW_ADC { grpc_client_credentials_builder_set_mode(last_grpc_client_credentials_builder, GCAM_ADC); } '(' ')'
+/*
+ * gRPC Credentials Builders
+ *
+ * TODO: These should be in a separate file, which can be included to other gRPC based drivers' grammar.
+ */
+
+grpc_server_credentials_builder_option
+  : KW_INSECURE { grpc_server_credentials_builder_set_mode(last_grpc_server_credentials_builder, GSAM_INSECURE); } '(' ')'
+  | KW_TLS { grpc_server_credentials_builder_set_mode(last_grpc_server_credentials_builder, GSAM_TLS); } '(' grpc_server_credentials_builder_tls_options ')'
+  | KW_ALTS { grpc_server_credentials_builder_set_mode(last_grpc_server_credentials_builder, GSAM_ALTS); } '(' ')'
   ;
 
-destination_otel_auth_tls_options
-  : destination_otel_auth_tls_option destination_otel_auth_tls_options
+grpc_server_credentials_builder_tls_options
+  : grpc_server_credentials_builder_tls_option grpc_server_credentials_builder_tls_options
   |
   ;
 
-destination_otel_auth_tls_option
+grpc_server_credentials_builder_tls_option
+  : KW_KEY_FILE '(' string ')'
+      {
+        CHECK_ERROR(grpc_server_credentials_builder_set_tls_key_path(last_grpc_server_credentials_builder, $3), @1, "Failed to set key-file()");
+        free($3);
+      }
+  | KW_CERT_FILE '(' string ')'
+      {
+        CHECK_ERROR(grpc_server_credentials_builder_set_tls_cert_path(last_grpc_server_credentials_builder, $3), @1, "Failed to set cert-file()");
+        free($3);
+      }
+  | KW_CA_FILE '(' string ')'
+      {
+        CHECK_ERROR(grpc_server_credentials_builder_set_tls_ca_path(last_grpc_server_credentials_builder, $3), @1, "Failed to set ca-file()");
+        free($3);
+      }
+  | KW_PEER_VERIFY '(' grpc_server_credentials_builder_tls_peer_verify ')'
+      {
+        grpc_server_credentials_builder_set_tls_peer_verify(last_grpc_server_credentials_builder, $3);
+      }
+  ;
+
+grpc_server_credentials_builder_tls_peer_verify
+  : KW_OPTIONAL_UNTRUSTED { $$ = GSTPV_OPTIONAL_UNTRUSTED; }
+  | KW_OPTIONAL_TRUSTED { $$ = GSTPV_OPTIONAL_TRUSTED; }
+  | KW_REQUIRED_UNTRUSTED { $$ = GSTPV_REQUIRED_UNTRUSTED; }
+  | KW_REQUIRED_TRUSTED { $$ = GSTPV_REQUIRED_TRUSTED; }
+  ;
+
+grpc_client_credentials_option
+  : KW_INSECURE { grpc_client_credentials_builder_set_mode(last_grpc_client_credentials_builder, GCAM_INSECURE); } '(' ')'
+  | KW_TLS { grpc_client_credentials_builder_set_mode(last_grpc_client_credentials_builder, GCAM_TLS); } '(' grpc_client_credentials_builder_tls_options ')'
+  | KW_ALTS { grpc_client_credentials_builder_set_mode(last_grpc_client_credentials_builder, GCAM_ALTS); } '(' grpc_client_credentials_builder_alts_options ')'
+  | KW_ADC { grpc_client_credentials_builder_set_mode(last_grpc_client_credentials_builder, GCAM_ADC); } '(' ')'
+  ;
+
+grpc_client_credentials_builder_tls_options
+  : grpc_client_credentials_builder_tls_option grpc_client_credentials_builder_tls_options
+  |
+  ;
+
+grpc_client_credentials_builder_tls_option
   : KW_KEY_FILE '(' string ')'
       {
         CHECK_ERROR(grpc_client_credentials_builder_set_tls_key_path(last_grpc_client_credentials_builder, $3), @1, "Failed to set key-file()");
@@ -209,22 +215,22 @@ destination_otel_auth_tls_option
       }
   ;
 
-destination_otel_auth_alts_options
-  : destination_otel_auth_alts_option destination_otel_auth_alts_options
+grpc_client_credentials_builder_alts_options
+  : grpc_client_credentials_builder_alts_option grpc_client_credentials_builder_alts_options
   |
   ;
 
-destination_otel_auth_alts_option
-  : KW_TARGET_SERVICE_ACCOUNTS '(' destination_otel_auth_alts_target_service_accounts ')'
+grpc_client_credentials_builder_alts_option
+  : KW_TARGET_SERVICE_ACCOUNTS '(' grpc_client_credentials_builder_alts_target_service_accounts ')'
   ;
 
-destination_otel_auth_alts_target_service_accounts
+grpc_client_credentials_builder_alts_target_service_accounts
   : string
       {
         grpc_client_credentials_builder_add_alts_target_service_account(last_grpc_client_credentials_builder, $1);
         free($1);
       }
-    destination_otel_auth_alts_target_service_accounts
+    grpc_client_credentials_builder_alts_target_service_accounts
   |
   ;
 

--- a/modules/grpc/otel/otel-grammar.ym
+++ b/modules/grpc/otel/otel-grammar.ym
@@ -33,6 +33,7 @@
 #include "otel-source.h"
 #include "otel-protobuf-parser.h"
 #include "otel-dest.h"
+#include "syslog-ng-otlp-dest.h"
 
 GrpcServerCredentialsBuilderW *last_grpc_server_credentials_builder;
 GrpcClientCredentialsBuilderW *last_grpc_client_credentials_builder;
@@ -68,11 +69,13 @@ GrpcClientCredentialsBuilderW *last_grpc_client_credentials_builder;
 %token KW_URL
 %token KW_TARGET_SERVICE_ACCOUNTS
 %token KW_ADC
+%token KW_SYSLOG_NG_OTLP
 
 %type <ptr> source_otel
 %type <ptr> parser_otel
 %type <num> grpc_server_credentials_builder_tls_peer_verify
 %type <ptr> destination_otel
+%type <ptr> destination_syslog_ng_otlp
 
 %%
 
@@ -80,6 +83,7 @@ start
   : LL_CONTEXT_SOURCE source_otel { YYACCEPT; }
   | LL_CONTEXT_PARSER parser_otel { YYACCEPT; }
   | LL_CONTEXT_DESTINATION destination_otel { YYACCEPT; }
+  | LL_CONTEXT_DESTINATION destination_syslog_ng_otlp { YYACCEPT; }
   ;
 
 source_otel
@@ -137,6 +141,23 @@ destination_otel_option
   | threaded_dest_driver_general_option
   | threaded_dest_driver_batch_option
   | threaded_dest_driver_workers_option
+  ;
+
+destination_syslog_ng_otlp
+  : KW_SYSLOG_NG_OTLP
+    {
+      last_driver = *instance = syslog_ng_otlp_dd_new(configuration);
+    }
+    '(' _inner_dest_context_push destination_syslog_ng_otlp_options _inner_dest_context_pop ')' { $$ = last_driver; }
+  ;
+
+destination_syslog_ng_otlp_options
+  : destination_syslog_ng_otlp_option destination_syslog_ng_otlp_options
+  |
+  ;
+
+destination_syslog_ng_otlp_option
+  : destination_otel_option
   ;
 
 /*

--- a/modules/grpc/otel/otel-grammar.ym
+++ b/modules/grpc/otel/otel-grammar.ym
@@ -86,8 +86,13 @@ start
   | LL_CONTEXT_DESTINATION destination_syslog_ng_otlp { YYACCEPT; }
   ;
 
-source_otel
+kw_opentelemetry_or_syslog_ng_otlp
   : KW_OPENTELEMETRY
+  | KW_SYSLOG_NG_OTLP
+  ;
+
+source_otel
+  : kw_opentelemetry_or_syslog_ng_otlp
     {
       last_driver = *instance = otel_sd_new(configuration);
     }

--- a/modules/grpc/otel/otel-parser.c
+++ b/modules/grpc/otel/otel-parser.c
@@ -47,6 +47,7 @@ static CfgLexerKeyword otel_keywords[] =
   { "url",                       KW_URL },
   { "target_service_accounts",   KW_TARGET_SERVICE_ACCOUNTS },
   { "adc",                       KW_ADC },
+  { "syslog_ng_otlp",            KW_SYSLOG_NG_OTLP },
   { NULL }
 };
 

--- a/modules/grpc/otel/otel-plugin.c
+++ b/modules/grpc/otel/otel-plugin.c
@@ -44,6 +44,11 @@ static Plugin otel_plugins[] =
     .name = "opentelemetry",
     .parser = &otel_parser,
   },
+  {
+    .type = LL_CONTEXT_DESTINATION,
+    .name = "syslog_ng_otlp",
+    .parser = &otel_parser,
+  },
 };
 
 gboolean

--- a/modules/grpc/otel/otel-plugin.c
+++ b/modules/grpc/otel/otel-plugin.c
@@ -49,6 +49,11 @@ static Plugin otel_plugins[] =
     .name = "syslog_ng_otlp",
     .parser = &otel_parser,
   },
+  {
+    .type = LL_CONTEXT_SOURCE,
+    .name = "syslog_ng_otlp",
+    .parser = &otel_parser,
+  },
 };
 
 gboolean

--- a/modules/grpc/otel/otel-protobuf-formatter.cpp
+++ b/modules/grpc/otel/otel-protobuf-formatter.cpp
@@ -304,7 +304,7 @@ ProtobufFormatter::get_and_set_repeated_KeyValues(LogMessage *msg, const char *p
 
   LogTemplateOptions template_options;
   log_template_options_defaults(&template_options);
-  LogTemplateEvalOptions options = {&template_options, LTZ_LOCAL, 11, NULL, LM_VT_STRING};
+  LogTemplateEvalOptions options = {&template_options, LTZ_LOCAL, -1, NULL, LM_VT_STRING};
 
   gpointer user_data[2];
   user_data[0] = key_values;

--- a/modules/grpc/otel/otel-protobuf-formatter.hpp
+++ b/modules/grpc/otel/otel-protobuf-formatter.hpp
@@ -25,6 +25,7 @@
 
 #include "compat/cpp-start.h"
 #include "logmsg/logmsg.h"
+#include "value-pairs/value-pairs.h"
 #include "compat/cpp-end.h"
 
 #include "opentelemetry/proto/logs/v1/logs.pb.h"
@@ -68,11 +69,15 @@ class ProtobufFormatter
 {
 public:
   ProtobufFormatter(GlobalConfig *cfg);
+  ~ProtobufFormatter();
 
+  static void get_metadata_for_syslog_ng(Resource &resource, std::string &resource_schema_url,
+                                         InstrumentationScope &scope, std::string &scope_schema_url);
   bool get_metadata(LogMessage *msg, Resource &resource, std::string &resource_schema_url,
                     InstrumentationScope &scope, std::string &scope_schema_url);
   bool format(LogMessage *msg, LogRecord &log_record);
   void format_fallback(LogMessage *msg, LogRecord &log_record);
+  void format_syslog_ng(LogMessage *msg, LogRecord &log_record);
   bool format(LogMessage *msg, Metric &metric);
   bool format(LogMessage *msg, Span &span);
 
@@ -95,8 +100,18 @@ private:
   void add_summary_data_points(LogMessage *msg, const char *prefix, RepeatedPtrField<SummaryDataPoint> *data_points);
   void set_metric_summary_values(LogMessage *msg, Summary *summary);
 
+  /* syslog-ng */
+  void set_syslog_ng_nv_pairs(LogMessage *msg, LogRecord &log_record);
+  void set_syslog_ng_macros(LogMessage *msg, LogRecord &log_record);
+
 private:
   GlobalConfig *cfg;
+  struct
+  {
+    ValuePairs *vp;
+    LogTemplateOptions template_options;
+    LogTemplateEvalOptions template_eval_options;
+  } syslog_ng;
 };
 
 }

--- a/modules/grpc/otel/otel-protobuf-parser.cpp
+++ b/modules/grpc/otel/otel-protobuf-parser.cpp
@@ -1264,6 +1264,12 @@ syslogng::grpc::otel::ProtobufParser::process(LogMessage *msg)
   LogMessageValueType log_msg_type;
   const gchar *type = log_msg_get_value_by_name_with_type(msg, ".otel_raw.type", &len, &log_msg_type);
 
+  if (log_msg_type == LM_VT_NULL)
+    {
+      /* Not an opentelemetry() message or it is a syslog-ng-otlp() message already parsed in the source */
+      return true;
+    }
+
   if (log_msg_type != LM_VT_STRING)
     {
       msg_error("OpenTelemetry: unexpected .otel_raw.type LogMessage type",

--- a/modules/grpc/otel/otel-protobuf-parser.cpp
+++ b/modules/grpc/otel/otel-protobuf-parser.cpp
@@ -1247,9 +1247,9 @@ syslogng::grpc::otel::ProtobufParser::store_syslog_ng(LogMessage *msg, const Log
 
 bool
 syslogng::grpc::otel::ProtobufParser::is_syslog_ng_log_record(const Resource &resource,
-                                                              const std::string &resource_schema_url,
-                                                              const InstrumentationScope &scope,
-                                                              const std::string &scope_schema_url)
+    const std::string &resource_schema_url,
+    const InstrumentationScope &scope,
+    const std::string &scope_schema_url)
 {
   return scope.name().compare("@syslog-ng") == 0;
 }

--- a/modules/grpc/otel/otel-protobuf-parser.hpp
+++ b/modules/grpc/otel/otel-protobuf-parser.hpp
@@ -43,6 +43,7 @@ namespace otel {
 
 using opentelemetry::proto::resource::v1::Resource;
 using opentelemetry::proto::common::v1::InstrumentationScope;
+using opentelemetry::proto::common::v1::KeyValueList;
 using opentelemetry::proto::logs::v1::LogRecord;
 using opentelemetry::proto::metrics::v1::Metric;
 using opentelemetry::proto::trace::v1::Span;
@@ -58,6 +59,15 @@ public:
   static void store_raw(LogMessage *msg, const LogRecord &log_record);
   static void store_raw(LogMessage *msg, const Metric &metric);
   static void store_raw(LogMessage *msg, const Span &span);
+  static void store_syslog_ng(LogMessage *msg, const LogRecord &log_record);
+
+  static bool is_syslog_ng_log_record(const Resource &resource, const std::string &resource_schema_url,
+                                      const InstrumentationScope &scope, const std::string &scope_schema_url);
+
+private:
+  static void set_syslog_ng_nv_pairs(LogMessage *msg, const KeyValueList &types);
+  static void set_syslog_ng_macros(LogMessage *msg, const KeyValueList &macros);
+  static void parse_syslog_ng_tags(LogMessage *msg, const std::string &tags_as_str);
 };
 
 }

--- a/modules/grpc/otel/otel-source-services.hpp
+++ b/modules/grpc/otel/otel-source-services.hpp
@@ -155,9 +155,17 @@ syslogng::grpc::otel::LogsServiceCall::Proceed(bool ok)
           for (const LogRecord &log_record : scope_logs.log_records())
             {
               LogMessage *msg = log_msg_new_empty();
-              ProtobufParser::store_raw_metadata(msg, ctx.peer(), resource, resource_logs_schema_url, scope,
-                                                 scope_logs_schema_url);
-              ProtobufParser::store_raw(msg, log_record);
+              if (ProtobufParser::is_syslog_ng_log_record(resource, resource_logs_schema_url, scope,
+                                                          scope_logs_schema_url))
+                {
+                  ProtobufParser::store_syslog_ng(msg, log_record);
+                }
+              else
+                {
+                  ProtobufParser::store_raw_metadata(msg, ctx.peer(), resource, resource_logs_schema_url, scope,
+                                                     scope_logs_schema_url);
+                  ProtobufParser::store_raw(msg, log_record);
+                }
               if (!driver.post(msg))
                 {
                   response_status = ::grpc::Status(::grpc::StatusCode::UNAVAILABLE, "Server is unavailable");

--- a/modules/grpc/otel/otel-source.hpp
+++ b/modules/grpc/otel/otel-source.hpp
@@ -46,6 +46,7 @@ public:
   void run();
   void request_exit();
   void format_stats_key(StatsClusterKeyBuilder *kb);
+  const char *generate_persist_name();
   gboolean init();
   gboolean deinit();
 

--- a/modules/grpc/otel/syslog-ng-otlp-dest-worker.cpp
+++ b/modules/grpc/otel/syslog-ng-otlp-dest-worker.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 Attila Szakacs
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "syslog-ng-otlp-dest-worker.hpp"
+
+using namespace syslogng::grpc::otel;
+using namespace opentelemetry::proto::logs::v1;
+
+LogThreadedDestWorker *
+SyslogNgDestWorker::construct(LogThreadedDestDriver *o, gint worker_index)
+{
+  SyslogNgOtlpDestWorker *self = g_new0(SyslogNgOtlpDestWorker, 1);
+
+  otel_dw_init_super(&self->super, o, worker_index);
+  self->cpp = new SyslogNgDestWorker(self);
+
+  return &self->super;
+}
+
+ScopeLogs *
+SyslogNgDestWorker::lookup_scope_logs(LogMessage *msg)
+{
+  if (logs_service_request.resource_logs_size() > 0)
+    return logs_service_request.mutable_resource_logs(0)->mutable_scope_logs(0);
+
+  clear_current_msg_metadata();
+  formatter.get_metadata_for_syslog_ng(current_msg_metadata.resource, current_msg_metadata.resource_schema_url,
+                                       current_msg_metadata.scope, current_msg_metadata.scope_schema_url);
+
+  ResourceLogs *resource_logs = logs_service_request.add_resource_logs();
+  resource_logs->mutable_resource()->CopyFrom(current_msg_metadata.resource);
+  resource_logs->set_schema_url(current_msg_metadata.resource_schema_url);
+
+  ScopeLogs *scope_logs = resource_logs->add_scope_logs();
+  scope_logs->mutable_scope()->CopyFrom(current_msg_metadata.scope);
+  scope_logs->set_schema_url(current_msg_metadata.scope_schema_url);
+
+  return scope_logs;
+}
+
+LogThreadedResult
+SyslogNgDestWorker::insert(LogMessage *msg)
+{
+  ScopeLogs *scope_logs = lookup_scope_logs(msg);
+  LogRecord *log_record = scope_logs->add_log_records();
+  formatter.format_syslog_ng(msg, *log_record);
+
+  return LTR_QUEUED;
+}

--- a/modules/grpc/otel/syslog-ng-otlp-dest-worker.hpp
+++ b/modules/grpc/otel/syslog-ng-otlp-dest-worker.hpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023 Attila Szakacs
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SYSLOG_NG_OTLP_DEST_WORKER_HPP
+#define SYSLOG_NG_OTLP_DEST_WORKER_HPP
+
+#include "syslog-ng-otlp-dest.hpp"
+#include "otel-dest-worker.hpp"
+
+typedef OtelDestWorker SyslogNgOtlpDestWorker;
+
+namespace syslogng {
+namespace grpc {
+namespace otel {
+
+class SyslogNgDestWorker : public DestWorker
+{
+public:
+  using DestWorker::DestWorker;
+  static LogThreadedDestWorker *construct(LogThreadedDestDriver *o, gint worker_index);
+
+  ScopeLogs *lookup_scope_logs(LogMessage *msg) override;
+  LogThreadedResult insert(LogMessage *msg) override;
+};
+
+}
+}
+}
+
+#endif

--- a/modules/grpc/otel/syslog-ng-otlp-dest.cpp
+++ b/modules/grpc/otel/syslog-ng-otlp-dest.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2023 Attila Szakacs
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "syslog-ng-otlp-dest.hpp"
+#include "syslog-ng-otlp-dest-worker.hpp"
+
+using namespace syslogng::grpc::otel;
+
+/* C++ Implementations */
+
+const char *
+SyslogNgDestDriver::generate_persist_name()
+{
+  static char persist_name[1024];
+
+  if (super->super.super.super.super.persist_name)
+    g_snprintf(persist_name, sizeof(persist_name), "syslog-ng-otlp.%s",
+               super->super.super.super.super.persist_name);
+  else
+    g_snprintf(persist_name, sizeof(persist_name), "syslog-ng-otlp");
+
+  return persist_name;
+}
+
+const char *
+SyslogNgDestDriver::format_stats_key(StatsClusterKeyBuilder *kb)
+{
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "syslog-ng-otlp"));
+  stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("url", url.c_str()));
+
+  return NULL;
+}
+
+LogThreadedDestWorker *
+SyslogNgDestDriver::construct_worker(int worker_index)
+{
+  return SyslogNgDestWorker::construct(&super->super, worker_index);
+}
+
+/* C Wrappers */
+
+LogDriver *
+syslog_ng_otlp_dd_new(GlobalConfig *cfg)
+{
+  SyslogNgOtlpDestDriverWrapper *self = g_new0(SyslogNgOtlpDestDriverWrapper, 1);
+
+  otel_dd_init_super(&self->super, cfg);
+  self->super.stats_source = stats_register_type("syslog-ng-otlp");
+  self->cpp = new SyslogNgDestDriver(self);
+
+  return &self->super.super.super;
+}

--- a/modules/grpc/otel/syslog-ng-otlp-dest.h
+++ b/modules/grpc/otel/syslog-ng-otlp-dest.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Attila Szakacs
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SYSLOG_NG_OTLP_DEST_H
+#define SYSLOG_NG_OTLP_DEST_H
+
+#include "compat/cpp-start.h"
+
+#include "otel-dest.h"
+
+typedef OtelDestDriver SyslogNgOtlpDestDriverWrapper;
+
+LogDriver *syslog_ng_otlp_dd_new(GlobalConfig *cfg);
+
+#include "compat/cpp-end.h"
+
+#endif

--- a/modules/grpc/otel/syslog-ng-otlp-dest.hpp
+++ b/modules/grpc/otel/syslog-ng-otlp-dest.hpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023 Attila Szakacs
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SYSLOG_NG_OTLP_DEST_HPP
+#define SYSLOG_NG_OTLP_DEST_HPP
+
+#include "otel-dest.hpp"
+#include "syslog-ng-otlp-dest.h"
+
+namespace syslogng {
+namespace grpc {
+namespace otel {
+
+class SyslogNgDestDriver : public DestDriver
+{
+public:
+  using DestDriver::DestDriver;
+
+  const char *format_stats_key(StatsClusterKeyBuilder *kb) override;
+  const char *generate_persist_name() override;
+
+  LogThreadedDestWorker *construct_worker(int worker_index) override;
+};
+
+}
+}
+}
+
+#endif

--- a/modules/grpc/otel/tests/CMakeLists.txt
+++ b/modules/grpc/otel/tests/CMakeLists.txt
@@ -11,3 +11,10 @@ add_unit_test(
   SOURCES test-otel-protobuf-formatter.cpp
   INCLUDES ${OTEL_PROTO_BUILDDIR}
   DEPENDS otel-cpp)
+
+add_unit_test(
+  CRITERION
+  TARGET test_syslog_ng_otlp
+  SOURCES test-syslog-ng-otlp.cpp
+  INCLUDES ${OTEL_PROTO_BUILDDIR}
+  DEPENDS otel-cpp)

--- a/modules/grpc/otel/tests/Makefile.am
+++ b/modules/grpc/otel/tests/Makefile.am
@@ -2,7 +2,8 @@ if ENABLE_GRPC
 
 modules_grpc_otel_tests_TESTS = \
   modules/grpc/otel/tests/test_otel_protobuf_parser \
-  modules/grpc/otel/tests/test_otel_protobuf_formatter
+  modules/grpc/otel/tests/test_otel_protobuf_formatter \
+  modules/grpc/otel/tests/test_syslog_ng_otlp
 
 check_PROGRAMS += ${modules_grpc_otel_tests_TESTS}
 
@@ -38,6 +39,24 @@ modules_grpc_otel_tests_test_otel_protobuf_formatter_CXXFLAGS = \
   -I$(top_builddir)/modules/grpc/otel
 
 modules_grpc_otel_tests_test_otel_protobuf_formatter_LDADD = \
+  $(TEST_LDADD) \
+  $(top_builddir)/modules/grpc/otel/libotel_cpp.la \
+  $(top_builddir)/modules/grpc/protos/libgrpc-protos.la
+
+modules_grpc_otel_tests_test_syslog_ng_otlp_SOURCES = \
+  modules/grpc/otel/tests/test-syslog-ng-otlp.cpp
+
+modules_grpc_otel_tests_test_syslog_ng_otlp_DEPENDENCIES = \
+  $(top_builddir)/modules/grpc/otel/libotel_cpp.la \
+  $(top_builddir)/modules/grpc/protos/libgrpc-protos.la
+
+modules_grpc_otel_tests_test_syslog_ng_otlp_CXXFLAGS = \
+  $(TEST_CXXFLAGS) \
+  -I$(OPENTELEMETRY_PROTO_BUILDDIR) \
+  -I$(top_srcdir)/modules/grpc/otel \
+  -I$(top_builddir)/modules/grpc/otel
+
+modules_grpc_otel_tests_test_syslog_ng_otlp_LDADD = \
   $(TEST_LDADD) \
   $(top_builddir)/modules/grpc/otel/libotel_cpp.la \
   $(top_builddir)/modules/grpc/protos/libgrpc-protos.la

--- a/modules/grpc/otel/tests/test-syslog-ng-otlp.cpp
+++ b/modules/grpc/otel/tests/test-syslog-ng-otlp.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2023 Attila Szakacs
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "otel-protobuf-formatter.hpp"
+#include "otel-protobuf-parser.hpp"
+
+#include "compat/cpp-start.h"
+#include "apphook.h"
+#include "cfg.h"
+#include "compat/cpp-end.h"
+
+#include <criterion/criterion.h>
+
+using namespace syslogng::grpc::otel;
+
+Test(syslog_ng_otlp, metadata)
+{
+  Resource resource;
+  std::string resource_schema_url;
+  InstrumentationScope scope;
+  std::string scope_schema_url;
+
+  ProtobufFormatter::get_metadata_for_syslog_ng(resource, resource_schema_url, scope, scope_schema_url);
+  cr_assert(ProtobufParser::is_syslog_ng_log_record(resource, resource_schema_url, scope, scope_schema_url));
+}
+
+Test(syslog_ng_otlp, formatting_and_parsing)
+{
+  LogMessage *msg = log_msg_new_empty();
+
+  UnixTime stamp = {.ut_sec = 1, .ut_usec = 2, .ut_gmtoff = 3};
+  UnixTime recvd = {.ut_sec = 4, .ut_usec = 5, .ut_gmtoff = 6};
+  guint16 pri = LOG_KERN | LOG_ERR;
+  const char *tag = "foo_tag";
+  const char *host = "foo_host";
+  const char *host_from = "foo_host_from";
+  const char *message = "foo_message";
+  const char *program = "foo_program";
+  const char *pid = "1234";
+  const char *dot_nv_name = ".foo.name";
+  const char *dot_nv_value = "42";
+  LogMessageValueType dot_nv_type = LM_VT_INTEGER;
+  const char *nv_name = "foo.name";
+  const char *nv_value = "true";
+  LogMessageValueType nv_type = LM_VT_BOOLEAN;
+  const char *temp_nv_name = "0";
+  const char *temp_nv_value = "foo_temp_value";
+  LogMessageValueType temp_nv_type = LM_VT_STRING;
+
+  msg->timestamps[LM_TS_STAMP] = stamp;
+  msg->timestamps[LM_TS_RECVD] = recvd;
+  msg->pri = pri;
+  log_msg_set_tag_by_name(msg, tag);
+  log_msg_set_value_by_name_with_type(msg, "HOST", host, -1, LM_VT_STRING);
+  log_msg_set_value_by_name_with_type(msg, "HOST_FROM", host_from, -1, LM_VT_STRING);
+  log_msg_set_value_by_name_with_type(msg, "MESSAGE", message, -1, LM_VT_STRING);
+  log_msg_set_value_by_name_with_type(msg, "PROGRAM", program, -1, LM_VT_STRING);
+  log_msg_set_value_by_name_with_type(msg, "PID", pid, -1, LM_VT_STRING);
+  log_msg_set_value_by_name_with_type(msg, dot_nv_name, dot_nv_value, -1, dot_nv_type);
+  log_msg_set_value_by_name_with_type(msg, nv_name, nv_value, -1, nv_type);
+  log_msg_set_value_by_name_with_type(msg, temp_nv_name, temp_nv_value, -1, temp_nv_type);
+
+  LogRecord log_record;
+  ProtobufFormatter(configuration).format_syslog_ng(msg, log_record);
+  log_msg_unref(msg);
+
+  msg = log_msg_new_empty();
+  ProtobufParser::store_syslog_ng(msg, log_record);
+
+  LogMessageValueType type;
+
+  cr_assert_eq(memcmp(&msg->timestamps[LM_TS_STAMP], &stamp, sizeof(stamp)), 0);
+  cr_assert_eq(memcmp(&msg->timestamps[LM_TS_RECVD], &recvd, sizeof(recvd)), 0);
+  cr_assert_eq(msg->pri, pri);
+  cr_assert_str_eq(log_msg_get_value_by_name_with_type(msg, "TAGS", NULL, &type), tag);
+  cr_assert_eq(type, LM_VT_LIST);
+  cr_assert_str_eq(log_msg_get_value_by_name_with_type(msg, "HOST", NULL, &type), host);
+  cr_assert_eq(type, LM_VT_STRING);
+  cr_assert_str_eq(log_msg_get_value_by_name_with_type(msg, "HOST_FROM", NULL, &type), host_from);
+  cr_assert_eq(type, LM_VT_STRING);
+  cr_assert_str_eq(log_msg_get_value_by_name_with_type(msg, "MESSAGE", NULL, &type), message);
+  cr_assert_eq(type, LM_VT_STRING);
+  cr_assert_str_eq(log_msg_get_value_by_name_with_type(msg, "PROGRAM", NULL, &type), program);
+  cr_assert_eq(type, LM_VT_STRING);
+  cr_assert_str_eq(log_msg_get_value_by_name_with_type(msg, "PID", NULL, &type), pid);
+  cr_assert_eq(type, LM_VT_STRING);
+  cr_assert_str_eq(log_msg_get_value_by_name_with_type(msg, dot_nv_name, NULL, &type), dot_nv_value);
+  cr_assert_eq(type, dot_nv_type);
+  cr_assert_str_eq(log_msg_get_value_by_name_with_type(msg, nv_name, NULL, &type), nv_value);
+  cr_assert_eq(type, nv_type);
+  /* Temp NVs (0, 1, ..., 256) are skipped. */
+  cr_assert_str_eq(log_msg_get_value_by_name_with_type(msg, temp_nv_name, NULL, &type), "");
+  cr_assert_eq(type, LM_VT_NULL);
+
+  log_msg_unref(msg);
+}
+
+void
+setup(void)
+{
+  app_startup();
+  configuration = cfg_new_snippet();
+}
+
+void
+teardown(void)
+{
+  cfg_free(configuration);
+  app_shutdown();
+}
+
+TestSuite(syslog_ng_otlp, .init = setup, .fini = teardown);

--- a/news/feature-4564.md
+++ b/news/feature-4564.md
@@ -1,0 +1,21 @@
+**Sending messages between syslog-ng instances via OTLP/gRPC**
+
+The `syslog-ng-otlp()` source and destination helps to transfer the internal representation
+of a log message between syslog-ng instances. In contrary to the `syslog-ng()` (`ewmm()`)
+drivers, `syslog-ng-otlp()` does not transfer the messages on simple TCP connections, but uses
+the OpenTelemetry protocol to do so.
+
+It is easily scalable (`workers()` option), uses built-in application layer acknowledgement,
+out of the box supports google service authentication (ADC or ALTS), and gives the possibility
+of better load balancing.
+
+The performance is currently similar to `ewmm()` (OTLP is ~30% quicker) but there is a source
+side limitation, which will be optimized. We measured 200-300% performance improvement with a
+PoC optimized code using multiple threads, so stay tuned.
+
+Note: The `syslog-ng-otlp()` source is only an alias to the `opentelemetry()` source.
+This is useful for not needing to open different ports for the syslog-ng messages and other
+OpenTelemetry messages. The syslog-ng messages are marked with a `@syslog-ng` scope name and
+the current syslog-ng version as the scope version. Both sources will handle the incoming
+syslog-ng messages as syslog-ng messages, and all other messages as simple OpenTelemetry
+messages.

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -181,6 +181,7 @@ modules/grpc/otel/otel-(grammar|parser|plugin|source|source-services|servicecall
 modules/grpc/otel/grpc-credentials-builder\.(h|cpp|hpp)$
 modules/grpc/otel/syslog-ng-otlp-(dest|dest-worker)\.(h|cpp|hpp)$
 modules/grpc/otel/tests/test-otel-(protobuf-parser|protobuf-formatter)\.cpp$
+modules/grpc/otel/tests/test-syslog-ng-otlp\.cpp$
 modules/examples/inner-destinations/tls-test-validation
 modules/examples/sources/random-choice-generator
 modules/python/python-options.(c|h)$

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -179,6 +179,7 @@ modules/metrics-probe/label-template\.(c|h)$
 modules/metrics-probe/tests/test_metrics_probe\.c$
 modules/grpc/otel/otel-(grammar|parser|plugin|source|source-services|servicecall|protobuf-parser|protobuf-formatter|dest|dest-worker)\.(c|h|cpp|hpp|ym)$
 modules/grpc/otel/grpc-credentials-builder\.(h|cpp|hpp)$
+modules/grpc/otel/syslog-ng-otlp-(dest|dest-worker)\.(h|cpp|hpp)$
 modules/grpc/otel/tests/test-otel-(protobuf-parser|protobuf-formatter)\.cpp$
 modules/examples/inner-destinations/tls-test-validation
 modules/examples/sources/random-choice-generator


### PR DESCRIPTION
The `syslog-ng-otlp()` source and destination helps to transfer the internal representation of a log message between syslog-ng instances. In contrary to the `syslog-ng()` (`ewmm()`) drivers, `syslog-ng-otlp()` does not transfer the messages on simple TCP connections, but uses the OpenTelemetry protocol to do so.

It is easily scalable (`workers()` option), uses built-in application layer acknowledgement, out of the box supports google service authentication (ADC or ALTS), and gives the possibility of better load balancing.

The performance is currently similar to `ewmm()` (OTLP is ~30% quicker) but there is a source side limitation, which will be optimized. We measured 200-300% performance improvement with a PoC optimized code using multiple threads, so stay tuned.

_Note: The `syslog-ng-otlp()` source is only an alias to the `opentelemetry()` source. This is useful for not needing to open different ports for the syslog-ng messages and other OpenTelemetry messages. The syslog-ng messages are marked with a `@syslog-ng` scope name and the current syslog-ng version as the scope version. Both sources will handle the incoming
syslog-ng messages as syslog-ng messages, and all other messages as simple OpenTelemetry messages._


Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>
