### PR TITLE
python: reference count python-option

### DIFF
--- a/modules/python/python-dest.c
+++ b/modules/python/python-dest.c
@@ -85,12 +85,12 @@ python_dd_set_class(LogDriver *d, gchar *class_name)
   self->class = g_strdup(class_name);
 }
 
-void
-python_dd_add_options(LogDriver *d, PythonOptions *options)
+PythonOptions *
+python_dd_get_options(LogDriver *d)
 {
   PythonDestDriver *self = (PythonDestDriver *)d;
 
-  python_options_add_options(self->options, options);
+  return self->options;
 }
 
 void

--- a/modules/python/python-dest.h
+++ b/modules/python/python-dest.h
@@ -35,7 +35,7 @@ LogDriver *python_dd_new(GlobalConfig *cfg);
 void python_dd_set_loaders(LogDriver *d, GList *loaders);
 void python_dd_set_class(LogDriver *d, gchar *class_name);
 void python_dd_set_value_pairs(LogDriver *d, ValuePairs *vp);
-void python_dd_add_options(LogDriver *d, PythonOptions *options);
+PythonOptions *python_dd_get_options(LogDriver *d);
 LogTemplateOptions *python_dd_get_template_options(LogDriver *d);
 
 void py_log_destination_global_init(void);

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -75,12 +75,12 @@ python_fetcher_set_class(LogDriver *s, gchar *filename)
   self->class = g_strdup(filename);
 }
 
-void
-python_fetcher_add_options(LogDriver *s, PythonOptions *options)
+PythonOptions *
+python_fetcher_get_options(LogDriver *s)
 {
   PythonFetcherDriver *self = (PythonFetcherDriver *) s;
 
-  python_options_add_options(self->options, options);
+  return self->options;
 }
 
 void

--- a/modules/python/python-fetcher.h
+++ b/modules/python/python-fetcher.h
@@ -31,7 +31,7 @@
 LogDriver *python_fetcher_new(GlobalConfig *cfg);
 void python_fetcher_set_loaders(LogDriver *d, GList *loaders);
 void python_fetcher_set_class(LogDriver *d, gchar *class_name);
-void python_fetcher_add_options(LogDriver *d, PythonOptions *options);
+PythonOptions *python_fetcher_get_options(LogDriver *d);
 
 void py_log_fetcher_global_init(void);
 

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -142,7 +142,7 @@ python_dd_option
         | python_options_block
           {
             python_dd_add_options(last_driver, $1);
-            python_options_release($1);
+            python_options_free($1);
           }
         | threaded_dest_driver_general_option
         | threaded_dest_driver_batch_option
@@ -169,7 +169,7 @@ python_sd_option
         | python_options_block
           {
             python_sd_add_options(last_driver, $1);
-            python_options_release($1);
+            python_options_free($1);
           }
         | threaded_source_driver_option
         ;
@@ -190,7 +190,7 @@ python_fetcher_option
         | python_options_block
           {
             python_fetcher_add_options(last_driver, $1);
-            python_options_release($1);
+            python_options_free($1);
           }
         | threaded_source_driver_option
         | threaded_fetcher_driver_option
@@ -213,7 +213,7 @@ python_parser_option
         | python_options_block
           {
             python_parser_add_options(last_parser, $1);
-            python_options_release($1);
+            python_options_free($1);
           }
         | parser_opt
         ;
@@ -234,7 +234,7 @@ python_http_header_option
         | python_options_block
           {
             python_http_header_add_options(last_header, $1);
-            python_options_release($1);
+            python_options_free($1);
           }
         | KW_MARK_ERRORS_AS_CRITICAL '(' yesno ')'
           {
@@ -325,7 +325,12 @@ python_option
           ;
 
 python_options
-          : python_option { python_options_add_option(last_python_options, $1); } python_options
+          : python_option
+            {
+              python_options_add_option(last_python_options, $1);
+              python_option_unref($1);
+            }
+            python_options
           |
           ;
 

--- a/modules/python/python-grammar.ym
+++ b/modules/python/python-grammar.ym
@@ -139,11 +139,7 @@ python_dd_option
           }
         | KW_LOADERS python_dd_loaders
         | KW_IMPORTS python_dd_loaders
-        | python_options_block
-          {
-            python_dd_add_options(last_driver, $1);
-            python_options_free($1);
-          }
+        | { last_python_options = python_dd_get_options(last_driver); } python_options_block
         | threaded_dest_driver_general_option
         | threaded_dest_driver_batch_option
         | value_pair_option
@@ -166,11 +162,7 @@ python_sd_option
             free($3);
           }
         | KW_LOADERS python_sd_loaders
-        | python_options_block
-          {
-            python_sd_add_options(last_driver, $1);
-            python_options_free($1);
-          }
+        | { last_python_options = python_sd_get_options(last_driver); } python_options_block
         | threaded_source_driver_option
         ;
 
@@ -187,11 +179,7 @@ python_fetcher_option
             free($3);
           }
         | KW_LOADERS python_fetcher_loaders
-        | python_options_block
-          {
-            python_fetcher_add_options(last_driver, $1);
-            python_options_free($1);
-          }
+        | { last_python_options = python_fetcher_get_options(last_driver); } python_options_block
         | threaded_source_driver_option
         | threaded_fetcher_driver_option
         ;
@@ -210,11 +198,7 @@ python_parser_option
           }
         | KW_LOADERS python_parser_loaders
         | KW_IMPORTS python_parser_loaders
-        | python_options_block
-          {
-            python_parser_add_options(last_parser, $1);
-            python_options_free($1);
-          }
+        | { last_python_options = python_parser_get_options(last_parser); } python_options_block
         | parser_opt
         ;
 
@@ -231,11 +215,7 @@ python_http_header_option
             free($3);
           }
         | KW_LOADERS python_http_header_loaders
-        | python_options_block
-          {
-            python_http_header_add_options(last_header, $1);
-            python_options_free($1);
-          }
+        | { last_python_options = python_http_header_get_options(last_header); } python_options_block
         | KW_MARK_ERRORS_AS_CRITICAL '(' yesno ')'
           {
             python_http_header_set_mark_errors_as_critical(last_header, $3);
@@ -335,7 +315,7 @@ python_options
           ;
 
 python_options_block
-          : KW_OPTIONS { last_python_options = python_options_new(); } '(' python_options ')' { $$ = last_python_options; }
+          : KW_OPTIONS '(' python_options ')'
           ;
 
 /* INCLUDE_RULES */

--- a/modules/python/python-http-header.c
+++ b/modules/python/python-http-header.c
@@ -454,10 +454,10 @@ python_http_header_set_class(PythonHttpHeaderPlugin *self, gchar *class)
   self->class = g_strdup(class);
 }
 
-void
-python_http_header_add_options(PythonHttpHeaderPlugin *self, PythonOptions *options)
+PythonOptions *
+python_http_header_get_options(PythonHttpHeaderPlugin *self)
 {
-  python_options_add_options(self->options, options);
+  return self->options;
 }
 
 void

--- a/modules/python/python-http-header.h
+++ b/modules/python/python-http-header.h
@@ -32,7 +32,7 @@ PythonHttpHeaderPlugin *python_http_header_new(void);
 
 void python_http_header_set_loaders(PythonHttpHeaderPlugin *self, GList *loaders);
 void python_http_header_set_class(PythonHttpHeaderPlugin *self, gchar *class);
-void python_http_header_add_options(PythonHttpHeaderPlugin *self, PythonOptions *options);
+PythonOptions *python_http_header_get_options(PythonHttpHeaderPlugin *self);
 void python_http_header_set_mark_errors_as_critical(PythonHttpHeaderPlugin *self, gboolean enable);
 
 #endif

--- a/modules/python/python-logparser.c
+++ b/modules/python/python-logparser.c
@@ -66,12 +66,12 @@ python_parser_set_class(LogParser *d, gchar *class)
   self->class = g_strdup(class);
 }
 
-void
-python_parser_add_options(LogParser *d, PythonOptions *options)
+PythonOptions *
+python_parser_get_options(LogParser *d)
 {
   PythonParser *self = (PythonParser *)d;
 
-  python_options_add_options(self->options, options);
+  return self->options;
 }
 
 void
@@ -309,7 +309,9 @@ python_parser_clone(LogPipe *s)
   log_parser_clone_settings(&self->super, &cloned->super);
   python_parser_set_class(&cloned->super, self->class);
   cloned->loaders = string_list_clone(self->loaders);
-  python_parser_add_options(&cloned->super, self->options);
+
+  python_options_free(cloned->options);
+  cloned->options = python_options_clone(self->options);
 
   return &cloned->super.super;
 }

--- a/modules/python/python-logparser.h
+++ b/modules/python/python-logparser.h
@@ -31,7 +31,7 @@
 LogParser *python_parser_new(GlobalConfig *cfg);
 void python_parser_set_loaders(LogParser *s, GList *loaders);
 void python_parser_set_class(LogParser *s, gchar *class_name);
-void python_parser_add_options(LogParser  *s, PythonOptions *options);
+PythonOptions *python_parser_get_options(LogParser  *s);
 
 void py_log_parser_global_init(void);
 

--- a/modules/python/python-options.c
+++ b/modules/python/python-options.c
@@ -314,17 +314,21 @@ python_options_new(void)
   return self;
 }
 
+PythonOptions *
+python_options_clone(const PythonOptions *self)
+{
+  PythonOptions *cloned = python_options_new();
+
+  for (GList *elem = self->options; elem; elem = elem->next)
+    python_options_add_option(cloned, (PythonOption *) elem->data);
+
+  return cloned;
+}
+
 void
 python_options_add_option(PythonOptions *self, PythonOption *option)
 {
   self->options = g_list_append(self->options, python_option_ref(option));
-}
-
-void
-python_options_add_options(PythonOptions *self, PythonOptions *options)
-{
-  for (GList *elem = options->options; elem; elem = elem->next)
-    python_options_add_option(self, (PythonOption *) elem->data);
 }
 
 PyObject *

--- a/modules/python/python-options.c
+++ b/modules/python/python-options.c
@@ -26,11 +26,14 @@
 #include "python-logtemplate.h"
 #include "str-utils.h"
 #include "string-list.h"
+#include "atomic.h"
+
 
 /* Python Option */
 
 struct _PythonOption
 {
+  GAtomicCounter ref_cnt;
   gchar *name;
 
   PyObject *(*create_value_py_object)(const PythonOption *s);
@@ -40,6 +43,7 @@ struct _PythonOption
 static void
 python_option_init_instance(PythonOption *s, const gchar *name)
 {
+  g_atomic_counter_set(&s->ref_cnt, 1);
   s->name = __normalize_key(name);
 }
 
@@ -73,14 +77,31 @@ python_option_create_value_py_object(const PythonOption *s)
   return value;
 }
 
-void
-python_option_free(PythonOption *s)
+PythonOption *
+python_option_ref(PythonOption *s)
 {
-  if (s->free_fn)
-    s->free_fn(s);
+  g_assert(!s || g_atomic_counter_get(&s->ref_cnt) > 0);
 
-  g_free(s->name);
-  g_free(s);
+  if (s)
+    {
+      g_atomic_counter_inc(&s->ref_cnt);
+    }
+  return s;
+}
+
+void
+python_option_unref(PythonOption *s)
+{
+  g_assert(!s || g_atomic_counter_get(&s->ref_cnt));
+
+  if (s && (g_atomic_counter_dec_and_test(&s->ref_cnt)))
+    {
+      if (s->free_fn)
+        s->free_fn(s);
+
+      g_free(s->name);
+      g_free(s);
+    }
 }
 
 /* String */
@@ -296,7 +317,7 @@ python_options_new(void)
 void
 python_options_add_option(PythonOptions *self, PythonOption *option)
 {
-  self->options = g_list_append(self->options, option);
+  self->options = g_list_append(self->options, python_option_ref(option));
 }
 
 void
@@ -345,16 +366,6 @@ python_options_free(PythonOptions *self)
   if (!self)
     return;
 
-  g_list_free_full(self->options, (GDestroyNotify) python_option_free);
-  g_free(self);
-}
-
-void
-python_options_release(PythonOptions *self)
-{
-  if (!self)
-    return;
-
-  g_list_free(self->options);
+  g_list_free_full(self->options, (GDestroyNotify) python_option_unref);
   g_free(self);
 }

--- a/modules/python/python-options.h
+++ b/modules/python/python-options.h
@@ -43,7 +43,7 @@ typedef struct _PythonOptions PythonOptions;
 
 PythonOptions *python_options_new(void);
 void python_options_add_option(PythonOptions *self, PythonOption *option);
-void python_options_add_options(PythonOptions *self, PythonOptions *options);
+PythonOptions *python_options_clone(const PythonOptions *self);
 PyObject *python_options_create_py_dict(const PythonOptions *self);
 void python_options_free(PythonOptions *self);
 

--- a/modules/python/python-options.h
+++ b/modules/python/python-options.h
@@ -34,10 +34,10 @@ PythonOption *python_option_boolean_new(const gchar *name, gboolean value);
 PythonOption *python_option_string_list_new(const gchar *name, const GList *value);
 PythonOption *python_option_template_new(const gchar *name, const gchar *value);
 
+PythonOption *python_option_ref(PythonOption *self);
+void python_option_unref(PythonOption *self);
 const gchar *python_option_get_name(const PythonOption *self);
 PyObject *python_option_create_value_py_object(const PythonOption *self);
-
-void python_option_free(PythonOption *self);
 
 typedef struct _PythonOptions PythonOptions;
 
@@ -46,6 +46,5 @@ void python_options_add_option(PythonOptions *self, PythonOption *option);
 void python_options_add_options(PythonOptions *self, PythonOptions *options);
 PyObject *python_options_create_py_dict(const PythonOptions *self);
 void python_options_free(PythonOptions *self);
-void python_options_release(PythonOptions *self);
 
 #endif

--- a/modules/python/python-source.c
+++ b/modules/python/python-source.c
@@ -82,12 +82,12 @@ python_sd_set_class(LogDriver *s, gchar *filename)
   self->class = g_strdup(filename);
 }
 
-void
-python_sd_add_options(LogDriver *s, PythonOptions *options)
+PythonOptions *
+python_sd_get_options(LogDriver *s)
 {
   PythonSourceDriver *self = (PythonSourceDriver *) s;
 
-  python_options_add_options(self->options, options);
+  return self->options;
 }
 
 void

--- a/modules/python/python-source.h
+++ b/modules/python/python-source.h
@@ -31,7 +31,7 @@
 LogDriver *python_sd_new(GlobalConfig *cfg);
 void python_sd_set_loaders(LogDriver *d, GList *loaders);
 void python_sd_set_class(LogDriver *d, gchar *class_name);
-void python_sd_add_options(LogDriver *d, PythonOptions *options);
+PythonOptions *python_sd_get_options(LogDriver *d);
 
 void py_log_source_global_init(void);
 

--- a/modules/python/tests/test_python_options.c
+++ b/modules/python/tests/test_python_options.c
@@ -202,37 +202,25 @@ _generate_options_test_options(void)
   python_options_add_option(options, option);
   python_option_unref(option);
 
-  return options;
+  PythonOptions *cloned = python_options_clone(options);
+  python_options_free(options);
+
+  return cloned;
 }
 
-static PythonOptions *
-_generate_options_test_options2(void)
+Test(python_options, test_python_options)
 {
-  PythonOptions *options = python_options_new();
-  PythonOption *option;
+  const gchar *script = "import _syslogng\n"
+                        "assert options['string'] == 'example-value', 'Actual: {}'.format(options['string'])\n"
+                        "assert options['long'] == -42, 'Actual: {}'.format(options['long'])\n"
+                        "assert options['double'] == -13.37, 'Actual: {}'.format(options['double'])\n"
+                        "assert options['boolean'] == True, 'Actual: {}'.format(options['string'])\n"
+                        "assert options['string_list'] == ['example-value-1', 'example-value-2'], "
+                        "'Actual: {}'.format(options['string_list'])\n"
+                        "assert isinstance(options['template'], _syslogng.LogTemplate), 'Actual: {}'.format(type(options['template']))\n"
+                        "assert str(options['template']) == '${example-template}', 'Actual: {}'.format(str(options['template']))\n";
 
-  option = python_option_string_new("string2", "example-value2");
-  python_options_add_option(options, option);
-  python_option_unref(option);
-
-  option = python_option_long_new("long2", 42);
-  python_options_add_option(options, option);
-  python_option_unref(option);
-
-  option = python_option_double_new("double2", 13.37);
-  python_options_add_option(options, option);
-  python_option_unref(option);
-
-  option = python_option_boolean_new("boolean2", FALSE);
-  python_options_add_option(options, option);
-  python_option_unref(option);
-
-  return options;
-}
-
-static void
-_run_py_options_test(PythonOptions *options, const gchar *script)
-{
+  PythonOptions *options = _generate_options_test_options();
   PyObject *options_dict = python_options_create_py_dict(options);
 
   PyGILState_STATE gstate = PyGILState_Ensure();
@@ -248,30 +236,6 @@ _run_py_options_test(PythonOptions *options, const gchar *script)
   }
   Py_DECREF(options_dict);
   PyGILState_Release(gstate);
-}
-
-Test(python_options, test_python_options)
-{
-  const gchar *script = "import _syslogng\n"
-                        "assert options['string'] == 'example-value', 'Actual: {}'.format(options['string'])\n"
-                        "assert options['long'] == -42, 'Actual: {}'.format(options['long'])\n"
-                        "assert options['double'] == -13.37, 'Actual: {}'.format(options['double'])\n"
-                        "assert options['boolean'] == True, 'Actual: {}'.format(options['string'])\n"
-                        "assert options['string_list'] == ['example-value-1', 'example-value-2'], "
-                        "'Actual: {}'.format(options['string_list'])\n"
-                        "assert isinstance(options['template'], _syslogng.LogTemplate), 'Actual: {}'.format(type(options['template']))\n"
-                        "assert str(options['template']) == '${example-template}', 'Actual: {}'.format(str(options['template']))\n"
-                        "assert options['string2'] == 'example-value2', 'Actual: {}'.format(options['string2'])\n"
-                        "assert options['long2'] == 42, 'Actual: {}'.format(options['long2'])\n"
-                        "assert options['double2'] == 13.37, 'Actual: {}'.format(options['double2'])\n"
-                        "assert options['boolean2'] == False, 'Actual: {}'.format(options['string2'])\n";
-  PythonOptions *options = _generate_options_test_options();
-  PythonOptions *options2 = _generate_options_test_options2();
-
-  python_options_add_options(options, options2);
-  python_options_free(options2);
-
-  _run_py_options_test(options, script);
 
   python_options_free(options);
 }

--- a/modules/python/tests/test_python_options.c
+++ b/modules/python/tests/test_python_options.c
@@ -95,28 +95,28 @@ Test(python_options, test_python_option_string)
   PythonOption *option = python_option_string_new("string", string);
   g_free(string);
   _assert_python_option(option, "string", "'example-value'");
-  python_option_free(option);
+  python_option_unref(option);
 }
 
 Test(python_options, test_python_option_long)
 {
   PythonOption *option = python_option_long_new("long", -42);
   _assert_python_option(option, "long", "-42");
-  python_option_free(option);
+  python_option_unref(option);
 }
 
 Test(python_options, test_python_option_double)
 {
   PythonOption *option = python_option_double_new("double", -13.37);
   _assert_python_option(option, "double", "-13.37");
-  python_option_free(option);
+  python_option_unref(option);
 }
 
 Test(python_options, test_python_option_boolean)
 {
   PythonOption *option = python_option_boolean_new("boolean", TRUE);
   _assert_python_option(option, "boolean", "True");
-  python_option_free(option);
+  python_option_unref(option);
 }
 
 Test(python_options, test_python_option_string_list)
@@ -131,7 +131,7 @@ Test(python_options, test_python_option_string_list)
   PythonOption *option = python_option_string_list_new("string-list", string_list);
   string_list_free(string_list);
   _assert_python_option(option, "string_list", "['example-value-1', 'example-value-2']");
-  python_option_free(option);
+  python_option_unref(option);
 }
 
 Test(python_options, test_python_option_template)
@@ -161,7 +161,7 @@ Test(python_options, test_python_option_template)
   }
   PyGILState_Release(gstate);
 
-  python_option_free(option);
+  python_option_unref(option);
 }
 
 static PythonOptions *
@@ -172,15 +172,19 @@ _generate_options_test_options(void)
 
   option = python_option_string_new("string", "example-value");
   python_options_add_option(options, option);
+  python_option_unref(option);
 
   option = python_option_long_new("long", -42);
   python_options_add_option(options, option);
+  python_option_unref(option);
 
   option = python_option_double_new("double", -13.37);
   python_options_add_option(options, option);
+  python_option_unref(option);
 
   option = python_option_boolean_new("boolean", TRUE);
   python_options_add_option(options, option);
+  python_option_unref(option);
 
   const gchar *string_array[] =
   {
@@ -192,9 +196,11 @@ _generate_options_test_options(void)
   option = python_option_string_list_new("string-list", string_list);
   string_list_free(string_list);
   python_options_add_option(options, option);
+  python_option_unref(option);
 
   option = python_option_template_new("template", "${example-template}");
   python_options_add_option(options, option);
+  python_option_unref(option);
 
   return options;
 }
@@ -207,15 +213,19 @@ _generate_options_test_options2(void)
 
   option = python_option_string_new("string2", "example-value2");
   python_options_add_option(options, option);
+  python_option_unref(option);
 
   option = python_option_long_new("long2", 42);
   python_options_add_option(options, option);
+  python_option_unref(option);
 
   option = python_option_double_new("double2", 13.37);
   python_options_add_option(options, option);
+  python_option_unref(option);
 
   option = python_option_boolean_new("boolean2", FALSE);
   python_options_add_option(options, option);
+  python_option_unref(option);
 
   return options;
 }
@@ -259,7 +269,7 @@ Test(python_options, test_python_options)
   PythonOptions *options2 = _generate_options_test_options2();
 
   python_options_add_options(options, options2);
-  python_options_release(options2);
+  python_options_free(options2);
 
   _run_py_options_test(options, script);
 

--- a/modules/python/tests/test_python_persist_name.c
+++ b/modules/python/tests/test_python_persist_name.c
@@ -123,7 +123,7 @@ Test(python_persist_name, test_python_dest)
 
   PythonOptions *options = _create_custom_options_with_dummy_option();
   python_dd_add_options(d, options);
-  python_options_release(options);
+  python_options_free(options);
 
   cr_assert(log_pipe_init((LogPipe *)d));
 
@@ -152,7 +152,7 @@ Test(python_persist_name, test_python_fetcher)
 
   PythonOptions *options = _create_custom_options_with_dummy_option();
   python_fetcher_add_options(d, options);
-  python_options_release(options);
+  python_options_free(options);
 
   cr_assert(log_pipe_init((LogPipe *)d));
 
@@ -183,7 +183,7 @@ Test(python_persist_name, test_python_source)
 
   PythonOptions *options = _create_custom_options_with_dummy_option();
   python_sd_add_options(d, options);
-  python_options_release(options);
+  python_options_free(options);
 
   cr_assert(log_pipe_init((LogPipe *)d));
 
@@ -258,7 +258,7 @@ Test(python_persist_name, test_python_fetcher_no_generate_persist_name)
 
   PythonOptions *options = _create_custom_options_with_dummy_option();
   python_fetcher_add_options(d, options);
-  python_options_release(options);
+  python_options_free(options);
 
   log_pipe_set_persist_name((LogPipe *)d, "test_persist_name");
   cr_assert(log_pipe_init((LogPipe *)d));
@@ -287,7 +287,7 @@ Test(python_persist_name, test_python_source_no_generate_persist_name)
 
   PythonOptions *options = _create_custom_options_with_dummy_option();
   python_sd_add_options(d, options);
-  python_options_release(options);
+  python_options_free(options);
 
   log_pipe_set_persist_name((LogPipe *)d, "test_persist_name");
   cr_assert(log_pipe_init((LogPipe *)d));
@@ -375,7 +375,7 @@ Test(python_persist_name, test_python_fetcher_persist_preference)
 
   PythonOptions *options = _create_custom_options_with_dummy_option();
   python_fetcher_add_options(d, options);
-  python_options_release(options);
+  python_options_free(options);
 
   cr_assert(log_pipe_init((LogPipe *)d));
 
@@ -397,7 +397,7 @@ Test(python_persist_name, test_python_source_persist_preference)
 
   PythonOptions *options = _create_custom_options_with_dummy_option();
   python_sd_add_options(d, options);
-  python_options_release(options);
+  python_options_free(options);
 
   cr_assert(log_pipe_init((LogPipe *)d));
 

--- a/modules/python/tests/test_python_persist_name.c
+++ b/modules/python/tests/test_python_persist_name.c
@@ -97,12 +97,10 @@ _load_code(const gchar *code)
 
 TestSuite(python_persist_name, .init = setup, .fini = teardown);
 
-static PythonOptions *
-_create_custom_options_with_dummy_option(void)
+static void
+_add_dummy_option(PythonOptions *options)
 {
-  PythonOptions *custom_options = python_options_new();
-  python_options_add_option(custom_options, python_option_string_new("key", "value"));
-  return custom_options;
+  python_options_add_option(options, python_option_string_new("key", "value"));
 }
 
 const gchar *python_destination_code = "\n\
@@ -121,9 +119,7 @@ Test(python_persist_name, test_python_dest)
   LogDriver *d = python_dd_new(empty_cfg);
   python_dd_set_class(d, "Dest");
 
-  PythonOptions *options = _create_custom_options_with_dummy_option();
-  python_dd_add_options(d, options);
-  python_options_free(options);
+  _add_dummy_option(python_dd_get_options(d));
 
   cr_assert(log_pipe_init((LogPipe *)d));
 
@@ -150,9 +146,7 @@ Test(python_persist_name, test_python_fetcher)
   LogDriver *d = python_fetcher_new(empty_cfg);
   python_fetcher_set_class(d, "Fetcher");
 
-  PythonOptions *options = _create_custom_options_with_dummy_option();
-  python_fetcher_add_options(d, options);
-  python_options_free(options);
+  _add_dummy_option(python_fetcher_get_options(d));
 
   cr_assert(log_pipe_init((LogPipe *)d));
 
@@ -181,9 +175,7 @@ Test(python_persist_name, test_python_source)
   LogDriver *d = python_sd_new(empty_cfg);
   python_sd_set_class(d, "Source");
 
-  PythonOptions *options = _create_custom_options_with_dummy_option();
-  python_sd_add_options(d, options);
-  python_options_free(options);
+  _add_dummy_option(python_sd_get_options(d));
 
   cr_assert(log_pipe_init((LogPipe *)d));
 
@@ -256,9 +248,7 @@ Test(python_persist_name, test_python_fetcher_no_generate_persist_name)
   LogDriver *d = python_fetcher_new(empty_cfg);
   python_fetcher_set_class(d, "Fetcher");
 
-  PythonOptions *options = _create_custom_options_with_dummy_option();
-  python_fetcher_add_options(d, options);
-  python_options_free(options);
+  _add_dummy_option(python_fetcher_get_options(d));
 
   log_pipe_set_persist_name((LogPipe *)d, "test_persist_name");
   cr_assert(log_pipe_init((LogPipe *)d));
@@ -285,9 +275,7 @@ Test(python_persist_name, test_python_source_no_generate_persist_name)
   LogDriver *d = python_sd_new(empty_cfg);
   python_sd_set_class(d, "Source");
 
-  PythonOptions *options = _create_custom_options_with_dummy_option();
-  python_sd_add_options(d, options);
-  python_options_free(options);
+  _add_dummy_option(python_sd_get_options(d));
 
   log_pipe_set_persist_name((LogPipe *)d, "test_persist_name");
   cr_assert(log_pipe_init((LogPipe *)d));
@@ -373,9 +361,7 @@ Test(python_persist_name, test_python_fetcher_persist_preference)
   log_pipe_set_persist_name(&d->super, "test_persist_name");
   python_fetcher_set_class(d, "Fetcher");
 
-  PythonOptions *options = _create_custom_options_with_dummy_option();
-  python_fetcher_add_options(d, options);
-  python_options_free(options);
+  _add_dummy_option(python_fetcher_get_options(d));
 
   cr_assert(log_pipe_init((LogPipe *)d));
 
@@ -395,9 +381,7 @@ Test(python_persist_name, test_python_source_persist_preference)
   log_pipe_set_persist_name(&d->super, "test_persist_name");
   python_sd_set_class(d, "Source");
 
-  PythonOptions *options = _create_custom_options_with_dummy_option();
-  python_sd_add_options(d, options);
-  python_options_free(options);
+  _add_dummy_option(python_sd_get_options(d));
 
   cr_assert(log_pipe_init((LogPipe *)d));
 


### PR DESCRIPTION
`python_options_add_options()` took the ownership of the `PythonOption`, resulting in double frees in case of cloning.

Fixes #4566