### PR TITLE
logwriter: fix stats related memleak in case of reload

### DIFF
--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1806,10 +1806,16 @@ _set_metric_options(LogWriter *self, const gchar *stats_id, StatsClusterKeyBuild
                                              self->stats_id, instance_name);
   stats_cluster_key_builder_add_label(self->metrics.stats_kb, stats_cluster_label("id", self->stats_id));
 
+  if (self->metrics.output_events_key)
+    stats_cluster_key_free(self->metrics.output_events_key);
+
   self->metrics.output_events_key = stats_cluster_key_builder_build_logpipe(self->metrics.stats_kb);
 
   stats_cluster_key_builder_set_name(raw_bytes_stats_kb, "output_event_bytes_total");
   stats_cluster_key_builder_add_label(raw_bytes_stats_kb, stats_cluster_label("id", self->stats_id));
+
+  if (self->metrics.written_bytes_key)
+    stats_cluster_key_free(self->metrics.written_bytes_key);
 
   self->metrics.written_bytes_key = stats_cluster_key_builder_build_single(raw_bytes_stats_kb);
   stats_cluster_key_builder_free(raw_bytes_stats_kb);


### PR DESCRIPTION
`affile_dd_reuse_writer()` calls `affile_dw_set_owner()` on an already initialized writer.

Reproduction:
```
@version: 4.3

options {
    stats_level(1);
};

source s_local {
  example-msg-generator();
};

destination d_file {
  file("/tmp/b");
};

log {
  source(s_local);
  destination(d_file);
};
```
```
syslog-ng-ctl reload
```
<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
