### PR TITLE
Let the user control the ENABLE_CPP option on the Apple platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,10 +16,10 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 project(syslog-ng C)
 
-option(ENABLE_CPP "Enable C++" ON)
-
 if (APPLE)
-  set(ENABLE_CPP OFF)
+  option(ENABLE_CPP "Enable C++" OFF)
+else()
+  option(ENABLE_CPP "Enable C++" ON)
 endif()
 
 if (ENABLE_CPP)

--- a/modules/grpc/CMakeLists.txt
+++ b/modules/grpc/CMakeLists.txt
@@ -1,16 +1,57 @@
-set(GRPC_DEPS_FOUND ${ENABLE_CPP})
 
-if (GRPC_DEPS_FOUND)
-  find_package(Protobuf 3.6.1)
-  if (NOT Protobuf_FOUND)
+set(GRPC_DEPS_FOUND FALSE)
+
+if (NOT DEFINED ENABLE_GRPC OR ENABLE_GRPC)
+  set(GRPC_DEPS_FOUND TRUE)
+
+  if (NOT ENABLE_CPP)
+    if (ENABLE_GRPC)
+      message(FATAL_ERROR "C++ support is mandatory when the GRPC modules are enabled.")
+    endif()
+
     set(GRPC_DEPS_FOUND FALSE)
   endif()
-endif()
 
-if (GRPC_DEPS_FOUND)
-  find_package(gRPC 1.16.1)
-  if (NOT gRPC_FOUND)
-    set(GRPC_DEPS_FOUND FALSE)
+  if (GRPC_DEPS_FOUND)
+    find_package(Protobuf 3.6.1 QUIET)
+
+    if (NOT Protobuf_FOUND)
+      if (ENABLE_GRPC)
+        message(FATAL_ERROR "ProtoBuf libraries not found.")
+      endif()
+
+      set(GRPC_DEPS_FOUND FALSE)
+    else()
+      message(STATUS "Found ProtoBuf: ${PROTOBUF_LIBRARIES}")
+    endif()
+  endif()
+
+  if (GRPC_DEPS_FOUND)
+    find_library(GRPC++_LIBRARIES NAMES grpc++)
+
+    if (NOT GRPC++_LIBRARIES)
+      if (ENABLE_GRPC)
+        message(FATAL_ERROR "gRPC++ libraries not found.")
+      endif()
+
+      set(GRPC_DEPS_FOUND FALSE)
+    else()
+      message(STATUS "Found gRPC++: ${GRPC++_LIBRARIES}")
+    endif()
+  endif()
+
+  if (GRPC_DEPS_FOUND)
+    find_package(gRPC 1.16.1 QUIET)
+
+    if (NOT gRPC_FOUND)
+      if (ENABLE_GRPC)
+        message(FATAL_ERROR "gRPC libraries not found.")
+      endif()
+
+      set(GRPC_DEPS_FOUND FALSE)
+    else()
+      message(STATUS "Found gRPC: ${GRPC_LIBRARIES}")
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
Also, disable GRPC on the Apple platform by default independently from the ENABLE_CPP setting

Signed-off-by: Hofi <hofione@gmail.com>
