### PR TITLE
cmake: Riemann client is now supports OpenSSL as a backing TLS library

### DIFF
--- a/cmake/Modules/FindRiemannClient.cmake
+++ b/cmake/Modules/FindRiemannClient.cmake
@@ -25,8 +25,15 @@ include(LibFindMacros)
 
 libfind_pkg_detect(Riemann riemann-client FIND_PATH riemann/event.h FIND_LIBRARY riemann-client)
 if (NOT Riemann_LIBRARY)
+  libfind_pkg_detect(Riemann riemann-client FIND_PATH riemann/event.h FIND_LIBRARY riemann-client-openssl)
+endif()
+if (NOT Riemann_LIBRARY)
   libfind_pkg_detect(Riemann riemann-client FIND_PATH riemann/event.h FIND_LIBRARY riemann-client-no-tls)
 endif()
+if (Riemann_LIBRARY)
+      message(STATUS "Found Riemann client: ${Riemann_LIBRARY}")
+endif()
+
 set(Riemann_PROCESS_INCLUDES Riemann_INCLUDE_DIR)
 set(Riemann_PROCESS_LIBS Riemann_LIBRARY)
 


### PR DESCRIPTION
Added the new library naming changes to enhance package discovery

Signed-off-by: Hofi <hofione@gmail.com>