### PR TITLE
packaging: add libprotoc-dev and libabsl-dev builddep

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -41,6 +41,8 @@ Build-Depends: debhelper (>= 10~),
                libpaho-mqtt-dev <!sng-nomqtt>,
                protobuf-compiler <!sng-nogrpc>,
                protobuf-compiler-grpc <!sng-nogrpc>,
+               libprotoc-dev <!sng-nogrpc>,
+               libabsl-dev <!sng-nogrpc>,
                libprotobuf-dev <!sng-nogrpc>,
                libgrpc++-dev <!sng-nogrpc>
 Build-Conflicts: autoconf2.13


### PR DESCRIPTION
For example, to allow reflective usage of Protocol Buffers (parsing/loading protobufs at runtime).
`libabsl-dev`: `google::protobuf::compiler` leaks Abseil data structures.