### PR TITLE
stats-aggregator: refactor and realtime counters

### DIFF
--- a/lib/stats/aggregator/stats-aggregator-registry.c
+++ b/lib/stats/aggregator/stats-aggregator-registry.c
@@ -36,7 +36,6 @@
 typedef struct
 {
   GHashTable *aggregators;
-  struct iv_timer update_timer;
 } StatsAggregatorContainer;
 
 static StatsAggregatorContainer stats_container;
@@ -60,58 +59,7 @@ stats_aggregator_unlock(void)
 
 /* time based aggregation */
 
-static void
-_update_func (gpointer _key, gpointer _value, gpointer _user_data)
-{
-  StatsAggregator *aggr = (StatsAggregator *) _value;
 
-  if (!stats_aggregator_is_orphaned(aggr))
-    stats_aggregator_aggregate(aggr);
-}
-
-static void
-_start_timer(void)
-{
-  main_loop_assert_main_thread();
-  iv_validate_now();
-  stats_container.update_timer.expires = iv_now;
-  stats_container.update_timer.expires.tv_sec += FREQUENCY_OF_UPDATE;
-
-  iv_timer_register(&stats_container.update_timer);
-}
-
-static void
-_update(void *cookie)
-{
-  msg_trace("stats-aggregator-registry update");
-  g_hash_table_foreach(stats_container.aggregators, _update_func, NULL);
-
-  if(g_hash_table_size(stats_container.aggregators) > 0
-      && !iv_timer_registered(&stats_container.update_timer))
-    _start_timer();
-}
-
-static void
-_init_timer(void)
-{
-  IV_TIMER_INIT(&stats_container.update_timer);
-  stats_container.update_timer.cookie = NULL;
-  stats_container.update_timer.handler = _update;
-}
-
-static void
-_stop_timer(void)
-{
-  main_loop_assert_main_thread();
-  if (iv_timer_registered(&stats_container.update_timer))
-    iv_timer_unregister(&stats_container.update_timer);
-}
-
-static void
-_deinit_timer(void)
-{
-  _stop_timer();
-}
 
 /* handle orphaned of aggregators */
 
@@ -183,13 +131,11 @@ stats_aggregator_registry_init(void)
 
   stats_container.aggregators = g_hash_table_new_full((GHashFunc) stats_cluster_key_hash,
                                                       (GEqualFunc) stats_cluster_key_equal, NULL, NULL);
-  _init_timer();
 }
 
 void
 stats_aggregator_registry_deinit(void)
 {
-  _deinit_timer();
   stats_aggregator_lock();
   stats_aggregator_cleanup();
   stats_aggregator_unlock();
@@ -204,9 +150,6 @@ static void
 _insert_to_table(StatsAggregator *aggr)
 {
   g_hash_table_insert(stats_container.aggregators, &aggr->key, aggr);
-
-  if (!iv_timer_registered(&stats_container.update_timer))
-    _start_timer();
 }
 
 static gboolean

--- a/lib/stats/aggregator/stats-aggregator.c
+++ b/lib/stats/aggregator/stats-aggregator.c
@@ -22,6 +22,8 @@
  */
 
 #include "stats/aggregator/stats-aggregator.h"
+#include "stats/stats-registry.h"
+#include "stats/stats-cluster-single.h"
 #include "mainloop.h"
 
 
@@ -134,9 +136,27 @@ _is_orphaned(StatsAggregator *self)
 }
 
 static void
+_register(StatsAggregator *self)
+{
+  stats_lock();
+  stats_register_counter(self->stats_level, &self->key, SC_TYPE_SINGLE_VALUE, &self->output_counter);
+  stats_unlock();
+}
+
+static void
+_unregister(StatsAggregator *self)
+{
+  stats_lock();
+  stats_unregister_counter(&self->key, SC_TYPE_SINGLE_VALUE, &self->output_counter);
+  stats_unlock();
+}
+
+static void
 _set_virtual_functions(StatsAggregator *self)
 {
   self->is_orphaned = _is_orphaned;
+  self->register_aggr = _register;
+  self->unregister_aggr = _unregister;
 }
 
 void

--- a/lib/stats/aggregator/stats-aggregator.c
+++ b/lib/stats/aggregator/stats-aggregator.c
@@ -22,10 +22,85 @@
  */
 
 #include "stats/aggregator/stats-aggregator.h"
+#include "mainloop.h"
+
+
+static void
+_restart_timer(StatsAggregator *self)
+{
+  main_loop_assert_main_thread();
+
+  if (self->timer_period < 0)
+    return;
+
+  /* NOTE: our timer may still be registered if _restart_timer() is called
+   * after _reset(): in this case stats_aggregator_start() will find an
+   * orphaned counter whose timer is still running as the 0 value is caused
+   * by reset and not by reaching zero due to aggregate.
+   *
+   * I hate the orphaned lifecycle model implemented in aggregators: we are
+   * keeping counters active if they are non-zero (see the _is_orphaned()
+   * method below).  I understand it is nicer that the counter is listed as
+   * active, but the hoops we needed to jump just for this is insane.  We
+   * should have just kept updating those counters even if the related
+   * connection is not active at the moment, who would have cared?  */
+
+  if (iv_timer_registered(&self->update_timer))
+    return;
+
+  iv_validate_now();
+  self->update_timer.expires = iv_now;
+  self->update_timer.expires.tv_sec += self->timer_period;
+
+  iv_timer_register(&self->update_timer);
+}
+
+static void
+_stop_timer(StatsAggregator *self)
+{
+  main_loop_assert_main_thread();
+
+  if (iv_timer_registered(&self->update_timer))
+    iv_timer_unregister(&self->update_timer);
+}
+
+static void
+_timer_callback(void *cookie)
+{
+  StatsAggregator *self = (StatsAggregator *) cookie;
+
+  if (!stats_aggregator_is_orphaned(self))
+    stats_aggregator_aggregate(self);
+
+  /* we might become orphaned only after the aggregated value reaches 0 */
+  if (stats_aggregator_is_orphaned(self))
+    stats_aggregator_unregister(self);
+  else
+    _restart_timer(self);
+}
+
+void
+stats_aggregator_register(StatsAggregator *self)
+{
+  if (self->register_aggr)
+    self->register_aggr(self);
+  _restart_timer(self);
+}
+
+void
+stats_aggregator_unregister(StatsAggregator *self)
+{
+  if (self->unregister_aggr)
+    self->unregister_aggr(self);
+  _stop_timer(self);
+}
+
+/* start/stop aggregation */
 
 void
 stats_aggregator_start(StatsAggregator *self)
 {
+  main_loop_assert_main_thread();
   if (!self)
     return;
 
@@ -38,6 +113,7 @@ stats_aggregator_start(StatsAggregator *self)
 void
 stats_aggregator_stop(StatsAggregator *self)
 {
+  main_loop_assert_main_thread();
   if (!self)
     return;
 
@@ -70,6 +146,11 @@ stats_aggregator_init_instance(StatsAggregator *self, StatsClusterKey *sc_key, g
   self->stats_level = stats_level;
   stats_cluster_key_clone(&self->key, sc_key);
   _set_virtual_functions(self);
+
+  IV_TIMER_INIT(&self->update_timer);
+  self->update_timer.cookie = self;
+  self->update_timer.handler = _timer_callback;
+  self->timer_period = -1;
 }
 
 void

--- a/lib/stats/aggregator/stats-aggregator.h
+++ b/lib/stats/aggregator/stats-aggregator.h
@@ -25,8 +25,8 @@
 #define STATS_AGGREGATOR_H
 
 #include "stats/stats-counter.h"
-#include "syslog-ng.h"
 #include "stats/stats-cluster.h"
+#include <iv.h>
 
 typedef struct _StatsAggregator StatsAggregator;
 
@@ -44,6 +44,8 @@ struct _StatsAggregator
   gssize use_count;
   StatsClusterKey key;
   gint stats_level;
+  gint timer_period;
+  struct iv_timer update_timer;
 };
 
 static inline void
@@ -76,19 +78,8 @@ stats_aggregator_is_orphaned(StatsAggregator *self)
   return TRUE;
 }
 
-static inline void
-stats_aggregator_register(StatsAggregator *self)
-{
-  if (self && self->register_aggr)
-    self->register_aggr(self);
-}
-
-static inline void
-stats_aggregator_unregister(StatsAggregator *self)
-{
-  if (self && self->unregister_aggr)
-    self->unregister_aggr(self);
-}
+void stats_aggregator_register(StatsAggregator *self);
+void stats_aggregator_unregister(StatsAggregator *self);
 
 /* public */
 void stats_aggregator_add_data_point(StatsAggregator *self, gsize value);

--- a/lib/stats/aggregator/stats-aggregator.h
+++ b/lib/stats/aggregator/stats-aggregator.h
@@ -43,6 +43,7 @@ struct _StatsAggregator
 
   gssize use_count;
   StatsClusterKey key;
+  StatsCounterItem *output_counter;
   gint stats_level;
   gint timer_period;
   struct iv_timer update_timer;

--- a/lib/stats/aggregator/stats-change-per-second.c
+++ b/lib/stats/aggregator/stats-change-per-second.c
@@ -61,11 +61,6 @@ typedef struct
   CPSLogic start;
 } StatsAggregatorCPS;
 
-static inline gsize
-_get_count(StatsAggregatorCPS *self)
-{
-  return stats_counter_get(self->input_counter);
-}
 
 static void
 _reset_CPS_logic_values(CPSLogic *self)
@@ -212,7 +207,7 @@ _is_less_then_duration(StatsAggregatorCPS *self, CPSLogic *logic, time_t *now)
 static void
 _calc_sum(StatsAggregatorCPS *self, CPSLogic *logic, time_t *now)
 {
-  gsize count = _get_count(self);
+  gsize count = stats_counter_get(self->input_counter);
   gsize diff = count - logic->last_count;
   logic->last_count = count;
 

--- a/lib/stats/aggregator/stats-change-per-second.c
+++ b/lib/stats/aggregator/stats-change-per-second.c
@@ -302,9 +302,6 @@ _aggregate(StatsAggregator *s)
   _aggregate_CPS_logic(self, &self->hour, &now);
   _aggregate_CPS_logic(self, &self->day, &now);
   _aggregate_CPS_logic(self, &self->start, &now);
-
-  if (stats_aggregator_is_orphaned(&self->super))
-    _unregister(s);
 }
 
 static void

--- a/lib/stats/aggregator/stats-change-per-second.c
+++ b/lib/stats/aggregator/stats-change-per-second.c
@@ -366,6 +366,7 @@ stats_aggregator_cps_new(gint level, StatsClusterKey *sc_key, StatsClusterKey *s
   self->hour.duration = HOUR_IN_SEC;
   self->day.duration = DAY_IN_SEC;
   self->start.duration = -1;
+  self->super.timer_period = 60;
 
   return &self->super;
 }

--- a/lib/stats/aggregator/stats-maximum.c
+++ b/lib/stats/aggregator/stats-maximum.c
@@ -28,7 +28,6 @@
 typedef struct
 {
   StatsAggregator super;
-  StatsCounterItem *output_counter;
 } StatsAggregatorMaximum;
 
 static void
@@ -39,44 +38,19 @@ _add_data_point(StatsAggregator *s, gsize value)
 
   do
     {
-      current_max = stats_counter_get(self->output_counter);
+      current_max = stats_counter_get(self->super.output_counter);
 
       if (current_max >= value)
         break;
 
     }
-  while(!atomic_gssize_compare_and_exchange(&self->output_counter->value, current_max, value));
-}
-
-static void
-_register(StatsAggregator *s)
-{
-  StatsAggregatorMaximum *self = (StatsAggregatorMaximum *)s;
-  stats_lock();
-  stats_register_counter(self->super.stats_level, &self->super.key, SC_TYPE_SINGLE_VALUE, &self->output_counter);
-  stats_unlock();
-}
-
-static void
-_unregister(StatsAggregator *s)
-{
-  StatsAggregatorMaximum *self = (StatsAggregatorMaximum *)s;
-
-  if(self->output_counter)
-    {
-      stats_lock();
-      stats_unregister_counter(&self->super.key, SC_TYPE_SINGLE_VALUE, &self->output_counter);
-      self->output_counter = NULL;
-      stats_unlock();
-    }
+  while(!atomic_gssize_compare_and_exchange(&self->super.output_counter->value, current_max, value));
 }
 
 static void
 _set_virtual_function(StatsAggregatorMaximum *self)
 {
   self->super.add_data_point = _add_data_point;
-  self->super.register_aggr = _register;
-  self->super.unregister_aggr = _unregister;
 }
 
 StatsAggregator *


### PR DESCRIPTION
These commits were part of #4565.

This set of patches breaks KIRA for some reason. I think they are functionally correct, and further investigation is needed whether the testcase should be adjusted or the code. I have separated these commits as they are not necessary for #4565, so we should not block that PR on this change.

Depends on #4565.