### PR TITLE
SCL parser for PostgreSQL csvlog

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -127,6 +127,7 @@ set (LIB_HEADERS
     mainloop-control.h
     msg-format.h
     msg-stats.h
+    on-error.h
     parse-number.h
     pathutils.h
     persist-state.h
@@ -224,6 +225,7 @@ set(LIB_SOURCES
     mainloop-control.c
     msg-format.c
     msg-stats.c
+    on-error.c
     parse-number.c
     pathutils.c
     persist-state.c

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -148,6 +148,7 @@ pkginclude_HEADERS			+= \
 	lib/ml-batched-timer.h		\
 	lib/msg-format.h		\
 	lib/msg-stats.h			\
+	lib/on-error.h			\
 	lib/parse-number.h		\
 	lib/pathutils.h         \
 	lib/persist-state.h		\
@@ -243,6 +244,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	lib/ml-batched-timer.c		\
 	lib/msg-format.c		\
 	lib/msg-stats.c			\
+	lib/on-error.c			\
 	lib/parse-number.c		\
 	lib/pathutils.c         \
 	lib/persist-state.c		\

--- a/lib/on-error.c
+++ b/lib/on-error.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2013 Balabit
+ * Copyright (c) 1998-2013 Balázs Scheidler
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "on-error.h"
+
+gboolean
+on_error_parse(const gchar *strictness, gint *out)
+{
+  const gchar *p = strictness;
+  gboolean silently = FALSE;
+
+  if (!strictness)
+    {
+      *out = ON_ERROR_DROP_MESSAGE;
+      return TRUE;
+    }
+
+  if (strncmp(strictness, "silently-", strlen("silently-")) == 0)
+    {
+      silently = TRUE;
+      p = strictness + strlen("silently-");
+    }
+
+  if (strcmp(p, "drop-message") == 0)
+    *out = ON_ERROR_DROP_MESSAGE;
+  else if (strcmp(p, "drop-property") == 0)
+    *out = ON_ERROR_DROP_PROPERTY;
+  else if (strcmp(p, "fallback-to-string") == 0)
+    *out = ON_ERROR_FALLBACK_TO_STRING;
+  else
+    return FALSE;
+
+  if (silently)
+    *out |= ON_ERROR_SILENT;
+
+  return TRUE;
+}

--- a/lib/on-error.h
+++ b/lib/on-error.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2013 Balabit
+ * Copyright (c) 1998-2013 Balázs Scheidler
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef ON_ERROR_H_INCLUDED
+#define ON_ERROR_H_INCLUDED
+
+#include "syslog-ng.h"
+#include "atomic.h"
+
+typedef enum
+{
+  ON_ERROR_DROP_MESSAGE        = 0x01,
+  ON_ERROR_DROP_PROPERTY       = 0x02,
+  ON_ERROR_FALLBACK_TO_STRING  = 0x04, /* Valid for type hinting
+                                          only! */
+  ON_ERROR_SILENT              = 0x08
+} OnError;
+
+gboolean on_error_parse(const gchar *on_error, gint *out);
+
+#endif

--- a/lib/template/templates.c
+++ b/lib/template/templates.c
@@ -496,34 +496,7 @@ log_template_error_quark(void)
 gboolean
 log_template_on_error_parse(const gchar *strictness, gint *out)
 {
-  const gchar *p = strictness;
-  gboolean silently = FALSE;
-
-  if (!strictness)
-    {
-      *out = ON_ERROR_DROP_MESSAGE;
-      return TRUE;
-    }
-
-  if (strncmp(strictness, "silently-", strlen("silently-")) == 0)
-    {
-      silently = TRUE;
-      p = strictness + strlen("silently-");
-    }
-
-  if (strcmp(p, "drop-message") == 0)
-    *out = ON_ERROR_DROP_MESSAGE;
-  else if (strcmp(p, "drop-property") == 0)
-    *out = ON_ERROR_DROP_PROPERTY;
-  else if (strcmp(p, "fallback-to-string") == 0)
-    *out = ON_ERROR_FALLBACK_TO_STRING;
-  else
-    return FALSE;
-
-  if (silently)
-    *out |= ON_ERROR_SILENT;
-
-  return TRUE;
+  return on_error_parse(strictness, out);
 }
 
 void

--- a/lib/template/templates.h
+++ b/lib/template/templates.h
@@ -31,6 +31,7 @@
 #include "logmsg/type-hinting.h"
 #include "common-template-typedefs.h"
 #include "atomic.h"
+#include "on-error.h"
 
 #define LOG_TEMPLATE_ERROR log_template_error_quark()
 
@@ -42,14 +43,6 @@ enum LogTemplateError
   LOG_TEMPLATE_ERROR_COMPILE,
 };
 
-typedef enum
-{
-  ON_ERROR_DROP_MESSAGE        = 0x01,
-  ON_ERROR_DROP_PROPERTY       = 0x02,
-  ON_ERROR_FALLBACK_TO_STRING  = 0x04, /* Valid for type hinting
-                                          only! */
-  ON_ERROR_SILENT              = 0x08
-} LogTemplateOnError;
 
 /* structure that represents an expandable syslog-ng template */
 struct _LogTemplate

--- a/modules/csvparser/csvparser-grammar.ym
+++ b/modules/csvparser/csvparser-grammar.ym
@@ -60,6 +60,7 @@
 %token KW_CHARS
 %token KW_STRINGS
 %token KW_DROP_INVALID
+%token KW_ON_TYPE_ERROR
 
 %type	<ptr> parser_expr_csv
 %type   <ptr> parser_csv_columns
@@ -102,6 +103,15 @@ parser_csv_opt
         | KW_QUOTE_PAIRS '(' string ')'         { csv_scanner_options_set_quote_pairs(csv_parser_get_scanner_options(last_parser), $3); free($3); }
         | KW_NULL '(' string ')'                { csv_scanner_options_set_null_value(csv_parser_get_scanner_options(last_parser), $3); free($3); }
         | KW_COLUMNS '(' parser_csv_columns ')'        { csv_parser_set_columns(last_parser, $3); }
+        | KW_ON_TYPE_ERROR '(' string ')'
+        {
+          gint on_error;
+
+          CHECK_ERROR(on_error_parse($3, &on_error), @3, "Invalid on-type-error() setting \"%s\"", $3);
+          free($3);
+
+          csv_parser_set_on_error(last_parser, on_error);
+        }
         | parser_opt
         ;
 

--- a/modules/csvparser/csvparser-parser.c
+++ b/modules/csvparser/csvparser-parser.c
@@ -41,6 +41,7 @@ static CfgLexerKeyword csvparser_keywords[] =
   { "chars",        KW_CHARS },
   { "strings",      KW_STRINGS },
   { "drop_invalid", KW_DROP_INVALID },
+  { "on_type_error", KW_ON_TYPE_ERROR},
   { "null",         KW_NULL },
   { NULL }
 };

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -57,9 +57,9 @@ typedef struct _CSVParser
   LogParser super;
   CSVScannerOptions options;
   GList *columns;
-  gboolean drop_invalid;
   gchar *prefix;
   gint prefix_len;
+  gint on_error;
 } CSVParser;
 
 #define CSV_PARSER_FLAGS_SHIFT 16
@@ -113,7 +113,7 @@ csv_parser_set_flags(LogParser *s, guint32 flags)
       return FALSE;
     }
   if (flags & CSV_PARSER_DROP_INVALID)
-    self->drop_invalid = TRUE;
+    csv_parser_set_drop_invalid((LogParser *) self, TRUE);
   return TRUE;
 }
 
@@ -139,8 +139,10 @@ void
 csv_parser_set_drop_invalid(LogParser *s, gboolean drop_invalid)
 {
   CSVParser *self = (CSVParser *) s;
-
-  self->drop_invalid = drop_invalid;
+  if (drop_invalid)
+    self->on_error |= ON_ERROR_DROP_MESSAGE;
+  else
+    self->on_error &= ~ON_ERROR_DROP_MESSAGE;
 }
 
 static const gchar *
@@ -165,6 +167,12 @@ dispatch_key_formatter(gchar *prefix)
   return prefix ? _format_key_for_prefix : _return_key;
 }
 
+gboolean
+_should_drop_message(CSVParser *self)
+{
+  return (self->on_error & ON_ERROR_DROP_MESSAGE);
+}
+
 static gboolean
 _process_column(CSVParser *self, CSVScanner *scanner, LogMessage *msg, CSVParserColumn *current_column,
                 GString *key_scratch)
@@ -175,7 +183,7 @@ _process_column(CSVParser *self, CSVScanner *scanner, LogMessage *msg, CSVParser
   GError *error = NULL;
   key_formatter_t _key_formatter = dispatch_key_formatter(self->prefix);
 
-  if (self->drop_invalid && !type_cast_validate(current_value, current_column->type, &error))
+  if (_should_drop_message(self) && !type_cast_validate(current_value, current_column->type, &error))
     {
       msg_debug("csv-parser: error casting value to the type specified",
                 evt_tag_str("column", current_column->name),
@@ -249,10 +257,11 @@ csv_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_o
   if (!csv_scanner_is_scan_complete(&scanner))
     result = FALSE;
 
-  if (self->drop_invalid && !result)
+  if (_should_drop_message(self) && !result && !(self->on_error & ON_ERROR_SILENT))
     {
       msg_debug("csv-parser() failed",
-                evt_tag_str("error", "csv-parser() failed to parse its input and drop-invalid(yes) was specified"),
+                evt_tag_str("error",
+                            "csv-parser() failed to parse its input and drop-invalid(yes) or on-error(\"drop-message\") was specified"),
                 evt_tag_str("input", input));
     }
   else
@@ -273,7 +282,7 @@ csv_parser_clone(LogPipe *s)
   cloned->columns = g_list_copy_deep(self->columns, (GCopyFunc) csv_parser_column_clone, NULL);
   csv_scanner_options_copy(&cloned->options, &self->options);
   csv_parser_set_prefix(&cloned->super, self->prefix);
-  csv_parser_set_drop_invalid(&cloned->super, self->drop_invalid);
+  csv_parser_set_on_error(&cloned->super, self->on_error);
   return &cloned->super.super;
 }
 
@@ -312,6 +321,7 @@ csv_parser_new(GlobalConfig *cfg)
   self->super.super.free_fn = csv_parser_free;
   self->super.super.clone = csv_parser_clone;
   self->super.process = csv_parser_process;
+
   csv_scanner_options_set_delimiters(&self->options, " ");
   csv_scanner_options_set_quote_pairs(&self->options, "\"\"''");
   csv_scanner_options_set_flags(&self->options, CSV_SCANNER_STRIP_WHITESPACE);
@@ -349,4 +359,11 @@ csv_parser_lookup_dialect(const gchar *flag)
   else if (strcmp(flag, "escape-double-char") == 0)
     return CSV_SCANNER_ESCAPE_DOUBLE_CHAR;
   return -1;
+}
+
+void
+csv_parser_set_on_error(LogParser *s, gint on_error)
+{
+  CSVParser *self = (CSVParser *) s;
+  self->on_error = on_error;
 }

--- a/modules/csvparser/csvparser.h
+++ b/modules/csvparser/csvparser.h
@@ -43,6 +43,7 @@ void csv_parser_set_drop_invalid(LogParser *s, gboolean drop_invalid);
 void csv_parser_set_prefix(LogParser *s, const gchar *prefix);
 void csv_parser_set_list_name(LogParser *s, const gchar *list_name);
 LogParser *csv_parser_new(GlobalConfig *cfg);
+void csv_parser_set_on_error(LogParser *s, gint on_error);
 
 guint32 csv_parser_lookup_flag(const gchar *flag);
 gint csv_parser_lookup_dialect(const gchar *flag);

--- a/news/feature-4586.md
+++ b/news/feature-4586.md
@@ -1,0 +1,3 @@
+`postgresql-csvlog-parser()`: add a new parser to process CSV log formatted by
+PostgreSQL (https://www.postgresql.org/docs/current/runtime-config-logging.html).
+The CSV format is extracted into a set of name-value pairs.

--- a/scl/CMakeLists.txt
+++ b/scl/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SCL_DIRS
     osquery
     pacct
     paloalto
+    pgsql
     python
     rewrite
     slack

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -31,6 +31,7 @@ SCL_SUBDIRS	= \
 	osquery	\
 	pacct		\
 	paloalto 	\
+	pgsql 	\
 	python		\
 	rewrite	\
 	slack \

--- a/scl/pgsql/pgsql.conf
+++ b/scl/pgsql/pgsql.conf
@@ -35,37 +35,93 @@
 # avg read rate: 0.000 MB/s, avg write rate: 114.609 MB/s
 # system usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.00 s",,,,,,,,,""
 
-block parser postgresql-csvlog-parser(prefix(".pgsql.")) {
-    csv-parser(
-        columns(
-            "timestamp",
-            "username",
-            "database",
-            "pid",
-            "connection_from",
-            "session_id",
-            "session_line_num",
-            "command_tag",
-            "session_start_time",
-            "virtual_transaction_id",
-            "transaction_id",
-            "severity",
-            "sql_state_code",
-            "message",
-            "detail",
-            "hint",
-            "internal_query",
-            "internal_query_pos",
-            "context",
-            "query",
-            "query_pos",
-            "location",
-            "application_name",
-        )
-        delimiters(",")
-	dialect(escape-double-char)
-        flags(strip-whitespace)
-        prefix(`prefix`)
-        quote-pairs('""')
-    );
+block parser postgresql-csvlog-parser(internal(yes) prefix(".pgsql.") on-type-error("drop-property")) {
+    channel {
+        parser { csv-parser(
+            internal(yes)
+            columns(
+                "timestamp",
+                "username",
+                "database",
+                int("pid"),
+                "connection_from",
+                "session_id",
+                int("session_line_num"),
+                "command_tag",
+                "session_start_time",
+                "virtual_transaction_id",
+                int("transaction_id"),
+                "severity",
+                "sql_state_code",
+                "message",
+                "detail",
+                "hint",
+                "internal_query",
+                int("internal_query_pos"),
+                "context",
+                "query",
+                int("query_pos"),
+                "location",
+                "application_name",
+                # Available from vesion 13+
+                "backend_type",
+                # Available from vesion 14+
+                int("leader_pid"),
+                int("query_id"),
+            )
+            delimiters(",")
+            dialect(escape-double-char)
+            flags(strip-whitespace)
+            prefix(`prefix`)
+            quote-pairs('""')
+            on-type-error(`on-type-error`)
+        );
+        };
+        # Extract values into built-in macros
+        parser {
+          date-parser(
+            internal(yes)
+            # Extract without the specified timezone as it seems to be not standard compilant.
+            format("%Y-%m-%d %H:%M:%S.%f")
+            template("$(substr ${`prefix`timestamp} 0 23)")
+            );
+        };
+         rewrite {
+            set(int("${`prefix`pid}") value("PID") internal(yes));
+            set(string("$(if ('${`prefix`connection_from}' ne '') ${`prefix`connection_from} $HOST_FROM)") value("`prefix`connection_from") internal(yes));
+            set(string("${`prefix`message}") value("MESSAGE") internal(yes));
+        };
+        # Map severity
+        if (match("DEBUG[1-5]" value('`prefix`severity') type(pcre))) {
+            rewrite {
+                set-severity("DEBUG");
+            };
+        }
+        elif (match("WARNING" value('`prefix`severity') type(string))) {
+            rewrite {
+                set-severity("NOTICE");
+            };
+        }
+        elif (match("ERROR" value('`prefix`severity') type(string))) {
+            rewrite {
+                set-severity("WARNING");
+            };
+        }
+        elif (match("LOG" value('`prefix`severity') type(string))) {
+            rewrite {
+                set-severity("INFO");
+            };
+        }
+        elif (match("FATAL" value('`prefix`severity') type(string))) {
+            rewrite {
+                set-severity("ERR");
+            };
+        }
+        elif (match("PANIC" value('`prefix`severity') type(string))) {
+            rewrite {
+                set-severity("CRIT");
+            };
+        }
+        else {};
+    };
 };

--- a/scl/pgsql/pgsql.conf
+++ b/scl/pgsql/pgsql.conf
@@ -1,0 +1,71 @@
+#############################################################################
+# Copyright (c) 2023 Balazs Scheidler <balazs.scheidler@axoflow.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+#
+# PostgreSQL csvlog
+# (https://www.postgresql.org/docs/current/runtime-config-logging.html)
+#
+# NOTE the message sample below is a multi-line message with embedded NL
+# characters.  All of this is a single, multi line log entry that starts
+# with the timestamp.
+#
+# 2023-08-08 12:05:52.805 UTC,,,22113,,64d22fa0.5661,1,,2023-08-08 12:05:52 UTC,23/74060,0,LOG,00000,"automatic vacuum of table ""tablename"": index scans: 0
+# pages: 0 removed, 4 remain, 0 skipped due to pins, 0 skipped frozen
+# tuples: 114 removed, 268 remain, 0 are dead but not yet removable, oldest xmin: 149738000
+# buffer usage: 97 hits, 0 misses, 6 dirtied
+# avg read rate: 0.000 MB/s, avg write rate: 114.609 MB/s
+# system usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.00 s",,,,,,,,,""
+
+block parser postgresql-csvlog-parser(prefix(".pgsql.")) {
+    csv-parser(
+        columns(
+            "timestamp",
+            "username",
+            "database",
+            "pid",
+            "connection_from",
+            "session_id",
+            "session_line_num",
+            "command_tag",
+            "session_start_time",
+            "virtual_transaction_id",
+            "transaction_id",
+            "severity",
+            "sql_state_code",
+            "message",
+            "detail",
+            "hint",
+            "internal_query",
+            "internal_query_pos",
+            "context",
+            "query",
+            "query_pos",
+            "location",
+            "application_name",
+        )
+        delimiters(",")
+	dialect(escape-double-char)
+        flags(strip-whitespace)
+        prefix(`prefix`)
+        quote-pairs('""')
+    );
+};

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -224,6 +224,7 @@ tests/light/functional_tests/logpath/test_named_logpaths_with_fallback_flag.py
 tests/light/functional_tests/logpath/test_named_logpaths_with_final_flag.py
 tests/light/functional_tests/parsers/sdata-parser/test_sdata_parser\.py
 tests/light/functional_tests/parsers/group-lines-parser/test_group_lines_parser\.py
+tests/light/functional_tests/parsers/postgresql-csvlog-parser/test_postgresql_csvlog_parser\.py
 tests/light/functional_tests/logpath/test_conditionals\.py
 tests/light/functional_tests/logpath/test_midpoint_destinations\.py
 tests/light/functional_tests/value-pairs/test_value_pairs\.py

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -207,6 +207,7 @@ scl/python/python-modules\.conf$
 scl/splunk/splunk\.conf$
 scl/google/google-pubsub\.conf$
 scl/openobserve/.*\.conf$
+scl/pgsql/pgsql\.conf$
 modules/python-modules/syslogng/modules/kubernetes/.*
 modules/ebpf/.*
 modules/python-modules/syslogng/modules/hypr/.*

--- a/tests/light/functional_tests/Makefile.am
+++ b/tests/light/functional_tests/Makefile.am
@@ -37,6 +37,7 @@ EXTRA_DIST += \
 	tests/light/functional_tests/parsers/csv-parser/test_csv_parser.py \
 	tests/light/functional_tests/parsers/db_parser/test_db_parser.py \
 	tests/light/functional_tests/parsers/mariadb-parser/test_mariadb_audit_parser.py \
+	tests/light/functional_tests/parsers/postgresql-csvlog-parser/test_postgresql_csvlog_parser.py \
 	tests/light/functional_tests/parsers/panos/test_panos_parser.py \
 	tests/light/functional_tests/parsers/regexp-parser/test_regexp_parser.py \
 	tests/light/functional_tests/parsers/sdata-parser/test_sdata_parser.py \

--- a/tests/light/functional_tests/parsers/postgresql-csvlog-parser/test_postgresql_csvlog_parser.py
+++ b/tests/light/functional_tests/parsers/postgresql-csvlog-parser/test_postgresql_csvlog_parser.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2023 Szilard Parrag
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import json
+
+import pytest
+
+
+test_parameters = [
+    (
+        "2023-09-20 16:50:02.165 CET,,,407764,,650b069a.638d4,2,,2023-09-20 16:50:02 CET,,0,DEBUG3,00000,\"starting PostgreSQL 15.4 (Ubuntu 15.4-0ubuntu0.23.04.1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 12.3.0-1ubuntu1~23.04) 12.3.0, 64-bit\",,,,,,,,,\"\",\"postmaster\",,0",
+        {
+            "DATE": "Sep 20 16:50:02",
+            "HOST_FROM": "localhost",
+            "MSG": "starting PostgreSQL 15.4 (Ubuntu 15.4-0ubuntu0.23.04.1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 12.3.0-1ubuntu1~23.04) 12.3.0, 64-bit",
+            "PID": 407764,
+            "SEVERITY": "debug",
+            "_pgsql": {
+                "application_name": "",
+                "command_tag": "",
+                "connection_from": "localhost",
+                "context": "",
+                "database": "",
+                "detail": "",
+                "hint": "",
+                "internal_query": "",
+                "location": "",
+                "message": "starting PostgreSQL 15.4 (Ubuntu 15.4-0ubuntu0.23.04.1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 12.3.0-1ubuntu1~23.04) 12.3.0, 64-bit",
+                "pid": 407764,
+                "query": "",
+                "session_id": "650b069a.638d4",
+                "session_line_num": 2,
+                "session_start_time": "2023-09-20 16:50:02 CET",
+                "severity": "LOG",
+                "sql_state_code": "00000",
+                "timestamp": "2023-09-20 16:50:02.165 CET",
+                "transaction_id": "0",
+                "username": "",
+                "virtual_transaction_id": "",
+            },
+        },
+    ),
+    (
+        r'2023-08-08 12:05:52.805 UTC,,,22113,,64d22fa0.5661,1,,2023-08-08 12:05:52 UTC,23/74060,0,LOG,00000,"automatic vacuum of table ""tablename"": index scans: 0 pages: 0 removed, 4 remain, 0 skipped due to pins, 0 skipped frozen tuples: 114 removed, 268 remain, 0 are dead but not yet removable, oldest xmin: 149738000 buffer usage: 97 hits, 0 misses, 6 dirtied avg read rate: 0.000 MB/s, avg write rate: 114.609 MB/s system usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.00 s",,,,,,,,,""',
+        {
+            "DATE": "Aug  8 12:05:52",
+            "HOST_FROM": "localhost",
+            "MSG": r'automatic vacuum of table "tablename": index scans: 0 pages: 0 removed, 4 remain, 0 skipped due to pins, 0 skipped frozen tuples: 114 removed, 268 remain, 0 are dead but not yet removable, oldest xmin: 149738000 buffer usage: 97 hits, 0 misses, 6 dirtied avg read rate: 0.000 MB/s, avg write rate: 114.609 MB/s system usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.00 s',
+            "PID": 22113,
+            "SEVERITY": "info",
+            "_pgsql": {
+                "application_name": "",
+                "command_tag": "",
+                "connection_from": "localhost",
+                "context": "",
+                "database": "",
+                "detail": "",
+                "hint": "",
+                "internal_query": "",
+                "location": "",
+                "message": r'automatic vacuum of table "tablename": index scans: 0 pages: 0 removed, 4 remain, 0 skipped due to pins, 0 skipped frozen tuples: 114 removed, 268 remain, 0 are dead but not yet removable, oldest xmin: 149738000 buffer usage: 97 hits, 0 misses, 6 dirtied avg read rate: 0.000 MB/s, avg write rate: 114.609 MB/s system usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.00 s',
+                "pid": 22113,
+                "query": "",
+                "session_id": "64d22fa0.5661",
+                "session_line_num": 1,
+                "session_start_time": "2023-08-08 12:05:52 UTC",
+                "severity": "LOG",
+                "sql_state_code": "00000",
+                "timestamp": "2023-08-08 12:05:52.805 UTC",
+                "transaction_id": "0",
+                "username": "",
+                "virtual_transaction_id": "",
+            },
+        },
+    ),
+    (
+        # Less fields than specified in the scl
+        r'2023-08-08 12:05:52.805 UTC,,,22113,,64d22fa0.5661,1,,2023-08-08 12:05:52 UTC,23/74060,0,LOG,00000,',
+        {
+
+            "DATE": "Aug  8 12:05:52",
+            "HOST_FROM": "localhost",
+            "PID": 22113,
+            "SEVERITY": "info",
+            "_pgsql": {
+                "application_name": "",
+                "command_tag": "",
+                "connection_from": "localhost",
+                "context": "",
+                "database": "",
+                "detail": "",
+                "hint": "",
+                "internal_query": "",
+                "location": "",
+                "pid": 22113,
+                "query": "",
+                "session_id": "64d22fa0.5661",
+                "session_line_num": 1,
+                "session_start_time": "2023-08-08 12:05:52 UTC",
+                "severity": "LOG",
+                "sql_state_code": "00000",
+            },
+        },
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "input_message, expected_kv_pairs",
+    test_parameters,
+    ids=range(len(test_parameters)),
+)
+def test_postgresql_csvlog_parser(config, port_allocator, syslog_ng, input_message, expected_kv_pairs):
+    config.add_include("scl.conf")
+
+    network_source = config.create_network_source(ip="localhost", port=port_allocator(), flags="no-parse")
+    pgsql_csvlog_parser = config.create_postgresql_csvlog_parser()
+    file_destination = config.create_file_destination(
+        file_name="output.log",
+        template=config.stringify("$(format-json --scope everything)" + "\n"),
+    )
+    config.create_logpath(
+        statements=[network_source, pgsql_csvlog_parser, file_destination],
+    )
+
+    syslog_ng.start(config)
+    network_source.write_log(input_message)
+
+    output_json = json.loads(file_destination.read_log())
+
+    assert output_json["DATE"] == expected_kv_pairs["DATE"]
+    assert output_json["HOST_FROM"] == expected_kv_pairs["HOST_FROM"]
+    assert output_json["PID"] == expected_kv_pairs["PID"]
+    assert output_json["SEVERITY"] == expected_kv_pairs["SEVERITY"]
+
+    assert output_json["_pgsql"]["session_id"] == expected_kv_pairs["_pgsql"]["session_id"]
+    assert output_json["_pgsql"]["session_line_num"] == expected_kv_pairs["_pgsql"]["session_line_num"]
+    assert output_json["_pgsql"]["session_start_time"] == expected_kv_pairs["_pgsql"]["session_start_time"]
+
+    # If field is filled
+    if "timestamp" in expected_kv_pairs["_pgsql"]:
+        assert output_json["_pgsql"]["timestamp"] == expected_kv_pairs["_pgsql"]["timestamp"]

--- a/tests/light/functional_tests/parsers/postgresql-csvlog-parser/test_postgresql_csvlog_parser.py
+++ b/tests/light/functional_tests/parsers/postgresql-csvlog-parser/test_postgresql_csvlog_parser.py
@@ -121,6 +121,42 @@ test_parameters = [
             },
         },
     ),
+    (
+        # Log with query_id(v14+), backend_type(v13+)
+        r'2023-11-03 16:32:35.084 CET,"postgres","bench_test",3451998,"[local]",65451258.34ac5e,632376,"UPDATE",2023-11-03 16:31:36 CET,6/45171,228887,LOG,00000,"duration: 0.081 ms",,,,,,,,,"pgbench","client backend",,1521477082073268809',
+        {
+            "DATE": "Nov  3 16:32:35",
+            "HOST_FROM": "localhost",
+            "MSG": r'automatic vacuum of table "tablename": index scans: 0 pages: 0 removed, 4 remain, 0 skipped due to pins, 0 skipped frozen tuples: 114 removed, 268 remain, 0 are dead but not yet removable, oldest xmin: 149738000 buffer usage: 97 hits, 0 misses, 6 dirtied avg read rate: 0.000 MB/s, avg write rate: 114.609 MB/s system usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.00 s',
+            "PID": 3451998,
+            "SEVERITY": "info",
+            "_pgsql": {
+                "application_name": "",
+                "command_tag": "",
+                "connection_from": "localhost",
+                "context": "",
+                "database": "",
+                "detail": "",
+                "hint": "",
+                "internal_query": "",
+                "location": "",
+                "message": r'automatic vacuum of table "tablename": index scans: 0 pages: 0 removed, 4 remain, 0 skipped due to pins, 0 skipped frozen tuples: 114 removed, 268 remain, 0 are dead but not yet removable, oldest xmin: 149738000 buffer usage: 97 hits, 0 misses, 6 dirtied avg read rate: 0.000 MB/s, avg write rate: 114.609 MB/s system usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.00 s',
+                "pid": 22113,
+                "query": "",
+                "session_id": "65451258.34ac5e",
+                "session_line_num": 632376,
+                "session_start_time": "2023-11-03 16:31:36 CET",
+                "severity": "LOG",
+                "sql_state_code": "00000",
+                "timestamp": "2023-11-03 16:32:35.084 CET",
+                "transaction_id": "0",
+                "username": "",
+                "virtual_transaction_id": "",
+                "query_id": 1521477082073268809,
+                "backend_type": "client backend",
+            },
+        },
+    ),
 ]
 
 
@@ -159,3 +195,9 @@ def test_postgresql_csvlog_parser(config, port_allocator, syslog_ng, input_messa
     # If field is filled
     if "timestamp" in expected_kv_pairs["_pgsql"]:
         assert output_json["_pgsql"]["timestamp"] == expected_kv_pairs["_pgsql"]["timestamp"]
+
+    # Optional, extra fields
+    extra_fields = ["query_id", "backend_type"]
+    for extra_field in extra_fields:
+        if extra_field in expected_kv_pairs["_pgsql"]:
+            assert output_json["_pgsql"][extra_field] == expected_kv_pairs["_pgsql"][extra_field]

--- a/tests/light/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/light/src/syslog_ng_config/syslog_ng_config.py
@@ -166,6 +166,9 @@ class SyslogNgConfig(object):
     def create_mariadb_audit_parser(self, **options):
         return Parser("mariadb-audit-parser", **options)
 
+    def create_postgresql_csvlog_parser(self, **options):
+        return Parser("postgresql-csvlog-parser", **options)
+
     def create_file_destination(self, **options):
         file_destination = FileDestination(**options)
         self.teardown.register(file_destination.close_file)


### PR DESCRIPTION
add a new parser to process CSV log formatted by PostgreSQL (https://www.postgresql.org/docs/current/runtime-config-logging.html). The CSV format is extracted into a set of name-value pairs.
