### PR TITLE
packaging/debian: move the SCL package to syslog-ng-core

### DIFF
--- a/packaging/debian/syslog-ng-core.install
+++ b/packaging/debian/syslog-ng-core.install
@@ -38,6 +38,7 @@ usr/lib/syslog-ng/libloggen_helper-*.so.*
 usr/lib/syslog-ng/libloggen_plugin-*.so.*
 usr/share/syslog-ng/xsd/*
 usr/share/syslog-ng/smart-multi-line.fsm
+usr/share/syslog-ng/include/scl.conf
 [linux-any] usr/lib/syslog-ng/*/libsdjournal.so
 [linux-any] usr/lib/syslog-ng/*/libpacctformat.so
 

--- a/packaging/debian/syslog-ng-scl.install
+++ b/packaging/debian/syslog-ng-scl.install
@@ -1,2 +1,1 @@
 usr/share/syslog-ng/include/scl/*
-usr/share/syslog-ng/include/scl.conf


### PR DESCRIPTION
The default configuration includes "scl.conf", so unless syslog-ng-scl is installed, we would have a broken config.

Fixes: #4585

