### PR TITLE
Log queue remove unused code

### DIFF
--- a/lib/logqueue-fifo.c
+++ b/lib/logqueue-fifo.c
@@ -110,7 +110,7 @@ typedef struct _LogQueueFifo
  *
  * In the output thread, this means that this can get race-free. In the
  * input thread, the output_queue can change because of a
- * log_queue_fifo_push_head() or log_queue_fifo_rewind_backlog().
+ * log_queue_fifo_rewind_backlog().
  *
  */
 
@@ -215,9 +215,9 @@ static inline gboolean
 log_queue_fifo_calculate_num_of_messages_to_drop(LogQueueFifo *self, InputQueue *input_queue,
                                                  gint *num_of_messages_to_drop)
 {
-  /* since we're in the input thread, queue_len will be racy.
-   * It can increase due to log_queue_fifo_push_head() and can also decrease as
-   * items are removed from the output queue using log_queue_pop_head().
+  /* since we're in the input thread, queue_len will be racy.  It can
+   * increase due to log_queue_fifo_rewind_backlog() and can also decrease
+   * as items are removed from the output queue using log_queue_pop_head().
    *
    * The only reason we're using it here is to check for qoverflow
    * overflows, however the only side-effect of the race (if lost) is that
@@ -423,37 +423,6 @@ log_queue_fifo_push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *pat
   g_mutex_unlock(&self->super.lock);
 
   log_msg_unref(msg);
-}
-
-/*
- * Put an item back to the front of the queue.
- *
- * This is assumed to be called only from the output thread.
- *
- * NOTE: It consumes the reference passed by the caller.
- */
-static void
-log_queue_fifo_push_head(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
-{
-  LogQueueFifo *self = (LogQueueFifo *) s;
-  LogMessageQueueNode *node;
-
-  /* we don't check limits when putting items "in-front", as it
-   * normally happens when we start processing an item, but at the end
-   * can't deliver it. No checks, no drops either. */
-
-  log_msg_write_protect(msg);
-  node = log_msg_alloc_dynamic_queue_node(msg, path_options);
-  iv_list_add(&node->list, &self->output_queue.items);
-  self->output_queue.len++;
-
-  if (!path_options->flow_control_requested)
-    self->output_queue.non_flow_controlled_len++;
-
-  log_msg_unref(msg);
-
-  log_queue_queued_messages_inc(&self->super);
-  log_queue_memory_usage_add(&self->super, log_msg_get_size(msg));
 }
 
 /*
@@ -676,7 +645,6 @@ log_queue_fifo_new(gint log_fifo_size, const gchar *persist_name, gint stats_lev
   self->super.is_empty_racy = log_queue_fifo_is_empty_racy;
   self->super.keep_on_reload = log_queue_fifo_keep_on_reload;
   self->super.push_tail = log_queue_fifo_push_tail;
-  self->super.push_head = log_queue_fifo_push_head;
   self->super.pop_head = log_queue_fifo_pop_head;
   self->super.ack_backlog = log_queue_fifo_ack_backlog;
   self->super.rewind_backlog = log_queue_fifo_rewind_backlog;

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -61,7 +61,6 @@ struct _LogQueue
 {
   QueueType type;
   GAtomicCounter ref_cnt;
-  gboolean use_backlog;
 
   gint throttle;
   gint throttle_buckets;
@@ -143,27 +142,18 @@ log_queue_pop_head_ignore_throttle(LogQueue *self, LogPathOptions *path_options)
 static inline void
 log_queue_rewind_backlog(LogQueue *self, guint rewind_count)
 {
-  if (!self->use_backlog)
-    return;
-
   self->rewind_backlog(self, rewind_count);
 }
 
 static inline void
 log_queue_rewind_backlog_all(LogQueue *self)
 {
-  if (!self->use_backlog)
-    return;
-
   self->rewind_backlog_all(self);
 }
 
 static inline void
 log_queue_ack_backlog(LogQueue *self, guint rewind_count)
 {
-  if (!self->use_backlog)
-    return;
-
   self->ack_backlog(self, rewind_count);
 }
 
@@ -196,13 +186,6 @@ log_queue_set_throttle(LogQueue *self, gint throttle)
 {
   self->throttle = throttle;
   self->throttle_buckets = throttle;
-}
-
-static inline void
-log_queue_set_use_backlog(LogQueue *self, gboolean use_backlog)
-{
-  if (self)
-    self->use_backlog = use_backlog;
 }
 
 static inline gboolean

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -81,7 +81,6 @@ struct _LogQueue
   gint64 (*get_length)(LogQueue *self);
   gboolean (*is_empty_racy)(LogQueue *self);
   void (*push_tail)(LogQueue *self, LogMessage *msg, const LogPathOptions *path_options);
-  void (*push_head)(LogQueue *self, LogMessage *msg, const LogPathOptions *path_options);
   LogMessage *(*pop_head)(LogQueue *self, LogPathOptions *path_options);
   void (*ack_backlog)(LogQueue *self, gint n);
   void (*rewind_backlog)(LogQueue *self, guint rewind_count);
@@ -117,12 +116,6 @@ static inline void
 log_queue_push_tail(LogQueue *self, LogMessage *msg, const LogPathOptions *path_options)
 {
   self->push_tail(self, msg, path_options);
-}
-
-static inline void
-log_queue_push_head(LogQueue *self, LogMessage *msg, const LogPathOptions *path_options)
-{
-  self->push_head(self, msg, path_options);
 }
 
 static inline LogMessage *

--- a/lib/logthrdest/logthrdestdrv.c
+++ b/lib/logthrdest/logthrdestdrv.c
@@ -793,8 +793,6 @@ _acquire_worker_queue(LogThreadedDestWorker *self, gint stats_level, const Stats
   if (!self->queue)
     return FALSE;
 
-  log_queue_set_use_backlog(self->queue, TRUE);
-
   return TRUE;
 }
 

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -205,7 +205,6 @@ log_writer_set_queue(LogWriter *self, LogQueue *queue)
 {
   log_queue_unref(self->queue);
   self->queue = log_queue_ref(queue);
-  log_queue_set_use_backlog(self->queue, TRUE);
 }
 
 static void

--- a/lib/tests/test_logqueue.c
+++ b/lib/tests/test_logqueue.c
@@ -95,7 +95,6 @@ _threaded_consume(gpointer st)
   LogQueue *q = (LogQueue *) st;
   LogMessage *msg;
   LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
-  gint loops = 0;
   gint msg_count = 0;
 
   /* just to make sure time is properly cached */
@@ -116,23 +115,14 @@ _threaded_consume(gpointer st)
           if (slept > 10000)
             {
               /* slept for more than 10 seconds */
-              fprintf(stderr, "The wait for messages took too much time, loops=%d, msg_count=%d\n", loops, msg_count);
+              fprintf(stderr, "The wait for messages took too much time, msg_count=%d\n", msg_count);
               return GUINT_TO_POINTER(1);
             }
         }
 
-      if ((loops % 10) == 0)
-        {
-          /* push the message back to the queue */
-          log_queue_push_head(q, msg, &path_options);
-        }
-      else
-        {
-          log_msg_ack(msg, &path_options, AT_PROCESSED);
-          log_msg_unref(msg);
-          msg_count++;
-        }
-      loops++;
+      log_msg_ack(msg, &path_options, AT_PROCESSED);
+      log_msg_unref(msg);
+      msg_count++;
     }
 
   return NULL;

--- a/libtest/queue_utils_lib.c
+++ b/libtest/queue_utils_lib.c
@@ -75,14 +75,14 @@ feed_some_messages(LogQueue *q, int n)
 {
   LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
 
-  path_options.ack_needed = q->use_backlog;
+  path_options.ack_needed = TRUE;
   path_options.flow_control_requested = TRUE;
 
   feed_empty_messages(q, &path_options, n);
 }
 
 void
-send_some_messages(LogQueue *q, gint n)
+send_some_messages(LogQueue *q, gint n, gboolean remove_from_backlog)
 {
   gint i;
   LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
@@ -91,10 +91,13 @@ send_some_messages(LogQueue *q, gint n)
     {
       LogMessage *msg = log_queue_pop_head(q, &path_options);
       cr_assert_not_null(msg);
-      if (q->use_backlog)
+
+      if (path_options.ack_needed)
         {
           log_msg_ack(msg, &path_options, AT_PROCESSED);
         }
+      if (remove_from_backlog)
+        log_queue_ack_backlog(q, 1);
       log_msg_unref(msg);
     }
 }

--- a/libtest/queue_utils_lib.h
+++ b/libtest/queue_utils_lib.h
@@ -35,7 +35,7 @@ void test_ack(LogMessage *msg, AckType ack_type);
 void feed_empty_messages(LogQueue *q, const LogPathOptions *path_options, gint n);
 void feed_some_messages(LogQueue *q, int n);
 
-void send_some_messages(LogQueue *q, gint n);
+void send_some_messages(LogQueue *q, gint n, gboolean remove_from_backlog);
 
 gsize get_one_message_serialized_size(void);
 #endif

--- a/modules/diskq/dqtool.c
+++ b/modules/diskq/dqtool.c
@@ -181,7 +181,6 @@ dqtool_cat(int argc, char *argv[])
       if (!open_queue(argv[i], &lq, &options))
         continue;
 
-      log_queue_set_use_backlog(lq, TRUE);
       log_queue_rewind_backlog_all(lq);
 
       while ((log_msg = log_queue_pop_head(lq, &local_options)) != NULL)

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -313,8 +313,7 @@ success:
   log_queue_disk_update_disk_related_counters(&self->super);
   g_mutex_unlock(&s->lock);
 
-  if (s->use_backlog)
-    _push_tail_backlog(self, msg, path_options);
+  _push_tail_backlog(self, msg, path_options);
 
   if (stats_update)
     log_queue_queued_messages_dec(s);

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -322,12 +322,6 @@ success:
   return msg;
 }
 
-static void
-_push_head(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
-{
-  g_assert_not_reached();
-}
-
 /* _is_msg_serialization_needed_hint() must be called without holding the queue's lock.
  * This can only be used _as a hint_ for performance considerations, because as soon as the lock
  * is released, there will be no guarantee that the result of this function remain correct. */
@@ -549,7 +543,6 @@ _set_logqueue_virtual_functions(LogQueue *s)
   s->rewind_backlog = _rewind_backlog;
   s->rewind_backlog_all = _rewind_backlog_all;
   s->pop_head = _pop_head;
-  s->push_head = _push_head;
   s->push_tail = _push_tail;
   s->free_fn = _free;
 }

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -390,12 +390,6 @@ exit:
 }
 
 static void
-_push_head(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
-{
-  g_assert_not_reached();
-}
-
-static void
 _free(LogQueue *s)
 {
   LogQueueDiskReliable *self = (LogQueueDiskReliable *)s;
@@ -454,7 +448,6 @@ _set_logqueue_virtual_functions(LogQueue *s)
   s->rewind_backlog_all = _rewind_backlog_all;
   s->pop_head = _pop_head;
   s->push_tail = _push_tail;
-  s->push_head = _push_head;
   s->free_fn = _free;
 }
 

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -244,12 +244,10 @@ _pop_head(LogQueue *s, LogPathOptions *path_options)
       if (!_skip_message(&self->super))
         qdisk_corrupt = TRUE;
 
-      if (s->use_backlog)
-        {
-          log_msg_ref(msg);
-          _push_to_memory_queue_tail(self->backlog, position, msg, path_options);
-          log_queue_memory_usage_add(s, log_msg_get_size(msg));
-        }
+      /* push to backlog */
+      log_msg_ref(msg);
+      _push_to_memory_queue_tail(self->backlog, position, msg, path_options);
+      log_queue_memory_usage_add(s, log_msg_get_size(msg));
 
       goto exit;
     }
@@ -277,9 +275,6 @@ exit:
       g_mutex_unlock(&s->lock);
       return NULL;
     }
-
-  if (!s->use_backlog)
-    qdisk_empty_backlog(self->super.qdisk);
 
   log_queue_disk_update_disk_related_counters(&self->super);
   log_queue_queued_messages_dec(s);

--- a/modules/diskq/tests/Makefile.am
+++ b/modules/diskq/tests/Makefile.am
@@ -1,6 +1,6 @@
 DISKQ_TEST_C_FLAGS = $(TEST_CFLAGS) -I$(top_srcdir)/modules/diskq
-DISKQ_TEST_LD_FLAGS = $(TEST_LDFLAGS) -dlpreopen $(top_builddir)/modules/diskq/libdisk-buffer.la -lm
-DISKQ_TEST_LD_ADD = $(TEST_LDADD)
+DISKQ_TEST_LD_FLAGS = $(TEST_LDFLAGS)
+DISKQ_TEST_LD_ADD = $(TEST_LDADD) -dlpreopen $(top_builddir)/modules/diskq/libdisk-buffer.la -lm
 
 modules_diskq_tests_TESTS = \
   modules/diskq/tests/test_diskq \
@@ -18,8 +18,6 @@ EXTRA_DIST += modules/diskq/tests/CMakeLists.txt
 modules_diskq_tests_test_diskq_CFLAGS = $(DISKQ_TEST_C_FLAGS)
 modules_diskq_tests_test_diskq_LDFLAGS = $(DISKQ_TEST_LD_FLAGS)
 modules_diskq_tests_test_diskq_LDADD = $(DISKQ_TEST_LD_ADD)
-modules_diskq_tests_test_diskq_DEPENDENCIES =	\
-	$(top_builddir)/modules/diskq/libdisk-buffer.la
 modules_diskq_tests_test_diskq_SOURCES = \
 	modules/diskq/tests/test_diskq.c \
 	modules/diskq/tests/test_diskq_tools.h
@@ -27,8 +25,6 @@ modules_diskq_tests_test_diskq_SOURCES = \
 modules_diskq_tests_test_diskq_full_CFLAGS = $(DISKQ_TEST_C_FLAGS)
 modules_diskq_tests_test_diskq_full_LDFLAGS = $(DISKQ_TEST_LD_FLAGS)
 modules_diskq_tests_test_diskq_full_LDADD = $(DISKQ_TEST_LD_ADD)
-modules_diskq_tests_test_diskq_full_DEPENDENCIES =	\
-	$(top_builddir)/modules/diskq/libdisk-buffer.la
 modules_diskq_tests_test_diskq_full_SOURCES = \
 	modules/diskq/tests/test_diskq_full.c \
 	modules/diskq/tests/test_diskq_tools.h
@@ -36,8 +32,6 @@ modules_diskq_tests_test_diskq_full_SOURCES = \
 modules_diskq_tests_test_reliable_backlog_CFLAGS = $(DISKQ_TEST_C_FLAGS)
 modules_diskq_tests_test_reliable_backlog_LDFLAGS = $(DISKQ_TEST_LD_FLAGS)
 modules_diskq_tests_test_reliable_backlog_LDADD = $(DISKQ_TEST_LD_ADD)
-modules_diskq_tests_test_reliable_backlog_DEPENDENCIES =	\
-	$(top_builddir)/modules/diskq/libdisk-buffer.la
 modules_diskq_tests_test_reliable_backlog_SOURCES = \
 	modules/diskq/tests/test_reliable_backlog.c \
 	modules/diskq/tests/test_diskq_tools.h
@@ -45,8 +39,6 @@ modules_diskq_tests_test_reliable_backlog_SOURCES = \
 modules_diskq_tests_test_diskq_truncate_CFLAGS = $(DISKQ_TEST_C_FLAGS)
 modules_diskq_tests_test_diskq_truncate_LDFLAGS = $(DISKQ_TEST_LD_FLAGS)
 modules_diskq_tests_test_diskq_truncate_LDADD = $(DISKQ_TEST_LD_ADD)
-modules_diskq_tests_test_diskq_truncate_DEPENDENCIES =	\
-	$(top_builddir)/modules/diskq/libdisk-buffer.la
 modules_diskq_tests_test_diskq_truncate_SOURCES = \
 	modules/diskq/tests/test_diskq_truncate.c \
 	modules/diskq/tests/test_diskq_tools.h
@@ -54,8 +46,6 @@ modules_diskq_tests_test_diskq_truncate_SOURCES = \
 modules_diskq_tests_test_qdisk_CFLAGS = $(DISKQ_TEST_C_FLAGS)
 modules_diskq_tests_test_qdisk_LDFLAGS = $(DISKQ_TEST_LD_FLAGS)
 modules_diskq_tests_test_qdisk_LDADD = $(DISKQ_TEST_LD_ADD)
-modules_diskq_tests_test_qdisk_DEPENDENCIES =	\
-	$(top_builddir)/modules/diskq/libdisk-buffer.la
 modules_diskq_tests_test_qdisk_SOURCES = \
 	modules/diskq/tests/test_qdisk.c \
 	modules/diskq/tests/test_diskq_tools.h
@@ -63,8 +53,6 @@ modules_diskq_tests_test_qdisk_SOURCES = \
 modules_diskq_tests_test_logqueue_disk_CFLAGS = $(DISKQ_TEST_C_FLAGS)
 modules_diskq_tests_test_logqueue_disk_LDFLAGS = $(DISKQ_TEST_LD_FLAGS)
 modules_diskq_tests_test_logqueue_disk_LDADD = $(DISKQ_TEST_LD_ADD)
-modules_diskq_tests_test_logqueue_disk_DEPENDENCIES =	\
-	$(top_builddir)/modules/diskq/libdisk-buffer.la
 modules_diskq_tests_test_logqueue_disk_SOURCES = \
 	modules/diskq/tests/test_logqueue_disk.c \
 	modules/diskq/tests/test_diskq_tools.h
@@ -72,8 +60,6 @@ modules_diskq_tests_test_logqueue_disk_SOURCES = \
 modules_diskq_tests_test_diskq_counters_CFLAGS = $(DISKQ_TEST_C_FLAGS)
 modules_diskq_tests_test_diskq_counters_LDFLAGS = $(DISKQ_TEST_LD_FLAGS)
 modules_diskq_tests_test_diskq_counters_LDADD = $(DISKQ_TEST_LD_ADD)
-modules_diskq_tests_test_diskq_counters_DEPENDENCIES =	\
-	$(top_builddir)/modules/diskq/libdisk-buffer.la
 modules_diskq_tests_test_diskq_counters_SOURCES = \
 	modules/diskq/tests/test_diskq_counters.c \
 	modules/diskq/tests/test_diskq_tools.h

--- a/modules/diskq/tests/test_diskq_counters.c
+++ b/modules/diskq/tests/test_diskq_counters.c
@@ -81,7 +81,7 @@ static void
 _push_one_message(LogQueue *q, gssize *memory_size, gssize *serialized_size)
 {
   LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
-  path_options.ack_needed = q->use_backlog;
+  path_options.ack_needed = FALSE;
   path_options.flow_control_requested = TRUE;
 
   gchar data[1024] = {0};
@@ -195,14 +195,12 @@ Test(diskq_counters, test_non_reliable,
                    QDISK_RESERVED_SPACE + one_message_serialized_size, __LINE__);
 
   /* Pop one message, disk usage should reduce */
-  send_some_messages(queue, 1);
-  log_queue_ack_backlog(queue, 1);
+  send_some_messages(queue, 1, TRUE);
   _assert_counters(queue, 1, one_message_memory_size, expected_capacity, 0,
                    QDISK_RESERVED_SPACE + one_message_serialized_size, __LINE__);
 
   /* Pop one message, memory usage should reduce */
-  send_some_messages(queue, 1);
-  log_queue_ack_backlog(queue, 1);
+  send_some_messages(queue, 1, TRUE);
   _assert_counters(queue, 0, 0, expected_capacity, 0, QDISK_RESERVED_SPACE + one_message_serialized_size, __LINE__);
 
   stats_cluster_key_builder_free(queue_sck_builder);
@@ -264,8 +262,7 @@ Test(diskq_counters, test_reliable,
                    QDISK_RESERVED_SPACE + one_message_serialized_size, __LINE__);
 
   /* Pop the message, disk usage should reduce */
-  send_some_messages(queue, 1);
-  log_queue_ack_backlog(queue, 1);
+  send_some_messages(queue, 1, TRUE);
   _assert_counters(queue, 0, 0, expected_capacity, 0, QDISK_RESERVED_SPACE + one_message_serialized_size, __LINE__);
 
   stats_cluster_key_builder_free(queue_sck_builder);

--- a/modules/diskq/tests/test_diskq_full.c
+++ b/modules/diskq/tests/test_diskq_full.c
@@ -73,8 +73,6 @@ test_diskq_become_full(gboolean reliable, const gchar *filename)
   stats_cluster_key_builder_free(driver_sck_builder);
   stats_cluster_key_builder_free(queue_sck_builder);
 
-  log_queue_set_use_backlog(q, TRUE);
-
   unlink(filename);
   log_queue_disk_start(q);
   feed_some_messages(q, 1000);

--- a/modules/diskq/tests/test_reliable_backlog.c
+++ b/modules/diskq/tests/test_reliable_backlog.c
@@ -69,7 +69,6 @@ _init_diskq_for_test(const gchar *filename, gint64 size, gint64 membuf_size)
   cr_assert_eq(written, 1, "%s", "Can't write to diskq file");
   fstat(dq->super.qdisk->fd, &st);
   cr_assert_eq(st.st_size, size, "%s", "INITIALIZATION FAILED");
-  dq->super.super.use_backlog = TRUE;
   return dq;
 }
 


### PR DESCRIPTION
This branch removes some unused aspects of the LogQueue interface, namely the push_head() method (which aborted in
the disk buffer cases) and the optionality of the backlog queue.

NEWS file not needed.

