### PR TITLE
http: Fix assert macro breaking gcc compiler

### DIFF
--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -172,7 +172,7 @@ _setup_static_options_in_curl(HTTPDestinationWorker *self)
   if (owner->method_type == METHOD_TYPE_PUT)
     curl_easy_setopt(self->curl, CURLOPT_CUSTOMREQUEST, "PUT");
 
-  g_assert(curl_easy_setopt(self->curl, CURLOPT_ACCEPT_ENCODING, owner->accept_encoding->str) == CURLE_OK);
+  curl_easy_setopt(self->curl, CURLOPT_ACCEPT_ENCODING, owner->accept_encoding->str);
 }
 
 


### PR DESCRIPTION
On certain systems with certain gcc versions (notably gcc 2.11) curl_easy_setopt() nested inside g_assert() is too complex/long for the compiler.

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
