### PR TITLE
stats-cluster-key-builder: add stack feature

### DIFF
--- a/lib/driver.c
+++ b/lib/driver.c
@@ -259,7 +259,7 @@ log_src_driver_free(LogPipe *s)
 
 static LogQueue *
 _create_memory_queue(LogDestDriver *self, const gchar *persist_name, gint stats_level,
-                     const StatsClusterKeyBuilder *driver_sck_builder, StatsClusterKeyBuilder *queue_sck_builder)
+                     StatsClusterKeyBuilder *driver_sck_builder, StatsClusterKeyBuilder *queue_sck_builder)
 {
   GlobalConfig *cfg = log_pipe_get_config(&self->super.super);
 
@@ -282,7 +282,7 @@ _create_memory_queue(LogDestDriver *self, const gchar *persist_name, gint stats_
 /* returns a reference */
 static LogQueue *
 log_dest_driver_acquire_memory_queue(LogDestDriver *self, const gchar *persist_name, gint stats_level,
-                                     const StatsClusterKeyBuilder *driver_sck_builder,
+                                     StatsClusterKeyBuilder *driver_sck_builder,
                                      StatsClusterKeyBuilder *queue_sck_builder)
 {
   GlobalConfig *cfg = log_pipe_get_config(&self->super.super);

--- a/lib/driver.h
+++ b/lib/driver.h
@@ -159,7 +159,7 @@ struct _LogDestDriver
   LogDriver super;
 
   LogQueue *(*acquire_queue)(LogDestDriver *s, const gchar *persist_name, gint stats_level,
-                             const StatsClusterKeyBuilder *driver_sck_builder,
+                             StatsClusterKeyBuilder *driver_sck_builder,
                              StatsClusterKeyBuilder *queue_sck_builder);
   void (*release_queue)(LogDestDriver *s, LogQueue *q);
 
@@ -175,7 +175,7 @@ struct _LogDestDriver
 /* returns a reference */
 static inline LogQueue *
 log_dest_driver_acquire_queue(LogDestDriver *self, const gchar *persist_name, gint stats_level,
-                              const StatsClusterKeyBuilder *driver_sck_builder,
+                              StatsClusterKeyBuilder *driver_sck_builder,
                               StatsClusterKeyBuilder *queue_sck_builder)
 {
   LogQueue *q;

--- a/lib/logqueue-fifo.h
+++ b/lib/logqueue-fifo.h
@@ -28,10 +28,10 @@
 #include "logqueue.h"
 
 LogQueue *log_queue_fifo_new(gint log_fifo_size, const gchar *persist_name, gint stats_level,
-                             const StatsClusterKeyBuilder *driver_sck_builder,
+                             StatsClusterKeyBuilder *driver_sck_builder,
                              StatsClusterKeyBuilder *queue_sck_builder);
 LogQueue *log_queue_fifo_legacy_new(gint log_fifo_size, const gchar *persist_name, gint stats_level,
-                                    const StatsClusterKeyBuilder *driver_sck_builder,
+                                    StatsClusterKeyBuilder *driver_sck_builder,
                                     StatsClusterKeyBuilder *queue_sck_builder);
 
 QueueType log_queue_fifo_get_type(void);

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -212,7 +212,7 @@ void log_queue_set_parallel_push(LogQueue *self, LogQueuePushNotifyFunc parallel
 gboolean log_queue_check_items(LogQueue *self, gint *timeout, LogQueuePushNotifyFunc parallel_push_notify,
                                gpointer user_data, GDestroyNotify user_data_destroy);
 void log_queue_init_instance(LogQueue *self, const gchar *persist_name, gint stats_level,
-                             const StatsClusterKeyBuilder *driver_sck_builder,
+                             StatsClusterKeyBuilder *driver_sck_builder,
                              StatsClusterKeyBuilder *queue_sck_builder);
 
 void log_queue_free_method(LogQueue *self);

--- a/lib/stats/stats-cluster-key-builder.c
+++ b/lib/stats/stats-cluster-key-builder.c
@@ -75,38 +75,25 @@ stats_cluster_key_builder_new(void)
 StatsClusterKeyBuilder *
 stats_cluster_key_builder_clone(const StatsClusterKeyBuilder *self)
 {
-  StatsClusterKeyBuilder *cloned = stats_cluster_key_builder_new();
-
-  stats_cluster_key_builder_set_name(cloned, self->name);
-  stats_cluster_key_builder_set_name_prefix(cloned, self->name_prefix);
-  stats_cluster_key_builder_set_name_suffix(cloned, self->name_suffix);
-  for (guint i = 0; i < self->labels->len; i++)
-    {
-      StatsClusterLabel *label = &g_array_index(self->labels, StatsClusterLabel, i);
-      stats_cluster_key_builder_add_label(cloned, stats_cluster_label(label->name, label->value));
-    }
-  stats_cluster_key_builder_set_unit(cloned, self->unit);
-  stats_cluster_key_builder_set_frame_of_reference(cloned, self->frame_of_reference);
-  stats_cluster_key_builder_set_legacy_alias(cloned, self->legacy.component, self->legacy.id, self->legacy.instance);
-  stats_cluster_key_builder_set_legacy_alias_name(cloned, self->legacy.name);
-  cloned->legacy.set = self->legacy.set;
-
-  if (!_has_legacy_labels(self))
-    return cloned;
-
-  for (guint i = 0; i < self->legacy_labels->len; i++)
-    {
-      StatsClusterLabel *label = &g_array_index(self->legacy_labels, StatsClusterLabel, i);
-      stats_cluster_key_builder_add_legacy_label(cloned, stats_cluster_label(label->name, label->value));
-    }
-
-  return cloned;
+  /* TODO: Remove */
+  return NULL;
 }
 
 void
 stats_cluster_key_builder_free(StatsClusterKeyBuilder *self)
 {
-  stats_cluster_key_builder_reset(self);
+  stats_cluster_key_builder_set_name(self, NULL);
+  stats_cluster_key_builder_set_name_prefix(self, NULL);
+  stats_cluster_key_builder_set_name_suffix(self, NULL);
+
+  g_array_remove_range(self->labels, 0, self->labels->len);
+
+  if (self->legacy_labels)
+    g_array_remove_range(self->legacy_labels, 0, self->legacy_labels->len);
+
+  stats_cluster_key_builder_set_legacy_alias(self, 0, NULL, NULL);
+  stats_cluster_key_builder_set_legacy_alias_name(self, NULL);
+
   g_array_free(self->labels, TRUE);
 
   if (self->legacy_labels)
@@ -182,21 +169,7 @@ stats_cluster_key_builder_set_legacy_alias_name(StatsClusterKeyBuilder *self, co
 void
 stats_cluster_key_builder_reset(StatsClusterKeyBuilder *self)
 {
-  stats_cluster_key_builder_set_name(self, NULL);
-  stats_cluster_key_builder_set_name_prefix(self, NULL);
-  stats_cluster_key_builder_set_name_suffix(self, NULL);
-
-  g_array_remove_range(self->labels, 0, self->labels->len);
-
-  if (self->legacy_labels)
-    g_array_remove_range(self->legacy_labels, 0, self->legacy_labels->len);
-
-  stats_cluster_key_builder_set_legacy_alias(self, 0, NULL, NULL);
-  stats_cluster_key_builder_set_legacy_alias_name(self, NULL);
-  self->legacy.set = FALSE;
-
-  self->unit = SCU_NONE;
-  self->frame_of_reference = SCFOR_ABSOLUTE;
+  /* TODO: Remove */
 }
 
 static gint
@@ -351,8 +324,7 @@ stats_cluster_key_builder_add_legacy_label(StatsClusterKeyBuilder *self, const S
 void
 stats_cluster_key_builder_clear_legacy_labels(StatsClusterKeyBuilder *self)
 {
-  if (self->legacy_labels)
-    g_array_remove_range(self->legacy_labels, 0, self->legacy_labels->len);
+  /* TODO: Remove */
 }
 
 const gchar *

--- a/lib/stats/stats-cluster-key-builder.c
+++ b/lib/stats/stats-cluster-key-builder.c
@@ -103,13 +103,6 @@ stats_cluster_key_builder_new(void)
   return self;
 }
 
-StatsClusterKeyBuilder *
-stats_cluster_key_builder_clone(const StatsClusterKeyBuilder *self)
-{
-  /* TODO: Remove */
-  return NULL;
-}
-
 void
 stats_cluster_key_builder_push(StatsClusterKeyBuilder *self)
 {
@@ -214,12 +207,6 @@ stats_cluster_key_builder_set_legacy_alias_name(StatsClusterKeyBuilder *self, co
 
   g_free(options->legacy.name);
   options->legacy.name = g_strdup(name);
-}
-
-void
-stats_cluster_key_builder_reset(StatsClusterKeyBuilder *self)
-{
-  /* TODO: Remove */
 }
 
 static gint
@@ -498,12 +485,6 @@ stats_cluster_key_builder_add_legacy_label(StatsClusterKeyBuilder *self, const S
 
   StatsClusterLabel own_label = stats_cluster_label(g_strdup(label.name), g_strdup(label.value));
   options->legacy_labels = g_array_append_vals(options->legacy_labels, &own_label, 1);
-}
-
-void
-stats_cluster_key_builder_clear_legacy_labels(StatsClusterKeyBuilder *self)
-{
-  /* TODO: Remove */
 }
 
 const gchar *

--- a/lib/stats/stats-cluster-key-builder.h
+++ b/lib/stats/stats-cluster-key-builder.h
@@ -32,7 +32,6 @@ typedef struct _StatsClusterKeyBuilder StatsClusterKeyBuilder;
 StatsClusterKeyBuilder *stats_cluster_key_builder_new(void);
 void stats_cluster_key_builder_push(StatsClusterKeyBuilder *self);
 void stats_cluster_key_builder_pop(StatsClusterKeyBuilder *self);
-StatsClusterKeyBuilder *stats_cluster_key_builder_clone(const StatsClusterKeyBuilder *self);
 void stats_cluster_key_builder_free(StatsClusterKeyBuilder *self);
 
 void stats_cluster_key_builder_set_name(StatsClusterKeyBuilder *self, const gchar *name);
@@ -46,14 +45,11 @@ void stats_cluster_key_builder_set_legacy_alias(StatsClusterKeyBuilder *self, gu
                                                 const gchar *instance);
 void stats_cluster_key_builder_set_legacy_alias_name(StatsClusterKeyBuilder *self, const gchar *name);
 
-void stats_cluster_key_builder_reset(StatsClusterKeyBuilder *self);
-
 StatsClusterKey *stats_cluster_key_builder_build_single(const StatsClusterKeyBuilder *self);
 StatsClusterKey *stats_cluster_key_builder_build_logpipe(const StatsClusterKeyBuilder *self);
 
 /* Compatibility functions for reproducing stats_instance names based on unsorted labels */
 void stats_cluster_key_builder_add_legacy_label(StatsClusterKeyBuilder *self, const StatsClusterLabel label);
-void stats_cluster_key_builder_clear_legacy_labels(StatsClusterKeyBuilder *self);
 const gchar *stats_cluster_key_builder_format_legacy_stats_instance(const StatsClusterKeyBuilder *self,
     gchar *buf, gsize buf_size);
 

--- a/lib/stats/stats-cluster-key-builder.h
+++ b/lib/stats/stats-cluster-key-builder.h
@@ -30,6 +30,8 @@
 typedef struct _StatsClusterKeyBuilder StatsClusterKeyBuilder;
 
 StatsClusterKeyBuilder *stats_cluster_key_builder_new(void);
+void stats_cluster_key_builder_push(StatsClusterKeyBuilder *self);
+void stats_cluster_key_builder_pop(StatsClusterKeyBuilder *self);
 StatsClusterKeyBuilder *stats_cluster_key_builder_clone(const StatsClusterKeyBuilder *self);
 void stats_cluster_key_builder_free(StatsClusterKeyBuilder *self);
 
@@ -52,7 +54,7 @@ StatsClusterKey *stats_cluster_key_builder_build_logpipe(const StatsClusterKeyBu
 /* Compatibility functions for reproducing stats_instance names based on unsorted labels */
 void stats_cluster_key_builder_add_legacy_label(StatsClusterKeyBuilder *self, const StatsClusterLabel label);
 void stats_cluster_key_builder_clear_legacy_labels(StatsClusterKeyBuilder *self);
-const gchar *stats_cluster_key_builder_format_legacy_stats_instance(StatsClusterKeyBuilder *self,
+const gchar *stats_cluster_key_builder_format_legacy_stats_instance(const StatsClusterKeyBuilder *self,
     gchar *buf, gsize buf_size);
 
 #endif

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -64,7 +64,8 @@ typedef enum _StatsClusterUnit
 
 typedef enum _StatsClusterFrameOfReference
 {
-  SCFOR_ABSOLUTE = 0,
+  SCFOR_NONE = 0,
+  SCFOR_ABSOLUTE,
 
   /*
    * Only applicable for counters with seconds, minutes or hours unit.

--- a/lib/stats/tests/test_stats_cluster_key_builder.c
+++ b/lib/stats/tests/test_stats_cluster_key_builder.c
@@ -40,17 +40,15 @@ _assert_built_sc_key_equals(const StatsClusterKeyBuilder *builder, KeyType type,
   StatsClusterKey expected_sc_key;
   StatsClusterKey *built_key;
 
-  StatsClusterKeyBuilder *cloned_builder = stats_cluster_key_builder_clone(builder);
-
   if (type == TEST_LOGPIPE)
     {
       stats_cluster_logpipe_key_set(&expected_sc_key, name, labels, labels_len);
-      built_key = stats_cluster_key_builder_build_logpipe(cloned_builder);
+      built_key = stats_cluster_key_builder_build_logpipe(builder);
     }
   else if (type == TEST_SINGLE)
     {
       stats_cluster_single_key_set(&expected_sc_key, name, labels, labels_len);
-      built_key = stats_cluster_key_builder_build_single(cloned_builder);
+      built_key = stats_cluster_key_builder_build_single(builder);
     }
   else
     {
@@ -61,34 +59,29 @@ _assert_built_sc_key_equals(const StatsClusterKeyBuilder *builder, KeyType type,
   cr_assert_eq(memcmp(&expected_sc_key.formatting, &built_key->formatting, sizeof(built_key->formatting)), 0);
 
   stats_cluster_key_free(built_key);
-  stats_cluster_key_builder_free(cloned_builder);
 }
 
 static void
 _assert_built_sc_key_has_unit(const StatsClusterKeyBuilder *builder, KeyType type, StatsClusterUnit unit)
 {
-  StatsClusterKeyBuilder *cloned_builder = stats_cluster_key_builder_clone(builder);
-  StatsClusterKey *built_key = stats_cluster_key_builder_build_single(cloned_builder);
+  StatsClusterKey *built_key = stats_cluster_key_builder_build_single(builder);
 
   if (type == TEST_SINGLE)
     cr_assert(built_key->formatting.stored_unit == unit);
 
   stats_cluster_key_free(built_key);
-  stats_cluster_key_builder_free(cloned_builder);
 }
 
 static void
 _assert_built_sc_key_has_frame_of_reference(const StatsClusterKeyBuilder *builder, KeyType type,
                                             StatsClusterFrameOfReference frame_of_reference)
 {
-  StatsClusterKeyBuilder *cloned_builder = stats_cluster_key_builder_clone(builder);
-  StatsClusterKey *built_key = stats_cluster_key_builder_build_single(cloned_builder);
+  StatsClusterKey *built_key = stats_cluster_key_builder_build_single(builder);
 
   if (type == TEST_SINGLE)
     cr_assert(built_key->formatting.frame_of_reference == frame_of_reference);
 
   stats_cluster_key_free(built_key);
-  stats_cluster_key_builder_free(cloned_builder);
 }
 
 static void
@@ -100,13 +93,11 @@ _assert_built_sc_key_equals_with_legacy(const StatsClusterKeyBuilder *builder, K
   StatsClusterKey expected_sc_key;
   StatsClusterKey *built_key;
 
-  StatsClusterKeyBuilder *cloned_builder = stats_cluster_key_builder_clone(builder);
-
   if (type == TEST_LOGPIPE)
     {
       stats_cluster_logpipe_key_set(&expected_sc_key, name, labels, labels_len);
       stats_cluster_logpipe_key_add_legacy_alias(&expected_sc_key, legacy_component, legacy_id, legacy_instance);
-      built_key = stats_cluster_key_builder_build_logpipe(cloned_builder);
+      built_key = stats_cluster_key_builder_build_logpipe(builder);
     }
   else if (type == TEST_SINGLE)
     {
@@ -120,7 +111,7 @@ _assert_built_sc_key_equals_with_legacy(const StatsClusterKeyBuilder *builder, K
         {
           stats_cluster_single_key_add_legacy_alias(&expected_sc_key, legacy_component, legacy_id, legacy_instance);
         }
-      built_key = stats_cluster_key_builder_build_single(cloned_builder);
+      built_key = stats_cluster_key_builder_build_single(builder);
     }
   else
     {
@@ -130,7 +121,6 @@ _assert_built_sc_key_equals_with_legacy(const StatsClusterKeyBuilder *builder, K
   cr_assert(stats_cluster_key_equal(&expected_sc_key, built_key));
 
   stats_cluster_key_free(built_key);
-  stats_cluster_key_builder_free(cloned_builder);
 }
 static void
 _assert_built_sc_key_equals_with_legacy_only(const StatsClusterKeyBuilder *builder, KeyType type,
@@ -140,17 +130,15 @@ _assert_built_sc_key_equals_with_legacy_only(const StatsClusterKeyBuilder *build
   StatsClusterKey expected_sc_key;
   StatsClusterKey *built_key = NULL;
 
-  StatsClusterKeyBuilder *cloned_builder = stats_cluster_key_builder_clone(builder);
-
   if (type == TEST_LOGPIPE)
     {
       stats_cluster_logpipe_key_legacy_set(&expected_sc_key, legacy_component, legacy_id, legacy_instance);
-      built_key = stats_cluster_key_builder_build_logpipe(cloned_builder);
+      built_key = stats_cluster_key_builder_build_logpipe(builder);
     }
   else if (type == TEST_SINGLE)
     {
       stats_cluster_single_key_legacy_set(&expected_sc_key, legacy_component, legacy_id, legacy_instance);
-      built_key = stats_cluster_key_builder_build_single(cloned_builder);
+      built_key = stats_cluster_key_builder_build_single(builder);
     }
   else
     {
@@ -161,7 +149,6 @@ _assert_built_sc_key_equals_with_legacy_only(const StatsClusterKeyBuilder *build
   cr_assert(stats_cluster_key_equal(&expected_sc_key, built_key));
 
   stats_cluster_key_free(built_key);
-  stats_cluster_key_builder_free(cloned_builder);
 }
 
 static void
@@ -239,16 +226,13 @@ _test_builder(KeyType type)
                                               dummy_legacy_instance, dummy_legacy_name);
     }
 
-  /* Reset */
-  stats_cluster_key_builder_reset(builder);
-  stats_cluster_key_builder_set_name(builder, dummy_name);
-  _assert_built_sc_key_equals(builder, type, dummy_name, empty_labels, G_N_ELEMENTS(empty_labels));
-
   /* Legacy only */
-  stats_cluster_key_builder_reset(builder);
-  stats_cluster_key_builder_set_legacy_alias(builder, dummy_legacy_component, dummy_legacy_id, dummy_legacy_instance);
-  _assert_built_sc_key_equals_with_legacy_only(builder, type, dummy_legacy_component, dummy_legacy_id,
+  StatsClusterKeyBuilder *legacy_only_builder = stats_cluster_key_builder_new();
+  stats_cluster_key_builder_set_legacy_alias(legacy_only_builder, dummy_legacy_component, dummy_legacy_id,
+                                             dummy_legacy_instance);
+  _assert_built_sc_key_equals_with_legacy_only(legacy_only_builder, type, dummy_legacy_component, dummy_legacy_id,
                                                dummy_legacy_instance);
+  stats_cluster_key_builder_free(legacy_only_builder);
 
   stats_cluster_key_builder_free(builder);
 }

--- a/lib/stats/tests/test_stats_cluster_key_builder.c
+++ b/lib/stats/tests/test_stats_cluster_key_builder.c
@@ -159,80 +159,191 @@ _test_builder(KeyType type)
   const gchar *dummy_name = "dummy_name";
   const gchar *dummy_name_2 = "dummy_name_2";
   const gchar *dummy_name_prefix = "dummy_name_prefix_";
-  const gchar *dummy_name_2_with_prefix = "dummy_name_prefix_dummy_name_2";
+  const gchar *dummy_name_with_prefix = "dummy_name_prefix_dummy_name";
+  const gchar *dummy_name_with_foobar_prefix = "foobardummy_name";
   const gchar *dummy_name_suffix = "_dummy_name_suffix";
-  const gchar *dummy_name_2_with_prefix_and_suffix = "dummy_name_prefix_dummy_name_2_dummy_name_suffix";
+  const gchar *dummy_name_with_suffix = "dummy_name_dummy_name_suffix";
+  const gchar *dummy_name_with_foobar_suffix = "dummy_namefoobar";
 
   guint16 dummy_legacy_component = 42;
   const gchar *dummy_legacy_id = "dummy_legacy_id";
   const gchar *dummy_legacy_instance = "dummy_legacy_instance";
   const gchar *dummy_legacy_name = "dummy_legacy_name";
 
-  /* Name only */
-  stats_cluster_key_builder_set_name(builder, dummy_name);
-  StatsClusterLabel empty_labels[] = {};
-  _assert_built_sc_key_equals(builder, type, dummy_name, empty_labels, G_N_ELEMENTS(empty_labels));
-
-  /* One label */
-  stats_cluster_key_builder_add_label(builder, stats_cluster_label("dummy-label-name-99", "dummy-label-value-99"));
-  StatsClusterLabel one_label[] =
+  stats_cluster_key_builder_push(builder);
   {
-    stats_cluster_label("dummy-label-name-99", "dummy-label-value-99"),
-  };
-  _assert_built_sc_key_equals(builder, type, dummy_name, one_label, G_N_ELEMENTS(one_label));
+    /* Name only */
+    stats_cluster_key_builder_set_name(builder, dummy_name);
+    StatsClusterLabel empty_labels[] = {};
+    _assert_built_sc_key_equals(builder, type, dummy_name, empty_labels, G_N_ELEMENTS(empty_labels));
 
-  /* Two labels, set in wrong ordering */
-  stats_cluster_key_builder_add_label(builder, stats_cluster_label("dummy-label-name-00", "dummy-label-value-00"));
-  StatsClusterLabel two_labels[] =
-  {
-    stats_cluster_label("dummy-label-name-00", "dummy-label-value-00"),
-    stats_cluster_label("dummy-label-name-99", "dummy-label-value-99"),
-  };
-  _assert_built_sc_key_equals(builder, type, dummy_name, two_labels, G_N_ELEMENTS(two_labels));
-
-  /* New name */
-  stats_cluster_key_builder_set_name(builder, dummy_name_2);
-  _assert_built_sc_key_equals(builder, type, dummy_name_2, two_labels, G_N_ELEMENTS(two_labels));
-
-  /* Name prefix */
-  stats_cluster_key_builder_set_name_prefix(builder, dummy_name_prefix);
-  _assert_built_sc_key_equals(builder, type, dummy_name_2_with_prefix, two_labels, G_N_ELEMENTS(two_labels));
-
-  /* Name suffix */
-  stats_cluster_key_builder_set_name_suffix(builder, dummy_name_suffix);
-  _assert_built_sc_key_equals(builder, type, dummy_name_2_with_prefix_and_suffix, two_labels, G_N_ELEMENTS(two_labels));
-
-  /* Unit */
-  stats_cluster_key_builder_set_unit(builder, SCU_NANOSECONDS);
-  _assert_built_sc_key_has_unit(builder, type, SCU_NANOSECONDS);
-
-  /* Frame of reference */
-  stats_cluster_key_builder_set_frame_of_reference(builder, SCFOR_RELATIVE_TO_TIME_OF_QUERY);
-  _assert_built_sc_key_has_frame_of_reference(builder, type, SCFOR_RELATIVE_TO_TIME_OF_QUERY);
-
-  /* Legacy alias */
-  stats_cluster_key_builder_set_legacy_alias(builder, dummy_legacy_component, dummy_legacy_id, dummy_legacy_instance);
-  _assert_built_sc_key_equals_with_legacy(builder, type, dummy_name_2_with_prefix_and_suffix, two_labels,
-                                          G_N_ELEMENTS(two_labels), dummy_legacy_component, dummy_legacy_id,
-                                          dummy_legacy_instance, NULL);
-
-  /* Legacy alias name */
-  if (type == TEST_SINGLE)
+    /* One label */
+    stats_cluster_key_builder_push(builder);
     {
-      /* LOGPIPE does not support setting the legacy name */
-      stats_cluster_key_builder_set_legacy_alias_name(builder, dummy_legacy_name);
-      _assert_built_sc_key_equals_with_legacy(builder, type, dummy_name_2_with_prefix_and_suffix, two_labels,
-                                              G_N_ELEMENTS(two_labels), dummy_legacy_component, dummy_legacy_id,
-                                              dummy_legacy_instance, dummy_legacy_name);
+      stats_cluster_key_builder_add_label(builder, stats_cluster_label("dummy-label-name-99", "dummy-label-value-99"));
+      StatsClusterLabel one_label[] =
+      {
+        stats_cluster_label("dummy-label-name-99", "dummy-label-value-99"),
+      };
+      _assert_built_sc_key_equals(builder, type, dummy_name, one_label, G_N_ELEMENTS(one_label));
     }
+    stats_cluster_key_builder_pop(builder);
+    _assert_built_sc_key_equals(builder, type, dummy_name, empty_labels, G_N_ELEMENTS(empty_labels));
+
+    /* Two labels, set in wrong ordering */
+    stats_cluster_key_builder_push(builder);
+    {
+      stats_cluster_key_builder_add_label(builder, stats_cluster_label("dummy-label-name-99", "dummy-label-value-99"));
+      stats_cluster_key_builder_push(builder);
+      {
+        stats_cluster_key_builder_add_label(builder,
+                                            stats_cluster_label("dummy-label-name-00", "dummy-label-value-00"));
+        StatsClusterLabel two_labels[] =
+        {
+          stats_cluster_label("dummy-label-name-00", "dummy-label-value-00"),
+          stats_cluster_label("dummy-label-name-99", "dummy-label-value-99"),
+        };
+        _assert_built_sc_key_equals(builder, type, dummy_name, two_labels, G_N_ELEMENTS(two_labels));
+      }
+      stats_cluster_key_builder_pop(builder);
+    }
+    stats_cluster_key_builder_pop(builder);
+    _assert_built_sc_key_equals(builder, type, dummy_name, empty_labels, G_N_ELEMENTS(empty_labels));
+
+    /* New name */
+    stats_cluster_key_builder_push(builder);
+    {
+      stats_cluster_key_builder_set_name(builder, dummy_name_2);
+      _assert_built_sc_key_equals(builder, type, dummy_name_2, empty_labels, G_N_ELEMENTS(empty_labels));
+    }
+    stats_cluster_key_builder_pop(builder);
+
+    /* Name prefix */
+    stats_cluster_key_builder_push(builder);
+    {
+      stats_cluster_key_builder_set_name_prefix(builder, dummy_name_prefix);
+      stats_cluster_key_builder_push(builder);
+      {
+        _assert_built_sc_key_equals(builder, type, dummy_name_with_prefix, empty_labels, G_N_ELEMENTS(empty_labels));
+        stats_cluster_key_builder_set_name_prefix(builder, "foobar");
+        _assert_built_sc_key_equals(builder, type, dummy_name_with_foobar_prefix, empty_labels,
+                                    G_N_ELEMENTS(empty_labels));
+      }
+      stats_cluster_key_builder_pop(builder);
+      _assert_built_sc_key_equals(builder, type, dummy_name_with_prefix, empty_labels, G_N_ELEMENTS(empty_labels));
+    }
+    stats_cluster_key_builder_pop(builder);
+
+    /* Name suffix */
+    stats_cluster_key_builder_push(builder);
+    {
+      stats_cluster_key_builder_set_name_suffix(builder, dummy_name_suffix);
+      stats_cluster_key_builder_push(builder);
+      {
+        _assert_built_sc_key_equals(builder, type, dummy_name_with_suffix, empty_labels, G_N_ELEMENTS(empty_labels));
+        stats_cluster_key_builder_set_name_suffix(builder, "foobar");
+        _assert_built_sc_key_equals(builder, type, dummy_name_with_foobar_suffix, empty_labels,
+                                    G_N_ELEMENTS(empty_labels));
+      }
+      stats_cluster_key_builder_pop(builder);
+      _assert_built_sc_key_equals(builder, type, dummy_name_with_suffix, empty_labels, G_N_ELEMENTS(empty_labels));
+    }
+    stats_cluster_key_builder_pop(builder);
+
+    /* Unit */
+    stats_cluster_key_builder_push(builder);
+    {
+      stats_cluster_key_builder_set_unit(builder, SCU_NANOSECONDS);
+      stats_cluster_key_builder_push(builder);
+      {
+        _assert_built_sc_key_has_unit(builder, type, SCU_NANOSECONDS);
+        stats_cluster_key_builder_set_unit(builder, SCU_KIB);
+        _assert_built_sc_key_has_unit(builder, type, SCU_KIB);
+      }
+      stats_cluster_key_builder_pop(builder);
+      _assert_built_sc_key_has_unit(builder, type, SCU_NANOSECONDS);
+    }
+    stats_cluster_key_builder_pop(builder);
+
+    /* Frame of reference */
+    stats_cluster_key_builder_push(builder);
+    {
+      stats_cluster_key_builder_set_frame_of_reference(builder, SCFOR_RELATIVE_TO_TIME_OF_QUERY);
+      stats_cluster_key_builder_push(builder);
+      {
+        _assert_built_sc_key_has_frame_of_reference(builder, type, SCFOR_RELATIVE_TO_TIME_OF_QUERY);
+        stats_cluster_key_builder_set_frame_of_reference(builder, SCFOR_ABSOLUTE);
+        _assert_built_sc_key_has_frame_of_reference(builder, type, SCFOR_ABSOLUTE);
+      }
+      stats_cluster_key_builder_pop(builder);
+      _assert_built_sc_key_has_frame_of_reference(builder, type, SCFOR_RELATIVE_TO_TIME_OF_QUERY);
+    }
+    stats_cluster_key_builder_pop(builder);
+
+    /* Legacy alias */
+    stats_cluster_key_builder_push(builder);
+    {
+      stats_cluster_key_builder_set_legacy_alias(builder, 1337, "foobar", "foobar");
+      stats_cluster_key_builder_push(builder);
+      {
+        _assert_built_sc_key_equals_with_legacy(builder, type, dummy_name, empty_labels,
+                                                G_N_ELEMENTS(empty_labels), 1337, "foobar", "foobar", NULL);
+        stats_cluster_key_builder_set_legacy_alias(builder, dummy_legacy_component, dummy_legacy_id,
+                                                   dummy_legacy_instance);
+        _assert_built_sc_key_equals_with_legacy(builder, type, dummy_name, empty_labels, G_N_ELEMENTS(empty_labels),
+                                                dummy_legacy_component, dummy_legacy_id, dummy_legacy_instance, NULL);
+      }
+      stats_cluster_key_builder_pop(builder);
+      _assert_built_sc_key_equals_with_legacy(builder, type, dummy_name, empty_labels,
+                                              G_N_ELEMENTS(empty_labels), 1337, "foobar", "foobar", NULL);
+    }
+    stats_cluster_key_builder_pop(builder);
+
+    /* Legacy alias name */
+    if (type == TEST_SINGLE)
+      {
+        /* LOGPIPE does not support setting the legacy name */
+        stats_cluster_key_builder_push(builder);
+        {
+          stats_cluster_key_builder_set_legacy_alias(builder, dummy_legacy_component, dummy_legacy_id,
+                                                     dummy_legacy_instance);
+          stats_cluster_key_builder_set_legacy_alias_name(builder, "foobar");
+          stats_cluster_key_builder_push(builder);
+          {
+            _assert_built_sc_key_equals_with_legacy(builder, type, dummy_name, empty_labels, G_N_ELEMENTS(empty_labels),
+                                                    dummy_legacy_component, dummy_legacy_id, dummy_legacy_instance,
+                                                    "foobar");
+            stats_cluster_key_builder_set_legacy_alias_name(builder, dummy_legacy_name);
+            _assert_built_sc_key_equals_with_legacy(builder, type, dummy_name, empty_labels, G_N_ELEMENTS(empty_labels),
+                                                    dummy_legacy_component, dummy_legacy_id, dummy_legacy_instance,
+                                                    dummy_legacy_name);
+          }
+          stats_cluster_key_builder_pop(builder);
+          _assert_built_sc_key_equals_with_legacy(builder, type, dummy_name, empty_labels, G_N_ELEMENTS(empty_labels),
+                                                  dummy_legacy_component, dummy_legacy_id, dummy_legacy_instance,
+                                                  "foobar");
+        }
+        stats_cluster_key_builder_pop(builder);
+      }
+  }
+  stats_cluster_key_builder_pop(builder);
 
   /* Legacy only */
-  StatsClusterKeyBuilder *legacy_only_builder = stats_cluster_key_builder_new();
-  stats_cluster_key_builder_set_legacy_alias(legacy_only_builder, dummy_legacy_component, dummy_legacy_id,
-                                             dummy_legacy_instance);
-  _assert_built_sc_key_equals_with_legacy_only(legacy_only_builder, type, dummy_legacy_component, dummy_legacy_id,
-                                               dummy_legacy_instance);
-  stats_cluster_key_builder_free(legacy_only_builder);
+  stats_cluster_key_builder_push(builder);
+  {
+    stats_cluster_key_builder_set_legacy_alias(builder, 1337, "foobar", "foobar");
+    stats_cluster_key_builder_push(builder);
+    {
+      _assert_built_sc_key_equals_with_legacy_only(builder, type, 1337, "foobar", "foobar");
+      stats_cluster_key_builder_set_legacy_alias(builder, dummy_legacy_component, dummy_legacy_id,
+                                                 dummy_legacy_instance);
+      _assert_built_sc_key_equals_with_legacy_only(builder, type, dummy_legacy_component, dummy_legacy_id,
+                                                   dummy_legacy_instance);
+    }
+    stats_cluster_key_builder_pop(builder);
+    _assert_built_sc_key_equals_with_legacy_only(builder, type, 1337, "foobar", "foobar");
+  }
+  stats_cluster_key_builder_pop(builder);
 
   stats_cluster_key_builder_free(builder);
 }

--- a/lib/tests/test_logqueue.c
+++ b/lib/tests/test_logqueue.c
@@ -382,7 +382,8 @@ Test(logqueue, log_queue_fifo_multiple_queues)
   StatsClusterKeyBuilder *queue_sck_builder = stats_cluster_key_builder_new();
   stats_cluster_key_builder_add_label(queue_sck_builder, stats_cluster_label("log_queue_fifo_multiple_queues", "1"));
   LogQueue *queue_1 = log_queue_fifo_new(fifo_size, NULL, STATS_LEVEL0, driver_sck_builder, queue_sck_builder);
-  stats_cluster_key_builder_reset(queue_sck_builder);
+  stats_cluster_key_builder_free(queue_sck_builder);
+  queue_sck_builder = stats_cluster_key_builder_new();
   stats_cluster_key_builder_add_label(queue_sck_builder, stats_cluster_label("log_queue_fifo_multiple_queues", "2"));
   LogQueue *queue_2 = log_queue_fifo_new(fifo_size, NULL, STATS_LEVEL0, driver_sck_builder, queue_sck_builder);
 
@@ -409,7 +410,8 @@ Test(logqueue, log_queue_fifo_multiple_queues)
   cr_assert_eq(stats_counter_get(queue_2->metrics.shared.queued_messages), 1);
   cr_assert_eq(stats_counter_get(queue_2->metrics.owned.queued_messages), 1);
 
-  stats_cluster_key_builder_reset(queue_sck_builder);
+  stats_cluster_key_builder_free(queue_sck_builder);
+  queue_sck_builder = stats_cluster_key_builder_new();
   stats_cluster_key_builder_add_label(queue_sck_builder, stats_cluster_label("queue", "1"));
   queue_1 = log_queue_fifo_new(fifo_size, NULL, STATS_LEVEL0, driver_sck_builder, queue_sck_builder);
 

--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -189,14 +189,18 @@ _init_stats_key_builders(AFFileDestWriter *self, StatsClusterKeyBuilder **writer
   stats_cluster_key_builder_add_label(*writer_sck_builder, stats_cluster_label("driver", "file"));
   stats_cluster_key_builder_add_legacy_label(*writer_sck_builder, stats_cluster_label("filename", self->filename));
 
-  *driver_sck_builder = stats_cluster_key_builder_clone(*writer_sck_builder);
+  *driver_sck_builder = stats_cluster_key_builder_new();
+  stats_cluster_key_builder_add_label(*driver_sck_builder, stats_cluster_label("driver", "file"));
   stats_cluster_key_builder_add_label(*driver_sck_builder, stats_cluster_label("id", self->owner->super.super.id));
+  stats_cluster_key_builder_add_legacy_label(*driver_sck_builder, stats_cluster_label("filename", self->filename));
   stats_cluster_key_builder_set_legacy_alias(*driver_sck_builder,
                                              self->owner->writer_options.stats_source | SCS_DESTINATION,
                                              self->owner->super.super.id, self->filename);
 
-  *queue_sck_builder = stats_cluster_key_builder_clone(*writer_sck_builder);
+  *queue_sck_builder = stats_cluster_key_builder_new();
+  stats_cluster_key_builder_add_label(*queue_sck_builder, stats_cluster_label("driver", "file"));
   stats_cluster_key_builder_add_label(*queue_sck_builder, stats_cluster_label("id", self->owner->super.super.id));
+  stats_cluster_key_builder_add_legacy_label(*queue_sck_builder, stats_cluster_label("filename", self->filename));
 }
 
 static gboolean

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -535,14 +535,20 @@ _init_stats_key_builders(AFProgramDestDriver *self, StatsClusterKeyBuilder **wri
   stats_cluster_key_builder_add_legacy_label(*writer_sck_builder, stats_cluster_label("command",
                                              self->process_info.cmdline->str));
 
-  *driver_sck_builder = stats_cluster_key_builder_clone(*writer_sck_builder);
+  *driver_sck_builder = stats_cluster_key_builder_new();
+  stats_cluster_key_builder_add_label(*driver_sck_builder, stats_cluster_label("driver", "program"));
   stats_cluster_key_builder_add_label(*driver_sck_builder, stats_cluster_label("id", self->super.super.id));
+  stats_cluster_key_builder_add_legacy_label(*driver_sck_builder, stats_cluster_label("command",
+                                             self->process_info.cmdline->str));
   stats_cluster_key_builder_set_legacy_alias(*driver_sck_builder,
                                              self->writer_options.stats_source | SCS_DESTINATION,
                                              self->super.super.id, self->process_info.cmdline->str);
 
-  *queue_sck_builder = stats_cluster_key_builder_clone(*writer_sck_builder);
+  *queue_sck_builder = stats_cluster_key_builder_new();
+  stats_cluster_key_builder_add_label(*queue_sck_builder, stats_cluster_label("driver", "program"));
   stats_cluster_key_builder_add_label(*queue_sck_builder, stats_cluster_label("id", self->super.super.id));
+  stats_cluster_key_builder_add_legacy_label(*queue_sck_builder, stats_cluster_label("command",
+                                             self->process_info.cmdline->str));
 }
 
 static gboolean

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -505,14 +505,24 @@ _init_stats_key_builders(AFSocketDestDriver *self, StatsClusterKeyBuilder **writ
   stats_cluster_key_builder_add_legacy_label(*writer_sck_builder, stats_cluster_label("address",
                                              afsocket_dd_get_dest_name(self)));
 
-  *driver_sck_builder = stats_cluster_key_builder_clone(*writer_sck_builder);
+  *driver_sck_builder = stats_cluster_key_builder_new();
+  stats_cluster_key_builder_add_label(*driver_sck_builder, stats_cluster_label("driver", "afsocket"));
   stats_cluster_key_builder_add_label(*driver_sck_builder, stats_cluster_label("id", self->super.super.id));
+  stats_cluster_key_builder_add_legacy_label(*driver_sck_builder, stats_cluster_label("transport",
+                                             self->transport_mapper->transport));
+  stats_cluster_key_builder_add_legacy_label(*driver_sck_builder, stats_cluster_label("address",
+                                             afsocket_dd_get_dest_name(self)));
   stats_cluster_key_builder_set_legacy_alias(*driver_sck_builder,
                                              self->writer_options.stats_source | SCS_DESTINATION,
                                              self->super.super.id, afsocket_dd_stats_instance(self));
 
-  *queue_sck_builder = stats_cluster_key_builder_clone(*writer_sck_builder);
+  *queue_sck_builder = stats_cluster_key_builder_new();
+  stats_cluster_key_builder_add_label(*queue_sck_builder, stats_cluster_label("driver", "afsocket"));
   stats_cluster_key_builder_add_label(*queue_sck_builder, stats_cluster_label("id", self->super.super.id));
+  stats_cluster_key_builder_add_legacy_label(*queue_sck_builder, stats_cluster_label("transport",
+                                             self->transport_mapper->transport));
+  stats_cluster_key_builder_add_legacy_label(*queue_sck_builder, stats_cluster_label("address",
+                                             afsocket_dd_get_dest_name(self)));
 }
 
 static gboolean

--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -54,7 +54,7 @@ log_queue_disk_is_file_in_directory(const gchar *file, const gchar *directory)
 
 static LogQueue *
 _create_disk_queue(DiskQDestPlugin *self, const gchar *filename, const gchar *persist_name, gint stats_level,
-                   const StatsClusterKeyBuilder *driver_sck_builder, StatsClusterKeyBuilder *queue_sck_builder)
+                   StatsClusterKeyBuilder *driver_sck_builder, StatsClusterKeyBuilder *queue_sck_builder)
 {
   if (self->options.reliable)
     return log_queue_disk_reliable_new(&self->options, filename, persist_name, stats_level, driver_sck_builder,
@@ -78,7 +78,7 @@ _warn_if_dir_changed(const gchar *qfile_name, const gchar *dir)
 static LogQueue *
 _create_and_start_disk_queue_with_filename_from_persist(DiskQDestPlugin *self, const gchar *persist_qfile_name,
                                                         const gchar *persist_name, gint stats_level,
-                                                        const StatsClusterKeyBuilder *driver_sck_builder,
+                                                        StatsClusterKeyBuilder *driver_sck_builder,
                                                         StatsClusterKeyBuilder *queue_sck_builder)
 {
   if (!persist_qfile_name)
@@ -117,7 +117,7 @@ _create_and_start_disk_queue_with_filename_from_persist(DiskQDestPlugin *self, c
 static LogQueue *
 _create_and_start_disk_queue_with_new_filename(DiskQDestPlugin *self, const gchar *new_qfile_name,
                                                const gchar *persist_name, gint stats_level,
-                                               const StatsClusterKeyBuilder *driver_sck_builder,
+                                               StatsClusterKeyBuilder *driver_sck_builder,
                                                StatsClusterKeyBuilder *queue_sck_builder)
 {
   if (!new_qfile_name)
@@ -136,7 +136,7 @@ _create_and_start_disk_queue_with_new_filename(DiskQDestPlugin *self, const gcha
 
 static LogQueue *
 _acquire_queue(LogDestDriver *dd, const gchar *persist_name, gint stats_level,
-               const StatsClusterKeyBuilder *driver_sck_builder, StatsClusterKeyBuilder *queue_sck_builder)
+               StatsClusterKeyBuilder *driver_sck_builder, StatsClusterKeyBuilder *queue_sck_builder)
 {
   DiskQDestPlugin *self = log_driver_get_plugin(&dd->super, DiskQDestPlugin, DISKQ_PLUGIN_NAME);
   GlobalConfig *cfg = log_pipe_get_config(&dd->super.super);

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -563,7 +563,7 @@ _set_virtual_functions(LogQueueDiskNonReliable *self)
 
 LogQueue *
 log_queue_disk_non_reliable_new(DiskQueueOptions *options, const gchar *filename, const gchar *persist_name,
-                                gint stats_level, const StatsClusterKeyBuilder *driver_sck_builder,
+                                gint stats_level, StatsClusterKeyBuilder *driver_sck_builder,
                                 StatsClusterKeyBuilder *queue_sck_builder)
 {
   g_assert(options->reliable == FALSE);

--- a/modules/diskq/logqueue-disk-non-reliable.h
+++ b/modules/diskq/logqueue-disk-non-reliable.h
@@ -37,7 +37,7 @@ typedef struct _LogQueueDiskNonReliable
 } LogQueueDiskNonReliable;
 
 LogQueue *log_queue_disk_non_reliable_new(DiskQueueOptions *options, const gchar *filename, const gchar *persist_name,
-                                          gint stats_level, const StatsClusterKeyBuilder *driver_sck_builder,
+                                          gint stats_level, StatsClusterKeyBuilder *driver_sck_builder,
                                           StatsClusterKeyBuilder *queue_sck_builder);
 
 #endif /* LOG_QUEUE_DISK_NON_RELIABLE_H_ */

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -462,7 +462,7 @@ _set_virtual_functions(LogQueueDiskReliable *self)
 
 LogQueue *
 log_queue_disk_reliable_new(DiskQueueOptions *options, const gchar *filename, const gchar *persist_name,
-                            gint stats_level, const StatsClusterKeyBuilder *driver_sck_builder,
+                            gint stats_level, StatsClusterKeyBuilder *driver_sck_builder,
                             StatsClusterKeyBuilder *queue_sck_builder)
 {
   g_assert(options->reliable == TRUE);

--- a/modules/diskq/logqueue-disk-reliable.h
+++ b/modules/diskq/logqueue-disk-reliable.h
@@ -36,7 +36,7 @@ typedef struct _LogQueueDiskReliable
 } LogQueueDiskReliable;
 
 LogQueue *log_queue_disk_reliable_new(DiskQueueOptions *options, const gchar *filename, const gchar *persist_name,
-                                      gint stats_level, const StatsClusterKeyBuilder *driver_sck_builder,
+                                      gint stats_level, StatsClusterKeyBuilder *driver_sck_builder,
                                       StatsClusterKeyBuilder *queue_sck_builder);
 
 #endif /* LOGQUEUE_DISK_RELIABLE_H_ */

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -65,7 +65,7 @@ gboolean log_queue_disk_stop(LogQueue *self, gboolean *persistent);
 gboolean log_queue_disk_start(LogQueue *self);
 void log_queue_disk_init_instance(LogQueueDisk *self, DiskQueueOptions *options, const gchar *qdisk_file_id,
                                   const gchar *filename, const gchar *persist_name, gint stats_level,
-                                  const StatsClusterKeyBuilder *driver_sck_builder,
+                                  StatsClusterKeyBuilder *driver_sck_builder,
                                   StatsClusterKeyBuilder *queue_sck_builder);
 void log_queue_disk_restart_corrupted(LogQueueDisk *self);
 void log_queue_disk_free_method(LogQueueDisk *self);

--- a/modules/diskq/tests/test_diskq_counters.c
+++ b/modules/diskq/tests/test_diskq_counters.c
@@ -187,7 +187,8 @@ Test(diskq_counters, test_non_reliable,
   /* Release and reacquire queue, same counters are expected */
   log_dest_driver_release_queue(driver, queue);
 
-  stats_cluster_key_builder_reset(queue_sck_builder);
+  stats_cluster_key_builder_free(queue_sck_builder);
+  queue_sck_builder = stats_cluster_key_builder_new();
   queue = log_queue_ref(log_dest_driver_acquire_queue(driver, queue_persist_name, STATS_LEVEL0, NULL,
                                                       queue_sck_builder));
   cr_assert(queue);
@@ -254,7 +255,8 @@ Test(diskq_counters, test_reliable,
   /* Release and reacquire queue, only disk usage is expected, as front cache is not refilled */
   log_dest_driver_release_queue(driver, queue);
 
-  stats_cluster_key_builder_reset(queue_sck_builder);
+  stats_cluster_key_builder_free(queue_sck_builder);
+  queue_sck_builder = stats_cluster_key_builder_new();
   queue = log_queue_ref(log_dest_driver_acquire_queue(driver, queue_persist_name, STATS_LEVEL0, NULL,
                                                       queue_sck_builder));
   cr_assert(queue);

--- a/modules/diskq/tests/test_logqueue_disk.c
+++ b/modules/diskq/tests/test_logqueue_disk.c
@@ -308,7 +308,8 @@ Test(logqueue_disk, restart_corrupted_non_reliable_with_front_cache)
   gboolean persistent;
   log_queue_disk_stop(queue, &persistent);
   log_queue_unref(queue);
-  stats_cluster_key_builder_reset(queue_sck_builder);
+  stats_cluster_key_builder_free(queue_sck_builder);
+  queue_sck_builder = stats_cluster_key_builder_new();
   queue = log_queue_disk_non_reliable_new(&options, filename, "restart_corrupted_non_reliable_with_front_cache",
                                           STATS_LEVEL0, driver_sck_builder, queue_sck_builder);
   cr_assert(log_queue_disk_start(queue));
@@ -345,7 +346,8 @@ Test(logqueue_disk, restart_corrupted_with_multiple_queues)
   StatsClusterKeyBuilder *queue_sck_builder = stats_cluster_key_builder_new();
   LogQueue *queue_1 = log_queue_disk_reliable_new(&options, filename_1, "restart_corrupted_with_multiple_queues_1",
                                                   STATS_LEVEL0, driver_sck_builder, queue_sck_builder);
-  stats_cluster_key_builder_reset(queue_sck_builder);
+  stats_cluster_key_builder_free(queue_sck_builder);
+  queue_sck_builder = stats_cluster_key_builder_new();
   LogQueue *queue_2 = log_queue_disk_reliable_new(&options, filename_2, "restart_corrupted_with_multiple_queues_2",
                                                   STATS_LEVEL0, driver_sck_builder, queue_sck_builder);
 
@@ -373,7 +375,8 @@ Test(logqueue_disk, restart_corrupted_with_multiple_queues)
   cr_assert_eq(stats_counter_get(queue_2->metrics.shared.queued_messages), 1);
   cr_assert_eq(stats_counter_get(queue_2->metrics.owned.queued_messages), 1);
 
-  stats_cluster_key_builder_reset(queue_sck_builder);
+  stats_cluster_key_builder_free(queue_sck_builder);
+  queue_sck_builder = stats_cluster_key_builder_new();
   queue_1 = log_queue_disk_reliable_new(&options, filename_1, "restart_corrupted_with_multiple_queues_1",
                                         STATS_LEVEL0, driver_sck_builder, queue_sck_builder);
   cr_assert(log_queue_disk_start(queue_1));

--- a/modules/examples/sources/threaded-diskq-source/threaded-diskq-source.c
+++ b/modules/examples/sources/threaded-diskq-source/threaded-diskq-source.c
@@ -191,7 +191,9 @@ _init(LogPipe *s)
       return FALSE;
     }
 
-  stats_cluster_key_builder_reset(self->queue_sck_builder);
+  stats_cluster_key_builder_free(self->queue_sck_builder);
+  self->queue_sck_builder = stats_cluster_key_builder_new();
+
   stats_cluster_key_builder_add_label(self->queue_sck_builder,
                                       stats_cluster_label("id", self->super.super.super.super.id ? : ""));
   _format_stats_key(&self->super.super, self->queue_sck_builder);


### PR DESCRIPTION
This PR adds the functionality to set the options of the builder on different layers, so we don't need to unnecessarily clone and reset it. The call site calls a `push()`, does its thing, then calls a `pop()`, and the builder's state will be restored.

News file entry not needed.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>
