### PR TITLE
ivikys: set submodule lib/ivikys default branch to iv-work-pool-support-for-slave-work-items and synced HEAD to latest from the origin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,8 @@
 [submodule "lib/ivykis"]
-        path = lib/ivykis
-        url = https://github.com/bazsi/ivykis.git
-        ignore = dirty
+	path = lib/ivykis
+	url = https://github.com/bazsi/ivykis.git
+	ignore = dirty
+	branch = iv-work-pool-support-for-slave-work-items
 [submodule "modules/grpc/otel/opentelemetry-proto"]
 	path = modules/grpc/protos/opentelemetry-proto
 	url = https://github.com/open-telemetry/opentelemetry-proto.git


### PR DESCRIPTION
the last missing step to get the latest ivikys fork state in syslog-ng builds

Signed-off-by: Hofi <hofione@gmail.com>