### PR TITLE
`metrics-probe`: Add dynamic labelling support via name-value pairs   

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules ${PROJECT_SOURCE_DIR}/cmake/)
 set(CMAKE_POSITION_INDEPENDENT_CODE 1)
-set(BISON_FLAGS "-Wno-other -Werror=conflicts-sr -Werror=conflicts-rr")
+set(BISON_FLAGS "-Wno-other -Werror=conflicts-sr -Werror=conflicts-rr -Wcounterexamples")
 
 include(CheckIncludeFiles)
 include(ExternalProject)

--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,7 @@
 SUBDIRS			=
 DIST_SUBDIRS		=
 AM_MAKEFLAGS		= --no-print-directory
-AM_YFLAGS		= -Wno-yacc -Wno-other -Werror=conflicts-sr -Werror=conflicts-rr
+AM_YFLAGS		= -Wno-yacc -Wno-other -Werror=conflicts-sr -Werror=conflicts-rr -Wcounterexamples
 
 AM_TESTS_ENVIRONMENT	= top_srcdir="$(top_srcdir)" CRITERION_TEST_PATTERN='!(*/*performance*)' ASAN_OPTIONS="detect_odr_violation=0"
 if ENABLE_SANITIZER

--- a/modules/metrics-probe/metrics-probe-grammar.ym
+++ b/modules/metrics-probe/metrics-probe-grammar.ym
@@ -76,16 +76,21 @@ metrics_probe_opts
 
 metrics_probe_opt
         : KW_KEY '(' string ')' { metrics_probe_set_key(last_parser, $3); g_free($3); }
-        | KW_LABELS '(' metrics_probe_label_templates ')'
+        | KW_LABELS '(' metrics_probe_labels_opts ')'
         | KW_INCREMENT '(' template_content ')' { metrics_probe_set_increment_template(last_parser, $3); log_template_unref($3); }
         | KW_LEVEL '(' nonnegative_integer ')' { metrics_probe_set_level(last_parser, $3); }
         | { last_template_options = metrics_probe_get_template_options(last_parser); } template_option
         | parser_opt
         ;
 
-metrics_probe_label_templates
-        : metrics_probe_label_template metrics_probe_label_templates
+metrics_probe_labels_opts
+        : metrics_probe_labels_opt metrics_probe_labels_opts
         |
+        ;
+
+metrics_probe_labels_opt
+        : metrics_probe_label_template
+        | { last_value_pairs = metrics_probe_get_value_pairs(last_parser); } vp_option
         ;
 
 metrics_probe_label_template

--- a/modules/metrics-probe/metrics-probe-grammar.ym
+++ b/modules/metrics-probe/metrics-probe-grammar.ym
@@ -91,7 +91,7 @@ metrics_probe_label_templates
 metrics_probe_label_template
         : string LL_ARROW template_content
           {
-            CHECK_ERROR(metrics_probe_add_label_template(last_parser, $1, $3), @1, "Error adding label: maximum number of labels reached");
+            metrics_probe_add_label_template(last_parser, $1, $3);
             free($1);
             log_template_unref($3);
           }

--- a/modules/metrics-probe/metrics-probe.h
+++ b/modules/metrics-probe/metrics-probe.h
@@ -25,6 +25,7 @@
 
 #include "parser/parser-expr.h"
 #include "template/templates.h"
+#include "value-pairs/value-pairs.h"
 
 LogParser *metrics_probe_new(GlobalConfig *cfg);
 
@@ -34,5 +35,6 @@ void metrics_probe_set_increment_template(LogParser *s, LogTemplate *increment_t
 void metrics_probe_set_level(LogParser *s, gint level);
 
 LogTemplateOptions *metrics_probe_get_template_options(LogParser *s);
+ValuePairs *metrics_probe_get_value_pairs(LogParser *s);
 
 #endif

--- a/modules/metrics-probe/metrics-probe.h
+++ b/modules/metrics-probe/metrics-probe.h
@@ -29,7 +29,7 @@
 LogParser *metrics_probe_new(GlobalConfig *cfg);
 
 void metrics_probe_set_key(LogParser *s, const gchar *key);
-gboolean metrics_probe_add_label_template(LogParser *s, const gchar *label, LogTemplate *value_template);
+void metrics_probe_add_label_template(LogParser *s, const gchar *label, LogTemplate *value_template);
 void metrics_probe_set_increment_template(LogParser *s, LogTemplate *increment_template);
 void metrics_probe_set_level(LogParser *s, gint level);
 

--- a/news/feature-4610.md
+++ b/news/feature-4610.md
@@ -1,0 +1,17 @@
+`metrics-probe`: Added dynamic labelling support via name-value pairs
+
+You can use all value-pairs options, like `key()`, `rekey()`, `pair()` or `scope()`, etc...
+
+Example:
+```
+metrics-probe(
+  key("foo")
+  labels(
+    "static-label" => "bar"
+    key(".my_prefix.*" rekey(shift-levels(1)))
+  )
+);
+```
+```
+syslogng_foo{static_label="bar",my_prefix_baz="almafa",my_prefix_foo="bar",my_prefix_nested_axo="flow"} 4
+```


### PR DESCRIPTION
You can use all value-pairs options, like `key()`, `rekey()`, `pair()` or `scope()`, etc...

Example:
```
metrics-probe(
  key("foo")
  labels(
    "static-label" => "bar"
    key(".my_prefix.*" rekey(shift-levels(1)))
  )
);
```
```
syslogng_foo{static_label="bar",my_prefix_baz="almafa",my_prefix_foo="bar",my_prefix_nested_axo="flow"} 4
```

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>
