### PR TITLE
scl/elasticsearch-http: allow the deprecated `type()` field to be omitted

### DIFF
--- a/scl/elasticsearch/elastic-http.conf
+++ b/scl/elasticsearch/elastic-http.conf
@@ -25,7 +25,7 @@
 block destination elasticsearch-http(
   url()
   index()
-  type()
+  type("")
   custom_id("")
   workers(4)
   batch_lines(100)


### PR DESCRIPTION
Setting it to non-empty value is not compatible with Elasticsearch v7+.

Signed-off-by: Szilard Parrag <szilard.parrag@axoflow.com>


<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
