### PR TITLE
http: Fix strcmp() failing on SLES 12 compiler check

### DIFF
--- a/modules/http/compression.c
+++ b/modules/http/compression.c
@@ -35,7 +35,7 @@ gchar *curl_compression_types[] = {"identity", "gzip", "deflate"};
 gboolean
 http_dd_curl_compression_string_match(const gchar *string, gint curl_compression_index)
 {
-  return (strcmp(string, curl_compression_types[curl_compression_index]) == 0);
+  return (g_strcmp0(string, curl_compression_types[curl_compression_index]) == 0);
 }
 
 gboolean


### PR DESCRIPTION
<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->

SLES 12 has rather stringent requirements for compiling on the platform. Such a check failed on the ground of strcmp() not being fortified.

resolves #4603 

<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
