### PR TITLE
tls-context: add no-hostname-check option for TLS

### DIFF
--- a/lib/transport/tls-context.c
+++ b/lib/transport/tls-context.c
@@ -662,6 +662,8 @@ tls_context_set_ssl_options_by_name(TLSContext *self, GList *options)
       else if (strcasecmp(l->data, "ignore-unexpected-eof") == 0 || strcasecmp(l->data, "ignore_unexpected_eof") == 0)
         self->ssl_options |= TSO_IGNORE_UNEXPECTED_EOF;
 #endif
+      else if (strcasecmp(l->data, "ignore-hostname-mismatch") == 0 || strcasecmp(l->data, "ignore_hostname_mismatch") == 0)
+        self->ssl_options |= TSO_IGNORE_HOSTNAME_MISMATCH;
       else
         return FALSE;
     }
@@ -679,6 +681,12 @@ void
 tls_context_set_verify_mode(TLSContext *self, gint verify_mode)
 {
   self->verify_mode = verify_mode;
+}
+
+gboolean
+tls_context_ignore_hostname_mismatch(TLSContext *self)
+{
+  return self->ssl_options & TSO_IGNORE_HOSTNAME_MISMATCH;
 }
 
 static int

--- a/lib/transport/tls-context.h
+++ b/lib/transport/tls-context.h
@@ -54,6 +54,7 @@ typedef enum
   TSO_NOTLSv12=0x0010,
   TSO_NOTLSv13=0x0020,
   TSO_IGNORE_UNEXPECTED_EOF=0x0040,
+  TSO_IGNORE_HOSTNAME_MISMATCH=0x0080,
 } TLSSslOptions;
 
 typedef enum
@@ -116,6 +117,7 @@ gboolean tls_context_set_verify_mode_by_name(TLSContext *self, const gchar *mode
 gboolean tls_context_set_ssl_options_by_name(TLSContext *self, GList *options);
 gint tls_context_get_verify_mode(const TLSContext *self);
 void tls_context_set_verify_mode(TLSContext *self, gint verify_mode);
+gboolean tls_context_ignore_hostname_mismatch(TLSContext *self);
 void tls_context_set_key_file(TLSContext *self, const gchar *key_file);
 void tls_context_set_cert_file(TLSContext *self, const gchar *cert_file);
 gboolean tls_context_set_keylog_file(TLSContext *self, gchar *keylog_file_path, GError **error);

--- a/lib/transport/tls-verifier.h
+++ b/lib/transport/tls-verifier.h
@@ -42,7 +42,7 @@ TLSVerifier *tls_verifier_new(TLSSessionVerifyFunc verify_func, gpointer verify_
 TLSVerifier *tls_verifier_ref(TLSVerifier *self);
 void tls_verifier_unref(TLSVerifier *self);
 
-gboolean tls_verify_certificate_name(X509 *cert, const gchar *hostname);
+gboolean tls_verify_certificate_name(X509 *cert, const gchar *hostname, gpointer user_data);
 
 
 #endif

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -144,7 +144,7 @@ afinet_dd_verify_callback(gint ok, X509_STORE_CTX *ctx, gpointer user_data)
   if (ok && current_cert == cert && self->hostname
       && (tls_context_get_verify_mode(self->tls_context) & TVM_TRUSTED))
     {
-      ok = tls_verify_certificate_name(cert, self->hostname);
+      ok = tls_verify_certificate_name(cert, self->hostname, self->tls_context);
       if (ok)
         {
           AFSocketTLSCertificateValidationSignalData signal_data = {0};

--- a/modules/examples/inner-destinations/tls-test-validation/tls-test-validation.c
+++ b/modules/examples/inner-destinations/tls-test-validation/tls-test-validation.c
@@ -44,7 +44,7 @@ static void
 _slot_append_test_identity(TlsTestValidationPlugin *self, AFSocketTLSCertificateValidationSignalData *data)
 {
   X509 *cert = X509_STORE_CTX_get0_cert(data->ctx);
-  data->failure = !tls_verify_certificate_name(cert, self->identity);
+  data->failure = !tls_verify_certificate_name(cert, self->identity, NULL);
 
   msg_debug("TlsTestValidationPlugin validated");
 }


### PR DESCRIPTION
Error message:
"Certificate subject does not match configured hostname;"

In some cases you want to verify the ssl certificate authenticity but don't care about a mismatched hostname. For example when using self-signed certificates that don't contain a hostname at all. Currently there is no way to do this except for simply not verifying the certificate at all.

This option disables the ssl certificate hostname check, but still does all other verification steps.