### PR TITLE
docker: add license header

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -33,6 +33,7 @@ syslog-ng/
 syslog-ng-ctl/
 persist-tool/
 tests/loggen/
+docker/
 
 The syslog-ng modules (modules/ and scl/ subdirectories, except the ones that
 declare LGPL-2.1-or-later in their license notices) is free software; you can

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,26 @@
+#############################################################################
+# Copyright (c) 2015-2023 Balabit
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
 FROM debian:testing
 LABEL maintainer="Andras Mitzki <andras.mitzki@balabit.com>, László Várady <laszlo.varady@balabit.com>"
 LABEL org.opencontainers.image.source="https://github.com/syslog-ng/syslog-ng"


### PR DESCRIPTION
Based on:
https://github.com/balabit/syslog-ng-docker/blob/master/LICENSE

Resolves #4425