### PR TITLE
autotools and cmake tests run for different set of test cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -427,10 +427,8 @@ add_subdirectory(scripts)
 add_subdirectory(syslog-ng)
 add_subdirectory(syslog-ng-ctl)
 add_subdirectory(persist-tool)
-if (BUILD_TESTING)
-  add_test_subdirectory(libtest)
-  add_subdirectory(tests)
-endif()
+add_subdirectory(tests)
+add_subdirectory(libtest)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/syslog-ng-config.h.in ${CMAKE_CURRENT_BINARY_DIR}/syslog-ng-config.h)
 


### PR DESCRIPTION
- CMake: Based on the [earlier discussion](https://github.com/syslog-ng/syslog-ng/pull/4601#discussion_r1304022662) tests and libtest  should not be excluded based on the BUILD_TESTING option, only their tests sub-folders (that is already presented in the CMake files)
- ...

Signed-off-by: Hofi <hofione@gmail.com>

