### PR TITLE
macOS CMake check fails

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -52,6 +52,7 @@ jobs:
             --enable-tests
             --with-ivykis=system
             --with-python=3
+            --with-systemd-journal=no
             --disable-smtp
             --disable-grpc
             --disable-java
@@ -66,6 +67,7 @@ jobs:
             -DBUILD_TESTING=ON
             -DIVYKIS_SOURCE=system
             -DPYTHON_VERSION=3
+            -DENABLE_JOURNALD=OFF
             -DENABLE_AFSMTP=OFF
             -DENABLE_GRPC=OFF
             -DENABLE_JAVA=OFF

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -109,11 +109,7 @@ jobs:
       - name: cmake check
         if: matrix.build-tool == 'cmake'
         run: |
-          # FIXME: Should fix these tests first, latest result is
-          #        98% tests passed, 4 tests failed out of 194
-          #        that is strange as in the autotools case 199 out of 199(!) is passed
-          #cmake --build ./build -j ${THREADS} --target check
-          true
+          cmake --build ./build -j ${THREADS} --target check
 
       - name: make
         if: matrix.build-tool == 'autotools'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,7 +347,7 @@ set_target_properties(check-copyright PROPERTIES
 if (CRITERION_FOUND)
   option(BUILD_TESTING "Enable unit tests" ON)
 else()
-  option(BUILD_TESTING  "Enable unit tests" OFF)
+  option(BUILD_TESTING "Enable unit tests" OFF)
 endif()
 
 include(add_tests)
@@ -365,7 +365,14 @@ if (BUILD_TESTING)
       "G_DEBUG=fatal-warnings,fatal-criticals,gc-friendly")
     include(CTest)
 
+    # This flag might be a security issue, do not use in production code, unfortunately we still need it for criterion tests and the current mocking soution
+    if (APPLE)
+      SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-flat_namespace")
+    endif()
+
     add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -j $$(nproc) --output-on-failure)
+    # This one is useful to see the failed tests in details
+    add_custom_target(check_failed COMMAND ${CMAKE_CTEST_COMMAND} -j $$(nproc) --rerun-failed --output-on-failure)
   endif()
 endif()
 

--- a/configure.ac
+++ b/configure.ac
@@ -666,7 +666,10 @@ case "$ostype" in
 		;;
 	Darwin)
 		MODULE_LDFLAGS="-avoid-version -dylib"
-		LDFLAGS="$LDFLAGS -Wl,-flat_namespace"
+                # This flag might be a security issue, do not use in production code, unfortunately we still need it for criterion tests and the current mocking solution
+                if test "x$enable_tests" = "xyes"; then
+		        LDFLAGS="$LDFLAGS -Wl,-flat_namespace"
+                fi
                 # NOTE: This is now seems to be an Apple/Xcode "only" issue, but probably much better a clang one, so later we might want to add this globally
                 # XCode15 new linker has some issues (e.g. https://developer.apple.com/forums/thread/737707)
                 # switch back to classic linking till not fixed (https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes#Linking)

--- a/modules/python/tests/CMakeLists.txt
+++ b/modules/python/tests/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (NOT ENABLE_PYTHON)
+  return()
+endif()
+
 add_unit_test(LIBTEST CRITERION
   TARGET test_python_logmsg
   INCLUDES "${PYTHON_INCLUDE_DIR}" "${PYTHON_INCLUDE_DIRS}"

--- a/modules/python/tests/Makefile.am
+++ b/modules/python/tests/Makefile.am
@@ -1,3 +1,5 @@
+if ENABLE_PYTHON
+
 PYTHONMALLOC=malloc_debug
 export PYTHONMALLOC
 
@@ -67,5 +69,7 @@ modules_python_tests_test_python_reloc_CFLAGS = $(TEST_CFLAGS) $(PYTHON_CFLAGS) 
 modules_python_tests_test_python_reloc_LDADD = $(TEST_LDADD) \
 	-dlpreopen $(top_builddir)/modules/python/libmod-python.la \
 	$(PYTHON_LIBS)
+
+endif
 
 EXTRA_DIST += modules/python/tests/CMakeLists.txt


### PR DESCRIPTION
- CI: Re-enabled cmake check build step in the CI Action
- cmake/autotools: added the missing -flat_namespace linker option to cmake builds and made this option conditional, it is not needed for production build just for the current mocking solution in the criterion tests

Fixes: https://github.com/syslog-ng/syslog-ng/issues/4625

Signed-off-by: hofione@gmail.com