### PR TITLE
logthrdestdrv: worker partitioning

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -195,6 +195,7 @@
 %token KW_SYSLOG_STATS                10405
 %token KW_HEALTHCHECK_FREQ            10406
 %token KW_WORKER_PARTITION_KEY        10407
+%token KW_FLUSH_ON_WORKER_KEY_CHANGE  10408
 
 %token KW_CHAIN_HOSTNAMES             10090
 %token KW_NORMALIZE_HOSTNAMES         10091
@@ -1299,6 +1300,7 @@ threaded_dest_driver_batch_option
 threaded_dest_driver_workers_option
         : KW_WORKERS '(' positive_integer ')'  { log_threaded_dest_driver_set_num_workers(last_driver, $3); }
         | KW_WORKER_PARTITION_KEY '(' template_content ')' { log_threaded_dest_driver_set_worker_partition_key_ref(last_driver, $3); }
+        | KW_FLUSH_ON_WORKER_KEY_CHANGE '(' yesno ')'	{ log_threaded_dest_driver_set_flush_on_worker_key_change(last_driver, $3); }
         ;
 
 /* implies dest_driver_option */

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -195,7 +195,6 @@
 %token KW_SYSLOG_STATS                10405
 %token KW_HEALTHCHECK_FREQ            10406
 %token KW_WORKER_PARTITION_KEY        10407
-%token KW_FLUSH_ON_WORKER_KEY_CHANGE  10408
 
 %token KW_CHAIN_HOSTNAMES             10090
 %token KW_NORMALIZE_HOSTNAMES         10091
@@ -1300,7 +1299,6 @@ threaded_dest_driver_batch_option
 threaded_dest_driver_workers_option
         : KW_WORKERS '(' positive_integer ')'  { log_threaded_dest_driver_set_num_workers(last_driver, $3); }
         | KW_WORKER_PARTITION_KEY '(' template_content ')' { log_threaded_dest_driver_set_worker_partition_key_ref(last_driver, $3); }
-        | KW_FLUSH_ON_WORKER_KEY_CHANGE '(' yesno ')'	{ log_threaded_dest_driver_set_flush_on_worker_key_change(last_driver, $3); }
         ;
 
 /* implies dest_driver_option */

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -194,6 +194,7 @@
 %token KW_MAX_DYNAMIC                 10404
 %token KW_SYSLOG_STATS                10405
 %token KW_HEALTHCHECK_FREQ            10406
+%token KW_WORKER_PARTITION_KEY        10407
 
 %token KW_CHAIN_HOSTNAMES             10090
 %token KW_NORMALIZE_HOSTNAMES         10091
@@ -1297,6 +1298,7 @@ threaded_dest_driver_batch_option
 
 threaded_dest_driver_workers_option
         : KW_WORKERS '(' positive_integer ')'  { log_threaded_dest_driver_set_num_workers(last_driver, $3); }
+        | KW_WORKER_PARTITION_KEY '(' template_content ')' { log_threaded_dest_driver_set_worker_partition_key_ref(last_driver, $3); }
         ;
 
 /* implies dest_driver_option */

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -182,6 +182,7 @@ static CfgLexerKeyword main_keywords[] =
   { "retries",            KW_RETRIES },
   { "workers",            KW_WORKERS },
   { "worker_partition_key", KW_WORKER_PARTITION_KEY },
+  { "flush_on_worker_key_change", KW_FLUSH_ON_WORKER_KEY_CHANGE },
   { "batch_lines",        KW_BATCH_LINES },
   { "batch_timeout",      KW_BATCH_TIMEOUT },
 

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -181,6 +181,7 @@ static CfgLexerKeyword main_keywords[] =
 
   { "retries",            KW_RETRIES },
   { "workers",            KW_WORKERS },
+  { "worker_partition_key", KW_WORKER_PARTITION_KEY },
   { "batch_lines",        KW_BATCH_LINES },
   { "batch_timeout",      KW_BATCH_TIMEOUT },
 

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -182,7 +182,6 @@ static CfgLexerKeyword main_keywords[] =
   { "retries",            KW_RETRIES },
   { "workers",            KW_WORKERS },
   { "worker_partition_key", KW_WORKER_PARTITION_KEY },
-  { "flush_on_worker_key_change", KW_FLUSH_ON_WORKER_KEY_CHANGE },
   { "batch_lines",        KW_BATCH_LINES },
   { "batch_timeout",      KW_BATCH_TIMEOUT },
 

--- a/lib/logqueue.h
+++ b/lib/logqueue.h
@@ -81,6 +81,7 @@ struct _LogQueue
   gboolean (*is_empty_racy)(LogQueue *self);
   void (*push_tail)(LogQueue *self, LogMessage *msg, const LogPathOptions *path_options);
   LogMessage *(*pop_head)(LogQueue *self, LogPathOptions *path_options);
+  LogMessage *(*peek_head)(LogQueue *self);
   void (*ack_backlog)(LogQueue *self, gint n);
   void (*rewind_backlog)(LogQueue *self, guint rewind_count);
   void (*rewind_backlog_all)(LogQueue *self);
@@ -131,6 +132,12 @@ log_queue_pop_head(LogQueue *self, LogPathOptions *path_options)
     self->throttle_buckets--;
 
   return msg;
+}
+
+static inline LogMessage *
+log_queue_peek_head(LogQueue *self)
+{
+  return self->peek_head(self);
 }
 
 static inline LogMessage *

--- a/lib/logscheduler.h
+++ b/lib/logscheduler.h
@@ -26,6 +26,8 @@
 
 #include "logpipe.h"
 #include "mainloop-io-worker.h"
+#include "template/templates.h"
+
 #include <iv_list.h>
 #include <iv_event.h>
 

--- a/lib/logthrdest/logthrdestdrv.c
+++ b/lib/logthrdest/logthrdestdrv.c
@@ -397,7 +397,6 @@ _perform_flush(LogThreadedDestWorker *self)
 static void
 _perform_inserts(LogThreadedDestWorker *self)
 {
-  LogMessage *msg;
   LogThreadedResult result;
   LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
 
@@ -411,10 +410,12 @@ _perform_inserts(LogThreadedDestWorker *self)
       self->last_flush_time = iv_now;
     }
 
-  while (G_LIKELY(!self->owner->under_termination) &&
-         !self->suspended &&
-         (msg = log_queue_pop_head(self->queue, &path_options)) != NULL)
+  while (G_LIKELY(!self->owner->under_termination) && !self->suspended)
     {
+      LogMessage *msg = log_queue_pop_head(self->queue, &path_options);
+      if (!msg)
+        break;
+
       msg_set_context(msg);
       log_msg_refcache_start_consumer(msg, &path_options);
 

--- a/lib/logthrdest/logthrdestdrv.c
+++ b/lib/logthrdest/logthrdestdrv.c
@@ -1036,8 +1036,8 @@ log_threaded_dest_driver_set_max_retries_on_error(LogDriver *s, gint max_retries
 LogThreadedDestWorker *
 _lookup_worker(LogThreadedDestDriver *self, LogMessage *msg)
 {
-  gint worker_index = self->last_worker % self->num_workers;
-  self->last_worker++;
+  guint worker_index = self->last_worker;
+  self->last_worker = (self->last_worker + 1) % self->num_workers;
 
   /* here would come the lookup mechanism that maps msg -> worker that doesn't exist yet. */
   return self->workers[worker_index];

--- a/lib/logthrdest/logthrdestdrv.c
+++ b/lib/logthrdest/logthrdestdrv.c
@@ -30,6 +30,8 @@
 #include "scratch-buffers.h"
 #include "mainloop-threaded-worker.h"
 
+#include <string.h>
+
 #define MAX_RETRIES_ON_ERROR_DEFAULT 3
 #define MAX_RETRIES_BEFORE_SUSPEND_DEFAULT 3
 
@@ -368,9 +370,10 @@ _process_result(LogThreadedDestWorker *self, gint result)
 
 }
 
-static void
+static LogThreadedResult
 _perform_flush(LogThreadedDestWorker *self)
 {
+  LogThreadedResult result = LTR_SUCCESS;
   /* NOTE: earlier we had a condition on only calling flush() if batch_size
    * is non-zero.  This was removed, as the language bindings that were done
    * _before_ the batching support in LogThreadedDestDriver relies on
@@ -384,11 +387,33 @@ _perform_flush(LogThreadedDestWorker *self)
                 evt_tag_int("worker_index", self->worker_index),
                 evt_tag_int("batch_size", self->batch_size));
 
-      LogThreadedResult result = log_threaded_dest_worker_flush(self, LTF_FLUSH_NORMAL);
+      result = log_threaded_dest_worker_flush(self, LTF_FLUSH_NORMAL);
       _process_result(self, result);
     }
 
   iv_invalidate_now();
+  return result;
+}
+
+static inline gboolean
+_flush_on_worker_partition_key_change_enabled(LogThreadedDestWorker *self)
+{
+  return self->owner->flush_on_key_change && self->owner->worker_partition_key;
+}
+
+static inline gboolean
+_should_flush_due_to_partition_key_change(LogThreadedDestWorker *self, LogMessage *msg)
+{
+  GString *buffer = scratch_buffers_alloc();
+
+  LogTemplateEvalOptions options = DEFAULT_TEMPLATE_EVAL_OPTIONS;
+  log_template_format(self->owner->worker_partition_key, msg, &options, buffer);
+
+  gboolean should_flush = self->batch_size != 0 && strcmp(self->partitioning.last_key->str, buffer->str) != 0;
+
+  g_string_assign(self->partitioning.last_key, buffer->str);
+
+  return should_flush;
 }
 
 /* NOTE: runs in the worker thread, whenever items on our queue are
@@ -412,19 +437,38 @@ _perform_inserts(LogThreadedDestWorker *self)
 
   while (G_LIKELY(!self->owner->under_termination) && !self->suspended)
     {
+      ScratchBuffersMarker mark;
+      scratch_buffers_mark(&mark);
+
+      if (G_UNLIKELY(_flush_on_worker_partition_key_change_enabled(self)))
+        {
+          LogMessage *msg = log_queue_peek_head(self->queue);
+          if (!msg)
+            {
+              scratch_buffers_reclaim_marked(mark);
+              break;
+            }
+
+          if (_should_flush_due_to_partition_key_change(self, msg))
+            {
+              gboolean flush_result = _perform_flush(self);
+              if (flush_result != LTR_SUCCESS && flush_result != LTR_EXPLICIT_ACK_MGMT)
+                goto flush_error;
+            }
+        }
+
       LogMessage *msg = log_queue_pop_head(self->queue, &path_options);
       if (!msg)
-        break;
+        {
+          scratch_buffers_reclaim_marked(mark);
+          break;
+        }
 
       msg_set_context(msg);
       log_msg_refcache_start_consumer(msg, &path_options);
 
       self->batch_size++;
-      ScratchBuffersMarker mark;
-      scratch_buffers_mark(&mark);
-
       result = log_threaded_dest_worker_insert(self, msg);
-      scratch_buffers_reclaim_marked(mark);
 
       _process_result(self, result);
 
@@ -435,6 +479,8 @@ _perform_inserts(LogThreadedDestWorker *self)
       msg_set_context(NULL);
       log_msg_refcache_stop();
 
+flush_error:
+      scratch_buffers_reclaim_marked(mark);
       if (self->rewound_batch_size)
         {
           self->rewound_batch_size--;
@@ -884,12 +930,17 @@ log_threaded_dest_worker_init_method(LogThreadedDestWorker *self)
   if (self->time_reopen == -1)
     self->time_reopen = self->owner->time_reopen;
 
+  if (self->owner->flush_on_key_change)
+    self->partitioning.last_key = g_string_sized_new(128);
+
   return TRUE;
 }
 
 void
 log_threaded_dest_worker_deinit_method(LogThreadedDestWorker *self)
 {
+  if (self->partitioning.last_key)
+    g_string_free(self->partitioning.last_key, TRUE);
 }
 
 void
@@ -914,6 +965,9 @@ log_threaded_dest_worker_init_instance(LogThreadedDestWorker *self, LogThreadedD
   self->free_fn = log_threaded_dest_worker_free_method;
   self->owner = owner;
   self->time_reopen = -1;
+
+  self->partitioning.last_key = NULL;
+
   _init_watches(self);
 
   /* cannot be moved to the thread's init() as neither StatsByteCounter nor format_stats_key() is thread-safe */
@@ -945,6 +999,14 @@ log_threaded_dest_driver_set_worker_partition_key_ref(LogDriver *s, LogTemplate 
 
   log_template_unref(self->worker_partition_key);
   self->worker_partition_key = key;
+}
+
+void
+log_threaded_dest_driver_set_flush_on_worker_key_change(LogDriver *s, gboolean f)
+{
+  LogThreadedDestDriver *self = (LogThreadedDestDriver *) s;
+
+  self->flush_on_key_change = f;
 }
 
 /* compatibility bridge between LogThreadedDestWorker */
@@ -1405,4 +1467,6 @@ log_threaded_dest_driver_init_instance(LogThreadedDestDriver *self, GlobalConfig
 
   self->retries_on_error_max = MAX_RETRIES_ON_ERROR_DEFAULT;
   self->retries_max = MAX_RETRIES_BEFORE_SUSPEND_DEFAULT;
+
+  self->flush_on_key_change = FALSE;
 }

--- a/lib/logthrdest/logthrdestdrv.h
+++ b/lib/logthrdest/logthrdestdrv.h
@@ -35,6 +35,7 @@
 #include "seqnum.h"
 #include "mainloop-threaded-worker.h"
 #include "timeutils/misc.h"
+#include "template/templates.h"
 
 #include <iv.h>
 #include <iv_event.h>
@@ -166,6 +167,7 @@ struct _LogThreadedDestDriver
   gint created_workers;
   guint last_worker;
 
+  LogTemplate *worker_partition_key;
   gint stats_source;
 
   /* this counter is not thread safe if there are multiple worker threads,
@@ -292,6 +294,7 @@ void log_threaded_dest_driver_free(LogPipe *s);
 
 void log_threaded_dest_driver_set_max_retries_on_error(LogDriver *s, gint max_retries);
 void log_threaded_dest_driver_set_num_workers(LogDriver *s, gint num_workers);
+void log_threaded_dest_driver_set_worker_partition_key_ref(LogDriver *s, LogTemplate *key);
 void log_threaded_dest_driver_set_batch_lines(LogDriver *s, gint batch_lines);
 void log_threaded_dest_driver_set_batch_timeout(LogDriver *s, gint batch_timeout);
 void log_threaded_dest_driver_set_time_reopen(LogDriver *s, time_t time_reopen);

--- a/lib/logthrdest/logthrdestdrv.h
+++ b/lib/logthrdest/logthrdestdrv.h
@@ -94,6 +94,11 @@ struct _LogThreadedDestWorker
 
   struct
   {
+    GString *last_key;
+  } partitioning;
+
+  struct
+  {
     StatsClusterKey *output_event_bytes_sc_key;
     StatsClusterKey *message_delay_sample_key;
     StatsClusterKey *message_delay_sample_age_key;
@@ -167,6 +172,7 @@ struct _LogThreadedDestDriver
   gint created_workers;
   guint last_worker;
 
+  gboolean flush_on_key_change;
   LogTemplate *worker_partition_key;
   gint stats_source;
 
@@ -295,6 +301,7 @@ void log_threaded_dest_driver_free(LogPipe *s);
 void log_threaded_dest_driver_set_max_retries_on_error(LogDriver *s, gint max_retries);
 void log_threaded_dest_driver_set_num_workers(LogDriver *s, gint num_workers);
 void log_threaded_dest_driver_set_worker_partition_key_ref(LogDriver *s, LogTemplate *key);
+void log_threaded_dest_driver_set_flush_on_worker_key_change(LogDriver *s, gboolean f);
 void log_threaded_dest_driver_set_batch_lines(LogDriver *s, gint batch_lines);
 void log_threaded_dest_driver_set_batch_timeout(LogDriver *s, gint batch_timeout);
 void log_threaded_dest_driver_set_time_reopen(LogDriver *s, time_t time_reopen);

--- a/lib/template/eval.h
+++ b/lib/template/eval.h
@@ -84,4 +84,6 @@ void log_template_format_value_and_type_with_context(LogTemplate *self, LogMessa
 void log_template_format_with_context(LogTemplate *self, LogMessage **messages, gint num_messages,
                                       LogTemplateEvalOptions *options, GString *result);
 
+guint log_template_hash(LogTemplate *self, LogMessage *lm, LogTemplateEvalOptions *options);
+
 #endif

--- a/modules/diskq/logqueue-disk.h
+++ b/modules/diskq/logqueue-disk.h
@@ -72,6 +72,7 @@ void log_queue_disk_free_method(LogQueueDisk *self);
 
 void log_queue_disk_update_disk_related_counters(LogQueueDisk *self);
 LogMessage *log_queue_disk_read_message(LogQueueDisk *self, LogPathOptions *path_options);
+LogMessage *log_queue_disk_peek_message(LogQueueDisk *self);
 void log_queue_disk_drop_message(LogQueueDisk *self, LogMessage *msg, const LogPathOptions *path_options);
 gboolean log_queue_disk_serialize_msg(LogQueueDisk *self, LogMessage *msg, GString *serialized);
 gboolean log_queue_disk_deserialize_msg(LogQueueDisk *self, GString *serialized, LogMessage **msg);

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -883,6 +883,25 @@ qdisk_get_next_head_position(QDisk *self)
 }
 
 gboolean
+qdisk_peek_head(QDisk *self, GString *record)
+{
+  if (self->hdr->read_head == self->hdr->write_head)
+    return FALSE;
+
+  if (self->hdr->read_head > self->hdr->write_head)
+    self->hdr->read_head = _correct_position_if_max_size_is_reached(self, self->hdr->read_head);
+
+  guint32 record_length;
+  if (!_try_reading_record_length(self, self->hdr->read_head, &record_length))
+    return FALSE;
+
+  if (!_read_record_from_disk(self, record, record_length))
+    return FALSE;
+
+  return TRUE;
+}
+
+gboolean
 qdisk_pop_head(QDisk *self, GString *record)
 {
   if (self->hdr->read_head == self->hdr->write_head)

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -62,6 +62,7 @@ gint64 qdisk_get_empty_space(QDisk *self);
 gint64 qdisk_get_used_useful_space(QDisk *self);
 gboolean qdisk_push_tail(QDisk *self, GString *record);
 gboolean qdisk_pop_head(QDisk *self, GString *record);
+gboolean qdisk_peek_head(QDisk *self, GString *record);
 gboolean qdisk_remove_head(QDisk *self);
 gboolean qdisk_ack_backlog(QDisk *self);
 gboolean qdisk_rewind_backlog(QDisk *self, guint rewind_count);

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -86,6 +86,7 @@ HttpResponseHandler last_response_handler;
 %token KW_RETRY
 %token KW_DROP
 %token KW_DISCONNECT
+%token KW_FLUSH_ON_WORKER_KEY_CHANGE
 
 
 %type   <ptr> driver
@@ -161,6 +162,7 @@ http_option
     | threaded_dest_driver_batch_option
     | threaded_dest_driver_workers_option
     | http_tls_option
+    | KW_FLUSH_ON_WORKER_KEY_CHANGE '(' yesno ')' { log_threaded_dest_driver_set_flush_on_worker_key_change(last_driver, $3); }
     | KW_TLS '(' http_tls_options ')'
     | KW_ACCEPT_ENCODING '(' string ')' { http_dd_set_accept_encoding(last_driver, $3); free($3); }
     | KW_CONTENT_COMPRESSION '(' string ')' { http_dd_set_message_compression(last_driver, $3); free($3); }

--- a/modules/http/http-parser.c
+++ b/modules/http/http-parser.c
@@ -63,6 +63,7 @@ static CfgLexerKeyword http_keywords[] =
   { "batch_bytes",      KW_BATCH_BYTES },
   { "flush_lines",      KW_BATCH_LINES, KWS_OBSOLETE, "The flush-lines option is deprecated. Use batch-lines instead."},
   { "flush_timeout",    KW_BATCH_TIMEOUT, KWS_OBSOLETE, "The flush-timeout option is deprecated. Use batch-timeout instead."},
+  { "flush_on_worker_key_change", KW_FLUSH_ON_WORKER_KEY_CHANGE },
   { "body_prefix",      KW_BODY_PREFIX },
   { "body_suffix",      KW_BODY_SUFFIX },
   { "delimiter",        KW_DELIMITER },


### PR DESCRIPTION
This PR is a preparation step for the Loki destination driver.

### `worker-partition-key()`:

This option can be used to direct similar messages to the same worker.
Similarity is determined based on hashing the value of the `worker-partition-key()` template specified by the user.
It can be used to retain ordering for a subset of messages or, to accumulate batches of certain types of messages.

When the `flush_on_key_change` flag is set, the destination driver will close and flush batches when a key change (key collision) is detected.
