### PR TITLE
python: Fix use-after-free

### DIFF
--- a/modules/python/python-startup.c
+++ b/modules/python/python-startup.c
@@ -371,8 +371,8 @@ _py_activate_venv(void)
   wchar_t *python_programname = Py_DecodeLocale(python_venv_binary, NULL);
 
   msg_debug("python: activating virtualenv",
-           evt_tag_str("path", python_venv_path),
-           evt_tag_str("executable", python_venv_binary));
+            evt_tag_str("path", python_venv_path),
+            evt_tag_str("executable", python_venv_binary));
   g_free(python_venv_binary);
 
   Py_SetProgramName(python_programname);

--- a/modules/python/python-startup.c
+++ b/modules/python/python-startup.c
@@ -370,7 +370,7 @@ _py_activate_venv(void)
   gchar *python_venv_binary = g_build_path(G_DIR_SEPARATOR_S, python_venv_path, "bin", "python", NULL);
   wchar_t *python_programname = Py_DecodeLocale(python_venv_binary, NULL);
 
-  msg_info("python: activating virtualenv",
+  msg_debug("python: activating virtualenv",
            evt_tag_str("path", python_venv_path),
            evt_tag_str("executable", python_venv_binary));
   g_free(python_venv_binary);

--- a/modules/python/python-startup.c
+++ b/modules/python/python-startup.c
@@ -369,11 +369,11 @@ _py_activate_venv(void)
 
   gchar *python_venv_binary = g_build_path(G_DIR_SEPARATOR_S, python_venv_path, "bin", "python", NULL);
   wchar_t *python_programname = Py_DecodeLocale(python_venv_binary, NULL);
-  g_free(python_venv_binary);
 
   msg_info("python: activating virtualenv",
            evt_tag_str("path", python_venv_path),
            evt_tag_str("executable", python_venv_binary));
+  g_free(python_venv_binary);
 
   Py_SetProgramName(python_programname);
   return TRUE;


### PR DESCRIPTION
The `python_venv_binary` variable should not be freed before the value is used to output an informational message.

---

While investigating an issue on a legacy Ubuntu Bionic node (Puppet reports "invalid byte sequence in UTF-8" when testing patterndb rules), I ran the command by hand and saw this message:

```sh-session
# pdbtool test /tmp/syslog-ng/patterndb/default.xml --module=mod-python 
python: activating virtualenv; path='/var/lib/syslog-ng/python-venv', executable='�5�S.V'
[...]
# echo $?
0
```

On each run, the garbage I got at the end of the first line was different.

With this patch, the reported path is the expected one:

```sh-session
# pdbtool test --module=mod-python /tmp/syslog-ng/patterndb/default.xml
python: activating virtualenv; path='/var/lib/syslog-ng/python-venv', executable='/var/lib/syslog-ng/python-venv/bin/python'
[...]
```

Puppet is now happy with the command stdout/stderr.