### PR TITLE
tls-context: add ignore-validity-period option for TLS

### DIFF
--- a/lib/transport/tls-context.c
+++ b/lib/transport/tls-context.c
@@ -690,6 +690,8 @@ tls_context_set_ssl_options_by_name(TLSContext *self, GList *options)
 #endif
       else if (strcasecmp(l->data, "ignore-hostname-mismatch") == 0 || strcasecmp(l->data, "ignore_hostname_mismatch") == 0)
         self->ssl_options |= TSO_IGNORE_HOSTNAME_MISMATCH;
+      else if (strcasecmp(l->data, "ignore-validity-period") == 0 || strcasecmp(l->data, "ignore_validity_period") == 0)
+        self->ssl_options |= TSO_IGNORE_VALIDITY_PERIOD;
       else
         return FALSE;
     }
@@ -713,6 +715,12 @@ gboolean
 tls_context_ignore_hostname_mismatch(TLSContext *self)
 {
   return self->ssl_options & TSO_IGNORE_HOSTNAME_MISMATCH;
+}
+
+gboolean
+tls_context_ignore_validity_period(TLSContext *self)
+{
+  return self->ssl_options & TSO_IGNORE_VALIDITY_PERIOD;
 }
 
 static int

--- a/lib/transport/tls-context.h
+++ b/lib/transport/tls-context.h
@@ -55,6 +55,7 @@ typedef enum
   TSO_NOTLSv13=0x0020,
   TSO_IGNORE_UNEXPECTED_EOF=0x0040,
   TSO_IGNORE_HOSTNAME_MISMATCH=0x0080,
+  TSO_IGNORE_VALIDITY_PERIOD=0x0100,
 } TLSSslOptions;
 
 typedef enum
@@ -118,6 +119,7 @@ gboolean tls_context_set_ssl_options_by_name(TLSContext *self, GList *options);
 gint tls_context_get_verify_mode(const TLSContext *self);
 void tls_context_set_verify_mode(TLSContext *self, gint verify_mode);
 gboolean tls_context_ignore_hostname_mismatch(TLSContext *self);
+gboolean tls_context_ignore_validity_period(TLSContext *self);
 void tls_context_set_key_file(TLSContext *self, const gchar *key_file);
 void tls_context_set_cert_file(TLSContext *self, const gchar *cert_file);
 gboolean tls_context_set_keylog_file(TLSContext *self, gchar *keylog_file_path, GError **error);

--- a/lib/transport/tls-session.c
+++ b/lib/transport/tls-session.c
@@ -232,6 +232,14 @@ tls_session_verify(TLSSession *self, int ok, X509_STORE_CTX *ctx)
                   tls_context_format_location_tag(self->ctx));
       return 1;
     }
+  if (!ok && tls_context_ignore_validity_period(self->ctx) &&
+      (X509_STORE_CTX_get_error(ctx) == X509_V_ERR_CERT_NOT_YET_VALID ||
+       X509_STORE_CTX_get_error(ctx) == X509_V_ERR_CERT_HAS_EXPIRED))
+    {
+      msg_notice("Ignoring not yet valid / expired certificate error due to ssl_options(ignore-validity-period)",
+                 tls_context_format_location_tag(self->ctx));
+      return 1;
+    }
   return ok;
 }
 

--- a/news/feature-4642.md
+++ b/news/feature-4642.md
@@ -1,0 +1,4 @@
+`network()` and `syslog()` drivers: Added `ignore-validity-period` as a new flag to `ssl-options()`.
+
+By specifying `ignore-validity-period`, you can ignore the validity periods
+of certificates during the certificate validation process.


### PR DESCRIPTION
In some cases you want to verify the ssl certificate authenticity but don't care about the validity period. For example when working in a system without an NTP server.
Currently there is no way to do this except for simply not verifying the certificate at all.

This option disables the ssl validity period check, but still does all other verification steps.

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
