### PR TITLE
Add heavy weight config check

### DIFF
--- a/lib/mainloop.h
+++ b/lib/mainloop.h
@@ -35,6 +35,7 @@ typedef struct _MainLoopOptions
 {
   gchar *preprocess_into;
   gboolean syntax_only;
+  gboolean check_startup;
   gboolean config_id;
   gboolean interactive_mode;
   gboolean server_mode;

--- a/news/feature-4646.md
+++ b/news/feature-4646.md
@@ -1,0 +1,7 @@
+`--check-startup`: a new command line option for syslog-ng along with the
+existing `--syntax-only`. This new option will do a complete configuration
+initialization and then exit with exit code indicating the result. Since
+this also initializes things like network listeners, it will probably _not_
+work when there is another syslog-ng instance running in the background. The
+recommended use of this option is a dedicated config check container, as
+explained in #4592.

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -116,6 +116,7 @@ interactive_mode(void)
   debug_flag = FALSE;
   verbose_flag = FALSE;
   msg_init(TRUE);
+  g_process_set_mode(G_PM_FOREGROUND);
 }
 
 gboolean
@@ -294,8 +295,10 @@ main(int argc, char *argv[])
   gboolean exit_before_main_loop_run = main_loop_options.syntax_only
                                        || main_loop_options.preprocess_into
                                        || main_loop_options.config_id;
+  if (exit_before_main_loop_run)
+    interactive_mode();
 
-  if (debug_flag || exit_before_main_loop_run)
+  if (debug_flag)
     {
       g_process_set_mode(G_PM_FOREGROUND);
     }

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -82,6 +82,7 @@ static GOptionEntry syslogng_options[] =
   { "persist-file",      'R',         0, G_OPTION_ARG_STRING, &resolved_configurable_paths.persist_file, "Set the name of the persistent configuration file, default=" PATH_PERSIST_CONFIG, "<fname>" },
   { "preprocess-into",     0,         0, G_OPTION_ARG_STRING, &main_loop_options.preprocess_into, "Write the preprocessed configuration file to the file specified and quit", "output" },
   { "syntax-only",       's',         0, G_OPTION_ARG_NONE, &main_loop_options.syntax_only, "Only read and parse config file", NULL},
+  { "check-startup",       0,         0, G_OPTION_ARG_NONE, &main_loop_options.check_startup, "Check if syslog-ng would start up and then exit", NULL},
   { "config-id",           0,         0, G_OPTION_ARG_NONE, &main_loop_options.config_id, "Parse config file, print configuration ID, and quit", NULL},
   { "control",           'c',         0, G_OPTION_ARG_STRING, &resolved_configurable_paths.ctlfilename, "Set syslog-ng control socket, default=" PATH_CONTROL_SOCKET, "<ctlpath>" },
   { "interactive",       'i',         0, G_OPTION_ARG_NONE, &main_loop_options.interactive_mode, "Enable interactive mode" },
@@ -294,7 +295,9 @@ main(int argc, char *argv[])
 
   gboolean exit_before_main_loop_run = main_loop_options.syntax_only
                                        || main_loop_options.preprocess_into
-                                       || main_loop_options.config_id;
+                                       || main_loop_options.config_id
+                                       || main_loop_options.check_startup;
+
   if (exit_before_main_loop_run)
     interactive_mode();
 

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -277,12 +277,12 @@ main(int argc, char *argv[])
 
   setup_caps();
 
-  if(startup_debug_flag && debug_flag)
+  if (startup_debug_flag && debug_flag)
     {
       startup_debug_flag = FALSE;
     }
 
-  if(startup_debug_flag)
+  if (startup_debug_flag)
     {
       debug_flag = TRUE;
     }


### PR DESCRIPTION
This should fix #4592 

It adds a --check-startup command line option that causes syslog-ng to perform a complete config initialization and then
exit with the exit code indicating the result: 0 indicates complete success, non-zero indicates failure. (1 indicates syntax error, 2 a runtime error)
