### PR TITLE
Disable capability management when running as non root

### DIFF
--- a/lib/gprocess.c
+++ b/lib/gprocess.c
@@ -976,19 +976,23 @@ g_process_change_caps(void)
 
 #endif
 
-static void
+static gboolean
 g_process_resolve_names(void)
 {
+  gboolean result = TRUE;
   if (process_opts.user && !resolve_user(process_opts.user, &process_opts.uid))
     {
       g_process_message("Error resolving user; user='%s'", process_opts.user);
       process_opts.uid = -1;
+      result = FALSE;
     }
   if (process_opts.group && !resolve_group(process_opts.group, &process_opts.gid))
     {
       g_process_message("Error resolving group; group='%s'", process_opts.group);
       process_opts.gid = -1;
+      result = FALSE;
     }
+  return result;
 }
 
 /**
@@ -1360,7 +1364,10 @@ g_process_start(void)
 
   g_process_detach_tty();
   g_process_change_limits();
-  g_process_resolve_names();
+  if (!g_process_resolve_names())
+    {
+      exit(1);
+    }
 
   if (process_opts.mode == G_PM_BACKGROUND)
     {

--- a/syslog-ng/main.c
+++ b/syslog-ng/main.c
@@ -203,6 +203,9 @@ setup_caps (void)
   static gchar *capsstr_syslog = BASE_CAPS "cap_syslog=ep";
   static gchar *capsstr_sys_admin = BASE_CAPS "cap_sys_admin=ep";
 
+  if (geteuid() != 0)
+    g_process_disable_caps();
+
   if (!g_process_is_cap_enabled())
     return;
 


### PR DESCRIPTION
There's an ugly warning message at startup in containers, unless the --no-caps command line option is explicitly used. This PR should prevent that by disabling capability management completely when we are running as non-root.

At the moment, I am checking this with euid == 0, which might not be the best way to check this.

I've also added stricter validation for the --user and --group options so that we exit if either cannot be resolved.