### PR TITLE
cmake: Made Loki and Otel modules both switchable in cmake builds and made the corresponding module switches always visible

### DIFF
--- a/modules/grpc/CMakeLists.txt
+++ b/modules/grpc/CMakeLists.txt
@@ -57,18 +57,20 @@ endif()
 
 module_switch(ENABLE_GRPC "Enable GRPC" GRPC_DEPS_FOUND)
 
-if (NOT ENABLE_GRPC)
-  return()
+if (ENABLE_GRPC)
+  include(ProtobufGenerateCpp)
+
+  set(MODULE_GRPC_LIBS
+    gRPC::grpc
+    gRPC::grpc++
+    protobuf::libprotobuf)
+
+  add_subdirectory(credentials)
+  add_subdirectory(protos)
 endif()
 
-add_subdirectory(credentials)
-
-include(ProtobufGenerateCpp)
-
-set(MODULE_GRPC_LIBS
-  gRPC::grpc
-  gRPC::grpc++
-  protobuf::libprotobuf)
-
-add_subdirectory(protos)
+# These are intentionally not inside the above if (ENABLE_GRPC) block
+# Let the module_switch-es take effect and is being always visible
+# (both modules are protected via ENABLE_GRPC as well)
+add_subdirectory(loki)
 add_subdirectory(otel)

--- a/modules/grpc/loki/CMakeLists.txt
+++ b/modules/grpc/loki/CMakeLists.txt
@@ -1,5 +1,10 @@
-module_switch(ENABLE_LOKI "Enable Loki")
-if (NOT ENABLE_LOKI)
+if(ENABLE_LOKI AND NOT ENABLE_GRPC)
+  message(FATAL_ERROR "GRPC support is mandatory when the Loki modules are enabled.")
+endif()
+
+module_switch(ENABLE_LOKI "Enable Loki" ENABLE_GRPC)
+
+if(NOT ENABLE_LOKI OR NOT ENABLE_GRPC)
   return()
 endif()
 
@@ -12,5 +17,6 @@ set(LOKI_SOURCES
 add_module(
   TARGET loki
   GRAMMAR loki-grammar
+  INCLUDES ${PROJECT_SOURCE_DIR}/modules/grpc
   SOURCES ${LOKI_SOURCES}
 )

--- a/modules/grpc/otel/CMakeLists.txt
+++ b/modules/grpc/otel/CMakeLists.txt
@@ -1,3 +1,13 @@
+if(ENABLE_OTEL AND NOT ENABLE_GRPC)
+  message(FATAL_ERROR "GRPC support is mandatory when the Otel modules are enabled.")
+endif()
+
+module_switch(ENABLE_OTEL "Enable Otel" ENABLE_GRPC)
+
+if(NOT ENABLE_OTEL OR NOT ENABLE_GRPC)
+  return()
+endif()
+
 set(OTEL_CPP_SOURCES
   ${GRPC_CREDENTIALS_SOURCES}
   otel-source.cpp


### PR DESCRIPTION
Signed-off-by: Hofi <hofione@gmail.com>