### PR TITLE
cfg-grammar.y: fix location information for blocks

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -940,7 +940,7 @@ block_stmt
             gint context_type = cfg_lexer_lookup_context_type_by_name($3);
             CHECK_ERROR(context_type, @3, "unknown context \"%s\"", $3);
 
-            block = cfg_block_new(context_type, $4, $10, last_block_args, &@1);
+            block = cfg_block_new(context_type, $4, $10, last_block_args, &@10);
             cfg_lexer_register_generator_plugin(&configuration->plugin_context, block);
             free($3);
             free($4);


### PR DESCRIPTION
syslog-ng was giving me invalid error traces whenever I was using blocks, at least if the starting brace of the block was not on the same line as the "block" keyword. E.g:

```
# brace same line, works correctly
block source whatever() {
};

# brace on a separate line, did not work correctly 
block source whatever(
  foo(bar)
  baz(bat)
)
{
};
```

The fix is to record the location of the block content instead of the block statement as a whole. This fixes up @line references that are emitted as blocks get expanded.

