### PR TITLE
cfg-args: fix __VARARGS__ substitution of NULL values

### DIFF
--- a/lib/cfg-args.c
+++ b/lib/cfg-args.c
@@ -61,7 +61,7 @@ _resolve_unknown_blockargs_as_varargs(gpointer key, gpointer value, gpointer use
 
   if (!defaults || !cfg_args_contains(defaults, key))
     {
-      g_string_append_printf(varargs, "%s(%s) ", (gchar *)key, (gchar *)value);
+      g_string_append_printf(varargs, "%s(%s) ", (gchar *)key, (gchar *)value ? : "");
     }
 }
 


### PR DESCRIPTION
Required block parameters are represented as NULL values in the CfgArgs object, which means that we can encounter NULL as value for a block argument when formatting __VARARGS__.

Take care of this by substituting an empty string in this case.
