### PR TITLE
Dont activate listener for port 0

### DIFF
--- a/lib/host-resolve.c
+++ b/lib/host-resolve.c
@@ -444,10 +444,6 @@ _init_options(HostResolveOptions *options)
 {
   if (options->use_dns == 0)
     {
-      if (options->use_dns_cache != 0)
-        {
-          msg_warning("WARNING: With use-dns(no), dns-cache() will be forced to 'no' too!");
-        }
       options->use_dns_cache = 0;
     }
 }

--- a/modules/afsocket/afinet-source.c
+++ b/modules/afsocket/afinet-source.c
@@ -92,6 +92,7 @@ afinet_sd_setup_addresses(AFSocketSourceDriver *s)
   else
     g_sockaddr_set_port(self->super.bind_addr, afinet_lookup_service(self->super.transport_mapper, self->bind_port));
 
+  self->super.activate_listener = (g_sockaddr_get_port(self->super.bind_addr) != 0);
   return TRUE;
 }
 

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -1147,6 +1147,16 @@ _sd_open_dgram(AFSocketSourceDriver *self)
 static gboolean
 afsocket_sd_open_listener(AFSocketSourceDriver *self)
 {
+  if (!self->activate_listener)
+    {
+      gchar buf[256];
+
+      msg_debug("Not opening socket, listener activation disabled",
+                evt_tag_str("addr", g_sockaddr_format(self->bind_addr, buf, sizeof(buf), GSA_FULL)),
+                log_pipe_location_tag(&self->super.super.super));
+      return TRUE;
+    }
+
   if (self->transport_mapper->sock_type == SOCK_STREAM)
     {
       return _sd_open_stream(self);
@@ -1392,6 +1402,6 @@ afsocket_sd_init_instance(AFSocketSourceDriver *self,
   log_reader_options_defaults(&self->reader_options);
   self->reader_options.super.stats_level = STATS_LEVEL1;
   self->reader_options.super.stats_source = transport_mapper->stats_source;
-
+  self->activate_listener = TRUE;
   afsocket_sd_init_watches(self);
 }

--- a/modules/afsocket/afsocket-source.h
+++ b/modules/afsocket/afsocket-source.h
@@ -41,7 +41,8 @@ struct _AFSocketSourceDriver
 {
   LogSrcDriver super;
   guint32 connections_kept_alive_across_reloads:1,
-          window_size_initialized:1;
+          window_size_initialized:1,
+          activate_listener:1;
   struct iv_fd listen_fd;
   struct iv_timer dynamic_window_timer;
   gsize dynamic_window_size;

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -187,10 +187,7 @@ Test(basicfuncs, test_str_funcs)
 #if SYSLOG_NG_ENABLE_IPV6
   assert_template_format("$(dns-resolve-ip 1996::04:30)", "resolved-TEST-host");
 #endif
-  start_grabbing_messages();
   assert_template_format("$(dns-resolve-ip --use-dns=no --dns-cache=yes 123.123.123.123)", "123.123.123.123");
-  assert_grabbed_log_contains("WARNING: With use-dns(no), dns-cache() will be forced to 'no' too!");
-  stop_grabbing_messages();
 
   assert_template_format("$(length $HOST $PID)", "5 5");
   assert_template_format("$(length $HOST)", "5");


### PR DESCRIPTION
When the port is set to 0, we would allocate a dynamic port for
our listeners. This can happen when we explicitly set port to 0 or when
we use an unknown service name (as syslog-ng will happily resolve the
service from /etc/services).

This behaviour does not add too much value, syslog-ng would open a port randomly.

This patch changes afsocket to avoid opening the listener in these cases.

The intent for this change is to be able to list source drivers in a
complex driver such as default-network-drivers() and still be able to
disable the constituent drivers just by setting their port to 0.
