### PR TITLE
Make building examples optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,6 +193,9 @@ AC_ARG_WITH(package_name,
    [  --with-package-name=package name Package name is printed out when syslog-ng started with --version],
    PACKAGE_NAME=$with_package_name)
 
+AC_ARG_ENABLE(build-example-modules,
+              [  --enable-build-example-modules Enable building example modules.],, enable_build_example_modules="no")
+
 AC_ARG_ENABLE(forced_server_mode,
               [  --enable-forced-server-mode   Enable forced server mode.],, enable_forced_server_mode="yes")
 
@@ -2192,6 +2195,7 @@ AM_CONDITIONAL([HAVE_GETRANDOM], [test x$ac_cv_func_getrandom = xyes])
 AM_CONDITIONAL([HAVE_FMEMOPEN], [test x$ac_cv_func_fmemopen = xyes])
 AM_CONDITIONAL([HAVE_JAVAH], [test -n "$JAVAH_BIN"])
 AM_CONDITIONAL(ENABLE_IPV6, [test $enable_ipv6 = yes])
+AM_CONDITIONAL(BUILD_EXAMPLE_MODULES, [test "$enable_build_example_modules" = "yes"])
 
 
 AC_SUBST(PYTHON_VENV)
@@ -2309,6 +2313,7 @@ echo "  JSON support                : $with_jsonc"
 echo " Build options:"
 echo "  Generate manual pages       : ${enable_manpages:=no}"
 echo "  Install manual pages        : ${enable_manpages_install:=no}"
+echo "  Build example modules       : ${enable_build_example_modules:=no}"
 echo " Modules:"
 echo "  Module search path          : ${module_path}"
 echo "  Sun STREAMS support (module): ${enable_sun_streams:=no}"

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -19,7 +19,11 @@ include modules/csvparser/Makefile.am
 include modules/timestamp/Makefile.am
 include modules/correlation/Makefile.am
 include modules/diskq/Makefile.am
+
+if BUILD_EXAMPLE_MODULES
 include modules/examples/Makefile.am
+endif
+
 include modules/ebpf/Makefile.am
 include modules/geoip2/Makefile.am
 include modules/getent/Makefile.am


### PR DESCRIPTION
Issue #4496 reports an issue where building the example module random-choice-generator fails with clang++ due to the following error:

../lib/atomic-gssize.h:118:10: error: cannot initialize a parameter of type 'gssize *' (aka 'long *') with an rvalue of type 'void *'
  118 |   return g_atomic_pointer_compare_and_exchange(&a->value, oldval, newval);
/usr/include/glib-2.0/glib/gatomic.h:258:44: note: expanded from macro 'g_atomic_pointer_compare_and_exchange'
  258 |     __atomic_compare_exchange_n ((atomic), (void *) (&(gapcae_oldval)), (newval), FALSE, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST) ? TRUE : FALSE; \

with passing '--disable-cpp' being the recommended work-around. This commit proposes an alternate work-around by updating the system so building example modules is optional.

The value of this work-around is it provides a means of reducing compile-time and work for builders who do not need to build the example modules.