### PR TITLE
gha: fix light reports folder upload

### DIFF
--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -115,26 +115,17 @@ jobs:
         id: prepare-light-reports
         if: always() && steps.light.outcome == 'failure'
         run: |
-          if [ ${{ matrix.build-tool }} = 'autotools' ]
-          then
-            REPORTS_DIR=build/reports
-          elif [ ${{ matrix.build-tool }} = 'cmake' ]
-          then
-            REPORTS_DIR=build/tests/light/reports
-          else
-            echo Unrecognized build tool: ${{ matrix.build-tool }}.
-            exit 1
-          fi
-
+          REPORTS_DIR=tests/light/reports
           cp -r ${REPORTS_DIR} /tmp/light-reports
-          rm -f `find /tmp/light-reports -type p,s`
+          find /tmp/light-reports -type p,s -print0 | xargs -0 rm -f 
+          tar -cz -f /tmp/light-reports.tar.gz /tmp/light-reports 
 
       - name: "Artifact: light-reports"
         uses: actions/upload-artifact@v3
         if: always() && steps.prepare-light-reports.outcome == 'success'
         with:
           name: light-reports-${{ matrix.build-tool }}-${{ matrix.cc }}
-          path: /tmp/light-reports
+          path: /tmp/light-reports.tar.gz
 
       - name: Dump corefile backtrace
         working-directory: ${{ env.COREFILES_DIR }}


### PR DESCRIPTION
Please note the `-print0` part, which is needed as some filenames have special characters in them that are not allowed (e.g., *).

This has been split off from the PostgreSQL csvlog parser as it is valuable by itself and currently 2 PRs are affected by it as well ([4660](https://github.com/syslog-ng/syslog-ng/actions/runs/6387435123/job/17340795274?pr=4660) and [4544](https://github.com/syslog-ng/syslog-ng/actions/runs/6420892834/job/17434026527?pr=4544))

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
