### PR TITLE
Add option to turn on/off all example modules

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -199,6 +199,9 @@ AC_ARG_ENABLE(forced_server_mode,
 AC_ARG_ENABLE(debug,
               [  --enable-debug      Enable debugging code.],, enable_debug="no")
 
+AC_ARG_ENABLE(example-modules,
+              [  --enable-example-modules Enable example modules.],, enable_example_modules="yes")
+
 AC_ARG_ENABLE(force_gnu99,
               [  --enable-force-gnu99      Enforce C99 with gnu extensions.],, force_gnu99="no")
 
@@ -2217,6 +2220,7 @@ AM_CONDITIONAL(ENABLE_MANPAGES_INSTALL, [test "$enable_manpages_install" != "no"
 AM_CONDITIONAL(ENABLE_NATIVE, [test "$enable_native" != "no"])
 AM_CONDITIONAL(ENABLE_EXTRA_WARNINGS, [test "$enable_extra_warnings" = "yes"])
 AM_CONDITIONAL(ENABLE_TESTING, [test "$enable_tests" != "no"])
+AM_CONDITIONAL(ENABLE_EXAMPLE_MODULES, [test "$enable_example_modules" = "yes"])
 AM_CONDITIONAL(ENABLE_SANITIZER, [test "$with_sanitizer" != "no"])
 AM_CONDITIONAL(ENABLE_DEBUG, [test "$enable_debug" != "no"])
 AM_CONDITIONAL([HAVE_INOTIFY], [test x$ac_cv_func_inotify_init = xyes])
@@ -2370,3 +2374,4 @@ echo "  Java modules                : ${enable_java_modules:=no}"
 echo "  afsnmp module               : ${enable_afsnmp:=no}"
 echo "  eBPF module                 : ${enable_ebpf:=no}"
 echo "  native bindings             : ${enable_native:=no}"
+echo "  Example modules             : ${enable_example_modules:=yes}"

--- a/modules/examples/CMakeLists.txt
+++ b/modules/examples/CMakeLists.txt
@@ -1,5 +1,10 @@
-add_library(examples SHARED example-plugins.c)
+module_switch(ENABLE_EXAMPLE_MODULES "Enable example modules" ON)
 
+if(NOT ENABLE_EXAMPLE_MODULES)
+  return()
+endif()
+
+add_library(examples SHARED example-plugins.c)
 
 add_subdirectory(sources/msg-generator)
 add_subdirectory(sources/threaded-random-generator)
@@ -10,10 +15,10 @@ add_subdirectory(inner-destinations/http-test-slots)
 add_subdirectory(inner-destinations/tls-test-validation)
 add_subdirectory(destinations/example_destination)
 
-
 target_link_libraries(examples PRIVATE msg-generator)
 target_link_libraries(examples PRIVATE threaded-random-generator)
 target_link_libraries(examples PRIVATE threaded-diskq-source)
+
 if(ENABLE_CPP)
   target_link_libraries(examples PRIVATE random-choice-generator)
 endif()

--- a/modules/examples/Makefile.am
+++ b/modules/examples/Makefile.am
@@ -1,3 +1,5 @@
+if ENABLE_EXAMPLE_MODULES
+
 include modules/examples/sources/msg-generator/Makefile.am
 include modules/examples/sources/threaded-diskq-source/Makefile.am
 include modules/examples/sources/threaded-random-generator/Makefile.am
@@ -5,7 +7,6 @@ include modules/examples/inner-destinations/http-test-slots/Makefile.am
 include modules/examples/inner-destinations/tls-test-validation/Makefile.am
 include modules/examples/destinations/example_destination/Makefile.am
 include modules/examples/sources/random-choice-generator/Makefile.am
-
 
 EXAMPLE_PLUGINS = \
   $(top_builddir)/modules/examples/sources/libmsg-generator.la \
@@ -38,5 +39,8 @@ endif
 EXTRA_DIST += modules/examples/CMakeLists.txt
 
 modules/examples modules/examples/ mod-examples: modules/examples/libexamples.la
+else
+modules/examples modules/examples/ mod-examples:
+endif
 
 .PHONY: modules/examples/ mod-examples

--- a/modules/examples/destinations/example_destination/CMakeLists.txt
+++ b/modules/examples/destinations/example_destination/CMakeLists.txt
@@ -1,8 +1,3 @@
-module_switch(ENABLE_EXAMPLE_DESTINATION "Enable example_destination")
-if (NOT ENABLE_EXAMPLE_DESTINATION)
-  return()
-endif()
-
 set(example_destination_SOURCES
     "example_destination-parser.h"
     "example_destination-plugin.c"


### PR DESCRIPTION
This is a bit more generic version of https://github.com/syslog-ng/syslog-ng/pull/4660 that allows switching on/off all the example modules both in cmake and autotools builds

- Removed autotools, and `example_destination` example only compile switch ENABLE_EXAMPLE_DESTINATION
- Added example modules wide common option ENABLE_EXAMPLE_MODULES both to autotools and cmake builds


Signed-off-by: Hofi <hofione@gmail.com>