### PR TITLE
Fix macOS C++ builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,16 @@ if (ENV_LD_LIBRARY_PATH)
   set(SYSLOG_NG_ENABLE_ENV_WRAPPER 1)
 endif()
 
+# NOTE: This is now seems to be an Apple/Xcode "only" issue, but probably much better a clang one, so later we might want to add this globally
+if (APPLE)
+  module_switch(FORCE_CLASSIC_LINKING "Enable classic linking" OFF)
+  if (FORCE_CLASSIC_LINKING)
+    # XCode15 new linker has some issues (e.g. https://developer.apple.com/forums/thread/737707)
+    # switch back to classic linking till not fixed (https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes#Linking)
+    SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-ld_classic")
+  endif()
+endif()
+
 option(WITH_COMPILE_DATE "Include compile date in binary" "ON")
 if (WITH_COMPILE_DATE)
   set(SYSLOG_NG_WITH_COMPILE_DATE 1)

--- a/cmake/print_config_summary.cmake
+++ b/cmake/print_config_summary.cmake
@@ -111,6 +111,9 @@ function(print_config_summary)
     endif()
 
     list(APPEND _importantVariableNames "IVYKIS_INTERNAL" "BUILD_TESTING")
+    if (APPLE)
+      list(APPEND _importantVariableNames "FORCE_CLASSIC_LINKING")
+    endif()
     _print_importants("${_variableNames}" "${_importantVariableNames}")
     _print_separator()
 

--- a/configure.ac
+++ b/configure.ac
@@ -225,6 +225,9 @@ AC_ARG_ENABLE(dynamic-linking,
 AC_ARG_ENABLE(mixed-linking,
               [  --enable-mixed-linking          Link 3rd party libraries statically, system libraries dynamically],,enable_mixed_linking="auto")
 
+AC_ARG_ENABLE(force-classic-linking,
+              [  --enable-force-classic-linking  Link using ld-classic (default: no)],, enable_force_classic_linking="no")
+
 AC_ARG_ENABLE(ipv6,
               [  --enable-ipv6           Enable support for IPv6.],,enable_ipv6="auto")
 
@@ -661,6 +664,12 @@ case "$ostype" in
 	Darwin)
 		MODULE_LDFLAGS="-avoid-version -dylib"
 		LDFLAGS="$LDFLAGS -Wl,-flat_namespace"
+                # NOTE: This is now seems to be an Apple/Xcode "only" issue, but probably much better a clang one, so later we might want to add this globally
+                # XCode15 new linker has some issues (e.g. https://developer.apple.com/forums/thread/737707)
+                # switch back to classic linking till not fixed (https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes#Linking)
+                if test "x$enable_force_classic_linking" = "xyes"; then
+                        LDFLAGS="$LDFLAGS -Wl,-ld_classic"
+                fi
 		CFLAGS="$CFLAGS -D__APPLE_USE_RFC_3542"
     ;;
 	OSF1)
@@ -2309,6 +2318,9 @@ fi
 echo "  linker flags                : $LDFLAGS $LIBS"
 echo "  prefix                      : $prefix"
 echo "  linking mode                : $linking_mode"
+if test $ostype = "Darwin"; then
+echo "  classic linking mode        : ${enable_force_classic_linking:=no}"
+fi
 echo "  embedded crypto             : ${with_embedded_crypto:=no}"
 echo "  __thread keyword            : ${ac_cv_have_tls:=no}"
 echo " Test dependencies:"


### PR DESCRIPTION
autotools, cmake: macOS XCode15 new linker has some issues, added options (--enable-force-classic-linking, FORCE_CLASSIC_LINKING) to switch back to classic linking till  those are not fixed

Signed-off-by: Hofi [hofione@gmail.com](mailto:hofione@gmail.com)