### PR TITLE
.gitmodules: instead of a PR use a syslog-ng specific tip branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
 	path = lib/ivykis
 	url = https://github.com/bazsi/ivykis.git
 	ignore = dirty
-	branch = iv-work-pool-support-for-slave-work-items
+	branch = tip/syslog-ng
 [submodule "modules/grpc/otel/opentelemetry-proto"]
 	path = modules/grpc/protos/opentelemetry-proto
 	url = https://github.com/open-telemetry/opentelemetry-proto.git


### PR DESCRIPTION
Instead of merging all syslog-ng originated patches from a PR, create a tip branch that incorporates them all.

The ivykis commit id itself is not changed with this patch, it remains the same.

This would be pretty important to be merged as new git clones would checkout the wrong branch without this.

I've cleaned up the original PR so that can be merged to ivykis master.
