### PR TITLE
Minor warning fixes

### DIFF
--- a/lib/secret-storage/tests/test_secret_storage.c
+++ b/lib/secret-storage/tests/test_secret_storage.c
@@ -265,16 +265,15 @@ Test(secretstorage, test_rlimit)
   cr_assert(!setrlimit(RLIMIT_MEMLOCK, &locked_limit));
   const gsize pagesize = sysconf(_SC_PAGE_SIZE);
 
-  gchar *key_fmt = g_strdup("keyXXX");
+  gchar key_fmt[32];
   int i = 0;
   int for_limit = locked_limit.rlim_cur/pagesize;
   for (; i < for_limit; i++)
     {
-      sprintf(key_fmt, "key%03d", i);
+      g_snprintf(key_fmt, sizeof(key_fmt), "key%03d", i);
       cr_assert(secret_storage_store_string(key_fmt, "value"), "offending_key: %s, for_limit: %d", key_fmt, for_limit);
     }
 
-  g_free(key_fmt);
 }
 
 static void

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -445,11 +445,12 @@ afprogram_dd_open_program(AFProgramDestDriver *self, int *fd)
 static gboolean
 afprogram_dd_reopen(AFProgramDestDriver *self)
 {
-  int fd;
+  int fd = -1;
 
   afprogram_dd_kill_child(self);
 
-  if (!afprogram_dd_open_program(self, &fd))
+  if (!afprogram_dd_open_program(self, &fd) ||
+      fd < 0)
     return FALSE;
 
   log_writer_reopen(self->writer, log_proto_text_client_new(log_transport_pipe_new(fd),

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -47,7 +47,6 @@ static struct
   gboolean initialized;
   NVHandle is_synced;
   NVHandle cisco_seqid;
-  NVHandle raw_message;
 } handles;
 
 static inline gboolean
@@ -1073,7 +1072,6 @@ syslog_format_init(void)
     {
       handles.is_synced = log_msg_get_value_handle(".SDATA.timeQuality.isSynced");
       handles.cisco_seqid = log_msg_get_value_handle(".SDATA.meta.sequenceId");
-      handles.raw_message = log_msg_get_value_handle("RAWMSG");
       handles.initialized = TRUE;
     }
 


### PR DESCRIPTION
This branch fixes a warning that just popped up for me with a new gcc.

It also contains a fix for an older, but so far unfixed warning in afprog.c

And gets rid off some dead code in syslog-format.

No user visible changes, no NEWS file.
