### PR TITLE
grpc: Further Loki and Otel module switches corrections

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1547,25 +1547,9 @@ if ! test "x$enable_grpc" = "xno"; then
 fi
 
 dnl ***************************************************************************
-dnl Cloud Auth
+dnl GRPC - OTEL
 dnl ***************************************************************************
-if ! test "x$enable_cloud_auth" = "xno"; then
-    if test "x$enable_cpp" = "xno"; then
-        if test "x$enable_cloud_auth" = "xyes"; then
-            AC_MSG_ERROR(C++ support is mandatory when the cloud-auth module is enabled.)
-        else
-            enable_cloud_auth=no
-        fi
-    fi
-fi
 
-if ! test "x$enable_cloud_auth" = "xno"; then
-    enable_cloud_auth=yes
-fi
-
-dnl ***************************************************************************
-dnl OTEL
-dnl ***************************************************************************
 if ! test "x$enable_otel" = "xno"; then
     if test "x$enable_cpp" = "xno"; then
         if test "x$enable_otel" = "xyes"; then
@@ -1588,8 +1572,9 @@ if ! test "x$enable_otel" = "xno"; then
 fi
 
 dnl ***************************************************************************
-dnl Loki
+dnl GRPC - Loki
 dnl ***************************************************************************
+
 if ! test "x$enable_loki" = "xno"; then
     if test "x$enable_cpp" = "xno"; then
         if test "x$enable_loki" = "xyes"; then
@@ -1611,6 +1596,33 @@ if ! test "x$enable_loki" = "xno"; then
     enable_loki=yes
 fi
 
+dnl ***************************************************************************
+dnl Final GRPC check based on the state of the GRPC based modules
+dnl ***************************************************************************
+
+if test "x$enable_grpc" = "xyes"; then
+    if test "x$enable_loki" = "xno" && test "x$enable_otel" = "xno"; then
+        AC_MSG_WARN([All GRPC based modules are disabled, disabling GRPC.])
+        enable_grpc=no
+    fi
+fi
+
+dnl ***************************************************************************
+dnl Cloud Auth
+dnl ***************************************************************************
+if ! test "x$enable_cloud_auth" = "xno"; then
+    if test "x$enable_cpp" = "xno"; then
+        if test "x$enable_cloud_auth" = "xyes"; then
+            AC_MSG_ERROR(C++ support is mandatory when the cloud-auth module is enabled.)
+        else
+            enable_cloud_auth=no
+        fi
+    fi
+fi
+
+if ! test "x$enable_cloud_auth" = "xno"; then
+    enable_cloud_auth=yes
+fi
 
 dnl ***************************************************************************
 dnl libcurl headers/libraries
@@ -2254,9 +2266,11 @@ AM_CONDITIONAL(ENABLE_SMTP, [test "$enable_smtp" = "yes"])
 AM_CONDITIONAL(ENABLE_MQTT, [test "$enable_mqtt" = "yes"])
 AM_CONDITIONAL(ENABLE_CPP, [test "$enable_cpp" = "yes"])
 AM_CONDITIONAL(ENABLE_GRPC, [test "$enable_grpc" = "yes"])
-AM_CONDITIONAL(ENABLE_CLOUD_AUTH, [test "$enable_cloud_auth" = "yes"])
 AM_CONDITIONAL(ENABLE_OTEL, [test "$enable_otel" = "yes"])
+AM_CONDITIONAL(BUILD_OTEL, [test "$enable_grpc" = "yes"] && [test "$enable_otel" = "yes"])
 AM_CONDITIONAL(ENABLE_LOKI, [test "$enable_loki" = "yes"])
+AM_CONDITIONAL(BUILD_LOKI, [test "$enable_grpc" = "yes"] && [test "$enable_loki" = "yes"])
+AM_CONDITIONAL(ENABLE_CLOUD_AUTH, [test "$enable_cloud_auth" = "yes"])
 AM_CONDITIONAL(ENABLE_HTTP, [test "$enable_http" = "yes"])
 AM_CONDITIONAL(ENABLE_AMQP, [test "$enable_amqp" = "yes"])
 AM_CONDITIONAL(ENABLE_STOMP, [test "$enable_stomp" = "yes"])
@@ -2421,9 +2435,9 @@ echo "  AMQP destination (module)   : ${enable_amqp:=no}"
 echo "  STOMP destination (module)  : ${enable_stomp:=no}"
 echo "  MQTT (module)               : ${enable_mqtt:=no}"
 echo "  GRPC (module)               : ${enable_grpc:=no}"
-echo "  Cloud Auth (module)         : ${enable_cloud_auth:=no}"
 echo "  OTEL (module)               : ${enable_otel:=no}"
 echo "  Loki (module)               : ${enable_loki:=no}"
+echo "  Cloud Auth (module)         : ${enable_cloud_auth:=no}"
 echo "  GEOIP2 support (module)     : ${enable_geoip2:=no}"
 echo "  Redis support (module)      : ${enable_redis:=no}"
 echo "  Kafka support (module)      : ${enable_kafka:=no}"

--- a/configure.ac
+++ b/configure.ac
@@ -327,6 +327,14 @@ AC_ARG_ENABLE(cloud_auth,
               [  --enable-cloud-auth     Enable cloud authentication methods (GCP) (default: auto)]
               ,,enable_cloud_auth="auto")
 
+AC_ARG_ENABLE(otel,
+              [  --enable-otel           Enable OTEL support (OpenTelemetry) (default: auto)]
+              ,,enable_otel="auto")
+
+AC_ARG_ENABLE(loki,
+              [  --enable-loki           Enable LOKI support (default: auto)]
+              ,,enable_loki="auto")
+
 AC_ARG_ENABLE(cpp,
               [  --enable-cpp           Enable C++ support (default: auto)]
               ,,enable_cpp="auto")
@@ -1556,6 +1564,55 @@ if ! test "x$enable_cloud_auth" = "xno"; then
 fi
 
 dnl ***************************************************************************
+dnl OTEL
+dnl ***************************************************************************
+if ! test "x$enable_otel" = "xno"; then
+    if test "x$enable_cpp" = "xno"; then
+        if test "x$enable_otel" = "xyes"; then
+            AC_MSG_ERROR(C++ support is mandatory when the otel module is enabled.)
+        else
+            enable_otel=no
+        fi
+    fi
+    if test "x$enable_grpc" = "xno"; then
+        if test "x$enable_otel" = "xyes"; then
+            AC_MSG_ERROR(GRPC support is mandatory when the otel module is enabled.)
+        else
+            enable_otel=no
+        fi
+    fi
+fi
+
+if ! test "x$enable_otel" = "xno"; then
+    enable_otel=yes
+fi
+
+dnl ***************************************************************************
+dnl Loki
+dnl ***************************************************************************
+if ! test "x$enable_loki" = "xno"; then
+    if test "x$enable_cpp" = "xno"; then
+        if test "x$enable_loki" = "xyes"; then
+            AC_MSG_ERROR(C++ support is mandatory when the loki module is enabled.)
+        else
+            enable_loki=no
+        fi
+    fi
+    if test "x$enable_grpc" = "xno"; then
+        if test "x$enable_loki" = "xyes"; then
+            AC_MSG_ERROR(GRPC support is mandatory when the loki module is enabled.)
+        else
+            enable_loki=no
+        fi
+    fi
+fi
+
+if ! test "x$enable_loki" = "xno"; then
+    enable_loki=yes
+fi
+
+
+dnl ***************************************************************************
 dnl libcurl headers/libraries
 dnl ***************************************************************************
 if test "x$enable_http" != "xno" && test "x$with_libcurl" != "xno"; then
@@ -2198,6 +2255,8 @@ AM_CONDITIONAL(ENABLE_MQTT, [test "$enable_mqtt" = "yes"])
 AM_CONDITIONAL(ENABLE_CPP, [test "$enable_cpp" = "yes"])
 AM_CONDITIONAL(ENABLE_GRPC, [test "$enable_grpc" = "yes"])
 AM_CONDITIONAL(ENABLE_CLOUD_AUTH, [test "$enable_cloud_auth" = "yes"])
+AM_CONDITIONAL(ENABLE_OTEL, [test "$enable_otel" = "yes"])
+AM_CONDITIONAL(ENABLE_LOKI, [test "$enable_loki" = "yes"])
 AM_CONDITIONAL(ENABLE_HTTP, [test "$enable_http" = "yes"])
 AM_CONDITIONAL(ENABLE_AMQP, [test "$enable_amqp" = "yes"])
 AM_CONDITIONAL(ENABLE_STOMP, [test "$enable_stomp" = "yes"])
@@ -2363,6 +2422,8 @@ echo "  STOMP destination (module)  : ${enable_stomp:=no}"
 echo "  MQTT (module)               : ${enable_mqtt:=no}"
 echo "  GRPC (module)               : ${enable_grpc:=no}"
 echo "  Cloud Auth (module)         : ${enable_cloud_auth:=no}"
+echo "  OTEL (module)               : ${enable_otel:=no}"
+echo "  Loki (module)               : ${enable_loki:=no}"
 echo "  GEOIP2 support (module)     : ${enable_geoip2:=no}"
 echo "  Redis support (module)      : ${enable_redis:=no}"
 echo "  Kafka support (module)      : ${enable_kafka:=no}"

--- a/modules/Makefile.am
+++ b/modules/Makefile.am
@@ -70,7 +70,7 @@ SYSLOG_NG_MODULES	=	\
 	mod-map-value-pairs mod-tags-parser mod-xml \
 	mod-appmodel mod-openbsd mod-snmp mod-secure-logging \
 	mod-mqtt mod-regexp-parser mod-rate-limit-filter mod-metrics-probe \
-	mod-grpc mod-cloud-auth
+	mod-grpc mod-otel mod-loki mod-cloud-auth
 
 modules modules/: ${SYSLOG_NG_MODULES}
 

--- a/modules/grpc/Makefile.am
+++ b/modules/grpc/Makefile.am
@@ -7,9 +7,9 @@ include modules/grpc/loki/Makefile.am
 
 if ENABLE_GRPC
 modules/grpc modules/grpc/ mod-grpc: mod-otel mod-loki
+else
+modules/grpc modules/grpc/ mod-grpc:
 endif
-
-.PHONY: modules/grpc/otel/ mod-otel modules/grpc/loki/ mod-loki
 
 EXTRA_DIST += \
   modules/grpc/CMakeLists.txt

--- a/modules/grpc/loki/CMakeLists.txt
+++ b/modules/grpc/loki/CMakeLists.txt
@@ -9,14 +9,15 @@ if(NOT ENABLE_LOKI OR NOT ENABLE_GRPC)
 endif()
 
 set(LOKI_SOURCES
-    loki-parser.h
-    loki-plugin.c
-    loki-parser.c
+  loki-parser.h
+  loki-plugin.c
+  loki-parser.c
 )
 
 add_module(
   TARGET loki
   GRAMMAR loki-grammar
+  DEPENDS ${MODULE_GRPC_LIBS} grpc-protos
   INCLUDES ${PROJECT_SOURCE_DIR}/modules/grpc
   SOURCES ${LOKI_SOURCES}
 )

--- a/modules/grpc/loki/Makefile.am
+++ b/modules/grpc/loki/Makefile.am
@@ -1,4 +1,5 @@
 if ENABLE_GRPC
+if ENABLE_LOKI
 
 noinst_LTLIBRARIES += modules/grpc/loki/libloki_cpp.la
 
@@ -52,6 +53,9 @@ modules_grpc_loki_libloki_la_DEPENDENCIES = \
 
 modules/grpc/loki modules/grpc/loki/ mod-loki: modules/grpc/loki/libloki.la
 
+else
+modules/grpc/loki modules/grpc/loki/ mod-loki:
+endif
 else
 modules/grpc/loki modules/grpc/loki/ mod-loki:
 endif

--- a/modules/grpc/loki/Makefile.am
+++ b/modules/grpc/loki/Makefile.am
@@ -1,5 +1,4 @@
-if ENABLE_GRPC
-if ENABLE_LOKI
+if BUILD_LOKI # means ENABLE_GRPC && ENABLE_LOKI
 
 noinst_LTLIBRARIES += modules/grpc/loki/libloki_cpp.la
 
@@ -51,22 +50,23 @@ modules_grpc_loki_libloki_la_DEPENDENCIES = \
   $(top_builddir)/modules/grpc/protos/libgrpc-protos.la \
   $(top_builddir)/modules/grpc/loki/libloki_cpp.la
 
-modules/grpc/loki modules/grpc/loki/ mod-loki: modules/grpc/loki/libloki.la
-
-else
-modules/grpc/loki modules/grpc/loki/ mod-loki:
-endif
-else
-modules/grpc/loki modules/grpc/loki/ mod-loki:
-endif
-
 BUILT_SOURCES += \
   modules/grpc/loki/loki-grammar.y \
   modules/grpc/loki/loki-grammar.c \
   modules/grpc/loki/loki-grammar.h
 
 EXTRA_DIST += \
-  modules/grpc/loki/loki-grammar.ym \
+  modules/grpc/loki/loki-grammar.ym
+
+modules/grpc/loki modules/grpc/loki/ mod-loki: modules/grpc/loki/libloki.la
+
+else
+
+modules/grpc/loki modules/grpc/loki/ mod-loki:
+
+endif
+
+EXTRA_DIST += \
   modules/grpc/loki/CMakeLists.txt
 
 .PHONY: modules/grpc/loki/ mod-loki

--- a/modules/grpc/otel/Makefile.am
+++ b/modules/grpc/otel/Makefile.am
@@ -1,4 +1,5 @@
 if ENABLE_GRPC
+if ENABLE_OTEL
 
 noinst_LTLIBRARIES += modules/grpc/otel/libotel_cpp.la
 
@@ -66,6 +67,9 @@ modules_grpc_otel_libotel_la_DEPENDENCIES = \
   $(top_builddir)/modules/grpc/otel/libotel_cpp.la
 
 modules/grpc/otel modules/grpc/otel/ mod-otel: modules/grpc/otel/libotel.la
+else
+modules/grpc/otel modules/grpc/otel/ mod-otel:
+endif
 else
 modules/grpc/otel modules/grpc/otel/ mod-otel:
 endif

--- a/modules/grpc/otel/Makefile.am
+++ b/modules/grpc/otel/Makefile.am
@@ -1,5 +1,4 @@
-if ENABLE_GRPC
-if ENABLE_OTEL
+if BUILD_OTEL # means ENABLE_GRPC && ENABLE_OTEL
 
 noinst_LTLIBRARIES += modules/grpc/otel/libotel_cpp.la
 
@@ -66,21 +65,23 @@ modules_grpc_otel_libotel_la_DEPENDENCIES = \
   $(top_builddir)/modules/grpc/protos/libgrpc-protos.la \
   $(top_builddir)/modules/grpc/otel/libotel_cpp.la
 
-modules/grpc/otel modules/grpc/otel/ mod-otel: modules/grpc/otel/libotel.la
-else
-modules/grpc/otel modules/grpc/otel/ mod-otel:
-endif
-else
-modules/grpc/otel modules/grpc/otel/ mod-otel:
-endif
-
 BUILT_SOURCES += \
   modules/grpc/otel/otel-grammar.y \
   modules/grpc/otel/otel-grammar.c \
   modules/grpc/otel/otel-grammar.h
 
 EXTRA_DIST += \
-  modules/grpc/otel/otel-grammar.ym \
+  modules/grpc/otel/otel-grammar.ym
+
+modules/grpc/otel modules/grpc/otel/ mod-otel: modules/grpc/otel/libotel.la
+
+else
+
+modules/grpc/otel modules/grpc/otel/ mod-otel:
+
+endif
+
+EXTRA_DIST += \
   modules/grpc/otel/CMakeLists.txt
 
 .PHONY: modules/grpc/otel/ mod-otel

--- a/modules/grpc/otel/tests/Makefile.am
+++ b/modules/grpc/otel/tests/Makefile.am
@@ -1,4 +1,4 @@
-if ENABLE_GRPC
+if BUILD_OTEL # means ENABLE_GRPC && ENABLE_OTEL
 
 modules_grpc_otel_tests_TESTS = \
   modules/grpc/otel/tests/test_otel_protobuf_parser \

--- a/modules/grpc/protos/CMakeLists.txt
+++ b/modules/grpc/protos/CMakeLists.txt
@@ -2,33 +2,46 @@ set(OTEL_PROTO_SRCDIR "${CMAKE_CURRENT_SOURCE_DIR}/opentelemetry-proto")
 set(OTEL_PROTO_BUILDDIR "${CMAKE_CURRENT_BINARY_DIR}/opentelemetry-proto")
 set(OTEL_PROTO_BUILDDIR ${OTEL_PROTO_BUILDDIR} PARENT_SCOPE)
 
-set(GRPC_PROTO_SOURCES
+set(LOKI_PROTO_SRCDIR "${CMAKE_CURRENT_SOURCE_DIR}/grafana-loki")
+set(LOKI_PROTO_BUILDDIR "${CMAKE_CURRENT_BINARY_DIR}/grafana-loki")
+set(LOKI_PROTO_BUILDDIR ${LOKI_PROTO_BUILDDIR} PARENT_SCOPE)
+
+set(OTEL_PROTO_SOURCES
   opentelemetry/proto/common/v1/common.proto
   opentelemetry/proto/logs/v1/logs.proto
   opentelemetry/proto/metrics/v1/metrics.proto
   opentelemetry/proto/trace/v1/trace.proto
   opentelemetry/proto/resource/v1/resource.proto)
 
-set(GRPC_PROTO_GRPC_SOURCES
+set(OTEL_PROTO_GRPC_SOURCES
   opentelemetry/proto/collector/logs/v1/logs_service.proto
   opentelemetry/proto/collector/metrics/v1/metrics_service.proto
   opentelemetry/proto/collector/trace/v1/trace_service.proto)
 
+set(LOKI_PROTO_GRPC_SOURCES
+  push.proto)
+
 protobuf_generate_cpp(
   PROTO_PATH ${OTEL_PROTO_SRCDIR}
   CPP_OUT ${OTEL_PROTO_BUILDDIR}
-  OUT_SRCS GRPC_PROTO_GENERATED_SOURCES
-  PROTOS ${GRPC_PROTO_SOURCES})
+  OUT_SRCS OTEL_PROTO_GENERATED_SOURCES
+  PROTOS ${OTEL_PROTO_SOURCES})
 
 protobuf_generate_cpp_grpc(
   PROTO_PATH ${OTEL_PROTO_SRCDIR}
   CPP_OUT ${OTEL_PROTO_BUILDDIR}
-  OUT_SRCS GRPC_PROTO_GENERATED_GRPC_SOURCES
-  PROTOS ${GRPC_PROTO_GRPC_SOURCES})
+  OUT_SRCS OTEL_PROTO_GENERATED_GRPC_SOURCES
+  PROTOS ${OTEL_PROTO_GRPC_SOURCES})
+
+protobuf_generate_cpp_grpc(
+  PROTO_PATH ${LOKI_PROTO_SRCDIR}
+  CPP_OUT ${LOKI_PROTO_BUILDDIR}
+  OUT_SRCS LOKI_PROTO_GENERATED_GRPC_SOURCES
+  PROTOS ${LOKI_PROTO_GRPC_SOURCES})
 
 add_module(
   TARGET grpc-protos
-  SOURCES ${GRPC_PROTO_GENERATED_SOURCES} ${GRPC_PROTO_GENERATED_GRPC_SOURCES}
+  SOURCES ${OTEL_PROTO_GENERATED_SOURCES} ${OTEL_PROTO_GENERATED_GRPC_SOURCES} ${LOKI_PROTO_GENERATED_GRPC_SOURCES}
   DEPENDS ${MODULE_GRPC_LIBS}
-  INCLUDES ${OTEL_PROTO_BUILDDIR}
+  INCLUDES ${OTEL_PROTO_BUILDDIR} ${LOKI_PROTO_BUILDDIR}
 )

--- a/modules/grpc/protos/Makefile.am
+++ b/modules/grpc/protos/Makefile.am
@@ -9,14 +9,17 @@ GRPC_PROTOS_BUILDDIR = $(top_builddir)/modules/grpc/protos
 
 OPENTELEMETRY_PROTO_SRCDIR = $(GRPC_PROTOS_SRCDIR)/opentelemetry-proto
 OPENTELEMETRY_PROTO_BUILDDIR = $(GRPC_PROTOS_BUILDDIR)/otlp
+OPENTELEMETRY_PROTO_PROTOC_FLAGS = $(PROTOC_GEN_GRPC_CPP_PLUGIN_FLAGS) --proto_path=$(OPENTELEMETRY_PROTO_SRCDIR) --cpp_out=$(OPENTELEMETRY_PROTO_BUILDDIR)
 
 LOKI_PROTO_SRCDIR = $(GRPC_PROTOS_SRCDIR)/grafana-loki
 LOKI_PROTO_BUILDDIR = $(GRPC_PROTOS_BUILDDIR)/loki
+LOKI_PROTO_PROTOC_FLAGS = $(PROTOC_GEN_GRPC_CPP_PLUGIN_FLAGS) --proto_path=$(LOKI_PROTO_SRCDIR) --cpp_out=$(LOKI_PROTO_BUILDDIR)
 
 if ENABLE_GRPC
 
-OPENTELEMETRY_PROTO_PROTOC_FLAGS = $(PROTOC_GEN_GRPC_CPP_PLUGIN_FLAGS) --proto_path=$(OPENTELEMETRY_PROTO_SRCDIR) --cpp_out=$(OPENTELEMETRY_PROTO_BUILDDIR)
-LOKI_PROTO_PROTOC_FLAGS = $(PROTOC_GEN_GRPC_CPP_PLUGIN_FLAGS) --proto_path=$(LOKI_PROTO_SRCDIR) --cpp_out=$(LOKI_PROTO_BUILDDIR)
+GRPC_PROTOS_BUILT_SOURCES =
+
+if BUILD_OTEL # means ENABLE_GRPC && ENABLE_OTEL
 
 modules/grpc/protos/otlp/%.grpc.pb.cc modules/grpc/protos/otlp/%.grpc.pb.h:
 	mkdir -p $(OPENTELEMETRY_PROTO_BUILDDIR)
@@ -26,15 +29,7 @@ modules/grpc/protos/otlp/%.pb.cc modules/grpc/protos/otlp/%.pb.h:
 	mkdir -p $(OPENTELEMETRY_PROTO_BUILDDIR)
 	$(PROTOC) $(OPENTELEMETRY_PROTO_PROTOC_FLAGS) $*.proto
 
-modules/grpc/protos/loki/%.grpc.pb.cc modules/grpc/protos/loki/%.grpc.pb.h:
-	mkdir -p $(LOKI_PROTO_BUILDDIR)
-	$(PROTOC) $(LOKI_PROTO_PROTOC_FLAGS) --grpc-cpp_out=$(LOKI_PROTO_BUILDDIR) $*.proto
-
-modules/grpc/protos/loki/%.pb.cc modules/grpc/protos/loki/%.pb.h:
-	mkdir -p $(LOKI_PROTO_BUILDDIR)
-	$(PROTOC) $(LOKI_PROTO_PROTOC_FLAGS) $*.proto
-
-GRPC_PROTOS_BUILT_SOURCES = \
+GRPC_PROTOS_BUILT_SOURCES += \
   $(OPENTELEMETRY_PROTO_BUILDDIR)/opentelemetry/proto/collector/logs/v1/logs_service.grpc.pb.cc \
   $(OPENTELEMETRY_PROTO_BUILDDIR)/opentelemetry/proto/collector/logs/v1/logs_service.grpc.pb.h \
   $(OPENTELEMETRY_PROTO_BUILDDIR)/opentelemetry/proto/collector/logs/v1/logs_service.pb.cc \
@@ -56,12 +51,27 @@ GRPC_PROTOS_BUILT_SOURCES = \
   $(OPENTELEMETRY_PROTO_BUILDDIR)/opentelemetry/proto/resource/v1/resource.pb.cc \
   $(OPENTELEMETRY_PROTO_BUILDDIR)/opentelemetry/proto/resource/v1/resource.pb.h \
   $(OPENTELEMETRY_PROTO_BUILDDIR)/opentelemetry/proto/trace/v1/trace.pb.cc \
-  $(OPENTELEMETRY_PROTO_BUILDDIR)/opentelemetry/proto/trace/v1/trace.pb.h \
-  \
+  $(OPENTELEMETRY_PROTO_BUILDDIR)/opentelemetry/proto/trace/v1/trace.pb.h
+
+endif # if BUILD_OTEL
+
+if BUILD_LOKI # means ENABLE_GRPC && ENABLE_LOKI
+
+modules/grpc/protos/loki/%.grpc.pb.cc modules/grpc/protos/loki/%.grpc.pb.h:
+	mkdir -p $(LOKI_PROTO_BUILDDIR)
+	$(PROTOC) $(LOKI_PROTO_PROTOC_FLAGS) --grpc-cpp_out=$(LOKI_PROTO_BUILDDIR) $*.proto
+
+modules/grpc/protos/loki/%.pb.cc modules/grpc/protos/loki/%.pb.h:
+	mkdir -p $(LOKI_PROTO_BUILDDIR)
+	$(PROTOC) $(LOKI_PROTO_PROTOC_FLAGS) $*.proto
+
+GRPC_PROTOS_BUILT_SOURCES += \
   $(LOKI_PROTO_BUILDDIR)/push.grpc.pb.cc \
   $(LOKI_PROTO_BUILDDIR)/push.grpc.pb.h \
   $(LOKI_PROTO_BUILDDIR)/push.pb.cc \
   $(LOKI_PROTO_BUILDDIR)/push.pb.h
+
+endif # if BUILD_LOKI
 
 lib_LTLIBRARIES += modules/grpc/protos/libgrpc-protos.la
 
@@ -92,7 +102,7 @@ BUILT_SOURCES += \
 NODIST_BUILT_SOURCES += \
   $(GRPC_PROTOS_BUILT_SOURCES)
 
-endif
+endif # if ENABLE_GRPC
 
 EXTRA_DIST += \
   $(OPENTELEMETRY_PROTO_SRCDIR) \


### PR DESCRIPTION
- added the missing autotools counterpart of the earlier addition of the cmake otel and loki switches  
#4649
- added the missing cmake grpc-protos lib dependency to loki module
- added missing loki protobuf generation to the cmake builds

Signed-off-by: Hofi <hofione@gmail.com>
