### PR TITLE
Csv parser columnless

### DIFF
--- a/lib/scanner/csv-scanner/csv-scanner.c
+++ b/lib/scanner/csv-scanner/csv-scanner.c
@@ -25,6 +25,7 @@
 #include "str-utils.h"
 #include "string-list.h"
 #include "scratch-buffers.h"
+#include "messages.h"
 
 #include <string.h>
 
@@ -130,6 +131,12 @@ csv_scanner_options_clean(CSVScannerOptions *options)
   g_free(options->delimiters);
   string_list_free(options->string_delimiters);
   string_list_free(options->columns);
+}
+
+gboolean
+csv_scanner_options_validate(CSVScannerOptions *options)
+{
+  return TRUE;
 }
 
 /************************************************************************

--- a/lib/scanner/csv-scanner/csv-scanner.h
+++ b/lib/scanner/csv-scanner/csv-scanner.h
@@ -53,6 +53,7 @@ typedef struct _CSVScannerOptions
 
 void csv_scanner_options_clean(CSVScannerOptions *options);
 void csv_scanner_options_copy(CSVScannerOptions *dst, CSVScannerOptions *src);
+gboolean csv_scanner_options_validate(CSVScannerOptions *options);
 
 void csv_scanner_options_set_dialect(CSVScannerOptions *options, CSVScannerDialect dialect);
 void csv_scanner_options_set_flags(CSVScannerOptions *options, guint32 flags);

--- a/lib/scanner/csv-scanner/csv-scanner.h
+++ b/lib/scanner/csv-scanner/csv-scanner.h
@@ -81,6 +81,7 @@ typedef struct
   const gchar *src;
   GString *current_value;
   gchar current_quote;
+  gboolean columnless;
 } CSVScanner;
 
 const gchar *csv_scanner_get_current_name(CSVScanner *pstate);

--- a/lib/scanner/csv-scanner/tests/test_csv_scanner.c
+++ b/lib/scanner/csv-scanner/tests/test_csv_scanner.c
@@ -415,6 +415,34 @@ Test(csv_scanner, escape_backslash_invalid_x_sequence)
   csv_scanner_deinit(&scanner);
 }
 
+Test(csv_scanner, columnless_no_flags)
+{
+  const gchar *columns[] = { NULL };
+
+  csv_scanner_init(&scanner, _default_options(columns), "val1,val2,val3");
+
+  cr_expect(_column_name_unset());
+  cr_expect(!_scan_complete());
+
+  cr_expect(_scan_next());
+  cr_expect(strcmp(csv_scanner_get_current_value(&scanner), "val1")==0);
+  cr_expect(!_scan_complete());
+
+  cr_expect(_scan_next());
+  cr_expect(strcmp(csv_scanner_get_current_value(&scanner), "val2")==0);
+  cr_expect(!_scan_complete());
+
+  cr_expect(_scan_next());
+  cr_expect(strcmp(csv_scanner_get_current_value(&scanner), "val3")==0);
+  cr_expect(!_scan_complete());
+
+  /* go past the last column */
+  cr_expect(!_scan_next());
+  cr_expect(_scan_complete());
+  cr_expect(_column_name_unset());
+  csv_scanner_deinit(&scanner);
+}
+
 static void
 setup(void)
 {

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -198,6 +198,17 @@ csv_parser_free(LogPipe *s)
   log_parser_free_method(s);
 }
 
+static gboolean
+csv_parser_init(LogPipe *s)
+{
+  CSVParser *self = (CSVParser *) s;
+
+  if (!csv_scanner_options_validate(&self->options))
+    return FALSE;
+
+  return log_parser_init_method(s);
+}
+
 /*
  * Parse comma-separated values from a log message.
  */
@@ -207,6 +218,7 @@ csv_parser_new(GlobalConfig *cfg)
   CSVParser *self = g_new0(CSVParser, 1);
 
   log_parser_init_instance(&self->super, cfg);
+  self->super.super.init = csv_parser_init;
   self->super.super.free_fn = csv_parser_free;
   self->super.super.clone = csv_parser_clone;
   self->super.process = csv_parser_process;

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -151,13 +151,29 @@ csv_parser_process(LogParser *s, LogMessage **pmsg, const LogPathOptions *path_o
     g_string_assign(key_scratch, self->prefix);
 
   key_formatter_t _key_formatter = dispatch_key_formatter(self->prefix);
+  gint match_index = 1;
+
   while (csv_scanner_scan_next(&scanner))
     {
+      const gchar *current_name = csv_scanner_get_current_name(&scanner);
 
-      log_msg_set_value_by_name(msg,
-                                _key_formatter(key_scratch, csv_scanner_get_current_name(&scanner), self->prefix_len),
-                                csv_scanner_get_current_value(&scanner),
-                                csv_scanner_get_current_value_len(&scanner));
+      if (current_name)
+        {
+          log_msg_set_value_by_name(msg,
+                                    _key_formatter(key_scratch, csv_scanner_get_current_name(&scanner), self->prefix_len),
+                                    csv_scanner_get_current_value(&scanner),
+                                    csv_scanner_get_current_value_len(&scanner));
+        }
+      else
+        {
+          if (match_index == 1)
+            log_msg_unset_match(msg, 0);
+          log_msg_set_match_with_type(msg,
+                                      match_index, csv_scanner_get_current_value(&scanner),
+                                      csv_scanner_get_current_value_len(&scanner),
+                                      LM_VT_STRING);
+        }
+      match_index++;
     }
 
   gboolean result = TRUE;

--- a/modules/csvparser/csvparser.h
+++ b/modules/csvparser/csvparser.h
@@ -31,6 +31,7 @@ CSVScannerOptions *csv_parser_get_scanner_options(LogParser *s);
 gboolean csv_parser_set_flags(LogParser *s, guint32 flags);
 void csv_parser_set_drop_invalid(LogParser *s, gboolean drop_invalid);
 void csv_parser_set_prefix(LogParser *s, const gchar *prefix);
+void csv_parser_set_list_name(LogParser *s, const gchar *list_name);
 LogParser *csv_parser_new(GlobalConfig *cfg);
 
 guint32 csv_parser_lookup_flag(const gchar *flag);

--- a/modules/csvparser/tests/Makefile.am
+++ b/modules/csvparser/tests/Makefile.am
@@ -1,12 +1,15 @@
 modules_csvparser_tests_TESTS			=	\
 	modules/csvparser/tests/test_csvparser		\
 	modules/csvparser/tests/test_csvparser_from_config \
-	modules/csvparser/tests/test_csvparser_perf
+	modules/csvparser/tests/test_csvparser_perf 
 
 check_PROGRAMS					+=	\
-	${modules_csvparser_tests_TESTS}
+	${modules_csvparser_tests_TESTS} 
 
-EXTRA_DIST += modules/csvparser/tests/CMakeLists.txt
+EXTRA_DIST += modules/csvparser/tests/CMakeLists.txt \
+	modules/basicfuncs/list-funcs.c			\
+	modules/basicfuncs/tf-template.c		\
+	modules/basicfuncs/tests/CMakeLists.txt 
 
 modules_csvparser_tests_test_csvparser_CFLAGS	=	\
 	$(TEST_CFLAGS) -I$(top_srcdir)/modules/csvparser
@@ -18,7 +21,8 @@ modules_csvparser_tests_test_csvparser_from_config_CFLAGS	=	\
 	$(TEST_CFLAGS) -I$(top_srcdir)/modules/csvparser
 modules_csvparser_tests_test_csvparser_from_config_LDADD	=	\
 	$(TEST_LDADD)					\
-	-dlpreopen $(top_builddir)/modules/csvparser/libcsvparser.la
+	$(PREOPEN_SYSLOGFORMAT) $(PREOPEN_BASICFUNCS) \
+	-dlpreopen $(top_builddir)/modules/csvparser/libcsvparser.la 
 
 modules_csvparser_tests_test_csvparser_perf_CFLAGS	=	\
 	$(TEST_CFLAGS) -I$(top_srcdir)/modules/csvparser

--- a/modules/csvparser/tests/test_csvparser.c
+++ b/modules/csvparser/tests/test_csvparser.c
@@ -103,6 +103,7 @@ ParameterizedTestParameters(parser, test_csv_parser)
     // string delim & multi char & a char is in the string
     {
       .msg = "PTHREAD support :initialized",
+      .max_columns = -1,
       .drop_invalid = FALSE,
       .dialect = CSV_SCANNER_ESCAPE_NONE,
       .flags = 0,

--- a/modules/csvparser/tests/test_csvparser_from_config.c
+++ b/modules/csvparser/tests/test_csvparser_from_config.c
@@ -94,6 +94,17 @@ Test(parser, condition_success)
   assert_log_message_value_by_name(msg, "c", "baz");
 }
 
+Test(parser, test_index_macros)
+{
+  LogParser *test_parser = create_parser_rule("csv-parser();");
+
+  invoke_parser_rule(test_parser, msg);
+  assert_log_message_value_by_name(msg, "1", "foo");
+  assert_log_message_value_by_name(msg, "2", "bar");
+  assert_log_message_value_by_name(msg, "3", "baz");
+  assert_template_format_msg("$*", "foo,bar,baz", msg);
+}
+
 void
 setup(void)
 {

--- a/news/feature-4678.md
+++ b/news/feature-4678.md
@@ -1,0 +1,3 @@
+`csv-parser()`: allow parsing the extracted values into matches ($1, $2, $3 ...)
+by omitting the columns() parameter, which normally specifies the column
+names.


### PR DESCRIPTION
This is a slightly reworked version of #4160  which allows csv-parser() to parse into the anonymous list $*

With this config:

            @version: current
    
            log {
                    source { tcp(port(2000) flags(no-parse)); };
    
                    parser { csv-parser(delimiters(',')  dialect(escape-backslash)); };
                    destination { stdout(template("$ISODATE $*\n")); };
            };
