### PR TITLE
Csv parser typing

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -392,6 +392,7 @@
 %type   <ptr> template_content_list
 %type   <ptr> template_name_or_content
 %type   <ptr> template_name_or_content_tail
+%type   <num> type_hint
 
 %type   <ptr> filter_content
 
@@ -893,15 +894,14 @@ template_content_inner
           CHECK_ERROR_GERROR(log_template_compile($<ptr>0, $1, &error), @1, error, "Error compiling template");
           free($1);
         }
-        | LL_IDENTIFIER '(' string_or_number ')'
+        | type_hint '(' string_or_number ')'
         {
           GError *error = NULL;
 
           CHECK_ERROR_GERROR(log_template_compile($<ptr>0, $3, &error), @3, error, "Error compiling template");
           free($3);
 
-          CHECK_ERROR_GERROR(log_template_set_type_hint($<ptr>0, $1, &error), @1, error, "Error setting the template type-hint \"%s\"", $1);
-          free($1);
+          log_template_set_type_hint_value($<ptr>0, $1);
         }
         | LL_NUMBER
         {
@@ -917,6 +917,17 @@ template_content_inner
           log_template_set_type_hint($<ptr>0, "float", NULL);
         }
         ;
+
+type_hint
+        : LL_IDENTIFIER
+          {
+            LogMessageValueType type;
+            GError *error = NULL;
+
+            CHECK_ERROR_GERROR(type_hint_parse($1, &type, &error), @1, error, "Unknown type hint");
+            free($1);
+            $$ = type;
+          };
 
 template_content
         : <ptr>{

--- a/lib/logmsg/type-hinting.c
+++ b/lib/logmsg/type-hinting.c
@@ -221,3 +221,34 @@ type_cast_to_datetime_msec(const gchar *value, gint64 *out, GError **error)
   *out = ut.ut_sec * 1000 + ut.ut_usec / 1000;
   return TRUE;
 }
+
+gboolean
+type_cast_validate(const gchar *value, LogMessageValueType type, GError **error)
+{
+  gboolean b;
+  gint64 i64;
+  gdouble d;
+  UnixTime ut;
+
+  switch (type)
+    {
+    case LM_VT_STRING:
+    case LM_VT_JSON:
+    case LM_VT_NULL:
+    case LM_VT_BYTES:
+    case LM_VT_PROTOBUF:
+    case LM_VT_LIST:
+      return TRUE;
+    case LM_VT_BOOLEAN:
+      return type_cast_to_boolean(value, &b, error);
+    case LM_VT_INTEGER:
+      return type_cast_to_int64(value, &i64, error);
+    case LM_VT_DOUBLE:
+      return type_cast_to_double(value, &d, error);
+    case LM_VT_DATETIME:
+      return type_cast_to_datetime_unixtime(value, &ut, error);
+    default:
+      g_assert_not_reached();
+    }
+  return TRUE;
+}

--- a/lib/logmsg/type-hinting.h
+++ b/lib/logmsg/type-hinting.h
@@ -50,4 +50,6 @@ gboolean type_cast_to_double(const gchar *value, gdouble *out, GError **error);
 gboolean type_cast_to_datetime_msec(const gchar *value, gint64 *out, GError **error);
 gboolean type_cast_to_datetime_unixtime(const gchar *value, UnixTime *ut, GError **error);
 
+gboolean type_cast_validate(const gchar *value, LogMessageValueType type, GError **error);
+
 #endif

--- a/lib/scanner/csv-scanner/csv-scanner.h
+++ b/lib/scanner/csv-scanner/csv-scanner.h
@@ -41,13 +41,13 @@ typedef enum
 
 typedef struct _CSVScannerOptions
 {
-  GList *columns;
   gchar *delimiters;
   gchar *quotes_start;
   gchar *quotes_end;
   gchar *null_value;
   GList *string_delimiters;
   CSVScannerDialect dialect;
+  gint expected_columns;
   guint32 flags;
 } CSVScannerOptions;
 
@@ -57,7 +57,7 @@ gboolean csv_scanner_options_validate(CSVScannerOptions *options);
 
 void csv_scanner_options_set_dialect(CSVScannerOptions *options, CSVScannerDialect dialect);
 void csv_scanner_options_set_flags(CSVScannerOptions *options, guint32 flags);
-void csv_scanner_options_set_columns(CSVScannerOptions *options, GList *columns);
+void csv_scanner_options_set_expected_columns(CSVScannerOptions *options, gint expected_columns);
 void csv_scanner_options_set_delimiters(CSVScannerOptions *options, const gchar *delimiters);
 void csv_scanner_options_set_string_delimiters(CSVScannerOptions *options, GList *string_delimiters);
 void csv_scanner_options_set_quotes_start_and_end(CSVScannerOptions *options, const gchar *quotes_start,
@@ -77,14 +77,13 @@ typedef struct
     CSV_STATE_PARTIAL_INPUT,
     CSV_STATE_FINISH,
   } state;
-  GList *current_column;
   const gchar *src;
+  gint current_column;
   GString *current_value;
   gchar current_quote;
-  gboolean columnless;
 } CSVScanner;
 
-const gchar *csv_scanner_get_current_name(CSVScanner *pstate);
+gint csv_scanner_get_current_column(CSVScanner *self);
 const gchar *csv_scanner_get_current_value(CSVScanner *pstate);
 gint csv_scanner_get_current_value_len(CSVScanner *self);
 gboolean csv_scanner_scan_next(CSVScanner *pstate);

--- a/lib/template/templates.c
+++ b/lib/template/templates.c
@@ -323,6 +323,12 @@ log_template_set_type_hint(LogTemplate *self, const gchar *type_hint, GError **e
   return result;
 }
 
+void
+log_template_set_type_hint_value(LogTemplate *self, LogMessageValueType type_hint)
+{
+  self->explicit_type_hint = self->type_hint = type_hint;
+}
+
 /* NOTE: we should completely get rid off the name property of templates,
  * we basically use it at two locations:
  *

--- a/lib/template/templates.h
+++ b/lib/template/templates.h
@@ -77,6 +77,7 @@ struct _LogTemplate
 
 void log_template_set_escape(LogTemplate *self, gboolean enable);
 gboolean log_template_set_type_hint(LogTemplate *self, const gchar *hint, GError **error);
+void log_template_set_type_hint_value(LogTemplate *self, LogMessageValueType type);
 gboolean log_template_compile(LogTemplate *self, const gchar *template_str, GError **error);
 gboolean log_template_compile_with_type_hint(LogTemplate *self, const gchar *template_and_typehint, GError **error);
 void log_template_forget_template_string(LogTemplate *self);

--- a/modules/add-contextual-data/context-info-db.c
+++ b/modules/add-contextual-data/context-info-db.c
@@ -221,6 +221,8 @@ void
 context_info_db_insert(ContextInfoDB *self,
                        const ContextualDataRecord *record)
 {
+  log_template_forget_template_string(record->value);
+
   g_array_append_val(self->data, *record);
   self->is_data_indexed = FALSE;
   if (self->is_ordering_enabled && !g_list_find_custom(self->ordered_selectors, record->selector, _g_strcmp))

--- a/modules/add-contextual-data/contextual-data-record-scanner.c
+++ b/modules/add-contextual-data/contextual-data-record-scanner.c
@@ -170,7 +170,6 @@ _fetch_value(ContextualDataRecordScanner *self, ContextualDataRecord *record)
       g_clear_error(&error);
       return FALSE;
     }
-  log_template_forget_template_string(record->value);
   return TRUE;
 }
 

--- a/modules/add-contextual-data/contextual-data-record-scanner.c
+++ b/modules/add-contextual-data/contextual-data-record-scanner.c
@@ -43,8 +43,11 @@ _fetch_next(ContextualDataRecordScanner *self)
 {
   if (!csv_scanner_scan_next(&self->scanner))
     {
+      const gchar *columns[] = { "selector", "name", "value", NULL };
+      gint column_index = csv_scanner_get_current_column(&self->scanner);
+      const gchar *column_name = column_index < 3 ? columns[column_index] : "out-of-range";
       msg_error("add-contextual-data(): error parsing CSV file, expecting an additional column which was not found. Expecting (selector, name, value) triplets",
-                evt_tag_str("target", csv_scanner_get_current_name(&self->scanner)));
+                evt_tag_str("target", column_name));
       return FALSE;
     }
 
@@ -235,9 +238,7 @@ contextual_data_record_scanner_new(GlobalConfig *cfg, const gchar *name_prefix)
 
   csv_scanner_options_set_delimiters(&self->options, ",");
   csv_scanner_options_set_quote_pairs(&self->options, "\"\"''");
-  const gchar *column_array[] = { "selector", "name", "value", NULL };
-  csv_scanner_options_set_columns(&self->options,
-                                  string_array_to_list(column_array));
+  csv_scanner_options_set_expected_columns(&self->options, 3);
   csv_scanner_options_set_flags(&self->options, CSV_SCANNER_STRIP_WHITESPACE);
   csv_scanner_options_set_dialect(&self->options, CSV_SCANNER_ESCAPE_DOUBLE_CHAR);
   self->name_prefix = g_strdup(name_prefix);

--- a/modules/csvparser/csvparser-grammar.ym
+++ b/modules/csvparser/csvparser-grammar.ym
@@ -62,6 +62,8 @@
 %token KW_DROP_INVALID
 
 %type	<ptr> parser_expr_csv
+%type   <ptr> parser_csv_columns
+%type   <ptr> parser_csv_column
 %type   <cptr> parser_csv_flag
 %type   <num> parser_csv_flags
 %type   <num> parser_csv_dialect
@@ -99,7 +101,7 @@ parser_csv_opt
         | KW_QUOTES '(' string ')'              { csv_scanner_options_set_quotes(csv_parser_get_scanner_options(last_parser), $3); free($3); }
         | KW_QUOTE_PAIRS '(' string ')'         { csv_scanner_options_set_quote_pairs(csv_parser_get_scanner_options(last_parser), $3); free($3); }
         | KW_NULL '(' string ')'                { csv_scanner_options_set_null_value(csv_parser_get_scanner_options(last_parser), $3); free($3); }
-        | KW_COLUMNS '(' string_list ')'        { csv_scanner_options_set_columns(csv_parser_get_scanner_options(last_parser), $3); }
+        | KW_COLUMNS '(' parser_csv_columns ')'        { csv_parser_set_columns(last_parser, $3); }
         | parser_opt
         ;
 
@@ -141,6 +143,16 @@ parser_csv_dialect
                                                   free($1);
 						  $$ = mode;
                                                 }
+
+parser_csv_columns
+	: parser_csv_column parser_csv_columns		{ $$ = g_list_prepend($2, $1); }
+	|						{ $$ = NULL; }
+	;
+
+parser_csv_column
+	: string					{ $$ = csv_parser_column_new($1, LM_VT_STRING); }
+	| type_hint '(' string ')'			{ $$ = csv_parser_column_new($3, $1); }
+	;
 
 /* INCLUDE_RULES */
 

--- a/modules/csvparser/csvparser.h
+++ b/modules/csvparser/csvparser.h
@@ -27,7 +27,17 @@
 #include "parser/parser-expr.h"
 #include "scanner/csv-scanner/csv-scanner.h"
 
+typedef struct _CSVParserColumn
+{
+  gchar *name;
+  LogMessageValueType type;
+} CSVParserColumn;
+
+CSVParserColumn *csv_parser_column_new(const gchar *name, LogMessageValueType type);
+void csv_parser_column_free(CSVParserColumn *s);
+
 CSVScannerOptions *csv_parser_get_scanner_options(LogParser *s);
+void csv_parser_set_columns(LogParser *s, GList *columns);
 gboolean csv_parser_set_flags(LogParser *s, guint32 flags);
 void csv_parser_set_drop_invalid(LogParser *s, gboolean drop_invalid);
 void csv_parser_set_prefix(LogParser *s, const gchar *prefix);

--- a/modules/csvparser/tests/test_csvparser_perf.c
+++ b/modules/csvparser/tests/test_csvparser_perf.c
@@ -36,51 +36,9 @@ _construct_parser(gint max_columns, gint dialect, gchar *delimiters, gchar *quot
 {
   LogParser *p;
 
-  const gchar *column_array[] =
-  {
-    "C1",
-    "C2",
-    "C3",
-    "C4",
-    "C5",
-    "C6",
-    "C7",
-    "C8",
-    "C9",
-    "C10",
-    "C11",
-    "C12",
-    "C13",
-    "C14",
-    "C15",
-    "C16",
-    "C17",
-    "C18",
-    "C19",
-    "C20",
-    "C21",
-    "C22",
-    "C23",
-    "C24",
-    "C25",
-    "C26",
-    "C27",
-    "C28",
-    "C29",
-    "C30",
-    NULL
-  };
-
-  if (max_columns != -1)
-    {
-      g_assert(max_columns < (sizeof(column_array) / sizeof(column_array[0])));
-
-      column_array[max_columns] = NULL;
-    }
-
   p = csv_parser_new(NULL);
   csv_scanner_options_set_dialect(csv_parser_get_scanner_options(p), dialect);
-  csv_scanner_options_set_columns(csv_parser_get_scanner_options(p), string_array_to_list(column_array));
+  csv_scanner_options_set_expected_columns(csv_parser_get_scanner_options(p), max_columns < 0 ? 30 : max_columns);
   if (delimiters)
     csv_scanner_options_set_delimiters(csv_parser_get_scanner_options(p), delimiters);
   if (quotes)

--- a/modules/csvparser/tests/test_csvparser_statistics.c
+++ b/modules/csvparser/tests/test_csvparser_statistics.c
@@ -36,7 +36,6 @@ static LogParser *
 _create_parser(GlobalConfig *cfg)
 {
   LogParser *p = csv_parser_new(cfg);
-  const gchar *column_array[] = { "header1", NULL };
 
   stats_lock();
   StatsClusterKey sc_key;
@@ -45,7 +44,7 @@ _create_parser(GlobalConfig *cfg)
   stats_unlock();
 
   csv_scanner_options_set_delimiters(csv_parser_get_scanner_options(p), ",");
-  csv_scanner_options_set_columns(csv_parser_get_scanner_options(p), string_array_to_list(column_array));
+  csv_scanner_options_set_expected_columns(csv_parser_get_scanner_options(p), 1);
   csv_parser_set_drop_invalid(p, TRUE);
 
   return p;

--- a/modules/examples/sources/msg-generator/msg-generator-source.c
+++ b/modules/examples/sources/msg-generator/msg-generator-source.c
@@ -100,9 +100,11 @@ _add_name_value(gpointer key, gpointer value, gpointer data)
   gchar *name = (gchar *) key;
   LogTemplate *val = (LogTemplate *) value;
   LogMessage *msg = (LogMessage *) data;
+  LogMessageValueType type;
+
   GString *msg_body = g_string_sized_new(128);
-  log_template_format(val, msg, &DEFAULT_TEMPLATE_EVAL_OPTIONS, msg_body);
-  log_msg_set_value_by_name(msg, name, msg_body->str, msg_body->len);
+  log_template_format_value_and_type(val, msg, &DEFAULT_TEMPLATE_EVAL_OPTIONS, msg_body, &type);
+  log_msg_set_value_by_name_with_type(msg, name, msg_body->str, msg_body->len, type);
   g_string_free(msg_body, TRUE);
 
 }


### PR DESCRIPTION
This PR adds type validation support to csv-parser:

```
csv-parser(delimiters(',')  columns(int(a), float(b)) dialect(escape-backslash));
```

Notice the type-hints around the column names. If the type validation fails, the parsing will fail too. What happens is determined by drop-invalid.

This PR depends on #4678 