### PR TITLE
cmake: Loki and Otel module building corrections

### DIFF
--- a/modules/grpc/CMakeLists.txt
+++ b/modules/grpc/CMakeLists.txt
@@ -70,7 +70,7 @@ if (ENABLE_GRPC)
 endif()
 
 # These are intentionally not inside the above if (ENABLE_GRPC) block
-# Let the module_switch-es take effect and is being always visible
+# Let any other possible module_switch-es take effect and is being always visible
 # (both modules are protected via ENABLE_GRPC as well)
 add_subdirectory(loki)
 add_subdirectory(otel)

--- a/modules/grpc/loki/CMakeLists.txt
+++ b/modules/grpc/loki/CMakeLists.txt
@@ -1,10 +1,4 @@
-if(ENABLE_LOKI AND NOT ENABLE_GRPC)
-  message(FATAL_ERROR "GRPC support is mandatory when the Loki modules are enabled.")
-endif()
-
-module_switch(ENABLE_LOKI "Enable Loki" ENABLE_GRPC)
-
-if(NOT ENABLE_LOKI OR NOT ENABLE_GRPC)
+if(NOT ENABLE_GRPC)
   return()
 endif()
 

--- a/modules/grpc/loki/CMakeLists.txt
+++ b/modules/grpc/loki/CMakeLists.txt
@@ -9,14 +9,15 @@ if(NOT ENABLE_LOKI OR NOT ENABLE_GRPC)
 endif()
 
 set(LOKI_SOURCES
-    loki-parser.h
-    loki-plugin.c
-    loki-parser.c
+  loki-parser.h
+  loki-plugin.c
+  loki-parser.c
 )
 
 add_module(
   TARGET loki
   GRAMMAR loki-grammar
+  DEPENDS ${MODULE_GRPC_LIBS} grpc-protos
   INCLUDES ${PROJECT_SOURCE_DIR}/modules/grpc
   SOURCES ${LOKI_SOURCES}
 )

--- a/modules/grpc/otel/CMakeLists.txt
+++ b/modules/grpc/otel/CMakeLists.txt
@@ -1,10 +1,4 @@
-if(ENABLE_OTEL AND NOT ENABLE_GRPC)
-  message(FATAL_ERROR "GRPC support is mandatory when the Otel modules are enabled.")
-endif()
-
-module_switch(ENABLE_OTEL "Enable Otel" ENABLE_GRPC)
-
-if(NOT ENABLE_OTEL OR NOT ENABLE_GRPC)
+if(NOT ENABLE_GRPC)
   return()
 endif()
 

--- a/modules/grpc/protos/CMakeLists.txt
+++ b/modules/grpc/protos/CMakeLists.txt
@@ -2,33 +2,46 @@ set(OTEL_PROTO_SRCDIR "${CMAKE_CURRENT_SOURCE_DIR}/opentelemetry-proto")
 set(OTEL_PROTO_BUILDDIR "${CMAKE_CURRENT_BINARY_DIR}/opentelemetry-proto")
 set(OTEL_PROTO_BUILDDIR ${OTEL_PROTO_BUILDDIR} PARENT_SCOPE)
 
-set(GRPC_PROTO_SOURCES
+set(LOKI_PROTO_SRCDIR "${CMAKE_CURRENT_SOURCE_DIR}/grafana-loki")
+set(LOKI_PROTO_BUILDDIR "${CMAKE_CURRENT_BINARY_DIR}/grafana-loki")
+set(LOKI_PROTO_BUILDDIR ${LOKI_PROTO_BUILDDIR} PARENT_SCOPE)
+
+set(OTEL_PROTO_SOURCES
   opentelemetry/proto/common/v1/common.proto
   opentelemetry/proto/logs/v1/logs.proto
   opentelemetry/proto/metrics/v1/metrics.proto
   opentelemetry/proto/trace/v1/trace.proto
   opentelemetry/proto/resource/v1/resource.proto)
 
-set(GRPC_PROTO_GRPC_SOURCES
+set(OTEL_PROTO_GRPC_SOURCES
   opentelemetry/proto/collector/logs/v1/logs_service.proto
   opentelemetry/proto/collector/metrics/v1/metrics_service.proto
   opentelemetry/proto/collector/trace/v1/trace_service.proto)
 
+set(LOKI_PROTO_GRPC_SOURCES
+  push.proto)
+
 protobuf_generate_cpp(
   PROTO_PATH ${OTEL_PROTO_SRCDIR}
   CPP_OUT ${OTEL_PROTO_BUILDDIR}
-  OUT_SRCS GRPC_PROTO_GENERATED_SOURCES
-  PROTOS ${GRPC_PROTO_SOURCES})
+  OUT_SRCS OTEL_PROTO_GENERATED_SOURCES
+  PROTOS ${OTEL_PROTO_SOURCES})
 
 protobuf_generate_cpp_grpc(
   PROTO_PATH ${OTEL_PROTO_SRCDIR}
   CPP_OUT ${OTEL_PROTO_BUILDDIR}
-  OUT_SRCS GRPC_PROTO_GENERATED_GRPC_SOURCES
-  PROTOS ${GRPC_PROTO_GRPC_SOURCES})
+  OUT_SRCS OTEL_PROTO_GENERATED_GRPC_SOURCES
+  PROTOS ${OTEL_PROTO_GRPC_SOURCES})
+
+protobuf_generate_cpp_grpc(
+  PROTO_PATH ${LOKI_PROTO_SRCDIR}
+  CPP_OUT ${LOKI_PROTO_BUILDDIR}
+  OUT_SRCS LOKI_PROTO_GENERATED_GRPC_SOURCES
+  PROTOS ${LOKI_PROTO_GRPC_SOURCES})
 
 add_module(
   TARGET grpc-protos
-  SOURCES ${GRPC_PROTO_GENERATED_SOURCES} ${GRPC_PROTO_GENERATED_GRPC_SOURCES}
+  SOURCES ${OTEL_PROTO_GENERATED_SOURCES} ${OTEL_PROTO_GENERATED_GRPC_SOURCES} ${LOKI_PROTO_GENERATED_GRPC_SOURCES}
   DEPENDS ${MODULE_GRPC_LIBS}
-  INCLUDES ${OTEL_PROTO_BUILDDIR}
+  INCLUDES ${OTEL_PROTO_BUILDDIR} ${LOKI_PROTO_BUILDDIR}
 )


### PR DESCRIPTION
- added the missing cmake grpc-protos lib dependency to loki module
- added missing loki protobuf generation to the cmake builds
- based on our conversation with @bazsi dropped all the grpc sub-module switches, only enable-grpc remained
  - dropped the otel/loki autotools module switch PR (#4676)
  - removed the earlier (cmake only) otel/loki module switches  (#4649)

Signed-off-by: Hofi [hofione@gmail.com](mailto:hofione@gmail.com)