### PR TITLE
cfg-grammar: fix setting template-escape() in template block

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -873,7 +873,7 @@ template_fn
 	;
 
 template_items
-	: { $<ptr>$ = $<ptr>0; } template_item semicolons template_items
+	: { $<ptr>$ = $<ptr>0; } template_item semicolons { $<ptr>$ = $<ptr>0; } template_items
 	|
 	;
 


### PR DESCRIPTION
The template_item nonterminal overwrites the value of $0, so we need to set it again.

Bug was catched via valgrind:
```
==2803776== Invalid read of size 1
==2803776==    at 0x491A973: log_template_set_escape (templates.c:298)
==2803776==    by 0x48EAA94: main_parse (cfg-grammar.y:883)
==2803776==    by 0x48AD89A: cfg_parser_parse (cfg-parser.c:434)
==2803776==    by 0x48A7994: cfg_run_parser (cfg.c:562)
==2803776==    by 0x48A7E8D: cfg_read_config (cfg.c:684)
==2803776==    by 0x48CD526: main_loop_read_and_init_config (mainloop.c:692)
==2803776==    by 0x10ADF6: main (main.c:320)
==2803776==  Address 0x6782808 is 40 bytes inside a block of size 87 free'd
==2803776==    at 0x484B27F: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==2803776==    by 0x48EAB75: main_parse (cfg-grammar.y:896)
==2803776==    by 0x48AD89A: cfg_parser_parse (cfg-parser.c:434)
==2803776==    by 0x48A7994: cfg_run_parser (cfg.c:562)
==2803776==    by 0x48A7E8D: cfg_read_config (cfg.c:684)
==2803776==    by 0x48CD526: main_loop_read_and_init_config (mainloop.c:692)
==2803776==    by 0x10ADF6: main (main.c:320)
==2803776==  Block was alloc'd at
==2803776==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==2803776==    by 0x4BBE58E: strdup (strdup.c:42)
==2803776==    by 0x48E1E00: _cfg_lexer_lex (cfg-lex.l:349)
==2803776==    by 0x48AB66F: _invoke__cfg_lexer_lex (cfg-lexer.c:908)
==2803776==    by 0x48AB804: cfg_lexer_lex_next_token (cfg-lexer.c:952)
==2803776==    by 0x48ABE3F: cfg_lexer_lex (cfg-lexer.c:1116)
==2803776==    by 0x48AD01F: main_lex (cfg-parser.c:230)
==2803776==    by 0x48E90FF: main_parse (cfg-grammar.c:3694)
==2803776==    by 0x48AD89A: cfg_parser_parse (cfg-parser.c:434)
==2803776==    by 0x48A7994: cfg_run_parser (cfg.c:562)
==2803776==    by 0x48A7E8D: cfg_read_config (cfg.c:684)
==2803776==    by 0x48CD526: main_loop_read_and_init_config (mainloop.c:692)
==2849960==
==2849960== Invalid write of size 1
==2849960==    at 0x491A99A: log_template_set_escape (templates.c:298)
==2849960==    by 0x48EAAB2: main_parse (cfg-grammar.y:883)
==2849960==    by 0x48AD89A: cfg_parser_parse (cfg-parser.c:434)
==2849960==    by 0x48A7994: cfg_run_parser (cfg.c:562)
==2849960==    by 0x48A7E8D: cfg_read_config (cfg.c:684)
==2849960==    by 0x48CD526: main_loop_read_and_init_config (mainloop.c:692)
==2849960==    by 0x10ADF6: main (main.c:320)
==2849960==  Address 0x6782808 is 40 bytes inside a block of size 87 free'd
==2849960==    at 0x484B27F: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==2849960==    by 0x48EAB93: main_parse (cfg-grammar.y:896)
==2849960==    by 0x48AD89A: cfg_parser_parse (cfg-parser.c:434)
==2849960==    by 0x48A7994: cfg_run_parser (cfg.c:562)
==2849960==    by 0x48A7E8D: cfg_read_config (cfg.c:684)
==2849960==    by 0x48CD526: main_loop_read_and_init_config (mainloop.c:692)
==2849960==    by 0x10ADF6: main (main.c:320)
==2849960==  Block was alloc'd at
==2849960==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==2849960==    by 0x4BBE58E: strdup (strdup.c:42)
==2849960==    by 0x48E1E00: _cfg_lexer_lex (cfg-lex.l:349)
==2849960==    by 0x48AB66F: _invoke__cfg_lexer_lex (cfg-lexer.c:908)
==2849960==    by 0x48AB804: cfg_lexer_lex_next_token (cfg-lexer.c:952)
==2849960==    by 0x48ABE3F: cfg_lexer_lex (cfg-lexer.c:1116)
==2849960==    by 0x48AD01F: main_lex (cfg-parser.c:230)
==2849960==    by 0x48E90FF: main_parse (cfg-grammar.c:3694)
==2849960==    by 0x48AD89A: cfg_parser_parse (cfg-parser.c:434)
==2849960==    by 0x48A7994: cfg_run_parser (cfg.c:562)
==2849960==    by 0x48A7E8D: cfg_read_config (cfg.c:684)
==2849960==    by 0x48CD526: main_loop_read_and_init_config (mainloop.c:692)
```

Triggered by `scl/osquery/plugin.conf`
```
template t_osquery {
  template("\"${ISODATE}\",\"${HOST}\",\"${LEVEL_NUM}\",\"${FACILITY}\",\"${PROGRAM}\",\"${ESCAPED_MESSAGE}\"\n");
  template_escape(no);
};
```

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>
