### PR TITLE
cfg-parser: fix flag buffer overflow

### DIFF
--- a/news/bugfix-4689.md
+++ b/news/bugfix-4689.md
@@ -1,0 +1,2 @@
+`flags()` argument to various drivers: fix a potential crash in case a flag with at least 32 characters is used.
+No such flag is defined by syslog-ng, so the only way to trigger the crash is to use an invalid configuration file.


### PR DESCRIPTION
If the input was at least 32 bytes long, then the terminating NULL character was placed on the flag[32] position instead of flag[31].

I was only able to reproduce it using [axosyslog](https://github.com/axoflow/axosyslog-docker/pkgs/container/axosyslog) images.