### PR TITLE
Fix per reload memory leak and a use after free in trace level logging

### DIFF
--- a/lib/filter/filter-cmp.c
+++ b/lib/filter/filter-cmp.c
@@ -339,7 +339,7 @@ fop_cmp_clone(FilterExprNode *s)
 }
 
 FilterExprNode *
-fop_cmp_new(LogTemplate *left, LogTemplate *right, const gchar *type, gint compare_mode, EVTTAG *location)
+fop_cmp_new(LogTemplate *left, LogTemplate *right, const gchar *type, gint compare_mode, const gchar *location)
 {
   FilterCmp *self = g_new0(FilterCmp, 1);
 
@@ -371,7 +371,7 @@ fop_cmp_new(LogTemplate *left, LogTemplate *right, const gchar *type, gint compa
                           "You seem to be using numeric operators in this filter expression, so "
                           "please make sure that once the type-aware behavior is turned on it remains correct, "
                           "see this blog post for more information: https://syslog-ng-future.blog/syslog-ng-4-theme-typing/",
-                          location);
+                          evt_tag_str("location", location));
             }
           self->compare_mode = (self->compare_mode & ~FCMP_TYPE_AWARE) | FCMP_NUM_BASED;
         }
@@ -385,7 +385,7 @@ fop_cmp_new(LogTemplate *left, LogTemplate *right, const gchar *type, gint compa
                   "As we are operating in compatibility mode, syslog-ng will exhibit the buggy "
                   "behaviour as previous versions until you bump the @version value in your "
                   "configuration file",
-                  location);
+                  evt_tag_str("location", location));
       self->compare_mode &= ~FCMP_TYPE_AWARE;
       self->compare_mode |= FCMP_STRING_BASED;
     }

--- a/lib/filter/filter-cmp.h
+++ b/lib/filter/filter-cmp.h
@@ -41,6 +41,6 @@
 
 FilterExprNode *fop_cmp_new(LogTemplate *left, LogTemplate *right,
                             const gchar *type, gint compare_mode,
-                            EVTTAG *location);
+                            const gchar *location);
 
 #endif

--- a/lib/filter/filter-expr-grammar.ym
+++ b/lib/filter/filter-expr-grammar.ym
@@ -232,9 +232,12 @@ filter_identifier
 filter_comparison
 	: template_content operator <cptr>{ $$ = strdup(lexer->token_text->str); } template_content
 	  {
+            gchar buf[256];
             $1 = _translate_number_literals(lexer, $2, $1, &@1);
             $4 = _translate_number_literals(lexer, $2, $4, &@4);
-	    $$ = fop_cmp_new($1, $4, $3, $2, cfg_lexer_format_location_tag(lexer, &@0));
+
+            cfg_lexer_format_location(lexer, &@0, buf, sizeof(buf));
+	    $$ = fop_cmp_new($1, $4, $3, $2, buf);
             free($3);
           }
         ;

--- a/lib/parser/parser-expr.c
+++ b/lib/parser/parser-expr.c
@@ -90,7 +90,6 @@ log_parser_queue_method(LogPipe *s, LogMessage *msg, const LogPathOptions *path_
 {
   LogParser *self = (LogParser *) s;
   gboolean success;
-  gchar *parser_result;
 
   msg_trace(">>>>>> parser rule evaluation begin",
             evt_tag_str("rule", self->name),
@@ -99,23 +98,22 @@ log_parser_queue_method(LogPipe *s, LogMessage *msg, const LogPathOptions *path_
 
   success = log_parser_process_message(self, &msg, path_options);
 
+  msg_trace("<<<<<< parser rule evaluation result",
+            evt_tag_str("result", success ? "accepted" : "rejected"),
+            evt_tag_str("rule", self->name),
+            log_pipe_location_tag(s),
+            evt_tag_msg_reference(msg));
+
   if (success)
     {
-      parser_result = "Forwarding message to the next LogPipe";
       log_pipe_forward_msg(s, msg, path_options);
     }
   else
     {
-      parser_result = "Dropping message from LogPipe";
       if (path_options->matched)
         (*path_options->matched) = FALSE;
       log_msg_drop(msg, path_options, AT_PROCESSED);
     }
-  msg_trace("<<<<<< parser rule evaluation result",
-            evt_tag_str("result", parser_result),
-            evt_tag_str("rule", self->name),
-            log_pipe_location_tag(s),
-            evt_tag_msg_reference(msg));
 }
 
 static void


### PR DESCRIPTION
Something I stumbled into while working on something else. I am not sure it warrants a news entry.

* We leak an EVTTAG instance per filter comparison operator upon each reload (~100 bytes per operator)
* we might use the LogMessage instance right after being freed if trace level logging is enabled (to query the rcptid)

