### PR TITLE
app-parser(): allow multiple apps to match

### DIFF
--- a/lib/filter/filter-tags.c
+++ b/lib/filter/filter-tags.c
@@ -45,17 +45,25 @@ filter_tags_eval(FilterExprNode *s, LogMessage **msgs, gint num_msg, LogTemplate
       LogTagId tag_id = g_array_index(self->tags, LogTagId, i);
       if (log_msg_is_tag_by_id(msg, tag_id))
         {
-          res = TRUE;
-          msg_trace("tags() evaluation started",
+          msg_trace("tags() evaluation result, matching tag is found",
                     evt_tag_str("tag", log_tags_get_by_id(tag_id)),
                     evt_tag_msg_reference(msg));
+
+          res = TRUE;
           return res ^ s->comp;
+        }
+      else
+        {
+          msg_trace("tags() evaluation progress, tag is not set",
+                    evt_tag_str("tag", log_tags_get_by_id(tag_id)),
+                    evt_tag_int("value", log_msg_is_tag_by_id(msg, tag_id)),
+                    evt_tag_msg_reference(msg));
         }
     }
 
-  res = FALSE;
-  msg_trace("tags() evaluation started",
+  msg_trace("tags() evaluation result, none of the tags is present",
             evt_tag_msg_reference(msg));
+  res = FALSE;
   return res ^ s->comp;
 }
 

--- a/modules/appmodel/app-parser-generator.c
+++ b/modules/appmodel/app-parser-generator.c
@@ -36,6 +36,7 @@ typedef struct _AppParserGenerator
   const gchar *excluded_apps;
   gboolean is_parsing_enabled;
   gboolean first_app_generated;
+  gboolean allow_overlaps;
 } AppParserGenerator;
 
 static const gchar *
@@ -81,12 +82,15 @@ _generate_parser(AppParserGenerator *self, const gchar *parser_expr)
 static void
 _generate_action(AppParserGenerator *self, Application *app)
 {
-  g_string_append_printf(self->block,
-                         "            rewrite {\n"
-                         "                set-tag('.app.%s');\n"
-                         "                set('%s' value('.app.name'));\n"
-                         "            };\n",
-                         app->name, app->name);
+  if (!self->allow_overlaps)
+    {
+      g_string_append_printf(self->block,
+                             "            rewrite {\n"
+                             "                set-tag('.app.%s');\n"
+                             "                set('%s' value('.app.name'));\n"
+                             "            };\n",
+                             app->name, app->name);
+    }
 }
 
 static gboolean
@@ -120,20 +124,31 @@ _generate_application(Application *app, Application *base_app, gpointer user_dat
   if (_is_application_excluded(self, app))
     return;
 
-  if (!self->first_app_generated)
+  if (self->first_app_generated)
     {
-      self->first_app_generated = TRUE;
-      g_string_append(self->block,    "        if {\n");
+      if (self->allow_overlaps)
+        g_string_append(self->block,
+                        "        ;\n"
+                        "        if {\n");
+      else
+        g_string_append(self->block,
+                        "        elif {\n");
     }
   else
-    g_string_append(self->block,      "        elif {\n");
-  g_string_append_printf(self->block, "            #Start Application %s\n", app->name);
+    {
+      self->first_app_generated = TRUE;
+      g_string_append(self->block,
+                      "        if {\n");
+    }
+  g_string_append_printf(self->block,
+                         "            #Start Application %s\n", app->name);
 
   _generate_filter(self, _get_filter_expr(app, base_app));
   _generate_parser(self, _get_parser_expr(app, base_app));
   _generate_action(self, app);
-  g_string_append_printf(self->block, "            #End Application %s\n", app->name);
-  g_string_append(self->block,        "        }\n");
+  g_string_append_printf(self->block,
+                         "            #End Application %s\n", app->name);
+  g_string_append(self->block, "        }\n");
 
 }
 
@@ -146,18 +161,29 @@ _generate_applications(AppParserGenerator *self, AppModelContext *appmodel)
 static void
 _generate_framing(AppParserGenerator *self, AppModelContext *appmodel)
 {
-  g_string_append(self->block,   "\n"
-                                 "channel {\n");
+  g_string_append(self->block,
+                  "\nchannel {\n");
 
   self->first_app_generated = FALSE;
-  _generate_applications(self, appmodel);
-  if (self->first_app_generated)
-    g_string_append(self->block, "    else {\n");
+  if (!self->allow_overlaps)
+    {
+      _generate_applications(self, appmodel);
+      if (self->first_app_generated)
+        g_string_append(self->block, "        else {\n");
+      else
+        g_string_append(self->block, "        channel {\n");
+
+      g_string_append(self->block,
+                      "            filter { tags('.app.doesnotexist'); };\n"
+                      "        };\n");
+    }
   else
-    g_string_append(self->block, "    if {\n");
-  g_string_append(self->block,   "        filter { tags('.app.doesnotexist'); };\n"
-                                 "    };");
-  g_string_append(self->block,   "}");
+    {
+      _generate_applications(self, appmodel);
+      if (self->first_app_generated)
+        g_string_append(self->block, "        ;\n");
+    }
+  g_string_append(self->block, "}");
 }
 
 static void
@@ -212,6 +238,17 @@ _parse_topic_arg(AppParserGenerator *self, CfgArgs *args, const gchar *reference
 }
 
 static gboolean
+_parse_allow_overlaps(AppParserGenerator *self, CfgArgs *args, const gchar *reference)
+{
+  const gchar *v = cfg_args_get(args, "allow-overlaps");
+  if (v)
+    self->allow_overlaps = cfg_process_yesno(v);
+  else
+    self->allow_overlaps = FALSE;
+  return TRUE;
+}
+
+static gboolean
 _parse_arguments(AppParserGenerator *self, CfgArgs *args, const gchar *reference)
 {
   g_assert(args != NULL);
@@ -223,6 +260,8 @@ _parse_arguments(AppParserGenerator *self, CfgArgs *args, const gchar *reference
   if (!_parse_auto_parse_exclude_arg(self, args, reference))
     return FALSE;
   if (!_parse_auto_parse_include_arg(self, args, reference))
+    return FALSE;
+  if (!_parse_allow_overlaps(self, args, reference))
     return FALSE;
   return TRUE;
 }

--- a/modules/appmodel/app-parser-generator.c
+++ b/modules/appmodel/app-parser-generator.c
@@ -61,25 +61,31 @@ static void
 _generate_filter(AppParserGenerator *self, const gchar *filter_expr)
 {
   if (filter_expr)
-    g_string_append_printf(self->block, "    filter { %s };\n", filter_expr);
+    g_string_append_printf(self->block,
+                           "            filter {\n"
+                           "                %s\n"
+                           "            };\n", filter_expr);
 }
 
 static void
 _generate_parser(AppParserGenerator *self, const gchar *parser_expr)
 {
   if (parser_expr)
-    g_string_append_printf(self->block, "    parser { %s };\n", parser_expr);
+    g_string_append_printf(self->block,
+                           "            parser {\n"
+                           "                %s\n"
+                           "            };\n", parser_expr);
 }
 
 static void
 _generate_action(AppParserGenerator *self, Application *app)
 {
   g_string_append_printf(self->block,
-                         "    rewrite {\n"
-                         "       set-tag('.app.%s');\n"
-                         "       set('%s' value('.app.name'));\n"
-                         "    };\n"
-                         "    flags(final);\n",
+                         "            rewrite {\n"
+                         "                set-tag('.app.%s');\n"
+                         "                set('%s' value('.app.name'));\n"
+                         "            };\n",
+                         "            flags(final);\n",
                          app->name, app->name);
 }
 
@@ -114,13 +120,13 @@ _generate_application(Application *app, Application *base_app, gpointer user_dat
   if (_is_application_excluded(self, app))
     return;
 
-  g_string_append_printf(self->block, "\n#Start Application %s\n", app->name);
-  g_string_append(self->block, "channel {\n");
+  g_string_append(self->block,        "        channel {\n");
+  g_string_append_printf(self->block, "            #Start Application %s\n", app->name);
   _generate_filter(self, _get_filter_expr(app, base_app));
   _generate_parser(self, _get_parser_expr(app, base_app));
   _generate_action(self, app);
-  g_string_append(self->block, "};\n");
-  g_string_append_printf(self->block, "\n#End Application %s\n", app->name);
+  g_string_append_printf(self->block, "            #End Application %s\n", app->name);
+  g_string_append(self->block,        "        };\n");
 
 }
 

--- a/tests/light/functional_tests/parsers/app-parser/test_app_parser.py
+++ b/tests/light/functional_tests/parsers/app-parser/test_app_parser.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2019 Balabit
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import pytest
+
+
+test_parameters_first_match = [
+    ("""foo foomessage""", "${.app.name}", "foo"),
+    ("""bar barmessage""", "${.app.name}", "bar"),
+    ("""foobar foobarmessage""", "${.app.name}", "foo"),
+]
+
+
+test_parameters_all_matches = [
+    ("""foo foomessage""", "${FOOVALUE} ${BARVALUE}", "foo "),
+    ("""bar barmessage""", "${FOOVALUE} ${BARVALUE}", " bar"),
+    ("""foobar foobarmessage""", "${FOOVALUE} ${BARVALUE}", "foo bar"),
+]
+
+
+preamble_foobar_apps = """
+application foo[syslog] {
+    filter { program("foo"); };
+    parser {
+        channel {
+            rewrite { set("foo" value("FOOVALUE"));  };
+        };
+    };
+};
+
+application bar[syslog] {
+    filter { program("bar"); };
+    parser {
+        channel {
+            rewrite { set("bar" value("BARVALUE")); };
+        };
+    };
+};
+"""
+
+
+@pytest.mark.parametrize(
+    "input_message, template, expected_value", test_parameters_first_match,
+    ids=list(map(str, range(len(test_parameters_first_match)))),
+)
+def test_app_parser_first_match_without_overlaps_only_traverses_the_first_app(config, syslog_ng, input_message, template, expected_value):
+    config.add_preamble(preamble_foobar_apps)
+    generator_source = config.create_example_msg_generator_source(num=1, template=config.stringify(input_message))
+    syslog_parser = config.create_syslog_parser(flags="syslog-protocol")
+    app_parser = config.create_app_parser(topic="syslog")
+    file_destination = config.create_file_destination(file_name="output.log", template=config.stringify(template + '\n'))
+    config.create_logpath(statements=[generator_source, syslog_parser, app_parser, file_destination])
+
+    syslog_ng.start(config)
+    assert file_destination.read_log().strip() == expected_value
+
+
+@pytest.mark.parametrize(
+    "input_message, template, expected_value", test_parameters_all_matches,
+    ids=list(map(str, range(len(test_parameters_all_matches)))),
+)
+def test_app_parser_allow_overlaps_causes_all_apps_to_be_traversed(config, syslog_ng, input_message, template, expected_value):
+    config.add_preamble(preamble_foobar_apps)
+    generator_source = config.create_example_msg_generator_source(num=1, template=config.stringify(input_message))
+    syslog_parser = config.create_syslog_parser(flags="syslog-protocol")
+    app_parser = config.create_app_parser(topic="syslog", allow_overlaps="yes")
+    file_destination = config.create_file_destination(file_name="output.log", template=config.stringify(template + '\n'))
+    config.create_logpath(statements=[generator_source, syslog_parser, app_parser, file_destination])
+
+    syslog_ng.start(config)
+    assert file_destination.read_log()[:-1] == expected_value
+
+
+def test_app_parser_dont_match_causes_the_message_to_be_dropped(config, syslog_ng):
+    config.add_preamble(preamble_foobar_apps)
+    config.update_global_options(stats_level=1)
+    generator_source = config.create_example_msg_generator_source(num=1, template=config.stringify("almafa message"))
+    syslog_parser = config.create_syslog_parser(flags="syslog-protocol")
+    app_parser = config.create_app_parser(topic="syslog")
+    file_destination = config.create_file_destination(file_name="output.log", template=config.stringify("foobar"))
+    config.create_logpath(statements=[generator_source, syslog_parser, app_parser, file_destination])
+
+    syslog_ng.start(config)
+    assert "processed" not in file_destination.get_stats()
+
+
+def test_app_parser_auto_parse_disabled_causes_the_message_to_be_dropped(config, syslog_ng):
+    config.add_preamble(preamble_foobar_apps)
+    config.update_global_options(stats_level=1)
+    generator_source = config.create_example_msg_generator_source(num=1, template=config.stringify("foo foomessage"))
+    syslog_parser = config.create_syslog_parser(flags="syslog-protocol")
+    app_parser = config.create_app_parser(topic="syslog", auto_parse="no")
+    file_destination = config.create_file_destination(file_name="output.log")
+    config.create_logpath(statements=[generator_source, syslog_parser, app_parser, file_destination])
+
+    syslog_ng.start(config)
+    assert "processed" not in file_destination.get_stats()
+
+
+def test_app_parser_auto_parse_disabled_plus_overlaps_causes_the_message_to_be_accepted(config, syslog_ng):
+    config.add_preamble(preamble_foobar_apps)
+    config.update_global_options(stats_level=1)
+    generator_source = config.create_example_msg_generator_source(num=1, template=config.stringify("foo foomessage"))
+    syslog_parser = config.create_syslog_parser(flags="syslog-protocol")
+    app_parser = config.create_app_parser(topic="syslog", auto_parse="no", allow_overlaps="yes")
+    file_destination = config.create_file_destination(file_name="output.log")
+    config.create_logpath(statements=[generator_source, syslog_parser, app_parser, file_destination])
+
+    syslog_ng.start(config)
+    assert "processed" not in file_destination.get_stats()

--- a/tests/light/src/syslog_ng_config/renderer.py
+++ b/tests/light/src/syslog_ng_config/renderer.py
@@ -197,6 +197,7 @@ class ConfigRenderer(object):
         version = self.__syslog_ng_config["version"]
         includes = self.__syslog_ng_config["includes"]
         global_options = self.__syslog_ng_config["global_options"]
+        preamble = self.__syslog_ng_config["preamble"]
         templates = self.__syslog_ng_config["templates"]
         statement_groups = self.__syslog_ng_config["statement_groups"]
         logpath_groups = self.__syslog_ng_config["logpath_groups"]
@@ -209,6 +210,8 @@ class ConfigRenderer(object):
             config += render_includes(includes)
         if global_options:
             config += render_global_options(global_options)
+        if preamble:
+            config += preamble
         if templates:
             config += render_templates(templates)
         if statement_groups:

--- a/tests/light/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/light/src/syslog_ng_config/syslog_ng_config.py
@@ -61,6 +61,7 @@ class SyslogNgConfig(object):
             "version": version,
             "includes": [],
             "global_options": {},
+            "preamble": "",
             "templates": [],
             "statement_groups": [],
             "logpath_groups": [],
@@ -93,6 +94,9 @@ class SyslogNgConfig(object):
 
     def update_global_options(self, **options):
         self.__syslog_ng_config["global_options"].update(options)
+
+    def add_preamble(self, preamble):
+        self.__syslog_ng_config["preamble"] += "\n" + preamble
 
     def add_template(self, template):
         self.__syslog_ng_config["templates"].append(template)


### PR DESCRIPTION
This branch adds the new allow-overlaps() option to control whether application adapters are assumed to not overlap. In this case the first matching app wins and the rest of the patterns are not even tried.

If allow-overlaps(yes) is specified to app-parser(), that would mean that all adapters are tried sequentially and matching
continues even if we found the first matching one.

There are a couple of changes in this mode:
   
``` 
    app-parser(allow-overlaps(yes)) changes app-parser the following ways:
    
    1) all applications are tried and we don't stop at the first matching one
    2) app-parser() will accept the message by default, even if NO app matches it
    3) the ${.app.name} value is not set
    
```
