### PR TITLE
optional-dev-requirements: add syslog-ng-cfg-helper

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,6 +43,7 @@ EXTRA_DIST		= $(filter-out ${NODIST_BUILT_SOURCES},${BUILT_SOURCES}) VERSION NEW
 			  syslog-ng-ctl/CMakeLists.txt	\
 			  requirements.txt	\
 			  dev-requirements.txt  \
+			  optional-dev-requirements.txt  \
 			  README.md	\
 			  .astylerc
 

--- a/optional-dev-requirements.txt
+++ b/optional-dev-requirements.txt
@@ -1,0 +1,1 @@
+syslog-ng-cfg-helper

--- a/scripts/build-python-venv.sh
+++ b/scripts/build-python-venv.sh
@@ -34,13 +34,15 @@ PYTHON=$1
 PYTHON_VENV_DIR=$2
 top_srcdir=$3
 REQUIREMENTS_FILE=${top_srcdir}/dev-requirements.txt
+OPTIONAL_REQUIREMENTS_FILE=${top_srcdir}/optional-dev-requirements.txt
 
 set -e
 
-echo "Building dev virtualenv for syslog-ng at ${PYTHON_VENV_DIR} from ${REQUIREMENTS_FILE}"
+echo "Building dev virtualenv for syslog-ng at ${PYTHON_VENV_DIR} from ${REQUIREMENTS_FILE} and ${OPTIONAL_REQUIREMENTS_FILE}"
 
 rm -rf ${PYTHON_VENV_DIR}
 ${PYTHON} -m venv ${PYTHON_VENV_DIR}
 ${PYTHON_VENV_DIR}/bin/python -m pip install --upgrade pip
 ${PYTHON_VENV_DIR}/bin/python -m pip install --upgrade setuptools
 ${PYTHON_VENV_DIR}/bin/python -m pip install -r $REQUIREMENTS_FILE
+${PYTHON_VENV_DIR}/bin/python -m pip install -r $OPTIONAL_REQUIREMENTS_FILE || echo "Some optional pip packages were not installed. Continuing..."


### PR DESCRIPTION
This tool helps in development, too.

You can find it in devshell at: `/source/dbld/build/venv/bin/syslog-ng-cfg-helper`

---

I have added this as an optional dev requirement, because old platforms (centos-7) does not support it.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
