### PR TITLE
type-hinting,parse-number: use locale independent `strtod()`

### DIFF
--- a/lib/logmsg/type-hinting.c
+++ b/lib/logmsg/type-hinting.c
@@ -137,7 +137,7 @@ type_cast_to_double(const gchar *value, gdouble *out, GError **error)
   gboolean success = TRUE;
 
   errno = 0;
-  *out = strtod(value, &endptr);
+  *out = g_ascii_strtod(value, &endptr);
   if (errno == ERANGE && (*out >= HUGE_VAL || *out <= -HUGE_VAL))
     success = FALSE;
   if (endptr == value)

--- a/lib/parse-number.c
+++ b/lib/parse-number.c
@@ -171,7 +171,7 @@ _parse_double(const gchar *s, gchar **endptr, gdouble *d)
   gdouble val;
 
   errno = 0;
-  val = strtod(s, endptr);
+  val = g_ascii_strtod(s, endptr);
 
   if (errno == ERANGE)
     return FALSE;

--- a/news/bugfix-4702.md
+++ b/news/bugfix-4702.md
@@ -1,0 +1,1 @@
+type hinting: Parsing and casting fractions are now done locale independently.


### PR DESCRIPTION
Fixes #4699.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>
