### PR TITLE
Switch default warning fixes

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -29,10 +29,6 @@
    with care. If you need additional headers, please look for a
    massive list of includes further below. */
 
-#pragma GCC diagnostic ignored "-Wswitch-default"
-#if (defined(__GNUC__) && __GNUC__ >= 6) || (defined(__clang__) && __clang_major__ >= 10)
-#  pragma GCC diagnostic ignored "-Wmisleading-indentation"
-#endif
 /* YYSTYPE and YYLTYPE is defined by the lexer */
 #include "cfg-lexer.h"
 #include "cfg-grammar-internal.h"
@@ -61,6 +57,12 @@
 %define parse.error verbose
 
 %code {
+
+#pragma GCC diagnostic ignored "-Wswitch-default"
+#if (defined(__GNUC__) && __GNUC__ >= 6) || (defined(__clang__) && __clang_major__ >= 10)
+#  pragma GCC diagnostic ignored "-Wmisleading-indentation"
+#endif
+
 
 # define YYLLOC_DEFAULT(Current, Rhs, N)                                \
   do {                                                                  \

--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -251,6 +251,8 @@ _cfg_lex_extend_token_location_to_next_line(CfgLexer *lexer)
 #define YYSTYPE CFG_STYPE
 #define YYLTYPE CFG_LTYPE
 
+#pragma GCC diagnostic ignored "-Wswitch-default"
+
 %}
 
 %option bison-bridge bison-locations reentrant

--- a/modules/afsmtp/afsmtp.c
+++ b/modules/afsmtp/afsmtp.c
@@ -371,6 +371,8 @@ afsmtp_dd_cb_monitor(const gchar *buf, gint buflen, gint writing,
                 evt_tag_str("driver", self->super.super.super.id),
                 evt_tag_mem("data", buf, buflen));
       break;
+    default:
+      break;
     }
 }
 


### PR DESCRIPTION
This PR moves a warning disabling pragma to a private location and fixing the couple of warnings that result from the change. No NEWS file needed.

