### PR TITLE
type-hinting: support explicit value length

### DIFF
--- a/lib/filter/filter-cmp.c
+++ b/lib/filter/filter-cmp.c
@@ -138,7 +138,7 @@ _convert_to_number(const GString *value, LogMessageValueType type, GenericNumber
     {
       gboolean b;
 
-      if (type_cast_to_boolean(value->str, &b, NULL))
+      if (type_cast_to_boolean(value->str, -1, &b, NULL))
         gn_set_int64(number, b);
       else
         gn_set_int64(number, 0);
@@ -148,7 +148,7 @@ _convert_to_number(const GString *value, LogMessageValueType type, GenericNumber
     {
       gint64 msec;
 
-      if (type_cast_to_datetime_msec(value->str, &msec, NULL))
+      if (type_cast_to_datetime_msec(value->str, -1, &msec, NULL))
         gn_set_int64(number, msec);
       else
         gn_set_int64(number, 0);

--- a/lib/logmsg/tests/test_type_hints.c
+++ b/lib/logmsg/tests/test_type_hints.c
@@ -128,7 +128,7 @@ ParameterizedTest(StringBoolPair *string_value_pair, type_hints, test_bool_cast)
   gboolean value;
   GError *error = NULL;
 
-  cr_assert_eq(type_cast_to_boolean(string_value_pair->string, &value, &error), TRUE,
+  cr_assert_eq(type_cast_to_boolean(string_value_pair->string, -1, &value, &error), TRUE,
                "Type cast of \"%s\" to gboolean failed", string_value_pair->string);
   cr_assert_eq(value, string_value_pair->value);
   cr_assert_null(error);
@@ -140,7 +140,7 @@ Test(type_hints, test_invalid_bool_cast)
   gboolean value;
 
   /* test invalid boolean value cast */
-  cr_assert_eq(type_cast_to_boolean("booyah", &value, &error), FALSE,
+  cr_assert_eq(type_cast_to_boolean("booyah", -1, &value, &error), FALSE,
                "Type cast \"booyah\" to gboolean should be failed");
   cr_assert_not_null(error);
   cr_assert_eq(error->domain, TYPE_HINTING_ERROR);
@@ -154,20 +154,20 @@ Test(type_hints, test_int32_cast)
   GError *error = NULL;
   gint32 value;
 
-  cr_assert(type_cast_to_int32("12345", &value, &error), "Type cast of \"12345\" to gint32 failed");
+  cr_assert(type_cast_to_int32("12345", -1, &value, &error), "Type cast of \"12345\" to gint32 failed");
   cr_assert_eq(value, 12345);
   cr_assert_null(error);
 
-  cr_assert(type_cast_to_int32("0x1000", &value, &error), "Type cast of \"0x1000\" to gint32 failed");
+  cr_assert(type_cast_to_int32("0x1000", -1, &value, &error), "Type cast of \"0x1000\" to gint32 failed");
   cr_assert_eq(value, 0x1000);
   cr_assert_null(error);
 
-  cr_assert(type_cast_to_int32("0111", &value, &error), "Type cast of \"0111\" to gint32 failed");
+  cr_assert(type_cast_to_int32("0111", -1, &value, &error), "Type cast of \"0111\" to gint32 failed");
   cr_assert_eq(value, 111);
   cr_assert_null(error);
 
   /* test for invalid string */
-  cr_assert_not(type_cast_to_int32("12345a", &value, &error),
+  cr_assert_not(type_cast_to_int32("12345a", -1, &value, &error),
                 "Type cast of invalid string to gint32 should be failed");
   cr_assert_not_null(error);
   cr_assert_eq(error->domain, TYPE_HINTING_ERROR);
@@ -175,7 +175,7 @@ Test(type_hints, test_int32_cast)
   g_clear_error(&error);
 
   /* empty string */
-  cr_assert_not(type_cast_to_int32("", &value, &error),
+  cr_assert_not(type_cast_to_int32("", -1, &value, &error),
                 "Type cast of empty string to gint32 should be failed");
   cr_assert_not_null(error);
   cr_assert_eq(error->domain, TYPE_HINTING_ERROR);
@@ -184,26 +184,62 @@ Test(type_hints, test_int32_cast)
   g_clear_error(&error);
 }
 
+Test(type_hints, test_int32_nonzero_terminated)
+{
+  GError *error = NULL;
+  gint32 int32_value;
+  gint64 int64_value;
+  gboolean bool_value;
+  gdouble dbl_value;
+  UnixTime ut_value;
+
+  cr_assert(type_cast_to_int32("12345", 3, &int32_value, &error),
+            "Type cast of non-zero terminated \"123\" to gint32 failed");
+  cr_assert_eq(int32_value, 123);
+  cr_assert_null(error);
+
+  cr_assert(type_cast_to_int64("12345", 3, &int64_value, &error),
+            "Type cast of non-zero terminated \"123\" to gint64 failed");
+  cr_assert_eq(int64_value, 123);
+  cr_assert_null(error);
+
+  cr_assert(type_cast_to_boolean("12", 1, &bool_value, &error),
+            "Type cast of non-zero terminated \"1\" to gboolean failed");
+  cr_assert_eq(bool_value, 1);
+  cr_assert_null(error);
+
+  cr_assert(type_cast_to_double("123456", 3, &dbl_value, &error),
+            "Type cast of non-zero terminated \"123\" to gdouble failed");
+  cr_assert(dbl_value - 123 < 0.1);
+  cr_assert_null(error);
+
+  cr_assert(type_cast_to_datetime_unixtime("1699134067.123", 12, &ut_value, &error),
+            "Type cast of non-zero terminated \"1699134067.1\" to unixtime failed");
+  cr_assert(ut_value.ut_sec == 1699134067);
+  cr_assert(ut_value.ut_usec == 100000);
+  cr_assert_null(error);
+}
+
 Test(type_hints, test_int64_cast)
 {
   GError *error = NULL;
   gint64 value;
 
-  cr_assert(type_cast_to_int64("12345", &value, &error), "Type cast of \"12345\" to gint64 failed");
+  cr_assert(type_cast_to_int64("12345", -1, &value, &error), "Type cast of \"12345\" to gint64 failed");
   cr_assert_eq(value, 12345);
   cr_assert_null(error);
 
-  cr_assert(type_cast_to_int64("0x1000", &value, &error), "Type cast of \"0x1000\" to gint64 failed");
+  cr_assert(type_cast_to_int64("0x1000", -1, &value, &error), "Type cast of \"0x1000\" to gint64 failed");
   cr_assert_eq(value, 0x1000);
   cr_assert_null(error);
 
-  cr_assert(type_cast_to_int64("0111", &value, &error), "Type cast of \"0111\" to gint64 failed");
+  cr_assert(type_cast_to_int64("0111", -1, &value, &error), "Type cast of \"0111\" to gint64 failed");
   cr_assert_eq(value, 111);
   cr_assert_null(error);
 
 
   /* test for invalid string */
-  cr_assert_not(type_cast_to_int64("12345a", &value, &error),
+  cr_assert_not(type_cast_to_int64("12345a", -1, &value, &error),
                 "Type cast of invalid string to gint64 should be failed");
   cr_assert_not_null(error);
   cr_assert_eq(error->domain, TYPE_HINTING_ERROR);
@@ -211,7 +247,7 @@ Test(type_hints, test_int64_cast)
   g_clear_error(&error);
 
   /* empty string */
-  cr_assert_not(type_cast_to_int64("", &value, &error),
+  cr_assert_not(type_cast_to_int64("", -1, &value, &error),
                 "Type cast of empty string to gint64 should be failed");
   cr_assert_not_null(error);
   cr_assert_eq(error->domain, TYPE_HINTING_ERROR);
@@ -255,7 +291,7 @@ ParameterizedTest(StringDoublePair *string_value_pair, type_hints, test_double_c
   gdouble value;
   GError *error = NULL;
 
-  cr_assert(type_cast_to_double(string_value_pair->string, &value, &error),
+  cr_assert(type_cast_to_double(string_value_pair->string, -1, &value, &error),
             "Type cast of \"%s\" to double failed", string_value_pair->string);
 
   cr_assert_gdouble_eq(value, string_value_pair->value);
@@ -281,7 +317,7 @@ ParameterizedTest(StringDoublePair *string_value_pair, type_hints, test_invalid_
   gdouble value;
   GError *error = NULL;
 
-  cr_assert_not(type_cast_to_double(string_value_pair->string, &value, &error),
+  cr_assert_not(type_cast_to_double(string_value_pair->string, -1, &value, &error),
                 "Type cast of invalid string (%s) to double should be failed", string_value_pair->string);
   cr_assert_not_null(error);
   cr_assert_eq(error->domain, TYPE_HINTING_ERROR);
@@ -313,7 +349,7 @@ ParameterizedTest(StringUInt64Pair *string_value_pair, type_hints, test_datetime
   gint64 value;
   GError *error = NULL;
 
-  cr_assert_eq(type_cast_to_datetime_msec(string_value_pair->string, &value, &error), TRUE,
+  cr_assert_eq(type_cast_to_datetime_msec(string_value_pair->string, -1, &value, &error), TRUE,
                "Type cast of \"%s\" to msecs failed", string_value_pair->string);
   cr_assert_eq(value, string_value_pair->value,
                "datetime cast failed %" G_GINT64_FORMAT " != %" G_GINT64_FORMAT,
@@ -345,7 +381,7 @@ ParameterizedTest(StringUInt64Pair *string_value_pair, type_hints, test_invalid_
   GError *error = NULL;
   gint64 value;
 
-  cr_assert_eq(type_cast_to_datetime_msec(string_value_pair->string, &value, &error), FALSE,
+  cr_assert_eq(type_cast_to_datetime_msec(string_value_pair->string, -1, &value, &error), FALSE,
                "Type cast of invalid string to gint64 should have failed %s", string_value_pair->string);
   cr_assert_not_null(error);
   cr_assert_eq(error->domain, TYPE_HINTING_ERROR);

--- a/lib/logmsg/type-hinting.h
+++ b/lib/logmsg/type-hinting.h
@@ -40,16 +40,16 @@ enum TypeHintingError
 
 gboolean type_hint_parse(const gchar *hint, LogMessageValueType *out_hint, GError **error);
 
-gboolean type_cast_drop_helper(gint drop_flags, const gchar *value,
+gboolean type_cast_drop_helper(gint drop_flags, const gchar *value, gssize value_len,
                                const gchar *type_hint);
 
-gboolean type_cast_to_boolean(const gchar *value, gboolean *out, GError **error);
-gboolean type_cast_to_int32(const gchar *value, gint32 *out, GError **error);
-gboolean type_cast_to_int64(const gchar *value, gint64 *out, GError **error);
-gboolean type_cast_to_double(const gchar *value, gdouble *out, GError **error);
-gboolean type_cast_to_datetime_msec(const gchar *value, gint64 *out, GError **error);
-gboolean type_cast_to_datetime_unixtime(const gchar *value, UnixTime *ut, GError **error);
+gboolean type_cast_to_boolean(const gchar *value, gssize value_len, gboolean *out, GError **error);
+gboolean type_cast_to_int32(const gchar *value, gssize value_len, gint32 *out, GError **error);
+gboolean type_cast_to_int64(const gchar *value, gssize value_len, gint64 *out, GError **error);
+gboolean type_cast_to_double(const gchar *value, gssize value_len, gdouble *out, GError **error);
+gboolean type_cast_to_datetime_msec(const gchar *value, gssize value_len, gint64 *out, GError **error);
+gboolean type_cast_to_datetime_unixtime(const gchar *value, gssize value_len, UnixTime *ut, GError **error);
 
-gboolean type_cast_validate(const gchar *value, LogMessageValueType type, GError **error);
+gboolean type_cast_validate(const gchar *value, gssize value_len, LogMessageValueType type, GError **error);
 
 #endif

--- a/modules/afmongodb/afmongodb-worker.c
+++ b/modules/afmongodb/afmongodb-worker.c
@@ -285,11 +285,11 @@ _vp_process_value(const gchar *name, const gchar *prefix, LogMessageValueType ty
     {
       gboolean b;
 
-      if (type_cast_to_boolean(value, &b, NULL))
+      if (type_cast_to_boolean(value, value_len, &b, NULL))
         bson_append_bool(o, name, -1, b);
       else
         {
-          gboolean r = type_cast_drop_helper(owner->template_options.on_error, value, "boolean");
+          gboolean r = type_cast_drop_helper(owner->template_options.on_error, value, value_len, "boolean");
 
           if (fallback)
             bson_append_utf8(o, name, -1, value, value_len);
@@ -302,7 +302,7 @@ _vp_process_value(const gchar *name, const gchar *prefix, LogMessageValueType ty
     {
       gint64 i;
 
-      if (type_cast_to_int64(value, &i, NULL))
+      if (type_cast_to_int64(value, value_len, &i, NULL))
         {
           if (G_MININT32 <= i && i <= G_MAXINT32)
             bson_append_int32(o, name, -1, i);
@@ -311,7 +311,7 @@ _vp_process_value(const gchar *name, const gchar *prefix, LogMessageValueType ty
         }
       else
         {
-          gboolean r = type_cast_drop_helper(owner->template_options.on_error, value, "integer");
+          gboolean r = type_cast_drop_helper(owner->template_options.on_error, value, value_len, "integer");
 
           if (fallback)
             bson_append_utf8(o, name, -1, value, value_len);
@@ -325,11 +325,11 @@ _vp_process_value(const gchar *name, const gchar *prefix, LogMessageValueType ty
     {
       gdouble d;
 
-      if (type_cast_to_double(value, &d, NULL))
+      if (type_cast_to_double(value, value_len, &d, NULL))
         bson_append_double(o, name, -1, d);
       else
         {
-          gboolean r = type_cast_drop_helper(owner->template_options.on_error, value, "double");
+          gboolean r = type_cast_drop_helper(owner->template_options.on_error, value, value_len, "double");
           if (fallback)
             bson_append_utf8(o, name, -1, value, value_len);
           else
@@ -342,11 +342,11 @@ _vp_process_value(const gchar *name, const gchar *prefix, LogMessageValueType ty
     {
       gint64 msec;
 
-      if (type_cast_to_datetime_msec(value, &msec, NULL))
+      if (type_cast_to_datetime_msec(value, value_len, &msec, NULL))
         bson_append_date_time(o, name, -1, msec);
       else
         {
-          gboolean r = type_cast_drop_helper(owner->template_options.on_error, value, "datetime");
+          gboolean r = type_cast_drop_helper(owner->template_options.on_error, value, value_len, "datetime");
 
           if (fallback)
             bson_append_utf8(o, name, -1, value, value_len);
@@ -394,7 +394,7 @@ _vp_process_value(const gchar *name, const gchar *prefix, LogMessageValueType ty
         }
       else
         {
-          gboolean r = type_cast_drop_helper(owner->template_options.on_error, value, "json");
+          gboolean r = type_cast_drop_helper(owner->template_options.on_error, value, value_len, "json");
 
           if (fallback)
             bson_append_utf8(o, name, -1, value, value_len);

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -840,14 +840,14 @@ afsql_dd_append_value_to_be_inserted(AFSqlDestDriver *self,
     case LM_VT_INTEGER:
     {
       gint64 k;
-      if (type_cast_to_int64(value->str, &k, NULL))
+      if (type_cast_to_int64(value->str, -1, &k, NULL))
         {
           g_string_append_len(insert_command, value->str, value->len);
         }
       else
         {
           need_drop = type_cast_drop_helper(self->template_options.on_error,
-                                            value->str, "int");
+                                            value->str, -1, "int");
           if (fallback)
             afsql_dd_append_quoted_value(self, value, insert_command);
         }
@@ -856,14 +856,14 @@ afsql_dd_append_value_to_be_inserted(AFSqlDestDriver *self,
     case LM_VT_DOUBLE:
     {
       gdouble d;
-      if (type_cast_to_double(value->str, &d, NULL))
+      if (type_cast_to_double(value->str, -1, &d, NULL))
         {
           g_string_append_len(insert_command, value->str, value->len);
         }
       else
         {
           need_drop = type_cast_drop_helper(self->template_options.on_error,
-                                            value->str, "double");
+                                            value->str, -1, "double");
           if (fallback)
             afsql_dd_append_quoted_value(self, value, insert_command);
         }
@@ -872,7 +872,7 @@ afsql_dd_append_value_to_be_inserted(AFSqlDestDriver *self,
     case LM_VT_BOOLEAN:
     {
       gboolean b;
-      if (type_cast_to_boolean(value->str, &b, NULL))
+      if (type_cast_to_boolean(value->str, -1, &b, NULL))
         {
           if (b)
             g_string_append(insert_command, "TRUE");
@@ -882,7 +882,7 @@ afsql_dd_append_value_to_be_inserted(AFSqlDestDriver *self,
       else
         {
           need_drop = type_cast_drop_helper(self->template_options.on_error,
-                                            value->str, "boolean");
+                                            value->str, -1, "boolean");
           if (fallback)
             afsql_dd_append_quoted_value(self, value, insert_command);
         }

--- a/modules/correlation/pdbtool/pdbtool.c
+++ b/modules/correlation/pdbtool/pdbtool.c
@@ -787,16 +787,16 @@ pdbtool_test_value_type_callback(NVHandle handle, const gchar *name,
       valid = TRUE;
       break;
     case LM_VT_DATETIME:
-      valid = type_cast_to_datetime_unixtime(value, &ut, &error);
+      valid = type_cast_to_datetime_unixtime(value, length, &ut, &error);
       break;
     case LM_VT_INTEGER:
-      valid = type_cast_to_int64(value, &i64, &error);
+      valid = type_cast_to_int64(value, length, &i64, &error);
       break;
     case LM_VT_DOUBLE:
-      valid = type_cast_to_double(value, &d, &error);
+      valid = type_cast_to_double(value, length, &d, &error);
       break;
     case LM_VT_BOOLEAN:
-      valid = type_cast_to_boolean(value, &b, &error);
+      valid = type_cast_to_boolean(value, length, &b, &error);
       break;
     }
   if (!valid)

--- a/modules/csvparser/csvparser.c
+++ b/modules/csvparser/csvparser.c
@@ -206,7 +206,7 @@ _process_column(CSVParser *self, CSVScanner *scanner, LogMessage *msg, CSVParser
   key_formatter_t _key_formatter = dispatch_key_formatter(self->prefix);
   gboolean should_set_value = TRUE;
 
-  if (!type_cast_validate(current_value, current_column_type, &error))
+  if (!type_cast_validate(current_value, -1, current_column_type, &error))
     {
       if (!(self->on_error & ON_ERROR_SILENT))
         {
@@ -216,7 +216,7 @@ _process_column(CSVParser *self, CSVScanner *scanner, LogMessage *msg, CSVParser
         }
       g_clear_error(&error);
 
-      gboolean need_drop = type_cast_drop_helper(self->on_error, current_value,
+      gboolean need_drop = type_cast_drop_helper(self->on_error, current_value, -1,
                                                  log_msg_value_type_to_str(current_column_type));
       if (need_drop)
         {

--- a/modules/grpc/bigquery/bigquery-worker.cpp
+++ b/modules/grpc/bigquery/bigquery-worker.cpp
@@ -231,9 +231,9 @@ DestinationWorker::insert_field(const google::protobuf::Reflection *reflection, 
     case FieldDescriptor::CppType::CPPTYPE_INT32:
     {
       int32_t v;
-      if (!type_cast_to_int32(value.str, &v, NULL))
+      if (!type_cast_to_int32(value.str, -1, &v, NULL))
         {
-          type_cast_drop_helper(owner->template_options.on_error, value.str, "integer");
+          type_cast_drop_helper(owner->template_options.on_error, value.str, -1, "integer");
           goto error;
         }
       reflection->SetInt32(message, field.field_desc, v);
@@ -242,9 +242,9 @@ DestinationWorker::insert_field(const google::protobuf::Reflection *reflection, 
     case FieldDescriptor::CppType::CPPTYPE_INT64:
     {
       int64_t v;
-      if (!type_cast_to_int64(value.str, &v, NULL))
+      if (!type_cast_to_int64(value.str, -1, &v, NULL))
         {
-          type_cast_drop_helper(owner->template_options.on_error, value.str, "integer");
+          type_cast_drop_helper(owner->template_options.on_error, value.str, -1, "integer");
           goto error;
         }
       reflection->SetInt64(message, field.field_desc, v);
@@ -253,9 +253,9 @@ DestinationWorker::insert_field(const google::protobuf::Reflection *reflection, 
     case FieldDescriptor::CppType::CPPTYPE_UINT32:
     {
       int64_t v;
-      if (!type_cast_to_int64(value.str, &v, NULL))
+      if (!type_cast_to_int64(value.str, -1, &v, NULL))
         {
-          type_cast_drop_helper(owner->template_options.on_error, value.str, "integer");
+          type_cast_drop_helper(owner->template_options.on_error, value.str, -1, "integer");
           goto error;
         }
       reflection->SetUInt32(message, field.field_desc, (uint32_t) v);
@@ -264,9 +264,9 @@ DestinationWorker::insert_field(const google::protobuf::Reflection *reflection, 
     case FieldDescriptor::CppType::CPPTYPE_UINT64:
     {
       int64_t v;
-      if (!type_cast_to_int64(value.str, &v, NULL))
+      if (!type_cast_to_int64(value.str, -1, &v, NULL))
         {
-          type_cast_drop_helper(owner->template_options.on_error, value.str, "integer");
+          type_cast_drop_helper(owner->template_options.on_error, value.str, -1, "integer");
           goto error;
         }
       reflection->SetUInt64(message, field.field_desc, (uint64_t) v);
@@ -275,9 +275,9 @@ DestinationWorker::insert_field(const google::protobuf::Reflection *reflection, 
     case FieldDescriptor::CppType::CPPTYPE_DOUBLE:
     {
       double v;
-      if (!type_cast_to_double(value.str, &v, NULL))
+      if (!type_cast_to_double(value.str, -1, &v, NULL))
         {
-          type_cast_drop_helper(owner->template_options.on_error, value.str, "double");
+          type_cast_drop_helper(owner->template_options.on_error, value.str, -1, "double");
           goto error;
         }
       reflection->SetDouble(message, field.field_desc, v);
@@ -286,9 +286,9 @@ DestinationWorker::insert_field(const google::protobuf::Reflection *reflection, 
     case FieldDescriptor::CppType::CPPTYPE_FLOAT:
     {
       double v;
-      if (!type_cast_to_double(value.str, &v, NULL))
+      if (!type_cast_to_double(value.str, -1, &v, NULL))
         {
-          type_cast_drop_helper(owner->template_options.on_error, value.str, "double");
+          type_cast_drop_helper(owner->template_options.on_error, value.str, -1, "double");
           goto error;
         }
       reflection->SetFloat(message, field.field_desc, (float) v);
@@ -297,9 +297,9 @@ DestinationWorker::insert_field(const google::protobuf::Reflection *reflection, 
     case FieldDescriptor::CppType::CPPTYPE_BOOL:
     {
       gboolean v;
-      if (!type_cast_to_boolean(value.str, &v, NULL))
+      if (!type_cast_to_boolean(value.str, -1, &v, NULL))
         {
-          type_cast_drop_helper(owner->template_options.on_error, value.str, "boolean");
+          type_cast_drop_helper(owner->template_options.on_error, value.str, -1, "boolean");
           goto error;
         }
       reflection->SetBool(message, field.field_desc, v);

--- a/modules/grpc/otel/otel-protobuf-formatter.cpp
+++ b/modules/grpc/otel/otel-protobuf-formatter.cpp
@@ -113,7 +113,7 @@ _get_bool(LogMessage *msg, const gchar *name)
     return false;
 
   gboolean b = false;
-  if (!type_cast_to_boolean(value, &b, NULL))
+  if (!type_cast_to_boolean(value, len, &b, NULL))
     return false;
 
   return b;
@@ -130,7 +130,7 @@ _get_double(LogMessage *msg, const gchar *name)
     return 0;
 
   gdouble d = 0;
-  if (!type_cast_to_double(value, &d, NULL))
+  if (!type_cast_to_double(value, len, &d, NULL))
     return 0;
 
   return d;
@@ -195,7 +195,7 @@ _set_AnyValue(const gchar *value, gssize len, LogMessageValueType type, AnyValue
     case LM_VT_BOOLEAN:
     {
       gboolean b = FALSE;
-      if (!type_cast_to_boolean(value, &b, &error))
+      if (!type_cast_to_boolean(value, len, &b, &error))
         {
           msg_error("OpenTelemetry: Cannot parse boolean value, falling back to FALSE",
                     evt_tag_str("name", name_for_error_log),
@@ -209,7 +209,7 @@ _set_AnyValue(const gchar *value, gssize len, LogMessageValueType type, AnyValue
     case LM_VT_DOUBLE:
     {
       gdouble d = 0;
-      if (!type_cast_to_double(value, &d, &error))
+      if (!type_cast_to_double(value, len, &d, &error))
         {
           msg_error("OpenTelemetry: Cannot parse double value, falling back to 0",
                     evt_tag_str("name", name_for_error_log),
@@ -223,7 +223,7 @@ _set_AnyValue(const gchar *value, gssize len, LogMessageValueType type, AnyValue
     case LM_VT_INTEGER:
     {
       gint64 ll = 0;
-      if (!type_cast_to_int64(value, &ll, &error))
+      if (!type_cast_to_int64(value, len, &ll, &error))
         {
           msg_error("OpenTelemetry: Cannot parse integer value, falling back to 0",
                     evt_tag_str("name", name_for_error_log),
@@ -589,7 +589,7 @@ ProtobufFormatter::add_exemplars(LogMessage *msg, std::string &key_buffer, Repea
       if (type == LM_VT_INTEGER)
         {
           gint64 ll = 0;
-          if (!type_cast_to_int64(value, &ll, &error))
+          if (!type_cast_to_int64(value, len, &ll, &error))
             {
               msg_error("OpenTelemetry: Cannot parse integer value, falling back to 0",
                         evt_tag_str("name", key_buffer.c_str()),
@@ -602,7 +602,7 @@ ProtobufFormatter::add_exemplars(LogMessage *msg, std::string &key_buffer, Repea
       else if (type == LM_VT_DOUBLE)
         {
           gdouble d = 0;
-          if (!type_cast_to_double(value, &d, &error))
+          if (!type_cast_to_double(value, len, &d, &error))
             {
               msg_error("OpenTelemetry: Cannot parse double value, falling back to 0",
                         evt_tag_str("name", key_buffer.c_str()),
@@ -675,7 +675,7 @@ ProtobufFormatter::add_number_data_points(LogMessage *msg, const char *prefix,
       if (type == LM_VT_INTEGER)
         {
           gint64 ll = 0;
-          if (!type_cast_to_int64(value, &ll, &error))
+          if (!type_cast_to_int64(value, len, &ll, &error))
             {
               msg_error("OpenTelemetry: Cannot parse integer value, falling back to 0",
                         evt_tag_str("name", key_buffer.c_str()),
@@ -688,7 +688,7 @@ ProtobufFormatter::add_number_data_points(LogMessage *msg, const char *prefix,
       else if (type == LM_VT_DOUBLE)
         {
           gdouble d = 0;
-          if (!type_cast_to_double(value, &d, &error))
+          if (!type_cast_to_double(value, len, &d, &error))
             {
               msg_error("OpenTelemetry: Cannot parse double value, falling back to 0",
                         evt_tag_str("name", key_buffer.c_str()),

--- a/modules/json/format-json.c
+++ b/modules/json/format-json.c
@@ -315,7 +315,7 @@ tf_json_append_with_type_hint(const gchar *name, LogMessageValueType type, json_
       const gchar *v = value;
       gsize v_len = value_len;
 
-      if (!type_cast_to_int64(value, &i64, NULL))
+      if (!type_cast_to_int64(value, value_len, &i64, NULL))
         {
           if ((on_error & ON_ERROR_FALLBACK_TO_STRING))
             {
@@ -323,7 +323,7 @@ tf_json_append_with_type_hint(const gchar *name, LogMessageValueType type, json_
               return TRUE;
             }
 
-          *drop = type_cast_drop_helper(on_error, value, "integer");
+          *drop = type_cast_drop_helper(on_error, value, value_len, "integer");
           return FALSE;
         }
 
@@ -336,7 +336,7 @@ tf_json_append_with_type_hint(const gchar *name, LogMessageValueType type, json_
       const gchar *v = value;
       gsize v_len = value_len;
 
-      if (!type_cast_to_double(value, &d, NULL))
+      if (!type_cast_to_double(value, value_len, &d, NULL))
         {
           if ((on_error & ON_ERROR_FALLBACK_TO_STRING))
             {
@@ -344,7 +344,7 @@ tf_json_append_with_type_hint(const gchar *name, LogMessageValueType type, json_
               return TRUE;
             }
 
-          *drop = type_cast_drop_helper(on_error, value, "double");
+          *drop = type_cast_drop_helper(on_error, value, value_len, "double");
           return FALSE;
         }
 
@@ -357,7 +357,7 @@ tf_json_append_with_type_hint(const gchar *name, LogMessageValueType type, json_
       const gchar *v = value;
       gsize v_len = value_len;
 
-      if (!type_cast_to_boolean(value, &b, NULL))
+      if (!type_cast_to_boolean(value, value_len, &b, NULL))
         {
           if ((on_error & ON_ERROR_FALLBACK_TO_STRING))
             {
@@ -365,7 +365,7 @@ tf_json_append_with_type_hint(const gchar *name, LogMessageValueType type, json_
               return TRUE;
             }
 
-          *drop = type_cast_drop_helper(on_error, value, "boolean");
+          *drop = type_cast_drop_helper(on_error, value, value_len, "boolean");
           return FALSE;
         }
 

--- a/modules/python/python-types.c
+++ b/modules/python/python-types.c
@@ -182,7 +182,7 @@ py_obj_from_log_msg_value(const gchar *value, gssize value_len, LogMessageValueT
     case LM_VT_INTEGER:
     {
       gint64 l;
-      if (type_cast_to_int64(value, &l, NULL))
+      if (type_cast_to_int64(value, value_len, &l, NULL))
         return py_long_from_long(l);
       goto type_cast_error;
     }
@@ -190,7 +190,7 @@ py_obj_from_log_msg_value(const gchar *value, gssize value_len, LogMessageValueT
     case LM_VT_DOUBLE:
     {
       gdouble d;
-      if (type_cast_to_double(value, &d, NULL))
+      if (type_cast_to_double(value, value_len, &d, NULL))
         return py_double_from_double(d);
       goto type_cast_error;
     }
@@ -198,7 +198,7 @@ py_obj_from_log_msg_value(const gchar *value, gssize value_len, LogMessageValueT
     case LM_VT_BOOLEAN:
     {
       gboolean b;
-      if (type_cast_to_boolean(value, &b, NULL))
+      if (type_cast_to_boolean(value, value_len, &b, NULL))
         return py_boolean_from_boolean(b);
       goto type_cast_error;
     }
@@ -213,7 +213,7 @@ py_obj_from_log_msg_value(const gchar *value, gssize value_len, LogMessageValueT
     {
       gint64 msec = 0;
 
-      if (type_cast_to_datetime_msec(value, &msec, NULL))
+      if (type_cast_to_datetime_msec(value, value_len, &msec, NULL))
         return py_datetime_from_msec(msec);
       goto type_cast_error;
     }

--- a/modules/python/python-value-pairs.c
+++ b/modules/python/python-value-pairs.c
@@ -46,7 +46,7 @@ python_worker_vp_add_one(const gchar *name,
                 evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
       _py_finish_exception_handling();
 
-      return type_cast_drop_helper(template_options->on_error, value, log_msg_value_type_to_str(type));
+      return type_cast_drop_helper(template_options->on_error, value, value_len, log_msg_value_type_to_str(type));
     }
 
   PyDict_SetItemString(dict, name, obj);

--- a/modules/riemann/riemann-worker.c
+++ b/modules/riemann/riemann-worker.c
@@ -190,12 +190,12 @@ riemann_add_metric_to_event(RiemannDestWorker *self, riemann_event_t *event, Log
     {
       gint64 i;
 
-      if (type_cast_to_int64(str->str, &i, NULL))
+      if (type_cast_to_int64(str->str, -1, &i, NULL))
         riemann_event_set(event, RIEMANN_EVENT_FIELD_METRIC_S64, i,
                           RIEMANN_EVENT_FIELD_NONE);
       else
         return !type_cast_drop_helper(owner->template_options.on_error,
-                                      str->str, "int");
+                                      str->str, -1, "int");
       break;
     }
     case LM_VT_DOUBLE:
@@ -203,17 +203,17 @@ riemann_add_metric_to_event(RiemannDestWorker *self, riemann_event_t *event, Log
     {
       gdouble d;
 
-      if (type_cast_to_double(str->str, &d, NULL))
+      if (type_cast_to_double(str->str, -1, &d, NULL))
         riemann_event_set(event, RIEMANN_EVENT_FIELD_METRIC_D, d,
                           RIEMANN_EVENT_FIELD_NONE);
       else
         return !type_cast_drop_helper(owner->template_options.on_error,
-                                      str->str, "double");
+                                      str->str, -1, "double");
       break;
     }
     default:
       return !type_cast_drop_helper(owner->template_options.on_error,
-                                    str->str, "<unknown>");
+                                    str->str, -1, "<unknown>");
       break;
     }
   return TRUE;
@@ -233,12 +233,12 @@ riemann_add_ttl_to_event(RiemannDestWorker *self, riemann_event_t *event, LogMes
   if (str->len == 0)
     return TRUE;
 
-  if (type_cast_to_double (str->str, &d, NULL))
+  if (type_cast_to_double (str->str, -1, &d, NULL))
     riemann_event_set(event, RIEMANN_EVENT_FIELD_TTL, d,
                       RIEMANN_EVENT_FIELD_NONE);
   else
     return !type_cast_drop_helper(owner->template_options.on_error,
-                                  str->str, "double");
+                                  str->str, -1, "double");
   return TRUE;
 }
 

--- a/modules/timestamp/tf-format-date.c
+++ b/modules/timestamp/tf-format-date.c
@@ -116,7 +116,7 @@ tf_format_date_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvo
   if (state->super.argc != 0)
     {
       const gchar *ts = args->argv[0]->str;
-      if (!type_cast_to_datetime_unixtime(ts, &ut, NULL))
+      if (!type_cast_to_datetime_unixtime(ts, -1, &ut, NULL))
         {
           ut.ut_sec = 0;
           ut.ut_usec = 0;


### PR DESCRIPTION
Sometimes we are casting strings with an explicit length value, but the type hinting code simply assumed that everything was NUL terminated, which is not the case for indirect values.

No NEWS needed.
