### PR TITLE
timeutils: accept BSD timestamps where the day-of-month is not padded with spaces

### DIFF
--- a/lib/timeutils/tests/test_scan-timestamp.c
+++ b/lib/timeutils/tests/test_scan-timestamp.c
@@ -173,6 +173,13 @@ Test(parse_timestamp, bsd_extensions)
   _expect_rfc3164_timestamp_eq("Dec  3 2019 09:10:12 ", "2019-12-03T09:10:12.000+01:00");
 }
 
+Test(parse_timestamp, bsd_invalid)
+{
+  /* single space between month and mday */
+  _expect_rfc3164_timestamp_eq("Dec 3 09:10:12", "2017-12-03T09:10:12.000+01:00");
+  _expect_rfc3164_timestamp_eq("Dec 3 09:10:12.987", "2017-12-03T09:10:12.987+01:00");
+}
+
 Test(parse_timestamp, accept_iso_timestamps_with_space)
 {
   _expect_rfc3164_timestamp_eq("2017-12-03 09:10:12.987+01:00", "2017-12-03T09:10:12.987+01:00");


### PR DESCRIPTION
A discussion on reddit me at 3am triggered me to look into this, and due to past refactors this was a lot easier than I thought.

This is an often occuring issue with incoming syslog style logs.
