### PR TITLE
stats: counter underflow after `query --reset`

### DIFF
--- a/lib/logqueue.c
+++ b/lib/logqueue.c
@@ -257,8 +257,8 @@ _register_shared_counters(LogQueue *self, gint stats_level, StatsClusterKeyBuild
                            &self->metrics.shared.queued_messages);
     stats_register_counter(stats_level, self->metrics.shared.output_events_sc_key, SC_TYPE_DROPPED,
                            &self->metrics.shared.dropped_messages);
-    stats_register_counter_and_index(stats_level, self->metrics.shared.memory_usage_sc_key, SC_TYPE_SINGLE_VALUE,
-                                     &self->metrics.shared.memory_usage);
+    stats_register_counter(stats_level, self->metrics.shared.memory_usage_sc_key, SC_TYPE_SINGLE_VALUE,
+                           &self->metrics.shared.memory_usage);
   }
   stats_unlock();
 }

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -367,6 +367,27 @@ stats_cluster_untrack_counter(StatsCluster *self, gint type, StatsCounterItem **
   *counter = NULL;
 }
 
+static inline void
+_reset_counter_if_needed(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data)
+{
+  if (strcmp(stats_cluster_get_type_name(sc, type), "memory_usage") == 0)
+    return;
+
+  switch (type)
+    {
+    case SC_TYPE_QUEUED:
+      return;
+    default:
+      stats_counter_set(counter, 0);
+    }
+}
+
+void
+stats_cluster_reset_counter_if_needed(StatsCluster *sc, StatsCounterItem *counter)
+{
+  _reset_counter_if_needed(sc, counter->type, counter, NULL);
+}
+
 static gchar *
 _stats_build_query_key(StatsCluster *self)
 {

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -228,10 +228,9 @@ stats_cluster_foreach_counter(StatsCluster *self, StatsForeachCounterFunc func, 
 
   for (type = 0; type < self->counter_group.capacity; type++)
     {
-      if (self->live_mask & (1 << type))
-        {
-          func(self, type, &self->counter_group.counters[type], user_data);
-        }
+      StatsCounterItem *counter = stats_cluster_get_counter(self, type);
+      if (counter)
+        func(self, type, counter, user_data);
     }
 }
 

--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -396,14 +396,6 @@ stats_cluster_is_alive(StatsCluster *self, gint type)
   return !!((1<<type) & self->live_mask);
 }
 
-gboolean
-stats_cluster_is_indexed(StatsCluster *self, gint type)
-{
-  g_assert(type < self->counter_group.capacity);
-
-  return !!((1<<type) & self->indexed_mask);
-}
-
 StatsCluster *
 stats_cluster_new(const StatsClusterKey *key)
 {

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -182,6 +182,7 @@ StatsCounterItem *stats_cluster_track_counter(StatsCluster *self, gint type);
 StatsCounterItem *stats_cluster_get_counter(StatsCluster *self, gint type);
 void stats_cluster_untrack_counter(StatsCluster *self, gint type, StatsCounterItem **counter);
 gboolean stats_cluster_is_alive(StatsCluster *self, gint type);
+void stats_cluster_reset_counter_if_needed(StatsCluster *sc, StatsCounterItem *counter);
 
 static inline gboolean
 stats_cluster_is_orphaned(StatsCluster *self)

--- a/lib/stats/stats-cluster.h
+++ b/lib/stats/stats-cluster.h
@@ -157,7 +157,6 @@ typedef struct _StatsCluster
   StatsCounterGroup counter_group;
   guint16 use_count;
   guint16 live_mask;
-  guint16 indexed_mask;
   guint16 dynamic:1;
   gchar *query_key;
 } StatsCluster;
@@ -183,7 +182,6 @@ StatsCounterItem *stats_cluster_track_counter(StatsCluster *self, gint type);
 StatsCounterItem *stats_cluster_get_counter(StatsCluster *self, gint type);
 void stats_cluster_untrack_counter(StatsCluster *self, gint type, StatsCounterItem **counter);
 gboolean stats_cluster_is_alive(StatsCluster *self, gint type);
-gboolean stats_cluster_is_indexed(StatsCluster *self, gint type);
 
 static inline gboolean
 stats_cluster_is_orphaned(StatsCluster *self)

--- a/lib/stats/stats-control.c
+++ b/lib/stats/stats-control.c
@@ -36,12 +36,6 @@
 
 #include <string.h>
 
-static void
-_reset_counter(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data)
-{
-  stats_counter_set(counter, 0);
-}
-
 static inline void
 _reset_counter_if_needed(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data)
 {
@@ -53,8 +47,14 @@ _reset_counter_if_needed(StatsCluster *sc, gint type, StatsCounterItem *counter,
     case SC_TYPE_QUEUED:
       return;
     default:
-      _reset_counter(sc, type, counter, user_data);
+      stats_counter_set(counter, 0);
     }
+}
+
+void
+stats_control_reset_counter_if_needed(StatsCluster *sc, StatsCounterItem *counter)
+{
+  _reset_counter_if_needed(sc, counter->type, counter, NULL);
 }
 
 static void

--- a/lib/stats/stats-control.c
+++ b/lib/stats/stats-control.c
@@ -36,25 +36,11 @@
 
 #include <string.h>
 
+
 static inline void
 _reset_counter_if_needed(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data)
 {
-  if (strcmp(stats_cluster_get_type_name(sc, type), "memory_usage") == 0)
-    return;
-
-  switch (type)
-    {
-    case SC_TYPE_QUEUED:
-      return;
-    default:
-      stats_counter_set(counter, 0);
-    }
-}
-
-void
-stats_control_reset_counter_if_needed(StatsCluster *sc, StatsCounterItem *counter)
-{
-  _reset_counter_if_needed(sc, counter->type, counter, NULL);
+  stats_cluster_reset_counter_if_needed(sc, counter);
 }
 
 static void

--- a/lib/stats/stats-control.c
+++ b/lib/stats/stats-control.c
@@ -45,9 +45,6 @@ _reset_counter(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer 
 static inline void
 _reset_counter_if_needed(StatsCluster *sc, gint type, StatsCounterItem *counter, gpointer user_data)
 {
-  if (stats_counter_read_only(counter))
-    return;
-
   if (strcmp(stats_cluster_get_type_name(sc, type), "memory_usage") == 0)
     return;
 

--- a/lib/stats/stats-control.h
+++ b/lib/stats/stats-control.h
@@ -28,6 +28,5 @@
 #include "stats/stats-cluster.h"
 
 void stats_register_control_commands(void);
-void stats_control_reset_counter_if_needed(StatsCluster *sc, StatsCounterItem *counter);
 
 #endif

--- a/lib/stats/stats-control.h
+++ b/lib/stats/stats-control.h
@@ -25,7 +25,9 @@
 #define STATS_CONTROL_H_INCLUDED 1
 
 #include "syslog-ng.h"
+#include "stats/stats-cluster.h"
 
 void stats_register_control_commands(void);
+void stats_control_reset_counter_if_needed(StatsCluster *sc, StatsCounterItem *counter);
 
 #endif

--- a/lib/stats/stats-query-commands.c
+++ b/lib/stats/stats-query-commands.c
@@ -54,17 +54,21 @@ _append_reset_msg_if_found_matching_counters(gboolean found_match, GString *resu
 }
 
 static gboolean
-_ctl_format_get(StatsCounterItem *ctr, gpointer user_data)
+_ctl_format_get(gpointer user_data)
 {
-  GString *str = (GString *)user_data;
+  gpointer *args = (gpointer *) user_data;
+  StatsCounterItem *ctr = (StatsCounterItem *) args[0];
+  GString *str = (GString *)args[1];
   g_string_append_printf(str, "%s=%"G_GSIZE_FORMAT"\n", stats_counter_get_name(ctr), stats_counter_get(ctr));
   return TRUE;
 }
 
 static gboolean
-_ctl_format_name_without_value(StatsCounterItem *ctr, gpointer user_data)
+_ctl_format_name_without_value(gpointer user_data)
 {
-  GString *str = (GString *)user_data;
+  gpointer *args = (gpointer *) user_data;
+  StatsCounterItem *ctr = (StatsCounterItem *) args[0];
+  GString *str = (GString *)args[1];
   g_string_append_printf(str, "%s\n", stats_counter_get_name(ctr));
   return TRUE;
 }

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -77,7 +77,7 @@ _process_counter_if_matching(StatsCluster *sc, gint type, StatsCounterItem *coun
 
           process_func(counter, process_func_user_data, format_cb, format_cb_user_data);
           if (must_reset)
-            stats_control_reset_counter_if_needed(sc, counter);
+            stats_cluster_reset_counter_if_needed(sc, counter);
 
           if (single_match)
             {

--- a/lib/stats/stats-query.h
+++ b/lib/stats/stats-query.h
@@ -27,19 +27,13 @@
 #include "stats-cluster.h"
 #include "syslog-ng.h"
 
-typedef gboolean (*StatsFormatCb)(StatsCounterItem *ctr, gpointer user_data);
-typedef gboolean (*StatsSumFormatCb)(gpointer user_data);
+typedef gboolean (*StatsFormatCb)(gpointer user_data);
 
 gboolean stats_query_list(const gchar *expr, StatsFormatCb format_cb, gpointer result);
 gboolean stats_query_list_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, gpointer result);
 gboolean stats_query_get(const gchar *expr, StatsFormatCb format_cb, gpointer result);
 gboolean stats_query_get_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, gpointer result);
-gboolean stats_query_get_sum(const gchar *expr, StatsSumFormatCb format_cb, gpointer result);
-gboolean stats_query_get_sum_and_reset_counters(const gchar *expr, StatsSumFormatCb format_cb, gpointer result);
+gboolean stats_query_get_sum(const gchar *expr, StatsFormatCb format_cb, gpointer result);
+gboolean stats_query_get_sum_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, gpointer result);
 
-void stats_query_init(void);
-void stats_query_deinit(void);
-
-void stats_query_index_counter(StatsCluster *cluster, gint type);
-void stats_query_deindex_cluster(StatsCluster *cluster);
 #endif

--- a/lib/stats/stats.c
+++ b/lib/stats/stats.c
@@ -241,13 +241,11 @@ stats_init(void)
   stats_cluster_init();
   stats_registry_init();
   stats_aggregator_registry_init();
-  stats_query_init();
 }
 
 void
 stats_destroy(void)
 {
-  stats_query_deinit();
   stats_aggregator_registry_deinit();
   stats_registry_deinit();
   stats_cluster_deinit();

--- a/lib/stats/tests/test_stats_query.c
+++ b/lib/stats/tests/test_stats_query.c
@@ -129,10 +129,12 @@ _initialize_counter_hash(void)
 }
 
 static gboolean
-_test_format_log_msg_get(StatsCounterItem *ctr, gpointer user_data)
+_test_format_log_msg_get(gpointer user_data)
 {
+  gpointer *args = (gpointer *) user_data;
+  StatsCounterItem *ctr = (StatsCounterItem *) args[0];
+  LogMessage *msg = (LogMessage *) args[1];
   gchar *name, *value;
-  LogMessage *msg = (LogMessage *)user_data;
 
   name = g_strdup_printf("%s", stats_counter_get_name(ctr));
   value = g_strdup_printf("%"G_GSIZE_FORMAT, stats_counter_get(ctr));
@@ -146,9 +148,11 @@ _test_format_log_msg_get(StatsCounterItem *ctr, gpointer user_data)
 }
 
 static gboolean
-_test_format_str_get(StatsCounterItem *ctr, gpointer user_data)
+_test_format_str_get(gpointer user_data)
 {
-  GString *str = (GString *)user_data;
+  gpointer *args = (gpointer *) user_data;
+  StatsCounterItem *ctr = (StatsCounterItem *) args[0];
+  GString *str = (GString *) args[1];
   g_string_append_printf(str, "%s: %"G_GSIZE_FORMAT"\n", stats_counter_get_name(ctr), stats_counter_get(ctr));
 
   return TRUE;
@@ -185,9 +189,11 @@ _test_format_str_get_sum(gpointer user_data)
 }
 
 static gboolean
-_test_format_list(StatsCounterItem *ctr, gpointer user_data)
+_test_format_list(gpointer user_data)
 {
-  GString *str = (GString *)user_data;
+  gpointer *args = (gpointer *) user_data;
+  StatsCounterItem *ctr = (StatsCounterItem *) args[0];
+  GString *str = (GString *) args[1];
   g_string_append_printf(str, "%s\n", stats_counter_get_name(ctr));
 
   return TRUE;


### PR DESCRIPTION
- added and using now a common implementation of stat counter reset
- stats-query refactored
    - removed local hash table cache, using the stat cluster/counter instances directly
    - it uses now a single pass to process the given query

- Doc PR: https://github.com/axoflow/axosyslog-core-docs/pull/37

Fixes: #4696

Signed-off-by: Hofi <hofione@gmail.com>