### PR TITLE
http: Bugfix: http dd does not detect cURL compression support

### DIFF
--- a/modules/http/compression.c
+++ b/modules/http/compression.c
@@ -29,29 +29,8 @@
 #define _DEFLATE_WBITS_DEFLATE MAX_WBITS
 #define _DEFLATE_WBITS_GZIP MAX_WBITS + 16
 
-gint8 CURL_COMPRESSION_DEFAULT = CURL_COMPRESSION_UNCOMPRESSED;
 gchar *CURL_COMPRESSION_LITERAL_ALL = "all";
-gchar *curl_compression_types[] = {"identity", "gzip", "deflate"};
-
-gboolean
-http_dd_curl_compression_string_match(const gchar *string, gint curl_compression_index)
-{
-  return (g_strcmp0(string, curl_compression_types[curl_compression_index]) == 0);
-}
-
-gboolean
-http_dd_check_curl_compression(const gchar *type)
-{
-  if(http_dd_curl_compression_string_match(type, CURL_COMPRESSION_UNCOMPRESSED))
-    return TRUE;
-#if SYSLOG_NG_HTTP_COMPRESSION_ENABLED
-  if(http_dd_curl_compression_string_match(type, CURL_COMPRESSION_GZIP))
-    return TRUE;
-  if(http_dd_curl_compression_string_match(type, CURL_COMPRESSION_DEFLATE))
-    return TRUE;
-#endif
-  return FALSE;
-}
+static gchar *curl_compression_types[] = {"unknown", "identity", "gzip", "deflate"};
 
 struct Compressor
 {
@@ -313,4 +292,24 @@ construct_compressor_by_type(enum CurlCompressionTypes type)
     default:
       return NULL;
     }
+}
+
+static gboolean
+_curl_compression_string_match(const gchar *string, gint curl_compression_index)
+{
+  return (g_strcmp0(string, curl_compression_types[curl_compression_index]) == 0);
+}
+
+enum CurlCompressionTypes
+compressor_lookup_type(const gchar *name)
+{
+  if (_curl_compression_string_match(name, CURL_COMPRESSION_UNCOMPRESSED))
+    return CURL_COMPRESSION_UNCOMPRESSED;
+#if SYSLOG_NG_HTTP_COMPRESSION_ENABLED
+  if (_curl_compression_string_match(name, CURL_COMPRESSION_GZIP))
+    return CURL_COMPRESSION_GZIP;
+  if (_curl_compression_string_match(name, CURL_COMPRESSION_DEFLATE))
+    return CURL_COMPRESSION_DEFLATE;
+#endif
+  return CURL_COMPRESSION_UNKNOWN;
 }

--- a/modules/http/compression.c
+++ b/modules/http/compression.c
@@ -42,12 +42,13 @@ http_dd_curl_compression_string_match(const gchar *string, gint curl_compression
 gboolean
 http_dd_check_curl_compression(const gchar *type)
 {
-  if(http_dd_curl_compression_string_match(type, CURL_COMPRESSION_UNCOMPRESSED)) return TRUE;
-#if defined(SYSLOG_NG_HAVE_ZLIB) && defined(CURL_VERSION_LIBZ)
-  if(http_dd_curl_compression_string_match(type, CURL_COMPRESSION_GZIP)) return TRUE;
-#endif
-#if defined(SYSLOG_NG_HAVE_ZLIB) && defined(CURL_VERSION_LIBZ)
-  if(http_dd_curl_compression_string_match(type, CURL_COMPRESSION_DEFLATE)) return TRUE;
+  if(http_dd_curl_compression_string_match(type, CURL_COMPRESSION_UNCOMPRESSED))
+    return TRUE;
+#if SYSLOG_NG_HTTP_COMPRESSION_ENABLED
+  if(http_dd_curl_compression_string_match(type, CURL_COMPRESSION_GZIP))
+    return TRUE;
+  if(http_dd_curl_compression_string_match(type, CURL_COMPRESSION_DEFLATE))
+    return TRUE;
 #endif
   return FALSE;
 }

--- a/modules/http/compression.c
+++ b/modules/http/compression.c
@@ -288,3 +288,21 @@ deflate_compressor_new(void)
   return &rval->super;
 }
 #endif
+
+
+Compressor *
+construct_compressor_by_type(enum CurlCompressionTypes type)
+{
+  switch (type)
+    {
+#if SYSLOG_NG_HTTP_COMPRESSION_ENABLED
+    case CURL_COMPRESSION_GZIP:
+      return gzip_compressor_new();
+    case CURL_COMPRESSION_DEFLATE:
+      return deflate_compressor_new();
+#endif
+    case CURL_COMPRESSION_UNCOMPRESSED:
+    default:
+      return NULL;
+    }
+}

--- a/modules/http/compression.c
+++ b/modules/http/compression.c
@@ -42,10 +42,10 @@ gboolean
 http_dd_check_curl_compression(const gchar *type)
 {
   if(http_dd_curl_compression_string_match(type, CURL_COMPRESSION_UNCOMPRESSED)) return TRUE;
-#ifdef SYSLOG_NG_HAVE_ZLIB
+#if defined(SYSLOG_NG_HAVE_ZLIB) && defined(CURL_VERSION_LIBZ)
   if(http_dd_curl_compression_string_match(type, CURL_COMPRESSION_GZIP)) return TRUE;
 #endif
-#ifdef SYSLOG_NG_HAVE_ZLIB
+#if defined(SYSLOG_NG_HAVE_ZLIB) && defined(CURL_VERSION_LIBZ)
   if(http_dd_curl_compression_string_match(type, CURL_COMPRESSION_DEFLATE)) return TRUE;
 #endif
   return FALSE;
@@ -85,6 +85,7 @@ compressor_init_instance(Compressor *self)
   self->free_fn = compressor_free_method;
 }
 
+#if SYSLOG_NG_HTTP_COMPRESSION_ENABLED
 enum _DeflateAlgorithmTypes
 {
   DEFLATE_TYPE_DEFLATE,
@@ -284,3 +285,4 @@ deflate_compressor_new(void)
   rval->super.compress = _deflate_compressor_compress;
   return &rval->super;
 }
+#endif

--- a/modules/http/compression.c
+++ b/modules/http/compression.c
@@ -21,12 +21,13 @@
  *
  */
 
-#define _DEFLATE_WBITS_DEFLATE MAX_WBITS
-#define _DEFLATE_WBITS_GZIP MAX_WBITS + 16
 
 #include "compression.h"
 #include "messages.h"
 #include <zlib.h>
+
+#define _DEFLATE_WBITS_DEFLATE MAX_WBITS
+#define _DEFLATE_WBITS_GZIP MAX_WBITS + 16
 
 gint8 CURL_COMPRESSION_DEFAULT = CURL_COMPRESSION_UNCOMPRESSED;
 gchar *CURL_COMPRESSION_LITERAL_ALL = "all";

--- a/modules/http/compression.h
+++ b/modules/http/compression.h
@@ -35,19 +35,15 @@
 
 enum CurlCompressionTypes
 {
-  CURL_COMPRESSION_UNCOMPRESSED = 0,
-  CURL_COMPRESSION_GZIP = 1,
-  CURL_COMPRESSION_DEFLATE = 2
+  CURL_COMPRESSION_UNKNOWN,
+
+  CURL_COMPRESSION_UNCOMPRESSED,
+  CURL_COMPRESSION_DEFAULT = CURL_COMPRESSION_UNCOMPRESSED,
+  CURL_COMPRESSION_GZIP,
+  CURL_COMPRESSION_DEFLATE,
 };
 
-extern gint8 CURL_COMPRESSION_DEFAULT;
 extern gchar *CURL_COMPRESSION_LITERAL_ALL;
-
-extern gchar *curl_compression_types[];
-gboolean http_dd_curl_compression_string_match(const gchar *string, gint curl_compression_index);
-gboolean http_dd_check_curl_compression(const gchar *type);
-
-
 
 typedef struct Compressor Compressor;
 
@@ -67,5 +63,7 @@ Compressor *deflate_compressor_new(void);
 
 Compressor *
 construct_compressor_by_type(enum CurlCompressionTypes type);
+enum CurlCompressionTypes
+compressor_lookup_type(const gchar *name);
 
 #endif //SYSLOG_NG_COMPRESSION_H

--- a/modules/http/compression.h
+++ b/modules/http/compression.h
@@ -24,13 +24,13 @@
 #ifndef SYSLOG_NG_COMPRESSION_H
 #define SYSLOG_NG_COMPRESSION_H
 
+#include "syslog-ng.h"
+
 #ifdef SYSLOG_NG_HAVE_ZLIB
 #define SYSLOG_NG_HTTP_COMPRESSION_ENABLED 1
 #else
 #define SYSLOG_NG_HTTP_COMPRESSION_ENABLED 0
 #endif
-
-#include <glib.h>
 
 enum CurlCompressionTypes
 {

--- a/modules/http/compression.h
+++ b/modules/http/compression.h
@@ -51,6 +51,7 @@ gboolean http_dd_check_curl_compression(const gchar *type);
 
 typedef struct Compressor Compressor;
 
+const gchar *compressor_get_encoding_name(Compressor *self);
 gboolean compressor_compress(Compressor *self, GString *compressed, const GString *message);
 void compressor_free(Compressor *self);
 

--- a/modules/http/compression.h
+++ b/modules/http/compression.h
@@ -51,10 +51,8 @@ gboolean http_dd_check_curl_compression(const gchar *type);
 
 typedef struct Compressor Compressor;
 
-void compressor_init_instance(Compressor *self);
 gboolean compressor_compress(Compressor *self, GString *compressed, const GString *message);
 void compressor_free(Compressor *self);
-void compressor_free_method(Compressor *self);
 
 #if SYSLOG_NG_HTTP_COMPRESSION_ENABLED
 typedef struct GzipCompressor GzipCompressor;

--- a/modules/http/compression.h
+++ b/modules/http/compression.h
@@ -24,6 +24,12 @@
 #ifndef SYSLOG_NG_COMPRESSION_H
 #define SYSLOG_NG_COMPRESSION_H
 
+#ifdef SYSLOG_NG_HAVE_ZLIB
+#define SYSLOG_NG_HTTP_COMPRESSION_ENABLED 1
+#else
+#define SYSLOG_NG_HTTP_COMPRESSION_ENABLED 0
+#endif
+
 #include <glib.h>
 
 enum CurlCompressionTypes
@@ -51,6 +57,7 @@ void compressor_free(Compressor *self);
 
 void compressor_free_method(Compressor *self);
 
+#if SYSLOG_NG_HTTP_COMPRESSION_ENABLED
 typedef struct GzipCompressor GzipCompressor;
 
 Compressor *gzip_compressor_new(void);
@@ -58,5 +65,6 @@ Compressor *gzip_compressor_new(void);
 typedef struct DeflateCompressor DeflateCompressor;
 
 Compressor *deflate_compressor_new(void);
+#endif
 
 #endif //SYSLOG_NG_COMPRESSION_H

--- a/modules/http/compression.h
+++ b/modules/http/compression.h
@@ -25,8 +25,9 @@
 #define SYSLOG_NG_COMPRESSION_H
 
 #include "syslog-ng.h"
+#include "compat/curl.h"
 
-#ifdef SYSLOG_NG_HAVE_ZLIB
+#if defined(SYSLOG_NG_HAVE_ZLIB) && defined(CURL_VERSION_LIBZ)
 #define SYSLOG_NG_HTTP_COMPRESSION_ENABLED 1
 #else
 #define SYSLOG_NG_HTTP_COMPRESSION_ENABLED 0

--- a/modules/http/compression.h
+++ b/modules/http/compression.h
@@ -48,14 +48,12 @@ gboolean http_dd_curl_compression_string_match(const gchar *string, gint curl_co
 gboolean http_dd_check_curl_compression(const gchar *type);
 
 
+
 typedef struct Compressor Compressor;
 
 void compressor_init_instance(Compressor *self);
-
 gboolean compressor_compress(Compressor *self, GString *compressed, const GString *message);
-
 void compressor_free(Compressor *self);
-
 void compressor_free_method(Compressor *self);
 
 #if SYSLOG_NG_HTTP_COMPRESSION_ENABLED
@@ -67,5 +65,8 @@ typedef struct DeflateCompressor DeflateCompressor;
 
 Compressor *deflate_compressor_new(void);
 #endif
+
+Compressor *
+construct_compressor_by_type(enum CurlCompressionTypes type);
 
 #endif //SYSLOG_NG_COMPRESSION_H

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -170,7 +170,11 @@ http_option
     | KW_FLUSH_ON_WORKER_KEY_CHANGE '(' yesno ')' { log_threaded_dest_driver_set_flush_on_worker_key_change(last_driver, $3); }
     | KW_TLS '(' http_tls_options ')'
     | KW_ACCEPT_ENCODING '(' string ')' { http_dd_set_accept_encoding(last_driver, $3); free($3); }
-    | KW_CONTENT_COMPRESSION '(' string ')' { http_dd_set_message_compression(last_driver, $3); free($3); }
+    | KW_CONTENT_COMPRESSION '(' string ')'
+      {
+        CHECK_ERROR(http_dd_set_content_compression(last_driver, $3), @3, "Unrecognized compression type");
+        free($3);
+      }
     | { last_template_options = http_dd_get_template_options(last_driver); } template_option
     | KW_RESPONSE_ACTION '(' response_action_items ')'
     ;

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -535,7 +535,7 @@ _curl_perform_request(HTTPDestinationWorker *self, const gchar *url)
             evt_tag_str("url", url));
 
   curl_easy_setopt(self->curl, CURLOPT_URL, url);
-  if (owner->message_compression != CURL_COMPRESSION_UNCOMPRESSED)
+  if (owner->content_compression != CURL_COMPRESSION_UNCOMPRESSED)
     {
       if (compressor_compress(self->compressor, self->request_body_compressed, self->request_body))
         {
@@ -863,10 +863,10 @@ _init(LogThreadedDestWorker *s)
 
   self->request_body = g_string_sized_new(32768);
 #if SYSLOG_NG_HTTP_COMPRESSION_ENABLED
-  if (owner->message_compression != CURL_COMPRESSION_UNCOMPRESSED)
+  if (owner->content_compression != CURL_COMPRESSION_UNCOMPRESSED)
     {
       self->request_body_compressed = g_string_sized_new(32768);
-      switch (owner->message_compression)
+      switch (owner->content_compression)
         {
         case CURL_COMPRESSION_GZIP:
           self->compressor = gzip_compressor_new();
@@ -877,7 +877,7 @@ _init(LogThreadedDestWorker *s)
         default:
           g_assert_not_reached();
         }
-      gchar *buffer = g_strdup_printf("Content-Encoding: %s", curl_compression_types[owner->message_compression]);
+      gchar *buffer = g_strdup_printf("Content-Encoding: %s", curl_compression_types[owner->content_compression]);
       owner->headers= g_list_append(owner->headers,  buffer);
     }
 #endif
@@ -910,7 +910,7 @@ _deinit(LogThreadedDestWorker *s)
   if (self->request_body_compressed)
     g_string_free(self->request_body_compressed, TRUE);
 
-  if (owner->message_compression != CURL_COMPRESSION_UNCOMPRESSED)
+  if (owner->content_compression != CURL_COMPRESSION_UNCOMPRESSED)
     compressor_free(self->compressor);
   list_free(self->request_headers);
   curl_easy_cleanup(self->curl);

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -862,23 +862,11 @@ _init(LogThreadedDestWorker *s)
     }
 
   self->request_body = g_string_sized_new(32768);
-#if SYSLOG_NG_HTTP_COMPRESSION_ENABLED
   if (owner->content_compression != CURL_COMPRESSION_UNCOMPRESSED)
     {
       self->request_body_compressed = g_string_sized_new(32768);
-      switch (owner->content_compression)
-        {
-        case CURL_COMPRESSION_GZIP:
-          self->compressor = gzip_compressor_new();
-          break;
-        case CURL_COMPRESSION_DEFLATE:
-          self->compressor = deflate_compressor_new();
-          break;
-        default:
-          g_assert_not_reached();
-        }
+      self->compressor = construct_compressor_by_type(owner->content_compression);
     }
-#endif
   self->request_headers = http_curl_header_list_new();
   if (!(self->curl = curl_easy_init()))
     {

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -899,7 +899,6 @@ static void
 _deinit(LogThreadedDestWorker *s)
 {
   HTTPDestinationWorker *self = (HTTPDestinationWorker *) s;
-  HTTPDestinationDriver *owner = (HTTPDestinationDriver *) self->super.owner;
 
   if (self->url_buffer)
     g_string_free(self->url_buffer, TRUE);
@@ -908,7 +907,7 @@ _deinit(LogThreadedDestWorker *s)
   if (self->request_body_compressed)
     g_string_free(self->request_body_compressed, TRUE);
 
-  if (owner->content_compression != CURL_COMPRESSION_UNCOMPRESSED)
+  if (self->compressor)
     compressor_free(self->compressor);
   list_free(self->request_headers);
   curl_easy_cleanup(self->curl);

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -541,7 +541,7 @@ _curl_perform_request(HTTPDestinationWorker *self, const gchar *url)
         {
           curl_easy_setopt(self->curl, CURLOPT_POSTFIELDS, self->request_body_compressed->str);
           curl_easy_setopt(self->curl, CURLOPT_POSTFIELDSIZE, self->request_body_compressed->len);
-          _add_header(self->request_headers, "Content-Encoding", curl_compression_types[owner->content_compression]);
+          _add_header(self->request_headers, "Content-Encoding", compressor_get_encoding_name(self->compressor));
         }
       else
         {

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -862,6 +862,7 @@ _init(LogThreadedDestWorker *s)
     }
 
   self->request_body = g_string_sized_new(32768);
+#if SYSLOG_NG_HTTP_COMPRESSION_ENABLED
   if (owner->message_compression != CURL_COMPRESSION_UNCOMPRESSED)
     {
       self->request_body_compressed = g_string_sized_new(32768);
@@ -879,6 +880,7 @@ _init(LogThreadedDestWorker *s)
       gchar *buffer = g_strdup_printf("Content-Encoding: %s", curl_compression_types[owner->message_compression]);
       owner->headers= g_list_append(owner->headers,  buffer);
     }
+#endif
   self->request_headers = http_curl_header_list_new();
   if (!(self->curl = curl_easy_init()))
     {

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -307,19 +307,8 @@ http_dd_set_content_compression(LogDriver *d, const gchar *encoding)
 {
   HTTPDestinationDriver *self = (HTTPDestinationDriver *) d;
 
-#if SYSLOG_NG_HTTP_COMPRESSION_ENABLED
-  if (http_dd_curl_compression_string_match(encoding, CURL_COMPRESSION_UNCOMPRESSED))
-    self->content_compression = CURL_COMPRESSION_UNCOMPRESSED;
-  else if (http_dd_curl_compression_string_match(encoding, CURL_COMPRESSION_GZIP))
-    self->content_compression = CURL_COMPRESSION_GZIP;
-  else if (http_dd_curl_compression_string_match(encoding, CURL_COMPRESSION_DEFLATE))
-    self->content_compression = CURL_COMPRESSION_DEFLATE;
-  else
-    return FALSE;
-  return TRUE;
-#else
-  return FALSE;
-#endif
+  self->content_compression = compressor_lookup_type(encoding);
+  return self->content_compression != CURL_COMPRESSION_UNKNOWN;
 }
 
 
@@ -541,6 +530,7 @@ http_dd_new(GlobalConfig *cfg)
                                        SYSLOG_NG_VERSION, curl_info->version);
 
   self->response_handlers = http_response_handlers_new();
+  self->content_compression = CURL_COMPRESSION_DEFAULT;
 
   return &self->super.super.super;
 }

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -290,7 +290,7 @@ http_dd_set_accept_encoding(LogDriver *d, const gchar *encoding)
 
   if (self->accept_encoding != NULL)
     g_string_free(self->accept_encoding, TRUE);
-#ifdef CURL_VERSION_LIBZ
+#if SYSLOG_NG_HTTP_COMPRESSION_ENABLED
   if (strcmp(encoding, CURL_COMPRESSION_LITERAL_ALL) == 0)
     self->accept_encoding = g_string_new("");
   else

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -302,26 +302,23 @@ http_dd_set_accept_encoding(LogDriver *d, const gchar *encoding)
 #endif
 }
 
-void
-http_dd_set_message_compression(LogDriver *d, const gchar *encoding)
+gboolean
+http_dd_set_content_compression(LogDriver *d, const gchar *encoding)
 {
   HTTPDestinationDriver *self = (HTTPDestinationDriver *) d;
 
 #if SYSLOG_NG_HTTP_COMPRESSION_ENABLED
-  gboolean _encoding_valid = FALSE;
-  _encoding_valid = http_dd_check_curl_compression(encoding);
-  g_assert(_encoding_valid);
-
   if (http_dd_curl_compression_string_match(encoding, CURL_COMPRESSION_UNCOMPRESSED))
-    self->message_compression = CURL_COMPRESSION_UNCOMPRESSED;
+    self->content_compression = CURL_COMPRESSION_UNCOMPRESSED;
   else if (http_dd_curl_compression_string_match(encoding, CURL_COMPRESSION_GZIP))
-    self->message_compression = CURL_COMPRESSION_GZIP;
+    self->content_compression = CURL_COMPRESSION_GZIP;
   else if (http_dd_curl_compression_string_match(encoding, CURL_COMPRESSION_DEFLATE))
-    self->message_compression = CURL_COMPRESSION_DEFLATE;
+    self->content_compression = CURL_COMPRESSION_DEFLATE;
   else
-    self->message_compression = CURL_COMPRESSION_DEFAULT;
+    return FALSE;
+  return TRUE;
 #else
-  self->message_compression = CURL_COMPRESSION_UNCOMPRESSED;
+  return FALSE;
 #endif
 }
 

--- a/modules/http/http.h
+++ b/modules/http/http.h
@@ -57,7 +57,7 @@ typedef struct
   GString *delimiter;
   int ssl_version;
   GString *accept_encoding;
-  gint8 message_compression;
+  gint8 content_compression;
   gboolean peer_verify;
   gboolean ocsp_stapling_verify;
   gboolean accept_redirects;
@@ -99,6 +99,6 @@ void http_dd_set_delimiter(LogDriver *d, const gchar *delimiter);
 void http_dd_insert_response_handler(LogDriver *d, HttpResponseHandler *response_handler);
 LogTemplateOptions *http_dd_get_template_options(LogDriver *d);
 void http_dd_set_accept_encoding(LogDriver *d, const gchar *encoding);
-void http_dd_set_message_compression(LogDriver *d, const gchar *encoding);
+gboolean http_dd_set_content_compression(LogDriver *d, const gchar *encoding);
 
 #endif

--- a/modules/http/tests/test_compression.c
+++ b/modules/http/tests/test_compression.c
@@ -26,6 +26,8 @@
 #include <criterion/redirect.h>
 #include "compression.h"
 
+#if SYSLOG_NG_HTTP_COMPRESSION_ENABLED
+
 char *test_message =
   "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
 
@@ -158,4 +160,6 @@ Test(compression, compressor_deflate_compression)
   compressor_free(compressor);
   g_string_free(result, TRUE);
 }
+#endif
+
 #endif


### PR DESCRIPTION
So far the compilation of http_dd with compression options only detected the presence of Zlib. This caused a compilation error when Zlib was found, but cURL on the system has been compiled without it.

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
