### PR TITLE
Capture the end of a message with NLSTRING

### DIFF
--- a/modules/correlation/radix.c
+++ b/modules/correlation/radix.c
@@ -100,11 +100,14 @@ r_parser_nlstring(gchar *str, gint *len, const gchar *param, gpointer state, RPa
       /* drop CR before to LF */
       if (end - str >= 1 && *(end - 1) == '\r')
         end--;
-      *len = (end - str);
-      return TRUE;
     }
   else
-    return FALSE;
+    {
+      end = strchr(str, '\0');
+    }
+
+  *len = (end - str);
+  return TRUE;
 }
 
 gboolean

--- a/modules/correlation/tests/test_radix.c
+++ b/modules/correlation/tests/test_radix.c
@@ -1064,6 +1064,21 @@ ParameterizedTestParameters(dbparser, test_radix_search_matches)
       .node_to_insert = {"@NLSTRING:nlstring@", NULL},
       .key = "\r\nbaz",
       .expected_pattern = {"nlstring", "", NULL},
+    },
+    {
+      .node_to_insert = {"@NLSTRING:nlstring@", NULL},
+      .key = "foobar\r\n",
+      .expected_pattern = {"nlstring", "foobar", NULL},
+    },
+    {
+      .node_to_insert = {"@NLSTRING:nlstring@", NULL},
+      .key = "foobar\n",
+      .expected_pattern = {"nlstring", "foobar", NULL},
+    },
+    {
+      .node_to_insert = {"@NLSTRING:nlstring@", NULL},
+      .key = "foobar",
+      .expected_pattern = {"nlstring", "foobar", NULL},
     }
   };
   return cr_make_param_array(RadixTestParam, parser_params, G_N_ELEMENTS(parser_params));


### PR DESCRIPTION
When parsing a message, NLSTRING stops when it finds a `\n` char.  If the message does not contain any `\n` char, the matching fail and the message portion is not matched.

However, the documentation says that:
> For single-line messages, NLSTRING is equivalent with ANYSTRING

In order to match what the documentation say, we need to not return an error when `\n` is not found, and instead capture the end of the message.
