### PR TITLE
patterndb: Add support for nested quotted string in @QSTRING@

### DIFF
--- a/modules/correlation/tests/test_radix.c
+++ b/modules/correlation/tests/test_radix.c
@@ -731,6 +731,21 @@ ParameterizedTestParameters(dbparser, test_radix_search_matches)
       .expected_pattern = {"qstring", "quoted string", NULL}
     },
     {
+      .node_to_insert = {"@QSTRING:qstring:()@", NULL},
+      .key = "(quoted string) hehehe",
+      .expected_pattern = {"qstring", "quoted string", NULL}
+    },
+    {
+      .node_to_insert = {"@QSTRING:qstring:()@", NULL},
+      .key = "(nested (quoted string())) hehehe",
+      .expected_pattern = {"qstring", "nested (quoted string())", NULL}
+    },
+    {
+      .node_to_insert = {"@QSTRING:qstring:()@", NULL},
+      .key = "(unbalanced (nested (quoted string())) hehehe",
+      .expected_pattern = {NULL}
+    },
+    {
       .node_to_insert = {"@QSTRING:qstring:'@", NULL},
       .key = "v12345",
       .expected_pattern = {NULL}


### PR DESCRIPTION
When using 2 chars to match quoted strings (e.g. `(), `[]`, `{}`), we
want to detect nesting to capture the whole containing expression.

Matching `(foo (bar (baz) qux)) quux` against `@QSTRING::()@` previously
captured `(foo (bar (baz)` and now capture `(foo (bar (baz) qux))`.

Fixes: #4716

Signed-off-by: Romain Tartière <romain@blogreen.org>
