### PR TITLE
github-actions: use gh instead of hub

### DIFF
--- a/.github/workflows/comment-on-version-bump-pr.yml
+++ b/.github/workflows/comment-on-version-bump-pr.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           . .github/workflows/gh-tools.sh
 
-          PR_NUMBER=$(hub pr list --state=open --format="%I %l%n" | grep "version-bump" | grep -Po "^[0-9]+") || true
+          PR_NUMBER=$(gh pr list --state "open" --label "version-bump" --json "number" --jq ".[0].number")
 
           [ -z ${PR_NUMBER} ] && echo "No version bump PR is open. Skipping."
           gh_export PR_NUMBER
@@ -35,9 +35,8 @@ jobs:
       - name: Comment
         if: env.PR_NUMBER != ''
         run: |
-          COMMENT_ENDPOINT=repos/${{ github.repository_owner }}/syslog-ng/issues/${PR_NUMBER}/comments
           COMMENT="There are new commits (${COMMIT_URL}) on master. Please follow-up any necessary changes."
 
-          hub api \
-            ${COMMENT_ENDPOINT} \
-            --field body="${COMMENT}"
+          gh pr comment \
+            "${PR_NUMBER}" \
+            --body "${COMMENT}"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -25,7 +25,6 @@ env:
   GITHUB_TOKEN: ${{ secrets.PAT_FOR_ACTIONS }}
   WORKFLOW_NAME: "**Draft release** workflow"
   CURRENT_WORKFLOW_RUN_URL: https://github.com/${{ github.repository_owner }}/syslog-ng/actions/runs/${{ github.run_id }}
-  COMMENT_ENDPOINT: repos/${{ github.repository_owner }}/syslog-ng/issues/${{ github.event.number }}/comments
   RELEASES_URL: https://github.com/${{ github.repository_owner }}/syslog-ng/releases
 
 
@@ -39,17 +38,17 @@ jobs:
       RELEASE_NAME: ${{ steps.setup-environment.outputs.RELEASE_NAME }}
       TARBALL_NAME: ${{ steps.setup-environment.outputs.TARBALL_NAME }}
     steps:
+      - name: Checkout syslog-ng source
+        uses: actions/checkout@v3
+
       - name: "Comment: job started"
         if: github.event_name == 'pull_request'
         run: |
           COMMENT="${WORKFLOW_NAME} started: ${CURRENT_WORKFLOW_RUN_URL}."
 
-          hub api \
-            ${COMMENT_ENDPOINT} \
-            --field body="${COMMENT}"
-
-      - name: Checkout syslog-ng source
-        uses: actions/checkout@v3
+          gh pr comment \
+            "${{ github.event.number }}" \
+            --body "${COMMENT}"
 
       - name: Setup environment
         id: setup-environment
@@ -105,13 +104,12 @@ jobs:
 
       - name: Create draft release
         run: |
-          sed "1 i${{ needs.create-release-tarball.outputs.RELEASE_NAME }}\n" NEWS.md > /tmp/message
-
-          hub release create \
+          gh release create \
+            "${{ needs.create-release-tarball.outputs.RELEASE_TAG }}" \
+            "${{ needs.create-release-tarball.outputs.TARBALL_NAME }}" \
             --draft \
-            --file /tmp/message \
-            --attach ${{ needs.create-release-tarball.outputs.TARBALL_NAME }} \
-            ${{ needs.create-release-tarball.outputs.RELEASE_TAG }}
+            --title "${{ needs.create-release-tarball.outputs.RELEASE_NAME }}" \
+            --notes-file "NEWS.md"
 
   comment-workflow-result:
     runs-on: ubuntu-latest
@@ -127,6 +125,6 @@ jobs:
             COMMENT="${WORKFLOW_NAME} failed."
           fi
 
-          hub api \
-            ${COMMENT_ENDPOINT} \
-            --field body="${COMMENT}"
+          gh pr comment \
+            "${{ github.event.number }}" \
+            --body "${COMMENT}"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Check existing PR
         run: |
-          EXISTS=$(hub pr list --state=open --head=${VERSION_BUMP_BRANCH} | wc -l)
+          EXISTS=$(gh pr list --state open --head "${VERSION_BUMP_BRANCH}" --json "number" --jq ". | length")
 
           if [ ${EXISTS} -ne 0 ]
           then
@@ -87,10 +87,10 @@ jobs:
         run: |
           TITLE="Version: ${RELEASE_VERSION}"
           DESCRIPTION="Tarball is available at: ${CURRENT_RUN_URL}"
-          echo -e "${TITLE}\n\n${DESCRIPTION}" > /tmp/message
 
           git push --force origin ${VERSION_BUMP_BRANCH}
-          hub pull-request \
-            --base ${GITHUB_REF} \
-            --file /tmp/message \
-            --labels "version-bump"
+          gh pr create \
+            --base "${GITHUB_REF}" \
+            --title "${TITLE}" \
+            --body "${DESCRIPTION}" \
+            --label "version-bump"


### PR DESCRIPTION
`hub` has been removed from the `ubuntu-latest` image.

Test runs:
* Version Bump: https://github.com/alltilla/syslog-ng/actions/runs/6956723251/job/18928427298
* PR: https://github.com/alltilla/syslog-ng/pull/126
* Draft Release: https://github.com/alltilla/syslog-ng/actions/runs/6957504148/job/18930527572

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>