### PR TITLE
doc/man: add missing copyright information

### DIFF
--- a/doc/man/dqtool.1.xml
+++ b/doc/man/dqtool.1.xml
@@ -1,4 +1,26 @@
 <?xml version="1.0"?>
+<!--
+
+  Copyright (c) 2017 Balabit
+
+  This program is free software; you can redistribute it and/or modify it
+  under the terms of the GNU General Public License version 2 as published
+  by the Free Software Foundation, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  As an additional exemption you are allowed to compile & link against the
+  OpenSSL libraries as published by the OpenSSL project. See the file
+  COPYING for details.
+
+-->
 <reference xmlns="http://docbook.org/ns/docbook" version="5.0">
   <info>
     <productname/>

--- a/doc/man/loggen.1.xml
+++ b/doc/man/loggen.1.xml
@@ -1,4 +1,26 @@
 <?xml version="1.0"?>
+<!--
+
+  Copyright (c) 2012 Balabit
+
+  This program is free software; you can redistribute it and/or modify it
+  under the terms of the GNU General Public License version 2 as published
+  by the Free Software Foundation, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  As an additional exemption you are allowed to compile & link against the
+  OpenSSL libraries as published by the OpenSSL project. See the file
+  COPYING for details.
+
+-->
 <reference xmlns="http://docbook.org/ns/docbook" version="5.0">
   <info>
     <productname/>

--- a/doc/man/pdbtool.1.xml
+++ b/doc/man/pdbtool.1.xml
@@ -1,4 +1,26 @@
 <?xml version="1.0"?>
+<!--
+
+  Copyright (c) 2012 Balabit
+
+  This program is free software; you can redistribute it and/or modify it
+  under the terms of the GNU General Public License version 2 as published
+  by the Free Software Foundation, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  As an additional exemption you are allowed to compile & link against the
+  OpenSSL libraries as published by the OpenSSL project. See the file
+  COPYING for details.
+
+-->
 <reference xmlns="http://docbook.org/ns/docbook" xml:id="pdbtool-man-page" version="5.0">
   <info>
     <productname/>

--- a/doc/man/persist-tool.1.xml
+++ b/doc/man/persist-tool.1.xml
@@ -1,4 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+
+  Copyright (c) 2020 Balazs Scheidler <bazsi77@gmail.com>
+
+  This program is free software; you can redistribute it and/or modify it
+  under the terms of the GNU General Public License version 2 as published
+  by the Free Software Foundation, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  As an additional exemption you are allowed to compile & link against the
+  OpenSSL libraries as published by the OpenSSL project. See the file
+  COPYING for details.
+
+-->
 <reference xmlns="http://docbook.org/ns/docbook" version="5.0">
     <info>
         <productname/>

--- a/doc/man/secure-logging.7.xml
+++ b/doc/man/secure-logging.7.xml
@@ -1,4 +1,26 @@
 <?xml version="1.0"?>
+<!--
+
+  Copyright (c) 2020 Airbus Secure Logging Team
+
+  This program is free software; you can redistribute it and/or modify it
+  under the terms of the GNU General Public License version 2 as published
+  by the Free Software Foundation, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  As an additional exemption you are allowed to compile & link against the
+  OpenSSL libraries as published by the OpenSSL project. See the file
+  COPYING for details.
+
+-->
 <reference xmlns="http://docbook.org/ns/docbook" xml:id="secure-logging-man-page" version="5.0">
   <info>
     <productname/>

--- a/doc/man/slogencrypt.1.xml
+++ b/doc/man/slogencrypt.1.xml
@@ -1,4 +1,26 @@
 <?xml version="1.0"?>
+<!--
+
+  Copyright (c) 2020 Airbus Secure Logging Team
+
+  This program is free software; you can redistribute it and/or modify it
+  under the terms of the GNU General Public License version 2 as published
+  by the Free Software Foundation, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  As an additional exemption you are allowed to compile & link against the
+  OpenSSL libraries as published by the OpenSSL project. See the file
+  COPYING for details.
+
+-->
 <reference xmlns="http://docbook.org/ns/docbook" version="5.0">
   <info>
     <productname/>

--- a/doc/man/slogkey.1.xml
+++ b/doc/man/slogkey.1.xml
@@ -1,4 +1,26 @@
 <?xml version="1.0"?>
+<!--
+
+  Copyright (c) 2020 Airbus Secure Logging Team
+
+  This program is free software; you can redistribute it and/or modify it
+  under the terms of the GNU General Public License version 2 as published
+  by the Free Software Foundation, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  As an additional exemption you are allowed to compile & link against the
+  OpenSSL libraries as published by the OpenSSL project. See the file
+  COPYING for details.
+
+-->
 <reference xmlns="http://docbook.org/ns/docbook" version="5.0">
   <info>
     <productname/>

--- a/doc/man/slogverify.1.xml
+++ b/doc/man/slogverify.1.xml
@@ -1,4 +1,26 @@
 <?xml version="1.0"?>
+<!--
+
+  Copyright (c) 2020 Airbus Secure Logging Team
+
+  This program is free software; you can redistribute it and/or modify it
+  under the terms of the GNU General Public License version 2 as published
+  by the Free Software Foundation, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  As an additional exemption you are allowed to compile & link against the
+  OpenSSL libraries as published by the OpenSSL project. See the file
+  COPYING for details.
+
+-->
 <reference xmlns="http://docbook.org/ns/docbook" version="5.0">
   <info>
     <productname/>

--- a/doc/man/syslog-ng-ctl.1.xml
+++ b/doc/man/syslog-ng-ctl.1.xml
@@ -1,4 +1,26 @@
 <?xml version="1.0"?>
+<!--
+
+  Copyright (c) 2012 Balabit
+
+  This program is free software; you can redistribute it and/or modify it
+  under the terms of the GNU General Public License version 2 as published
+  by the Free Software Foundation, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  As an additional exemption you are allowed to compile & link against the
+  OpenSSL libraries as published by the OpenSSL project. See the file
+  COPYING for details.
+
+-->
 <reference xmlns="http://docbook.org/ns/docbook" xml:id="syslog-ng-ctl-man-page" version="5.0">
   <info>
     <productname/>

--- a/doc/man/syslog-ng-debun.1.xml
+++ b/doc/man/syslog-ng-debun.1.xml
@@ -1,4 +1,26 @@
 <?xml version="1.0"?>
+<!--
+
+  Copyright (c) 2017 Balabit
+
+  This program is free software; you can redistribute it and/or modify it
+  under the terms of the GNU General Public License version 2 as published
+  by the Free Software Foundation, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  As an additional exemption you are allowed to compile & link against the
+  OpenSSL libraries as published by the OpenSSL project. See the file
+  COPYING for details.
+
+-->
 <reference xmlns="http://docbook.org/ns/docbook" version="5.0">
   <info>
     <productname/>

--- a/doc/man/syslog-ng.8.xml
+++ b/doc/man/syslog-ng.8.xml
@@ -1,4 +1,26 @@
 <?xml version="1.0"?>
+<!--
+
+  Copyright (c) 2012 Balabit
+
+  This program is free software; you can redistribute it and/or modify it
+  under the terms of the GNU General Public License version 2 as published
+  by the Free Software Foundation, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  As an additional exemption you are allowed to compile & link against the
+  OpenSSL libraries as published by the OpenSSL project. See the file
+  COPYING for details.
+
+-->
 <reference xmlns="http://docbook.org/ns/docbook" version="5.0">
   <info>
     <productname/>

--- a/doc/man/syslog-ng.conf.5.xml
+++ b/doc/man/syslog-ng.conf.5.xml
@@ -1,4 +1,26 @@
 <?xml version="1.0"?>
+<!--
+
+  Copyright (c) 2012 Balabit
+
+  This program is free software; you can redistribute it and/or modify it
+  under the terms of the GNU General Public License version 2 as published
+  by the Free Software Foundation, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+  As an additional exemption you are allowed to compile & link against the
+  OpenSSL libraries as published by the OpenSSL project. See the file
+  COPYING for details.
+
+-->
 <reference xmlns="http://docbook.org/ns/docbook" version="5.0">
   <info>
     <productname/>


### PR DESCRIPTION
This patch restores the copyright attribution / license to the manual pages.

The Copyright attribution is restored based on the commit + signed-of-by lines that created the file in the first place.

The license is GPL like the rest of the project (as per COPYING)
