### PR TITLE
pcre2: don't warn on JIT unavailability

### DIFF
--- a/lib/logmatcher.c
+++ b/lib/logmatcher.c
@@ -354,9 +354,9 @@ _jit_pcre2_regexp(LogMatcherPcreRe *self, const gchar *re, GError **error)
       PCRE2_UCHAR error_message[128];
 
       pcre2_get_error_message(rc, error_message, sizeof(error_message));
-      msg_warning("Failed to JIT compile regular expression, you might want to use flags(disable-jit)",
-                  evt_tag_str("regexp", re),
-                  evt_tag_str("error", (gchar *) error_message));
+      msg_debug("Failed to JIT compile regular expression, you might want to use flags(disable-jit) to stop trying",
+                evt_tag_str("regexp", re),
+                evt_tag_str("error", (gchar *) error_message));
     }
   return TRUE;
 }

--- a/lib/multi-line/multi-line-pattern.c
+++ b/lib/multi-line/multi-line-pattern.c
@@ -54,9 +54,9 @@ multi_line_pattern_compile(const gchar *regexp, GError **error)
       PCRE2_UCHAR error_message[128];
 
       pcre2_get_error_message(rc, error_message, sizeof(error_message));
-      msg_warning("multi-line-pattern: Error while JIT compiling regular expression",
-                  evt_tag_str("regexp", regexp),
-                  evt_tag_str("error", (gchar *) error_message));
+      msg_debug("multi-line-pattern: Error while JIT compiling regular expression, continuing without JIT",
+                evt_tag_str("regexp", regexp),
+                evt_tag_str("error", (gchar *) error_message));
     }
 
   return self;

--- a/modules/basicfuncs/list-funcs.c
+++ b/modules/basicfuncs/list-funcs.c
@@ -393,9 +393,9 @@ string_matcher_prepare_pcre(StringMatcher *self)
       PCRE2_UCHAR error_message[128];
 
       pcre2_get_error_message(rc, error_message, sizeof(error_message));
-      msg_warning("$(list-search): Failed to JIT compile regular expression",
-                  evt_tag_str("regexp", self->pattern),
-                  evt_tag_str("error", (gchar *) error_message));
+      msg_debug("$(list-search): Failed to JIT compile regular expression, continuing without JIT",
+                evt_tag_str("regexp", self->pattern),
+                evt_tag_str("error", (gchar *) error_message));
     }
   return TRUE;
 }

--- a/modules/correlation/radix.c
+++ b/modules/correlation/radix.c
@@ -250,10 +250,10 @@ r_parser_pcre_compile_state(const gchar *expr)
       PCRE2_UCHAR error_message[128];
 
       pcre2_get_error_message(rc, error_message, sizeof(error_message));
-      msg_warning("radix: Error while JIT compiling regular expression",
-                  evt_tag_str("regular_expression", expr),
-                  evt_tag_str("error_message", (gchar *) error_message),
-                  evt_tag_int("error_code", rc));
+      msg_debug("radix: Error while JIT compiling regular expression, continuing without using JIT",
+                evt_tag_str("regular_expression", expr),
+                evt_tag_str("error_message", (gchar *) error_message),
+                evt_tag_int("error_code", rc));
     }
 
   return (gpointer) self;


### PR DESCRIPTION
This is coming from a syslog-ng mailing list message. I don't think this warrants a NEWS entry.