### PR TITLE
cfg-lex: suppress warnings in generated code

### DIFF
--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -252,6 +252,9 @@ _cfg_lex_extend_token_location_to_next_line(CfgLexer *lexer)
 #define YYLTYPE CFG_LTYPE
 
 #pragma GCC diagnostic ignored "-Wswitch-default"
+#if (defined(__GNUC__) && __GNUC__ >= 6) || (defined(__clang__) && __clang_major__ >= 10)
+#  pragma GCC diagnostic ignored "-Wmisleading-indentation"
+#endif
 
 %}
 


### PR DESCRIPTION
983d45c353b16696d57bee3b42a64dd7c443b046 moved the suppression of -Wmisleading-indentation to a private position.

This patch is a follow-up as the lexer code requires the same warning suppression.