### PR TITLE
UTF-8 sanitization/validation improvements

### DIFF
--- a/lib/tests/test_msgparse.c
+++ b/lib/tests/test_msgparse.c
@@ -1241,6 +1241,14 @@ Test(msgparse, test_sanitize_utf8)
       .expected_host = "",
       .expected_msg = "hello\\xf0(\\x8c\\xbcrena",
     },
+    {
+      .msg = "<7>1 - bzorp openvpn 2499 - - PTHREAD \xf0\x28\x8c\x28 initialized",
+      .parse_flags = LP_SYSLOG_PROTOCOL | LP_SANITIZE_UTF8,
+      .expected_pri = 7,
+      .expected_program = "openvpn",
+      .expected_host = "bzorp",
+      .expected_msg = "PTHREAD \\xf0(\\x8c( initialized",
+    },
     {NULL}
   };
   run_parameterized_test(params);

--- a/lib/tests/test_msgparse.c
+++ b/lib/tests/test_msgparse.c
@@ -1228,3 +1228,20 @@ Test(msgparse, test_no_rfc3164_fallback_flag)
   };
   run_parameterized_test(params);
 }
+
+Test(msgparse, test_sanitize_utf8)
+{
+  struct msgparse_params params[] =
+  {
+    {
+      .msg = "<189>program hello\xf0\x28\x8c\xbcrena",
+      .parse_flags = LP_SANITIZE_UTF8,
+      .expected_pri = 189,
+      .expected_program = "program",
+      .expected_host = "",
+      .expected_msg = "hello\\xf0(\\x8c\\xbcrena",
+    },
+    {NULL}
+  };
+  run_parameterized_test(params);
+}

--- a/lib/tests/test_msgparse.c
+++ b/lib/tests/test_msgparse.c
@@ -1249,6 +1249,12 @@ Test(msgparse, test_sanitize_utf8)
       .expected_host = "bzorp",
       .expected_msg = "PTHREAD \\xf0(\\x8c( initialized",
     },
+    {
+      .msg = "rena\xa0\xa1",
+      .parse_flags = LP_NOPARSE | LP_SANITIZE_UTF8,
+      .expected_pri = 65535,
+      .expected_msg = "rena\\xa0\\xa1",
+    },
     {NULL}
   };
   run_parameterized_test(params);

--- a/lib/utf8utils.h
+++ b/lib/utf8utils.h
@@ -41,4 +41,30 @@ void append_unsafe_utf8_as_escaped(GString *escaped_output, const gchar *raw,
                                    gssize raw_len, const gchar *unsafe_chars,
                                    const gchar *control_format,
                                    const gchar *invalid_format);
+
+
+/* for performance-critical use only */
+
+#define SANITIZE_UTF8_BUFFER_SIZE(l) (l * 6 + 1)
+
+static inline const gchar *
+optimized_sanitize_utf8_to_escaped_binary(const guchar *data, gint length, gsize *new_length, gchar *out,
+                                          gsize out_size)
+{
+  GString sanitized_message;
+
+  /* avoid GString allocation */
+  sanitized_message.str = out;
+  sanitized_message.len = 0;
+  sanitized_message.allocated_len = out_size;
+
+  append_unsafe_utf8_as_escaped_binary(&sanitized_message, (const gchar *) data, length, NULL);
+
+  /* MUST NEVER BE REALLOCATED */
+  g_assert(sanitized_message.str == out);
+
+  *new_length = sanitized_message.len;
+  return out;
+}
+
 #endif

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -929,6 +929,8 @@ _syslog_format_parse_legacy(const MsgFormatOptions *parse_options,
           msg->flags |= LF_UTF8;
           return TRUE;
         }
+      else
+        msg->flags |= LF_UTF8;
     }
 
   log_msg_set_value(msg, LM_V_MESSAGE, (gchar *) src, left);

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -932,14 +932,10 @@ _syslog_format_parse_legacy(const MsgFormatOptions *parse_options,
       else
         msg->flags |= LF_UTF8;
     }
+  else if ((parse_options->flags & LP_VALIDATE_UTF8) && g_utf8_validate((gchar *) src, left, NULL))
+    msg->flags |= LF_UTF8;
 
   log_msg_set_value(msg, LM_V_MESSAGE, (gchar *) src, left);
-
-  /* we don't need revalidation if sanitize already said it was valid utf8 */
-  if ((parse_options->flags & LP_VALIDATE_UTF8) &&
-      ((parse_options->flags & LP_SANITIZE_UTF8) == 0) &&
-      g_utf8_validate((gchar *) src, left, NULL))
-    msg->flags |= LF_UTF8;
 
   return TRUE;
 error:

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -39,7 +39,6 @@
 #include <string.h>
 
 #define SD_NAME_SIZE 256
-#define SANITIZE_UTF8_BUFFER_SIZE(l) (l * 6 + 1)
 
 static const char aix_fwd_string[] = "Message forwarded from ";
 static const char repeat_msg_string[] = "last message repeated";
@@ -870,25 +869,6 @@ _syslog_format_parse_legacy_header(LogMessage *msg, const guchar **data, gint *l
   return TRUE;
 }
 
-static inline const gchar *
-_sanitize_utf8(const guchar *data, gint length, gsize *new_length, gchar *out, gsize out_size)
-{
-  GString sanitized_message;
-
-  /* avoid GString allocation */
-  sanitized_message.str = out;
-  sanitized_message.len = 0;
-  sanitized_message.allocated_len = out_size;
-
-  append_unsafe_utf8_as_escaped_binary(&sanitized_message, (const gchar *) data, length, NULL);
-
-  /* MUST NEVER BE REALLOCATED */
-  g_assert(sanitized_message.str == out);
-
-  *new_length = sanitized_message.len;
-  return out;
-}
-
 /**
  * _syslog_format_parse_legacy:
  * @msg: LogMessage instance to store parsed information into
@@ -924,7 +904,7 @@ _syslog_format_parse_legacy(const MsgFormatOptions *parse_options,
         {
           gchar buf[SANITIZE_UTF8_BUFFER_SIZE(left)];
           gsize sanitized_length;
-          _sanitize_utf8(src, left, &sanitized_length, buf, sizeof(buf));
+          optimized_sanitize_utf8_to_escaped_binary(src, left, &sanitized_length, buf, sizeof(buf));
           log_msg_set_value(msg, LM_V_MESSAGE, buf, sanitized_length);
           msg->flags |= LF_UTF8;
           return TRUE;
@@ -1053,7 +1033,7 @@ _syslog_format_parse_syslog_proto(const MsgFormatOptions *parse_options, const g
             {
               gchar buf[SANITIZE_UTF8_BUFFER_SIZE(left)];
               gsize sanitized_length;
-              _sanitize_utf8(src, left, &sanitized_length, buf, sizeof(buf));
+              optimized_sanitize_utf8_to_escaped_binary(src, left, &sanitized_length, buf, sizeof(buf));
               log_msg_set_value(msg, LM_V_MESSAGE, buf, sanitized_length);
               msg->flags |= LF_UTF8;
               return TRUE;

--- a/news/bugfix-4744.md
+++ b/news/bugfix-4744.md
@@ -1,0 +1,1 @@
+`network()` source: fix marking originally valid utf-8 messages when `sanitize-utf8` is enabled

--- a/news/other-4744.md
+++ b/news/other-4744.md
@@ -1,0 +1,3 @@
+`network()`/`syslog()` sources: support UTF-8 sanitization/validation of RFC 5424 and `no-parse` messages
+
+The `sanitize-utf8`, `validate-utf8` flags are now supported when parsing RFC 5424 messages or when parsing is disabled.


### PR DESCRIPTION
- ~SDATA fields are now sanitized when the `sanitize-utf8-sdata` flag is enabled for RFC5424 inputs~
- the message field is sanitized when no utf-8 BOM is present and `sanitize-utf8` is enabled for RFC5424 inputs
- `sanitize-utf8` and `validate-utf8` now works with `flags(no-parse)` 