### PR TITLE
Hop by hop sequence number

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1325,12 +1325,26 @@ threaded_dest_driver_workers_option
 
 /* implies dest_driver_option */
 threaded_dest_driver_general_option
+        : threaded_dest_driver_general_option_noflags
+        | threaded_dest_driver_flags_option
+        ;
+
+threaded_dest_driver_general_option_noflags
 	: KW_RETRIES '(' positive_integer ')'
         {
           log_threaded_dest_driver_set_max_retries_on_error(last_driver, $3);
         }
         | KW_TIME_REOPEN '(' positive_integer ')' { log_threaded_dest_driver_set_time_reopen(last_driver, $3); }
         | dest_driver_option
+        ;
+
+threaded_dest_driver_flags_option
+        : KW_FLAGS '(' threaded_dest_driver_flags ')'
+        ;
+
+threaded_dest_driver_flags
+        : string threaded_dest_driver_flags     { CHECK_ERROR(log_threaded_dest_driver_process_flag(last_driver, $1), @1, "Unknown flag \"%s\"", $1); free($1); }
+        |
         ;
 
 /* implies source_driver_option and source_option */

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1437,10 +1437,10 @@ dest_writer_options
 	|
 	;
 
-dest_writer_option
-        /* NOTE: plugins need to set "last_writer_options" in order to incorporate this rule in their grammar */
 
-	: KW_FLAGS '(' dest_writer_options_flags ')' { last_writer_options->options = $3; }
+/* NOTE: plugins need to set "last_writer_options" in order to incorporate this rule in their grammar */
+dest_writer_option
+        : KW_FLAGS '(' dest_writer_options_flags ')'
 	| KW_FLUSH_LINES '(' nonnegative_integer ')'		{ last_writer_options->flush_lines = $3; }
 	| KW_FLUSH_TIMEOUT '(' positive_integer ')'	{ }
         | KW_SUPPRESS '(' nonnegative_integer ')'            { last_writer_options->suppress = $3; }
@@ -1460,9 +1460,9 @@ dest_writer_option
 	;
 
 dest_writer_options_flags
-	: normalized_flag dest_writer_options_flags   { $$ = log_writer_options_lookup_flag($1) | $2; free($1); }
-	|					      { $$ = 0; }
-	;
+        : string dest_writer_options_flags     { CHECK_ERROR(log_writer_options_process_flag(last_writer_options, $1), @1, "Unknown flag \"%s\"", $1); free($1); }
+        |
+        ;
 
 file_perm_option
 	: KW_OWNER '(' string_or_number ')'	{ file_perm_options_set_file_uid(last_file_perm_options, $3); free($3); }

--- a/lib/logthrdest/logthrdestdrv.c
+++ b/lib/logthrdest/logthrdestdrv.c
@@ -54,7 +54,6 @@ log_threaded_result_to_str(LogThreadedResult self)
   return as_str[self];
 }
 
-/* LogThreadedDestWorker */
 
 void
 log_threaded_dest_driver_set_batch_lines(LogDriver *s, gint batch_lines)
@@ -79,6 +78,22 @@ log_threaded_dest_driver_set_time_reopen(LogDriver *s, time_t time_reopen)
 
   self->time_reopen = time_reopen;
 }
+
+CfgFlagHandler log_threaded_dest_driver_flag_handlers[] =
+{
+  { "seqnum-all",      CFH_SET, offsetof(LogThreadedDestDriver, flags), LTDF_SEQNUM_ALL },
+  { "no-seqnum-all",   CFH_CLEAR, offsetof(LogThreadedDestDriver, flags), LTDF_SEQNUM_ALL },
+  { NULL },
+};
+
+gboolean
+log_threaded_dest_driver_process_flag(LogDriver *s, const gchar *flag)
+{
+  LogThreadedDestDriver *self = (LogThreadedDestDriver *) s;
+  return cfg_process_flag(log_threaded_dest_driver_flag_handlers, self, flag);
+}
+
+/* LogThreadedDestWorker */
 
 /* this should be used in combination with LTR_EXPLICIT_ACK_MGMT to actually confirm message delivery. */
 void

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -2015,17 +2015,18 @@ log_writer_options_destroy(LogWriterOptions *options)
   options->initialized = FALSE;
 }
 
-gint
-log_writer_options_lookup_flag(const gchar *flag)
+CfgFlagHandler log_writer_flag_handlers[] =
 {
-  if (strcmp(flag, "syslog-protocol") == 0)
-    return LWO_SYSLOG_PROTOCOL;
-  if (strcmp(flag, "no-multi-line") == 0)
-    return LWO_NO_MULTI_LINE;
-  if (strcmp(flag, "threaded") == 0)
-    return LWO_THREADED;
-  if (strcmp(flag, "ignore-errors") == 0)
-    return LWO_IGNORE_ERRORS;
-  msg_error("Unknown dest writer flag", evt_tag_str("flag", flag));
-  return 0;
+  /* LogReaderOptions */
+  { "syslog-protocol", CFH_SET, offsetof(LogWriterOptions, options), LWO_SYSLOG_PROTOCOL },
+  { "no-multi-line",   CFH_SET, offsetof(LogWriterOptions, options), LWO_NO_MULTI_LINE },
+  { "threaded",        CFH_SET, offsetof(LogWriterOptions, options), LWO_THREADED },
+  { "ignore-errors",   CFH_SET, offsetof(LogWriterOptions, options), LWO_IGNORE_ERRORS },
+  { NULL },
+};
+
+gboolean
+log_writer_options_process_flag(LogWriterOptions *options, const gchar *flag)
+{
+  return cfg_process_flag(log_writer_flag_handlers, options, flag);
 }

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -938,6 +938,9 @@ _get_seq_num(LogWriter *self, LogMessage  *lm)
 {
   static NVHandle meta_seqid = 0;
 
+  if (self->options->options & LWO_SEQNUM_ALL)
+    return self->seq_num;
+
   if (!meta_seqid)
     meta_seqid = log_msg_get_value_handle(".SDATA.meta.sequenceId");
 
@@ -1260,9 +1263,8 @@ log_writer_write_message(LogWriter *self, LogMessage *msg, LogPathOptions *path_
 
   if (consumed)
     {
-      if (msg->flags & LF_LOCAL)
+      if ((self->options->options & LWO_SEQNUM_ALL) || (msg->flags & LF_LOCAL))
         step_sequence_number(&self->seq_num);
-
 
       log_writer_update_message_stats(self, msg, msg_len);
       stats_byte_counter_add(&self->metrics.written_bytes, msg_len);
@@ -2023,11 +2025,12 @@ log_writer_options_destroy(LogWriterOptions *options)
 
 CfgFlagHandler log_writer_flag_handlers[] =
 {
-  /* LogReaderOptions */
   { "syslog-protocol", CFH_SET, offsetof(LogWriterOptions, options), LWO_SYSLOG_PROTOCOL },
   { "no-multi-line",   CFH_SET, offsetof(LogWriterOptions, options), LWO_NO_MULTI_LINE },
   { "threaded",        CFH_SET, offsetof(LogWriterOptions, options), LWO_THREADED },
   { "ignore-errors",   CFH_SET, offsetof(LogWriterOptions, options), LWO_IGNORE_ERRORS },
+  { "seqnum-all",      CFH_SET, offsetof(LogWriterOptions, options), LWO_SEQNUM_ALL },
+  { "no-seqnum-all",   CFH_CLEAR, offsetof(LogWriterOptions, options), LWO_SEQNUM_ALL },
   { NULL },
 };
 

--- a/lib/logwriter.h
+++ b/lib/logwriter.h
@@ -94,6 +94,6 @@ void log_writer_options_defaults(LogWriterOptions *options);
 void log_writer_options_init(LogWriterOptions *options, GlobalConfig *cfg, guint32 option_flags);
 void log_writer_options_destroy(LogWriterOptions *options);
 void log_writer_options_set_mark_mode(LogWriterOptions *options, const gchar *mark_mode);
-gint log_writer_options_lookup_flag(const gchar *flag);
+gboolean log_writer_options_process_flag(LogWriterOptions *options, const gchar *flag);
 
 #endif

--- a/lib/logwriter.h
+++ b/lib/logwriter.h
@@ -45,6 +45,7 @@
 #define LWO_NO_STATS        0x0004
 #define LWO_THREADED        0x0010
 #define LWO_IGNORE_ERRORS   0x0020
+#define LWO_SEQNUM_ALL      0x0040
 
 typedef struct _LogWriterOptions
 {

--- a/modules/afsql/afsql-grammar.ym
+++ b/modules/afsql/afsql-grammar.ym
@@ -120,11 +120,11 @@ dest_afsql_option
         | KW_IGNORE_TNS_CONFIG '(' yesno ')'    { afsql_dd_set_ignore_tns_config(last_driver,$3); }
         | KW_NULL '(' string ')'                { afsql_dd_set_null_value(last_driver, $3); free($3); }
         | KW_SESSION_STATEMENTS '(' string_list ')' { afsql_dd_set_session_statements(last_driver, $3); }
-        | KW_FLAGS '(' dest_afsql_flags ')'     { afsql_dd_set_flags(last_driver, $3); }
+	| KW_FLAGS '(' dest_afsql_flags ')'
 	| KW_CREATE_STATEMENT_APPEND '(' string ')' { afsql_dd_set_create_statement_append(last_driver, $3); free($3); }
 
 	| { last_template_options = &((AFSqlDestDriver *) last_driver)->template_options; } template_option
-	| threaded_dest_driver_general_option
+	| threaded_dest_driver_general_option_noflags
         | threaded_dest_driver_batch_option
         ;
 
@@ -139,9 +139,10 @@ dest_afsql_values_build
         ;
 
 dest_afsql_flags
-        : normalized_flag dest_afsql_flags      { $$ = afsql_dd_lookup_flag($1) | $2; free($1); }
-        |                                       { $$ = 0; }
+        : string dest_afsql_flags     { CHECK_ERROR(afsql_dd_process_flag(last_driver, $1), @1, "Unknown flag \"%s\"", $1); free($1); }
+        |
         ;
+
 
 /* INCLUDE_RULES */
 

--- a/modules/afsql/afsql.h
+++ b/modules/afsql/afsql.h
@@ -39,8 +39,8 @@ enum
 /* destination driver flags */
 enum
 {
-  AFSQL_DDF_EXPLICIT_COMMITS = 0x0001,
-  AFSQL_DDF_DONT_CREATE_TABLES = 0x0002,
+  AFSQL_DDF_EXPLICIT_COMMITS = 0x1000,
+  AFSQL_DDF_DONT_CREATE_TABLES = 0x2000,
 };
 
 typedef struct _AFSqlField
@@ -82,7 +82,6 @@ typedef struct _AFSqlDestDriver
   AFSqlField *fields;
   gchar *null_value;
   gchar *quote_as_string;
-  gint flags;
   gboolean ignore_tns_config;
   GList *session_statements;
 
@@ -113,7 +112,6 @@ void afsql_dd_set_values(LogDriver *s, GList *values);
 void afsql_dd_set_null_value(LogDriver *s, const gchar *null);
 void afsql_dd_set_indexes(LogDriver *s, GList *indexes);
 void afsql_dd_set_session_statements(LogDriver *s, GList *session_statements);
-void afsql_dd_set_flags(LogDriver *s, gint flags);
 void afsql_dd_set_create_statement_append(LogDriver *s, const gchar *create_statement_append);
 LogDriver *afsql_dd_new(GlobalConfig *cfg);
 gint afsql_dd_lookup_flag(const gchar *flag);
@@ -122,5 +120,8 @@ void afsql_dd_add_dbd_option_numeric(LogDriver *s, const gchar *name, gint value
 void afsql_dd_set_dbi_driver_dir(LogDriver *s, const gchar *dbi_driver_dir);
 void afsql_dd_set_quote_char(LogDriver *s, const gchar *quote);
 void afsql_dd_set_ignore_tns_config(LogDriver *s, const gboolean ignore_tns_config);
+
+gboolean afsql_dd_process_flag(LogDriver *driver, const gchar *flag);
+
 
 #endif

--- a/news/feature-4745.md
+++ b/news/feature-4745.md
@@ -1,0 +1,21 @@
+`flags(seqnum-all)`: available in all destination drivers, this new flag
+changes $SEQNUM behaviour, so that all messages get a sequence number, not
+just local ones.  Previously syslog-ng followed the logic of the RFC5424
+meta.sequenceId structured data element, e.g.  only local messages were to
+get a sequence number, forwarded messages retained their original sequenceId
+that we could potentially receive ourselves.
+
+For example, this destination would include the meta.sequenceId SDATA
+element even for non-local logs and increment that value by every message
+transmitted:
+
+	destination { syslog("127.0.0.1" port(2001) flags(seqnum-all)); };
+
+This generates a message like this on the output, even if the message is
+not locally generated (e.g. forwarded from another syslog sender):
+
+        <13>1 2023-12-09T21:51:30+00:00 localhost sdff - - [meta sequenceId="1"] f sdf fsd
+        <13>1 2023-12-09T21:51:32+00:00 localhost sdff - - [meta sequenceId="2"] f sdf fsd
+        <13>1 2023-12-09T21:51:32+00:00 localhost sdff - - [meta sequenceId="3"] f sdf fsd
+        <13>1 2023-12-09T21:51:32+00:00 localhost sdff - - [meta sequenceId="4"] f sdf fsd
+        <13>1 2023-12-09T21:51:32+00:00 localhost sdff - - [meta sequenceId="5"] f sdf fsd


### PR DESCRIPTION
This branch adds a "seqnum-all" flag and a "no-seqnum-all" flags to all output drivers. 

With that flag set $SEQNUM would always be set  a sequence number that is related to the output connection, thereby incrementing an output sequence numbering.

This was requested by here: 
* https://github.com/syslog-ng/syslog-ng/discussions/4363
* https://github.com/syslog-ng/syslog-ng/discussions/4721

and I remember it came up before.