### PR TITLE
Unterminated quotes in the config file can lead to partially parsed/included sub config files silently

### DIFF
--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -361,6 +361,9 @@ word	[^ \#'"\(\)\{\}\[\]\\;\r\n\t,|\.@:]
 			     yylval->cptr = strdup(yyextra->string_buffer->str);
 			     return LL_STRING;
 			   }
+<qstring><<EOF>>           {
+                             YY_FATAL_ERROR( "Unterminated quote" );
+                           }
 
     /* the rule below will only be applied to embedded newlines within
      * string/qstring.  There's a difference how we handle backslash quotation


### PR DESCRIPTION
Added detection of unterminated quotes in the config lexer.

fixes #4746

Signed-off-by: Hofi <hofione@gmail.com>