### PR TITLE
metrics-probe: fix not cleaning labels when only dynamic labels are set 

### DIFF
--- a/modules/metrics-probe/metrics-probe.c
+++ b/modules/metrics-probe/metrics-probe.c
@@ -154,6 +154,8 @@ _add_dynamic_labels(MetricsProbe *self, LogMessage *msg)
 static void
 _calculate_stats_cluster_key(MetricsProbe *self, LogMessage *msg, StatsClusterKey *key)
 {
+  label_buffers = g_array_set_size(label_buffers, 0);
+
   gint label_idx = 0;
   for (GList *elem = g_list_first(self->label_templates); elem; elem = elem->next)
     {

--- a/news/bugfix-4750.md
+++ b/news/bugfix-4750.md
@@ -1,0 +1,1 @@
+`metrics-probe()`: Fixed not cleaning up dynamic labels for each message if no static labels are set.


### PR DESCRIPTION
The `label_buffers = g_array_set_size(label_buffers, label_idx + 1);` code cleans the array, but if there are not static labels it is not executed.

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>