### PR TITLE
helm: improve deployment and service manifest

### DIFF
--- a/contrib/syslog-ng-helm-chart/Chart.yaml
+++ b/contrib/syslog-ng-helm-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: syslog-ng
 description: Syslog-ng
-version: 0.2
+version: 0.3
 appVersion: 3.27.1
 maintainers:
   - name: zakkg3

--- a/contrib/syslog-ng-helm-chart/templates/deployment.yaml
+++ b/contrib/syslog-ng-helm-chart/templates/deployment.yaml
@@ -25,6 +25,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 
       containers:
         - name: {{ .Chart.Name }}
@@ -32,6 +36,14 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.extraArgs }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
           - name: tcp-port
             containerPort: 601
@@ -47,6 +59,9 @@ spec:
           - mountPath: /var/log
             name: logs
         {{- end }}
+        {{- with .Values.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       volumes:
       - name: config
         configMap:
@@ -56,7 +71,9 @@ spec:
         persistentVolumeClaim:
           claimName: {{ include "syslog-ng.fullname" . }}-pvc
       {{- end }}
-
+      {{- with .Values.extraVolumes }}
+        {{ toYaml . | nindent 6 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/contrib/syslog-ng-helm-chart/templates/service.yaml
+++ b/contrib/syslog-ng-helm-chart/templates/service.yaml
@@ -3,10 +3,13 @@ kind: Service
 metadata:
   name: {{ include "syslog-ng.fullname" . }}
   labels:
-    {{- include "syslog-ng.labels" . | nindent 4 }}
+    {{- include "syslog-ng.labels" . | nindent 4 }}  
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  {{- if eq .Values.service.type "externalip" }}
-  
+  {{- if eq .Values.service.type "externalip" }}  
   {{- with .Values.service.externalIPs }}
   externalIPs:
     {{- toYaml . | nindent 3 }}
@@ -14,6 +17,18 @@ spec:
   {{- else}}
   type: {{ .Values.service.type }}
   {{- end }}
+  {{- if .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
+{{- end }}
+{{- if .Values.service.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.service.loadBalancerClass }}
+{{- end }}
+{{- if .Values.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+{{- end }}
+{{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+{{- end }}
   ports:
     - name: udp-port
       port: 514

--- a/contrib/syslog-ng-helm-chart/values.yaml
+++ b/contrib/syslog-ng-helm-chart/values.yaml
@@ -72,7 +72,7 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-# syslog-ng have fixed ports tcp 601  and udp 514
+# syslog-ng have fixed ports tcp 601 and udp 514
 service:
   type: ClusterIP
   # use externalip for a pre routede exter al ip.
@@ -80,6 +80,13 @@ service:
   # type: externalip
   # externalIPs: 
   #   - 10.205.212.12
+  annotations: {}
+    # external-dns.alpha.kubernetes.io/hostname: "syslog.example.com"
+  loadBalancerSourceRanges: []
+    # - 10.2.3.0/24
+  loadBalancerClass: ~
+  sessionAffinity: ~
+  externalTrafficPolicy: Cluster
 
 
 resources: {}

--- a/news/other-4752.md
+++ b/news/other-4752.md
@@ -1,0 +1,4 @@
+helm: improve deployment and service manifest
+    
+Add support for custom resource definition and extend customisation of
+service specific settings.


### PR DESCRIPTION
Add support for custom resource definition and extend customisation of service specific settings.

This change is necessary if you want to apply least privilege policy via security context.  Here is a custom `values.yaml` that can be used to achieve just that:

```yaml
  securityContext: 
    privileged: true

  podSecurityContext: 
    fsGroup: 65534
    runAsUser: 65534
    runAsGroup: 65534
    seccompProfile: 
      type: RuntimeDefault
    sysctls:
      - name: net.ipv4.ip_unprivileged_port_start
        value: "500"

  securityContext: 
    capabilities:
      drop:
      - ALL
    readOnlyRootFilesystem: true
    allowPrivilegeEscalation: false
    runAsNonRoot: true
    runAsUser: 65534
    runAsGroup: 65534

  extraArgs:
    - --no-caps
   
  resources: 
    limits:
      cpu: 100m
      memory: 128Mi
    requests:
      cpu: 100m
      memory: 128Mi


  extraVolumeMounts:
    - mountPath: /var/log/syslog
      name: logs
    - mountPath: /var/lib/syslog-ng
      name: libs
  extraVolumes:
    - name: logs
      emptyDir: 
        sizeLimit: 10Gi
    - name: libs
      emptyDir: 
        sizeLimit: 100Mi
```

