### PR TITLE
bigquery: move failable operations to connect() from init()

### DIFF
--- a/modules/grpc/bigquery/bigquery-worker.cpp
+++ b/modules/grpc/bigquery/bigquery-worker.cpp
@@ -66,18 +66,6 @@ DestinationWorker::~DestinationWorker()
 }
 
 bool
-DestinationWorker::init()
-{
-  return log_threaded_dest_worker_init_method(&this->super->super);
-}
-
-void
-DestinationWorker::deinit()
-{
-  log_threaded_dest_worker_deinit_method(&this->super->super);
-}
-
-bool
 DestinationWorker::connect()
 {
   if (!this->channel)
@@ -486,20 +474,6 @@ _disconnect(LogThreadedDestWorker *s)
   self->cpp->disconnect();
 }
 
-static gboolean
-_init(LogThreadedDestWorker *s)
-{
-  BigQueryDestWorker *self = (BigQueryDestWorker *) s;
-  return self->cpp->init();
-}
-
-static void
-_deinit(LogThreadedDestWorker *s)
-{
-  BigQueryDestWorker *self = (BigQueryDestWorker *) s;
-  self->cpp->deinit();
-}
-
 static void
 _free(LogThreadedDestWorker *s)
 {
@@ -518,8 +492,6 @@ bigquery_dw_new(LogThreadedDestDriver *o, gint worker_index)
 
   self->cpp = new DestinationWorker(self);
 
-  self->super.init = _init;
-  self->super.deinit = _deinit;
   self->super.connect = _connect;
   self->super.disconnect = _disconnect;
   self->super.insert = _insert;

--- a/modules/grpc/bigquery/bigquery-worker.hpp
+++ b/modules/grpc/bigquery/bigquery-worker.hpp
@@ -66,6 +66,7 @@ public:
   LogThreadedResult flush(LogThreadedFlushMode mode);
 
 private:
+  std::shared_ptr<::grpc::Channel> create_channel();
   void construct_write_stream();
   void prepare_batch();
   bool insert_field(const google::protobuf::Reflection *reflection, const Field &field,


### PR DESCRIPTION
We cannot fail in a threaded workers init(), because of lib/cfg.c:344.

```
  /*
   * TLDR: A half-initialized pipeline turned out to be really hard to deinitialize
   * correctly when dedicated source/destination threads are spawned (because we
   * would have to wait for workers to stop and guarantee some internal
   * task/timer/fdwatch ordering in ivykis during this action).
   * See: https://github.com/syslog-ng/syslog-ng/pull/3176#issuecomment-638849597
   */
  g_assert(cfg_tree_post_config_init(&cfg->tree));
```

No news file needed as it is not a released feature yet.

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
