### PR TITLE
cloud-auth: implement gcp(user-managed-service-account()) 

### DIFF
--- a/modules/cloud-auth/CMakeLists.txt
+++ b/modules/cloud-auth/CMakeLists.txt
@@ -49,7 +49,7 @@ add_module(
 )
 
 add_module(
-  TARGET cloud-auth
+  TARGET cloud_auth
   GRAMMAR cloud-auth-grammar
   DEPENDS cloud-auth-cpp
   INCLUDES ${PROJECT_SOURCE_DIR}

--- a/modules/cloud-auth/CMakeLists.txt
+++ b/modules/cloud-auth/CMakeLists.txt
@@ -8,6 +8,19 @@ if(NOT ENABLE_CLOUD_AUTH OR NOT ENABLE_CPP)
   return()
 endif()
 
+if (NOT DEFINED ENABLE_CLOUD_AUTH_CURL OR ENABLE_CLOUD_AUTH_CURL)
+  find_package(Curl)
+endif()
+
+module_switch(ENABLE_CLOUD_AUTH_CURL "Enable cURL support for cloud-auth()" Curl_FOUND)
+if (NOT ENABLE_CLOUD_AUTH_CURL)
+  return ()
+endif ()
+
+if (NOT Curl_FOUND)
+  message(FATAL_ERROR "cURL support for cloud-auth() enabled, but libcurl not found")
+endif ()
+
 set(CLOUD_AUTH_CPP_SOURCES
   cloud-auth.c
   cloud-auth.h
@@ -30,6 +43,8 @@ add_module(
   INCLUDES ${PROJECT_SOURCE_DIR}
            ${PROJECT_SOURCE_DIR}/modules/cloud-auth
            ${PROJECT_SOURCE_DIR}/modules/cloud-auth/jwt-cpp/include
+           ${Curl_INCLUDE_DIR}
+  DEPENDS ${Curl_LIBRARIES}
   LIBRARY_TYPE STATIC
 )
 

--- a/modules/cloud-auth/Makefile.am
+++ b/modules/cloud-auth/Makefile.am
@@ -10,12 +10,13 @@ modules_cloud_auth_libcloud_auth_cpp_la_SOURCES = \
 
 modules_cloud_auth_libcloud_auth_cpp_la_CXXFLAGS = \
   $(AM_CXXFLAGS) \
+  $(LIBCURL_CFLAGS) \
   -I$(top_srcdir)/modules/cloud-auth \
   -I$(top_builddir)/modules/cloud-auth \
   -isystem $(top_srcdir)/modules/cloud-auth/jwt-cpp/include \
   -isystem $(top_builddir)/modules/cloud-auth/jwt-cpp/include
 
-modules_cloud_auth_libcloud_auth_cpp_la_LIBADD = $(MODULE_DEPS_LIBS)
+modules_cloud_auth_libcloud_auth_cpp_la_LIBADD = $(MODULE_DEPS_LIBS) $(LIBCURL_LIBS)
 modules_cloud_auth_libcloud_auth_cpp_la_LDFLAGS = $(MODULE_LDFLAGS)
 modules_cloud_auth_libcloud_auth_cpp_la_DEPENDENCIES = $(MODULE_DEPS_LIBS)
 

--- a/modules/cloud-auth/cloud-auth-grammar.ym
+++ b/modules/cloud-auth/cloud-auth-grammar.ym
@@ -52,6 +52,9 @@ CloudAuthenticator *last_authenticator;
 %token KW_KEY
 %token KW_AUDIENCE
 %token KW_TOKEN_VALIDITY_DURATION
+%token KW_USER_MANAGED_SERVICE_ACCOUNT
+%token KW_NAME
+%token KW_METADATA_URL
 
 %%
 
@@ -91,6 +94,11 @@ google_dest_auth_option
       google_authenticator_set_auth_mode(last_authenticator, GAAM_SERVICE_ACCOUNT);
     }
     '(' google_dest_auth_service_account_options ')'
+  | KW_USER_MANAGED_SERVICE_ACCOUNT
+    {
+      google_authenticator_set_auth_mode(last_authenticator, GAAM_USER_MANAGED_SERVICE_ACCOUNT);
+    }
+    '(' google_dest_auth_user_managed_service_account_options ')'
   ;
 
 google_dest_auth_service_account_options
@@ -102,6 +110,16 @@ google_dest_auth_service_account_option
   : KW_KEY '(' path_secret ')' { google_authenticator_set_service_account_key_path(last_authenticator, $3); free($3); }
   | KW_AUDIENCE '(' string ')' { google_authenticator_set_service_account_audience(last_authenticator, $3); free($3); }
   | KW_TOKEN_VALIDITY_DURATION '(' nonnegative_integer64 ')' { google_authenticator_set_service_account_token_validity_duration(last_authenticator, $3); }
+  ;
+
+google_dest_auth_user_managed_service_account_options
+  : google_dest_auth_user_managed_service_account_option google_dest_auth_user_managed_service_account_options
+  |
+  ;
+
+google_dest_auth_user_managed_service_account_option
+  : KW_NAME '(' string ')' { google_authenticator_set_user_managed_service_account_name(last_authenticator, $3); free($3); }
+  | KW_METADATA_URL '(' string ')' { google_authenticator_set_user_managed_service_account_metadata_url(last_authenticator, $3); free($3); }
   ;
 
 /* INCLUDE_RULES */

--- a/modules/cloud-auth/cloud-auth-parser.c
+++ b/modules/cloud-auth/cloud-auth-parser.c
@@ -35,6 +35,9 @@ static CfgLexerKeyword cloud_auth_keywords[] =
   { "key",                      KW_KEY },
   { "audience",                 KW_AUDIENCE },
   { "token_validity_duration",  KW_TOKEN_VALIDITY_DURATION },
+  { "user_managed_service_account",  KW_USER_MANAGED_SERVICE_ACCOUNT },
+  { "name",                          KW_NAME},
+  { "metadata_url",                  KW_METADATA_URL },
   { NULL }
 };
 

--- a/modules/cloud-auth/google-auth.h
+++ b/modules/cloud-auth/google-auth.h
@@ -41,8 +41,6 @@ void google_authenticator_set_service_account_token_validity_duration(CloudAuthe
     guint64 token_validity_duration);
 
 void google_authenticator_set_user_managed_service_account_name(CloudAuthenticator *s, const gchar *name);
-void google_authenticator_set_user_managed_service_account_token_validity_duration(CloudAuthenticator *s,
-    guint64 token_validity_duration);
 void google_authenticator_set_user_managed_service_account_metadata_url(CloudAuthenticator *s,
     const gchar *metadata_url);
 

--- a/modules/cloud-auth/google-auth.h
+++ b/modules/cloud-auth/google-auth.h
@@ -29,14 +29,22 @@ typedef enum _GoogleAuthenticatorAuthMode
 {
   GAAM_UNDEFINED,
   GAAM_SERVICE_ACCOUNT,
+  GAAM_USER_MANAGED_SERVICE_ACCOUNT,
 } GoogleAuthenticatorAuthMode;
 
 CloudAuthenticator *google_authenticator_new(void);
 void google_authenticator_set_auth_mode(CloudAuthenticator *s, GoogleAuthenticatorAuthMode auth_mode);
+
 void google_authenticator_set_service_account_key_path(CloudAuthenticator *s, const gchar *key_path);
 void google_authenticator_set_service_account_audience(CloudAuthenticator *s, const gchar *audience);
 void google_authenticator_set_service_account_token_validity_duration(CloudAuthenticator *s,
     guint64 token_validity_duration);
+
+void google_authenticator_set_user_managed_service_account_name(CloudAuthenticator *s, const gchar *name);
+void google_authenticator_set_user_managed_service_account_token_validity_duration(CloudAuthenticator *s,
+    guint64 token_validity_duration);
+void google_authenticator_set_user_managed_service_account_metadata_url(CloudAuthenticator *s,
+    const gchar *metadata_url);
 
 
 #endif

--- a/modules/cloud-auth/google-auth.hpp
+++ b/modules/cloud-auth/google-auth.hpp
@@ -54,6 +54,19 @@ private:
   uint64_t token_validity_duration;
 };
 
+class UserManagedServiceAccountAuthenticator: public syslogng::cloud_auth::Authenticator
+{
+public:
+  UserManagedServiceAccountAuthenticator(const char *name, const char *metadata_url);
+  ~UserManagedServiceAccountAuthenticator() {};
+
+  void handle_http_header_request(HttpHeaderRequestSignalData *data);
+
+private:
+  std::string name;
+  uint64_t token_validity_duration;
+  std::string metadata_url;
+};
 }
 }
 }

--- a/news/feature-4755.md
+++ b/news/feature-4755.md
@@ -1,0 +1,40 @@
+`cloud-auth()`: Added support for `user-managed-service-account()` `gcp()` auth method.
+
+This authentication method can be used on VMs in GCP to use the linked service.
+
+Example minimal config, which tries to use the "default" service account:
+```
+cloud-auth(
+  gcp(
+    user-managed-service-account()
+  )
+)
+```
+
+Full config:
+```
+cloud-auth(
+  gcp(
+    user-managed-service-account(
+      name("alltilla@syslog-ng-test-project.iam.gserviceaccount.com")
+      metadata-url("my-custom-metadata-server:8080")
+    )
+  )
+)
+```
+
+This authentication method is extremely useful with syslog-ng's `google-pubsub()` destination,
+when it is running on VMs in GCP, for example:
+```
+destination {
+  google-pubsub(
+    project("syslog-ng-test-project")
+    topic("syslog-ng-test-topic")
+    auth(user-managed-service-account())
+  );
+};
+```
+
+For more info about this GCP authentication method, see:
+ * https://cloud.google.com/compute/docs/access/authenticate-workloads#curl
+ * https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances

--- a/scl/CMakeLists.txt
+++ b/scl/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SCL_DIRS
     elasticsearch
     ewmm
     fortigate
+    google
     graphite
     graylog2
     hdfs


### PR DESCRIPTION
This authentication method can be used on VMs in GCP to use the linked service.

Example minimal config, which tries to use the "default" service account:
```
cloud-auth(
  gcp(
    user-managed-service-account()
  )
)
```

Full config:
```
cloud-auth(
  gcp(
    user-managed-service-account(
      name("alltilla@syslog-ng-test-project.iam.gserviceaccount.com")
      metadata-url("my-custom-metadata-server:8080")
    )
  )
)
```

This authentication method is extremely useful with syslog-ng's `google-pubsub()` destination,
when it is running on VMs in GCP, for example:
```
destination {
  google-pubsub(
    project("syslog-ng-test-project")
    topic("syslog-ng-test-topic")
    auth(user-managed-service-account())
  );
};
```

For more info about this GCP authentication method, see:
 * https://cloud.google.com/compute/docs/access/authenticate-workloads#curl
 * https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances