### PR TITLE
`bigquery()`: add `batch-bytes()`

### DIFF
--- a/modules/grpc/bigquery/bigquery-dest.cpp
+++ b/modules/grpc/bigquery/bigquery-dest.cpp
@@ -183,7 +183,11 @@ DestinationDriver::init()
       return false;
     }
 
-  return log_threaded_dest_driver_init_method(&this->super->super.super.super.super);
+  if (!log_threaded_dest_driver_init_method(&this->super->super.super.super.super))
+    return false;
+
+  log_threaded_dest_driver_register_aggregated_stats(&this->super->super);
+  return true;
 }
 
 bool

--- a/modules/grpc/bigquery/bigquery-dest.cpp
+++ b/modules/grpc/bigquery/bigquery-dest.cpp
@@ -90,7 +90,7 @@ private:
 
 DestinationDriver::DestinationDriver(BigQueryDestDriver *s)
   : super(s), url("bigquerystorage.googleapis.com"),
-    keepalive_time(-1), keepalive_timeout(-1), keepalive_max_pings_without_data(-1)
+    keepalive_time(-1), keepalive_timeout(-1), keepalive_max_pings_without_data(-1), batch_bytes(10 * 1000 * 1000)
 {
   log_template_options_defaults(&this->template_options);
 }
@@ -380,6 +380,13 @@ bigquery_dd_set_protobuf_schema(LogDriver *d, const gchar *proto_path, GList *va
 {
   BigQueryDestDriver *self = (BigQueryDestDriver *) d;
   self->cpp->set_protobuf_schema(proto_path, values);
+}
+
+void
+bigquery_dd_set_batch_bytes(LogDriver *d, glong b)
+{
+  BigQueryDestDriver *self = (BigQueryDestDriver *) d;
+  self->cpp->set_batch_bytes((size_t) b);
 }
 
 void

--- a/modules/grpc/bigquery/bigquery-dest.h
+++ b/modules/grpc/bigquery/bigquery-dest.h
@@ -41,6 +41,8 @@ void bigquery_dd_set_table(LogDriver *d, const gchar *table);
 gboolean bigquery_dd_add_field(LogDriver *d, const gchar *name, const gchar *type, LogTemplate *value);
 void bigquery_dd_set_protobuf_schema(LogDriver *d, const gchar *proto_path, GList *values);
 
+void bigquery_dd_set_batch_bytes(LogDriver *d, glong b);
+
 void bigquery_dd_set_keepalive_time(LogDriver *d, gint t);
 void bigquery_dd_set_keepalive_timeout(LogDriver *d, gint t);
 void bigquery_dd_set_keepalive_max_pings(LogDriver *d, gint p);

--- a/modules/grpc/bigquery/bigquery-dest.hpp
+++ b/modules/grpc/bigquery/bigquery-dest.hpp
@@ -114,6 +114,11 @@ public:
     this->table = t;
   }
 
+  void set_batch_bytes(size_t b)
+  {
+    this->batch_bytes = b;
+  }
+
   void set_keepalive_time(int t)
   {
     this->keepalive_time = t;
@@ -162,6 +167,8 @@ private:
   std::string project;
   std::string dataset;
   std::string table;
+
+  size_t batch_bytes;
 
   int keepalive_time;
   int keepalive_timeout;

--- a/modules/grpc/bigquery/bigquery-grammar.ym
+++ b/modules/grpc/bigquery/bigquery-grammar.ym
@@ -54,6 +54,7 @@
 %token KW_TABLE
 %token KW_SCHEMA
 %token KW_PROTOBUF_SCHEMA
+%token KW_BATCH_BYTES
 
 %token KW_KEEP_ALIVE
 %token KW_TIME
@@ -91,6 +92,11 @@ bigquery_dest_option
     {
       bigquery_dd_set_protobuf_schema(last_driver, $3, $5);
       free($3);
+    }
+  | KW_BATCH_BYTES '(' positive_integer ')'
+    {
+      CHECK_ERROR($3 <= (10 * 1000 * 1000), @3, "batch-bytes() cannot be larger than 10 MB. For more info see https://cloud.google.com/bigquery/quotas#write-api-limits");
+      bigquery_dd_set_batch_bytes(last_driver, $3);
     }
   | KW_KEEP_ALIVE '(' bigquery_keepalive_options ')'
   | threaded_dest_driver_general_option

--- a/modules/grpc/bigquery/bigquery-parser.c
+++ b/modules/grpc/bigquery/bigquery-parser.c
@@ -37,6 +37,7 @@ static CfgLexerKeyword bigquery_keywords[] =
   { "table", KW_TABLE },
   { "schema", KW_SCHEMA },
   { "protobuf_schema", KW_PROTOBUF_SCHEMA },
+  { "batch_bytes", KW_BATCH_BYTES },
   { "keep_alive", KW_KEEP_ALIVE },
   { "time", KW_TIME },
   { "timeout", KW_TIMEOUT },

--- a/modules/grpc/bigquery/bigquery-worker.cpp
+++ b/modules/grpc/bigquery/bigquery-worker.cpp
@@ -324,6 +324,7 @@ DestinationWorker::insert(LogMessage *msg)
   rows->add_serialized_rows(std::move(serialized_row));
 
   this->current_batch_bytes += row_bytes;
+  log_threaded_dest_driver_insert_msg_length_stats(this->super->super.owner, row_bytes);
 
   msg_trace("Message added to BigQuery batch", log_pipe_location_tag((LogPipe *) this->super->super.owner));
 
@@ -398,6 +399,9 @@ DestinationWorker::flush(LogThreadedFlushMode mode)
 
       goto exit;
     }
+
+  log_threaded_dest_worker_written_bytes_add(&this->super->super, this->current_batch_bytes);
+  log_threaded_dest_driver_insert_batch_length_stats(this->super->super.owner, this->current_batch_bytes);
 
   msg_debug("BigQuery batch delivered", log_pipe_location_tag((LogPipe *) this->super->super.owner));
   result = LTR_SUCCESS;

--- a/modules/grpc/bigquery/bigquery-worker.hpp
+++ b/modules/grpc/bigquery/bigquery-worker.hpp
@@ -69,6 +69,7 @@ private:
   std::shared_ptr<::grpc::Channel> create_channel();
   void construct_write_stream();
   void prepare_batch();
+  bool should_initiate_flush();
   bool insert_field(const google::protobuf::Reflection *reflection, const Field &field,
                     LogMessage *msg, google::protobuf::Message *message);
   LogThreadedResult handle_row_errors(const google::cloud::bigquery::storage::v1::AppendRowsResponse &response);
@@ -92,6 +93,7 @@ private:
   /* batch state */
   google::cloud::bigquery::storage::v1::AppendRowsRequest current_batch;
   size_t batch_size = 0;
+  size_t current_batch_bytes = 0;
 };
 
 }


### PR DESCRIPTION
BigQuery does not let us send a batch with more than 10 MB data: https://cloud.google.com/bigquery/quotas#write-api-limits

The new `batch-bytes()` option let's the user set an upper bytes size limit of the batch. By default it is 10 MB, and syslog-ng does not let the user set a larger value.

Please note that due to a framework limitation, the batch is possible to be at most 1 message larger than the set limit. You can set this limit to a lower value, but BigQuery never dropped a batch because of this in my manual E2E tests. _This might be because maybe Google meant 10 MiB as the limit not 10 MB, but we are following what the doc says._

---

Example config:
```
  bigquery(
    project("syslog-ng-bigquery-project")
    dataset("syslog_ng_bigquery_dataset")
    table("syslog-ng-bigquery-table")
    schema(
      "my_string" STRING => "${MESSAGE}"
      "my_int" INTEGER => "${R_MSEC}"
      "my_bool" bool => "$(% ${R_MSEC} 2) == 0"
    )
    workers(16)
    log-fifo-size(1000000)

    batch-timeout(5000) # ms
    batch-lines(1000000) # Huge limit, batch-bytes() will limit us sooner

    # batch-bytes(21MiB) # syslog-ng will not start as it is larger than 10MB
    batch-bytes(1MB) # closes and flushes the batch after the last message pushed it above the 1MB limit
    # not setting batch-bytes() defaults to 10MB, which is the maximal allowed by BigQuery
  );
```

---

New stats are also added to the legacy CSV output:
```
$ ./sbin/syslog-ng-ctl stats | grep "msg\|batch"
dst.bigquery;d_bq#0;bigquery,bigquerystorage.googleapis.com,syslog-ng-test-project,syslog_ng_test_dataset,syslog-ng-test-table;a;batch_size_avg;27828
dst.bigquery;d_bq#0;bigquery,bigquerystorage.googleapis.com,syslog-ng-test-project,syslog_ng_test_dataset,syslog-ng-test-table;a;batch_size_max;27828
dst.bigquery;d_bq#0;bigquery,bigquerystorage.googleapis.com,syslog-ng-test-project,syslog_ng_test_dataset,syslog-ng-test-table;a;msg_size_avg;6957
dst.bigquery;d_bq#0;bigquery,bigquerystorage.googleapis.com,syslog-ng-test-project,syslog_ng_test_dataset,syslog-ng-test-table;a;msg_size_max;6957
global;msg_clones;;a;processed;0
```

No news file needed as `bigquery()` was not released in a stable version, yet.