### PR TITLE
logmatcher: fix storing matches if source handle changes

### DIFF
--- a/news/bugfix-4759.md
+++ b/news/bugfix-4759.md
@@ -1,0 +1,1 @@
+`regexp-parser()`: Fixed a bug, which stored some values incorrectly if `${MESSAGE}` was changed with a capture group.


### PR DESCRIPTION
Example config for reproduction:
```
@version: 4.5
@include "scl.conf"

source s_local {
  example-msg-generator(template("foo bar baz"));
};

destination d_local {
  stdout(template("$A_foobar $MESSAGE $Z_barbaz"));
};

log {
  source(s_local);

  parser {
    regexp-parser(
      patterns("(?<A_foobar>[a-z]+) (?<MESSAGE>[a-z]+) (?<Z_barbaz>[a-z]+)")
    );
  };

  destination(d_local);
};
```