### PR TITLE
dbld: get rid of gosu and the fake-sudo commands

### DIFF
--- a/dbld/Makefile.am
+++ b/dbld/Makefile.am
@@ -20,7 +20,6 @@ EXTRA_DIST += \
 	dbld/pip_packages.manifest \
 	dbld/images/entrypoint.sh \
 	dbld/images/fake-sudo.sh \
-	dbld/images/gosu.pubkey \
 	dbld/images/yum-builddep.sha1 \
 	dbld/images/debian.prepare.sh \
 	dbld/images/ubuntu.prepare.sh \

--- a/dbld/README.md
+++ b/dbld/README.md
@@ -131,21 +131,3 @@ All artifacts (tarball, deb/rpm packages) are stored in `./dbld/release/<VERSION
 The script does not undertake publishing the artifacts or the tag in any
 way. It is expected that some kind of CI system will perform this (jenkins,
 travis, github-actions).
-
-## sudo
-The `sudo` command is not available inside this development container.
-
->Short explanation:
->
->Many of the image maintainers (mostly for security reasons) do not install the sudo package by default. Additionally (to avoid access problems to your repository outside of this container), we
->- mount directories
->- run commands
->
->inside this container using your external Username and ID.
-
-There are many options to circumvent this limitation (i.e. Create your own image, based on this one.), but probably the easiest way is to start a new privileged shell in the already running container, using `docker exec`.
-```bash
-$ docker exec -it <container-name or ID> /bin/bash
-```
-
-> note: We installed a fake `sudo` command inside the container, which will print out a copy-paste ready version of the `docker exec` command in case someone accidentally calls it.

--- a/dbld/builddeps
+++ b/dbld/builddeps
@@ -68,17 +68,6 @@ function install_criterion() {
 
 }
 
-function install_gosu() {
-    GOSU_VERSION=1.10
-    ARCHITECTURE=$1
-    cat $DBLD_DIR/images/gosu.pubkey | gpg --import
-    download_target "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${ARCHITECTURE}" /usr/local/bin/gosu
-    download_target "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${ARCHITECTURE}.asc" /usr/local/bin/gosu.asc
-    gpg --verify /usr/local/bin/gosu.asc
-    rm /usr/local/bin/gosu.asc
-    chmod +x /usr/local/bin/gosu
-}
-
 function set_jvm_paths() {
     find / -name 'libjvm.so' | sed 's@/libjvm.so@@g' | tee --append /etc/ld.so.conf.d/openjdk-libjvm.conf
     ldconfig

--- a/dbld/images/README.md
+++ b/dbld/images/README.md
@@ -34,11 +34,7 @@ In this section we will install all the dependencies we need, in the following o
 | install_pip_packages | [python -m pip](https://packaging.python.org/tutorials/installing-packages/) | See [pip_packages.manifest](/dbld/pip_packages.manifest) |
 | install_criterion | [Criterion](https://github.com/Snaipe/Criterion) | We use criterion for unit testing. |
 | install_gradle | [Gradle](https://gradle.org/) | We use gradle to build Java based drivers. |
-| install_gosu \<platform\> | [Gosu](https://github.com/tianon/gosu) | We use gosu to drop root privileges inside the containers. |
 > Note: These functions can be found in [dbld/builddeps](/dbld/builddeps)
-
-### fake sudo
-Just a simple `echo` command to make life easier. Reasons are explained in details in [/dbld/README.md](/dbld/README.md)
 
 ### volumes
 Creating the `/source` and `/build` folders for our work. (note: `install` folder will be placed inside the build folder)

--- a/dbld/images/centos-7.dockerfile
+++ b/dbld/images/centos-7.dockerfile
@@ -8,7 +8,6 @@ ARG COMMIT
 ENV IMAGE_PLATFORM ${ARG_IMAGE_PLATFORM}
 LABEL COMMIT=${COMMIT}
 
-COPY images/fake-sudo.sh /usr/bin/sudo
 COPY images/entrypoint.sh /
 COPY . /dbld/
 
@@ -20,7 +19,6 @@ RUN /dbld/builddeps install_rpm_build_deps
 
 RUN /dbld/builddeps install_criterion
 RUN /dbld/builddeps install_gradle
-RUN /dbld/builddeps install_gosu amd64
 
 VOLUME /source
 VOLUME /build

--- a/dbld/images/debian-bookworm.dockerfile
+++ b/dbld/images/debian-bookworm.dockerfile
@@ -12,7 +12,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
 ENV LANG C.UTF-8
 
-COPY images/fake-sudo.sh /usr/bin/sudo
 COPY images/entrypoint.sh /
 COPY . /dbld/
 

--- a/dbld/images/debian-bullseye.dockerfile
+++ b/dbld/images/debian-bullseye.dockerfile
@@ -12,7 +12,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
 ENV LANG C.UTF-8
 
-COPY images/fake-sudo.sh /usr/bin/sudo
 COPY images/entrypoint.sh /
 COPY . /dbld/
 

--- a/dbld/images/debian-buster.dockerfile
+++ b/dbld/images/debian-buster.dockerfile
@@ -12,7 +12,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
 ENV LANG C.UTF-8
 
-COPY images/fake-sudo.sh /usr/bin/sudo
 COPY images/entrypoint.sh /
 COPY . /dbld/
 

--- a/dbld/images/debian-sid.dockerfile
+++ b/dbld/images/debian-sid.dockerfile
@@ -12,7 +12,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
 ENV LANG C.UTF-8
 
-COPY images/fake-sudo.sh /usr/bin/sudo
 COPY images/entrypoint.sh /
 COPY . /dbld/
 

--- a/dbld/images/debian-testing.dockerfile
+++ b/dbld/images/debian-testing.dockerfile
@@ -12,7 +12,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
 ENV LANG C.UTF-8
 
-COPY images/fake-sudo.sh /usr/bin/sudo
 COPY images/entrypoint.sh /
 COPY . /dbld/
 

--- a/dbld/images/entrypoint.sh
+++ b/dbld/images/entrypoint.sh
@@ -19,9 +19,12 @@ else
         useradd $USER_NAME --uid=$USER_ID --gid=$GROUP_ID &>/dev/null || \
             useradd dockerguest --uid=$USER_ID --gid=$GROUP_ID &>/dev/null || \
             echo "Failed to add user $USER_NAME/$USER_ID in docker entrypoint-debian.sh";
+	usermod -a -G sudo $USER_NAME || usermod -a -G wheel $USER_NAME
+	sed -i -e '/^%sudo\s\+ALL=/s,ALL$,NOPASSWD: ALL,' /etc/sudoers
+	sed -i -e '/^%wheel\s\+ALL=/s,ALL$,NOPASSWD: ALL,' /etc/sudoers
         mkdir -p /home/$USER_NAME
         chown $USER_NAME:$GROUP_ID /home/$USER_NAME
     fi
 
-    exec gosu "${USER_NAME}" "$@"
+    exec sudo --preserve-env -u "${USER_NAME}" "$@"
 fi

--- a/dbld/images/fedora-39.dockerfile
+++ b/dbld/images/fedora-39.dockerfile
@@ -8,7 +8,6 @@ ARG COMMIT
 ENV IMAGE_PLATFORM ${ARG_IMAGE_PLATFORM}
 LABEL COMMIT=${COMMIT}
 
-COPY images/fake-sudo.sh /usr/bin/sudo
 COPY images/entrypoint.sh /
 COPY . /dbld/
 
@@ -20,7 +19,6 @@ RUN /dbld/builddeps install_rpm_build_deps
 
 RUN /dbld/builddeps install_criterion
 RUN /dbld/builddeps install_gradle
-RUN /dbld/builddeps install_gosu amd64
 
 VOLUME /source
 VOLUME /build

--- a/dbld/images/ubuntu-focal.dockerfile
+++ b/dbld/images/ubuntu-focal.dockerfile
@@ -12,7 +12,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
 ENV LANG C.UTF-8
 
-COPY images/fake-sudo.sh /usr/bin/sudo
 COPY images/entrypoint.sh /
 COPY . /dbld/
 

--- a/dbld/images/ubuntu-jammy.dockerfile
+++ b/dbld/images/ubuntu-jammy.dockerfile
@@ -12,7 +12,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
 ENV LANG C.UTF-8
 
-COPY images/fake-sudo.sh /usr/bin/sudo
 COPY images/entrypoint.sh /
 COPY . /dbld/
 

--- a/dbld/images/ubuntu-lunar.dockerfile
+++ b/dbld/images/ubuntu-lunar.dockerfile
@@ -12,7 +12,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
 ENV LANG C.UTF-8
 
-COPY images/fake-sudo.sh /usr/bin/sudo
 COPY images/entrypoint.sh /
 COPY . /dbld/
 

--- a/dbld/images/ubuntu-mantic.dockerfile
+++ b/dbld/images/ubuntu-mantic.dockerfile
@@ -12,7 +12,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
 ENV LANG C.UTF-8
 
-COPY images/fake-sudo.sh /usr/bin/sudo
 COPY images/entrypoint.sh /
 COPY . /dbld/
 

--- a/dbld/packages.manifest
+++ b/dbld/packages.manifest
@@ -2,9 +2,7 @@
 # packages required to build the docker image
 ##################################################
 
-# packages to run gosu installation
 gnupg                           [centos, fedora]
-gosu				[ubuntu, debian]
 
 # download various stuff over https
 wget                            [centos, fedora, debian, ubuntu]
@@ -23,6 +21,7 @@ bzip2                           [centos, fedora, debian, ubuntu]
 # Basic interactive tools
 less                            [centos, fedora, debian, ubuntu]
 vim                             [centos, fedora, debian, ubuntu]
+sudo				[centos, fedora, debian, ubuntu]
 
 #############################################################################
 # Essential build tools not explicitly referenced from

--- a/dbld/rules
+++ b/dbld/rules
@@ -261,7 +261,7 @@ exec-%: setup
 	$(DOCKER) exec -ti  $$container $(EXEC_COMMAND)
 
 login: login-$(DEFAULT_IMAGE)
-login-%: EXEC_COMMAND=gosu $(shell whoami) /dbld/shell
+login-%: EXEC_COMMAND=sudo -u $(shell whoami) /dbld/shell
 login-%: exec-%
 	@true
 


### PR DESCRIPTION
Instead of having to exec into the container as root to install extra packages make it possible to use sudo, without a password.

We can do this as our containers are meant to be used for development purposes only (e.g. building syslog-ng), the production container is separate.

No NEWS file is needed.
