### PR TITLE
OTLP compression support

### DIFF
--- a/modules/grpc/bigquery/bigquery-dest.cpp
+++ b/modules/grpc/bigquery/bigquery-dest.cpp
@@ -90,7 +90,7 @@ private:
 
 DestinationDriver::DestinationDriver(BigQueryDestDriver *s)
   : super(s), url("bigquerystorage.googleapis.com"),
-    keepalive_time(-1), keepalive_timeout(-1), keepalive_max_pings_without_data(-1), batch_bytes(10 * 1000 * 1000)
+    batch_bytes(10 * 1000 * 1000), keepalive_time(-1), keepalive_timeout(-1), keepalive_max_pings_without_data(-1)
 {
   log_template_options_defaults(&this->template_options);
 }

--- a/modules/grpc/otel/otel-dest-worker.cpp
+++ b/modules/grpc/otel/otel-dest-worker.cpp
@@ -45,7 +45,13 @@ DestWorker::DestWorker(OtelDestWorker *s)
     owner(*((OtelDestDriver *) s->super.owner)->cpp),
     formatter(s->super.owner->super.super.super.cfg)
 {
-  channel = ::grpc::CreateChannel(owner.get_url(), owner.credentials_builder.build());
+  ::grpc::ChannelArguments args;
+
+  if (owner.get_compression())
+    {
+      args.SetCompressionAlgorithm(GRPC_COMPRESS_DEFLATE);
+    }
+  channel = ::grpc::CreateCustomChannel(owner.get_url(), owner.credentials_builder.build(), args);
   logs_service_stub = LogsService::NewStub(channel);
   metrics_service_stub = MetricsService::NewStub(channel);
   trace_service_stub = TraceService::NewStub(channel);

--- a/modules/grpc/otel/otel-dest.cpp
+++ b/modules/grpc/otel/otel-dest.cpp
@@ -30,7 +30,7 @@ using namespace syslogng::grpc::otel;
 /* C++ Implementations */
 
 DestDriver::DestDriver(OtelDestDriver *s)
-  : super(s)
+  : super(s), compression(false)
 {
   credentials_builder_wrapper.self = &credentials_builder;
 }
@@ -45,6 +45,18 @@ const std::string &
 DestDriver::get_url() const
 {
   return url;
+}
+
+void
+DestDriver::set_compression(bool compression_)
+{
+  compression = compression_;
+}
+
+bool
+DestDriver::get_compression() const
+{
+  return compression;
 }
 
 const char *
@@ -113,6 +125,12 @@ void
 otel_dd_set_url(LogDriver *s, const gchar *url)
 {
   get_DestDriver(s)->set_url(url);
+}
+
+void
+otel_dd_set_compression(LogDriver *s, gboolean enable)
+{
+  get_DestDriver(s)->set_compression(enable);
 }
 
 GrpcClientCredentialsBuilderW *

--- a/modules/grpc/otel/otel-dest.h
+++ b/modules/grpc/otel/otel-dest.h
@@ -32,6 +32,7 @@ typedef struct OtelDestDriver_ OtelDestDriver;
 
 LogDriver *otel_dd_new(GlobalConfig *cfg);
 void otel_dd_set_url(LogDriver *s, const gchar *url);
+void otel_dd_set_compression(LogDriver *s, gboolean enable);
 GrpcClientCredentialsBuilderW *otel_dd_get_credentials_builder(LogDriver *s);
 
 #include "compat/cpp-end.h"

--- a/modules/grpc/otel/otel-dest.hpp
+++ b/modules/grpc/otel/otel-dest.hpp
@@ -46,6 +46,9 @@ public:
   void set_url(const char *url);
   const std::string &get_url() const;
 
+  void set_compression(bool enable);
+  bool get_compression() const;
+
   virtual bool init();
   virtual bool deinit();
   virtual const char *format_stats_key(StatsClusterKeyBuilder *kb);
@@ -60,6 +63,7 @@ protected:
   friend class DestWorker;
   OtelDestDriver *super;
   std::string url;
+  bool compression;
   GrpcClientCredentialsBuilderW credentials_builder_wrapper;
 };
 

--- a/modules/grpc/otel/otel-grammar.ym
+++ b/modules/grpc/otel/otel-grammar.ym
@@ -70,6 +70,7 @@ GrpcClientCredentialsBuilderW *last_grpc_client_credentials_builder;
 %token KW_TARGET_SERVICE_ACCOUNTS
 %token KW_ADC
 %token KW_SYSLOG_NG_OTLP
+%token KW_COMPRESSION
 
 %type <ptr> source_otel
 %type <ptr> parser_otel
@@ -143,6 +144,7 @@ destination_otel_options
 destination_otel_option
   : KW_URL '(' string ')' { otel_dd_set_url(last_driver, $3); free($3); }
   | KW_AUTH { last_grpc_client_credentials_builder = otel_dd_get_credentials_builder(last_driver); } '(' grpc_client_credentials_option ')'
+  | KW_COMPRESSION '(' yesno ')' { otel_dd_set_compression(last_driver, $3); }
   | threaded_dest_driver_general_option
   | threaded_dest_driver_batch_option
   | threaded_dest_driver_workers_option

--- a/modules/grpc/otel/otel-parser.c
+++ b/modules/grpc/otel/otel-parser.c
@@ -48,6 +48,7 @@ static CfgLexerKeyword otel_keywords[] =
   { "target_service_accounts",   KW_TARGET_SERVICE_ACCOUNTS },
   { "adc",                       KW_ADC },
   { "syslog_ng_otlp",            KW_SYSLOG_NG_OTLP },
+  { "compression",               KW_COMPRESSION },
   { NULL }
 };
 

--- a/news/feature-4765.md
+++ b/news/feature-4765.md
@@ -1,0 +1,3 @@
+Add compression to `syslog-ng-otlp()` and `opentelemetry()`: the new
+compression() option can be used to enable deflate compression in gRPC
+requests.


### PR DESCRIPTION
This patch adds a new compression(yes/no) option to syslog-ng-otlp() and opentelemetry() destinations.

While gRPC could support various compression methods, right now it only supports gzip or deflate, which are basically the same. This patch picks deflate if compression(yes) is specified.
