### PR TITLE
`$(tag)` template function

### DIFF
--- a/modules/basicfuncs/Makefile.am
+++ b/modules/basicfuncs/Makefile.am
@@ -26,6 +26,7 @@ EXTRA_DIST					+=	\
 	modules/basicfuncs/tf-template.c		\
 	modules/basicfuncs/tf-iterate.c			\
 	modules/basicfuncs/tf-map.c			\
+	modules/basicfuncs/tf-tag.c			\
 	modules/basicfuncs/tf-filter.c			\
 	modules/basicfuncs/vp-funcs.c			\
 	modules/basicfuncs/CMakeLists.txt

--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -67,6 +67,7 @@ _append_args_with_separator(gint argc, GString *argv[], GString *result, gchar s
 #include "tf-iterate.c"
 #include "tf-map.c"
 #include "tf-filter.c"
+#include "tf-tag.c"
 #include "vp-funcs.c"
 
 static Plugin basicfuncs_plugins[] =
@@ -138,6 +139,9 @@ static Plugin basicfuncs_plugins[] =
   TEMPLATE_FUNCTION_PLUGIN(tf_urlencode, "url-encode"),
   TEMPLATE_FUNCTION_PLUGIN(tf_urldecode, "url-decode"),
   TEMPLATE_FUNCTION_PLUGIN(tf_base64encode, "base64-encode"),
+
+  /* tags */
+  TEMPLATE_FUNCTION_PLUGIN(tf_tag, "tag"),
 
   /* functional */
   TEMPLATE_FUNCTION_PLUGIN(tf_iterate, "iterate"),

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -562,6 +562,15 @@ Test(basicfuncs, test_vp_funcs)
   assert_template_format_with_context("$(names)", "");
 }
 
+Test(basicfuncs, test_tag)
+{
+  assert_template_format_value_and_type("$(tag alma)", "1", LM_VT_BOOLEAN);
+  assert_template_format_value_and_type("$(tag korte)", "1", LM_VT_BOOLEAN);
+  assert_template_format_value_and_type("$(tag narancs)", "0", LM_VT_BOOLEAN);
+
+  assert_template_format_value_and_type("$(tag alma true false)", "true", LM_VT_STRING);
+  assert_template_format_value_and_type("$(tag narancs true false)", "false", LM_VT_STRING);
+}
 
 Test(basicfuncs, test_tfurlencode)
 {

--- a/modules/basicfuncs/tf-tag.c
+++ b/modules/basicfuncs/tf-tag.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+typedef struct _TFTagState
+{
+  LogTagId tag_id;
+  GString *value_if_set;
+  GString *value_if_unset;
+  gboolean value_is_boolean;
+} TFTagState;
+
+static gboolean
+tf_tag_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, gint argc, gchar *argv[],
+               GError **error)
+{
+  TFTagState *state = (TFTagState *) s;
+
+  if (argc < 2 || argc > 4)
+    {
+      g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
+                  "Wrong number of arguments. Example: $(tag tag-name value-if-set value-if-unset).\n");
+      return FALSE;
+    }
+
+  state->tag_id = log_tags_get_by_name(argv[1]);
+  state->value_if_set = g_string_new(argc >= 3 ? argv[2] : "1");
+  state->value_if_unset = g_string_new(argc >= 4 ? argv[3] : "0");
+  state->value_is_boolean = argc < 3;
+  return TRUE;
+}
+
+
+static void
+tf_tag_call(LogTemplateFunction *self, gpointer s, const LogTemplateInvokeArgs *args, GString *result,
+            LogMessageValueType *type)
+{
+  TFTagState *state = (TFTagState *) s;
+  LogMessage *msg = args->messages[0];
+
+  *type = state->value_is_boolean ? LM_VT_BOOLEAN : LM_VT_STRING;
+  if (log_msg_is_tag_by_id(msg, state->tag_id))
+    g_string_append_len(result, state->value_if_set->str, state->value_if_set->len);
+  else
+    g_string_append_len(result, state->value_if_unset->str, state->value_if_unset->len);
+}
+
+static void
+tf_tag_free_state(gpointer s)
+{
+  TFTagState *state = (TFTagState *) s;
+
+  g_string_free(state->value_if_set, TRUE);
+  g_string_free(state->value_if_unset, TRUE);
+}
+
+TEMPLATE_FUNCTION(TFTagState, tf_tag, tf_tag_prepare, NULL, tf_tag_call, tf_tag_free_state, NULL);

--- a/news/feature-4766.md
+++ b/news/feature-4766.md
@@ -1,0 +1,13 @@
+`$(tag)` template function: expose bit-like tags that are set on
+messages.
+
+Syntax:
+    $(tag <name-of-the-tag> <value-if-set> <value-if-unset>)
+
+Unless the value-if-set/unset arguments are specified $(tag) results in a
+boolean type, expanding to "0" or "1" depending on whether the message has
+the specified tag set.
+
+If value-if-set/unset are present, $(tag) would return a string, picking the
+second argument <value-if-set> if the message has <tag> and picking the
+third argument <value-if-unset> if the message does not have <tag>

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -178,6 +178,7 @@ modules/affile/tests/test_file_writer\.c$
 modules/affile/stdout\.[ch]
 modules/afsocket/socket-options-unix\.[ch]$
 modules/basicfuncs/vp-funcs\.[ch]$
+modules/basicfuncs/tf-tag\.c$
 modules/diskq/diskq-global-metrics\.[ch]$
 modules/diskq/tests/test_logqueue_disk\.c$
 modules/metrics-probe/metrics-probe(|-parser|-plugin|-grammar)\.(c|h|ym)$


### PR DESCRIPTION
Syntax: 
```
    $(tag <name-of-the-tag> <value-if-set> <value-if-unset>)
```
 
Unless the value-if-set/unset arguments are specified $(tag) results in a
boolean type, expanding to "0" or "1" depending on whether the message has
the specified tag set.
    
If value-if-set/unset are present, $(tag) would return a string, picking the
second argument <value-if-set> if the message has <tag> and picking the
third argument <value-if-unset> if the message does not have <tag>