### PR TITLE
packaging: add fakeroot as a debian build dependency

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -5,6 +5,7 @@ Maintainer: syslog-ng maintainers <syslog-ng-maintainers@alioth-lists.debian.net
 Uploaders: Laszlo Boszormenyi (GCS) <gcs@debian.org>,
            SZALAY Attila <sasa@debian.org>
 Build-Depends: debhelper (>= 10~),
+               fakeroot,
                automake (>= 1:1.11.1),
                autoconf-archive,
                tzdata,


### PR DESCRIPTION
Fixes packaging on `debian-sid`:

```
Runnign build as:  env DEB_BUILD_PROFILES=sng-python3 nojava  dpkg-buildpackage -rfakeroot -d
dpkg-buildpackage: error: fakeroot not found, either install the fakeroot
package, specify a command with the -r option, or run this as root
```

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
