### PR TITLE
dbld: use home dir of the container user

### DIFF
--- a/dbld/images/entrypoint.sh
+++ b/dbld/images/entrypoint.sh
@@ -26,5 +26,5 @@ else
         chown $USER_NAME:$GROUP_ID /home/$USER_NAME
     fi
 
-    exec sudo --preserve-env -u "${USER_NAME}" "$@"
+    exec sudo --preserve-env -Hu "${USER_NAME}" "$@"
 fi


### PR DESCRIPTION
This commit fixes packaging on debian buster, which broke with the removal of gosu.

While creating a python venv, some cache files are to be written to the $HOME dir, which is /root, and the current user does not have a write permission to it.

With the gosu method the $HOME dir was still /root, but python did not try to use /root/.cache for some reason. I tried to pinpoint the cause, but could not find it. I also do not know why it only affects buster, but I wasted too much time to investigate.

Example run: https://github.com/alltilla/syslog-ng/actions/runs/7387771879

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
