### PR TITLE
`opentelemetry()`, `syslog-ng-otlp()` destinations: add `batch-bytes()` option

### DIFF
--- a/modules/grpc/bigquery/bigquery-dest.cpp
+++ b/modules/grpc/bigquery/bigquery-dest.cpp
@@ -468,6 +468,7 @@ bigquery_dd_new(GlobalConfig *cfg)
 
   self->super.format_stats_key = _format_stats_key;
   self->super.stats_source = stats_register_type("bigquery");
+  self->super.metrics.raw_bytes_enabled = TRUE;
 
   self->super.worker.construct = bigquery_dw_new;
 

--- a/modules/grpc/otel/otel-dest-worker.cpp
+++ b/modules/grpc/otel/otel-dest-worker.cpp
@@ -387,7 +387,15 @@ DestWorker::flush_log_records()
   logs_service_response.Clear();
   ::grpc::Status status = logs_service_stub->Export(&client_context, logs_service_request,
                                                     &logs_service_response);
-  return _map_grpc_status_to_log_threaded_result(status);
+  LogThreadedResult result = _map_grpc_status_to_log_threaded_result(status);
+
+  if (result == LTR_SUCCESS)
+    {
+      log_threaded_dest_worker_written_bytes_add(&super->super, logs_current_batch_bytes);
+      log_threaded_dest_driver_insert_batch_length_stats(super->super.owner, logs_current_batch_bytes);
+    }
+
+  return result;
 }
 
 LogThreadedResult
@@ -397,7 +405,15 @@ DestWorker::flush_metrics()
   metrics_service_response.Clear();
   ::grpc::Status status = metrics_service_stub->Export(&client_context, metrics_service_request,
                                                        &metrics_service_response);
-  return _map_grpc_status_to_log_threaded_result(status);
+  LogThreadedResult result = _map_grpc_status_to_log_threaded_result(status);
+
+  if (result == LTR_SUCCESS)
+    {
+      log_threaded_dest_worker_written_bytes_add(&super->super, metrics_current_batch_bytes);
+      log_threaded_dest_driver_insert_batch_length_stats(super->super.owner, metrics_current_batch_bytes);
+    }
+
+  return result;
 }
 
 LogThreadedResult
@@ -407,7 +423,15 @@ DestWorker::flush_spans()
   trace_service_response.Clear();
   ::grpc::Status status = trace_service_stub->Export(&client_context, trace_service_request,
                                                      &trace_service_response);
-  return _map_grpc_status_to_log_threaded_result(status);
+  LogThreadedResult result = _map_grpc_status_to_log_threaded_result(status);
+
+  if (result == LTR_SUCCESS)
+    {
+      log_threaded_dest_worker_written_bytes_add(&super->super, spans_current_batch_bytes);
+      log_threaded_dest_driver_insert_batch_length_stats(super->super.owner, spans_current_batch_bytes);
+    }
+
+  return result;
 }
 
 LogThreadedResult

--- a/modules/grpc/otel/otel-dest-worker.cpp
+++ b/modules/grpc/otel/otel-dest-worker.cpp
@@ -246,6 +246,7 @@ DestWorker::insert_log_record_from_log_msg(LogMessage *msg)
     {
       size_t log_record_bytes = log_record->ByteSizeLong();
       logs_current_batch_bytes += log_record_bytes;
+      log_threaded_dest_driver_insert_msg_length_stats(super->super.owner, log_record_bytes);
     }
 
   return result;
@@ -260,6 +261,7 @@ DestWorker::insert_fallback_log_record_from_log_msg(LogMessage *msg)
 
   size_t log_record_bytes = log_record->ByteSizeLong();
   logs_current_batch_bytes += log_record_bytes;
+  log_threaded_dest_driver_insert_msg_length_stats(super->super.owner, log_record_bytes);
 }
 
 bool
@@ -273,6 +275,7 @@ DestWorker::insert_metric_from_log_msg(LogMessage *msg)
     {
       size_t metric_bytes = metric->ByteSizeLong();
       metrics_current_batch_bytes += metric_bytes;
+      log_threaded_dest_driver_insert_msg_length_stats(super->super.owner, metric_bytes);
     }
 
   return result;
@@ -289,6 +292,7 @@ DestWorker::insert_span_from_log_msg(LogMessage *msg)
     {
       size_t span_bytes = span->ByteSizeLong();
       spans_current_batch_bytes += span_bytes;
+      log_threaded_dest_driver_insert_msg_length_stats(super->super.owner, span_bytes);
     }
 
   return result;

--- a/modules/grpc/otel/otel-dest-worker.hpp
+++ b/modules/grpc/otel/otel-dest-worker.hpp
@@ -77,6 +77,8 @@ protected:
   virtual ScopeMetrics *lookup_scope_metrics(LogMessage *msg);
   virtual ScopeSpans *lookup_scope_spans(LogMessage *msg);
 
+  bool should_initiate_flush();
+
   bool insert_log_record_from_log_msg(LogMessage *msg);
   void insert_fallback_log_record_from_log_msg(LogMessage *msg);
   bool insert_metric_from_log_msg(LogMessage *msg);
@@ -97,10 +99,13 @@ protected:
 
   ExportLogsServiceRequest logs_service_request;
   ExportLogsServiceResponse logs_service_response;
+  size_t logs_current_batch_bytes;
   ExportMetricsServiceRequest metrics_service_request;
   ExportMetricsServiceResponse metrics_service_response;
+  size_t metrics_current_batch_bytes;
   ExportTraceServiceRequest trace_service_request;
   ExportTraceServiceResponse trace_service_response;
+  size_t spans_current_batch_bytes;
 
   ProtobufFormatter formatter;
 

--- a/modules/grpc/otel/otel-dest.cpp
+++ b/modules/grpc/otel/otel-dest.cpp
@@ -30,7 +30,7 @@ using namespace syslogng::grpc::otel;
 /* C++ Implementations */
 
 DestDriver::DestDriver(OtelDestDriver *s)
-  : super(s), compression(false)
+  : super(s), compression(false), batch_bytes(4 * 1000 * 1000)
 {
   credentials_builder_wrapper.self = &credentials_builder;
 }
@@ -57,6 +57,18 @@ bool
 DestDriver::get_compression() const
 {
   return compression;
+}
+
+void
+DestDriver::set_batch_bytes(size_t batch_bytes_)
+{
+  batch_bytes = batch_bytes_;
+}
+
+size_t
+DestDriver::get_batch_bytes() const
+{
+  return batch_bytes;
 }
 
 const char *
@@ -131,6 +143,12 @@ void
 otel_dd_set_compression(LogDriver *s, gboolean enable)
 {
   get_DestDriver(s)->set_compression(enable);
+}
+
+void
+otel_dd_set_batch_bytes(LogDriver *s, glong b)
+{
+  get_DestDriver(s)->set_batch_bytes((size_t) b);
 }
 
 GrpcClientCredentialsBuilderW *

--- a/modules/grpc/otel/otel-dest.cpp
+++ b/modules/grpc/otel/otel-dest.cpp
@@ -116,7 +116,11 @@ DestDriver::init()
       return false;
     }
 
-  return log_threaded_dest_driver_init_method(&super->super.super.super.super);
+  if (!log_threaded_dest_driver_init_method(&this->super->super.super.super.super))
+    return false;
+
+  log_threaded_dest_driver_register_aggregated_stats(&this->super->super);
+  return true;
 }
 
 bool

--- a/modules/grpc/otel/otel-dest.cpp
+++ b/modules/grpc/otel/otel-dest.cpp
@@ -211,6 +211,7 @@ otel_dd_init_super(LogThreadedDestDriver *s, GlobalConfig *cfg)
   s->worker.construct = _construct_worker;
   s->stats_source = stats_register_type("opentelemetry");
   s->format_stats_key = _format_stats_key;
+  s->metrics.raw_bytes_enabled = TRUE;
 }
 
 LogDriver *

--- a/modules/grpc/otel/otel-dest.h
+++ b/modules/grpc/otel/otel-dest.h
@@ -33,6 +33,7 @@ typedef struct OtelDestDriver_ OtelDestDriver;
 LogDriver *otel_dd_new(GlobalConfig *cfg);
 void otel_dd_set_url(LogDriver *s, const gchar *url);
 void otel_dd_set_compression(LogDriver *s, gboolean enable);
+void otel_dd_set_batch_bytes(LogDriver *s, glong b);
 GrpcClientCredentialsBuilderW *otel_dd_get_credentials_builder(LogDriver *s);
 
 #include "compat/cpp-end.h"

--- a/modules/grpc/otel/otel-dest.hpp
+++ b/modules/grpc/otel/otel-dest.hpp
@@ -49,6 +49,9 @@ public:
   void set_compression(bool enable);
   bool get_compression() const;
 
+  void set_batch_bytes(size_t bytes);
+  size_t get_batch_bytes() const;
+
   virtual bool init();
   virtual bool deinit();
   virtual const char *format_stats_key(StatsClusterKeyBuilder *kb);
@@ -64,6 +67,7 @@ protected:
   OtelDestDriver *super;
   std::string url;
   bool compression;
+  size_t batch_bytes;
   GrpcClientCredentialsBuilderW credentials_builder_wrapper;
 };
 

--- a/modules/grpc/otel/otel-grammar.ym
+++ b/modules/grpc/otel/otel-grammar.ym
@@ -71,6 +71,7 @@ GrpcClientCredentialsBuilderW *last_grpc_client_credentials_builder;
 %token KW_ADC
 %token KW_SYSLOG_NG_OTLP
 %token KW_COMPRESSION
+%token KW_BATCH_BYTES
 
 %type <ptr> source_otel
 %type <ptr> parser_otel
@@ -145,6 +146,7 @@ destination_otel_option
   : KW_URL '(' string ')' { otel_dd_set_url(last_driver, $3); free($3); }
   | KW_AUTH { last_grpc_client_credentials_builder = otel_dd_get_credentials_builder(last_driver); } '(' grpc_client_credentials_option ')'
   | KW_COMPRESSION '(' yesno ')' { otel_dd_set_compression(last_driver, $3); }
+  | KW_BATCH_BYTES '(' positive_integer ')' { otel_dd_set_batch_bytes(last_driver, $3); }
   | threaded_dest_driver_general_option
   | threaded_dest_driver_batch_option
   | threaded_dest_driver_workers_option

--- a/modules/grpc/otel/otel-parser.c
+++ b/modules/grpc/otel/otel-parser.c
@@ -49,6 +49,7 @@ static CfgLexerKeyword otel_keywords[] =
   { "adc",                       KW_ADC },
   { "syslog_ng_otlp",            KW_SYSLOG_NG_OTLP },
   { "compression",               KW_COMPRESSION },
+  { "batch_bytes",               KW_BATCH_BYTES },
   { NULL }
 };
 

--- a/modules/grpc/otel/syslog-ng-otlp-dest-worker.cpp
+++ b/modules/grpc/otel/syslog-ng-otlp-dest-worker.cpp
@@ -66,6 +66,7 @@ SyslogNgDestWorker::insert(LogMessage *msg)
 
   size_t log_record_bytes = log_record->ByteSizeLong();
   logs_current_batch_bytes += log_record_bytes;
+  log_threaded_dest_driver_insert_msg_length_stats(super->super.owner, log_record_bytes);
 
   if (should_initiate_flush())
     return log_threaded_dest_worker_flush(&super->super, LTF_FLUSH_NORMAL);

--- a/modules/grpc/otel/syslog-ng-otlp-dest-worker.cpp
+++ b/modules/grpc/otel/syslog-ng-otlp-dest-worker.cpp
@@ -64,5 +64,11 @@ SyslogNgDestWorker::insert(LogMessage *msg)
   LogRecord *log_record = scope_logs->add_log_records();
   formatter.format_syslog_ng(msg, *log_record);
 
+  size_t log_record_bytes = log_record->ByteSizeLong();
+  logs_current_batch_bytes += log_record_bytes;
+
+  if (should_initiate_flush())
+    return log_threaded_dest_worker_flush(&super->super, LTF_FLUSH_NORMAL);
+
   return LTR_QUEUED;
 }

--- a/news/feature-4772.md
+++ b/news/feature-4772.md
@@ -1,0 +1,28 @@
+`opentelemetry()`, `syslog-ng-otlp()` destinations: Added a new `batch-bytes()` option.
+
+This option lets the user limit the bytes size of a batch. As there is a
+default 4 MiB batch limit by OTLP, it is necessary to keep the batch size
+smaller, but it would be hard to configure without this option.
+
+Please note that the batch can be at most 1 message larger than the set
+limit, so consider this when setting this value.
+
+The default value is 4 MB, which is a bit below 4 MiB.
+
+The calculation of the batch size is done before compression, which is
+the same as the limit is calculated on the server.
+
+Example config:
+```
+  syslog-ng-otlp(
+    url("localhost:12345")
+    workers(16)
+    log-fifo-size(1000000)
+
+    batch-timeout(5000) # ms
+    batch-lines(1000000) # Huge limit, batch-bytes() will limit us sooner
+
+    batch-bytes(1MB) # closes and flushes the batch after the last message pushed it above the 1 MB limit
+    # not setting batch-bytes() defaults to 4 MB, which is a bit below the default 4 MiB limit
+  );
+```


### PR DESCRIPTION
`opentelemetry()`, `syslog-ng-otlp()` destinations: Added a new `batch-bytes()` option.

This option lets the user limit the bytes size of a batch. As there is a default 4 MiB batch limit by OTLP, it is necessary to keep the batch size smaller, but it would be hard to configure without this option.

Please note that the batch can be at most 1 message larger than the set limit, so consider this when setting this value.

The default value is 4 MB, which is a bit below 4 MiB.

The calculation of the batch size is done before compression, which is the same as the limit is calculated on the server.

Example config:
```
  syslog-ng-otlp(
    url("localhost:12345")
    workers(16)
    log-fifo-size(1000000)

    batch-timeout(5000) # ms
    batch-lines(1000000) # Huge limit, batch-bytes() will limit us sooner

    batch-bytes(1MB) # closes and flushes the batch after the last message pushed it above the 1 MB limit
    # not setting batch-bytes() defaults to 4 MB, which is a bit below the default 4 MiB limit
  );
```
