### PR TITLE
threaded source: multi-worker support

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -1342,6 +1342,10 @@ threaded_source_driver_option
         | source_driver_option
         ;
 
+threaded_source_driver_workers_option
+        : KW_WORKERS '(' positive_integer ')' { log_threaded_source_driver_set_num_workers(last_driver, $3); }
+        ;
+
 threaded_fetcher_driver_option
         : KW_FETCH_NO_DATA_DELAY '(' nonnegative_float ')' { log_threaded_fetcher_driver_set_fetch_no_data_delay(last_driver, $3); }
         | KW_TIME_REOPEN '(' positive_integer ')' { log_threaded_fetcher_driver_set_time_reopen(last_driver, $3); }

--- a/lib/logthrsource/tests/test_logthrfetcherdrv.c
+++ b/lib/logthrsource/tests/test_logthrfetcherdrv.c
@@ -74,7 +74,7 @@ static void _source_queue_mock(LogPipe *s, LogMessage *msg, const LogPathOptions
 static LogSource *
 _get_source(TestThreadedFetcherDriver *self)
 {
-  return (LogSource *) self->super.super.worker;
+  return (LogSource *) (self->super.super.workers[0]);
 }
 
 static void

--- a/modules/examples/sources/random-choice-generator/random-choice-generator-grammar.ym
+++ b/modules/examples/sources/random-choice-generator/random-choice-generator-grammar.ym
@@ -80,6 +80,7 @@ source_random_choice_generator_option
       random_choice_generator_set_freq(last_driver, $3);
     }
   | threaded_source_driver_option
+  | threaded_source_driver_workers_option
   ;
 
 /* INCLUDE_RULES */

--- a/modules/examples/sources/random-choice-generator/random-choice-generator.cpp
+++ b/modules/examples/sources/random-choice-generator/random-choice-generator.cpp
@@ -29,17 +29,19 @@
 #include "string-list.h"
 #include "compat/cpp-end.h"
 
-#define get_RandomChoiceGeneratorCpp(s) (((RandomChoiceGeneratorSourceDriver *) (s))->cpp)
+#define get_SourceDriver(s) (((RandomChoiceGeneratorSourceDriver *) (s))->cpp)
+
+using namespace syslogng::examples::random_choice_generator;
 
 /* C++ Implementations */
 
-RandomChoiceGeneratorCpp::RandomChoiceGeneratorCpp(RandomChoiceGeneratorSourceDriver *s)
+SourceDriver::SourceDriver(RandomChoiceGeneratorSourceDriver *s)
   : super(s)
 {
 }
 
 void
-RandomChoiceGeneratorCpp::run()
+SourceDriver::run()
 {
   while (!exit_requested)
     {
@@ -55,7 +57,7 @@ RandomChoiceGeneratorCpp::run()
 }
 
 void
-RandomChoiceGeneratorCpp::set_choices(GList *choices_)
+SourceDriver::set_choices(GList *choices_)
 {
   for (GList *elem = g_list_first(choices_); elem; elem = elem->next)
     {
@@ -67,25 +69,25 @@ RandomChoiceGeneratorCpp::set_choices(GList *choices_)
 }
 
 void
-RandomChoiceGeneratorCpp::set_freq(gdouble freq_)
+SourceDriver::set_freq(gdouble freq_)
 {
   freq = freq_;
 }
 
 void
-RandomChoiceGeneratorCpp::request_exit()
+SourceDriver::request_exit()
 {
   exit_requested = true;
 }
 
 void
-RandomChoiceGeneratorCpp::format_stats_key(StatsClusterKeyBuilder *kb)
+SourceDriver::format_stats_key(StatsClusterKeyBuilder *kb)
 {
   stats_cluster_key_builder_add_legacy_label(kb, stats_cluster_label("driver", "random-choice-generator"));
 }
 
 gboolean
-RandomChoiceGeneratorCpp::init()
+SourceDriver::init()
 {
   if (choices.size() == 0)
     {
@@ -98,7 +100,7 @@ RandomChoiceGeneratorCpp::init()
 }
 
 gboolean
-RandomChoiceGeneratorCpp::deinit()
+SourceDriver::deinit()
 {
   return log_threaded_source_driver_deinit_method(&super->super.super.super.super);
 }
@@ -108,49 +110,49 @@ RandomChoiceGeneratorCpp::deinit()
 static void
 _run(LogThreadedSourceDriver *s)
 {
-  get_RandomChoiceGeneratorCpp(s)->run();
+  get_SourceDriver(s)->run();
 }
 
 void
 random_choice_generator_set_choices(LogDriver *s, GList *choices)
 {
-  get_RandomChoiceGeneratorCpp(s)->set_choices(choices);
+  get_SourceDriver(s)->set_choices(choices);
 }
 
 void
 random_choice_generator_set_freq(LogDriver *s, gdouble freq)
 {
-  get_RandomChoiceGeneratorCpp(s)->set_freq(freq);
+  get_SourceDriver(s)->set_freq(freq);
 }
 
 static void
 _request_exit(LogThreadedSourceDriver *s)
 {
-  get_RandomChoiceGeneratorCpp(s)->request_exit();
+  get_SourceDriver(s)->request_exit();
 }
 
 static void
 _format_stats_key(LogThreadedSourceDriver *s, StatsClusterKeyBuilder *kb)
 {
-  get_RandomChoiceGeneratorCpp(s)->format_stats_key(kb);
+  get_SourceDriver(s)->format_stats_key(kb);
 }
 
 static gboolean
 _init(LogPipe *s)
 {
-  return get_RandomChoiceGeneratorCpp(s)->init();
+  return get_SourceDriver(s)->init();
 }
 
 static gboolean
 _deinit(LogPipe *s)
 {
-  return get_RandomChoiceGeneratorCpp(s)->deinit();
+  return get_SourceDriver(s)->deinit();
 }
 
 static void
 _free(LogPipe *s)
 {
-  delete get_RandomChoiceGeneratorCpp(s);
+  delete get_SourceDriver(s);
   log_threaded_source_driver_free_method(s);
 }
 
@@ -160,7 +162,7 @@ random_choice_generator_sd_new(GlobalConfig *cfg)
   RandomChoiceGeneratorSourceDriver *s = g_new0(RandomChoiceGeneratorSourceDriver, 1);
   log_threaded_source_driver_init_instance(&s->super, cfg);
 
-  s->cpp = new RandomChoiceGeneratorCpp(s);
+  s->cpp = new SourceDriver(s);
 
   s->super.super.super.super.init = _init;
   s->super.super.super.super.deinit = _deinit;

--- a/modules/examples/sources/random-choice-generator/random-choice-generator.hpp
+++ b/modules/examples/sources/random-choice-generator/random-choice-generator.hpp
@@ -31,24 +31,29 @@
 #include "logthrsource/logthrsourcedrv.h"
 #include "compat/cpp-end.h"
 
+typedef struct RandomChoiceGeneratorSourceWorker_ RandomChoiceGeneratorSourceWorker;
 typedef struct RandomChoiceGeneratorSourceDriver_ RandomChoiceGeneratorSourceDriver;
 
 namespace syslogng {
 namespace examples {
 namespace random_choice_generator {
 
+class SourceWorker;
+
 class SourceDriver
 {
 public:
   SourceDriver(RandomChoiceGeneratorSourceDriver *s);
 
-  void run();
   void set_choices(GList *choices);
   void set_freq(gdouble freq);
-  void request_exit();
   void format_stats_key(StatsClusterKeyBuilder *kb);
   gboolean init();
   gboolean deinit();
+  void request_exit();
+
+private:
+  friend SourceWorker;
 
 private:
   RandomChoiceGeneratorSourceDriver *super;
@@ -57,9 +62,28 @@ private:
   gdouble freq = 1000;
 };
 
+class SourceWorker
+{
+public:
+  SourceWorker(RandomChoiceGeneratorSourceWorker *s, SourceDriver &d);
+
+  void run();
+  void request_exit();
+
+private:
+  RandomChoiceGeneratorSourceWorker *super;
+  SourceDriver &driver;
+};
+
 }
 }
 }
+
+struct RandomChoiceGeneratorSourceWorker_
+{
+  LogThreadedSourceWorker super;
+  syslogng::examples::random_choice_generator::SourceWorker *cpp;
+};
 
 struct RandomChoiceGeneratorSourceDriver_
 {

--- a/modules/examples/sources/random-choice-generator/random-choice-generator.hpp
+++ b/modules/examples/sources/random-choice-generator/random-choice-generator.hpp
@@ -33,10 +33,14 @@
 
 typedef struct RandomChoiceGeneratorSourceDriver_ RandomChoiceGeneratorSourceDriver;
 
-class RandomChoiceGeneratorCpp
+namespace syslogng {
+namespace examples {
+namespace random_choice_generator {
+
+class SourceDriver
 {
 public:
-  RandomChoiceGeneratorCpp(RandomChoiceGeneratorSourceDriver *s);
+  SourceDriver(RandomChoiceGeneratorSourceDriver *s);
 
   void run();
   void set_choices(GList *choices);
@@ -53,10 +57,14 @@ private:
   gdouble freq = 1000;
 };
 
+}
+}
+}
+
 struct RandomChoiceGeneratorSourceDriver_
 {
   LogThreadedSourceDriver super;
-  RandomChoiceGeneratorCpp *cpp;
+  syslogng::examples::random_choice_generator::SourceDriver *cpp;
 };
 
 #endif

--- a/modules/examples/sources/threaded-random-generator/threaded-random-generator-grammar.ym
+++ b/modules/examples/sources/threaded-random-generator/threaded-random-generator-grammar.ym
@@ -98,6 +98,7 @@ source_threaded_random_generator_option
       free($3);
     }
   | threaded_source_driver_option
+  | threaded_source_driver_workers_option
   ;
 
 /* INCLUDE_RULES */

--- a/modules/grpc/otel/otel-grammar.ym
+++ b/modules/grpc/otel/otel-grammar.ym
@@ -110,6 +110,7 @@ source_otel_option
   : KW_PORT '(' positive_integer ')' { otel_sd_set_port(last_driver, $3); }
   | KW_AUTH { last_grpc_server_credentials_builder = otel_sd_get_credentials_builder(last_driver); } '(' grpc_server_credentials_builder_option ')'
   | threaded_source_driver_option
+  | threaded_source_driver_workers_option
   ;
 
 parser_otel

--- a/modules/grpc/otel/otel-source.h
+++ b/modules/grpc/otel/otel-source.h
@@ -28,6 +28,7 @@
 #include "driver.h"
 #include "credentials/grpc-credentials-builder.h"
 
+typedef struct OtelSourceWorker_ OtelSourceWorker;
 typedef struct OtelSourceDriver_ OtelSourceDriver;
 
 LogDriver *otel_sd_new(GlobalConfig *cfg);

--- a/modules/grpc/otel/otel-source.hpp
+++ b/modules/grpc/otel/otel-source.hpp
@@ -52,6 +52,10 @@ public:
 
   GrpcServerCredentialsBuilderW *get_credentials_builder_wrapper();
 
+  TraceService::AsyncService trace_service;
+  LogsService::AsyncService logs_service;
+  MetricsService::AsyncService metrics_service;
+
 private:
   bool post(LogMessage *msg);
 

--- a/modules/python/python-fetcher.c
+++ b/modules/python/python-fetcher.c
@@ -174,7 +174,7 @@ _ulong_to_fetch_result(unsigned long ulong, ThreadedFetchResult *result)
 static inline AckTracker *
 _py_fetcher_get_ack_tracker(PythonFetcherDriver *self)
 {
-  return ((LogSource *) self->super.super.worker)->ack_tracker;;
+  return (&self->super.super.workers[0]->super)->ack_tracker;
 }
 
 static gboolean

--- a/news/developer-note-4774.md
+++ b/news/developer-note-4774.md
@@ -1,0 +1,3 @@
+`LogThreadedSourceDriver`: Added multi-worker API, which is a breaking change.
+
+Check the Pull Request for inspiration on how to follow up these changes.

--- a/news/feature-4774.md
+++ b/news/feature-4774.md
@@ -1,0 +1,4 @@
+`opentelemetry()`, `syslog-ng-otlp()`: Added `workers()` option on source side.
+
+This feature enables processing the OTLP messages on multiple threads,
+which can greatly improve the performance.


### PR DESCRIPTION
This PR:
  * Changes the API to work on a Worker instead of a Driver.
  * Follows up the API changes at the users of the API.
  * Adds a new `workers()` option, which is opt-in for threaded source based drivers.
  * Starts multiple workers if set by the `self->num_workers` field.

Where it was easily applicable, I have implemented the multi worker support:
  * `opentelemetry()`
  * `random-choice-generator()`
  * `example-random-generator()`

Where it would have needed more work, I have added an assert and a comment to point out that although those drivers are using the multi-worker API, they are not prepared to work with multiple workers:
  * `python-source()`
  * `LogThreadedFetcher`

This is a breaking API change, but if I remember correctly, we do not have any threaded source driver based drivers in PE, only fetcher based. The fetcher based drivers might need a small change because of the new `workers` field that replaces `worker`, but it is a trivial one. (See the python fetcher code change.)

Signed-off-by: Attila Szakacs <attila.szakacs@axoflow.com>