### PR TITLE
bigquery:  Fixed missing check of the dependent C++ switch in cmake config

### DIFF
--- a/modules/grpc/bigquery/CMakeLists.txt
+++ b/modules/grpc/bigquery/CMakeLists.txt
@@ -1,10 +1,4 @@
-module_switch(ENABLE_BIGQUERY "Enable bigquery")
-
 if(NOT ENABLE_GRPC)
-  return()
-endif()
-
-if (NOT ENABLE_BIGQUERY)
   return()
 endif()
 


### PR DESCRIPTION
Yes, I know, i do not like it either, i would like to bring back in an upcoming round all the module switches for all the C++ modules (regardless if it is a GRPC-dependent or simple C++ one), but in a separate run.

Also, please NOTE that we do not have per-module switches now in any of the GRPC C++ modules, as we removed them earlier based on an agreement.
Also, we still/again have none matching settings in the cmake and autotools config files, I'd like to sync them too again in the above mentioned upcoming C++/GRPC module switch re-introduction round.

Signed-off-by: Hofi <hofione@gmail.com>