### PR TITLE
Set transport macro for local mechanisms

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1429,7 +1429,7 @@ _merge_value(NVHandle handle,
 {
   LogMessage *msg = (LogMessage *) user_data;
 
-  if (!nv_table_is_value_set(msg->payload, handle))
+  if (!log_msg_is_value_set(msg, handle))
     log_msg_set_value_with_type(msg, handle, value, value_len, type);
   return FALSE;
 }

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -450,6 +450,12 @@ log_msg_set_value_by_name(LogMessage *self, const gchar *name, const gchar *valu
   log_msg_set_value_by_name_with_type(self, name, value, length, LM_VT_STRING);
 }
 
+static inline void
+log_msg_set_value_to_string(LogMessage *self, NVHandle handle, const gchar *literal_string)
+{
+  log_msg_set_value(self, handle, literal_string, strlen(literal_string));
+}
+
 void log_msg_rename_value(LogMessage *self, NVHandle from, NVHandle to);
 
 void log_msg_append_format_sdata(const LogMessage *self, GString *result, guint32 seq_num);

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -350,6 +350,12 @@ log_msg_get_value_if_set_with_type(const LogMessage *self, NVHandle handle,
     return nv_table_get_value(self->payload, handle, value_len, type);
 }
 
+static inline gboolean
+log_msg_is_value_set(const LogMessage *self, NVHandle handle)
+{
+  return nv_table_is_value_set(self->payload, handle);
+}
+
 static inline const gchar *
 log_msg_get_value_with_type(const LogMessage *self, NVHandle handle, gssize *value_len, LogMessageValueType *type)
 {

--- a/modules/affile/affile-source.c
+++ b/modules/affile/affile-source.c
@@ -175,6 +175,10 @@ affile_sd_new(gchar *filename, GlobalConfig *cfg)
     {
       affile_sd_set_transport_name(self, "local+device");
       self->file_reader_options.follow_freq = 0;
+      if (_is_linux_dev_kmsg(self->filename->str))
+        self->file_opener = file_opener_for_devkmsg_new();
+      else
+        self->file_opener = file_opener_for_regular_source_files_new();
     }
   else if (_is_linux_proc_kmsg(filename))
     {
@@ -193,11 +197,6 @@ affile_sd_new(gchar *filename, GlobalConfig *cfg)
       self->file_opener_options.needs_privileges = TRUE;
       self->file_opener = file_opener_for_prockmsg_new();
     }
-  else if (_is_linux_dev_kmsg(self->filename->str))
-    self->file_opener = file_opener_for_devkmsg_new();
-  else if (self->file_reader_options.follow_freq == 0)
-    self->file_opener = file_opener_for_regular_source_files_new();
-
   self->file_reader_options.restore_state = self->file_reader_options.follow_freq > 0;
   file_opener_options_defaults_dont_change_permissions(&self->file_opener_options);
   self->file_opener_options.create_dirs = FALSE;

--- a/modules/affile/affile-source.c
+++ b/modules/affile/affile-source.c
@@ -184,6 +184,8 @@ affile_sd_new(gchar *filename, GlobalConfig *cfg)
     {
       affile_sd_set_transport_name(self, "local+prockmsg");
       self->file_reader_options.follow_freq = 0;
+      self->file_opener_options.needs_privileges = TRUE;
+      self->file_opener = file_opener_for_prockmsg_new();
     }
   else
     {
@@ -192,11 +194,6 @@ affile_sd_new(gchar *filename, GlobalConfig *cfg)
       self->file_opener = file_opener_for_regular_source_files_new();
     }
 
-  if (_is_linux_proc_kmsg(self->filename->str))
-    {
-      self->file_opener_options.needs_privileges = TRUE;
-      self->file_opener = file_opener_for_prockmsg_new();
-    }
   self->file_reader_options.restore_state = self->file_reader_options.follow_freq > 0;
   file_opener_options_defaults_dont_change_permissions(&self->file_opener_options);
   self->file_opener_options.create_dirs = FALSE;

--- a/modules/affile/affile-source.c
+++ b/modules/affile/affile-source.c
@@ -185,18 +185,17 @@ affile_sd_new(gchar *filename, GlobalConfig *cfg)
     {
       affile_sd_set_transport_name(self, "local+file");
       self->file_reader_options.follow_freq = 1000;
+      self->file_opener = file_opener_for_regular_source_files_new();
     }
 
-  if (self->file_reader_options.follow_freq > 0)
-    self->file_opener = file_opener_for_regular_source_files_new();
-  else if (_is_linux_proc_kmsg(self->filename->str))
+  if (_is_linux_proc_kmsg(self->filename->str))
     {
       self->file_opener_options.needs_privileges = TRUE;
       self->file_opener = file_opener_for_prockmsg_new();
     }
   else if (_is_linux_dev_kmsg(self->filename->str))
     self->file_opener = file_opener_for_devkmsg_new();
-  else
+  else if (self->file_reader_options.follow_freq == 0)
     self->file_opener = file_opener_for_regular_source_files_new();
 
   self->file_reader_options.restore_state = self->file_reader_options.follow_freq > 0;

--- a/modules/affile/affile-source.c
+++ b/modules/affile/affile-source.c
@@ -173,12 +173,17 @@ affile_sd_new(gchar *filename, GlobalConfig *cfg)
 
   if (_is_device_node(filename))
     {
-      affile_sd_set_transport_name(self, "local+device");
       self->file_reader_options.follow_freq = 0;
       if (_is_linux_dev_kmsg(self->filename->str))
-        self->file_opener = file_opener_for_devkmsg_new();
+        {
+          self->file_opener = file_opener_for_devkmsg_new();
+          affile_sd_set_transport_name(self, "local+devkmsg");
+        }
       else
-        self->file_opener = file_opener_for_regular_source_files_new();
+        {
+          self->file_opener = file_opener_for_regular_source_files_new();
+          affile_sd_set_transport_name(self, "local+device");
+        }
     }
   else if (_is_linux_proc_kmsg(filename))
     {

--- a/modules/affile/affile-source.h
+++ b/modules/affile/affile-source.h
@@ -37,8 +37,11 @@ typedef struct _AFFileSourceDriver
   FileOpener *file_opener;
   FileReaderOptions file_reader_options;
   FileOpenerOptions file_opener_options;
+  gchar *transport_name;
+  gsize transport_name_len;
 } AFFileSourceDriver;
 
+void affile_sd_set_transport_name(AFFileSourceDriver *s, const gchar *transport_name);
 AFFileSourceDriver *affile_sd_new_instance(gchar *filename, GlobalConfig *cfg);
 LogDriver *affile_sd_new(gchar *filename, GlobalConfig *cfg);
 

--- a/modules/affile/named-pipe.c
+++ b/modules/affile/named-pipe.c
@@ -139,6 +139,7 @@ pipe_sd_new(gchar *filename, GlobalConfig *cfg)
 
   self->file_opener = file_opener_for_named_pipes_new();
 
+  affile_sd_set_transport_name(self, "local+pipe");
   return &self->super.super;
 }
 

--- a/modules/affile/stdin.c
+++ b/modules/affile/stdin.c
@@ -63,5 +63,6 @@ stdin_sd_new(GlobalConfig *cfg)
   self->file_reader_options.exit_on_eof = TRUE;
   self->file_reader_options.reader_options.super.stats_source = stats_register_type("stdin");
   self->file_opener = file_opener_for_stdin_new();
+  affile_sd_set_transport_name(self, "local+stdin");
   return &self->super.super;
 }

--- a/modules/afprog/afprog.c
+++ b/modules/afprog/afprog.c
@@ -258,6 +258,13 @@ afprogram_sd_exit(pid_t pid, int status, gpointer s)
     }
 }
 
+static void
+afprogram_sd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
+{
+  log_msg_set_value_to_string(msg, LM_V_TRANSPORT, "local+program");
+  log_src_driver_queue_method(s, msg, path_options);
+}
+
 static gboolean
 afprogram_sd_init(LogPipe *s)
 {
@@ -370,6 +377,7 @@ afprogram_sd_new(gchar *cmdline, GlobalConfig *cfg)
   self->super.super.super.deinit = afprogram_sd_deinit;
   self->super.super.super.free_fn = afprogram_sd_free;
   self->super.super.super.notify = afprogram_sd_notify;
+  self->super.super.super.queue = afprogram_sd_queue;
   self->process_info.cmdline = g_string_new(cmdline);
   afprogram_set_inherit_environment(&self->process_info, TRUE);
   log_reader_options_defaults(&self->reader_options);

--- a/modules/afsocket/tests/test-transport-mapper-unix.c
+++ b/modules/afsocket/tests/test-transport-mapper-unix.c
@@ -38,7 +38,7 @@ Test(transport_mapper_unix, test_transport_mapper_unix_stream_apply_transport_se
   assert_transport_mapper_sock_proto(transport_mapper, 0);
   assert_transport_mapper_logproto(transport_mapper, "text");
   assert_transport_mapper_stats_source(transport_mapper, SCS_UNIX_STREAM);
-  assert_transport_mapper_transport_name(transport_mapper, "unix-stream");
+  assert_transport_mapper_transport_name(transport_mapper, "local+unix-stream");
 }
 
 Test(transport_mapper_unix, test_transport_mapper_unix_dgram_apply_transport_sets_defaults)
@@ -51,7 +51,7 @@ Test(transport_mapper_unix, test_transport_mapper_unix_dgram_apply_transport_set
   assert_transport_mapper_sock_proto(transport_mapper, 0);
   assert_transport_mapper_logproto(transport_mapper, "dgram");
   assert_transport_mapper_stats_source(transport_mapper, SCS_UNIX_DGRAM);
-  assert_transport_mapper_transport_name(transport_mapper, "unix-dgram");
+  assert_transport_mapper_transport_name(transport_mapper, "local+unix-dgram");
 }
 
 static void

--- a/modules/afsocket/transport-mapper-unix.c
+++ b/modules/afsocket/transport-mapper-unix.c
@@ -61,7 +61,7 @@ transport_mapper_unix_dgram_new(void)
   TransportMapperUnix *self = transport_mapper_unix_new_instance("unix-dgram", SOCK_DGRAM);
 
   self->super.logproto = "dgram";
-  self->super.transport_name = g_strdup("unix-dgram");
+  self->super.transport_name = g_strdup("local+unix-dgram");
   self->super.stats_source = stats_register_type("unix-dgram");
 
   return &self->super;
@@ -73,7 +73,7 @@ transport_mapper_unix_stream_new(void)
   TransportMapperUnix *self = transport_mapper_unix_new_instance("unix-stream", SOCK_STREAM);
 
   self->super.logproto = "text";
-  self->super.transport_name = g_strdup("unix-stream");
+  self->super.transport_name = g_strdup("local+unix-stream");
   self->super.stats_source = stats_register_type("unix-stream");
 
   return &self->super;

--- a/modules/afstreams/afstreams.c
+++ b/modules/afstreams/afstreams.c
@@ -156,6 +156,13 @@ afstreams_init_door(int hook_type G_GNUC_UNUSED, gpointer user_data)
     }
 }
 
+static void
+afstreams_sd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
+{
+  log_msg_set_value_to_string(msg, LM_V_TRANSPORT, "local+sunstreams");
+  log_src_driver_queue_method(s, msg, path_options);
+}
+
 static gboolean
 afstreams_sd_init(LogPipe *s)
 {
@@ -278,6 +285,7 @@ afstreams_sd_new(gchar *filename, GlobalConfig *cfg)
   self->super.super.super.init = afstreams_sd_init;
   self->super.super.super.deinit = afstreams_sd_deinit;
   self->super.super.super.free_fn = afstreams_sd_free;
+  self->super.super.super.queue = afstreams_sd_queue;
   log_reader_options_defaults(&self->reader_options);
   self->reader_options.parse_options.flags |= LP_LOCAL;
   self->reader_options.parse_options.flags &= ~LP_EXPECT_HOSTNAME;

--- a/modules/darwinosl/darwinosl-source.m
+++ b/modules/darwinosl/darwinosl-source.m
@@ -281,6 +281,7 @@ _fetch(DarwinOSLogSourceDriver *self)
 
   LogMessage *msg;
   gsize msg_len = _log_message_from_string(log_string, self->options.format_options, &msg);
+  log_msg_set_value_to_string(msg, LM_V_TRANSPORT, "local+darwinoslog");
   LogThreadedFetchResult result = {THREADED_FETCH_SUCCESS, msg};
   _log_reader_insert_msg_length_stats(self, msg_len);
   return result;

--- a/modules/mqtt/source/mqtt-source.c
+++ b/modules/mqtt/source/mqtt-source.c
@@ -65,7 +65,7 @@ _create_message(MQTTSourceDriver *self, const gchar *message, gint length)
 {
   LogMessage *msg = log_msg_new_empty();
   log_msg_set_value(msg, LM_V_MESSAGE, message, length);
-
+  log_msg_set_value_to_string(msg, LM_V_TRANSPORT, "mqtt");
   return msg;
 }
 

--- a/modules/openbsd/openbsd-driver.c
+++ b/modules/openbsd/openbsd-driver.c
@@ -102,6 +102,13 @@ openbsd_close_newsyslog_socket(OpenBSDDriver *self)
   self->klog    = -1;
 }
 
+static void
+_openbsd_sd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
+{
+  log_msg_set_value_to_string(msg, LM_V_TRANSPORT, "local+openbsd");
+  log_src_driver_queue_method(s, msg, path_options);
+}
+
 static gboolean
 _openbsd_sd_init(LogPipe *s)
 {
@@ -184,6 +191,7 @@ openbsd_sd_new(GlobalConfig *cfg)
   self->super.super.super.init    = _openbsd_sd_init;
   self->super.super.super.deinit  = _openbsd_sd_deinit;
   self->super.super.super.free_fn = _openbsd_sd_free;
+  self->super.super.super.queue   = _openbsd_sd_queue;
   log_reader_options_defaults(&self->reader_options);
   self->reader_options.parse_options.flags |= LP_LOCAL;
   self->reader_options.parse_options.flags &= ~LP_EXPECT_HOSTNAME;

--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -275,6 +275,12 @@ _set_program(JournalReaderOptions *options, LogMessage *msg)
 }
 
 static void
+_set_transport(LogMessage *msg)
+{
+  log_msg_set_value_to_string(msg, LM_V_TRANSPORT, "local+journal");
+}
+
+static void
 _set_message_timestamp(JournalReader *self, LogMessage *msg)
 {
   guint64 ts;
@@ -303,6 +309,7 @@ _handle_message(JournalReader *self)
 
   _set_message_timestamp(self, msg);
   _set_program(self->options, msg);
+  _set_transport(msg);
 
   msg_debug("Incoming log entry from journal",
             evt_tag_printf("input", "%s", log_msg_get_value(msg, LM_V_MESSAGE, NULL)),

--- a/modules/systemd-journal/tests/test_systemd_journal.c
+++ b/modules/systemd-journal/tests/test_systemd_journal.c
@@ -244,7 +244,7 @@ __check_value_len(NVHandle handle, const gchar *name,
 {
   TestCase *self = user_data;
   gchar *error_message = g_strdup_printf("Bad value size; name: %s, value: %s len: %ld", name, value, value_len);
-  if (strcmp(name, "HOST_FROM") != 0)
+  if (strcmp(name, "HOST_FROM") != 0 && strcmp(name, "TRANSPORT") != 0)
     {
       cr_assert_leq(value_len, GPOINTER_TO_INT(self->user_data), "%s", error_message);
     }

--- a/scl/darwinosl/plugin.conf
+++ b/scl/darwinosl/plugin.conf
@@ -78,6 +78,7 @@ block source darwin-oslog-stream(params("`def-osl-stream-params`")) {
 			set-pri("${.darwinoslog.unixpri}");
 			set("${.darwinoslog.processID}", value("PID"));
 			set("${.darwinoslog.activityIdentifier}$(if ('${.darwinoslog.subsystem}' != '') ' (${.darwinoslog.subsystem})' '')$(if ('${.darwinoslog.category}' != '') ' [${.darwinoslog.category}]' '') ${.darwinoslog.eventMessage}", value("MSG"));
+			set("local+darwinoslog_stream" value("TRANSPORT"));
 		};
 	};
 };


### PR DESCRIPTION
This rounds up the setting of the $TRANSPORT macro for local log transport mechanisms.

The convention used is: local+<whatever we used to get the message>
  * local+unix-stream, local+unix-dgram
  * local+file
  * local+pipe
  * local+program
  * local+devkmsg
  * local+journal
  * local+afstreams
  * local+openbsd

+1 mqtt now sets $TRANSPORT to mqtt