### PR TITLE
cfg-lexer: assume glob() returning success and zero files to be an error

### DIFF
--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -628,6 +628,8 @@ cfg_lexer_include_file_glob_at(CfgLexer *self, CfgIncludeLevel *level, const gch
 
   r = glob(pattern, GLOB_NOMAGIC, _cfg_lexer_glob_err, &globbuf);
 
+  if (r == 0 && globbuf.gl_pathc == 0)
+    r = GLOB_NOMATCH;
   if (r != 0)
     {
       globfree(&globbuf);


### PR DESCRIPTION
This causes a crash later. Still waiting for confirmation if this is what resolves the issue.

https://splunk-usergroups.slack.com/archives/C4SL594CS/p1704465488078239

