### PR TITLE
darwinosl: Set `read-old-records` option to FALSE by default

### DIFF
--- a/modules/darwinosl/darwinosl-source.m
+++ b/modules/darwinosl/darwinosl-source.m
@@ -582,7 +582,7 @@ darwinosl_sd_options_defaults(DarwinOSLogSourceOptions *self,
   self->super_source_options = super_source_options;
   self->super_source_options->super.stats_level = STATS_LEVEL0;
   self->super_source_options->super.stats_source = stats_register_type("darwinosl");
-  self->super_source_options->super.read_old_records = TRUE;
+  self->super_source_options->super.read_old_records = FALSE;
 
   /* No additional format options now, so intentionally referencing only, and not using msg_format_options_copy */
   self->format_options = &self->super_source_options->parse_options;

--- a/news/feature-4423.md
+++ b/news/feature-4423.md
@@ -29,7 +29,7 @@ The following parameters can be used for customization:
     - default value: 0, which means no limit
 - read-old-records
     - boolean value, controls if syslog-ng should start reading logs from the oldest available at first start (or if no bookmark can be found)
-    - default value: yes
+    - default value: no
 - fetch-delay
     - integer value, controls how much time syslog-ng should wait between reading/sending log messages, this is a fraction of a second, where wait_time = 1 second / n,  so, e.g. n=1 means that only about 1 log will be read and sent in each second, and n=1 000 000 means only 1 microsecond (the allowed minimum value now!) will be the delay between read/write attempts
     (Use with care, though lower delay time can increase log feed performance, at the same time could lead to a heavy system load!)


### PR DESCRIPTION
If the user has a single system() source it can be a huge, surprising change to read such a big amount of logs at next startup, keep the old behavior, as the earlier file source started to read from the end always.

Signed-off-by: Hofi <hofione@gmail.com>