### PR TITLE
syslog-ng-otlp(): send source and destination addresses to the peer

### DIFF
--- a/lib/gsockaddr.c
+++ b/lib/gsockaddr.c
@@ -117,31 +117,33 @@ g_sockaddr_set_port(GSockAddr *a, guint16 port)
 }
 
 guint8 *
-g_sockaddr_get_address(GSockAddr *self, guint8 *buffer, socklen_t buffer_size)
+g_sockaddr_get_address(GSockAddr *self, guint8 *buffer, gsize buffer_size, gsize *addr_len)
 {
   if (self->sa.sa_family == AF_INET)
     {
       struct in_addr addr = g_sockaddr_inet_get_address(self);
-      socklen_t len = sizeof(addr);
+      gsize len = sizeof(addr);
       if (buffer_size < len)
         {
           errno = EINVAL;
           return NULL;
         }
       memcpy(buffer, &addr, len);
+      *addr_len = len;
       return buffer;
     }
 #if SYSLOG_NG_ENABLE_IPV6
   else if (self->sa.sa_family == AF_INET6)
     {
       struct in6_addr *addr = g_sockaddr_inet6_get_address(self);
-      socklen_t len = sizeof(struct in6_addr);
+      gsize len = sizeof(struct in6_addr);
       if (buffer_size < len)
         {
           errno = EINVAL;
           return NULL;
         }
       memcpy(buffer, addr, len);
+      *addr_len = len;
       return buffer;
     }
 #endif

--- a/lib/gsockaddr.c
+++ b/lib/gsockaddr.c
@@ -147,8 +147,7 @@ g_sockaddr_get_address(GSockAddr *self, guint8 *buffer, socklen_t buffer_size)
 #endif
   else
     {
-      errno = EAFNOSUPPORT;
-      return NULL;
+      g_assert_not_reached();
     }
 }
 

--- a/lib/gsockaddr.h
+++ b/lib/gsockaddr.h
@@ -63,7 +63,7 @@ struct _GSockAddrFuncs
 gchar *g_sockaddr_format(GSockAddr *a, gchar *text, gulong n, gint format);
 guint16 g_sockaddr_get_port(GSockAddr *a);
 void g_sockaddr_set_port(GSockAddr *a, guint16 port);
-guint8 *g_sockaddr_get_address(GSockAddr *self, guint8 *buffer, socklen_t buffer_size);
+guint8 *g_sockaddr_get_address(GSockAddr *self, guint8 *buffer, gsize buffer_size, gsize *addr_len);
 gsize g_sockaddr_len(GSockAddr *a);
 
 GSockAddr *g_sockaddr_new(struct sockaddr *sa, int salen);

--- a/modules/grpc/otel/otel-protobuf-formatter.hpp
+++ b/modules/grpc/otel/otel-protobuf-formatter.hpp
@@ -53,6 +53,7 @@ using google::protobuf::RepeatedPtrField;
 using opentelemetry::proto::resource::v1::Resource;
 using opentelemetry::proto::common::v1::InstrumentationScope;
 using opentelemetry::proto::common::v1::KeyValue;
+using opentelemetry::proto::common::v1::KeyValueList;
 using opentelemetry::proto::logs::v1::LogRecord;
 using opentelemetry::proto::metrics::v1::Metric;
 using opentelemetry::proto::metrics::v1::Gauge;
@@ -105,6 +106,7 @@ private:
   /* syslog-ng */
   void set_syslog_ng_nv_pairs(LogMessage *msg, LogRecord &log_record);
   void set_syslog_ng_macros(LogMessage *msg, LogRecord &log_record);
+  void set_syslog_ng_addresses(LogMessage *msg, LogRecord &log_record);
 
 private:
   GlobalConfig *cfg;
@@ -114,6 +116,8 @@ private:
     LogTemplateOptions template_options;
     LogTemplateEvalOptions template_eval_options;
   } syslog_ng;
+
+  void set_syslog_ng_address_attrs(GSockAddr *sa, KeyValueList *address_attrs, bool include_port);
 };
 
 }

--- a/modules/grpc/otel/otel-protobuf-parser.hpp
+++ b/modules/grpc/otel/otel-protobuf-parser.hpp
@@ -67,6 +67,7 @@ public:
 private:
   static void set_syslog_ng_nv_pairs(LogMessage *msg, const KeyValueList &types);
   static void set_syslog_ng_macros(LogMessage *msg, const KeyValueList &macros);
+  static void set_syslog_ng_address(LogMessage *msg, GSockAddr **sa, const KeyValueList &addr);
   static void parse_syslog_ng_tags(LogMessage *msg, const std::string &tags_as_str);
 };
 


### PR DESCRIPTION
This PR causes the syslog-ng-otlp() driver to also send the source address and the destination address associated with the log message, so that $SOURCEIP and $DESTIP will be properly expanded on the server as if it was received from those IPs (irrespectively of the syslog-ng-otlp() transport that happened in the middle).

