### PR TITLE
syslog-ng-otlp(): only send tags that have global relevance (e.g. not starting with a dot)

### DIFF
--- a/lib/debugger/debugger.c
+++ b/lib/debugger/debugger.c
@@ -74,7 +74,7 @@ _display_msg_details(Debugger *self, LogMessage *msg)
 
   log_msg_values_foreach(msg, _format_nvpair, NULL);
   g_string_truncate(output, 0);
-  log_msg_format_tags(msg, output);
+  log_msg_format_tags(msg, output, TRUE);
   printf("TAGS=%s\n", output->str);
   printf("\n");
   g_string_free(output, TRUE);

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1268,20 +1268,22 @@ log_msg_append_tags_callback(const LogMessage *self, LogTagId tag_id, const gcha
 {
   GString *result = (GString *) ((gpointer *) user_data)[0];
   gint original_length = GPOINTER_TO_UINT(((gpointer *) user_data)[1]);
+  gboolean include_localtags = GPOINTER_TO_UINT(((gpointer *) user_data)[2]);
 
   g_assert(result);
 
   if (result->len > original_length)
     g_string_append_c(result, ',');
 
-  str_repr_encode_append(result, name, -1, ",");
+  if (include_localtags || name[0] != '.')
+    str_repr_encode_append(result, name, -1, ",");
   return TRUE;
 }
 
 void
-log_msg_format_tags(const LogMessage *self, GString *result)
+log_msg_format_tags(const LogMessage *self, GString *result, gboolean include_localtags)
 {
-  gpointer args[] = { result, GUINT_TO_POINTER(result->len) };
+  gpointer args[] = { result, GUINT_TO_POINTER(result->len), GUINT_TO_POINTER(include_localtags) };
 
   log_msg_tags_foreach(self, log_msg_append_tags_callback, args);
 }

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -492,7 +492,7 @@ void log_msg_clear_tag_by_name(LogMessage *self, const gchar *name);
 gboolean log_msg_is_tag_by_id(LogMessage *self, LogTagId id);
 gboolean log_msg_is_tag_by_name(LogMessage *self, const gchar *name);
 void log_msg_tags_foreach(const LogMessage *self, LogMessageTagsForeachFunc callback, gpointer user_data);
-void log_msg_format_tags(const LogMessage *self, GString *result);
+void log_msg_format_tags(const LogMessage *self, GString *result, gboolean include_localtags);
 void log_msg_format_matches(const LogMessage *self, GString *result);
 
 

--- a/lib/template/macros.c
+++ b/lib/template/macros.c
@@ -502,7 +502,7 @@ log_macro_expand(gint id, LogTemplateEvalOptions *options, const LogMessage *msg
     case M_TAGS:
     {
       t = LM_VT_LIST;
-      log_msg_format_tags(msg, result);
+      log_msg_format_tags(msg, result, TRUE);
       break;
     }
     case M__ASTERISK:

--- a/modules/correlation/pdbtool/pdbtool.c
+++ b/modules/correlation/pdbtool/pdbtool.c
@@ -371,7 +371,7 @@ pdbtool_pdb_emit(LogMessage *msg, gpointer user_data)
 
           nv_table_foreach(msg->payload, logmsg_registry, pdbtool_match_values, ret);
           g_string_truncate(output, 0);
-          log_msg_format_tags(msg, output);
+          log_msg_format_tags(msg, output, TRUE);
           printf("TAGS=%s\n", output->str);
           printf("\n");
         }

--- a/modules/grpc/otel/otel-protobuf-formatter.cpp
+++ b/modules/grpc/otel/otel-protobuf-formatter.cpp
@@ -612,11 +612,9 @@ ProtobufFormatter::set_syslog_ng_macros(LogMessage *msg, LogRecord &log_record)
   gssize len;
   const char *value;
 
-  static const NVHandle PRI_HANDLE = log_msg_get_value_handle("PRI");
-  value = log_msg_get_value_with_type(msg, PRI_HANDLE, &len, &type);
   KeyValue *pri_attr = macros_kvlist->add_values();
   pri_attr->set_key("PRI");
-  pri_attr->mutable_value()->set_bytes_value(value, len);
+  pri_attr->mutable_value()->set_int_value(msg->pri);
 
   static const NVHandle TAGS_HANDLE = log_msg_get_value_handle("TAGS");
   value = log_msg_get_value_with_type(msg, TAGS_HANDLE, &len, &type);

--- a/modules/grpc/otel/otel-protobuf-formatter.cpp
+++ b/modules/grpc/otel/otel-protobuf-formatter.cpp
@@ -608,19 +608,16 @@ ProtobufFormatter::set_syslog_ng_macros(LogMessage *msg, LogRecord &log_record)
   m->set_key("m");
   KeyValueList *macros_kvlist = m->mutable_value()->mutable_kvlist_value();
 
-  LogMessageValueType type;
-  gssize len;
-  const char *value;
-
   KeyValue *pri_attr = macros_kvlist->add_values();
   pri_attr->set_key("PRI");
   pri_attr->mutable_value()->set_int_value(msg->pri);
 
-  static const NVHandle TAGS_HANDLE = log_msg_get_value_handle("TAGS");
-  value = log_msg_get_value_with_type(msg, TAGS_HANDLE, &len, &type);
+  GString *tags_value = g_string_sized_new(64);
+  log_msg_format_tags(msg, tags_value, FALSE);
   KeyValue *tags_attr = macros_kvlist->add_values();
   tags_attr->set_key("TAGS");
-  tags_attr->mutable_value()->set_bytes_value(value, len);
+  tags_attr->mutable_value()->set_bytes_value(tags_value->str, tags_value->len);
+  g_string_free(tags_value, TRUE);
 
   KeyValue *stamp_gmtoff = macros_kvlist->add_values();
   stamp_gmtoff->set_key("STAMP_GMTOFF");

--- a/modules/grpc/otel/otel-protobuf-parser.cpp
+++ b/modules/grpc/otel/otel-protobuf-parser.cpp
@@ -1143,7 +1143,7 @@ _nanosec_to_unix_time(uint64_t nanosec, UnixTime *unix_time)
 }
 
 static bool
-_value_case_equals(LogMessage *msg, const KeyValue &kv, const AnyValue::ValueCase &expected_value_case)
+_value_case_equals_or_error(LogMessage *msg, const KeyValue &kv, const AnyValue::ValueCase &expected_value_case)
 {
   if (kv.value().value_case() != expected_value_case)
     {
@@ -1182,7 +1182,7 @@ syslogng::grpc::otel::ProtobufParser::set_syslog_ng_nv_pairs(LogMessage *msg, co
 
       for (const KeyValue &nv_pair : nv_pairs.values())
         {
-          if (!_value_case_equals(msg, nv_pair, AnyValue::kBytesValue))
+          if (!_value_case_equals_or_error(msg, nv_pair, AnyValue::kBytesValue))
             continue;
           const std::string &name = nv_pair.key();
           const std::string &value = nv_pair.value().bytes_value();
@@ -1200,25 +1200,25 @@ syslogng::grpc::otel::ProtobufParser::set_syslog_ng_macros(LogMessage *msg, cons
 
       if (name.compare("PRI") == 0)
         {
-          if (!_value_case_equals(msg, macro, AnyValue::kBytesValue))
+          if (!_value_case_equals_or_error(msg, macro, AnyValue::kBytesValue))
             continue;
           msg->pri = log_rewrite_set_pri_convert_pri(macro.value().bytes_value().c_str());
         }
       else if (name.compare("TAGS") == 0)
         {
-          if (!_value_case_equals(msg, macro, AnyValue::kBytesValue))
+          if (!_value_case_equals_or_error(msg, macro, AnyValue::kBytesValue))
             continue;
           parse_syslog_ng_tags(msg, macro.value().bytes_value());
         }
       else if (name.compare("STAMP_GMTOFF") == 0)
         {
-          if (!_value_case_equals(msg, macro, AnyValue::kIntValue))
+          if (!_value_case_equals_or_error(msg, macro, AnyValue::kIntValue))
             continue;
           msg->timestamps[LM_TS_STAMP].ut_gmtoff = (gint32) macro.value().int_value();
         }
       else if (name.compare("RECVD_GMTOFF") == 0)
         {
-          if (!_value_case_equals(msg, macro, AnyValue::kIntValue))
+          if (!_value_case_equals_or_error(msg, macro, AnyValue::kIntValue))
             continue;
           msg->timestamps[LM_TS_RECVD].ut_gmtoff = (gint32) macro.value().int_value();
         }
@@ -1243,13 +1243,13 @@ syslogng::grpc::otel::ProtobufParser::set_syslog_ng_address(LogMessage *msg, GSo
       const std::string &name = attr.key();
       if (name.compare("addr") == 0)
         {
-          if (!_value_case_equals(msg, attr, AnyValue::kBytesValue))
+          if (!_value_case_equals_or_error(msg, attr, AnyValue::kBytesValue))
             continue;
           addr_bytes = &attr.value().bytes_value();
         }
       else if (name.compare("port") == 0)
         {
-          if (!_value_case_equals(msg, attr, AnyValue::kIntValue))
+          if (!_value_case_equals_or_error(msg, attr, AnyValue::kIntValue))
             continue;
           port = attr.value().int_value();
         }

--- a/modules/grpc/otel/tests/test-otel-protobuf-parser.cpp
+++ b/modules/grpc/otel/tests/test-otel-protobuf-parser.cpp
@@ -46,7 +46,7 @@ _create_dummy_log_msg()
 {
   LogMessage *msg = log_msg_new_empty();
 
-  grpc::string peer = "ipv6:[::1]:36372";
+  grpc::string peer = "ipv4:127.0.0.5:36372";
   Resource resource;
   std::string resource_schema_url = "dummy_resource_schema_url";
   InstrumentationScope scope;
@@ -150,7 +150,8 @@ Test(otel_protobuf_parser, metadata)
   ProtobufParser::store_raw(msg, LogRecord());
   ProtobufParser().process(msg);
 
-  _assert_log_msg_value(msg, "HOST", "[::1]", -1, LM_VT_STRING);
+  cr_assert(msg->saddr != NULL);
+  _assert_log_msg_value(msg, "SOURCEIP", "::1", -1, LM_VT_STRING);
 
   _assert_log_msg_value(msg, ".otel.resource.attributes.null_key", "", -1, LM_VT_NULL);
   _assert_log_msg_value(msg, ".otel.resource.attributes.string_key", "string_attribute", -1, LM_VT_STRING);
@@ -206,6 +207,10 @@ Test(otel_protobuf_parser, log_record)
 
   ProtobufParser::store_raw(msg, log_record);
   cr_assert(ProtobufParser().process(msg));
+
+  cr_assert(msg->saddr != NULL);
+
+  _assert_log_msg_value(msg, "SOURCEIP", "127.0.0.5", -1, LM_VT_STRING);
 
   _assert_log_msg_value(msg, ".otel.type", "log", -1, LM_VT_STRING);
   _assert_log_msg_value(msg, ".otel.log.time_unix_nano", "111000222000", -1, LM_VT_INTEGER);


### PR DESCRIPTION
This branch starts to differentiate between global tags and local tags. Local tags start with a '.' and all previous built-in use of tags will be considered local).

The $TAGS macro would continue to expand to everything, so we would remain compatible, but the syslog-ng-otlp() driver is changed so that only global tags are transmitted to the peer.

This also contains a change to the $PRI value which is becoming a simple integer instead of a string representation of the same.
