### PR TITLE
Use tags for incorrect input reporting

### DIFF
--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -230,7 +230,6 @@ app_startup(void)
   healthcheck_stats_global_init();
   tzset();
   log_msg_global_init();
-  log_tags_global_init();
   log_source_global_init();
   log_template_global_init();
   value_pairs_global_init();
@@ -279,7 +278,6 @@ app_shutdown(void)
   scratch_buffers_global_deinit();
   value_pairs_global_deinit();
   log_template_global_deinit();
-  log_tags_global_deinit();
   log_msg_global_deinit();
 
   afinter_global_deinit();

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -2067,6 +2067,7 @@ void
 log_msg_global_init(void)
 {
   log_msg_registry_init();
+  log_tags_global_init();
 
   /* NOTE: we always initialize counters as they are on stats-level(0),
    * however we need to defer that as the stats subsystem may not be
@@ -2084,6 +2085,7 @@ log_msg_get_handle_name(NVHandle handle, gssize *length)
 void
 log_msg_global_deinit(void)
 {
+  log_tags_global_deinit();
   log_msg_registry_deinit();
 }
 

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1992,6 +1992,13 @@ log_msg_refcache_stop(void)
 }
 
 void
+log_msg_tags_init(void)
+{
+  log_tags_register_predefined_tag("message.utf8_sanitized", LM_T_MSG_UTF8_SANITIZED);
+  log_tags_register_predefined_tag("message.parse_error", LM_T_MSG_PARSE_ERROR);
+}
+
+void
 log_msg_registry_init(void)
 {
   gint i;
@@ -2068,6 +2075,7 @@ log_msg_global_init(void)
 {
   log_msg_registry_init();
   log_tags_global_init();
+  log_msg_tags_init();
 
   /* NOTE: we always initialize counters as they are on stats-level(0),
    * however we need to defer that as the stats subsystem may not be

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1996,6 +1996,13 @@ log_msg_tags_init(void)
 {
   log_tags_register_predefined_tag("message.utf8_sanitized", LM_T_MSG_UTF8_SANITIZED);
   log_tags_register_predefined_tag("message.parse_error", LM_T_MSG_PARSE_ERROR);
+
+  log_tags_register_predefined_tag("syslog.missing_pri", LM_T_SYSLOG_MISSING_PRI);
+  log_tags_register_predefined_tag("syslog.missing_timestamp", LM_T_SYSLOG_MISSING_TIMESTAMP);
+  log_tags_register_predefined_tag("syslog.invalid_hostname", LM_T_SYSLOG_INVALID_HOSTNAME);
+  log_tags_register_predefined_tag("syslog.unexpected_framing", LM_T_SYSLOG_UNEXPECTED_FRAMING);
+  log_tags_register_predefined_tag("syslog.rfc3164_missing_header", LM_T_SYSLOG_RFC3164_MISSING_HEADER);
+  log_tags_register_predefined_tag("syslog.rfc5424_unquoted_sdata_value", LM_T_SYSLOG_RFC5424_UNQUOTED_SDATA_VALUE);
 }
 
 void

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -103,6 +103,15 @@ enum
 
 enum
 {
+  /* means that the message is not valid utf8 */
+  LM_T_MSG_UTF8_SANITIZED,
+  /* msg-format parsing failed, "Error parsing ..." */
+  LM_T_MSG_PARSE_ERROR,
+  LM_T_PREDEFINED_MAX,
+};
+
+enum
+{
   LM_VF_SDATA = 0x0001,
   LM_VF_MATCH = 0x0002,
   LM_VF_MACRO = 0x0004,

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -107,6 +107,8 @@ enum
   LM_T_MSG_UTF8_SANITIZED,
   /* msg-format parsing failed, "Error parsing ..." */
   LM_T_MSG_PARSE_ERROR,
+  __LM_T_SYSLOG_TAGS_START,
+  __LM_T_SYSLOG_TAGS_END=__LM_T_SYSLOG_TAGS_START + 5,
   LM_T_PREDEFINED_MAX,
 };
 

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -107,8 +107,18 @@ enum
   LM_T_MSG_UTF8_SANITIZED,
   /* msg-format parsing failed, "Error parsing ..." */
   LM_T_MSG_PARSE_ERROR,
-  __LM_T_SYSLOG_TAGS_START,
-  __LM_T_SYSLOG_TAGS_END=__LM_T_SYSLOG_TAGS_START + 5,
+  /* missing <pri> value */
+  LM_T_SYSLOG_MISSING_PRI,
+  /* no timestamp present in the original message */
+  LM_T_SYSLOG_MISSING_TIMESTAMP,
+  /* hostname field does not seem valid, check-hostname(yes) failed */
+  LM_T_SYSLOG_INVALID_HOSTNAME,
+  /* we seem to have found an octet count in front of the message */
+  LM_T_SYSLOG_UNEXPECTED_FRAMING,
+  /* no date & host information in the syslog message */
+  LM_T_SYSLOG_RFC3164_MISSING_HEADER,
+  /* incorrectly quoted RFC5424 SDATA */
+  LM_T_SYSLOG_RFC5424_UNQUOTED_SDATA_VALUE,
   LM_T_PREDEFINED_MAX,
 };
 

--- a/lib/logmsg/tags.c
+++ b/lib/logmsg/tags.c
@@ -73,6 +73,12 @@ _register_tag(const gchar *name, guint id)
   g_hash_table_insert(log_tags_hash, new_tag.name, GUINT_TO_POINTER(id + 1));
   return id;
 }
+
+static guint
+_register_new_tag(const gchar *name)
+{
+  guint id = log_tags->len;
+  return _register_tag(name, id);
 }
 
 /*
@@ -107,7 +113,7 @@ log_tags_get_by_name(const gchar *name)
     {
       if (log_tags->len < LOG_TAGS_MAX - 1)
         {
-          id = _register_tag(name, log_tags->len);
+          id = _register_new_tag(name);
         }
       else
         id = 0;
@@ -120,6 +126,19 @@ log_tags_get_by_name(const gchar *name)
   g_mutex_unlock(&log_tags_lock);
 
   return id;
+}
+
+void
+log_tags_register_predefined_tag(const gchar *name, LogTagId id)
+{
+  g_mutex_lock(&log_tags_lock);
+
+  gpointer key = g_hash_table_lookup(log_tags_hash, name);
+  g_assert(key == NULL);
+
+  LogTagId rid = _register_tag(name, id);
+  g_assert(rid == id);
+  g_mutex_unlock(&log_tags_lock);
 }
 
 /*

--- a/lib/logmsg/tags.c
+++ b/lib/logmsg/tags.c
@@ -231,22 +231,15 @@ log_tags_reinit_stats(void)
 void
 log_tags_global_init(void)
 {
-  /* Necessary only in case of reinitialized tags */
-  g_mutex_lock(&log_tags_lock);
-
   log_tags_hash = g_hash_table_new(g_str_hash, g_str_equal);
   log_tags = g_array_new(FALSE, TRUE, sizeof(LogTag));
 
-
-  g_mutex_unlock(&log_tags_lock);
   register_application_hook(AH_CONFIG_CHANGED, (ApplicationHookFunc) log_tags_reinit_stats, NULL, AHM_RUN_REPEAT);
 }
 
 void
 log_tags_global_deinit(void)
 {
-  g_mutex_lock(&log_tags_lock);
-
   g_hash_table_destroy(log_tags_hash);
 
   stats_lock();
@@ -263,6 +256,4 @@ log_tags_global_deinit(void)
     }
   stats_unlock();
   g_array_free(log_tags, TRUE);
-
-  g_mutex_unlock(&log_tags_lock);
 }

--- a/lib/logmsg/tags.h
+++ b/lib/logmsg/tags.h
@@ -45,6 +45,7 @@ typedef guint16 LogTagId;
 
 LogTagId log_tags_get_by_name(const gchar *name);
 const gchar *log_tags_get_by_id(LogTagId id);
+void log_tags_register_predefined_tag(const gchar *name, LogTagId id);
 
 void log_tags_reinit_stats(void);
 void log_tags_global_init(void);

--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -29,7 +29,6 @@
 #include "stats/stats-cluster-logpipe.h"
 #include "stats/stats-cluster-single.h"
 #include "msg-stats.h"
-#include "logmsg/tags.h"
 #include "ack-tracker/ack_tracker.h"
 #include "ack-tracker/ack_tracker_factory.h"
 #include "timeutils/misc.h"

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -125,6 +125,7 @@ msg_format_process_message(MsgFormatOptions *options, LogMessage *msg,
               gsize sanitized_length;
               optimized_sanitize_utf8_to_escaped_binary(data, length, &sanitized_length, buf, sizeof(buf));
               log_msg_set_value(msg, LM_V_MESSAGE, buf, _rstripped_message_length((guchar *) buf, sanitized_length));
+              log_msg_set_tag_by_id(msg, LM_T_MSG_UTF8_SANITIZED);
               msg->flags |= LF_UTF8;
               return TRUE;
             }
@@ -170,6 +171,7 @@ msg_format_parse_into(MsgFormatOptions *options, LogMessage *msg,
 
   if (!msg_format_try_parse_into(options, msg, data, length, &problem_position))
     {
+      log_msg_set_tag_by_id(msg, LM_T_MSG_PARSE_ERROR);
       msg_format_inject_parse_error(msg, data, _rstripped_message_length(data, length), problem_position);
 
       /* the injected error message needs to be postprocessed too */

--- a/modules/basicfuncs/basic-funcs.c
+++ b/modules/basicfuncs/basic-funcs.c
@@ -142,6 +142,7 @@ static Plugin basicfuncs_plugins[] =
 
   /* tags */
   TEMPLATE_FUNCTION_PLUGIN(tf_tag, "tag"),
+  TEMPLATE_FUNCTION_PLUGIN(tf_tags_head, "tags-head"),
 
   /* functional */
   TEMPLATE_FUNCTION_PLUGIN(tf_iterate, "iterate"),

--- a/modules/basicfuncs/tests/test_basicfuncs.c
+++ b/modules/basicfuncs/tests/test_basicfuncs.c
@@ -570,6 +570,10 @@ Test(basicfuncs, test_tag)
 
   assert_template_format_value_and_type("$(tag alma true false)", "true", LM_VT_STRING);
   assert_template_format_value_and_type("$(tag narancs true false)", "false", LM_VT_STRING);
+
+  assert_template_format_value_and_type("$(tags-head alma korte narancs)", "alma", LM_VT_STRING);
+  assert_template_format_value_and_type("$(tags-head narancs alma korte)", "alma", LM_VT_STRING);
+  assert_template_format_value_and_type("$(tags-head narancs banan)", "", LM_VT_NULL);
 }
 
 Test(basicfuncs, test_tfurlencode)

--- a/modules/correlation/tests/test_patternize.c
+++ b/modules/correlation/tests/test_patternize.c
@@ -48,7 +48,6 @@ static void setup(void)
 
 static void teardown(void)
 {
-  log_tags_global_deinit();
   msg_format_options_destroy(&parse_options);
   app_shutdown();
 }

--- a/modules/diskq/dqtool.c
+++ b/modules/diskq/dqtool.c
@@ -729,10 +729,9 @@ main(int argc, char *argv[])
   scratch_buffers_global_init();
   scratch_buffers_allocator_init();
   log_template_global_init();
-  log_msg_registry_init();
-  log_tags_global_init();
+  log_msg_global_init();
   modes[mode].main(argc, argv);
-  log_tags_global_deinit();
+  log_msg_global_deinit();
   scratch_buffers_allocator_deinit();
   scratch_buffers_global_deinit();
   stats_destroy();

--- a/modules/kafka/tests/test_kafka-props.c
+++ b/modules/kafka/tests/test_kafka-props.c
@@ -78,6 +78,7 @@ static void
 setup(void)
 {
   msg_init(FALSE);
+  log_tags_global_init();
   log_msg_global_init();
 }
 

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -966,8 +966,9 @@ _syslog_format_parse_syslog_proto(const MsgFormatOptions *parse_options, const g
     }
 
   /* ISO time format */
+  time_t now = get_cached_realtime_sec();
   if (!_syslog_format_parse_date(msg, &src, &left, parse_options->flags,
-                                 time_zone_info_get_offset(parse_options->recv_time_zone_info, time(NULL))))
+                                 time_zone_info_get_offset(parse_options->recv_time_zone_info, now)))
     goto error;
 
   if (!_skip_space(&src, &left))

--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -40,25 +40,6 @@
 
 #define SD_NAME_SIZE 256
 
-enum
-{
-  /* missing <pri> value */
-  LM_T_SYSLOG_MISSING_PRI = __LM_T_SYSLOG_TAGS_START,
-  /* no timestamp present in the original message */
-  LM_T_SYSLOG_MISSING_TIMESTAMP,
-  /* hostname field does not seem valid, check-hostname(yes) failed */
-  LM_T_SYSLOG_INVALID_HOSTNAME,
-  /* we seem to have found an octet count in front of the message */
-  LM_T_SYSLOG_UNEXPECTED_FRAMING,
-  /* no date & host information in the syslog message */
-  LM_T_SYSLOG_RFC3164_MISSING_HEADER,
-  /* incorrectly quoted RFC5424 SDATA */
-  LM_T_SYSLOG_RFC5424_UNQUOTED_SDATA_VALUE,
-  __LM_T_SYSLOG_TAGS_MAX,
-};
-
-G_STATIC_ASSERT(__LM_T_SYSLOG_TAGS_END == __LM_T_SYSLOG_TAGS_MAX - 1);
-
 static const char aix_fwd_string[] = "Message forwarded from ";
 static const char repeat_msg_string[] = "last message repeated";
 static struct
@@ -1141,13 +1122,6 @@ syslog_format_init(void)
       handles.cisco_seqid = log_msg_get_value_handle(".SDATA.meta.sequenceId");
       handles.initialized = TRUE;
     }
-
-  log_tags_register_predefined_tag("syslog.missing_pri", LM_T_SYSLOG_MISSING_PRI);
-  log_tags_register_predefined_tag("syslog.missing_timestamp", LM_T_SYSLOG_MISSING_TIMESTAMP);
-  log_tags_register_predefined_tag("syslog.invalid_hostname", LM_T_SYSLOG_INVALID_HOSTNAME);
-  log_tags_register_predefined_tag("syslog.unexpected_framing", LM_T_SYSLOG_UNEXPECTED_FRAMING);
-  log_tags_register_predefined_tag("syslog.rfc3164_missing_header", LM_T_SYSLOG_RFC3164_MISSING_HEADER);
-  log_tags_register_predefined_tag("syslog.rfc5424_unquoted_sdata_value", LM_T_SYSLOG_RFC5424_UNQUOTED_SDATA_VALUE);
 
   _init_parse_hostname_invalid_chars();
 }


### PR DESCRIPTION
This PR makes it possible to report syslog parsing problems as builtin tags (e.g. named bit-like properties of the message).

These are the builtin tags:

  /* means that the message is not valid utf8 */
  LM_T_MSG_UTF8_SANITIZED,
  /* msg-format parsing failed, "Error parsing ..." */
  LM_T_MSG_PARSE_ERROR,
  /* missing <pri> value */
  LM_T_SYSLOG_MISSING_PRI,
  /* no timestamp present in the original message */
  LM_T_SYSLOG_MISSING_TIMESTAMP,
  /* hostname field does not seem valid, check-hostname(yes) failed */
  LM_T_SYSLOG_INVALID_HOSTNAME,
  /* we seem to have found an octet count in front of the message */
  LM_T_SYSLOG_UNEXPECTED_FRAMING,
  /* no date & host information in the syslog message */
  LM_T_SYSLOG_RFC3164_MISSING_HEADER,
  /* incorrectly quoted RFC5424 SDATA */
  LM_T_SYSLOG_RFC5424_UNQUOTED_SDATA_VALUE,

It also contains a $(tags-head) template function and some refactoring steps.
