### PR TITLE
http: add `syslogng_output_http_request_status_codes_total` metric

### DIFF
--- a/modules/http/http-worker.h
+++ b/modules/http/http-worker.h
@@ -41,6 +41,12 @@ typedef struct _HTTPDestinationWorker
   List *request_headers;
   GString *url_buffer;
   LogMessage *msg_for_templated_url;
+
+  struct
+  {
+    StatsClusterLabel *requests_labels;
+    gchar requests_response_code_str_buffer[4];
+  } metrics;
 } HTTPDestinationWorker;
 
 LogThreadedResult default_map_http_status_to_worker_status(HTTPDestinationWorker *self, const gchar *url,

--- a/news/feature-4805.md
+++ b/news/feature-4805.md
@@ -1,0 +1,11 @@
+`http()`: Added a new counter for HTTP requests.
+
+It is activated on `stats(level(1));`.
+
+Example metrics:
+```
+syslogng_output_http_requests_total{url="http://localhost:8888/bar",response_code="200",driver="http",id="#anon-destination0#0"} 16
+syslogng_output_http_requests_total{url="http://localhost:8888/bar",response_code="401",driver="http",id="#anon-destination0#0"} 2
+syslogng_output_http_requests_total{url="http://localhost:8888/bar",response_code="502",driver="http",id="#anon-destination0#0"} 1
+syslogng_output_http_requests_total{url="http://localhost:8888/foo",response_code="200",driver="http",id="#anon-destination0#0"} 24
+```


### PR DESCRIPTION
Example metrics:
```
syslogng_output_http_requests_total{url="http://localhost:8888/bar",response_code="200",driver="http",id="#anon-destination0#0"} 16
syslogng_output_http_requests_total{url="http://localhost:8888/bar",response_code="401",driver="http",id="#anon-destination0#0"} 2
syslogng_output_http_requests_total{url="http://localhost:8888/bar",response_code="502",driver="http",id="#anon-destination0#0"} 1
syslogng_output_http_requests_total{url="http://localhost:8888/foo",response_code="200",driver="http",id="#anon-destination0#0"} 24
```