### PR TITLE
logthrdest: add syslogng_output_event_retries_total metric 

### DIFF
--- a/lib/logthrdest/logthrdestdrv.h
+++ b/lib/logthrdest/logthrdestdrv.h
@@ -135,10 +135,12 @@ struct _LogThreadedDestDriver
   {
     StatsClusterKey *output_events_sc_key;
     StatsClusterKey *processed_sc_key;
+    StatsClusterKey *output_event_retries_sc_key;
 
     StatsCounterItem *dropped_messages;
     StatsCounterItem *processed_messages;
     StatsCounterItem *written_messages;
+    StatsCounterItem *output_event_retries;
 
     gboolean raw_bytes_enabled;
 

--- a/news/feature-4807.md
+++ b/news/feature-4807.md
@@ -1,0 +1,25 @@
+destinations: Added "syslogng_output_event_retries_total" counter.
+
+This counter is available for the following destination drivers:
+ * `amqp()`
+ * `bigquery()`
+ * `http()` and all http based drivers
+ * `java()`
+ * `kafka()`
+ * `loki()`
+ * `mongodb()`
+ * `mqtt()`
+ * `opentelemetry()`
+ * `python()` and all python based drivers
+ * `redis()`
+ * `riemann()`
+ * `smtp()`
+ * `snmp()`
+ * `sql()`
+ * `stomp()`
+ * `syslog-ng-otlp()`
+
+Example metrics:
+```
+syslogng_output_event_retries_total{driver="http",url="http://localhost:8888/${path}",id="#anon-destination0#0"} 5
+```


### PR DESCRIPTION
Example metrics:
```
syslogng_output_event_retries_total{driver="http",url="http://localhost:8888/${path}",id="#anon-destination0#0"} 5
```