### PR TITLE
grpc: add request related metrics

### DIFF
--- a/modules/grpc/CMakeLists.txt
+++ b/modules/grpc/CMakeLists.txt
@@ -71,6 +71,7 @@ if (ENABLE_GRPC)
     protobuf::libprotobuf)
 
   add_subdirectory(credentials)
+  add_subdirectory(metrics)
   add_subdirectory(protos)
 endif()
 

--- a/modules/grpc/Makefile.am
+++ b/modules/grpc/Makefile.am
@@ -1,6 +1,7 @@
 include modules/grpc/protos/Makefile.am
 
 include modules/grpc/credentials/Makefile.am
+include modules/grpc/metrics/Makefile.am
 
 include modules/grpc/otel/Makefile.am
 include modules/grpc/loki/Makefile.am

--- a/modules/grpc/bigquery/CMakeLists.txt
+++ b/modules/grpc/bigquery/CMakeLists.txt
@@ -3,6 +3,7 @@ if(NOT ENABLE_GRPC)
 endif()
 
 set(BIGQUERY_CPP_SOURCES
+  ${GRPC_METRICS_SOURCES}
   bigquery-dest.hpp
   bigquery-dest.cpp
   bigquery-dest.h

--- a/modules/grpc/bigquery/Makefile.am
+++ b/modules/grpc/bigquery/Makefile.am
@@ -3,6 +3,7 @@ if ENABLE_GRPC
 noinst_LTLIBRARIES += modules/grpc/bigquery/libbigquery_cpp.la
 
 modules_grpc_bigquery_libbigquery_cpp_la_SOURCES = \
+  $(grpc_metrics_sources) \
   modules/grpc/bigquery/bigquery-dest.h \
   modules/grpc/bigquery/bigquery-dest.hpp \
   modules/grpc/bigquery/bigquery-dest.cpp \
@@ -15,6 +16,7 @@ modules_grpc_bigquery_libbigquery_cpp_la_CXXFLAGS = \
   $(PROTOBUF_CLFAGS) \
   $(GRPCPP_CFLAGS) \
   -I$(GOOGLEAPIS_PROTO_BUILDDIR) \
+  -I$(top_srcdir)/modules/grpc \
   -I$(top_srcdir)/modules/grpc/bigquery \
   -I$(top_builddir)/modules/grpc/bigquery
 

--- a/modules/grpc/bigquery/bigquery-dest.cpp
+++ b/modules/grpc/bigquery/bigquery-dest.cpp
@@ -188,12 +188,18 @@ DestinationDriver::init()
     return false;
 
   log_threaded_dest_driver_register_aggregated_stats(&this->super->super);
+
+  StatsClusterKeyBuilder *kb = stats_cluster_key_builder_new();
+  this->format_stats_key(kb);
+  this->metrics.init(kb, log_pipe_is_internal(&this->super->super.super.super.super) ? STATS_LEVEL3 : STATS_LEVEL1);
+
   return true;
 }
 
 bool
 DestinationDriver::deinit()
 {
+  this->metrics.deinit();
   return log_threaded_dest_driver_deinit_method(&this->super->super.super.super.super);
 }
 

--- a/modules/grpc/bigquery/bigquery-dest.hpp
+++ b/modules/grpc/bigquery/bigquery-dest.hpp
@@ -30,6 +30,8 @@
 #include "stats/stats-cluster-key-builder.h"
 #include "compat/cpp-end.h"
 
+#include "metrics/grpc-metrics.hpp"
+
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/descriptor.pb.h>
 #include <google/protobuf/dynamic_message.h>
@@ -198,6 +200,8 @@ private:
   std::unique_ptr<google::protobuf::DynamicMessageFactory> msg_factory;
   const google::protobuf::Descriptor *schema_descriptor = nullptr;
   const google::protobuf::Message *schema_prototype  = nullptr;
+
+  DestDriverMetrics metrics;
 };
 
 

--- a/modules/grpc/bigquery/bigquery-worker.cpp
+++ b/modules/grpc/bigquery/bigquery-worker.cpp
@@ -362,6 +362,15 @@ DestinationWorker::handle_row_errors(const google::cloud::bigquery::storage::v1:
   return LTR_DROP;
 }
 
+static ::grpc::Status
+_append_rows_response_get_status(const google::cloud::bigquery::storage::v1::AppendRowsResponse &response)
+{
+  if (!response.has_error())
+    return ::grpc::Status::OK;
+
+  return ::grpc::Status((::grpc::StatusCode) response.error().code(), response.error().message());
+}
+
 LogThreadedResult
 DestinationWorker::flush(LogThreadedFlushMode mode)
 {
@@ -407,6 +416,7 @@ DestinationWorker::flush(LogThreadedFlushMode mode)
   result = LTR_SUCCESS;
 
 exit:
+  this->get_owner()->metrics.insert_grpc_request_stats(_append_rows_response_get_status(append_rows_response));
   this->prepare_batch();
   return result;
 }

--- a/modules/grpc/loki/CMakeLists.txt
+++ b/modules/grpc/loki/CMakeLists.txt
@@ -4,6 +4,7 @@ endif()
 
 set(LOKI_CPP_SOURCES
   ${GRPC_CREDENTIALS_SOURCES}
+  ${GRPC_METRICS_SOURCES}
   loki-dest.hpp
   loki-dest.cpp
   loki-dest.h

--- a/modules/grpc/loki/Makefile.am
+++ b/modules/grpc/loki/Makefile.am
@@ -4,6 +4,7 @@ noinst_LTLIBRARIES += modules/grpc/loki/libloki_cpp.la
 
 modules_grpc_loki_libloki_cpp_la_SOURCES = \
   $(grpc_credentials_sources) \
+  $(grpc_metrics_sources) \
   modules/grpc/loki/loki-dest.h \
   modules/grpc/loki/loki-dest.hpp \
   modules/grpc/loki/loki-dest.cpp \

--- a/modules/grpc/loki/loki-dest.cpp
+++ b/modules/grpc/loki/loki-dest.cpp
@@ -107,12 +107,20 @@ DestinationDriver::init()
   else
     log_threaded_dest_driver_set_worker_partition_key_ref(&this->super->super.super.super, worker_partition_key);
 
-  return log_threaded_dest_driver_init_method(&this->super->super.super.super.super);
+  if (!log_threaded_dest_driver_init_method(&this->super->super.super.super.super))
+    return false;
+
+  StatsClusterKeyBuilder *kb = stats_cluster_key_builder_new();
+  this->format_stats_key(kb);
+  this->metrics.init(kb, log_pipe_is_internal(&this->super->super.super.super.super) ? STATS_LEVEL3 : STATS_LEVEL1);
+
+  return true;
 }
 
 bool
 DestinationDriver::deinit()
 {
+  this->metrics.deinit();
   return log_threaded_dest_driver_deinit_method(&this->super->super.super.super.super);
 }
 

--- a/modules/grpc/loki/loki-dest.hpp
+++ b/modules/grpc/loki/loki-dest.hpp
@@ -32,6 +32,7 @@
 #include "compat/cpp-end.h"
 
 #include "credentials/grpc-credentials-builder.hpp"
+#include "metrics/grpc-metrics.hpp"
 
 #include <string>
 #include <vector>
@@ -155,6 +156,8 @@ private:
   int keepalive_time;
   int keepalive_timeout;
   int keepalive_max_pings_without_data;
+
+  DestDriverMetrics metrics;
 };
 
 

--- a/modules/grpc/loki/loki-worker.cpp
+++ b/modules/grpc/loki/loki-worker.cpp
@@ -230,6 +230,7 @@ DestinationWorker::flush(LogThreadedFlushMode mode)
     ctx.AddMetadata("x-scope-orgid", owner->tenant_id);
 
   ::grpc::Status status = this->stub->Push(&ctx, this->current_batch, &response);
+  this->get_owner()->metrics.insert_grpc_request_stats(status);
 
   if (!status.ok())
     {

--- a/modules/grpc/metrics/CMakeLists.txt
+++ b/modules/grpc/metrics/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(GRPC_METRICS_SOURCES
+    ${PROJECT_SOURCE_DIR}/modules/grpc/metrics/grpc-metrics.hpp
+    ${PROJECT_SOURCE_DIR}/modules/grpc/metrics/grpc-metrics.cpp
+    PARENT_SCOPE)

--- a/modules/grpc/metrics/Makefile.am
+++ b/modules/grpc/metrics/Makefile.am
@@ -1,0 +1,5 @@
+grpc_metrics_sources = \
+  modules/grpc/metrics/grpc-metrics.hpp \
+  modules/grpc/metrics/grpc-metrics.cpp
+
+EXTRA_DIST +=  modules/grpc/metrics/CMakeLists.txt

--- a/modules/grpc/metrics/grpc-metrics.cpp
+++ b/modules/grpc/metrics/grpc-metrics.cpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2024 Attila Szakacs
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "grpc-metrics.hpp"
+
+#include "compat/cpp-start.h"
+#include "messages.h"
+#include "compat/cpp-end.h"
+
+using namespace syslogng::grpc;
+
+/*
+ * Initializes the DestDriverMetrics instance.
+ * Takes the ownership of kb.
+ */
+void
+DestDriverMetrics::init(StatsClusterKeyBuilder *kb_, int stats_level_)
+{
+  kb = kb_;
+  stats_level = stats_level_;
+}
+
+void
+DestDriverMetrics::deinit()
+{
+  stats_lock();
+  {
+    for (const auto &clusters : grpc_request_clusters)
+      {
+        StatsCounterItem *counter = stats_cluster_single_get_counter(clusters.second);
+        stats_unregister_counter(&clusters.second->key, SC_TYPE_SINGLE_VALUE, &counter);
+      }
+  }
+  stats_unlock();
+
+  stats_cluster_key_builder_free(kb);
+}
+
+StatsCluster *
+DestDriverMetrics::create_grpc_request_cluster(::grpc::StatusCode response_code)
+{
+  static const std::map<::grpc::StatusCode, std::string> status_code_name_mappings =
+  {
+    {::grpc::StatusCode::OK, "ok"},
+    {::grpc::StatusCode::CANCELLED, "cancelled"},
+    {::grpc::StatusCode::UNKNOWN, "unknown"},
+    {::grpc::StatusCode::INVALID_ARGUMENT, "invalid_argument"},
+    {::grpc::StatusCode::DEADLINE_EXCEEDED, "deadline_exceeded"},
+    {::grpc::StatusCode::NOT_FOUND, "not_found"},
+    {::grpc::StatusCode::ALREADY_EXISTS, "already_exists"},
+    {::grpc::StatusCode::PERMISSION_DENIED, "permission_denied"},
+    {::grpc::StatusCode::UNAUTHENTICATED, "unauthenticated"},
+    {::grpc::StatusCode::RESOURCE_EXHAUSTED, "resource_exhausted"},
+    {::grpc::StatusCode::FAILED_PRECONDITION, "failed_precondition"},
+    {::grpc::StatusCode::ABORTED, "aborted"},
+    {::grpc::StatusCode::OUT_OF_RANGE, "out_of_range"},
+    {::grpc::StatusCode::UNIMPLEMENTED, "unimplemented"},
+    {::grpc::StatusCode::INTERNAL, "internal"},
+    {::grpc::StatusCode::UNAVAILABLE, "unavailable"},
+    {::grpc::StatusCode::DATA_LOSS, "data_loss"},
+  };
+
+  std::string response_code_label;
+  try
+    {
+      response_code_label = status_code_name_mappings.at(response_code);
+    }
+  catch (const std::out_of_range &)
+    {
+      msg_error("Failed to find metric label for gRPC response code", evt_tag_int("response_code", response_code));
+      return nullptr;
+    }
+
+  StatsCluster *cluster;
+  stats_cluster_key_builder_push(kb);
+  {
+    stats_cluster_key_builder_set_name(kb, "output_grpc_requests_total");
+    stats_cluster_key_builder_add_label(kb, stats_cluster_label("response_code", response_code_label.c_str()));
+    StatsClusterKey *sc_key = stats_cluster_key_builder_build_single(kb);
+
+    StatsCounterItem *counter;
+    cluster = stats_register_counter(stats_level, sc_key, SC_TYPE_SINGLE_VALUE, &counter);
+  }
+  stats_cluster_key_builder_pop(kb);
+
+  return cluster;
+}
+
+StatsCounterItem *
+DestDriverMetrics::lookup_grpc_request_counter(::grpc::StatusCode response_code)
+{
+  StatsCluster *cluster;
+
+  try
+    {
+      cluster = grpc_request_clusters.at(response_code);
+    }
+  catch (const std::out_of_range &)
+    {
+      stats_lock();
+      {
+        try
+          {
+            cluster = grpc_request_clusters.at(response_code);
+          }
+        catch (const std::out_of_range &)
+          {
+            grpc_request_clusters[response_code] = cluster = create_grpc_request_cluster(response_code);
+          }
+      }
+      stats_unlock();
+    }
+
+  return stats_cluster_single_get_counter(cluster);
+}
+
+void
+DestDriverMetrics::insert_grpc_request_stats(const ::grpc::Status &response_status)
+{
+  StatsCounterItem *counter = lookup_grpc_request_counter(response_status.error_code());
+  stats_counter_inc(counter);
+}

--- a/modules/grpc/metrics/grpc-metrics.hpp
+++ b/modules/grpc/metrics/grpc-metrics.hpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024 Attila Szakacs
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef GRPC_METRICS_HPP
+#define GRPC_METRICS_HPP
+
+#include "syslog-ng.h"
+
+#include "compat/cpp-start.h"
+#include "stats/stats-registry.h"
+#include "stats/stats-cluster-single.h"
+#include "stats/stats-cluster-key-builder.h"
+#include "compat/cpp-end.h"
+
+#include <grpc++/grpc++.h>
+#include <map>
+
+namespace syslogng {
+namespace grpc {
+
+class DestDriverMetrics
+{
+public:
+  void init(StatsClusterKeyBuilder *kb, int stats_level);
+  void deinit();
+
+  void insert_grpc_request_stats(const ::grpc::Status &response_status);
+
+private:
+  StatsCluster *create_grpc_request_cluster(::grpc::StatusCode response_code);
+  StatsCounterItem *lookup_grpc_request_counter(::grpc::StatusCode response_code);
+
+private:
+  StatsClusterKeyBuilder *kb;
+  int stats_level;
+
+  std::map<::grpc::StatusCode, StatsCluster *> grpc_request_clusters;
+};
+
+}
+}
+
+#endif

--- a/modules/grpc/otel/CMakeLists.txt
+++ b/modules/grpc/otel/CMakeLists.txt
@@ -4,6 +4,7 @@ endif()
 
 set(OTEL_CPP_SOURCES
   ${GRPC_CREDENTIALS_SOURCES}
+  ${GRPC_METRICS_SOURCES}
   otel-source.cpp
   otel-source.hpp
   otel-source.h

--- a/modules/grpc/otel/Makefile.am
+++ b/modules/grpc/otel/Makefile.am
@@ -4,6 +4,7 @@ noinst_LTLIBRARIES += modules/grpc/otel/libotel_cpp.la
 
 modules_grpc_otel_libotel_cpp_la_SOURCES = \
   $(grpc_credentials_sources) \
+  $(grpc_metrics_sources) \
   modules/grpc/otel/otel-source.h \
   modules/grpc/otel/otel-source.hpp \
   modules/grpc/otel/otel-source.cpp \

--- a/modules/grpc/otel/otel-dest-worker.cpp
+++ b/modules/grpc/otel/otel-dest-worker.cpp
@@ -400,6 +400,7 @@ DestWorker::flush_log_records()
   logs_service_response.Clear();
   ::grpc::Status status = logs_service_stub->Export(&client_context, logs_service_request,
                                                     &logs_service_response);
+  owner.metrics.insert_grpc_request_stats(status);
   LogThreadedResult result = _map_grpc_status_to_log_threaded_result(status);
 
   if (result == LTR_SUCCESS)
@@ -418,6 +419,7 @@ DestWorker::flush_metrics()
   metrics_service_response.Clear();
   ::grpc::Status status = metrics_service_stub->Export(&client_context, metrics_service_request,
                                                        &metrics_service_response);
+  owner.metrics.insert_grpc_request_stats(status);
   LogThreadedResult result = _map_grpc_status_to_log_threaded_result(status);
 
   if (result == LTR_SUCCESS)
@@ -436,6 +438,7 @@ DestWorker::flush_spans()
   trace_service_response.Clear();
   ::grpc::Status status = trace_service_stub->Export(&client_context, trace_service_request,
                                                      &trace_service_response);
+  owner.metrics.insert_grpc_request_stats(status);
   LogThreadedResult result = _map_grpc_status_to_log_threaded_result(status);
 
   if (result == LTR_SUCCESS)

--- a/modules/grpc/otel/otel-dest-worker.hpp
+++ b/modules/grpc/otel/otel-dest-worker.hpp
@@ -90,7 +90,7 @@ protected:
 
 protected:
   OtelDestWorker *super;
-  const DestDriver &owner;
+  DestDriver &owner;
 
   std::shared_ptr<::grpc::Channel> channel;
   std::unique_ptr<LogsService::Stub> logs_service_stub;

--- a/modules/grpc/otel/otel-dest.cpp
+++ b/modules/grpc/otel/otel-dest.cpp
@@ -120,12 +120,18 @@ DestDriver::init()
     return false;
 
   log_threaded_dest_driver_register_aggregated_stats(&this->super->super);
+
+  StatsClusterKeyBuilder *kb = stats_cluster_key_builder_new();
+  format_stats_key(kb);
+  metrics.init(kb, log_pipe_is_internal(&super->super.super.super.super) ? STATS_LEVEL3 : STATS_LEVEL1);
+
   return true;
 }
 
 bool
 DestDriver::deinit()
 {
+  metrics.deinit();
   return log_threaded_dest_driver_deinit_method(&super->super.super.super.super);
 }
 

--- a/modules/grpc/otel/otel-dest.hpp
+++ b/modules/grpc/otel/otel-dest.hpp
@@ -30,6 +30,7 @@
 #include "compat/cpp-end.h"
 
 #include "credentials/grpc-credentials-builder.hpp"
+#include "metrics/grpc-metrics.hpp"
 
 #include <grpcpp/server.h>
 
@@ -59,6 +60,7 @@ public:
   virtual LogThreadedDestWorker *construct_worker(int worker_index);
 
   GrpcClientCredentialsBuilderW *get_credentials_builder_wrapper();
+
 public:
   syslogng::grpc::ClientCredentialsBuilder credentials_builder;
 
@@ -69,6 +71,7 @@ protected:
   bool compression;
   size_t batch_bytes;
   GrpcClientCredentialsBuilderW credentials_builder_wrapper;
+  DestDriverMetrics metrics;
 };
 
 }

--- a/news/feature-4811.md
+++ b/news/feature-4811.md
@@ -1,0 +1,13 @@
+gRPC based destination drivers: Added gRPC request related metrics.
+
+Affected drivers:
+  * `opentelemetry()`
+  * `syslog-ng-otlp()`
+  * `bigquery()`
+  * `loki()`
+
+Example metrics:
+```
+syslogng_output_grpc_requests_total{driver="syslog-ng-otlp",url="localhost:12345",response_code="ok"} 49
+syslogng_output_grpc_requests_total{driver="syslog-ng-otlp",url="localhost:12345",response_code="unavailable"} 11
+```

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -198,6 +198,7 @@ modules/grpc/otel/tests/test-syslog-ng-otlp\.cpp$
 modules/grpc/loki
 modules/grpc/bigquery
 modules/grpc/credentials
+modules/grpc/metrics
 modules/cloud-auth/cloud-auth(|-grammar|-parser|-plugin)\.(c|h|cpp|hpp|ym)$
 modules/cloud-auth/google-auth\.(h|cpp|hpp)$
 modules/examples/inner-destinations/tls-test-validation


### PR DESCRIPTION
Implementing this with composition in each gRPC related dest driver is suboptimal.

The clean thing would be to have a common gRPC related dest driver, which already does handle metrics, and the otel, bigquery and loki drivers should descend from it. Unfortunately doing that would be a huge task right now.

IMO this should suffice for now, but we should really clean up the class hierarchy sometime later.

---

Affected drivers:
  * `opentelemetry()`
  * `syslog-ng-otlp()`
  * `bigquery()`
  * `loki()`

Example metrics:
```
syslogng_output_grpc_requests_total{driver="syslog-ng-otlp",url="localhost:12345",response_code="ok"} 49
syslogng_output_grpc_requests_total{driver="syslog-ng-otlp",url="localhost:12345",response_code="unavailable"} 11
```