### PR TITLE
loki: add tenant-id() option

### DIFF
--- a/modules/grpc/loki/loki-dest.cpp
+++ b/modules/grpc/loki/loki-dest.cpp
@@ -204,6 +204,13 @@ loki_dd_set_timestamp(LogDriver *d, const gchar *t)
 }
 
 void
+loki_dd_set_tenant_id(LogDriver *d, const gchar *tid)
+{
+  LokiDestDriver *self = (LokiDestDriver *) d;
+  return self->cpp->set_tenant_id(tid);
+}
+
+void
 loki_dd_set_keepalive_time(LogDriver *d, gint t)
 {
   LokiDestDriver *self = (LokiDestDriver *) d;

--- a/modules/grpc/loki/loki-dest.h
+++ b/modules/grpc/loki/loki-dest.h
@@ -39,6 +39,7 @@ void loki_dd_set_url(LogDriver *d, const gchar *url);
 void loki_dd_set_message_template_ref(LogDriver *d, LogTemplate *message);
 void loki_dd_add_label(LogDriver *d, const gchar *name, LogTemplate *value);
 gboolean loki_dd_set_timestamp(LogDriver *d, const gchar *t);
+void loki_dd_set_tenant_id(LogDriver *d, const gchar *tid);
 
 GrpcClientCredentialsBuilderW *loki_dd_get_credentials_builder(LogDriver *s);
 

--- a/modules/grpc/loki/loki-dest.hpp
+++ b/modules/grpc/loki/loki-dest.hpp
@@ -125,6 +125,11 @@ public:
     this->keepalive_max_pings_without_data = p;
   }
 
+  void set_tenant_id(std::string tid)
+  {
+    this->tenant_id = tid;
+  }
+
   const std::string &get_url()
   {
     return this->url;
@@ -138,6 +143,7 @@ private:
   LogTemplateOptions template_options;
 
   std::string url;
+  std::string tenant_id;
 
   LogTemplate *message = nullptr;
   std::vector<Label> labels;

--- a/modules/grpc/loki/loki-grammar.ym
+++ b/modules/grpc/loki/loki-grammar.ym
@@ -63,6 +63,7 @@ GrpcClientCredentialsBuilderW *last_grpc_client_credentials_builder;
 %token KW_ALTS
 %token KW_TARGET_SERVICE_ACCOUNTS
 %token KW_ADC
+%token KW_TENANT_ID
 
 %token KW_KEEP_ALIVE
 %token KW_TIME
@@ -94,6 +95,7 @@ loki_dest_option
   : KW_URL '(' string ')' { loki_dd_set_url(last_driver, $3); free($3); }
   | KW_KEEP_ALIVE '(' loki_keepalive_options ')'
   | KW_LABELS '(' loki_labels ')'
+  | KW_TENANT_ID '(' string ')' { loki_dd_set_tenant_id(last_driver, $3); free($3); }
   | KW_TIMESTAMP '(' string ')'
     {
       CHECK_ERROR(loki_dd_set_timestamp(last_driver, $3), @1, "Failed to set timestamp(). Valid values are: \"current\", \"received\", \"msg\"");

--- a/modules/grpc/loki/loki-parser.c
+++ b/modules/grpc/loki/loki-parser.c
@@ -47,6 +47,7 @@ static CfgLexerKeyword loki_keywords[] =
   { "alts", KW_ALTS },
   { "target_service_accounts", KW_TARGET_SERVICE_ACCOUNTS },
   { "adc", KW_ADC },
+  { "tenant_id", KW_TENANT_ID },
   { NULL }
 };
 

--- a/modules/grpc/loki/loki-worker.cpp
+++ b/modules/grpc/loki/loki-worker.cpp
@@ -216,6 +216,8 @@ DestinationWorker::insert(LogMessage *msg)
 LogThreadedResult
 DestinationWorker::flush(LogThreadedFlushMode mode)
 {
+  DestinationDriver *owner = this->get_owner();
+
   if (this->super->super.batch_size == 0)
     return LTR_SUCCESS;
 
@@ -223,6 +225,10 @@ DestinationWorker::flush(LogThreadedFlushMode mode)
   logproto::PushResponse response{};
 
   ::grpc::ClientContext ctx;
+
+  if (!owner->tenant_id.empty())
+    ctx.AddMetadata("x-scope-orgid", owner->tenant_id);
+
   ::grpc::Status status = this->stub->Push(&ctx, this->current_batch, &response);
 
   if (!status.ok())

--- a/news/feature-4812.md
+++ b/news/feature-4812.md
@@ -1,0 +1,1 @@
+`loki()`: Support multi-tenancy with the new `tenant-id()` option


### PR DESCRIPTION
For example:
```
    loki(
        url("localhost:9096")
        labels(
            "app" => "$PROGRAM",
            "host" => "$HOST",
        )
        workers(16)
        batch-timeout(10000)
        batch-lines(1000)

        tenant-id("testTenant")
    );
```

Questions: template support?