### PR TITLE
Implement rfc6587 auto detection

### DIFF
--- a/lib/logproto/CMakeLists.txt
+++ b/lib/logproto/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LOGPROTO_HEADERS
     logproto/logproto-server.h
     logproto/logproto-text-client.h
     logproto/logproto-text-server.h
+    logproto/logproto-auto-server.h
     logproto/logproto-proxied-text-server.h
     PARENT_SCOPE)
 
@@ -26,6 +27,7 @@ set(LOGPROTO_SOURCES
     logproto/logproto-server.c
     logproto/logproto-text-client.c
     logproto/logproto-text-server.c
+    logproto/logproto-auto-server.c
     logproto/logproto-proxied-text-server.c
     PARENT_SCOPE)
 

--- a/lib/logproto/Makefile.am
+++ b/lib/logproto/Makefile.am
@@ -11,6 +11,7 @@ logprotoinclude_HEADERS = \
 	lib/logproto/logproto-framed-server.h	\
 	lib/logproto/logproto-text-client.h  \
 	lib/logproto/logproto-text-server.h	\
+	lib/logproto/logproto-auto-server.h	\
 	lib/logproto/logproto-proxied-text-server.h	\
 	lib/logproto/logproto-multiline-server.h \
 	lib/logproto/logproto-record-server.h \
@@ -26,6 +27,7 @@ logproto_sources = \
 	lib/logproto/logproto-framed-server.c	\
 	lib/logproto/logproto-text-client.c  \
 	lib/logproto/logproto-text-server.c	\
+	lib/logproto/logproto-auto-server.c	\
 	lib/logproto/logproto-proxied-text-server.c	\
 	lib/logproto/logproto-multiline-server.c \
 	lib/logproto/logproto-record-server.c \

--- a/lib/logproto/logproto-auto-server.c
+++ b/lib/logproto/logproto-auto-server.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2024 Balázs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "logproto-auto-server.h"
+#include "logproto-text-server.h"
+#include "logproto-framed-server.h"
+#include "messages.h"
+
+typedef struct _LogProtoAutoServer
+{
+  LogProtoServer super;
+
+  /* the actual LogProto instance that we run after auto-detecting the protocol */
+  LogProtoServer *proto_impl;
+} LogProtoAutoServer;
+
+static LogProtoServer *
+_construct_detected_proto(LogProtoAutoServer *self, const gchar *detect_buffer, gsize detect_buffer_len)
+{
+  if (g_ascii_isdigit(detect_buffer[0]))
+    {
+      msg_debug("Auto-detected octet-counted-framing on RFC6587 connection, using framed transport",
+                evt_tag_int("fd", self->super.transport->fd));
+      return log_proto_framed_server_new(self->super.transport, self->super.options);
+    }
+  if (detect_buffer[0] == '<')
+    {
+      msg_debug("Auto-detected non-transparent-framing on RFC6587 connection, using simple text transport",
+                evt_tag_int("fd", self->super.transport->fd));
+    }
+  else
+    {
+      msg_debug("Unable to detect framing on RFC6587 connection, falling back to simple text transport",
+                evt_tag_int("fd", self->super.transport->fd),
+                evt_tag_mem("detect_buffer", detect_buffer, detect_buffer_len));
+    }
+  return log_proto_text_server_new(self->super.transport, self->super.options);
+}
+
+static LogProtoPrepareAction
+log_proto_auto_server_prepare(LogProtoServer *s, GIOCondition *cond, gint *timeout G_GNUC_UNUSED)
+{
+  LogProtoAutoServer *self = (LogProtoAutoServer *) s;
+
+  if (self->proto_impl)
+    return log_proto_server_prepare(self->proto_impl, cond, timeout);
+
+  *cond = self->super.transport->cond;
+  if (*cond == 0)
+    *cond = G_IO_IN;
+
+  return LPPA_POLL_IO;
+}
+
+static LogProtoStatus
+log_proto_auto_server_fetch(LogProtoServer *s, const guchar **msg, gsize *msg_len, gboolean *may_read,
+                            LogTransportAuxData *aux, Bookmark *bookmark)
+{
+  LogProtoAutoServer *self = (LogProtoAutoServer *) s;
+
+  if (self->proto_impl)
+    return log_proto_server_fetch(self->proto_impl, msg, msg_len, may_read, aux, bookmark);
+
+  g_assert_not_reached();
+}
+
+static gboolean
+log_proto_auto_handshake_in_progress(LogProtoServer *s)
+{
+  LogProtoAutoServer *self = (LogProtoAutoServer *) s;
+
+  if (self->proto_impl)
+    return log_proto_server_handshake_in_progress(self->proto_impl);
+
+  /* as long as the auto detection is not yet finished we are in handshake mode */
+  return TRUE;
+}
+
+static LogProtoStatus
+log_proto_auto_handshake(LogProtoServer *s)
+{
+  LogProtoAutoServer *self = (LogProtoAutoServer *) s;
+  /* allow the impl to do its handshake */
+  if (self->proto_impl)
+    return log_proto_server_handshake(self->proto_impl);
+
+  gchar detect_buffer[8];
+  gint rc;
+
+  rc = log_transport_read_ahead(self->super.transport, detect_buffer, sizeof(detect_buffer));
+  if (rc == 0)
+    return LPS_EOF;
+  else if (rc < 0)
+    return LPS_ERROR;
+
+  self->proto_impl = _construct_detected_proto(self, detect_buffer, rc);
+  if (self->proto_impl)
+    {
+      /* transport is handed over to the new proto */
+      self->super.transport = NULL;
+      return LPS_SUCCESS;
+    }
+  return LPS_ERROR;
+}
+
+static void
+log_proto_auto_server_free(LogProtoServer *s)
+{
+  LogProtoAutoServer *self = (LogProtoAutoServer *) s;
+
+  if (self->proto_impl)
+    log_proto_server_free(self->proto_impl);
+  log_proto_server_free_method(s);
+}
+
+LogProtoServer *
+log_proto_auto_server_new(LogTransport *transport, const LogProtoServerOptions *options)
+{
+  LogProtoAutoServer *self = g_new0(LogProtoAutoServer, 1);
+
+  log_proto_server_init(&self->super, transport, options);
+  self->super.handshake_in_progess = log_proto_auto_handshake_in_progress;
+  self->super.handshake = log_proto_auto_handshake;
+  self->super.prepare = log_proto_auto_server_prepare;
+  self->super.fetch = log_proto_auto_server_fetch;
+  self->super.free_fn = log_proto_auto_server_free;
+  return &self->super;
+}

--- a/lib/logproto/logproto-auto-server.h
+++ b/lib/logproto/logproto-auto-server.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 Balázs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef LOGPROTO_AUTO_SERVER_H_INCLUDED
+#define LOGPROTO_AUTO_SERVER_H_INCLUDED
+
+#include "logproto-server.h"
+
+LogProtoServer *log_proto_auto_server_new(LogTransport *transport, const LogProtoServerOptions *options);
+
+#endif

--- a/lib/logproto/logproto-builtins.c
+++ b/lib/logproto/logproto-builtins.c
@@ -27,6 +27,7 @@
 #include "logproto-proxied-text-server.h"
 #include "logproto-framed-client.h"
 #include "logproto-framed-server.h"
+#include "logproto-auto-server.h"
 #include "plugin.h"
 #include "plugin-types.h"
 
@@ -42,6 +43,7 @@ DEFINE_LOG_PROTO_SERVER(log_proto_proxied_text);
 DEFINE_LOG_PROTO_SERVER(log_proto_proxied_text_tls_passthrough, .use_multitransport = TRUE);
 DEFINE_LOG_PROTO_CLIENT(log_proto_framed);
 DEFINE_LOG_PROTO_SERVER(log_proto_framed);
+DEFINE_LOG_PROTO_SERVER(log_proto_auto);
 
 static Plugin framed_server_plugins[] =
 {
@@ -54,7 +56,8 @@ static Plugin framed_server_plugins[] =
   LOG_PROTO_SERVER_PLUGIN(log_proto_proxied_text, "proxied-tcp"),
   LOG_PROTO_SERVER_PLUGIN(log_proto_proxied_text_tls_passthrough, "proxied-tls-passthrough"),
   LOG_PROTO_CLIENT_PLUGIN(log_proto_framed, "framed"),
-  LOG_PROTO_SERVER_PLUGIN(log_proto_framed, "framed"),
+  LOG_PROTO_SERVER_PLUGIN(log_proto_framed, "force-framed"),
+  LOG_PROTO_SERVER_PLUGIN(log_proto_auto, "framed"),
 };
 
 void

--- a/lib/logproto/logproto-server.c
+++ b/lib/logproto/logproto-server.c
@@ -124,7 +124,8 @@ log_proto_server_validate_options_method(LogProtoServer *s)
 void
 log_proto_server_free_method(LogProtoServer *s)
 {
-  log_transport_free(s->transport);
+  if (s->transport)
+    log_transport_free(s->transport);
 }
 
 void

--- a/lib/transport/tests/Makefile.am
+++ b/lib/transport/tests/Makefile.am
@@ -1,5 +1,6 @@
 lib_transport_tests_TESTS		 = \
 	lib/transport/tests/test_aux_data \
+	lib/transport/tests/test_transport \
 	lib/transport/tests/test_transport_factory_id \
 	lib/transport/tests/test_transport_factory \
 	lib/transport/tests/test_transport_factory_registry \
@@ -14,6 +15,12 @@ lib_transport_tests_test_aux_data_CFLAGS  = $(TEST_CFLAGS) \
 lib_transport_tests_test_aux_data_LDADD	 = $(TEST_LDADD)
 lib_transport_tests_test_aux_data_SOURCES = 			\
 	lib/transport/tests/test_aux_data.c
+
+lib_transport_tests_test_transport_CFLAGS  = $(TEST_CFLAGS) \
+	-I${top_srcdir}/lib/transport/tests
+lib_transport_tests_test_transport_LDADD	 = $(TEST_LDADD)
+lib_transport_tests_test_transport_SOURCES = 			\
+	lib/transport/tests/test_transport.c
 
 lib_transport_tests_test_transport_factory_id_CFLAGS  = $(TEST_CFLAGS) \
 	-I${top_srcdir}/lib/transport/tests

--- a/lib/transport/tests/test_transport.c
+++ b/lib/transport/tests/test_transport.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2024 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include "libtest/mock-transport.h"
+
+#include "transport/logtransport.h"
+#include "apphook.h"
+
+#include <errno.h>
+
+Test(transport, test_read_ahead_bytes_get_shifted_into_the_actual_read)
+{
+  LogTransport *t = log_transport_mock_stream_new("readahead", -1, LTM_EOF);
+
+  gchar buf[12] = {0};
+  memset(buf, 0, sizeof(buf));
+  gint rc = log_transport_read_ahead(t, buf, 4);
+  cr_assert(rc == 4, "unexpected rc = %d", rc);
+  cr_assert_str_eq(buf, "read");
+
+  /* the read() returns the bytes that were read in advance */
+
+  memset(buf, 0, sizeof(buf));
+  rc = log_transport_read(t, buf, 4, NULL);
+  cr_assert(rc == 4, "unexpected rc = %d", rc);
+  cr_assert_str_eq(buf, "read");
+
+}
+
+Test(transport, test_read_ahead_bytes_and_new_read_is_combined)
+{
+  LogTransport *t = log_transport_mock_stream_new("readahead", -1, LTM_EOF);
+
+  gchar buf[12] = {0};
+  memset(buf, 0, sizeof(buf));
+  gint rc = log_transport_read_ahead(t, buf, 4);
+  cr_assert(rc == 4, "unexpected rc = %d", rc);
+  cr_assert_str_eq(buf, "read");
+
+  /* NOTE: the mock will return only a single byte for every read to
+   * exercise retry mechanisms, so only read a single character here */
+
+  memset(buf, 0, sizeof(buf));
+  rc = log_transport_read(t, buf, 5, NULL);
+  cr_assert(rc == 5, "unexpected rc = %d", rc);
+  cr_assert_str_eq(buf, "reada");
+
+}
+
+Test(transport, test_read_ahead_returns_the_same_buffer_any_number_of_times)
+{
+  LogTransport *t = log_transport_mock_stream_new("readahead", -1, LTM_EOF);
+
+  gchar buf[12];
+
+  memset(buf, 0, sizeof(buf));
+  cr_assert(log_transport_read_ahead(t, buf, 1) == 1);
+  cr_assert_str_eq(buf, "r");
+  memset(buf, 0, sizeof(buf));
+  cr_assert(log_transport_read_ahead(t, buf, 2) == 2);
+  cr_assert_str_eq(buf, "re");
+  memset(buf, 0, sizeof(buf));
+  cr_assert(log_transport_read_ahead(t, buf, 8) == 8);
+  cr_assert_str_eq(buf, "readahea");
+  memset(buf, 0, sizeof(buf));
+  cr_assert(log_transport_read_ahead(t, buf, 4) == 4);
+  cr_assert_str_eq(buf, "read");
+
+  /* the read() returns the bytes that were read in advance */
+  cr_assert(log_transport_read(t, buf, 9, NULL) == 9);
+  cr_assert_str_eq(buf, "readahead");
+
+}
+
+Test(transport, test_read_ahead_more_than_the_internal_buffer, .signal = SIGABRT)
+{
+  LogTransport *t = log_transport_mock_stream_new("12345678901234567890", -1, LTM_EOF);
+
+  /* 20 bytes, the internal look ahead buffer in LogTransport is 16 bytes which we are overflowing here */
+  cr_assert(sizeof(t->read_ahead_buf) == 16);
+
+  gchar buf[32];
+
+  memset(buf, 0, sizeof(buf));
+  cr_assert(log_transport_read_ahead(t, buf, 20) == 20);
+}
+
+Test(transport, test_read_ahead_with_packets_split_in_half)
+{
+  LogTransport *t = log_transport_mock_stream_new("1234", -1, LTM_INJECT_ERROR(EAGAIN), "5678", -1, LTM_EOF);
+
+  gchar buf[32];
+  memset(buf, 0, sizeof(buf));
+  gint rc = log_transport_read_ahead(t, buf, 8);
+  cr_assert(rc == 4, "unexpected rc = %d", rc);
+  cr_assert_str_eq(buf, "1234");
+
+  memset(buf, 0, sizeof(buf));
+  rc = log_transport_read_ahead(t, buf, 8);
+  cr_assert(rc == 8, "unexpected rc = %d", rc);
+  cr_assert_str_eq(buf, "12345678");
+}
+
+TestSuite(transport, .init = app_startup, .fini = app_shutdown);

--- a/libtest/mock-transport.c
+++ b/libtest/mock-transport.c
@@ -211,7 +211,7 @@ log_transport_mock_read_method(LogTransport *s, gpointer buf, gsize count, LogTr
   switch (g_array_index(self->value, data_t, self->current_value_ndx).type)
     {
     case DATA_STRING:
-      if (self->input_is_a_stream)
+      if (self->input_is_a_stream && count > 0)
         count = 1;
 
       current_iov = &g_array_index(self->value, data_t, self->current_value_ndx).iov;

--- a/news/feature-4814.md
+++ b/news/feature-4814.md
@@ -1,0 +1,5 @@
+`syslog()` source driver: add support for RFC6587 style auto-detection of
+octet-count based framing to avoid confusion that stems from the sender
+using a different protocol to the server.  This is automatically enabled for
+both the `transport(tcp)` and the `transport(tls)` settings.  You can disable
+auto-detection by using `transport(text)` or `transport(framed)`.

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -128,6 +128,8 @@ modules/python/python-confgen\.[ch]
 lib/tests/test_logscheduler\.c
 lib/filterx/.*\.[ch]
 lib/filterx/filterx-grammar\.ym
+lib/logproto/logproto-auto-server\.[ch]
+lib/transport/tests/test_transport\.c
 
 ###########################################################################
 # These tests are GPLd even though they reside under lib/ and are excluded


### PR DESCRIPTION
This is a pretty common misconfiguration that should be handled automatically. 

Open questions were resolved this way:
* syslog(transport(tcp/tls)) will default to enable  framing detection
* if you want to require framing transport(force-framed) will do that, but I doubt anyone needs that, so let's not document it.
* auto is only the name of the class, it's not user visible anymore.
* testcases are added
* 