### PR TITLE
Fix fedora rawhide i686 compilation

### DIFF
--- a/modules/secure-logging/slog.c
+++ b/modules/secure-logging/slog.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Gergo Ferenc Kovacs
  * Copyright (c) 2019 Airbus Commercial Aircraft
  *
  * This library is free software; you can redistribute it and/or
@@ -932,7 +933,7 @@ int writeKey(char *key, guint64 counter, gchar *keypath)
       return 0;
     }
 
-  guint64 outlen = 0;
+  gsize outlen = 0;
   // Write key
   status = g_io_channel_write_chars(keyfile, key, KEY_LENGTH, &outlen, &error);
   if(status != G_IO_STATUS_NORMAL)

--- a/modules/secure-logging/slogkey/slogkey.c
+++ b/modules/secure-logging/slogkey/slogkey.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Gergo Ferenc Kovacs
  * Copyright (c) 2019 Airbus Commercial Aircraft
  *
  * This library is free software; you can redistribute it and/or
@@ -157,7 +158,7 @@ int main(int argc, char **argv)
           msg_error("[SLOG] ERROR: Unable to read key file", evt_tag_str("file", keyfile));
           return ret;
         }
-      printf("counter=%zu\n", counterValue);
+      printf("counter=%" G_GUINT64_FORMAT "\n", counterValue);
     }
   else if (host)
     {

--- a/modules/secure-logging/tests/test_secure_logging.c
+++ b/modules/secure-logging/tests/test_secure_logging.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Gergo Ferenc Kovacs
  * Copyright (c) 2019 Airbus Commercial Aircraft
  *
  * This library is free software; you can redistribute it and/or
@@ -373,7 +374,7 @@ void corruptKey(TestData *testData)
 
   cr_assert(status == G_IO_STATUS_NORMAL, " Unable to set encoding for key file %s", testData->keyFile->str);
 
-  guint64 outlen = 0;
+  gsize outlen = 0;
 
   int buflen = KEY_LENGTH + CMAC_LENGTH + sizeof(guint64);
 


### PR DESCRIPTION
This PR fixes the two errors in fedora rawhide:

```
    modules/secure-logging/slog.c:937:63: error: passing argument 4 of 'g_io_channel_write_chars' from incompatible pointer type [-Wincompatible-pointer-types]
      937 |   status = g_io_channel_write_chars(keyfile, key, KEY_LENGTH, &outlen, &error);
          |                                                               ^~~~~~~
          |                                                               |
          |                                                               guint64 * {aka long long unsigned int *}
    In file included from /usr/include/glib-2.0/glib.h:56,
                    from modules/secure-logging/slog.c:28:
    /usr/include/glib-2.0/glib/giochannel.h:282:58: note: expected 'gsize *' {aka 'unsigned int *'} but argument is of type 'guint64 *' {aka 'long long unsigned int *'}
      282 |                                            gsize        *bytes_written,
```
> Based on https://gitlab.gnome.org/GNOME/glib/-/blob/2.32.0/glib/giochannel.c since 2.32.0 the type here is gsize


and
```
        modules/secure-logging/slogkey/slogkey.c:160:25: warning: format ‘%zu’ expects argument of type ‘size_t’, but argument 2 has type ‘guint64’ {aka ‘long long unsigned int’} [-Wformat=]
        160 |       printf("counter=%zu\n", counterValue);
            |                       ~~^     ~~~~~~~~~~~~
            |                         |     |
            |                         |     guint64 {aka long long unsigned int}
            |                         unsigned int
            |                       %llu
      */
```
> Here I used the G_GUINT64_FORMAT macro to avoid trying to guess the platform specific printf syntax for the guint64 type.