### PR TITLE
otel: add deadline to shutdown

### DIFF
--- a/modules/grpc/otel/otel-source.cpp
+++ b/modules/grpc/otel/otel-source.cpp
@@ -49,11 +49,8 @@ syslogng::grpc::otel::SourceDriver::SourceDriver(OtelSourceDriver *s)
 void
 syslogng::grpc::otel::SourceDriver::request_exit()
 {
-  if (server == nullptr)
-    return;
-
-  server->Shutdown();
-  server = nullptr;
+  msg_debug("Shutting down OpenTelemetry server", evt_tag_int("port", port));
+  server->Shutdown(std::chrono::system_clock::now() + std::chrono::seconds(30));
 }
 
 void


### PR DESCRIPTION
Shutdown() waits for all the working threads to finish, but they only finish, when _worker_wakeup() is called, but that only gets called after Shutdown(), so we have a deadlock.

Giving a deadline solves the issue:
> If all pending calls complete (and all their operations are
> retrieved by Next) before \a deadline expires, this finishes
> gracefully. Otherwise, forcefully cancel all pending calls associated
> with the server after \a deadline expires.

I have also removed the null-ing, as that frees the Server, which we still want to use in the worker threads for submitting the response.

Calling Shutdown() seems to be idempotent.

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
