### PR TITLE
otel: add support for `otel_logrecord($protobuf_value)` filterx fn

### DIFF
--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -60,6 +60,19 @@ filterx_bytes_get_value(FilterXObject *s, gsize *length)
   return self->str;
 }
 
+const gchar *
+filterx_protobuf_get_value(FilterXObject *s, gsize *length)
+{
+  FilterXString *self = (FilterXString *) s;
+
+  if (!filterx_object_is_type(s, &FILTERX_TYPE_NAME(protobuf)))
+    return NULL;
+
+  g_assert(length);
+  *length = self->str_len;
+
+  return self->str;
+}
 
 static gboolean
 _truthy(FilterXObject *s)

--- a/lib/filterx/object-string.h
+++ b/lib/filterx/object-string.h
@@ -31,6 +31,7 @@ FILTERX_DECLARE_TYPE(protobuf);
 
 const gchar *filterx_string_get_value(FilterXObject *s, gsize *length);
 const gchar *filterx_bytes_get_value(FilterXObject *s, gsize *length);
+const gchar *filterx_protobuf_get_value(FilterXObject *s, gsize *length);
 
 FilterXObject *filterx_string_new(const gchar *str, gssize str_len);
 FilterXObject *filterx_bytes_new(const gchar *str, gssize str_len);

--- a/modules/grpc/otel/filterx/otel-logrecord.hpp
+++ b/modules/grpc/otel/filterx/otel-logrecord.hpp
@@ -46,12 +46,14 @@ class OtelLogRecordCpp
 {
 public:
   OtelLogRecordCpp(FilterXOtelLogRecord *folr);
+  OtelLogRecordCpp(FilterXOtelLogRecord *folr, FilterXObject *protobuf_object);
   OtelLogRecordCpp(OtelLogRecordCpp &o) = delete;
   OtelLogRecordCpp(OtelLogRecordCpp &&o) = delete;
   FilterXObject *FilterX();
   bool SetField(const gchar *attribute, FilterXObject *value);
   std::string Marshal(void);
   FilterXObject *GetField(const gchar *attribute);
+  const LogRecord &GetValue() const;
 private:
   FilterXOtelLogRecord *super;
   LogRecord logRecord;

--- a/modules/grpc/otel/tests/CMakeLists.txt
+++ b/modules/grpc/otel/tests/CMakeLists.txt
@@ -18,3 +18,10 @@ add_unit_test(
   SOURCES test-syslog-ng-otlp.cpp
   INCLUDES ${OTEL_PROTO_BUILDDIR}
   DEPENDS otel-cpp)
+
+add_unit_test(
+  CRITERION
+  TARGET test_otel_filterx
+  SOURCES test-otel-filterx.cpp
+  INCLUDES ${OTEL_PROTO_BUILDDIR}
+  DEPENDS otel-cpp otel_filterx_logrecord_cpp)

--- a/modules/grpc/otel/tests/Makefile.am
+++ b/modules/grpc/otel/tests/Makefile.am
@@ -3,7 +3,8 @@ if ENABLE_GRPC
 modules_grpc_otel_tests_TESTS = \
   modules/grpc/otel/tests/test_otel_protobuf_parser \
   modules/grpc/otel/tests/test_otel_protobuf_formatter \
-  modules/grpc/otel/tests/test_syslog_ng_otlp
+  modules/grpc/otel/tests/test_syslog_ng_otlp \
+  modules/grpc/otel/tests/test_otel_filterx
 
 check_PROGRAMS += ${modules_grpc_otel_tests_TESTS}
 
@@ -60,6 +61,25 @@ modules_grpc_otel_tests_test_syslog_ng_otlp_LDADD = \
   $(TEST_LDADD) \
   $(top_builddir)/modules/grpc/otel/libotel_cpp.la \
   $(top_builddir)/modules/grpc/protos/libgrpc-protos.la
+
+modules_grpc_otel_tests_test_otel_filterx_SOURCES = \
+  modules/grpc/otel/tests/test-otel-filterx.cpp
+
+modules_grpc_otel_tests_test_otel_filterx_DEPENDENCIES = \
+  $(top_builddir)/modules/grpc/otel/libotel_cpp.la \
+  $(top_builddir)/modules/grpc/protos/libgrpc-protos.la
+
+modules_grpc_otel_tests_test_otel_filterx_CXXFLAGS = \
+  $(TEST_CXXFLAGS) \
+  -I$(OPENTELEMETRY_PROTO_BUILDDIR) \
+  -I$(top_srcdir)/modules/grpc/otel \
+  -I$(top_builddir)/modules/grpc/otel
+
+modules_grpc_otel_tests_test_otel_filterx_LDADD = \
+  $(TEST_LDADD) \
+  $(top_builddir)/modules/grpc/otel/libotel_cpp.la \
+  $(top_builddir)/modules/grpc/protos/libgrpc-protos.la \
+  $(top_builddir)/modules/grpc/otel/filterx/libfilterx.la
 
 endif
 

--- a/modules/grpc/otel/tests/test-otel-filterx.cpp
+++ b/modules/grpc/otel/tests/test-otel-filterx.cpp
@@ -20,12 +20,67 @@
  *
  */
 
+#include "filterx/otel-logrecord.hpp"
+
 #include "compat/cpp-start.h"
+#include "filterx/object-string.h"
 #include "apphook.h"
 #include "cfg.h"
 #include "compat/cpp-end.h"
 
+#include <google/protobuf/util/message_differencer.h>
+
 #include <criterion/criterion.h>
+
+using namespace syslogng::grpc::otel;
+using namespace opentelemetry::proto::logs::v1;
+using namespace opentelemetry::proto::common::v1;
+using namespace google::protobuf::util;
+
+Test(otel_filterx, logrecord_from_protobuf)
+{
+  LogRecord log_record;
+  log_record.mutable_body()->set_string_value("foobar");
+  log_record.set_observed_time_unix_nano(1234);
+  KeyValue *attribute = log_record.add_attributes();
+  attribute->set_key("attribute_key");
+  attribute->mutable_value()->set_int_value(42);
+
+  std::string serialized_log_record = log_record.SerializePartialAsString();
+  GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
+  g_ptr_array_insert(args, 0, filterx_protobuf_new(serialized_log_record.c_str(), serialized_log_record.length()));
+
+  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) otel_logrecord(args);
+  cr_assert(filterx_otel_logrecord);
+
+  const LogRecord &log_record_from_filterx = filterx_otel_logrecord->cpp->GetValue();
+  cr_assert(MessageDifferencer::Equals(log_record, log_record_from_filterx));
+
+  filterx_object_unref(&filterx_otel_logrecord->super);
+  g_ptr_array_free(args, TRUE);
+}
+
+Test(otel_filterx, logrecord_from_protobuf_invalid_arg)
+{
+  GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
+  g_ptr_array_insert(args, 0, filterx_string_new("", 0));
+
+  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) otel_logrecord(args);
+  cr_assert_not(filterx_otel_logrecord);
+
+  g_ptr_array_free(args, TRUE);
+}
+
+Test(otel_filterx, logrecord_from_protobuf_malformed_data)
+{
+  GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
+  g_ptr_array_insert(args, 0, filterx_protobuf_new("1234", 4));
+
+  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) otel_logrecord(args);
+  cr_assert_not(filterx_otel_logrecord);
+
+  g_ptr_array_free(args, TRUE);
+}
 
 void
 setup(void)

--- a/modules/grpc/otel/tests/test-otel-filterx.cpp
+++ b/modules/grpc/otel/tests/test-otel-filterx.cpp
@@ -37,6 +37,16 @@ using namespace opentelemetry::proto::logs::v1;
 using namespace opentelemetry::proto::common::v1;
 using namespace google::protobuf::util;
 
+Test(otel_filterx, logrecord_empty)
+{
+  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) otel_logrecord(NULL);
+  cr_assert(filterx_otel_logrecord);
+
+  cr_assert(MessageDifferencer::Equals(LogRecord(), filterx_otel_logrecord->cpp->GetValue()));
+
+  filterx_object_unref(&filterx_otel_logrecord->super);
+}
+
 Test(otel_filterx, logrecord_from_protobuf)
 {
   LogRecord log_record;
@@ -75,6 +85,18 @@ Test(otel_filterx, logrecord_from_protobuf_malformed_data)
 {
   GPtrArray *args = g_ptr_array_new_full(1, (GDestroyNotify) filterx_object_unref);
   g_ptr_array_insert(args, 0, filterx_protobuf_new("1234", 4));
+
+  FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) otel_logrecord(args);
+  cr_assert_not(filterx_otel_logrecord);
+
+  g_ptr_array_free(args, TRUE);
+}
+
+Test(otel_filterx, logrecord_too_many_args)
+{
+  GPtrArray *args = g_ptr_array_new_full(2, (GDestroyNotify) filterx_object_unref);
+  g_ptr_array_insert(args, 0, filterx_string_new("foo", 3));
+  g_ptr_array_insert(args, 1, filterx_protobuf_new("bar", 3));
 
   FilterXOtelLogRecord *filterx_otel_logrecord = (FilterXOtelLogRecord *) otel_logrecord(args);
   cr_assert_not(filterx_otel_logrecord);

--- a/modules/grpc/otel/tests/test-otel-filterx.cpp
+++ b/modules/grpc/otel/tests/test-otel-filterx.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 Attila Szakacs
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "compat/cpp-start.h"
+#include "apphook.h"
+#include "cfg.h"
+#include "compat/cpp-end.h"
+
+#include <criterion/criterion.h>
+
+void
+setup(void)
+{
+  app_startup();
+  configuration = cfg_new_snippet();
+}
+
+void
+teardown(void)
+{
+  cfg_free(configuration);
+  app_shutdown();
+}
+
+TestSuite(otel_filterx, .init = setup, .fini = teardown);

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -195,6 +195,7 @@ modules/grpc/otel/grpc-credentials-builder\.(h|cpp|hpp)$
 modules/grpc/otel/syslog-ng-otlp-(dest|dest-worker)\.(h|cpp|hpp)$
 modules/grpc/otel/tests/test-otel-(protobuf-parser|protobuf-formatter)\.cpp$
 modules/grpc/otel/tests/test-syslog-ng-otlp\.cpp$
+modules/grpc/otel/tests/test-otel-filterx\.cpp$
 modules/grpc/loki
 modules/grpc/bigquery
 modules/grpc/credentials


### PR DESCRIPTION
<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
