### PR TITLE
filterx: make storing virtual methods simpler

### DIFF
--- a/lib/filterx/filterx-object.c
+++ b/lib/filterx/filterx-object.c
@@ -24,16 +24,24 @@
 #include "filterx-eval.h"
 #include "mainloop-worker.h"
 
+#define INIT_TYPE_METHOD(type, method_name) do { \
+    if (!type->method_name) \
+      type->method_name = type->super_type->method_name; \
+  } while (0)
+
 void
 filterx_type_init(FilterXType *type)
 {
-  FilterXType *parent = type->super_type;
-
-  for (gint i = 0; i < G_N_ELEMENTS(type->__methods); i++)
-    {
-      if (!type->__methods[i])
-        type->__methods[i] = parent->__methods[i];
-    }
+  INIT_TYPE_METHOD(type, unmarshal);
+  INIT_TYPE_METHOD(type, marshal);
+  INIT_TYPE_METHOD(type, clone);
+  INIT_TYPE_METHOD(type, map_to_json);
+  INIT_TYPE_METHOD(type, truthy);
+  INIT_TYPE_METHOD(type, getattr);
+  INIT_TYPE_METHOD(type, setattr);
+  INIT_TYPE_METHOD(type, get_subscript);
+  INIT_TYPE_METHOD(type, set_subscript);
+  INIT_TYPE_METHOD(type, free_fn);
 }
 
 #define FILTERX_OBJECT_MAGIC_BIAS G_MAXINT32

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -34,23 +34,17 @@ struct _FilterXType
   FilterXType *super_type;
   const gchar *name;
   gboolean is_mutable;
-  union
-  {
-    struct
-    {
-      FilterXObject *(*unmarshal)(FilterXObject *self);
-      gboolean (*marshal)(FilterXObject *self, GString *repr, LogMessageValueType *t);
-      FilterXObject *(*clone)(FilterXObject *self);
-      gboolean (*map_to_json)(FilterXObject *self, struct json_object **object);
-      gboolean (*truthy)(FilterXObject *self);
-      FilterXObject *(*getattr)(FilterXObject *self, const gchar *attr_name);
-      gboolean (*setattr)(FilterXObject *self, const gchar *attr_name, FilterXObject *new_value);
-      FilterXObject *(*get_subscript)(FilterXObject *self, FilterXObject *index);
-      gboolean (*set_subscript)(FilterXObject *self, FilterXObject *index, FilterXObject *new_value);
-      void (*free_fn)(FilterXObject *self);
-    };
-    gpointer __methods[10];
-  };
+
+  FilterXObject *(*unmarshal)(FilterXObject *self);
+  gboolean (*marshal)(FilterXObject *self, GString *repr, LogMessageValueType *t);
+  FilterXObject *(*clone)(FilterXObject *self);
+  gboolean (*map_to_json)(FilterXObject *self, struct json_object **object);
+  gboolean (*truthy)(FilterXObject *self);
+  FilterXObject *(*getattr)(FilterXObject *self, const gchar *attr_name);
+  gboolean (*setattr)(FilterXObject *self, const gchar *attr_name, FilterXObject *new_value);
+  FilterXObject *(*get_subscript)(FilterXObject *self, FilterXObject *index);
+  gboolean (*set_subscript)(FilterXObject *self, FilterXObject *index, FilterXObject *new_value);
+  void (*free_fn)(FilterXObject *self);
 };
 
 void filterx_type_init(FilterXType *type);


### PR DESCRIPTION
Fixes a problem found in our nightly package build: https://github.com/syslog-ng/syslog-ng/actions/runs/8041425542

---

For some reason certain C++ compiler versions do not seem to be able to find the function pointers in the struct.
E.g. on debian-bullseye:
```
In file included from ../../modules/grpc/otel/filterx/otel-resource.hpp:29,
                 from ../../modules/grpc/otel/filterx/otel-resource.cpp:23:
../../lib/filterx/filterx-object.h:67:5: error: too many initializers for ‘FilterXType’ {aka ‘_FilterXType’}
   67 |     }
      |     ^
```

I did not investigate why certain compilers can and certain cannot handle this. We can do that, but I tried to save some time by just making the struct simpler and it seems to work.

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
