### PR TITLE
otel: support manipulating array and kvlist through logrecord

### DIFF
--- a/modules/grpc/otel/filterx/CMakeLists.txt
+++ b/modules/grpc/otel/filterx/CMakeLists.txt
@@ -29,3 +29,5 @@ add_module(
   INCLUDES ${OTEL_PROTO_BUILDDIR} ${PROJECT_SOURCE_DIR}/modules/grpc
   LIBRARY_TYPE STATIC
 )
+
+set_target_properties(otel_filterx_logrecord_cpp PROPERTIES COMPILE_FLAGS "-Wno-deprecated-declarations")

--- a/modules/grpc/otel/filterx/Makefile.am
+++ b/modules/grpc/otel/filterx/Makefile.am
@@ -26,7 +26,8 @@ modules_grpc_otel_filterx_libfilterx_la_CXXFLAGS = \
   $(GRPCPP_CFLAGS) \
   -I$(OPENTELEMETRY_PROTO_BUILDDIR) \
   -I$(top_srcdir)/modules/grpc/otel/filterx \
-  -I$(top_builddir)/modules/grpc/otel/filterx
+  -I$(top_builddir)/modules/grpc/otel/filterx \
+  -Wno-deprecated-declarations
 
 modules_grpc_otel_filterx_libfilterx_la_LIBADD = \
   $(MODULE_DEPS_LIBS) \

--- a/modules/grpc/otel/filterx/object-otel-array.cpp
+++ b/modules/grpc/otel/filterx/object-otel-array.cpp
@@ -68,7 +68,7 @@ Array::set_subscript(FilterXObject *key, FilterXObject *value)
 {
   if (!filterx_object_is_type(key, &FILTERX_TYPE_NAME(integer)))
     {
-      msg_error("FilterX: Failed to get OTel Array element",
+      msg_error("FilterX: Failed to set OTel Array element",
                 evt_tag_str("error", "Key must be integer type"));
       return false;
     }

--- a/modules/grpc/otel/filterx/object-otel-array.cpp
+++ b/modules/grpc/otel/filterx/object-otel-array.cpp
@@ -70,7 +70,7 @@ Array::set_subscript(FilterXObject *key, FilterXObject *value)
     {
       msg_error("FilterX: Failed to get OTel Array element",
                 evt_tag_str("error", "Key must be integer type"));
-      return NULL;
+      return false;
     }
 
   GenericNumber gn = filterx_primitive_get_value(key);

--- a/modules/grpc/otel/filterx/object-otel-array.cpp
+++ b/modules/grpc/otel/filterx/object-otel-array.cpp
@@ -136,7 +136,7 @@ Array::get_subscript(FilterXObject *key)
       return NULL;
     }
 
-  const AnyValue &any_value = array->values(index);
+  AnyValue *any_value = array->mutable_values(index);
   return any_field_converter.FilterXObjectDirectGetter(any_value);
 }
 
@@ -255,13 +255,13 @@ grpc_otel_filterx_array_construct_new(Plugin *self)
 }
 
 FilterXObject *
-OtelArrayField::FilterXObjectGetter(const google::protobuf::Message &message, ProtoReflectors reflectors)
+OtelArrayField::FilterXObjectGetter(google::protobuf::Message *message, ProtoReflectors reflectors)
 {
   try
     {
-      const Message &nestedMessage = reflectors.reflection->GetMessage(message, reflectors.fieldDescriptor);
-      const ArrayValue &array = dynamic_cast<const ArrayValue &>(nestedMessage);
-      return _new_borrowed(&(ArrayValue &) array);
+      Message *nestedMessage = reflectors.reflection->MutableMessage(message, reflectors.fieldDescriptor);
+      ArrayValue *array = dynamic_cast<ArrayValue *>(nestedMessage);
+      return _new_borrowed(array);
     }
   catch(const std::bad_cast &e)
     {

--- a/modules/grpc/otel/filterx/object-otel-array.cpp
+++ b/modules/grpc/otel/filterx/object-otel-array.cpp
@@ -94,6 +94,9 @@ Array::marshal(void)
 bool
 Array::set_subscript(FilterXObject *key, FilterXObject *value)
 {
+  if (!key)
+    return any_field_converter.FilterXObjectDirectSetter(array->add_values(), value);
+
   if (!filterx_object_is_type(key, &FILTERX_TYPE_NAME(integer)))
     {
       msg_error("FilterX: Failed to set OTel Array element",
@@ -105,14 +108,9 @@ Array::set_subscript(FilterXObject *key, FilterXObject *value)
   gint64 index = gn_as_int64(&gn);
 
   if (index >= array->values_size())
-    {
-      for (int i = 0; i < index + 1 - array->values_size(); i++)
-        array->add_values();
-    }
+    return false;
 
-  AnyValue *any_value = array->mutable_values(index);
-
-  return any_field_converter.FilterXObjectDirectSetter(any_value, value);
+  return any_field_converter.FilterXObjectDirectSetter(array->mutable_values(index), value);
 }
 
 FilterXObject *

--- a/modules/grpc/otel/filterx/object-otel-array.hpp
+++ b/modules/grpc/otel/filterx/object-otel-array.hpp
@@ -42,18 +42,22 @@ namespace grpc {
 namespace otel {
 namespace filterx {
 
+using opentelemetry::proto::common::v1::ArrayValue;
+
 class Array
 {
 public:
   Array(FilterXOtelArray *s);
+  Array(FilterXOtelArray *s, ArrayValue *a);
   Array(FilterXOtelArray *s, FilterXObject *protobuf_object);
   Array(Array &o) = delete;
   Array(Array &&o) = delete;
+  ~Array();
 
   std::string marshal();
   bool set_subscript(FilterXObject *key, FilterXObject *value);
   FilterXObject *get_subscript(FilterXObject *key);
-  const opentelemetry::proto::common::v1::ArrayValue &get_value() const;
+  const ArrayValue &get_value() const;
 
 private:
   Array(const Array &o, FilterXOtelArray *s);
@@ -61,7 +65,8 @@ private:
 
 private:
   FilterXOtelArray *super;
-  opentelemetry::proto::common::v1::ArrayValue array;
+  ArrayValue *array;
+  bool borrowed;
 
   friend class OtelArrayField;
 };

--- a/modules/grpc/otel/filterx/object-otel-array.hpp
+++ b/modules/grpc/otel/filterx/object-otel-array.hpp
@@ -74,7 +74,7 @@ private:
 class OtelArrayField : public ProtobufField
 {
 public:
-  FilterXObject *FilterXObjectGetter(const google::protobuf::Message &message, ProtoReflectors reflectors);
+  FilterXObject *FilterXObjectGetter(google::protobuf::Message *message, ProtoReflectors reflectors);
   bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object);
 };
 

--- a/modules/grpc/otel/filterx/object-otel-kvlist.cpp
+++ b/modules/grpc/otel/filterx/object-otel-kvlist.cpp
@@ -74,7 +74,9 @@ KVList::get_mutable_kv_for_key(const char *key)
         return possible_kv;
     }
 
-  return kvlist.add_values();
+  KeyValue *kv = kvlist.add_values();
+  kv->set_key(key);
+  return kv;
 }
 
 const opentelemetry::proto::common::v1::KeyValue &

--- a/modules/grpc/otel/filterx/object-otel-kvlist.cpp
+++ b/modules/grpc/otel/filterx/object-otel-kvlist.cpp
@@ -113,6 +113,13 @@ KVList::get_mutable_kv_for_key(const char *key)
 bool
 KVList::set_subscript(FilterXObject *key, FilterXObject *value)
 {
+  if (!key)
+    {
+      msg_error("FilterX: Failed to set OTel KVList element",
+                evt_tag_str("error", "Key is mandatory"));
+      return false;
+    }
+
   const gchar *key_c_str = filterx_string_get_value(key, NULL);
   if (!key_c_str)
     {

--- a/modules/grpc/otel/filterx/object-otel-kvlist.hpp
+++ b/modules/grpc/otel/filterx/object-otel-kvlist.hpp
@@ -59,7 +59,6 @@ private:
   KVList(const KVList &o, FilterXOtelKVList *s);
   friend FilterXObject *::_filterx_otel_kvlist_clone(FilterXObject *s);
   opentelemetry::proto::common::v1::KeyValue *get_mutable_kv_for_key(const char *key);
-  const opentelemetry::proto::common::v1::KeyValue &get_kv_for_key(const char *key);
 
 private:
   FilterXOtelKVList *super;
@@ -71,7 +70,7 @@ private:
 class OtelKVListField : public ProtobufField
 {
 public:
-  FilterXObject *FilterXObjectGetter(const google::protobuf::Message &message, ProtoReflectors reflectors);
+  FilterXObject *FilterXObjectGetter(google::protobuf::Message *message, ProtoReflectors reflectors);
   bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object);
 };
 

--- a/modules/grpc/otel/filterx/object-otel-kvlist.hpp
+++ b/modules/grpc/otel/filterx/object-otel-kvlist.hpp
@@ -42,27 +42,34 @@ namespace grpc {
 namespace otel {
 namespace filterx {
 
+using opentelemetry::proto::common::v1::KeyValue;
+using google::protobuf::RepeatedPtrField;
+
 class KVList
 {
+
 public:
   KVList(FilterXOtelKVList *s);
+  KVList(FilterXOtelKVList *s, RepeatedPtrField<KeyValue > *k);
   KVList(FilterXOtelKVList *s, FilterXObject *protobuf_object);
   KVList(KVList &o) = delete;
   KVList(KVList &&o) = delete;
+  ~KVList();
 
   std::string marshal();
   bool set_subscript(FilterXObject *key, FilterXObject *value);
   FilterXObject *get_subscript(FilterXObject *key);
-  const opentelemetry::proto::common::v1::KeyValueList &get_value() const;
+  const RepeatedPtrField<KeyValue> &get_value() const;
 
 private:
   KVList(const KVList &o, FilterXOtelKVList *s);
   friend FilterXObject *::_filterx_otel_kvlist_clone(FilterXObject *s);
-  opentelemetry::proto::common::v1::KeyValue *get_mutable_kv_for_key(const char *key);
+  KeyValue *get_mutable_kv_for_key(const char *key);
 
 private:
   FilterXOtelKVList *super;
-  opentelemetry::proto::common::v1::KeyValueList kvlist;
+  RepeatedPtrField<KeyValue> *repeated_kv;
+  bool borrowed;
 
   friend class OtelKVListField;
 };

--- a/modules/grpc/otel/filterx/object-otel-logrecord.cpp
+++ b/modules/grpc/otel/filterx/object-otel-logrecord.cpp
@@ -94,7 +94,7 @@ LogRecord::GetField(const gchar *attribute)
   try
     {
       ProtoReflectors reflectors(this->logRecord, attribute);
-      return otel_converter_by_field_descriptor(reflectors.fieldDescriptor)->Get(this->logRecord, attribute);
+      return otel_converter_by_field_descriptor(reflectors.fieldDescriptor)->Get(&this->logRecord, attribute);
     }
   catch(const std::exception &ex)
     {

--- a/modules/grpc/otel/filterx/object-otel-resource.cpp
+++ b/modules/grpc/otel/filterx/object-otel-resource.cpp
@@ -82,7 +82,7 @@ Resource::get_field(const gchar *attribute)
   try
     {
       ProtoReflectors reflectors(resource, attribute);
-      return otel_converter_by_field_descriptor(reflectors.fieldDescriptor)->Get(resource, attribute);
+      return otel_converter_by_field_descriptor(reflectors.fieldDescriptor)->Get(&resource, attribute);
     }
   catch (const std::invalid_argument &e)
     {

--- a/modules/grpc/otel/filterx/object-otel-scope.cpp
+++ b/modules/grpc/otel/filterx/object-otel-scope.cpp
@@ -82,7 +82,7 @@ Scope::get_field(const gchar *attribute)
   try
     {
       ProtoReflectors reflectors(scope, attribute);
-      return otel_converter_by_field_descriptor(reflectors.fieldDescriptor)->Get(scope, attribute);
+      return otel_converter_by_field_descriptor(reflectors.fieldDescriptor)->Get(&scope, attribute);
     }
   catch (const std::invalid_argument &e)
     {

--- a/modules/grpc/otel/filterx/otel-field.cpp
+++ b/modules/grpc/otel/filterx/otel-field.cpp
@@ -224,13 +224,9 @@ public:
         reflectors.reflection->SetUInt64(message, reflectors.fieldDescriptor, unix_epoch);
         return true;
       }
-    else
-      {
-        msg_error("field type not yet implemented",
-                  evt_tag_str("name", reflectors.fieldDescriptor->name().c_str()),
-                  evt_tag_int("type", reflectors.fieldType));
-        return false;
-      }
+
+    return protobuf_converter_by_type(reflectors.fieldDescriptor->type())->Set(message, reflectors.fieldDescriptor->name(),
+           object);
   }
 };
 

--- a/modules/grpc/otel/filterx/otel-field.cpp
+++ b/modules/grpc/otel/filterx/otel-field.cpp
@@ -44,23 +44,23 @@ using namespace syslogng::grpc::otel;
 using namespace google::protobuf;
 
 FilterXObject *
-AnyField::FilterXObjectGetter(const Message &message, ProtoReflectors reflectors)
+AnyField::FilterXObjectGetter(Message *message, ProtoReflectors reflectors)
 {
   if (reflectors.fieldDescriptor->type() == FieldDescriptor::TYPE_MESSAGE)
     {
-      const Message &nestedMessage = reflectors.reflection->GetMessage(message, reflectors.fieldDescriptor);
+      Message *nestedMessage = reflectors.reflection->MutableMessage(message, reflectors.fieldDescriptor);
 
-      const AnyValue *anyValue;
+      AnyValue *anyValue;
       try
         {
-          anyValue = dynamic_cast<const AnyValue *>(&nestedMessage);
+          anyValue = dynamic_cast<AnyValue *>(nestedMessage);
         }
       catch(const std::bad_cast &e)
         {
           g_assert_not_reached();
         }
 
-      return this->FilterXObjectDirectGetter(*anyValue);
+      return this->FilterXObjectDirectGetter(anyValue);
     }
 
   msg_error("otel-field: Unexpected protobuf field type",
@@ -86,11 +86,11 @@ AnyField::FilterXObjectSetter(Message *message, ProtoReflectors reflectors, Filt
 }
 
 FilterXObject *
-AnyField::FilterXObjectDirectGetter(const AnyValue &anyValue)
+AnyField::FilterXObjectDirectGetter(AnyValue *anyValue)
 {
   ProtobufField *converter = nullptr;
   std::string typeFieldName;
-  AnyValue::ValueCase valueCase = anyValue.value_case();
+  AnyValue::ValueCase valueCase = anyValue->value_case();
 
   switch (valueCase)
     {
@@ -209,9 +209,9 @@ AnyField syslogng::grpc::otel::any_field_converter;
 class OtelDatetimeConverter : public ProtobufField
 {
 public:
-  FilterXObject *FilterXObjectGetter(const Message &message, ProtoReflectors reflectors)
+  FilterXObject *FilterXObjectGetter(Message *message, ProtoReflectors reflectors)
   {
-    uint64_t val = reflectors.reflection->GetUInt64(message, reflectors.fieldDescriptor);
+    uint64_t val = reflectors.reflection->GetUInt64(*message, reflectors.fieldDescriptor);
     UnixTime utime = unix_time_from_unix_epoch(val);
     return filterx_datetime_new(&utime);
   }

--- a/modules/grpc/otel/filterx/otel-field.hpp
+++ b/modules/grpc/otel/filterx/otel-field.hpp
@@ -37,10 +37,10 @@ class AnyField : public ProtobufField
   using AnyValue = opentelemetry::proto::common::v1::AnyValue;
 
 public:
-  FilterXObject *FilterXObjectGetter(const Message &message, ProtoReflectors reflectors);
+  FilterXObject *FilterXObjectGetter(Message *message, ProtoReflectors reflectors);
   bool FilterXObjectSetter(Message *message, ProtoReflectors reflectors, FilterXObject *object);
 
-  FilterXObject *FilterXObjectDirectGetter(const AnyValue &anyValue);
+  FilterXObject *FilterXObjectDirectGetter(AnyValue *anyValue);
   bool FilterXObjectDirectSetter(AnyValue *anyValue, FilterXObject *object);
 };
 

--- a/modules/grpc/otel/filterx/protobuf-field.cpp
+++ b/modules/grpc/otel/filterx/protobuf-field.cpp
@@ -64,9 +64,9 @@ double_to_float_safe(double val)
 class BoolField : public ProtobufField
 {
 public:
-  FilterXObject *FilterXObjectGetter(const google::protobuf::Message &message, ProtoReflectors reflectors)
+  FilterXObject *FilterXObjectGetter(google::protobuf::Message *message, ProtoReflectors reflectors)
   {
-    return filterx_boolean_new(reflectors.reflection->GetBool(message, reflectors.fieldDescriptor));
+    return filterx_boolean_new(reflectors.reflection->GetBool(*message, reflectors.fieldDescriptor));
   }
   bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object)
   {
@@ -79,9 +79,9 @@ public:
 class i32Field : public ProtobufField
 {
 public:
-  FilterXObject *FilterXObjectGetter(const google::protobuf::Message &message, ProtoReflectors reflectors)
+  FilterXObject *FilterXObjectGetter(google::protobuf::Message *message, ProtoReflectors reflectors)
   {
-    return filterx_integer_new(gint32(reflectors.reflection->GetInt32(message, reflectors.fieldDescriptor)));
+    return filterx_integer_new(gint32(reflectors.reflection->GetInt32(*message, reflectors.fieldDescriptor)));
   }
   bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object)
   {
@@ -100,9 +100,9 @@ public:
 class i64Field : public ProtobufField
 {
 public:
-  FilterXObject *FilterXObjectGetter(const google::protobuf::Message &message, ProtoReflectors reflectors)
+  FilterXObject *FilterXObjectGetter(google::protobuf::Message *message, ProtoReflectors reflectors)
   {
-    return filterx_integer_new(gint64(reflectors.reflection->GetInt64(message, reflectors.fieldDescriptor)));
+    return filterx_integer_new(gint64(reflectors.reflection->GetInt64(*message, reflectors.fieldDescriptor)));
   }
   bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object)
   {
@@ -129,9 +129,9 @@ public:
 class u32Field : public ProtobufField
 {
 public:
-  FilterXObject *FilterXObjectGetter(const google::protobuf::Message &message, ProtoReflectors reflectors)
+  FilterXObject *FilterXObjectGetter(google::protobuf::Message *message, ProtoReflectors reflectors)
   {
-    return filterx_integer_new(guint32(reflectors.reflection->GetUInt32(message, reflectors.fieldDescriptor)));
+    return filterx_integer_new(guint32(reflectors.reflection->GetUInt32(*message, reflectors.fieldDescriptor)));
   }
   bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object)
   {
@@ -150,9 +150,9 @@ public:
 class u64Field : public ProtobufField
 {
 public:
-  FilterXObject *FilterXObjectGetter(const google::protobuf::Message &message, ProtoReflectors reflectors)
+  FilterXObject *FilterXObjectGetter(google::protobuf::Message *message, ProtoReflectors reflectors)
   {
-    uint64_t val = reflectors.reflection->GetUInt64(message, reflectors.fieldDescriptor);
+    uint64_t val = reflectors.reflection->GetUInt64(*message, reflectors.fieldDescriptor);
     if (val > INT64_MAX)
       {
         msg_error("protobuf-field: exceeding FilterX number value range",
@@ -189,10 +189,10 @@ public:
 class StringField : public ProtobufField
 {
 public:
-  FilterXObject *FilterXObjectGetter(const google::protobuf::Message &message, ProtoReflectors reflectors)
+  FilterXObject *FilterXObjectGetter(google::protobuf::Message *message, ProtoReflectors reflectors)
   {
     std::string bytesBuffer;
-    const std::string &bytesRef = reflectors.reflection->GetStringReference(message, reflectors.fieldDescriptor,
+    const std::string &bytesRef = reflectors.reflection->GetStringReference(*message, reflectors.fieldDescriptor,
                                   &bytesBuffer);
     return filterx_string_new(bytesRef.c_str(), bytesRef.length());
   }
@@ -228,9 +228,9 @@ public:
 class DoubleField : public ProtobufField
 {
 public:
-  FilterXObject *FilterXObjectGetter(const google::protobuf::Message &message, ProtoReflectors reflectors)
+  FilterXObject *FilterXObjectGetter(google::protobuf::Message *message, ProtoReflectors reflectors)
   {
-    return filterx_double_new(gdouble(reflectors.reflection->GetDouble(message, reflectors.fieldDescriptor)));
+    return filterx_double_new(gdouble(reflectors.reflection->GetDouble(*message, reflectors.fieldDescriptor)));
   }
   bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object)
   {
@@ -260,9 +260,9 @@ public:
 class FloatField : public ProtobufField
 {
 public:
-  FilterXObject *FilterXObjectGetter(const google::protobuf::Message &message, ProtoReflectors reflectors)
+  FilterXObject *FilterXObjectGetter(google::protobuf::Message *message, ProtoReflectors reflectors)
   {
-    return filterx_double_new(gdouble(reflectors.reflection->GetFloat(message, reflectors.fieldDescriptor)));
+    return filterx_double_new(gdouble(reflectors.reflection->GetFloat(*message, reflectors.fieldDescriptor)));
   }
   bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object)
   {
@@ -292,10 +292,10 @@ public:
 class BytesField : public ProtobufField
 {
 public:
-  FilterXObject *FilterXObjectGetter(const google::protobuf::Message &message, ProtoReflectors reflectors)
+  FilterXObject *FilterXObjectGetter(google::protobuf::Message *message, ProtoReflectors reflectors)
   {
     std::string bytesBuffer;
-    const std::string &bytesRef = reflectors.reflection->GetStringReference(message, reflectors.fieldDescriptor,
+    const std::string &bytesRef = reflectors.reflection->GetStringReference(*message, reflectors.fieldDescriptor,
                                   &bytesBuffer);
     return filterx_bytes_new(bytesRef.c_str(), bytesRef.length());
   }

--- a/modules/grpc/otel/filterx/protobuf-field.hpp
+++ b/modules/grpc/otel/filterx/protobuf-field.hpp
@@ -71,11 +71,11 @@ struct ProtoReflectors
 class ProtobufField
 {
 public:
-  FilterXObject *Get(const google::protobuf::Message &message, std::string fieldName)
+  FilterXObject *Get(google::protobuf::Message *message, std::string fieldName)
   {
     try
       {
-        ProtoReflectors reflectors(message, fieldName);
+        ProtoReflectors reflectors(*message, fieldName);
         return this->FilterXObjectGetter(message, reflectors);
       }
     catch(const std::exception &ex)
@@ -98,7 +98,7 @@ public:
       }
   }
 protected:
-  virtual FilterXObject *FilterXObjectGetter(const google::protobuf::Message &message, ProtoReflectors reflectors) = 0;
+  virtual FilterXObject *FilterXObjectGetter(google::protobuf::Message *message, ProtoReflectors reflectors) = 0;
   virtual bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors,
                                    FilterXObject *object) = 0;
 };

--- a/modules/grpc/otel/otel-plugin.c
+++ b/modules/grpc/otel/otel-plugin.c
@@ -79,7 +79,7 @@ static Plugin otel_plugins[] =
   },
   {
     .type = LL_CONTEXT_FILTERX_FUNC,
-    .name = "otel_kvlist",
+    .name = "otel_array",
     .construct = grpc_otel_filterx_array_construct_new,
   },
 };

--- a/modules/grpc/otel/tests/test-otel-filterx.cpp
+++ b/modules/grpc/otel/tests/test-otel-filterx.cpp
@@ -783,18 +783,14 @@ Test(otel_filterx, array_set_subscript)
   FilterXObject *filterx_otel_array = (FilterXObject *) otel_array_new(NULL);
   cr_assert(filterx_otel_array);
 
-  FilterXObject *element_1_key = filterx_integer_new(0);
   FilterXObject *element_1_value = filterx_integer_new(42);
-  FilterXObject *element_2_key = filterx_integer_new(1);
   FilterXObject *element_2_value = filterx_string_new("foobar", -1);
-  FilterXObject *element_3_key = filterx_integer_new(2);
   FilterXObject *element_3_value = otel_kvlist_new(NULL);
-  FilterXObject *element_4_key = filterx_integer_new(3);
   FilterXObject *element_4_value = otel_array_new(NULL);
-  cr_assert(filterx_object_set_subscript(filterx_otel_array, element_1_key, element_1_value));
-  cr_assert(filterx_object_set_subscript(filterx_otel_array, element_2_key, element_2_value));
-  cr_assert(filterx_object_set_subscript(filterx_otel_array, element_3_key, element_3_value));
-  cr_assert(filterx_object_set_subscript(filterx_otel_array, element_4_key, element_4_value));
+  cr_assert(filterx_object_set_subscript(filterx_otel_array, NULL, element_1_value));
+  cr_assert(filterx_object_set_subscript(filterx_otel_array, NULL, element_2_value));
+  cr_assert(filterx_object_set_subscript(filterx_otel_array, NULL, element_3_value));
+  cr_assert(filterx_object_set_subscript(filterx_otel_array, NULL, element_4_value));
 
   FilterXObject *invalid_element_key = filterx_string_new("invalid_key", -1);
   cr_assert_not(filterx_object_set_subscript(filterx_otel_array, invalid_element_key, element_1_value));
@@ -816,13 +812,9 @@ Test(otel_filterx, array_set_subscript)
   cr_assert(MessageDifferencer::Equals(array.values(3).array_value(), ArrayValue()));
 
   g_string_free(serialized, TRUE);
-  filterx_object_unref(element_1_key);
   filterx_object_unref(element_1_value);
-  filterx_object_unref(element_2_key);
   filterx_object_unref(element_2_value);
-  filterx_object_unref(element_3_key);
   filterx_object_unref(element_3_value);
-  filterx_object_unref(element_4_key);
   filterx_object_unref(element_4_value);
   filterx_object_unref(invalid_element_key);
   filterx_object_unref(filterx_otel_array);

--- a/modules/grpc/otel/tests/test-otel-filterx.cpp
+++ b/modules/grpc/otel/tests/test-otel-filterx.cpp
@@ -338,6 +338,7 @@ Test(otel_filterx, resource_set_field)
 
   g_string_free(serialized, TRUE);
   g_ptr_array_unref(attributes_kvlist_args);
+  filterx_object_unref(filterx_kvlist);
   filterx_object_unref(filterx_integer);
   filterx_object_unref(filterx_otel_resource);
 }


### PR DESCRIPTION
#4842 made it possible to create `Array` and `KVList`, but it had a big problem: the created instances' inner values were completely separate from the encapsulating object, e.g. `LogRecord`, so they are not suitable for real-life use.

When we `get()` an `ArrayValue` of a `Message`, the respective created `FilterXObject` should operate on the `ArrayValue`. The current code creates a new `ArrayValue` every time, which is incorrect. The same is true for `KeyValueList`.