### PR TITLE
filterx, otel: add severity_number enum support

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -150,9 +150,10 @@
 %token LL_CONTEXT_TEMPLATE_REF        21
 %token LL_CONTEXT_FILTERX             22
 %token LL_CONTEXT_FILTERX_FUNC        23
+%token LL_CONTEXT_FILTERX_ENUM        24
 
 /* this is a placeholder for unit tests, must be the latest & largest */
-%token LL_CONTEXT_MAX                 24
+%token LL_CONTEXT_MAX                 25
 
 /* operators in the filter language, the order of this determines precedence */
 %right KW_ASSIGN 9000

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -1259,6 +1259,7 @@ static const gchar *lexer_contexts[] =
   [LL_CONTEXT_TEMPLATE_REF] = "template-ref",
   [LL_CONTEXT_FILTERX] = "filterx",
   [LL_CONTEXT_FILTERX_FUNC] = "filterx-func",
+  [LL_CONTEXT_FILTERX_ENUM] = "filterx-enum",
 };
 
 gint

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -80,6 +80,7 @@ construct_template_expr(LogTemplate *template)
 
 %token KW_TRUE, KW_FALSE
 %token KW_NULL
+%token KW_ENUM
 
 %type <ptr> stmts
 %type <node> stmt
@@ -177,6 +178,13 @@ literal_object
 	| LL_FLOAT				{ $$ = filterx_double_new($1); }
 	| KW_NULL				{ $$ = filterx_null_new(); }
 	| boolean				{ $$ = filterx_boolean_new($1); }
+	| KW_ENUM '(' string '.' string ')'	{
+							FilterXObject *res = filterx_enum_new(configuration, $3, $5);
+							CHECK_ERROR(res, @1, "enum %s.%s not found", $3, $5);
+							free($3);
+							free($5);
+							$$ = res;
+						}
 	;
 
 lvalue

--- a/lib/filterx/filterx-parser.c
+++ b/lib/filterx/filterx-parser.c
@@ -42,6 +42,7 @@ static CfgLexerKeyword filterx_keywords[] =
   { "true",               KW_TRUE },
   { "false",              KW_FALSE },
   { "null",               KW_NULL },
+  { "enum",               KW_ENUM },
 
   { NULL }
 };

--- a/lib/filterx/object-primitive.h
+++ b/lib/filterx/object-primitive.h
@@ -36,9 +36,16 @@ typedef struct _FilterXPrimitive
   GenericNumber value;
 } FilterXPrimitive;
 
+typedef struct _FilterXEnumDefinition
+{
+  const gchar *name;
+  gint64 value;
+} FilterXEnumDefinition;
+
 FilterXObject *filterx_integer_new(gint64 value);
 FilterXObject *filterx_double_new(gdouble value);
 FilterXObject *filterx_boolean_new(gboolean value);
+FilterXObject *filterx_enum_new(GlobalConfig *cfg, const gchar *namespace_name, const gchar *enum_name);
 GenericNumber filterx_primitive_get_value(FilterXObject *s);
 
 static inline gboolean

--- a/modules/grpc/otel/filterx/object-otel.h
+++ b/modules/grpc/otel/filterx/object-otel.h
@@ -44,6 +44,8 @@ FilterXObject *otel_kvlist_new(GPtrArray *args);
 gpointer grpc_otel_filterx_array_construct_new(Plugin *self);
 FilterXObject *otel_array_new(GPtrArray *args);
 
+gpointer grpc_otel_filterx_enum_construct(Plugin *self);
+
 FILTERX_DECLARE_TYPE(otel_logrecord);
 FILTERX_DECLARE_TYPE(otel_resource);
 FILTERX_DECLARE_TYPE(otel_scope);

--- a/modules/grpc/otel/otel-plugin.c
+++ b/modules/grpc/otel/otel-plugin.c
@@ -58,6 +58,11 @@ static Plugin otel_plugins[] =
     .parser = &otel_parser,
   },
   {
+    .type = LL_CONTEXT_FILTERX_ENUM,
+    .name = "otel",
+    .construct = grpc_otel_filterx_enum_construct,
+  },
+  {
     .type = LL_CONTEXT_FILTERX_FUNC,
     .name = "otel_logrecord",
     .construct = grpc_otel_filterx_logrecord_contruct_new,


### PR DESCRIPTION
Example code:
```
  $otel_log = otel_logrecord();
  $otel_log.severity_number = enum(otel.SEVERITY_NUMBER_INFO4);
```