### PR TITLE
filterx: do not parse global keywords

### DIFF
--- a/lib/filterx/filterx-parser.c
+++ b/lib/filterx/filterx-parser.c
@@ -44,7 +44,7 @@ static CfgLexerKeyword filterx_keywords[] =
   { "null",               KW_NULL },
   { "enum",               KW_ENUM },
 
-  { NULL }
+  { CFG_KEYWORD_STOP },
 };
 
 CfgParser filterx_parser =


### PR DESCRIPTION
Now we can set `$log = ...;`

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
