### PR TITLE
Filterx condition introduced

### DIFF
--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -27,6 +27,7 @@ set(FILTERX_HEADERS
     filterx/object-null.h
     filterx/object-primitive.h
     filterx/object-string.h
+    filterx/expr-condition.h
     PARENT_SCOPE
     )
 
@@ -59,6 +60,7 @@ set(FILTERX_SOURCES
     filterx/object-null.c
     filterx/object-primitive.c
     filterx/object-string.c
+    filterx/expr-condition.c
     PARENT_SCOPE
     )
 

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -28,7 +28,8 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/object-message-value.h	\
 	lib/filterx/filterx-config.h		\
 	lib/filterx/filterx-pipe.h		\
-	lib/filterx/expr-function.h
+	lib/filterx/expr-function.h	\
+	lib/filterx/expr-condition.h
 
 
 filterx_sources = 				\
@@ -60,6 +61,7 @@ filterx_sources = 				\
 	lib/filterx/filterx-config.c		\
 	lib/filterx/filterx-pipe.c		\
 	lib/filterx/expr-function.c		\
+	lib/filterx/expr-condition.c		\
 	lib/filterx/filterx-grammar.y
 
 BUILT_SOURCES += 				\

--- a/lib/filterx/expr-condition.c
+++ b/lib/filterx/expr-condition.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2023 shifter <shifter@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "filterx/expr-condition.h"
+#include "filterx/object-primitive.h"
+
+static FilterXConditional *
+_tail_condition(FilterXConditional *c)
+{
+  g_assert(c != NULL);
+  if (c->false_branch != NULL)
+    return _tail_condition(c->false_branch);
+  else
+    return c;
+}
+
+static gboolean
+_handle_condition_expression(FilterXConditional *c)
+{
+  g_assert(c != NULL);
+  if (c->condition == FILTERX_CONDITIONAL_NO_CONDITION)
+    return TRUE;
+  FilterXObject *cond = filterx_expr_eval(c->condition);
+  if (!cond) return FALSE;
+  return filterx_object_truthy(cond);
+}
+
+static FilterXObject *
+_eval_condition(FilterXConditional *c)
+{
+  if (c == NULL)
+    {
+      // no condition-expression match, no elif or else case
+      return filterx_boolean_new(TRUE);
+    }
+  if (!_handle_condition_expression(c))
+    {
+      return _eval_condition(c->false_branch);
+    }
+  FilterXObject *result;
+  for (GList *l = c->statements; l; l = l->next)
+    {
+      FilterXExpr *expr = l->data;
+      result = filterx_expr_eval(expr);
+      if (!result || !filterx_object_truthy(result))
+        {
+          filterx_object_unref(result);
+          return filterx_boolean_new(FALSE);
+        }
+      if (l->next != NULL)
+        filterx_object_unref(result);
+    }
+  return result;
+}
+
+static void
+_free (FilterXExpr *s)
+{
+  FilterXConditional *self = (FilterXConditional *) s;
+
+  filterx_expr_unref(self->condition);
+  g_list_free_full(self->statements, (GDestroyNotify) filterx_expr_unref);
+  if (self->false_branch != NULL)
+    filterx_expr_unref(&self->false_branch->super);
+}
+
+static FilterXObject *
+_eval(FilterXExpr *s)
+{
+  FilterXConditional *self = (FilterXConditional *) s;
+  return _eval_condition(self);
+}
+
+FilterXExpr *
+filterx_conditional_new_conditional_codeblock(FilterXExpr *condition, GList *stmts)
+{
+  FilterXConditional *self = g_new0(FilterXConditional, 1);
+  filterx_expr_init_instance(&self->super);
+  self->super.eval = _eval;
+  self->super.free_fn = _free;
+  self->condition = condition;
+  self->statements = stmts;
+  return &self->super;
+}
+
+FilterXExpr *
+filterx_conditional_new_codeblock(GList *stmts)
+{
+  return filterx_conditional_new_conditional_codeblock(FILTERX_CONDITIONAL_NO_CONDITION, stmts);
+}
+
+
+FilterXExpr *
+filterx_conditional_add_false_branch(FilterXConditional *s, FilterXConditional *false_branch)
+{
+  g_assert(s != NULL);
+  FilterXConditional *last_condition = _tail_condition(s);
+
+  // avoid to create nested elses (if () {} else {} else {} else {})
+  g_assert(last_condition->condition);
+
+  last_condition->false_branch = false_branch;
+  return &s->super;
+}

--- a/lib/filterx/expr-condition.h
+++ b/lib/filterx/expr-condition.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023 shifter <shifter@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef FILTERX_CONDITION_H_INCLUDED
+#define FILTERX_CONDITION_H_INCLUDED
+
+#include "filterx/filterx-expr.h"
+
+typedef struct _FilterXConditional FilterXConditional;
+
+struct _FilterXConditional
+{
+  FilterXExpr super;
+  FilterXExpr *condition;
+  GList *statements;
+  FilterXConditional *false_branch;
+};
+
+#define FILTERX_CONDITIONAL_NO_CONDITION NULL
+
+FilterXExpr *filterx_conditional_new_conditional_codeblock(FilterXExpr *condition, GList *stmts);
+FilterXExpr *filterx_conditional_new_codeblock(GList *stmts);
+FilterXExpr *filterx_conditional_add_false_branch(FilterXConditional *s, FilterXConditional *fail_branch);
+
+#endif

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -48,6 +48,7 @@
 #include "filterx/object-string.h"
 #include "filterx/filterx-config.h"
 #include "filterx/expr-function.h"
+#include "filterx/expr-condition.h"
 
 #include "template/templates.h"
 
@@ -100,6 +101,9 @@ construct_template_expr(LogTemplate *template)
 %type <ptr> list_values
 %type <ptr> list_value
 %type <num> boolean
+%type <ptr> fxcondition
+%type <ptr> fxif
+%type <ptr> fxcodeblock
 
 %%
 
@@ -114,6 +118,7 @@ stmts
 
 stmt
 	: expr ';'				{ $$ = $1; }
+	| fxcondition ';'			{ $$ = $1; }
 	;
 
 expr
@@ -237,6 +242,27 @@ list_values
 
 list_value
 	: expr                                  { $$ = $1; }
+	;
+
+fxcondition
+	: fxif					{ $$ = $1; }
+	| fxif KW_ELSE fxcodeblock		{
+							$$ = filterx_conditional_add_false_branch((FilterXConditional*)$1, (FilterXConditional*)filterx_conditional_new_codeblock($3));
+						}
+	;
+
+fxif
+	: KW_IF '(' expr ')' fxcodeblock	{
+							$$ = filterx_conditional_new_conditional_codeblock($3, $5);
+						}
+	| fxif KW_ELIF '(' expr ')' fxcodeblock {
+							$$ = filterx_conditional_add_false_branch((FilterXConditional*)$1, (FilterXConditional*)filterx_conditional_new_conditional_codeblock($4, $6));
+						}
+	;
+
+
+fxcodeblock
+	: '{' stmts '}'				{ $$ = $2; }
 	;
 
 /* INCLUDE_RULES */

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -104,6 +104,7 @@ construct_template_expr(LogTemplate *template)
 %type <ptr> fxcondition
 %type <ptr> fxif
 %type <ptr> fxcodeblock
+%type <ptr> tenary
 
 %%
 
@@ -148,6 +149,7 @@ expr
         | expr KW_TAV_EQ expr			{ $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AND_VALUE_BASED | FCMPX_EQ); }
         | expr KW_TAV_NE expr			{ $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AND_VALUE_BASED | FCMPX_NE ); }
 	| '(' expr ')'				{ $$ = $2; }
+	| tenary				{ $$ = $1; }
 	;
 
 expr_value
@@ -263,6 +265,13 @@ fxif
 
 fxcodeblock
 	: '{' stmts '}'				{ $$ = $2; }
+	;
+
+tenary
+	: '(' expr '?' expr ':' expr ')'		{
+							FilterXConditional *cond = (FilterXConditional*)filterx_conditional_new_conditional_codeblock($2, g_list_append(NULL, $4));
+							$$ = filterx_conditional_add_false_branch(cond, (FilterXConditional*)filterx_conditional_new_codeblock(g_list_append(NULL, $6)));
+						}
 	;
 
 /* INCLUDE_RULES */

--- a/lib/filterx/filterx-parser.c
+++ b/lib/filterx/filterx-parser.c
@@ -44,6 +44,10 @@ static CfgLexerKeyword filterx_keywords[] =
   { "null",               KW_NULL },
   { "enum",               KW_ENUM },
 
+  { "if",                 KW_IF },
+  { "else",               KW_ELSE },
+  { "elif",               KW_ELIF },
+
   { CFG_KEYWORD_STOP },
 };
 

--- a/lib/filterx/tests/CMakeLists.txt
+++ b/lib/filterx/tests/CMakeLists.txt
@@ -6,3 +6,4 @@ add_unit_test(LIBTEST CRITERION TARGET test_object_null DEPENDS json-plugin ${JS
 add_unit_test(LIBTEST CRITERION TARGET test_object_primitive DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_object_string DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_expr_comparison DEPENDS json-plugin ${JSONC_LIBRARY})
+add_unit_test(LIBTEST CRITERION TARGET test_expr_condition DEPENDS json-plugin ${JSONC_LIBRARY})

--- a/lib/filterx/tests/Makefile.am
+++ b/lib/filterx/tests/Makefile.am
@@ -6,7 +6,8 @@ lib_filterx_tests_TESTS		 =              \
 		lib/filterx/tests/test_object_null	\
 		lib/filterx/tests/test_object_string	\
 		lib/filterx/tests/test_filterx_expr	\
-		lib/filterx/tests/test_expr_comparison
+		lib/filterx/tests/test_expr_comparison \
+		lib/filterx/tests/test_expr_condition
 
 EXTRA_DIST += lib/filterx/tests/CMakeLists.txt \
 	lib/filterx/tests/filterx-lib.h
@@ -36,3 +37,6 @@ lib_filterx_tests_test_filterx_expr_LDADD   = $(TEST_LDADD) $(PREOPEN_SYSLOGFORM
 
 lib_filterx_tests_test_expr_comparison_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_expr_comparison_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
+
+lib_filterx_tests_test_expr_condition_CFLAGS = $(TEST_CFLAGS)
+lib_filterx_tests_test_expr_condition_LDADD	 = $(TEST_LDADD) $(JSON_LIBS)

--- a/lib/filterx/tests/test_expr_condition.c
+++ b/lib/filterx/tests/test_expr_condition.c
@@ -1,0 +1,507 @@
+/*
+ * Copyright (c) 2023 shifter <shifter@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include "libtest/cr_template.h"
+
+#include "filterx/filterx-object.h"
+#include "filterx/object-primitive.h"
+#include "filterx/expr-comparison.h"
+#include "filterx/expr-condition.h"
+#include "filterx/filterx-expr.h"
+#include "filterx/expr-literal.h"
+#include "filterx/object-string.h"
+#include "filterx/object-null.h"
+#include "filterx/object-datetime.h"
+#include "filterx/object-message-value.h"
+#include "filterx/expr-assign.h"
+#include "filterx/expr-template.h"
+#include "filterx/expr-message-ref.h"
+
+#include "apphook.h"
+#include "scratch-buffers.h"
+
+
+FilterXExpr *_string_to_filterXExpr(const gchar *str)
+{
+  return filterx_literal_new(filterx_string_new(str, -1));
+}
+
+gint _assert_cmp_string_to_filterx_object(const char *str, FilterXObject *obj)
+{
+  cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(string)));
+  gsize string_len;
+  const gchar *string = filterx_string_get_value(obj, &string_len);
+  return strcmp(string, str);
+}
+
+FilterXExpr *_assert_assign_var(const char *var_name, FilterXExpr *value)
+{
+  FilterXExpr *control_variable = filterx_message_ref_expr_new(log_msg_get_value_handle(var_name));
+  cr_assert(control_variable != NULL);
+
+  return filterx_assign_new(control_variable, value);
+}
+
+void _assert_set_test_variable(const char *var_name, FilterXExpr *expr)
+{
+  FilterXExpr *assign = _assert_assign_var(var_name, expr);
+  cr_assert(assign != NULL);
+
+  FilterXObject *assign_eval_res = filterx_expr_eval(assign);
+  cr_assert(assign_eval_res != NULL);
+  cr_assert(filterx_object_truthy(assign_eval_res));
+
+  filterx_expr_unref(assign);
+  filterx_object_unref(assign_eval_res);
+}
+
+FilterXObject *_assert_get_test_variable(const char *var_name)
+{
+  FilterXExpr *control_variable = filterx_message_ref_expr_new(log_msg_get_value_handle(var_name));
+  cr_assert(control_variable != NULL);
+  FilterXObject *result = filterx_expr_eval(control_variable);
+  filterx_expr_unref(control_variable);
+  return result;
+}
+
+typedef struct _TestEnv
+{
+  LogMessage *msg;
+  FilterXScope *scope;
+  FilterXEvalContext context;
+} TestEnv;
+
+void init_test(TestEnv *env)
+{
+
+  cr_assert(env != NULL);
+  env->msg = create_sample_message();
+  env->scope = filterx_scope_new();
+
+  env->context = (FilterXEvalContext)
+  {
+    .msgs = &env->msg,
+    .num_msg = 1,
+    .template_eval_options = &DEFAULT_TEMPLATE_EVAL_OPTIONS,
+    .scope = env->scope,
+  };
+  filterx_eval_set_context(&env->context);
+
+}
+
+void deinit_test(const TestEnv *env)
+{
+  cr_assert(env != NULL);
+  log_msg_unref(env->msg);
+  filterx_scope_free(env->scope);
+  filterx_eval_set_context(NULL);
+}
+
+//// Actual tests
+
+Test(expr_condition, test_control_variable_set_get)
+{
+  TestEnv env;
+  init_test(&env);
+
+  _assert_set_test_variable("$control-value", _string_to_filterXExpr("default"));
+
+  FilterXObject *control_value = _assert_get_test_variable("$control-value");
+
+  cr_assert_eq(0, _assert_cmp_string_to_filterx_object("default", control_value));
+
+  filterx_object_unref(control_value);
+
+  deinit_test(&env);
+
+}
+
+
+Test(expr_condition, test_condition_with_null_expr_must_evaluated)
+{
+  TestEnv env;
+  init_test(&env);
+
+  _assert_set_test_variable("$control-value", _string_to_filterXExpr("default"));
+
+  /////
+
+  GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
+
+  FilterXExpr *cond = filterx_conditional_new_codeblock(stmts);
+  FilterXObject *cond_eval = filterx_expr_eval(cond);
+  cr_assert(cond_eval != NULL);
+  cr_assert(filterx_object_truthy(cond_eval) == TRUE);
+
+  FilterXObject *control_value = _assert_get_test_variable("$control-value");
+  cr_assert_eq(0, _assert_cmp_string_to_filterx_object("matching", control_value));
+
+  filterx_expr_unref(cond);
+  filterx_object_unref(control_value);
+  filterx_object_unref(cond_eval);
+  ////
+
+  deinit_test(&env);
+}
+
+Test(expr_condition, test_condition_matching_expression)
+{
+  TestEnv env;
+  init_test(&env);
+
+  _assert_set_test_variable("$control-value", _string_to_filterXExpr("default"));
+
+  /////
+
+  GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
+
+  FilterXExpr *cond = filterx_conditional_new_conditional_codeblock(filterx_literal_new(filterx_boolean_new(true)),
+                      stmts);
+  FilterXObject *cond_eval = filterx_expr_eval(cond);
+  cr_assert(cond_eval != NULL);
+  cr_assert(filterx_object_truthy(cond_eval) == TRUE);
+
+  FilterXObject *control_value = _assert_get_test_variable("$control-value");
+  cr_assert_eq(0, _assert_cmp_string_to_filterx_object("matching", control_value));
+
+  filterx_expr_unref(cond);
+  filterx_object_unref(control_value);
+  filterx_object_unref(cond_eval);
+  ////
+
+  deinit_test(&env);
+}
+
+
+Test(expr_condition, test_condition_non_matching_expression)
+{
+  TestEnv env;
+  init_test(&env);
+
+  _assert_set_test_variable("$control-value", _string_to_filterXExpr("default"));
+
+  /////
+
+  GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
+
+  FilterXExpr *cond = filterx_conditional_new_conditional_codeblock(filterx_literal_new(filterx_boolean_new(false)),
+                      stmts);
+  FilterXObject *cond_eval = filterx_expr_eval(cond);
+  cr_assert(cond_eval != NULL);
+  cr_assert(filterx_object_truthy(cond_eval) == TRUE);
+
+  FilterXObject *control_value = _assert_get_test_variable("$control-value");
+  cr_assert_eq(0, _assert_cmp_string_to_filterx_object("default", control_value));
+
+  filterx_expr_unref(cond);
+  filterx_object_unref(control_value);
+  filterx_object_unref(cond_eval);
+  ////
+
+  deinit_test(&env);
+}
+
+
+Test(expr_condition, test_condition_matching_elif_expression)
+{
+  TestEnv env;
+  init_test(&env);
+
+  _assert_set_test_variable("$control-value", _string_to_filterXExpr("default"));
+
+  /////
+
+  GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
+  GList *elif_stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("elif-matching")));
+
+  FilterXExpr *cond = filterx_conditional_new_conditional_codeblock(filterx_literal_new(filterx_boolean_new(false)),
+                      stmts);
+  cond = filterx_conditional_add_false_branch((FilterXConditional *)cond,
+                                              (FilterXConditional *)filterx_conditional_new_conditional_codeblock(filterx_literal_new(filterx_boolean_new(true)),
+                                                  elif_stmts));
+
+  FilterXObject *cond_eval = filterx_expr_eval(cond);
+  cr_assert(cond_eval != NULL);
+  cr_assert(filterx_object_truthy(cond_eval) == TRUE);
+
+  FilterXObject *control_value = _assert_get_test_variable("$control-value");
+  cr_assert_eq(0, _assert_cmp_string_to_filterx_object("elif-matching", control_value));
+
+  filterx_expr_unref(cond);
+  filterx_object_unref(control_value);
+  filterx_object_unref(cond_eval);
+  ////
+
+  deinit_test(&env);
+}
+
+
+Test(expr_condition, test_condition_non_matching_elif_expression)
+{
+  TestEnv env;
+  init_test(&env);
+
+  _assert_set_test_variable("$control-value", _string_to_filterXExpr("default"));
+
+  /////
+
+  GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
+  GList *elif_stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("elif-matching")));
+
+  FilterXExpr *cond = filterx_conditional_new_conditional_codeblock(filterx_literal_new(filterx_boolean_new(false)),
+                      stmts);
+  cond = filterx_conditional_add_false_branch((FilterXConditional *)cond,
+                                              (FilterXConditional *)filterx_conditional_new_conditional_codeblock(filterx_literal_new(filterx_boolean_new(false)),
+                                                  elif_stmts));
+
+  FilterXObject *cond_eval = filterx_expr_eval(cond);
+  cr_assert(cond_eval != NULL);
+  cr_assert(filterx_object_truthy(cond_eval) == TRUE);
+
+  FilterXObject *control_value = _assert_get_test_variable("$control-value");
+  cr_assert_eq(0, _assert_cmp_string_to_filterx_object("default", control_value));
+
+  filterx_expr_unref(cond);
+  filterx_object_unref(control_value);
+  filterx_object_unref(cond_eval);
+  ////
+
+  deinit_test(&env);
+}
+
+Test(expr_condition, test_condition_matching_else_expression)
+{
+  TestEnv env;
+  init_test(&env);
+
+  _assert_set_test_variable("$control-value", _string_to_filterXExpr("default"));
+
+  /////
+
+  GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
+  GList *elif_stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("elif-matching")));
+  GList *else_stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("else-matching")));
+
+  FilterXExpr *cond = filterx_conditional_new_conditional_codeblock(filterx_literal_new(filterx_boolean_new(false)),
+                      stmts);
+  cond = filterx_conditional_add_false_branch((FilterXConditional *)cond,
+                                              (FilterXConditional *)filterx_conditional_new_conditional_codeblock(filterx_literal_new(filterx_boolean_new(false)),
+                                                  elif_stmts));
+  cond = filterx_conditional_add_false_branch((FilterXConditional *)cond,
+                                              (FilterXConditional *)filterx_conditional_new_conditional_codeblock(NULL, else_stmts));
+
+
+  FilterXObject *cond_eval = filterx_expr_eval(cond);
+  cr_assert(cond_eval != NULL);
+  cr_assert(filterx_object_truthy(cond_eval) == TRUE);
+
+  FilterXObject *control_value = _assert_get_test_variable("$control-value");
+  cr_assert_eq(0, _assert_cmp_string_to_filterx_object("else-matching", control_value));
+
+  filterx_expr_unref(cond);
+  filterx_object_unref(control_value);
+  filterx_object_unref(cond_eval);
+  ////
+
+  deinit_test(&env);
+}
+
+Test(expr_condition, test_condition_subsequent_conditions_must_create_nested_condition)
+{
+  TestEnv env;
+  init_test(&env);
+
+  _assert_set_test_variable("$control-value", _string_to_filterXExpr("default"));
+
+  /////
+
+  GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
+  GList *elif_stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("elif-matching")));
+  GList *elif2_stmts = g_list_append(NULL, _assert_assign_var("$control-value",
+                                                              _string_to_filterXExpr("elif2-matching")));
+  GList *else_stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("else-matching")));
+
+  FilterXExpr *cond = filterx_conditional_new_conditional_codeblock(filterx_literal_new(filterx_boolean_new(false)),
+                      stmts);
+  FilterXConditional *cond2 = (FilterXConditional *)filterx_conditional_new_conditional_codeblock(filterx_literal_new(
+                                filterx_boolean_new(false)),
+                              elif_stmts);
+  FilterXConditional *cond3 = (FilterXConditional *)filterx_conditional_new_conditional_codeblock(filterx_literal_new(
+                                filterx_boolean_new(true)),
+                              elif2_stmts);
+  FilterXConditional *cond4 = (FilterXConditional *)filterx_conditional_new_conditional_codeblock(NULL, else_stmts);
+  cond = filterx_conditional_add_false_branch((FilterXConditional *)cond, cond2);
+  cond = filterx_conditional_add_false_branch((FilterXConditional *)cond, cond3);
+  cond = filterx_conditional_add_false_branch((FilterXConditional *)cond, cond4);
+
+  cr_assert(((FilterXConditional *)cond)->false_branch == cond2);
+  cr_assert(((FilterXConditional *)cond2)->false_branch == cond3);
+  cr_assert(((FilterXConditional *)cond3)->false_branch == cond4);
+  cr_assert(((FilterXConditional *)cond4)->false_branch == NULL);
+
+  filterx_expr_unref(cond);
+
+  ////
+
+  deinit_test(&env);
+}
+
+Test(expr_condition, test_condition_all_the_statements_must_executed)
+{
+  TestEnv env;
+  init_test(&env);
+
+  _assert_set_test_variable("$control-value", _string_to_filterXExpr("default"));
+
+  /////
+
+  GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
+  stmts = g_list_append(stmts, _assert_assign_var("$control-value2", _string_to_filterXExpr("matching2")));
+  stmts = g_list_append(stmts, _assert_assign_var("$control-value3", _string_to_filterXExpr("matching3")));
+
+  FilterXExpr *cond = filterx_conditional_new_conditional_codeblock(filterx_literal_new(filterx_boolean_new(true)),
+                      stmts);
+
+  FilterXObject *cond_eval = filterx_expr_eval(cond);
+  cr_assert(cond_eval != NULL);
+  cr_assert(filterx_object_truthy(cond_eval) == TRUE);
+
+  FilterXObject *control_value = _assert_get_test_variable("$control-value");
+  cr_assert_eq(0, _assert_cmp_string_to_filterx_object("matching", control_value));
+  filterx_object_unref(control_value);
+  control_value = _assert_get_test_variable("$control-value2");
+  cr_assert_eq(0, _assert_cmp_string_to_filterx_object("matching2", control_value));
+  filterx_object_unref(control_value);
+  control_value = _assert_get_test_variable("$control-value3");
+  cr_assert_eq(0, _assert_cmp_string_to_filterx_object("matching3", control_value));
+  filterx_object_unref(control_value);
+
+  filterx_expr_unref(cond);
+  filterx_object_unref(cond_eval);
+
+  ////
+
+  deinit_test(&env);
+}
+
+
+Test(expr_condition, test_condition_must_return_last_expression_from_evaluated_codeblock)
+{
+  TestEnv env;
+  init_test(&env);
+
+  _assert_set_test_variable("$control-value", _string_to_filterXExpr("default"));
+
+  /////
+
+  GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
+  stmts = g_list_append(stmts, _assert_assign_var("$control-value2", _string_to_filterXExpr("matching2")));
+  stmts = g_list_append(stmts, _string_to_filterXExpr("must be returned"));
+
+  FilterXExpr *cond = filterx_conditional_new_conditional_codeblock(filterx_literal_new(filterx_boolean_new(true)),
+                      stmts);
+
+  FilterXObject *cond_eval = filterx_expr_eval(cond);
+  cr_assert(cond_eval != NULL);
+  _assert_cmp_string_to_filterx_object("must be returned", cond_eval);
+
+  filterx_expr_unref(cond);
+  filterx_object_unref(cond_eval);
+  ////
+
+  deinit_test(&env);
+}
+
+
+Test(expr_condition, test_condition_falsey_expression_must_interrupt_sequential_code_execution)
+{
+  TestEnv env;
+  init_test(&env);
+
+  _assert_set_test_variable("$control-value", _string_to_filterXExpr("default"));
+  _assert_set_test_variable("$control-value3", _string_to_filterXExpr("default3"));
+
+  /////
+
+  GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
+  stmts = g_list_append(stmts, filterx_literal_new(filterx_boolean_new(false)));
+  stmts = g_list_append(stmts, _assert_assign_var("$control-value3", _string_to_filterXExpr("matching3")));
+
+  FilterXExpr *cond = filterx_conditional_new_conditional_codeblock(filterx_literal_new(filterx_boolean_new(true)),
+                      stmts);
+
+  FilterXObject *cond_eval = filterx_expr_eval(cond);
+  cr_assert(cond_eval != NULL);
+  cr_assert(filterx_object_truthy(cond_eval) == FALSE);
+
+  FilterXObject *control_value = _assert_get_test_variable("$control-value");
+  cr_assert_eq(0, _assert_cmp_string_to_filterx_object("matching", control_value));
+  filterx_object_unref(control_value);
+  control_value = _assert_get_test_variable("$control-value3");
+  cr_assert_eq(0, _assert_cmp_string_to_filterx_object("default3", control_value));
+  filterx_object_unref(control_value);
+
+
+  filterx_expr_unref(cond);
+  filterx_object_unref(cond_eval);
+  ////
+
+  deinit_test(&env);
+}
+
+
+Test(expr_condition, test_condition_do_not_allow_to_add_else_into_else, .signal=SIGABRT)
+{
+  TestEnv env;
+  init_test(&env);
+
+  /////
+
+  GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
+  GList *stmts2 = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
+
+  FilterXExpr *cond = filterx_conditional_new_codeblock(stmts);
+  cond = filterx_conditional_add_false_branch((FilterXConditional *) cond,
+                                              (FilterXConditional *) filterx_conditional_new_codeblock(stmts2));
+
+  filterx_expr_unref(cond);
+  ////
+
+  deinit_test(&env);
+}
+
+static void
+setup(void)
+{
+  app_startup();
+}
+
+static void
+teardown(void)
+{
+  scratch_buffers_explicit_gc();
+  app_shutdown();
+}
+
+TestSuite(expr_condition, .init = setup, .fini = teardown);

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -47,6 +47,8 @@ source genmsg {{
             "values.bytes" => bytes("binary whatever"),
             "values.protobuf" => protobuf("this is not a valid protobuf!!"),
             "values.json" => json('{{"emb_key1": "emb_key1 value", "emb_key2": "emb_key2 value"}}'),
+            "values.true_string" => string("boolean:true"),
+            "values.false_string" => string("boolean:false"),
         )
     );
 }};
@@ -306,7 +308,7 @@ def test_json_assignment_from_template(config, syslog_ng):
 
     assert file_true.get_stats()["processed"] == 1
     assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == """{"str":"string","null":null,"list":["foo","bar","baz"],"json":{"emb_key1": "emb_key1 value", "emb_key2": "emb_key2 value"},"int":5,"double":32.5,"datetime":"1701350398.123000+01:00","bool":true}\n"""
+    assert file_true.read_log() == """{"true_string":"boolean:true","str":"string","null":null,"list":["foo","bar","baz"],"json":{"emb_key1": "emb_key1 value", "emb_key2": "emb_key2 value"},"int":5,"false_string":"boolean:false","double":32.5,"datetime":"1701350398.123000+01:00","bool":true}\n"""
 
 
 def test_json_assignment_from_another_name_value_pair(config, syslog_ng):
@@ -525,3 +527,81 @@ $MSG = example_echo($list);
     assert "processed" not in file_false.get_stats()
     # foo remains unchanged while baz is changed
     assert file_true.read_log() == """foo,bar,baz\n"""
+
+
+def test_tenary_operator_true(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, """
+    $MSG = (true?${values.true_string}:${values.false_string});
+""",
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "boolean:true\n"
+
+
+def test_tenary_operator_false(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, """
+    $MSG = (false?${values.true_string}:${values.false_string});
+""",
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "boolean:false\n"
+
+
+def test_tenary_operator_expression_true(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, """
+    $MSG = ((0 === 0)?${values.true_string}:${values.false_string});
+""",
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "boolean:true\n"
+
+
+def test_tenary_operator_expression_false(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, """
+    $MSG = ((0 === 1)?${values.true_string}:${values.false_string});
+""",
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "boolean:false\n"
+
+
+def test_tenary_operator_inline_tenary_expression_true(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, """
+    $MSG = ((0 === 0)?("foo" eq "foo"? ${values.true_string} : "inner:false"):${values.false_string});
+""",
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "boolean:true\n"
+
+
+def test_tenary_operator_inline_tenary_expression_false(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, """
+    $MSG = ((0 === 0)?("foo" eq "bar"? ${values.true_string} : "inner:false"):${values.false_string});
+""",
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "inner:false\n"


### PR DESCRIPTION
Filterx language is now able to handle conditionals, like 'if' and 'tenary'.

```
filterx{
#tenary
	$baz = (("foo" eq "foo") ? "tenary-foo" : "tenary-not-foo");
#if,elif,else
	if (false) {
		$foo = "bar";
		$bar = $foo;
	} elif (false) {
		expressions...
	} else {
		expressions...
	};
}
```