### PR TITLE
[1/6] filterx: rework setattr() and set_subscript() virtual fns

### DIFF
--- a/lib/filterx/expr-list.c
+++ b/lib/filterx/expr-list.c
@@ -37,18 +37,14 @@ _eval_value(FilterXListExpr *self, FilterXObject *object, gint i, FilterXExpr *e
 {
   FilterXObject *index = filterx_integer_new(i);
   FilterXObject *value = filterx_expr_eval_typed(expr);
-  gboolean success = FALSE;
-
   if (!value)
-    goto fail;
+    return FALSE;
 
-  if (!filterx_object_set_subscript(object, index, value))
-    goto fail;
-
-  success = TRUE;
-fail:
+  FilterXObject *cloned_value = filterx_object_clone(value);
   filterx_object_unref(value);
-  filterx_object_unref(index);
+
+  gboolean success = filterx_object_set_subscript(object, index, cloned_value);
+  filterx_object_unref(cloned_value);
   return success;
 }
 

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -58,11 +58,16 @@ _eval(FilterXExpr *s)
   if (!new_value)
     goto exit;
 
-  if (!filterx_object_set_subscript(object, index, new_value))
-    goto exit;
-  result = filterx_object_ref(new_value);
-exit:
+  result = filterx_object_clone(new_value);
   filterx_object_unref(new_value);
+
+  if (!filterx_object_set_subscript(object, index, result))
+    {
+      filterx_object_unref(result);
+      result = NULL;
+    }
+
+exit:
   filterx_object_unref(index);
   filterx_object_unref(object);
   return result;

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -45,12 +45,17 @@ _eval(FilterXExpr *s)
   if (!new_value)
     goto exit;
 
-  if (!filterx_object_setattr(object, self->attr_name, new_value))
-    goto exit;
-  result = filterx_object_ref(new_value);
+  result = filterx_object_clone(new_value);
+  filterx_object_unref(new_value);
+
+  if (!filterx_object_setattr(object, self->attr_name, result))
+    {
+      filterx_object_unref(result);
+      result = NULL;
+    }
+
 exit:
   filterx_object_unref(object);
-  filterx_object_unref(new_value);
   return result;
 }
 

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -82,14 +82,18 @@ filterx_expr_eval_typed(FilterXExpr *self)
       filterx_object_unref(result);
       return NULL;
     }
-  if (result != unmarshalled)
+
+  if (result == unmarshalled)
     {
-      filterx_object_unref(result);
-      if (self->_update_repr)
-        self->_update_repr(self, unmarshalled);
-      result = unmarshalled;
+      filterx_object_unref(unmarshalled);
+      return result;
     }
-  return result;
+
+  filterx_object_unref(result);
+  if (self->_update_repr)
+    self->_update_repr(self, unmarshalled);
+
+  return unmarshalled;
 }
 
 

--- a/lib/filterx/object-json.c
+++ b/lib/filterx/object-json.c
@@ -192,14 +192,10 @@ _setattr(FilterXObject *s, const gchar *attr_name, FilterXObject *new_value)
   FilterXJSON *self = (FilterXJSON *) s;
   struct json_object *attr_value = NULL;
 
-  /* this only clones mutable objects */
-  new_value = filterx_object_clone(new_value);
-
   if (!filterx_object_map_to_json(new_value, &attr_value))
     return FALSE;
 
   filterx_json_associate_cached_object(attr_value, new_value);
-  filterx_object_unref(new_value);
 
   if (json_object_object_add(self->object, attr_name, attr_value) != 0)
     {
@@ -306,14 +302,10 @@ _set_subscript(FilterXObject *s, FilterXObject *index, FilterXObject *new_value)
   struct json_object *attr_value = NULL;
   gboolean result = FALSE;
 
-  /* this only clones mutable objects */
-  new_value = filterx_object_clone(new_value);
-
   if (!filterx_object_map_to_json(new_value, &attr_value))
     return FALSE;
 
   filterx_json_associate_cached_object(attr_value, new_value);
-  filterx_object_unref(new_value);
 
   if (json_object_is_type(self->object, json_type_array))
     result = _set_subscript_array(self, index, attr_value);

--- a/modules/grpc/otel/filterx/object-otel-array.cpp
+++ b/modules/grpc/otel/filterx/object-otel-array.cpp
@@ -281,18 +281,31 @@ OtelArrayField::FilterXObjectSetter(google::protobuf::Message *message, ProtoRef
     }
 
   FilterXOtelArray *filterx_array = (FilterXOtelArray *) object;
-  ArrayValue *array;
+  ArrayValue *array_value;
 
   try
     {
-      array = dynamic_cast<ArrayValue *>(reflectors.reflection->MutableMessage(message, reflectors.fieldDescriptor));
+      array_value = dynamic_cast<ArrayValue *>(reflectors.reflection->MutableMessage(message, reflectors.fieldDescriptor));
     }
   catch(const std::bad_cast &e)
     {
       g_assert_not_reached();
     }
 
-  array->CopyFrom(filterx_array->cpp->get_value());
+  array_value->CopyFrom(filterx_array->cpp->get_value());
+
+  Array *new_array;
+  try
+    {
+      new_array = new Array(filterx_array, array_value);
+    }
+  catch (const std::runtime_error &)
+    {
+      g_assert_not_reached();
+    }
+
+  delete filterx_array->cpp;
+  filterx_array->cpp = new_array;
 
   return true;
 }

--- a/modules/grpc/otel/tests/test-otel-filterx.cpp
+++ b/modules/grpc/otel/tests/test-otel-filterx.cpp
@@ -681,7 +681,9 @@ Test(otel_filterx, kvlist_through_logrecord)
   cr_assert(filterx_object_set_subscript(fx_kvlist, fx_key_0, fx_foo));
 
   /* $log.attributes = $kvlist; */
-  cr_assert(filterx_object_setattr(fx_logrecord, "attributes", fx_kvlist));
+  FilterXObject *fx_kvlist_clone = filterx_object_clone(fx_kvlist);
+  cr_assert(filterx_object_setattr(fx_logrecord, "attributes", fx_kvlist_clone));
+  filterx_object_unref(fx_kvlist_clone);
 
   /* $log.attributes["key_1"] = "bar"; */
   fx_get_1 = filterx_object_getattr(fx_logrecord, "attributes");
@@ -695,7 +697,9 @@ Test(otel_filterx, kvlist_through_logrecord)
   filterx_object_unref(fx_get_1);
   fx_get_1 = filterx_object_getattr(fx_logrecord, "attributes");
   cr_assert(fx_get_1);
-  cr_assert(filterx_object_set_subscript(fx_get_1, fx_key_3, fx_inner_kvlist));
+  FilterXObject *fx_inner_kvlist_clone = filterx_object_clone(fx_inner_kvlist);
+  cr_assert(filterx_object_set_subscript(fx_get_1, fx_key_3, fx_inner_kvlist_clone));
+  filterx_object_unref(fx_inner_kvlist_clone);
 
   /* $inner_kvlist["key_0"] = "foo"; */
   cr_assert(filterx_object_set_subscript(fx_inner_kvlist, fx_key_0, fx_foo));
@@ -931,7 +935,9 @@ Test(otel_filterx, array_through_logrecord)
   cr_assert(filterx_object_set_subscript(fx_array, nullptr, fx_foo));
 
   /* $log.body = $array; */
-  cr_assert(filterx_object_setattr(fx_logrecord, "body", fx_array));
+  FilterXObject *fx_array_clone = filterx_object_clone(fx_array);
+  cr_assert(filterx_object_setattr(fx_logrecord, "body", fx_array_clone));
+  filterx_object_unref(fx_array_clone);
 
   /* $log.body[] = "bar"; */
   fx_get_1 = filterx_object_getattr(fx_logrecord, "body");
@@ -945,7 +951,9 @@ Test(otel_filterx, array_through_logrecord)
   filterx_object_unref(fx_get_1);
   fx_get_1 = filterx_object_getattr(fx_logrecord, "body");
   cr_assert(fx_get_1);
-  cr_assert(filterx_object_set_subscript(fx_get_1, nullptr, fx_inner_array));
+  FilterXObject *fx_inner_array_clone = filterx_object_clone(fx_inner_array);
+  cr_assert(filterx_object_set_subscript(fx_get_1, nullptr, fx_inner_array_clone));
+  filterx_object_unref(fx_inner_array_clone);
 
   /* $inner_array[] = "foo"; */
   cr_assert(filterx_object_set_subscript(fx_inner_array, nullptr, fx_foo));


### PR DESCRIPTION
When we will write filterx based parsers, these functions will be used extensively. A recurring pattern is creating a dict or list, storing it as a kv pair in a parent dict with set_subscript() then wanting to add elements to it.

The current interface puts the responsibility to the Object's implementation to clone the value in the setter functions, and it always happens there.

For our internal parser codes, these clone() calls just waste resources, and makes it awkward to set the mutable value, and get the stored value immediately so it can modify it.

I have tried 3-4 different ways to solve this, but eventually came to this solution, which is the simplest and most performant: The Object interface now requires the implementation to accept the new value, and modify it, so that it represents the stored value. No cloning must happen there, we only clone on the end user related parts (expr-set-subscript and expr-setattr).

Our parser codes can simply set a mutable value, and operate on the same FilterXObject immediately, but must take care of cloning, where it is necessary (however it is extremely rare).

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
