### PR TITLE
[2/6] filterx: dict and list interfaces with json and otel

### DIFF
--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -27,6 +27,8 @@ set(FILTERX_HEADERS
     filterx/object-null.h
     filterx/object-primitive.h
     filterx/object-string.h
+    filterx/object-list-interface.h
+    filterx/object-dict-interface.h
     filterx/expr-condition.h
     filterx/filterx-globals-tests.h
     PARENT_SCOPE
@@ -61,6 +63,8 @@ set(FILTERX_SOURCES
     filterx/object-null.c
     filterx/object-primitive.c
     filterx/object-string.c
+    filterx/object-list-interface.c
+    filterx/object-dict-interface.c
     filterx/expr-condition.c
     PARENT_SCOPE
     )

--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -23,6 +23,7 @@ set(FILTERX_HEADERS
     filterx/filterx-weakrefs.h
     filterx/object-datetime.h
     filterx/object-json.h
+    filterx/object-json-internal.h
     filterx/object-message-value.h
     filterx/object-null.h
     filterx/object-primitive.h
@@ -59,6 +60,8 @@ set(FILTERX_SOURCES
     filterx/filterx-weakrefs.c
     filterx/object-datetime.c
     filterx/object-json.c
+    filterx/object-json-object.c
+    filterx/object-json-array.c
     filterx/object-message-value.c
     filterx/object-null.c
     filterx/object-primitive.c

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -26,6 +26,8 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/object-datetime.h		\
 	lib/filterx/object-null.h		\
 	lib/filterx/object-message-value.h	\
+	lib/filterx/object-list-interface.h	\
+	lib/filterx/object-dict-interface.h	\
 	lib/filterx/filterx-config.h		\
 	lib/filterx/filterx-pipe.h		\
 	lib/filterx/expr-function.h	\
@@ -59,6 +61,8 @@ filterx_sources = 				\
 	lib/filterx/object-datetime.c		\
 	lib/filterx/object-null.c		\
 	lib/filterx/object-message-value.c	\
+	lib/filterx/object-list-interface.c	\
+	lib/filterx/object-dict-interface.c	\
 	lib/filterx/filterx-config.c		\
 	lib/filterx/filterx-pipe.c		\
 	lib/filterx/expr-function.c		\

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -22,6 +22,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/filterx-scope.h		\
 	lib/filterx/filterx-eval.h		\
 	lib/filterx/object-json.h		\
+	lib/filterx/object-json-internal.h		\
 	lib/filterx/object-string.h		\
 	lib/filterx/object-datetime.h		\
 	lib/filterx/object-null.h		\
@@ -57,6 +58,8 @@ filterx_sources = 				\
 	lib/filterx/filterx-scope.c		\
 	lib/filterx/filterx-eval.c		\
 	lib/filterx/object-json.c		\
+	lib/filterx/object-json-object.c		\
+	lib/filterx/object-json-array.c		\
 	lib/filterx/object-string.c		\
 	lib/filterx/object-datetime.c		\
 	lib/filterx/object-null.c		\

--- a/lib/filterx/expr-comparison.c
+++ b/lib/filterx/expr-comparison.c
@@ -55,11 +55,6 @@ _convert_filterx_object_to_generic_number(FilterXObject *obj, GenericNumber *gn)
     }
   else if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(null)))
     gn_set_int64(gn, 0);
-  else if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(bytes)) ||
-           filterx_object_is_type(obj, &FILTERX_TYPE_NAME(protobuf)) ||
-           filterx_object_is_type(obj, &FILTERX_TYPE_NAME(message_value)) ||
-           filterx_object_is_type(obj, &FILTERX_TYPE_NAME(json)))
-    gn_set_nan(gn);
   else if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(datetime)))
     {
       const UnixTime utime = filterx_datetime_get_value(obj);
@@ -148,7 +143,8 @@ _evaluate_type_aware(FilterXObject *lhs, FilterXObject *rhs, gint operator)
       filterx_object_is_type(lhs, &FILTERX_TYPE_NAME(bytes)) ||
       filterx_object_is_type(lhs, &FILTERX_TYPE_NAME(protobuf)) ||
       filterx_object_is_type(lhs, &FILTERX_TYPE_NAME(message_value)) ||
-      filterx_object_is_type(lhs, &FILTERX_TYPE_NAME(json)))
+      filterx_object_is_type(lhs, &FILTERX_TYPE_NAME(json_object)) || // TODO: we should have generic map and array cmp
+      filterx_object_is_type(lhs, &FILTERX_TYPE_NAME(json_array)))
     return _evaluate_as_string(lhs, rhs, operator);
 
   if (filterx_object_is_type(lhs, &FILTERX_TYPE_NAME(null)) ||

--- a/lib/filterx/expr-dict.c
+++ b/lib/filterx/expr-dict.c
@@ -74,7 +74,7 @@ static FilterXObject *
 _eval(FilterXExpr *s)
 {
   FilterXDictExpr *self = (FilterXDictExpr *) s;
-  FilterXObject *object = filterx_json_new(json_object_new_object());
+  FilterXObject *object = filterx_json_object_new_empty();
 
   for (GList *l = self->key_values; l; l = l->next)
     {

--- a/lib/filterx/expr-list.c
+++ b/lib/filterx/expr-list.c
@@ -33,9 +33,8 @@ typedef struct _FilterXListExpr
 } FilterXListExpr;
 
 static gboolean
-_eval_value(FilterXListExpr *self, FilterXObject *object, gint i, FilterXExpr *expr)
+_eval_value(FilterXListExpr *self, FilterXObject *object, FilterXExpr *expr)
 {
-  FilterXObject *index = filterx_integer_new(i);
   FilterXObject *value = filterx_expr_eval_typed(expr);
   if (!value)
     return FALSE;
@@ -43,7 +42,7 @@ _eval_value(FilterXListExpr *self, FilterXObject *object, gint i, FilterXExpr *e
   FilterXObject *cloned_value = filterx_object_clone(value);
   filterx_object_unref(value);
 
-  gboolean success = filterx_object_set_subscript(object, index, cloned_value);
+  gboolean success = filterx_object_set_subscript(object, NULL, cloned_value);
   filterx_object_unref(cloned_value);
   return success;
 }
@@ -54,12 +53,10 @@ _eval(FilterXExpr *s)
   FilterXListExpr *self = (FilterXListExpr *) s;
   FilterXObject *object = filterx_json_array_new_empty();
 
-  gint index = 0;
   for (GList *l = self->values; l; l = l->next)
     {
-      if (!_eval_value(self, object, index, l->data))
+      if (!_eval_value(self, object, l->data))
         goto fail;
-      index += 1;
     }
   return object;
 fail:

--- a/lib/filterx/expr-list.c
+++ b/lib/filterx/expr-list.c
@@ -52,7 +52,7 @@ static FilterXObject *
 _eval(FilterXExpr *s)
 {
   FilterXListExpr *self = (FilterXListExpr *) s;
-  FilterXObject *object = filterx_json_new(json_object_new_array());
+  FilterXObject *object = filterx_json_array_new_empty();
 
   gint index = 0;
   for (GList *l = self->values; l; l = l->next)

--- a/lib/filterx/expr-list.c
+++ b/lib/filterx/expr-list.c
@@ -37,18 +37,14 @@ _eval_value(FilterXListExpr *self, FilterXObject *object, gint i, FilterXExpr *e
 {
   FilterXObject *index = filterx_integer_new(i);
   FilterXObject *value = filterx_expr_eval_typed(expr);
-  gboolean success = FALSE;
-
   if (!value)
-    goto fail;
+    return FALSE;
 
-  if (!filterx_object_set_subscript(object, index, value))
-    goto fail;
-
-  success = TRUE;
-fail:
+  FilterXObject *cloned_value = filterx_object_clone(value);
   filterx_object_unref(value);
-  filterx_object_unref(index);
+
+  gboolean success = filterx_object_set_subscript(object, index, cloned_value);
+  filterx_object_unref(cloned_value);
   return success;
 }
 

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -58,11 +58,16 @@ _eval(FilterXExpr *s)
   if (!new_value)
     goto exit;
 
-  if (!filterx_object_set_subscript(object, index, new_value))
-    goto exit;
-  result = filterx_object_ref(new_value);
-exit:
+  result = filterx_object_clone(new_value);
   filterx_object_unref(new_value);
+
+  if (!filterx_object_set_subscript(object, index, result))
+    {
+      filterx_object_unref(result);
+      result = NULL;
+    }
+
+exit:
   filterx_object_unref(index);
   filterx_object_unref(object);
   return result;

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -45,12 +45,17 @@ _eval(FilterXExpr *s)
   if (!new_value)
     goto exit;
 
-  if (!filterx_object_setattr(object, self->attr_name, new_value))
-    goto exit;
-  result = filterx_object_ref(new_value);
+  result = filterx_object_clone(new_value);
+  filterx_object_unref(new_value);
+
+  if (!filterx_object_setattr(object, self->attr_name, result))
+    {
+      filterx_object_unref(result);
+      result = NULL;
+    }
+
 exit:
   filterx_object_unref(object);
-  filterx_object_unref(new_value);
   return result;
 }
 

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -82,14 +82,18 @@ filterx_expr_eval_typed(FilterXExpr *self)
       filterx_object_unref(result);
       return NULL;
     }
-  if (result != unmarshalled)
+
+  if (result == unmarshalled)
     {
-      filterx_object_unref(result);
-      if (self->_update_repr)
-        self->_update_repr(self, unmarshalled);
-      result = unmarshalled;
+      filterx_object_unref(unmarshalled);
+      return result;
     }
-  return result;
+
+  filterx_object_unref(result);
+  if (self->_update_repr)
+    self->_update_repr(self, unmarshalled);
+
+  return unmarshalled;
 }
 
 

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -27,6 +27,8 @@
 #include "filterx/object-json.h"
 #include "filterx/object-datetime.h"
 #include "filterx/object-message-value.h"
+#include "filterx/object-list-interface.h"
+#include "filterx/object-dict-interface.h"
 
 static GHashTable *filterx_builtin_functions = NULL;
 
@@ -81,6 +83,9 @@ filterx_builtin_functions_deinit(void)
 void
 filterx_global_init(void)
 {
+  filterx_type_init(&FILTERX_TYPE_NAME(list));
+  filterx_type_init(&FILTERX_TYPE_NAME(dict));
+
   filterx_type_init(&FILTERX_TYPE_NAME(null));
   filterx_type_init(&FILTERX_TYPE_NAME(integer));
   filterx_type_init(&FILTERX_TYPE_NAME(boolean));

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -95,7 +95,8 @@ filterx_global_init(void)
   filterx_type_init(&FILTERX_TYPE_NAME(bytes));
   filterx_type_init(&FILTERX_TYPE_NAME(protobuf));
 
-  filterx_type_init(&FILTERX_TYPE_NAME(json));
+  filterx_type_init(&FILTERX_TYPE_NAME(json_object));
+  filterx_type_init(&FILTERX_TYPE_NAME(json_array));
   filterx_type_init(&FILTERX_TYPE_NAME(datetime));
   filterx_type_init(&FILTERX_TYPE_NAME(message_value));
 

--- a/lib/filterx/filterx-object.c
+++ b/lib/filterx/filterx-object.c
@@ -51,6 +51,7 @@ filterx_type_init(FilterXType *type)
   INIT_TYPE_METHOD(type, setattr);
   INIT_TYPE_METHOD(type, get_subscript);
   INIT_TYPE_METHOD(type, set_subscript);
+  INIT_TYPE_METHOD(type, has_subscript);
   INIT_TYPE_METHOD(type, free_fn);
 }
 

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -44,6 +44,7 @@ struct _FilterXType
   gboolean (*setattr)(FilterXObject *self, const gchar *attr_name, FilterXObject *new_value);
   FilterXObject *(*get_subscript)(FilterXObject *self, FilterXObject *index);
   gboolean (*set_subscript)(FilterXObject *self, FilterXObject *index, FilterXObject *new_value);
+  gboolean (*has_subscript)(FilterXObject *self, FilterXObject *key);
   void (*free_fn)(FilterXObject *self);
 };
 
@@ -192,6 +193,14 @@ filterx_object_set_subscript(FilterXObject *self, FilterXObject *index, FilterXO
 {
   if (self->type->set_subscript)
     return self->type->set_subscript(self, index, new_value);
+  return FALSE;
+}
+
+static inline gboolean
+filterx_object_has_subscript(FilterXObject *self, FilterXObject *index)
+{
+  if (self->type->has_subscript)
+    return self->type->has_subscript(self, index);
   return FALSE;
 }
 

--- a/lib/filterx/object-dict-interface.c
+++ b/lib/filterx/object-dict-interface.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2024 Attila Szakacs
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "filterx/object-dict-interface.h"
+#include "filterx/object-string.h"
+
+guint64
+filterx_dict_len(FilterXObject *s)
+{
+  FilterXDict *self = (FilterXDict *) s;
+  return self->len(self);
+}
+
+static FilterXObject *
+_get_subscript(FilterXObject *s, FilterXObject *key)
+{
+  FilterXDict *self = (FilterXDict *) s;
+
+  if (!key)
+    {
+      msg_error("FilterX: Failed to get element of dict, key is mandatory");
+      return NULL;
+    }
+
+  return self->get_subscript(self, key);
+}
+
+static gboolean
+_set_subscript(FilterXObject *s, FilterXObject *key, FilterXObject *new_value)
+{
+  FilterXDict *self = (FilterXDict *) s;
+
+  if (!key)
+    {
+      msg_error("FilterX: Failed to set element of dict, key is mandatory");
+      return FALSE;
+    }
+
+  return self->set_subscript(self, key, new_value);
+}
+
+static gboolean
+_has_subscript(FilterXObject *s, FilterXObject *key)
+{
+  FilterXDict *self = (FilterXDict *) s;
+
+  if (!key)
+    {
+      msg_error("FilterX: Failed to check key of dict, key is mandatory");
+      return FALSE;
+    }
+
+  if (self->has_subscript)
+    return self->has_subscript(self, key);
+
+  FilterXObject *value = self->get_subscript(self, key);
+  filterx_object_unref(value);
+  return !!value;
+}
+
+static FilterXObject *
+_getattr(FilterXObject *s, const gchar *attr_name)
+{
+  FilterXDict *self = (FilterXDict *) s;
+
+  if (!self->support_attr)
+    return NULL;
+
+  FilterXObject *key = filterx_string_new(attr_name, -1);
+  FilterXObject *result = self->get_subscript(self, key);
+  filterx_object_unref(key);
+  return result;
+}
+
+static gboolean
+_setattr(FilterXObject *s, const gchar *attr_name, FilterXObject *new_value)
+{
+  FilterXDict *self = (FilterXDict *) s;
+
+  if (!self->support_attr)
+    return FALSE;
+
+  FilterXObject *key = filterx_string_new(attr_name, -1);
+  gboolean result = self->set_subscript(self, key, new_value);
+  filterx_object_unref(key);
+  return result;
+}
+
+void
+filterx_dict_init_instance(FilterXDict *self, FilterXType *type)
+{
+  g_assert(type->is_mutable);
+  g_assert(type->get_subscript == _get_subscript);
+  g_assert(type->set_subscript == _set_subscript);
+  g_assert(type->has_subscript == _has_subscript);
+  g_assert(type->getattr == _getattr);
+  g_assert(type->setattr == _setattr);
+
+  filterx_object_init_instance(&self->super, type);
+
+  self->support_attr = TRUE;
+}
+
+FILTERX_DEFINE_TYPE(dict, FILTERX_TYPE_NAME(object),
+                    .is_mutable = TRUE,
+                    .get_subscript = _get_subscript,
+                    .set_subscript = _set_subscript,
+                    .has_subscript = _has_subscript,
+                    .getattr = _getattr,
+                    .setattr = _setattr,
+                   );

--- a/lib/filterx/object-dict-interface.h
+++ b/lib/filterx/object-dict-interface.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Attila Szakacs
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef FILTERX_OBJECT_DICT_INTERFACE_H_INCLUDED
+#define FILTERX_OBJECT_DICT_INTERFACE_H_INCLUDED
+
+#include "filterx/filterx-object.h"
+
+typedef struct FilterXDict_ FilterXDict;
+
+struct FilterXDict_
+{
+  FilterXObject super;
+  gboolean support_attr;
+
+  FilterXObject *(*get_subscript)(FilterXDict *s, FilterXObject *key);
+  gboolean (*set_subscript)(FilterXDict *s, FilterXObject *key, FilterXObject *new_value);
+  gboolean (*has_subscript)(FilterXDict *s, FilterXObject *key);
+  guint64 (*len)(FilterXDict *s);
+};
+
+guint64 filterx_dict_len(FilterXObject *s);
+
+void filterx_dict_init_instance(FilterXDict *self, FilterXType *type);
+
+FILTERX_DECLARE_TYPE(dict);
+
+#endif

--- a/lib/filterx/object-json-array.c
+++ b/lib/filterx/object-json-array.c
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2023 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "filterx/object-json-internal.h"
+#include "filterx/object-null.h"
+#include "filterx/object-primitive.h"
+#include "filterx/object-string.h"
+#include "filterx/filterx-weakrefs.h"
+#include "filterx/object-list-interface.h"
+
+#include "scanner/list-scanner/list-scanner.h"
+#include "str-repr/encode.h"
+
+#define JSON_ARRAY_MAX_SIZE 65536
+
+struct FilterXJsonArray_
+{
+  FilterXList super;
+  FilterXWeakRef root_container;
+  struct json_object *object;
+};
+
+static gboolean
+_truthy(FilterXObject *s)
+{
+  return TRUE;
+}
+
+static gboolean
+_marshal_to_json_literal(FilterXJsonArray *self, GString *repr, LogMessageValueType *t)
+{
+  g_string_truncate(repr, 0);
+  *t = LM_VT_JSON;
+
+  const gchar *json_repr = json_object_to_json_string_ext(self->object, JSON_C_TO_STRING_PLAIN);
+  g_string_append(repr, json_repr);
+
+  return TRUE;
+}
+
+static gboolean
+_marshal(FilterXObject *s, GString *repr, LogMessageValueType *t)
+{
+  FilterXJsonArray *self = (FilterXJsonArray *) s;
+
+  for (gint i = 0; i < json_object_array_length(self->object); i++)
+    {
+      struct json_object *el = json_object_array_get_idx(self->object, i);
+      if (json_object_get_type(el) != json_type_string)
+        return _marshal_to_json_literal(self, repr, t);
+
+      if (i != 0)
+        g_string_append_c(repr, ',');
+
+      str_repr_encode_append(repr, json_object_get_string(el), -1, NULL);
+    }
+
+  *t = LM_VT_LIST;
+  return TRUE;
+}
+
+static gboolean
+_map_to_json(FilterXObject *s, struct json_object **object)
+{
+  FilterXJsonArray *self = (FilterXJsonArray *) s;
+
+  *object = json_object_get(self->object);
+  return TRUE;
+}
+
+static FilterXObject *
+_clone(FilterXObject *s)
+{
+  FilterXJsonArray *self = (FilterXJsonArray *) s;
+
+  struct json_object *json_obj = filterx_json_deep_copy(self->object);
+  if (!json_obj)
+    return NULL;
+
+  return filterx_json_array_new_sub(json_obj, NULL);
+}
+
+static FilterXObject *
+_get_subscript(FilterXList *s, guint64 index)
+{
+  FilterXJsonArray *self = (FilterXJsonArray *) s;
+
+  struct json_object *result = json_object_array_get_idx(self->object, index);
+  if (!result)
+    return NULL;
+
+  return filterx_json_convert_json_to_object_cached(&s->super, &self->root_container, result);
+}
+
+static gboolean
+_append(FilterXList *s, FilterXObject *new_value)
+{
+  FilterXJsonArray *self = (FilterXJsonArray *) s;
+
+  if (G_UNLIKELY(filterx_list_len(&s->super) >= JSON_ARRAY_MAX_SIZE))
+    return FALSE;
+
+  struct json_object *new_json_value = NULL;
+  if (!filterx_object_map_to_json(new_value, &new_json_value))
+    return FALSE;
+
+  if (json_object_array_add(self->object, new_json_value) != 0)
+    {
+      json_object_put(new_json_value);
+      return FALSE;
+    }
+
+  self->super.super.modified_in_place = TRUE;
+  FilterXObject *root_container = filterx_weakref_get(&self->root_container);
+  if (root_container)
+    {
+      root_container->modified_in_place = TRUE;
+      filterx_object_unref(root_container);
+    }
+
+  return TRUE;
+}
+
+static gboolean
+_set_subscript(FilterXList *s, guint64 index, FilterXObject *new_value)
+{
+  FilterXJsonArray *self = (FilterXJsonArray *) s;
+
+  if (G_UNLIKELY(index >= JSON_ARRAY_MAX_SIZE))
+    return FALSE;
+
+  struct json_object *new_json_value = NULL;
+  if (!filterx_object_map_to_json(new_value, &new_json_value))
+    return FALSE;
+
+  filterx_json_associate_cached_object(new_json_value, new_value);
+
+  if (json_object_array_put_idx(self->object, index, new_json_value) != 0)
+    {
+      json_object_put(new_json_value);
+      return FALSE;
+    }
+
+  self->super.super.modified_in_place = TRUE;
+  FilterXObject *root_container = filterx_weakref_get(&self->root_container);
+  if (root_container)
+    {
+      root_container->modified_in_place = TRUE;
+      filterx_object_unref(root_container);
+    }
+
+  return TRUE;
+}
+
+static guint64
+_len(FilterXList *s)
+{
+  FilterXJsonArray *self = (FilterXJsonArray *) s;
+
+  return json_object_array_length(self->object);
+}
+
+/* NOTE: consumes root ref */
+FilterXObject *
+filterx_json_array_new_sub(struct json_object *object, FilterXObject *root)
+{
+  FilterXJsonArray *self = g_new0(FilterXJsonArray, 1);
+  filterx_list_init_instance(&self->super, &FILTERX_TYPE_NAME(json_array));
+
+  self->super.get_subscript = _get_subscript;
+  self->super.set_subscript = _set_subscript;
+  self->super.append = _append;
+  self->super.len = _len;
+
+  filterx_weakref_set(&self->root_container, root);
+  filterx_object_unref(root);
+  self->object = object;
+
+  return &self->super.super;
+}
+
+static void
+_free(FilterXObject *s)
+{
+  FilterXJsonArray *self = (FilterXJsonArray *) s;
+
+  json_object_put(self->object);
+  filterx_weakref_clear(&self->root_container);
+}
+
+FilterXObject *
+filterx_json_array_new_from_repr(const gchar *repr, gssize repr_len)
+{
+  struct json_object *object = json_object_new_array();
+
+  ListScanner scanner;
+  list_scanner_init(&scanner);
+  list_scanner_input_string(&scanner, repr, repr_len);
+  for (gint i = 0; list_scanner_scan_next(&scanner); i++)
+    {
+      json_object_array_put_idx(object, i,
+                                json_object_new_string_len(list_scanner_get_current_value(&scanner),
+                                                           list_scanner_get_current_value_len(&scanner)));
+    }
+  list_scanner_deinit(&scanner);
+
+  return filterx_json_array_new_sub(object, NULL);
+}
+
+FilterXObject *
+filterx_json_array_new_empty(void)
+{
+  return filterx_json_array_new_sub(json_object_new_array(), NULL);
+}
+
+FILTERX_DEFINE_TYPE(json_array, FILTERX_TYPE_NAME(list),
+                    .is_mutable = TRUE,
+                    .truthy = _truthy,
+                    .free_fn = _free,
+                    .marshal = _marshal,
+                    .map_to_json = _map_to_json,
+                    .clone = _clone,
+                   );

--- a/lib/filterx/object-json-internal.h
+++ b/lib/filterx/object-json-internal.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ * Copyright (c) 2024 Attila Szakacs
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,23 +21,19 @@
  * COPYING for details.
  *
  */
-#ifndef OBJECT_JSON_H_INCLUDED
-#define OBJECT_JSON_H_INCLUDED
+#ifndef OBJECT_JSON_INTERNAL_H_INCLUDED
+#define OBJECT_JSON_INTERNAL_H_INCLUDED
 
-#include "filterx/filterx-object.h"
-#include "compat/json.h"
+#include "object-json.h"
+#include "filterx/filterx-weakrefs.h"
 
-typedef struct FilterXJsonObject_ FilterXJsonObject;
-typedef struct FilterXJsonArray_ FilterXJsonArray;
+void filterx_json_associate_cached_object(struct json_object *json_obj, FilterXObject *filterx_object);
+FilterXObject *filterx_json_convert_json_to_object_cached(FilterXObject *self, FilterXWeakRef *root_container,
+                                                          struct json_object *json_obj);
 
-FILTERX_DECLARE_TYPE(json_object);
-FILTERX_DECLARE_TYPE(json_array);
+struct json_object *filterx_json_deep_copy(struct json_object *json_obj);
 
-FilterXObject *filterx_json_new_from_repr(const gchar *repr, gssize repr_len);
-FilterXObject *filterx_json_object_new_from_repr(const gchar *repr, gssize repr_len);
-FilterXObject *filterx_json_array_new_from_repr(const gchar *repr, gssize repr_len);
-
-FilterXObject *filterx_json_object_new_empty(void);
-FilterXObject *filterx_json_array_new_empty(void);
+FilterXObject *filterx_json_object_new_sub(struct json_object *json_obj, FilterXObject *root);
+FilterXObject *filterx_json_array_new_sub(struct json_object *json_obj, FilterXObject *root);
 
 #endif

--- a/lib/filterx/object-json-object.c
+++ b/lib/filterx/object-json-object.c
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2023 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "filterx/object-json-internal.h"
+#include "filterx/object-null.h"
+#include "filterx/object-primitive.h"
+#include "filterx/object-string.h"
+#include "filterx/filterx-weakrefs.h"
+#include "filterx/object-dict-interface.h"
+
+struct FilterXJsonObject_
+{
+  FilterXDict super;
+  FilterXWeakRef root_container;
+  struct json_object *object;
+};
+
+static gboolean
+_truthy(FilterXObject *s)
+{
+  return TRUE;
+}
+
+static gboolean
+_marshal(FilterXObject *s, GString *repr, LogMessageValueType *t)
+{
+  FilterXJsonObject *self = (FilterXJsonObject *) s;
+
+  *t = LM_VT_JSON;
+
+  const gchar *json_repr = json_object_to_json_string_ext(self->object, JSON_C_TO_STRING_PLAIN);
+  g_string_append(repr, json_repr);
+
+  return TRUE;
+}
+
+static gboolean
+_map_to_json(FilterXObject *s, struct json_object **json_obj)
+{
+  FilterXJsonObject *self = (FilterXJsonObject *) s;
+
+  *json_obj = json_object_get(self->object);
+  return TRUE;
+}
+
+static FilterXObject *
+_clone(FilterXObject *s)
+{
+  FilterXJsonObject *self = (FilterXJsonObject *) s;
+
+  struct json_object *json_obj = filterx_json_deep_copy(self->object);
+  if (!json_obj)
+    return NULL;
+
+  return filterx_json_object_new_sub(json_obj, NULL);
+}
+
+static FilterXObject *
+_get_subscript(FilterXDict *s, FilterXObject *key)
+{
+  FilterXJsonObject *self = (FilterXJsonObject *) s;
+
+  const gchar *key_str = filterx_string_get_value(key, NULL);
+  if (!key_str)
+    return NULL;
+
+  struct json_object *result = NULL;
+  if (!json_object_object_get_ex(self->object, key_str, &result))
+    return NULL;
+
+  return filterx_json_convert_json_to_object_cached(&s->super, &self->root_container, result);
+}
+
+static gboolean
+_set_subscript(FilterXDict *s, FilterXObject *key, FilterXObject *new_value)
+{
+  FilterXJsonObject *self = (FilterXJsonObject *) s;
+
+  const gchar *key_str = filterx_string_get_value(key, NULL);
+  if (!key_str)
+    return FALSE;
+
+  struct json_object *new_json_value = NULL;
+  if (!filterx_object_map_to_json(new_value, &new_json_value))
+    return FALSE;
+
+  filterx_json_associate_cached_object(new_json_value, new_value);
+
+  if (json_object_object_add(self->object, key_str, new_json_value) != 0)
+    {
+      json_object_put(new_json_value);
+      return FALSE;
+    }
+
+  self->super.super.modified_in_place = TRUE;
+  FilterXObject *root_container = filterx_weakref_get(&self->root_container);
+  if (root_container)
+    {
+      root_container->modified_in_place = TRUE;
+      filterx_object_unref(root_container);
+    }
+
+  return TRUE;
+}
+
+static guint64
+_len(FilterXDict *s)
+{
+  FilterXJsonObject *self = (FilterXJsonObject *) s;
+
+  return json_object_object_length(self->object);
+}
+
+/* NOTE: consumes root ref */
+FilterXObject *
+filterx_json_object_new_sub(struct json_object *json_obj, FilterXObject *root)
+{
+  FilterXJsonObject *self = g_new0(FilterXJsonObject, 1);
+  filterx_dict_init_instance(&self->super, &FILTERX_TYPE_NAME(json_object));
+
+  self->super.get_subscript = _get_subscript;
+  self->super.set_subscript = _set_subscript;
+  self->super.len = _len;
+
+  filterx_weakref_set(&self->root_container, root);
+  filterx_object_unref(root);
+  self->object = json_obj;
+
+  return &self->super.super;
+}
+
+static void
+_free(FilterXObject *s)
+{
+  FilterXJsonObject *self = (FilterXJsonObject *) s;
+
+  json_object_put(self->object);
+  filterx_weakref_clear(&self->root_container);
+}
+
+FilterXObject *
+filterx_json_object_new_from_repr(const gchar *repr, gssize repr_len)
+{
+  struct json_tokener *tokener = json_tokener_new();
+  struct json_object *json_obj;
+
+  json_obj = json_tokener_parse_ex(tokener, repr, repr_len < 0 ? strlen(repr) : repr_len);
+  if (repr_len >= 0 && json_tokener_get_error(tokener) == json_tokener_continue)
+    {
+      /* pass the closing NUL character */
+      json_obj = json_tokener_parse_ex(tokener, "", 1);
+    }
+
+  json_tokener_free(tokener);
+  return filterx_json_object_new_sub(json_obj, NULL);
+}
+
+FilterXObject *
+filterx_json_object_new_empty(void)
+{
+  return filterx_json_object_new_sub(json_object_new_object(), NULL);
+}
+
+FILTERX_DEFINE_TYPE(json_object, FILTERX_TYPE_NAME(dict),
+                    .is_mutable = TRUE,
+                    .truthy = _truthy,
+                    .free_fn = _free,
+                    .marshal = _marshal,
+                    .map_to_json = _map_to_json,
+                    .clone = _clone,
+                   );

--- a/lib/filterx/object-json.c
+++ b/lib/filterx/object-json.c
@@ -192,14 +192,10 @@ _setattr(FilterXObject *s, const gchar *attr_name, FilterXObject *new_value)
   FilterXJSON *self = (FilterXJSON *) s;
   struct json_object *attr_value = NULL;
 
-  /* this only clones mutable objects */
-  new_value = filterx_object_clone(new_value);
-
   if (!filterx_object_map_to_json(new_value, &attr_value))
     return FALSE;
 
   filterx_json_associate_cached_object(attr_value, new_value);
-  filterx_object_unref(new_value);
 
   if (json_object_object_add(self->object, attr_name, attr_value) != 0)
     {
@@ -306,14 +302,10 @@ _set_subscript(FilterXObject *s, FilterXObject *index, FilterXObject *new_value)
   struct json_object *attr_value = NULL;
   gboolean result = FALSE;
 
-  /* this only clones mutable objects */
-  new_value = filterx_object_clone(new_value);
-
   if (!filterx_object_map_to_json(new_value, &attr_value))
     return FALSE;
 
   filterx_json_associate_cached_object(attr_value, new_value);
-  filterx_object_unref(new_value);
 
   if (json_object_is_type(self->object, json_type_array))
     result = _set_subscript_array(self, index, attr_value);

--- a/lib/filterx/object-list-interface.c
+++ b/lib/filterx/object-list-interface.c
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2024 Attila Szakacs
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "filterx/object-list-interface.h"
+#include "filterx/object-primitive.h"
+
+guint64
+filterx_list_len(FilterXObject *s)
+{
+  FilterXList *self = (FilterXList *) s;
+  return self->len(self);
+}
+
+FilterXObject *
+filterx_list_get_subscript(FilterXObject *s, gint64 index)
+{
+  FilterXObject *index_obj = filterx_integer_new(index);
+  FilterXObject *result = filterx_object_get_subscript(s, index_obj);
+
+  filterx_object_unref(index_obj);
+  return result;
+}
+
+gboolean
+filterx_list_set_subscript(FilterXObject *s, gint64 index, FilterXObject *new_value)
+{
+  FilterXObject *index_obj = filterx_integer_new(index);
+  gboolean result = filterx_object_set_subscript(s, index_obj, new_value);
+
+  filterx_object_unref(index_obj);
+  return result;
+}
+
+gboolean
+filterx_list_append(FilterXObject *s, FilterXObject *new_value)
+{
+  return filterx_object_set_subscript(s, NULL, new_value);
+}
+
+static gboolean
+_normalize_index(FilterXList *self, gint64 index, guint64 *normalized_index, const gchar **error)
+{
+  guint64 len = filterx_list_len(&self->super);
+
+  if (index >= 0)
+    {
+      if (index >= len)
+        {
+          *error = "Index out of range";
+          return FALSE;
+        }
+
+      *normalized_index = (guint64) index;
+      return TRUE;
+    }
+
+  if (len > G_MAXINT64)
+    {
+      *error = "Index exceeds maximal supported value";
+      return FALSE;
+    }
+
+  *normalized_index = len + index;
+  if (*normalized_index < 0)
+    {
+      *error = "Index out of range";
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static FilterXObject *
+_get_subscript(FilterXObject *s, FilterXObject *key)
+{
+  FilterXList *self = (FilterXList *) s;
+
+  gint64 index;
+  if (!filterx_integer_unwrap(key, &index))
+    {
+      msg_error("FilterX: Failed to get element from list",
+                evt_tag_str("error", "Index must be integer"),
+                evt_tag_str("index_type", key->type->name));
+      return NULL;
+    }
+
+  guint64 normalized_index;
+  const gchar *error;
+  if (!_normalize_index(self, index, &normalized_index, &error))
+    {
+      msg_error("FilterX: Failed to get element from list",
+                evt_tag_str("error", error),
+                evt_tag_printf("index", "%" G_GINT64_FORMAT, index),
+                evt_tag_printf("len", "%" G_GUINT64_FORMAT, filterx_list_len(s)));
+      return NULL;
+    }
+
+  return self->get_subscript(self, normalized_index);
+}
+
+static gboolean
+_set_subscript(FilterXObject *s, FilterXObject *key, FilterXObject *new_value)
+{
+  FilterXList *self = (FilterXList *) s;
+
+  if (!key)
+    return self->append(self, new_value);
+
+  gint64 index;
+  if (!filterx_integer_unwrap(key, &index))
+    {
+      msg_error("FilterX: Failed to set element of list",
+                evt_tag_str("error", "Index must be integer"),
+                evt_tag_str("index_type", key->type->name));
+      return FALSE;
+    }
+
+  guint64 normalized_index;
+  const gchar *error;
+  if (!_normalize_index(self, index, &normalized_index, &error))
+    {
+      msg_error("FilterX: Failed to set element of list",
+                evt_tag_str("error", error),
+                evt_tag_printf("index", "%" G_GINT64_FORMAT, index),
+                evt_tag_printf("len", "%" G_GUINT64_FORMAT, filterx_list_len(s)));
+      return FALSE;
+    }
+
+  return self->set_subscript(self, normalized_index, new_value);
+}
+
+static gboolean
+_has_subscript(FilterXObject *s, FilterXObject *key)
+{
+  FilterXList *self = (FilterXList *) s;
+
+  if (!key)
+    {
+      msg_error("FilterX: Failed to check index of list",
+                evt_tag_str("error", "Index must be sey"));
+      return FALSE;
+    }
+
+  gint64 index;
+  if (!filterx_integer_unwrap(key, &index))
+    {
+      msg_error("FilterX: Failed to check index of list",
+                evt_tag_str("error", "Index must be integer"),
+                evt_tag_str("index_type", key->type->name));
+      return FALSE;
+    }
+
+  guint64 normalized_index;
+  const gchar *error;
+  return _normalize_index(self, index, &normalized_index, &error);
+}
+
+void
+filterx_list_init_instance(FilterXList *self, FilterXType *type)
+{
+  g_assert(type->is_mutable);
+  g_assert(type->get_subscript == _get_subscript);
+  g_assert(type->set_subscript == _set_subscript);
+  g_assert(type->has_subscript == _has_subscript);
+
+  filterx_object_init_instance(&self->super, type);
+}
+
+FILTERX_DEFINE_TYPE(list, FILTERX_TYPE_NAME(object),
+                    .is_mutable = TRUE,
+                    .get_subscript = _get_subscript,
+                    .set_subscript = _set_subscript,
+                    .has_subscript = _has_subscript,
+                   );

--- a/lib/filterx/object-list-interface.h
+++ b/lib/filterx/object-list-interface.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024 Attila Szakacs
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef FILTERX_OBJECT_LIST_INTERFACE_H_INCLUDED
+#define FILTERX_OBJECT_LIST_INTERFACE_H_INCLUDED
+
+#include "filterx/filterx-object.h"
+
+typedef struct FilterXList_ FilterXList;
+
+struct FilterXList_
+{
+  FilterXObject super;
+
+  FilterXObject *(*get_subscript)(FilterXList *s, guint64 index);
+  gboolean (*set_subscript)(FilterXList *s, guint64 index, FilterXObject *new_value);
+  gboolean (*append)(FilterXList *s, FilterXObject *new_value);
+  guint64 (*len)(FilterXList *s);
+};
+
+guint64 filterx_list_len(FilterXObject *s);
+FilterXObject *filterx_list_get_subscript(FilterXObject *s, gint64 index);
+gboolean filterx_list_set_subscript(FilterXObject *s, gint64 index, FilterXObject *new_value);
+gboolean filterx_list_append(FilterXObject *s, FilterXObject *new_value);
+
+void filterx_list_init_instance(FilterXList *self, FilterXType *type);
+
+FILTERX_DECLARE_TYPE(list);
+
+#endif

--- a/lib/filterx/object-message-value.c
+++ b/lib/filterx/object-message-value.c
@@ -88,7 +88,7 @@ _unmarshal_repr(const gchar *repr, gssize repr_len, LogMessageValueType t)
     case LM_VT_STRING:
       return filterx_string_new(repr, repr_len);
     case LM_VT_JSON:
-      return construct_filterx_json_from_repr(repr, repr_len);
+      return filterx_json_new_from_repr(repr, repr_len);
     case LM_VT_BOOLEAN:
       if (!type_cast_to_boolean(repr, repr_len, &b, NULL))
         return NULL;
@@ -106,7 +106,7 @@ _unmarshal_repr(const gchar *repr, gssize repr_len, LogMessageValueType t)
         return NULL;
       return filterx_datetime_new(&ut);
     case LM_VT_LIST:
-      return construct_filterx_json_from_list_repr(repr, repr_len);
+      return filterx_json_array_new_from_repr(repr, repr_len);
     case LM_VT_NULL:
       return filterx_null_new();
     case LM_VT_BYTES:

--- a/lib/filterx/tests/test_object_json.c
+++ b/lib/filterx/tests/test_object_json.c
@@ -39,14 +39,14 @@ assert_object_json_equals(FilterXObject *obj, const gchar *expected_json_repr)
 
 Test(filterx_json, test_filterx_object_json_marshals_to_the_stored_values)
 {
-  FilterXObject *fobj = construct_filterx_json_from_repr("{\"foo\": \"foovalue\"}", -1);
+  FilterXObject *fobj = filterx_json_object_new_from_repr("{\"foo\": \"foovalue\"}", -1);
   assert_marshaled_object(fobj, "{\"foo\":\"foovalue\"}", LM_VT_JSON);
   filterx_object_unref(fobj);
 }
 
 Test(filterx_json, test_filterx_object_value_maps_to_the_right_json_value)
 {
-  FilterXObject *fobj = construct_filterx_json_from_repr("{\"foo\": \"foovalue\"}", -1);
+  FilterXObject *fobj = filterx_json_object_new_from_repr("{\"foo\": \"foovalue\"}", -1);
   assert_object_json_equals(fobj, "{\"foo\":\"foovalue\"}");
   filterx_object_unref(fobj);
 }

--- a/modules/grpc/otel/filterx/object-otel-array.cpp
+++ b/modules/grpc/otel/filterx/object-otel-array.cpp
@@ -281,18 +281,31 @@ OtelArrayField::FilterXObjectSetter(google::protobuf::Message *message, ProtoRef
     }
 
   FilterXOtelArray *filterx_array = (FilterXOtelArray *) object;
-  ArrayValue *array;
+  ArrayValue *array_value;
 
   try
     {
-      array = dynamic_cast<ArrayValue *>(reflectors.reflection->MutableMessage(message, reflectors.fieldDescriptor));
+      array_value = dynamic_cast<ArrayValue *>(reflectors.reflection->MutableMessage(message, reflectors.fieldDescriptor));
     }
   catch(const std::bad_cast &e)
     {
       g_assert_not_reached();
     }
 
-  array->CopyFrom(filterx_array->cpp->get_value());
+  array_value->CopyFrom(filterx_array->cpp->get_value());
+
+  Array *new_array;
+  try
+    {
+      new_array = new Array(filterx_array, array_value);
+    }
+  catch (const std::runtime_error &)
+    {
+      g_assert_not_reached();
+    }
+
+  delete filterx_array->cpp;
+  filterx_array->cpp = new_array;
 
   return true;
 }

--- a/modules/grpc/otel/filterx/object-otel-array.hpp
+++ b/modules/grpc/otel/filterx/object-otel-array.hpp
@@ -26,7 +26,7 @@
 #include "syslog-ng.h"
 
 #include "compat/cpp-start.h"
-#include "filterx/filterx-object.h"
+#include "filterx/object-list-interface.h"
 #include "object-otel.h"
 #include "compat/cpp-end.h"
 
@@ -55,8 +55,10 @@ public:
   ~Array();
 
   std::string marshal();
-  bool set_subscript(FilterXObject *key, FilterXObject *value);
-  FilterXObject *get_subscript(FilterXObject *key);
+  bool set_subscript(uint64_t index, FilterXObject *value);
+  FilterXObject *get_subscript(uint64_t index);
+  bool append(FilterXObject *value);
+  uint64_t len() const;
   const ArrayValue &get_value() const;
 
 private:
@@ -87,7 +89,7 @@ extern OtelArrayField otel_array_converter;
 
 struct FilterXOtelArray_
 {
-  FilterXObject super;
+  FilterXList super;
   syslogng::grpc::otel::filterx::Array *cpp;
 };
 

--- a/modules/grpc/otel/filterx/object-otel-kvlist.hpp
+++ b/modules/grpc/otel/filterx/object-otel-kvlist.hpp
@@ -26,7 +26,7 @@
 #include "syslog-ng.h"
 
 #include "compat/cpp-start.h"
-#include "filterx/filterx-object.h"
+#include "filterx/object-dict-interface.h"
 #include "object-otel.h"
 #include "compat/cpp-end.h"
 
@@ -58,13 +58,15 @@ public:
 
   std::string marshal();
   bool set_subscript(FilterXObject *key, FilterXObject *value);
+  bool has_subscript(FilterXObject *key) const;
   FilterXObject *get_subscript(FilterXObject *key);
+  uint64_t len() const;
   const RepeatedPtrField<KeyValue> &get_value() const;
 
 private:
   KVList(const KVList &o, FilterXOtelKVList *s);
   friend FilterXObject *::_filterx_otel_kvlist_clone(FilterXObject *s);
-  KeyValue *get_mutable_kv_for_key(const char *key);
+  KeyValue *get_mutable_kv_for_key(const char *key) const;
 
 private:
   FilterXOtelKVList *super;
@@ -90,7 +92,7 @@ extern OtelKVListField otel_kvlist_converter;
 
 struct FilterXOtelKVList_
 {
-  FilterXObject super;
+  FilterXDict super;
   syslogng::grpc::otel::filterx::KVList *cpp;
 };
 

--- a/modules/grpc/otel/filterx/otel-field.cpp
+++ b/modules/grpc/otel/filterx/otel-field.cpp
@@ -213,7 +213,8 @@ AnyField::FilterXObjectDirectSetter(AnyValue *anyValue, FilterXObject *object)
       converter = &filterx::otel_array_converter;
       typeFieldName = "array_value";
     }
-  else if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(json)))
+  else if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(json_object)) ||
+           filterx_object_is_type(object, &FILTERX_TYPE_NAME(json_array)))
     {
       converter = protobuf_converter_by_type(FieldDescriptor::TYPE_STRING);
       typeFieldName = "string_value";

--- a/modules/grpc/otel/filterx/protobuf-field.cpp
+++ b/modules/grpc/otel/filterx/protobuf-field.cpp
@@ -206,7 +206,9 @@ public:
         reflectors.reflection->SetString(message, reflectors.fieldDescriptor, stdString);
         return true;
       }
-    else if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(json)))
+    else if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(json_object)) ||
+             filterx_object_is_type(object, &FILTERX_TYPE_NAME(
+                                      json_array))) // TODO: how legit is returning syslog-ng style list here?
       {
         GString *buf = scratch_buffers_alloc();
         LogMessageValueType t;

--- a/modules/grpc/otel/tests/test-otel-filterx.cpp
+++ b/modules/grpc/otel/tests/test-otel-filterx.cpp
@@ -681,7 +681,9 @@ Test(otel_filterx, kvlist_through_logrecord)
   cr_assert(filterx_object_set_subscript(fx_kvlist, fx_key_0, fx_foo));
 
   /* $log.attributes = $kvlist; */
-  cr_assert(filterx_object_setattr(fx_logrecord, "attributes", fx_kvlist));
+  FilterXObject *fx_kvlist_clone = filterx_object_clone(fx_kvlist);
+  cr_assert(filterx_object_setattr(fx_logrecord, "attributes", fx_kvlist_clone));
+  filterx_object_unref(fx_kvlist_clone);
 
   /* $log.attributes["key_1"] = "bar"; */
   fx_get_1 = filterx_object_getattr(fx_logrecord, "attributes");
@@ -695,7 +697,9 @@ Test(otel_filterx, kvlist_through_logrecord)
   filterx_object_unref(fx_get_1);
   fx_get_1 = filterx_object_getattr(fx_logrecord, "attributes");
   cr_assert(fx_get_1);
-  cr_assert(filterx_object_set_subscript(fx_get_1, fx_key_3, fx_inner_kvlist));
+  FilterXObject *fx_inner_kvlist_clone = filterx_object_clone(fx_inner_kvlist);
+  cr_assert(filterx_object_set_subscript(fx_get_1, fx_key_3, fx_inner_kvlist_clone));
+  filterx_object_unref(fx_inner_kvlist_clone);
 
   /* $inner_kvlist["key_0"] = "foo"; */
   cr_assert(filterx_object_set_subscript(fx_inner_kvlist, fx_key_0, fx_foo));
@@ -931,7 +935,9 @@ Test(otel_filterx, array_through_logrecord)
   cr_assert(filterx_object_set_subscript(fx_array, nullptr, fx_foo));
 
   /* $log.body = $array; */
-  cr_assert(filterx_object_setattr(fx_logrecord, "body", fx_array));
+  FilterXObject *fx_array_clone = filterx_object_clone(fx_array);
+  cr_assert(filterx_object_setattr(fx_logrecord, "body", fx_array_clone));
+  filterx_object_unref(fx_array_clone);
 
   /* $log.body[] = "bar"; */
   fx_get_1 = filterx_object_getattr(fx_logrecord, "body");
@@ -945,7 +951,9 @@ Test(otel_filterx, array_through_logrecord)
   filterx_object_unref(fx_get_1);
   fx_get_1 = filterx_object_getattr(fx_logrecord, "body");
   cr_assert(fx_get_1);
-  cr_assert(filterx_object_set_subscript(fx_get_1, nullptr, fx_inner_array));
+  FilterXObject *fx_inner_array_clone = filterx_object_clone(fx_inner_array);
+  cr_assert(filterx_object_set_subscript(fx_get_1, nullptr, fx_inner_array_clone));
+  filterx_object_unref(fx_inner_array_clone);
 
   /* $inner_array[] = "foo"; */
   cr_assert(filterx_object_set_subscript(fx_inner_array, nullptr, fx_foo));

--- a/modules/grpc/otel/tests/test-otel-filterx.cpp
+++ b/modules/grpc/otel/tests/test-otel-filterx.cpp
@@ -502,7 +502,7 @@ Test(otel_filterx, kvlist_empty)
 
   cr_assert_eq(filterx_otel_kvlist->cpp->get_value().size(), 0);
 
-  filterx_object_unref(&filterx_otel_kvlist->super);
+  filterx_object_unref(&filterx_otel_kvlist->super.super);
 }
 
 Test(otel_filterx, kvlist_from_protobuf)
@@ -524,7 +524,7 @@ Test(otel_filterx, kvlist_from_protobuf)
 
   _assert_repeated_kvs(filterx_otel_kvlist->cpp->get_value(), kvlist.values());
 
-  filterx_object_unref(&filterx_otel_kvlist->super);
+  filterx_object_unref(&filterx_otel_kvlist->super.super);
   g_ptr_array_free(args, TRUE);
 }
 
@@ -767,7 +767,7 @@ Test(otel_filterx, array_empty)
   cr_assert(MessageDifferencer::Equals(opentelemetry::proto::common::v1::ArrayValue(),
                                        filterx_otel_kvlist->cpp->get_value()));
 
-  filterx_object_unref(&filterx_otel_kvlist->super);
+  filterx_object_unref(&filterx_otel_kvlist->super.super);
 }
 
 Test(otel_filterx, array_from_protobuf)
@@ -788,7 +788,7 @@ Test(otel_filterx, array_from_protobuf)
   const opentelemetry::proto::common::v1::ArrayValue &array_from_filterx = filterx_otel_array->cpp->get_value();
   cr_assert(MessageDifferencer::Equals(array, array_from_filterx));
 
-  filterx_object_unref(&filterx_otel_array->super);
+  filterx_object_unref(&filterx_otel_array->super.super);
   g_ptr_array_free(args, TRUE);
 }
 
@@ -1000,6 +1000,7 @@ setup(void)
 {
   app_startup();
   configuration = cfg_new_snippet();
+  otel_filterx_objects_global_init();
 }
 
 void


### PR DESCRIPTION
We do not want to have generic lists and dicts in filterx, as converting to and from that intermediate layer wastes resources.

Instead we will have an interface for them, and we will write our parser codes by using that interface. We will also have multiple implementations (json and otel). After all these we just have to connect the two somehow.

Depends on #4860