### PR TITLE
syslogformat: fix crash in unit tests

### DIFF
--- a/modules/syslogformat/tests/test_syslog_format.c
+++ b/modules/syslogformat/tests/test_syslog_format.c
@@ -337,7 +337,6 @@ Test(syslog_format, test_frame_checking)
   const gchar *data = "5 aaaaa";
   gsize data_length = strlen(data);
 
-  msg_format_options_init(&parse_options, cfg);
   LogMessage *msg = msg_format_construct_message(&parse_options, (const guchar *) data, data_length);
 
   gsize problem_position;
@@ -346,7 +345,6 @@ Test(syslog_format, test_frame_checking)
   cr_assert(log_msg_is_tag_by_id(msg, LM_T_SYSLOG_UNEXPECTED_FRAMING));
 
   log_msg_unref(msg);
-  msg_format_options_destroy(&parse_options);
 }
 
 Test(syslog_format, test_framing_not_detected_when_frame_length_is_too_long)
@@ -354,7 +352,6 @@ Test(syslog_format, test_framing_not_detected_when_frame_length_is_too_long)
   const gchar *data = "99999999999 a";
   gsize data_length = strlen(data);
 
-  msg_format_options_init(&parse_options, cfg);
   LogMessage *msg = msg_format_construct_message(&parse_options, (const guchar *) data, data_length);
 
   gsize problem_position;
@@ -363,7 +360,6 @@ Test(syslog_format, test_framing_not_detected_when_frame_length_is_too_long)
   cr_assert_not(log_msg_is_tag_by_id(msg, LM_T_SYSLOG_UNEXPECTED_FRAMING));
 
   log_msg_unref(msg);
-  msg_format_options_destroy(&parse_options);
 }
 
 Test(syslog_format, test_framing_not_detected_on_input_starting_with_whitespace)
@@ -371,7 +367,6 @@ Test(syslog_format, test_framing_not_detected_on_input_starting_with_whitespace)
   const gchar *data = " non-framed-whitespace";
   gsize data_length = strlen(data);
 
-  msg_format_options_init(&parse_options, cfg);
   LogMessage *msg = msg_format_construct_message(&parse_options, (const guchar *) data, data_length);
 
   gsize problem_position;
@@ -380,5 +375,4 @@ Test(syslog_format, test_framing_not_detected_on_input_starting_with_whitespace)
   cr_assert_not(log_msg_is_tag_by_id(msg, LM_T_SYSLOG_UNEXPECTED_FRAMING));
 
   log_msg_unref(msg);
-  msg_format_options_destroy(&parse_options);
 }


### PR DESCRIPTION
Followup for: 7c3ea883339cea04d9165aa01e3597e29b79068d

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
