### PR TITLE
threaded-dests/afsocket: add new metric `syslogng_output_unreachable`

### DIFF
--- a/lib/logthrdest/logthrdestdrv.h
+++ b/lib/logthrdest/logthrdestdrv.h
@@ -107,10 +107,12 @@ struct _LogThreadedDestWorker
   struct
   {
     StatsClusterKey *output_event_bytes_sc_key;
+    StatsClusterKey *output_unreachable_key;
     StatsClusterKey *message_delay_sample_key;
     StatsClusterKey *message_delay_sample_age_key;
 
     StatsByteCounter written_bytes;
+    StatsCounterItem *output_unreachable;
     StatsCounterItem *message_delay_sample;
     StatsCounterItem *message_delay_sample_age;
 
@@ -219,6 +221,8 @@ log_threaded_dest_worker_connect(LogThreadedDestWorker *self)
   else
     self->connected = TRUE;
 
+
+  stats_counter_set(self->metrics.output_unreachable, !self->connected);
   return self->connected;
 }
 
@@ -228,6 +232,7 @@ log_threaded_dest_worker_disconnect(LogThreadedDestWorker *self)
   if (self->disconnect)
     self->disconnect(self);
   self->connected = FALSE;
+  stats_counter_set(self->metrics.output_unreachable, !self->connected);
 }
 
 static inline LogThreadedResult

--- a/modules/afsocket/afsocket-dest.h
+++ b/modules/afsocket/afsocket-dest.h
@@ -54,6 +54,11 @@ struct _AFSocketDestDriver
   SocketOptions *socket_options;
   TransportMapper *transport_mapper;
 
+  struct
+  {
+    StatsCounterItem *output_unreachable;
+  } metrics;
+
   LogWriter *(*construct_writer)(AFSocketDestDriver *self);
   gboolean (*setup_addresses)(AFSocketDestDriver *s);
   const gchar *(*get_dest_name)(const AFSocketDestDriver *s);

--- a/news/other-4876.md
+++ b/news/other-4876.md
@@ -1,0 +1,10 @@
+`metrics`: new metric to monitor destination reachability
+
+`syslogng_output_unreachable` is a bool-like metric, which shows whether a
+destination is reachable or not.
+
+`sum()` can be used to count all unreachable outputs, hence the negated name.
+
+It is currently available for the `network()`, `syslog()`, `unix-*()`
+destinations, and threaded destinations (`http()`, `opentelemetry()`, `redis()`,
+`mongodb()`, `python()`, etc.).


### PR DESCRIPTION
This bool-like metric shows whether a destination is reachable or not.
`sum()` can be used to count all unreachable outputs, hence the negated name.

For example:
```
syslogng_output_unreachable{driver="http",url="http://localhost",id="d_http#2",worker="0"} 0
syslogng_output_unreachable{id="d_network#0",driver="afsocket",transport="tcp",address="localhost:5555"} 1
```