### PR TITLE
macros: guard ipv6 code with SYSLOG_NG_ENABLE_IPV6

### DIFF
--- a/lib/template/macros.c
+++ b/lib/template/macros.c
@@ -277,12 +277,14 @@ _get_originating_ip_protocol(const LogMessage *msg)
     return 0;
   if (g_sockaddr_inet_check(msg->saddr))
     return 4;
+#if SYSLOG_NG_ENABLE_IPV6
   if (g_sockaddr_inet6_check(msg->saddr))
     {
       if (g_sockaddr_inet6_is_v4_mapped(msg->saddr))
         return 4;
       return 6;
     }
+#endif
   return 0;
 }
 


### PR DESCRIPTION
With ipv6 disabled, there are linking errors currently. This fixes it by not using the symbols when IPv6 is disabled.

Solves #4810 with my config options

https://github.com/openembedded/meta-openembedded/blob/2487e65ee3842b6ae0c7a2628985be6189ed9ebf/meta-oe/recipes-support/syslog-ng/syslog-ng_4.6.0.bb

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
