### PR TITLE
s3: make access_key and secret_key optional

### DIFF
--- a/modules/python-modules/syslogng/modules/s3/s3_destination.py
+++ b/modules/python-modules/syslogng/modules/s3/s3_destination.py
@@ -239,8 +239,8 @@ class S3Destination(LogDestination):
         self.client = client(
             service_name="s3",
             endpoint_url=self.url if self.url != "" else None,
-            aws_access_key_id=self.access_key,
-            aws_secret_access_key=self.secret_key,
+            aws_access_key_id=self.access_key if self.access_key != "" else None,
+            aws_secret_access_key=self.secret_key if self.secret_key != "" else None,
             region_name=self.region,
         )
 

--- a/modules/python-modules/syslogng/modules/s3/scl/s3.conf
+++ b/modules/python-modules/syslogng/modules/s3/scl/s3.conf
@@ -23,8 +23,8 @@
 block destination s3(
     url("")
     bucket()
-    access_key()
-    secret_key()
+    access_key("")
+    secret_key("")
     object_key()
     object_key_timestamp("")
     template("${MESSAGE}\n")
@@ -46,8 +46,8 @@ block destination s3(
         options(
             "url" => "`url`"
             "bucket" => `bucket`
-            "access_key" => `access_key`
-            "secret_key" => `secret_key`
+            "access_key" => "`access_key`"
+            "secret_key" => "`secret_key`"
             "object_key" => LogTemplate(`object_key`)
             "object_key_timestamp" => LogTemplate(`object_key_timestamp`)
             "template" => LogTemplate(`template`)


### PR DESCRIPTION
Making access_key and secret_key optional let the boto3 to execute the official credential chain process and use every supported authentication mechanism.

If the access_key and secret_key are set then those will be used as passing credentials in the parameter has the highest priority.

Please read [this](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html) page about the credential order.

This solves issue #4858.