### PR TITLE
Filterx add "declare"-d variables

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,7 +10,7 @@ jobs:
   general:
     strategy:
       matrix:
-        version: [latest, 14]
+        version: [13, 14]
         build-tool: [autotools, cmake]
       fail-fast: false
 
@@ -27,7 +27,7 @@ jobs:
 
       - name: Unlinking preinstalled Python (workaround)
               # The python@3 brew package has to be installed and linked system-wide (it's a dependency of glib and syslog-ng)
-              # The macos-latest GitHub runner has Python preinstalled as a pkg, this prevents linking the python@3
+              # The macos-13 GitHub runner has Python preinstalled as a pkg, this prevents linking the python@3
               # brew package, even when linking is forced. `brew "python@3", link: true, force: true`
               # also, brew cannot update the links even these cretated by itself for an earlier python version
         run : |

--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -6,7 +6,7 @@ set(FILTERX_HEADERS
     filterx/expr-getattr.h
     filterx/expr-get-subscript.h
     filterx/expr-literal.h
-    filterx/expr-message-ref.h
+    filterx/expr-variable.h
     filterx/expr-setattr.h
     filterx/expr-set-subscript.h
     filterx/expr-template.h
@@ -46,7 +46,7 @@ set(FILTERX_SOURCES
     filterx/expr-getattr.c
     filterx/expr-get-subscript.c
     filterx/expr-literal.c
-    filterx/expr-message-ref.c
+    filterx/expr-variable.c
     filterx/expr-setattr.c
     filterx/expr-set-subscript.c
     filterx/expr-template.c

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -12,7 +12,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/expr-setattr.h		\
 	lib/filterx/expr-get-subscript.h	\
 	lib/filterx/expr-set-subscript.h	\
-	lib/filterx/expr-message-ref.h		\
+	lib/filterx/expr-variable.h		\
 	lib/filterx/expr-comparison.h		\
 	lib/filterx/filterx-object.h		\
 	lib/filterx/filterx-weakrefs.h		\
@@ -51,7 +51,7 @@ filterx_sources = 				\
 	lib/filterx/expr-setattr.c		\
 	lib/filterx/expr-get-subscript.c	\
 	lib/filterx/expr-set-subscript.c	\
-	lib/filterx/expr-message-ref.c		\
+	lib/filterx/expr-variable.c		\
 	lib/filterx/expr-comparison.c		\
 	lib/filterx/filterx-object.c		\
 	lib/filterx/filterx-weakrefs.c		\

--- a/lib/filterx/expr-assign.c
+++ b/lib/filterx/expr-assign.c
@@ -22,6 +22,7 @@
  */
 #include "filterx/expr-assign.h"
 #include "filterx/object-primitive.h"
+#include "scratch-buffers.h"
 
 static FilterXObject *
 _eval(FilterXExpr *s)
@@ -34,7 +35,21 @@ _eval(FilterXExpr *s)
     return NULL;
 
   if (filterx_expr_assign(self->lhs, value))
-    result = filterx_boolean_new(TRUE);
+    {
+      result = filterx_boolean_new(TRUE);
+      if (trace_flag)
+        {
+          GString *buf = scratch_buffers_alloc();
+          if (value && !filterx_object_repr(value, buf))
+            {
+              LogMessageValueType t;
+              if (!filterx_object_marshal(value, buf, &t))
+                g_assert_not_reached();
+            }
+          msg_trace("Filterx assignment",
+                    evt_tag_mem("value", buf->str, buf->len));
+        }
+    }
 
   filterx_object_unref(value);
   return result;

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -29,6 +29,7 @@ typedef struct _FilterXVariableExpr
 {
   FilterXExpr super;
   NVHandle handle;
+  gboolean declared;
 } FilterXVariableExpr;
 
 static FilterXObject *
@@ -92,6 +93,8 @@ _assign(FilterXExpr *s, FilterXObject *new_value)
        * is considered changed due to the assignment */
 
       variable = filterx_scope_register_variable(scope, self->handle, NULL);
+      if (self->declared)
+        filterx_variable_mark_declared(variable);
     }
 
   /* this only clones mutable objects */
@@ -161,4 +164,13 @@ FilterXExpr *
 filterx_floating_variable_expr_new(const gchar *name)
 {
   return filterx_variable_expr_new(name, FX_VAR_FLOATING);
+}
+
+void
+filterx_variable_expr_declare(FilterXExpr *s)
+{
+  FilterXVariableExpr *self = (FilterXVariableExpr *) s;
+
+  g_assert(s->eval == _eval);
+  self->declared = TRUE;
 }

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -137,7 +137,7 @@ _unset(FilterXExpr *s)
 }
 
 FilterXExpr *
-filterx_variable_expr_new(NVHandle handle)
+filterx_variable_expr_new(const gchar *name)
 {
   FilterXVariableExpr *self = g_new0(FilterXVariableExpr, 1);
 
@@ -147,6 +147,6 @@ filterx_variable_expr_new(NVHandle handle)
   self->super.assign = _assign;
   self->super.isset = _isset;
   self->super.unset = _unset;
-  self->handle = handle;
+  self->handle = log_msg_get_value_handle(name);
   return &self->super;
 }

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -20,19 +20,19 @@
  * COPYING for details.
  *
  */
-#include "filterx/expr-message-ref.h"
+#include "filterx/expr-variable.h"
 #include "filterx/object-message-value.h"
 #include "filterx/filterx-scope.h"
 #include "logmsg/logmsg.h"
 
-typedef struct _FilterXMessageRefExpr
+typedef struct _FilterXVariableExpr
 {
   FilterXExpr super;
   NVHandle handle;
-} FilterXMessageRefExpr;
+} FilterXVariableExpr;
 
 static FilterXObject *
-_pull_variable_from_message(FilterXMessageRefExpr *self, FilterXEvalContext *context, LogMessage *msg)
+_pull_variable_from_message(FilterXVariableExpr *self, FilterXEvalContext *context, LogMessage *msg)
 {
   gssize value_len;
   LogMessageValueType t;
@@ -47,7 +47,7 @@ _pull_variable_from_message(FilterXMessageRefExpr *self, FilterXEvalContext *con
 
 /* NOTE: unset on a variable that only exists in the LogMessage, without making the message writable */
 static void
-_whiteout_variable(FilterXMessageRefExpr *self, FilterXEvalContext *context)
+_whiteout_variable(FilterXVariableExpr *self, FilterXEvalContext *context)
 {
   filterx_scope_register_variable(context->scope, self->handle, FALSE, NULL);
 }
@@ -55,7 +55,7 @@ _whiteout_variable(FilterXMessageRefExpr *self, FilterXEvalContext *context)
 static FilterXObject *
 _eval(FilterXExpr *s)
 {
-  FilterXMessageRefExpr *self = (FilterXMessageRefExpr *) s;
+  FilterXVariableExpr *self = (FilterXVariableExpr *) s;
   FilterXEvalContext *context = filterx_eval_get_context();
   FilterXVariable *variable;
 
@@ -69,7 +69,7 @@ _eval(FilterXExpr *s)
 static void
 _update_repr(FilterXExpr *s, FilterXObject *new_repr)
 {
-  FilterXMessageRefExpr *self = (FilterXMessageRefExpr *) s;
+  FilterXVariableExpr *self = (FilterXVariableExpr *) s;
   FilterXScope *scope = filterx_eval_get_scope();
   FilterXVariable *variable = filterx_scope_lookup_variable(scope, self->handle);
 
@@ -80,7 +80,7 @@ _update_repr(FilterXExpr *s, FilterXObject *new_repr)
 static gboolean
 _assign(FilterXExpr *s, FilterXObject *new_value)
 {
-  FilterXMessageRefExpr *self = (FilterXMessageRefExpr *) s;
+  FilterXVariableExpr *self = (FilterXVariableExpr *) s;
   FilterXScope *scope = filterx_eval_get_scope();
   FilterXVariable *variable = filterx_scope_lookup_variable(scope, self->handle);
 
@@ -104,7 +104,7 @@ _assign(FilterXExpr *s, FilterXObject *new_value)
 static gboolean
 _isset(FilterXExpr *s)
 {
-  FilterXMessageRefExpr *self = (FilterXMessageRefExpr *) s;
+  FilterXVariableExpr *self = (FilterXVariableExpr *) s;
   FilterXScope *scope = filterx_eval_get_scope();
 
   FilterXVariable *variable = filterx_scope_lookup_variable(scope, self->handle);
@@ -119,7 +119,7 @@ _isset(FilterXExpr *s)
 static gboolean
 _unset(FilterXExpr *s)
 {
-  FilterXMessageRefExpr *self = (FilterXMessageRefExpr *) s;
+  FilterXVariableExpr *self = (FilterXVariableExpr *) s;
   FilterXEvalContext *context = filterx_eval_get_context();
 
   FilterXVariable *variable = filterx_scope_lookup_variable(context->scope, self->handle);
@@ -137,9 +137,9 @@ _unset(FilterXExpr *s)
 }
 
 FilterXExpr *
-filterx_message_ref_expr_new(NVHandle handle)
+filterx_variable_expr_new(NVHandle handle)
 {
-  FilterXMessageRefExpr *self = g_new0(FilterXMessageRefExpr, 1);
+  FilterXVariableExpr *self = g_new0(FilterXVariableExpr, 1);
 
   filterx_expr_init_instance(&self->super);
   self->super.eval = _eval;

--- a/lib/filterx/expr-variable.h
+++ b/lib/filterx/expr-variable.h
@@ -20,11 +20,11 @@
  * COPYING for details.
  *
  */
-#ifndef FILTERX_MESSAGE_RESOLVER_H_INCLUDED
-#define FILTERX_MESSAGE_RESOLVER_H_INCLUDED
+#ifndef FILTERX_EXPR_VARIABLE_H_INCLUDED
+#define FILTERX_EXPR_VARIABLE_H_INCLUDED
 
 #include "filterx/filterx-expr.h"
 
-FilterXExpr *filterx_message_ref_expr_new(NVHandle handle);
+FilterXExpr *filterx_variable_expr_new(NVHandle handle);
 
 #endif

--- a/lib/filterx/expr-variable.h
+++ b/lib/filterx/expr-variable.h
@@ -27,5 +27,6 @@
 
 FilterXExpr *filterx_msg_variable_expr_new(const gchar *name);
 FilterXExpr *filterx_floating_variable_expr_new(const gchar *name);
+void filterx_variable_expr_declare(FilterXExpr *s);
 
 #endif

--- a/lib/filterx/expr-variable.h
+++ b/lib/filterx/expr-variable.h
@@ -25,6 +25,6 @@
 
 #include "filterx/filterx-expr.h"
 
-FilterXExpr *filterx_variable_expr_new(NVHandle handle);
+FilterXExpr *filterx_variable_expr_new(const gchar *name);
 
 #endif

--- a/lib/filterx/expr-variable.h
+++ b/lib/filterx/expr-variable.h
@@ -25,6 +25,7 @@
 
 #include "filterx/filterx-expr.h"
 
-FilterXExpr *filterx_variable_expr_new(const gchar *name);
+FilterXExpr *filterx_msg_variable_expr_new(const gchar *name);
+FilterXExpr *filterx_floating_variable_expr_new(const gchar *name);
 
 #endif

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -118,6 +118,7 @@ filterx_eval_exec_statements(FilterXScope *scope, GList *statements, LogMessage 
   /* NOTE: we only store the results into the message if the entire evaluation was successful */
   success = TRUE;
 fail:
+  filterx_scope_set_dirty(scope);
   filterx_eval_set_context(NULL);
   return success;
 }

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -125,5 +125,5 @@ fail:
 void
 filterx_eval_sync_scope_and_message(FilterXScope *scope, LogMessage *msg)
 {
-  filterx_scope_sync_to_message(scope, msg);
+  filterx_scope_sync(scope, msg);
 }

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -65,11 +65,12 @@ _evaluate_statement(FilterXExpr *expr)
   if (!success || trace_flag)
     {
       GString *buf = scratch_buffers_alloc();
-      LogMessageValueType t;
 
-      if (res && !filterx_object_marshal(res, buf, &t))
+      if (res && !filterx_object_repr(res, buf))
         {
-          g_assert_not_reached();
+          LogMessageValueType t;
+          if (!filterx_object_marshal(res, buf, &t))
+            g_assert_not_reached();
         }
 
       if (!success)
@@ -78,16 +79,14 @@ _evaluate_statement(FilterXExpr *expr)
                                  expr->lloc.name, expr->lloc.first_line, expr->lloc.first_column,
                                  expr->expr_text ? : "n/a"),
                   evt_tag_str("status", res == NULL ? "error" : "falsy"),
-                  evt_tag_str("value", buf->str),
-                  evt_tag_str("type", log_msg_value_type_to_str(t)));
+                  evt_tag_mem("value", buf->str, buf->len));
       else
         msg_trace("FILTERX",
                   evt_tag_printf("expr", "%s:%d:%d| %s",
                                  expr->lloc.name, expr->lloc.first_line, expr->lloc.first_column,
                                  expr->expr_text ? : "n/a"),
                   evt_tag_str("status", res == NULL ? "error" : (success ? "truthy" : "falsy")),
-                  evt_tag_str("value", buf->str),
-                  evt_tag_str("type", log_msg_value_type_to_str(t)),
+                  evt_tag_mem("value", buf->str, buf->len),
                   evt_tag_printf("result", "%p", res));
     }
 

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -122,9 +122,3 @@ fail:
   filterx_eval_set_context(NULL);
   return success;
 }
-
-void
-filterx_eval_sync_scope_and_message(FilterXScope *scope, LogMessage *msg)
-{
-  filterx_scope_sync(scope, msg);
-}

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -108,7 +108,6 @@ filterx_expr_eval_typed(FilterXExpr *self)
   return unmarshalled;
 }
 
-
 static inline gboolean
 filterx_expr_assign(FilterXExpr *self, FilterXObject *new_value)
 {

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -319,6 +319,7 @@ literal_object
 lvalue
 	: '$' LL_IDENTIFIER			{ $$ = filterx_msg_variable_expr_new($2); free($2); }
 	| LL_MESSAGE_REF			{ $$ = filterx_msg_variable_expr_new($1); free($1); }
+	| LL_IDENTIFIER				{ $$ = filterx_floating_variable_expr_new($1); free($1); }
 	;
 
 boolean

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -66,7 +66,8 @@ construct_template_expr(LogTemplate *template)
 		filterx_config_freeze_object(configuration,
 			filterx_string_new(log_template_get_literal_value(template, NULL), -1)));
   else if (log_template_is_trivial(template))
-    result = filterx_variable_expr_new(log_template_get_trivial_value_handle(template));
+    result = filterx_variable_expr_new(
+                log_msg_get_value_name(log_template_get_trivial_value_handle(template), NULL));
   else
     result = filterx_template_new(log_template_ref(template));
   log_template_unref(template);
@@ -316,8 +317,8 @@ literal_object
 	;
 
 lvalue
-	: '$' LL_IDENTIFIER			{ $$ = filterx_variable_expr_new(log_msg_get_value_handle($2)); free($2); }
-	| LL_MESSAGE_REF			{ $$ = filterx_variable_expr_new(log_msg_get_value_handle($1)); free($1); }
+	: '$' LL_IDENTIFIER			{ $$ = filterx_variable_expr_new($2); free($2); }
+	| LL_MESSAGE_REF			{ $$ = filterx_variable_expr_new($1); free($1); }
 	;
 
 

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -31,7 +31,7 @@
 
 /* filterx language constructs */
 #include "filterx/expr-literal.h"
-#include "filterx/expr-message-ref.h"
+#include "filterx/expr-variable.h"
 #include "filterx/expr-template.h"
 #include "filterx/expr-boolalg.h"
 #include "filterx/expr-assign.h"
@@ -66,7 +66,7 @@ construct_template_expr(LogTemplate *template)
 		filterx_config_freeze_object(configuration,
 			filterx_string_new(log_template_get_literal_value(template, NULL), -1)));
   else if (log_template_is_trivial(template))
-    result = filterx_message_ref_expr_new(log_template_get_trivial_value_handle(template));
+    result = filterx_variable_expr_new(log_template_get_trivial_value_handle(template));
   else
     result = filterx_template_new(log_template_ref(template));
   log_template_unref(template);
@@ -316,8 +316,8 @@ literal_object
 	;
 
 lvalue
-	: '$' LL_IDENTIFIER			{ $$ = filterx_message_ref_expr_new(log_msg_get_value_handle($2)); free($2); }
-	| LL_MESSAGE_REF			{ $$ = filterx_message_ref_expr_new(log_msg_get_value_handle($1)); free($1); }
+	: '$' LL_IDENTIFIER			{ $$ = filterx_variable_expr_new(log_msg_get_value_handle($2)); free($2); }
+	| LL_MESSAGE_REF			{ $$ = filterx_variable_expr_new(log_msg_get_value_handle($1)); free($1); }
 	;
 
 

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -66,7 +66,7 @@ construct_template_expr(LogTemplate *template)
 		filterx_config_freeze_object(configuration,
 			filterx_string_new(log_template_get_literal_value(template, NULL), -1)));
   else if (log_template_is_trivial(template))
-    result = filterx_variable_expr_new(
+    result = filterx_msg_variable_expr_new(
                 log_msg_get_value_name(log_template_get_trivial_value_handle(template), NULL));
   else
     result = filterx_template_new(log_template_ref(template));
@@ -317,10 +317,9 @@ literal_object
 	;
 
 lvalue
-	: '$' LL_IDENTIFIER			{ $$ = filterx_variable_expr_new($2); free($2); }
-	| LL_MESSAGE_REF			{ $$ = filterx_variable_expr_new($1); free($1); }
+	: '$' LL_IDENTIFIER			{ $$ = filterx_msg_variable_expr_new($2); free($2); }
+	| LL_MESSAGE_REF			{ $$ = filterx_msg_variable_expr_new($1); free($1); }
 	;
-
 
 boolean
 	: KW_TRUE				{ $$ = 1; }

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -89,12 +89,14 @@ construct_template_expr(LogTemplate *template)
 %token KW_ENUM
 %token KW_ISSET
 %token KW_UNSET
+%token KW_DECLARE
 
 %type <ptr> stmts
 %type <node> stmt
 %type <node> assignment
 %type <node> generator_assignment
 %type <node> generator_casted_assignment
+%type <node> declaration
 %type <node> expr
 %type <node> expr_value
 %type <node> expr_generator
@@ -104,6 +106,7 @@ construct_template_expr(LogTemplate *template)
 %type <node> literal
 %type <ptr> literal_object
 %type <node> lvalue
+%type <node> lvalue_floating
 %type <ptr> template
 %type <ptr> dict_generator
 %type <ptr> inner_dict_generator
@@ -134,6 +137,7 @@ stmt
 	: expr ';'				{ $$ = $1; }
 	| conditional ';'			{ $$ = $1; }
 	| assignment ';'			{ $$ = $1; }
+	| declaration ';'			{ $$ = $1; }
 	;
 
 assignment
@@ -243,6 +247,11 @@ generator_casted_assignment
 						}
 	;
 
+declaration
+	: KW_DECLARE lvalue_floating KW_ASSIGN expr	{ filterx_variable_expr_declare($2); $$ = filterx_assign_new($2, $4); }
+	;
+
+
 expr
 	: expr_value				{ $$ = $1; }
 	| function_call				{ $$ = $1; }
@@ -319,7 +328,11 @@ literal_object
 lvalue
 	: '$' LL_IDENTIFIER			{ $$ = filterx_msg_variable_expr_new($2); free($2); }
 	| LL_MESSAGE_REF			{ $$ = filterx_msg_variable_expr_new($1); free($1); }
-	| LL_IDENTIFIER				{ $$ = filterx_floating_variable_expr_new($1); free($1); }
+	| lvalue_floating
+	;
+
+lvalue_floating
+	: LL_IDENTIFIER				{ $$ = filterx_floating_variable_expr_new($1); free($1); }
 	;
 
 boolean

--- a/lib/filterx/filterx-parser.c
+++ b/lib/filterx/filterx-parser.c
@@ -50,6 +50,7 @@ static CfgLexerKeyword filterx_keywords[] =
 
   { "isset",              KW_ISSET },
   { "unset",              KW_UNSET },
+  { "declare",            KW_DECLARE },
 
   { CFG_KEYWORD_STOP },
 };

--- a/lib/filterx/filterx-pipe.c
+++ b/lib/filterx/filterx-pipe.c
@@ -53,31 +53,31 @@ log_filterx_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_o
   gboolean res;
 
   path_options = log_path_options_chain(&local_path_options, path_options);
-  msg_trace(">>>>>> filterx rule evaluation begin",
-            evt_tag_str("rule", self->name),
-            log_pipe_location_tag(s),
-            evt_tag_msg_reference(msg));
 
   FilterXScope *scope = filterx_scope_ref(path_options->filterx_scope);
   if (!scope)
-    local_path_options.filterx_scope = scope = filterx_scope_new();
-
+    scope = filterx_scope_new();
   filterx_scope_make_writable(&scope);
+
+  msg_trace(">>>>>> filterx rule evaluation begin",
+            evt_tag_str("rule", self->name),
+            log_pipe_location_tag(s),
+            evt_tag_printf("path_scope", "%p", path_options->filterx_scope),
+            evt_tag_printf("scope", "%p", scope),
+            evt_tag_msg_reference(msg));
 
   NVTable *payload = nv_table_ref(msg->payload);
   res = filterx_eval_exec_statements(scope, self->stmts, msg);
-  if (res)
-    {
-      log_msg_make_writable(&msg, path_options);
-      filterx_eval_sync_scope_and_message(scope, msg);
-    }
 
   msg_trace("<<<<<< filterx rule evaluation result",
             evt_tag_str("result", res ? "matched" : "unmatched"),
             evt_tag_str("rule", self->name),
             log_pipe_location_tag(s),
+            evt_tag_printf("scope", "%p", scope),
+            evt_tag_int("dirty", filterx_scope_is_dirty(scope)),
             evt_tag_msg_reference(msg));
 
+  local_path_options.filterx_scope = scope;
   if (res)
     {
       log_pipe_forward_msg(s, msg, path_options);
@@ -120,7 +120,7 @@ log_filterx_pipe_new(GList *stmts, GlobalConfig *cfg)
   LogFilterXPipe *self = g_new0(LogFilterXPipe, 1);
 
   log_pipe_init_instance(&self->super, cfg);
-  self->super.flags |= PIF_CONFIG_RELATED;
+  self->super.flags = (self->super.flags | PIF_CONFIG_RELATED) & ~PIF_SYNC_SCOPE;
   self->super.init = log_filterx_pipe_init;
   self->super.queue = log_filterx_pipe_queue;
   self->super.free_fn = log_filterx_pipe_free;

--- a/lib/filterx/filterx-scope.c
+++ b/lib/filterx/filterx-scope.c
@@ -84,6 +84,12 @@ filterx_variable_is_set(FilterXVariable *v)
   return v->value != NULL;
 }
 
+void
+filterx_variable_mark_declared(FilterXVariable *v)
+{
+  v->declared = TRUE;
+}
+
 static void
 _variable_free(FilterXVariable *v)
 {
@@ -187,8 +193,12 @@ filterx_scope_store_weak_ref(FilterXScope *self, FilterXObject *object)
     g_ptr_array_add(self->weak_refs, filterx_object_ref(object));
 }
 
+/*
+ * 1) sync objects to message
+ * 2) drop undeclared objects
+ */
 void
-filterx_scope_sync_to_message(FilterXScope *self, LogMessage *msg)
+filterx_scope_sync(FilterXScope *self, LogMessage *msg)
 {
   GString *buffer = scratch_buffers_alloc();
 
@@ -206,6 +216,10 @@ filterx_scope_sync_to_message(FilterXScope *self, LogMessage *msg)
        */
       if (filterx_variable_is_floating(v))
         {
+          if (!v->declared)
+            {
+              filterx_variable_set_value(v, NULL);
+            }
         }
       else if (v->value == NULL)
         {

--- a/lib/filterx/filterx-scope.h
+++ b/lib/filterx/filterx-scope.h
@@ -32,6 +32,7 @@ typedef enum
 {
   FX_VAR_MESSAGE,
   FX_VAR_FLOATING,
+  FX_VAR_DECLARED,
 } FilterXVariableType;
 
 gboolean filterx_variable_is_floating(FilterXVariable *v);
@@ -40,7 +41,7 @@ FilterXObject *filterx_variable_get_value(FilterXVariable *v);
 void filterx_variable_set_value(FilterXVariable *v, FilterXObject *new_value);
 void filterx_variable_unset_value(FilterXVariable *v);
 gboolean filterx_variable_is_set(FilterXVariable *v);
-
+void filterx_variable_mark_declared(FilterXVariable *v);
 
 /*
  * FilterXScope represents variables in a filterx scope.

--- a/lib/filterx/filterx-scope.h
+++ b/lib/filterx/filterx-scope.h
@@ -27,7 +27,15 @@
 #include "logmsg/logmsg.h"
 
 typedef struct _FilterXVariable FilterXVariable;
+typedef guint32 FilterXVariableHandle;
+typedef enum
+{
+  FX_VAR_MESSAGE,
+  FX_VAR_FLOATING,
+} FilterXVariableType;
 
+gboolean filterx_variable_is_floating(FilterXVariable *v);
+gboolean filterx_variable_handle_is_floating(FilterXVariableHandle handle);
 FilterXObject *filterx_variable_get_value(FilterXVariable *v);
 void filterx_variable_set_value(FilterXVariable *v, FilterXObject *new_value);
 void filterx_variable_unset_value(FilterXVariable *v);
@@ -47,11 +55,12 @@ gboolean filterx_variable_is_set(FilterXVariable *v);
  */
 typedef struct _FilterXScope FilterXScope;
 
-void filterx_scope_sync_to_message(FilterXScope *self, LogMessage *msg);
+void filterx_scope_sync(FilterXScope *self, LogMessage *msg);
 
-FilterXVariable *filterx_scope_lookup_variable(FilterXScope *self, NVHandle handle);
+FilterXVariableHandle filterx_scope_map_variable_to_handle(const gchar *name, FilterXVariableType type);
+FilterXVariable *filterx_scope_lookup_variable(FilterXScope *self, FilterXVariableHandle handle);
 FilterXVariable *filterx_scope_register_variable(FilterXScope *self,
-                                                 NVHandle handle, gboolean floating,
+                                                 FilterXVariableHandle handle,
                                                  FilterXObject *initial_value);
 
 void filterx_scope_store_weak_ref(FilterXScope *self, FilterXObject *object);

--- a/lib/filterx/filterx-scope.h
+++ b/lib/filterx/filterx-scope.h
@@ -56,6 +56,8 @@ void filterx_variable_mark_declared(FilterXVariable *v);
  */
 typedef struct _FilterXScope FilterXScope;
 
+void filterx_scope_set_dirty(FilterXScope *self);
+gboolean filterx_scope_is_dirty(FilterXScope *self);
 void filterx_scope_sync(FilterXScope *self, LogMessage *msg);
 
 FilterXVariableHandle filterx_scope_map_variable_to_handle(const gchar *name, FilterXVariableType type);

--- a/lib/filterx/tests/Makefile.am
+++ b/lib/filterx/tests/Makefile.am
@@ -14,6 +14,7 @@ lib_filterx_tests_TESTS		 =              \
 		lib/filterx/tests/test_expr_function	\
 		lib/filterx/tests/test_expr_comparison \
 		lib/filterx/tests/test_expr_condition \
+		lib/filterx/tests/test_expr_function \
 		lib/filterx/tests/test_builtin_functions \
 		lib/filterx/tests/test_type_registry \
 		lib/filterx/tests/test_filterx_object

--- a/lib/filterx/tests/test_builtin_functions.c
+++ b/lib/filterx/tests/test_builtin_functions.c
@@ -36,7 +36,7 @@
 #include "filterx/object-message-value.h"
 #include "filterx/expr-assign.h"
 #include "filterx/expr-template.h"
-#include "filterx/expr-message-ref.h"
+#include "filterx/expr-variable.h"
 #include "filterx/filterx-private.h"
 
 #include "apphook.h"

--- a/lib/filterx/tests/test_expr_condition.c
+++ b/lib/filterx/tests/test_expr_condition.c
@@ -36,7 +36,7 @@
 #include "filterx/object-message-value.h"
 #include "filterx/expr-assign.h"
 #include "filterx/expr-template.h"
-#include "filterx/expr-message-ref.h"
+#include "filterx/expr-variable.h"
 #include "filterx/expr-function.h"
 
 #include "apphook.h"
@@ -61,7 +61,7 @@ _assert_cmp_string_to_filterx_object(const char *str, FilterXObject *obj)
 FilterXExpr *
 _assert_assign_var(const char *var_name, FilterXExpr *value)
 {
-  FilterXExpr *control_variable = filterx_message_ref_expr_new(log_msg_get_value_handle(var_name));
+  FilterXExpr *control_variable = filterx_variable_expr_new(log_msg_get_value_handle(var_name));
   cr_assert(control_variable != NULL);
 
   return filterx_assign_new(control_variable, value);
@@ -84,7 +84,7 @@ _assert_set_test_variable(const char *var_name, FilterXExpr *expr)
 FilterXObject *
 _assert_get_test_variable(const char *var_name)
 {
-  FilterXExpr *control_variable = filterx_message_ref_expr_new(log_msg_get_value_handle(var_name));
+  FilterXExpr *control_variable = filterx_variable_expr_new(log_msg_get_value_handle(var_name));
   cr_assert(control_variable != NULL);
   FilterXObject *result = filterx_expr_eval(control_variable);
   filterx_expr_unref(control_variable);

--- a/lib/filterx/tests/test_expr_condition.c
+++ b/lib/filterx/tests/test_expr_condition.c
@@ -61,7 +61,7 @@ _assert_cmp_string_to_filterx_object(const char *str, FilterXObject *obj)
 FilterXExpr *
 _assert_assign_var(const char *var_name, FilterXExpr *value)
 {
-  FilterXExpr *control_variable = filterx_variable_expr_new(var_name);
+  FilterXExpr *control_variable = filterx_msg_variable_expr_new(var_name);
   cr_assert(control_variable != NULL);
 
   return filterx_assign_new(control_variable, value);
@@ -84,7 +84,7 @@ _assert_set_test_variable(const char *var_name, FilterXExpr *expr)
 FilterXObject *
 _assert_get_test_variable(const char *var_name)
 {
-  FilterXExpr *control_variable = filterx_variable_expr_new(var_name);
+  FilterXExpr *control_variable = filterx_msg_variable_expr_new(var_name);
   cr_assert(control_variable != NULL);
   FilterXObject *result = filterx_expr_eval(control_variable);
   filterx_expr_unref(control_variable);

--- a/lib/filterx/tests/test_expr_condition.c
+++ b/lib/filterx/tests/test_expr_condition.c
@@ -61,7 +61,7 @@ _assert_cmp_string_to_filterx_object(const char *str, FilterXObject *obj)
 FilterXExpr *
 _assert_assign_var(const char *var_name, FilterXExpr *value)
 {
-  FilterXExpr *control_variable = filterx_variable_expr_new(log_msg_get_value_handle(var_name));
+  FilterXExpr *control_variable = filterx_variable_expr_new(var_name);
   cr_assert(control_variable != NULL);
 
   return filterx_assign_new(control_variable, value);
@@ -84,7 +84,7 @@ _assert_set_test_variable(const char *var_name, FilterXExpr *expr)
 FilterXObject *
 _assert_get_test_variable(const char *var_name)
 {
-  FilterXExpr *control_variable = filterx_variable_expr_new(log_msg_get_value_handle(var_name));
+  FilterXExpr *control_variable = filterx_variable_expr_new(var_name);
   cr_assert(control_variable != NULL);
   FilterXObject *result = filterx_expr_eval(control_variable);
   filterx_expr_unref(control_variable);

--- a/lib/filterx/tests/test_expr_function.c
+++ b/lib/filterx/tests/test_expr_function.c
@@ -36,7 +36,7 @@
 #include "filterx/object-message-value.h"
 #include "filterx/expr-assign.h"
 #include "filterx/expr-template.h"
-#include "filterx/expr-message-ref.h"
+#include "filterx/expr-variable.h"
 #include "filterx/expr-function.h"
 
 #include "apphook.h"

--- a/lib/filterx/tests/test_filterx_expr.c
+++ b/lib/filterx/tests/test_filterx_expr.c
@@ -354,7 +354,7 @@ Test(filterx_expr, test_filterx_assign)
   };
   filterx_eval_set_context(&context);
 
-  FilterXExpr *result_var = filterx_variable_expr_new("$result-var");
+  FilterXExpr *result_var = filterx_msg_variable_expr_new("$result-var");
   cr_assert(result_var != NULL);
 
   FilterXExpr *assign = filterx_assign_new(result_var, filterx_literal_new(filterx_string_new("foobar", -1)));

--- a/lib/filterx/tests/test_filterx_expr.c
+++ b/lib/filterx/tests/test_filterx_expr.c
@@ -354,7 +354,7 @@ Test(filterx_expr, test_filterx_assign)
   };
   filterx_eval_set_context(&context);
 
-  FilterXExpr *result_var = filterx_variable_expr_new(log_msg_get_value_handle("$result-var"));
+  FilterXExpr *result_var = filterx_variable_expr_new("$result-var");
   cr_assert(result_var != NULL);
 
   FilterXExpr *assign = filterx_assign_new(result_var, filterx_literal_new(filterx_string_new("foobar", -1)));

--- a/lib/filterx/tests/test_filterx_expr.c
+++ b/lib/filterx/tests/test_filterx_expr.c
@@ -33,7 +33,7 @@
 #include "filterx/object-list-interface.h"
 #include "filterx/object-dict-interface.h"
 #include "filterx/expr-assign.h"
-#include "filterx/expr-message-ref.h"
+#include "filterx/expr-variable.h"
 #include "filterx/expr-setattr.h"
 
 #include "apphook.h"
@@ -354,7 +354,7 @@ Test(filterx_expr, test_filterx_assign)
   };
   filterx_eval_set_context(&context);
 
-  FilterXExpr *result_var = filterx_message_ref_expr_new(log_msg_get_value_handle("$result-var"));
+  FilterXExpr *result_var = filterx_variable_expr_new(log_msg_get_value_handle("$result-var"));
   cr_assert(result_var != NULL);
 
   FilterXExpr *assign = filterx_assign_new(result_var, filterx_literal_new(filterx_string_new("foobar", -1)));

--- a/lib/logmpx.c
+++ b/lib/logmpx.c
@@ -88,9 +88,13 @@ log_multiplexer_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_op
   log_path_options_push_junction(&local_path_options, &matched, path_options);
   if (_has_multiple_arcs(self))
     {
-      log_msg_write_protect(msg);
       if (path_options->filterx_scope)
-        filterx_scope_write_protect(path_options->filterx_scope);
+        {
+          log_msg_make_writable(&msg, path_options);
+          filterx_scope_sync(path_options->filterx_scope, msg);
+          filterx_scope_write_protect(path_options->filterx_scope);
+        }
+      log_msg_write_protect(msg);
     }
   for (fallback = 0; (fallback == 0) || (fallback == 1 && self->fallback_exists && !delivered); fallback++)
     {
@@ -216,6 +220,7 @@ log_multiplexer_new(GlobalConfig *cfg)
   LogMultiplexer *self = g_new0(LogMultiplexer, 1);
 
   log_pipe_init_instance(&self->super, cfg);
+  self->super.flags = self->super.flags & ~PIF_SYNC_SCOPE;
   self->super.init = log_multiplexer_init;
   self->super.deinit = log_multiplexer_deinit;
   self->super.queue = log_multiplexer_queue;

--- a/lib/logpipe.c
+++ b/lib/logpipe.c
@@ -82,6 +82,7 @@ log_pipe_init_instance(LogPipe *self, GlobalConfig *cfg)
   self->queue = NULL;
   self->free_fn = log_pipe_free_method;
   self->arcs = _arcs;
+  self->flags = PIF_SYNC_SCOPE;
 }
 
 LogPipe *

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -72,6 +72,8 @@
 /* node created directly by the user */
 #define PIF_CONFIG_RELATED    0x0100
 
+#define PIF_SYNC_SCOPE        0x0200
+
 /* private flags range, to be used by other LogPipe instances for their own purposes */
 
 #define PIF_PRIVATE(x)       ((x) << 16)
@@ -454,6 +456,14 @@ log_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
           log_msg_drop(msg, path_options, AT_PROCESSED);
           return;
         }
+    }
+
+  if ((s->flags & PIF_SYNC_SCOPE) &&
+      path_options->filterx_scope &&
+      filterx_scope_is_dirty(path_options->filterx_scope))
+    {
+      log_msg_make_writable(&msg, path_options);
+      filterx_scope_sync(path_options->filterx_scope, msg);
     }
 
   if (G_UNLIKELY(s->flags & (PIF_HARD_FLOW_CONTROL | PIF_JUNCTION_END | PIF_CONDITIONAL_MIDPOINT)))

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -252,6 +252,7 @@ tests/light/functional_tests/logpath/test_midpoint_destinations\.py
 tests/light/functional_tests/value-pairs/test_value_pairs\.py
 tests/light/functional_tests/templates/test_template_stmt\.py
 tests/light/functional_tests/filterx/test_filterx\.py
+tests/light/functional_tests/filterx/test_filterx_scope\.py
 tests/light/functional_tests/parsers/metrics-probe/test_metrics_probe\.py
 tests/light/src/syslog_ng_ctl/prometheus_stats_handler.py
 tests/light/src/syslog_ng_config/statements/template/template\.py

--- a/tests/light/functional_tests/filterx/test_filterx_scope.py
+++ b/tests/light/functional_tests/filterx/test_filterx_scope.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python
+#############################################################################
+# Copyright (c) 2023 Balazs Scheidler <balazs.scheidler@axoflow.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from src.syslog_ng_config.renderer import render_statement
+
+
+# noqa: E122
+
+
+def render_filterx_exprs(expressions):
+    return '\n'.join(f"filterx {{ { expr } }};" for expr in expressions)
+
+
+def create_config(config, init_exprs, true_exprs=(), false_exprs=(), msg="foobar"):
+    file_true = config.create_file_destination(file_name="dest-true.log", template="'$MSG\n'")
+    file_false = config.create_file_destination(file_name="dest-false.log", template="'$MSG\n'")
+
+    preamble = f"""
+@version: {config.get_version()}
+
+options {{ stats(level(1)); }};
+
+source genmsg {{
+    example-msg-generator(
+        num(1)
+        template("{msg}")
+        values(
+            "values.str" => string("string"),
+            "values.bool" => boolean(true),
+            "values.int" => int(5),
+            "values.double" => double(32.5),
+            "values.datetime" => datetime("1701350398.123000+01:00"),
+            "values.list" => list("foo,bar,baz"),
+            "values.null" => null(""),
+            "values.bytes" => bytes("binary whatever"),
+            "values.protobuf" => protobuf("this is not a valid protobuf!!"),
+            "values.json" => json('{{"emb_key1": "emb_key1 value", "emb_key2": "emb_key2 value"}}'),
+            "values.true_string" => string("boolean:true"),
+            "values.false_string" => string("boolean:false"),
+        )
+    );
+}};
+
+destination dest_true {{
+    {render_statement(file_true)};
+}};
+
+destination dest_false {{
+    {render_statement(file_false)};
+}};
+
+log {{
+    source(genmsg);
+    {render_filterx_exprs(init_exprs)};
+    if {{
+        {render_filterx_exprs(true_exprs)}
+        destination(dest_true);
+    }} else {{
+        {render_filterx_exprs(false_exprs)}
+        destination(dest_false);
+    }};
+}};
+"""
+    config.set_raw_config(preamble)
+    return (file_true, file_false)
+
+
+def test_message_tied_variables_are_propagated_to_the_output(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, [
+            """
+                $foo = "kecske";
+                isset($foo);
+            """,
+            """
+                isset($foo);
+                $MSG = $foo;
+            """,
+        ],
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "kecske\n"
+
+
+def test_message_tied_variables_are_propagated_to_the_output_in_junctions(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, init_exprs=[
+            """
+                $foo = "kecske";
+                isset($foo);
+            """,
+        ], true_exprs=[
+            """
+            isset($foo);
+            $MSG = $foo;
+            """,
+        ],
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "kecske\n"
+
+
+def test_message_tied_variables_do_not_propagate_to_parallel_branches(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, init_exprs=[
+            """
+            $foo = "kecske";
+            isset($foo);
+            """,
+        ], true_exprs=[
+            """
+            isset($foo);
+            $bar = $foo;
+            isset($bar);
+            $foo = "not kecske";
+            false;
+            """,
+        ], false_exprs=[
+            """
+            isset($foo);
+            not isset($bar);
+            $MSG = $foo;
+            """,
+        ],
+    )
+    syslog_ng.start(config)
+
+    assert file_false.get_stats()["processed"] == 1
+    assert "processed" not in file_true.get_stats()
+    assert file_false.read_log() == "kecske\n"
+
+
+def test_floating_variables_are_dropped_at_the_end_of_the_scope(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, [
+            """
+            foo = "kecske";
+            isset(foo);
+            """,
+            """
+            not isset(foo);
+            """,
+        ],
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "foobar\n"
+
+
+def test_floating_variables_are_dropped_at_the_end_of_the_scope_but_can_be_recreated(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, [
+            """
+            foo = "kecske";
+            isset(foo);
+            """,
+            """
+            not isset(foo);
+            foo = "barka";
+            isset(foo);
+            $MSG = foo;
+            """,
+        ],
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "barka\n"
+
+
+def test_declared_variables_are_retained_across_scopes(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, [
+            """
+            declare foo = "kecske";
+            isset(foo);
+            """,
+            """
+            isset(foo);
+            foo = "barka";
+            """,
+            """
+            isset(foo);
+            $MSG = foo;
+            """,
+        ],
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "barka\n"
+
+
+def test_declared_variables_are_retained_across_scopes_and_junctions(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, init_exprs=[
+            """
+            declare foo = "kecske";
+            isset(foo);
+            """,
+        ], true_exprs=[
+            """
+            isset(foo);
+            foo = "barka";
+            """,
+            """
+            isset(foo);
+            $MSG = foo;
+            """,
+        ],
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "barka\n"


### PR DESCRIPTION
This PR adds the "declare" keyword to filterx to indicate that a floating value is kept all along the pipeline.

With this patch we are going to have 3 different kinds of variables:
 * message-tied ($MSG): values that are extracted from the message and synced back if they are changed.
 * locals (foo, wihout the '$'): values that get assigned in a filterx block and destroyed once the block exits
 * pipeline variables (declare foo): same as locals but kept around for the entire input pipeline.

This branch also integrates filterx more with  the syslog-ng pipeline, as I made an effort to clone/sync the FilterXScore only when absolutely necessary, which needed integration with LogMultiplexer and LogPipe.

A FilterXScope:
* has a dirty state in which case it needs to be synced with the message
* can be write_protected, in which case it needs to be cloned before being written

A thorough review is needed :)