### PR TITLE
Filterx scope variables refactor

### DIFF
--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -75,6 +75,10 @@ static inline FilterXObject *
 filterx_expr_eval_typed(FilterXExpr *self)
 {
   FilterXObject *result = filterx_expr_eval(self);
+
+  if (!result)
+    return NULL;
+
   FilterXObject *unmarshalled = filterx_object_unmarshal(result);
 
   if (!unmarshalled)

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -106,9 +106,9 @@ construct_template_expr(LogTemplate *template)
 %type <ptr> list_values
 %type <ptr> list_value
 %type <num> boolean
-%type <ptr> fxcondition
-%type <ptr> fxif
-%type <ptr> fxcodeblock
+%type <ptr> conditional
+%type <ptr> if
+%type <ptr> codeblock
 %type <ptr> tenary
 
 %%
@@ -124,7 +124,7 @@ stmts
 
 stmt
 	: expr ';'				{ $$ = $1; }
-	| fxcondition ';'			{ $$ = $1; }
+	| conditional ';'			{ $$ = $1; }
 	;
 
 expr
@@ -267,32 +267,36 @@ list_value
 	| list_expr_inner                       { $$ = $1; }
 	;
 
-fxcondition
-	: fxif					{ $$ = $1; }
-	| fxif KW_ELSE fxcodeblock		{
-							$$ = filterx_conditional_add_false_branch((FilterXConditional*)$1, (FilterXConditional*)filterx_conditional_new_codeblock($3));
-						}
+conditional
+	: if					{ $$ = $1; }
+	| if KW_ELSE codeblock
+	  {
+	    $$ = filterx_conditional_add_false_branch((FilterXConditional*)$1, (FilterXConditional*)filterx_conditional_new_codeblock($3));
+	  }
 	;
 
-fxif
-	: KW_IF '(' expr ')' fxcodeblock	{
-							$$ = filterx_conditional_new_conditional_codeblock($3, $5);
-						}
-	| fxif KW_ELIF '(' expr ')' fxcodeblock {
-							$$ = filterx_conditional_add_false_branch((FilterXConditional*)$1, (FilterXConditional*)filterx_conditional_new_conditional_codeblock($4, $6));
-						}
+if
+	: KW_IF '(' expr ')' codeblock
+	  {
+	    $$ = filterx_conditional_new_conditional_codeblock($3, $5);
+	  }
+	| if KW_ELIF '(' expr ')' codeblock
+	  {
+	    $$ = filterx_conditional_add_false_branch((FilterXConditional*)$1, (FilterXConditional*)filterx_conditional_new_conditional_codeblock($4, $6));
+	  }
 	;
 
 
-fxcodeblock
+codeblock
 	: '{' stmts '}'				{ $$ = $2; }
 	;
 
 tenary
-	: '(' expr '?' expr ':' expr ')'		{
-							FilterXConditional *cond = (FilterXConditional*)filterx_conditional_new_conditional_codeblock($2, g_list_append(NULL, $4));
-							$$ = filterx_conditional_add_false_branch(cond, (FilterXConditional*)filterx_conditional_new_codeblock(g_list_append(NULL, $6)));
-						}
+	: '(' expr '?' expr ':' expr ')'
+	  {
+	    FilterXConditional *cond = (FilterXConditional*)filterx_conditional_new_conditional_codeblock($2, g_list_append(NULL, $4));
+	    $$ = filterx_conditional_add_false_branch(cond, (FilterXConditional*)filterx_conditional_new_codeblock(g_list_append(NULL, $6)));
+	  }
 	;
 
 /* INCLUDE_RULES */

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -81,16 +81,9 @@ struct _FilterXObject
    *     modified_in_place -- set to TRUE in case the value in this
    *                          FilterXObject was changed
    *
-   *     assigned          -- should be stored in the FilterXScope but we
-   *                          can reuse a bit here.  Signifies if the value was assigned to a
-   *                          name-value pair.
-   *
-   *     shadow            -- this object is a shadow of a LogMessage
-   *                          name-value pair.  Whenever assigned to another name-value pair,
-   *                          this needs to be copied.
    *
    */
-  guint thread_index:16, modified_in_place:1, shadow:1, assigned:1;
+  guint thread_index:16, modified_in_place:1;
   FilterXType *type;
 };
 

--- a/lib/filterx/filterx-scope.h
+++ b/lib/filterx/filterx-scope.h
@@ -26,12 +26,33 @@
 #include "filterx-object.h"
 #include "logmsg/logmsg.h"
 
+typedef struct _FilterXVariable FilterXVariable;
+
+FilterXObject *filterx_variable_get_value(FilterXVariable *v);
+void filterx_variable_set_value(FilterXVariable *v, FilterXObject *new_value);
+
+/*
+ * FilterXScope represents variables in a filterx scope.
+ *
+ * Variables are either tied to a LogMessage (when we are caching
+ * demarshalled values in the scope) or are values that are "floating", e.g.
+ * not yet tied to any values in the underlying LogMessage.
+ *
+ * Floating values are "temp" values that are not synced to the LogMessage
+ * upon the exit from the scope.
+ *
+ */
 typedef struct _FilterXScope FilterXScope;
 
 void filterx_scope_sync_to_message(FilterXScope *self, LogMessage *msg);
-FilterXObject *filterx_scope_lookup_message_ref(FilterXScope *self, NVHandle handle);
-void filterx_scope_register_message_ref(FilterXScope *self, NVHandle handle, FilterXObject *value);
+
+FilterXVariable *filterx_scope_lookup_variable(FilterXScope *self, NVHandle handle);
+FilterXVariable *filterx_scope_register_variable(FilterXScope *self,
+                                                 NVHandle handle, gboolean floating,
+                                                 FilterXObject *initial_value);
+
 void filterx_scope_store_weak_ref(FilterXScope *self, FilterXObject *object);
+
 
 /* copy on write */
 void filterx_scope_write_protect(FilterXScope *self);


### PR DESCRIPTION
This is a refactor on FilterXScope and how we represent filterx variables. This depends on #4882.

Also, this was extracted from #4885 as a separate PR, because:
* #4885 is still work-in-progress 
* this code is becoming a dependency of #4879 as well.

