### PR TITLE
filterx: fix expr eval truthy check on assign

### DIFF
--- a/lib/filterx/expr-assign.c
+++ b/lib/filterx/expr-assign.c
@@ -21,6 +21,7 @@
  *
  */
 #include "filterx/expr-assign.h"
+#include "filterx/object-primitive.h"
 
 static FilterXObject *
 _eval(FilterXExpr *s)
@@ -28,14 +29,15 @@ _eval(FilterXExpr *s)
   FilterXBinaryOp *self = (FilterXBinaryOp *) s;
 
   FilterXObject *value = filterx_expr_eval(self->rhs);
+  FilterXObject *result = NULL;
   if (!value)
     return NULL;
 
   if (filterx_expr_assign(self->lhs, value))
-    return value;
+    result = filterx_boolean_new(TRUE);
 
   filterx_object_unref(value);
-  return NULL;
+  return result;
 }
 
 /* NOTE: takes the object reference */

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -58,14 +58,13 @@ _eval(FilterXExpr *s)
   if (!new_value)
     goto exit;
 
-  result = filterx_object_clone(new_value);
+  FilterXObject *cloned = filterx_object_clone(new_value);
   filterx_object_unref(new_value);
 
-  if (!filterx_object_set_subscript(object, key, result))
-    {
-      filterx_object_unref(result);
-      result = NULL;
-    }
+  if (filterx_object_set_subscript(object, key, cloned))
+    result = filterx_boolean_new(TRUE);
+
+  filterx_object_unref(cloned);
 
 exit:
   filterx_object_unref(key);

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -45,14 +45,13 @@ _eval(FilterXExpr *s)
   if (!new_value)
     goto exit;
 
-  result = filterx_object_clone(new_value);
+  FilterXObject *cloned = filterx_object_clone(new_value);
   filterx_object_unref(new_value);
 
-  if (!filterx_object_setattr(object, self->attr_name, result))
-    {
-      filterx_object_unref(result);
-      result = NULL;
-    }
+  if (filterx_object_setattr(object, self->attr_name, cloned))
+    result = filterx_boolean_new(TRUE);
+
+  filterx_object_unref(cloned);
 
 exit:
   filterx_object_unref(object);

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -91,6 +91,7 @@ construct_template_expr(LogTemplate *template)
 
 %type <ptr> stmts
 %type <node> stmt
+%type <node> assignment
 %type <node> expr
 %type <node> expr_value
 %type <node> expr_generator
@@ -129,20 +130,24 @@ stmts
 stmt
 	: expr ';'				{ $$ = $1; }
 	| conditional ';'			{ $$ = $1; }
+	| assignment ';'			{ $$ = $1; }
+	;
+
+assignment
+	: lvalue KW_ASSIGN expr			{ $$ = filterx_assign_new($1, $3); }
+	| expr '.' LL_IDENTIFIER KW_ASSIGN expr	{ $$ = filterx_setattr_new($1, $3, $5); free($3); }
+	| expr '[' expr ']' KW_ASSIGN expr	{ $$ = filterx_set_subscript_new($1, $3, $6); }
+	| expr '[' ']' KW_ASSIGN expr  		{ $$ = filterx_set_subscript_new($1, NULL, $5); }
 	;
 
 expr
 	: expr_value				{ $$ = $1; }
 	| function_call				{ $$ = $1; }
-	| lvalue KW_ASSIGN expr			{ $$ = filterx_assign_new($1, $3); }
 	| KW_NOT expr				{ $$ = filterx_unary_not_new($2); }
 	| expr KW_OR expr			{ $$ = filterx_binary_or_new($1, $3); }
 	| expr KW_AND expr                      { $$ = filterx_binary_and_new($1, $3); }
 	| expr '.' LL_IDENTIFIER		{ $$ = filterx_getattr_new($1, $3); free($3); }
-	| expr '.' LL_IDENTIFIER KW_ASSIGN expr	{ $$ = filterx_setattr_new($1, $3, $5); free($3); }
 	| expr '[' expr ']'			{ $$ = filterx_get_subscript_new($1, $3); }
-	| expr '[' expr ']' KW_ASSIGN expr      { $$ = filterx_set_subscript_new($1, $3, $6); }
-	| expr '[' ']' KW_ASSIGN expr      	{ $$ = filterx_set_subscript_new($1, NULL, $5); }
 	| expr KW_PLUS_ASSIGN { last_fillable = $1; } expr_generator { $$ = $4; }
         | expr KW_TA_LT expr		        { $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AWARE | FCMPX_LT); }
         | expr KW_TA_LE expr			{ $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AWARE | FCMPX_LT | FCMPX_EQ); }
@@ -176,7 +181,7 @@ expr_generator
 	;
 
 function_call
-	: LL_IDENTIFIER '(' arguments ')'	{ 
+	: LL_IDENTIFIER '(' arguments ')'	{
 							FilterXExpr *res = filterx_function_lookup(configuration, $1, $3);
 							CHECK_ERROR(res, @1, "filterx function %s not found", $1);
 							$$ = res;

--- a/lib/filterx/tests/CMakeLists.txt
+++ b/lib/filterx/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_unit_test(LIBTEST CRITERION TARGET test_filterx_expr DEPENDS syslogformat)
+add_unit_test(LIBTEST CRITERION TARGET test_filterx_expr DEPENDS syslogformat json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_object_datetime DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_object_json DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_object_message DEPENDS json-plugin ${JSONC_LIBRARY})

--- a/lib/filterx/tests/Makefile.am
+++ b/lib/filterx/tests/Makefile.am
@@ -34,7 +34,7 @@ lib_filterx_tests_test_object_string_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_object_string_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
 
 lib_filterx_tests_test_filterx_expr_CFLAGS  = $(TEST_CFLAGS)
-lib_filterx_tests_test_filterx_expr_LDADD   = $(TEST_LDADD) $(PREOPEN_SYSLOGFORMAT)
+lib_filterx_tests_test_filterx_expr_LDADD   = $(TEST_LDADD) $(PREOPEN_SYSLOGFORMAT) $(JSON_LIBS)
 
 lib_filterx_tests_test_expr_comparison_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_expr_comparison_LDADD   = $(TEST_LDADD) $(JSON_LIBS)


### PR DESCRIPTION
truthy check on filterx assign caused the falsey values to turn statements evaluation to unmatched.

- expr-assign
- expr-setttr
- expr-set-subscipt 
are no longer return the value of their expression. they return TRUE on success, NULL on error.