### PR TITLE
filterx: `format_json()`: use repr() instead of marshal()

### DIFF
--- a/lib/filterx/filterx-object.c
+++ b/lib/filterx/filterx-object.c
@@ -155,17 +155,9 @@ filterx_object_unref(FilterXObject *self)
     }
 }
 
-static gboolean
-_repr(FilterXObject *self, GString *repr)
-{
-  /* empty */
-  return FALSE;
-}
-
 FilterXType FILTERX_TYPE_NAME(object) =
 {
   .super_type = NULL,
   .name = "object",
   .free_fn = filterx_object_free_method,
-  .repr = _repr,
 };

--- a/lib/filterx/object-json-array.c
+++ b/lib/filterx/object-json-array.c
@@ -47,7 +47,7 @@ _truthy(FilterXObject *s)
 }
 
 static gboolean
-_marshal_to_json_literal(FilterXJsonArray *self, GString *repr, LogMessageValueType *t)
+_marshal_to_json_literal_append(FilterXJsonArray *self, GString *repr, LogMessageValueType *t)
 {
   *t = LM_VT_JSON;
 
@@ -66,7 +66,7 @@ _marshal(FilterXObject *s, GString *repr, LogMessageValueType *t)
     {
       struct json_object *el = json_object_array_get_idx(self->object, i);
       if (json_object_get_type(el) != json_type_string)
-        return _marshal_to_json_literal(self, repr, t);
+        return _marshal_to_json_literal_append(self, repr, t);
 
       if (i != 0)
         g_string_append_c(repr, ',');

--- a/libtest/filterx.c
+++ b/libtest/filterx.c
@@ -43,10 +43,19 @@ filterx_test_list_new(void)
 const gchar *
 filterx_test_unknown_object_marshaled_repr(gssize *len)
 {
-  static const gchar *marshalled = "test_unknown_object";
+  static const gchar *marshaled = "test_unknown_object_marshaled";
   if (len)
-    *len = strlen(marshalled);
-  return marshalled;
+    *len = strlen(marshaled);
+  return marshaled;
+}
+
+const gchar *
+filterx_test_unknown_object_repr(gssize *len)
+{
+  static const gchar *repr = "test_unknown_object_repr";
+  if (len)
+    *len = strlen(repr);
+  return repr;
 }
 
 static gboolean
@@ -54,6 +63,13 @@ _unknown_marshal(FilterXObject *s, GString *repr, LogMessageValueType *t)
 {
   *t = LM_VT_STRING;
   g_string_append(repr, filterx_test_unknown_object_marshaled_repr(NULL));
+  return TRUE;
+}
+
+static gboolean
+_unknown_repr(FilterXObject *s, GString *repr)
+{
+  g_string_append(repr, filterx_test_unknown_object_repr(NULL));
   return TRUE;
 }
 
@@ -101,6 +117,7 @@ FILTERX_DEFINE_TYPE(test_unknown_object, FILTERX_TYPE_NAME(object),
                     .is_mutable = FALSE,
                     .truthy = _unknown_truthy,
                     .marshal = _unknown_marshal,
+                    .repr = _unknown_repr,
                     .map_to_json = _unknown_map_to_json,
                     .list_factory = filterx_test_list_new,
                     .dict_factory = filterx_test_dict_new);

--- a/libtest/filterx.h
+++ b/libtest/filterx.h
@@ -35,6 +35,7 @@ FilterXObject *filterx_test_list_new(void);
 FilterXObject *filterx_test_unknown_object_new(void);
 
 const gchar *filterx_test_unknown_object_marshaled_repr(gssize *len);
+const gchar *filterx_test_unknown_object_repr(gssize *len);
 
 void init_libtest_filterx(void);
 void deinit_libtest_filterx(void);

--- a/modules/json/tests/test_filterx_format_json.c
+++ b/modules/json/tests/test_filterx_format_json.c
@@ -127,8 +127,10 @@ Test(filterx_format_json, test_filterx_format_json)
   _assert_filterx_format_json_and_unref(filterx_message_value_new("[\"foo\" , 42]", -1, LM_VT_JSON), "[\"foo\" , 42]");
 
   /* unknown type */
-  _assert_filterx_format_json_and_unref(filterx_test_unknown_object_new(),
-                                        filterx_test_unknown_object_marshaled_repr(NULL));
+  GString *repr = g_string_new(NULL);
+  g_string_printf(repr, "\"%s\"", filterx_test_unknown_object_repr(NULL));
+  _assert_filterx_format_json_and_unref(filterx_test_unknown_object_new(), repr->str);
+  g_string_free(repr, TRUE);
 
   FilterXObject *foo = filterx_string_new("foo", -1);
   FilterXObject *bar = filterx_string_new("bar", -1);


### PR DESCRIPTION
<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
