### PR TITLE
s3: add role() option to assume role

### DIFF
--- a/modules/python-modules/syslogng/modules/s3/s3_destination.py
+++ b/modules/python-modules/syslogng/modules/s3/s3_destination.py
@@ -251,13 +251,13 @@ class S3Destination(LogDestination):
             # NOTE: child of the Credentials class.
             self.session._session._credentials = DeferredRefreshableCredentials(
                 refresh_using=create_assume_role_refresher(
-                    self.session.client( "sts" ),
-                    { "RoleArn": self.role, "RoleSessionName": "syslog-ng" }
+                    self.session.client("sts"),
+                    {"RoleArn": self.role, "RoleSessionName": "syslog-ng"}
                 ),
                 method="sts-assume-role",
             )
 
-        sts = self.session.client( "sts" )
+        sts = self.session.client("sts")
         whoami = sts.get_caller_identity().get("Arn")
         self.logger.info(f"Using {whoami} to access the bucket")
 

--- a/modules/python-modules/syslogng/modules/s3/scl/s3.conf
+++ b/modules/python-modules/syslogng/modules/s3/scl/s3.conf
@@ -25,6 +25,7 @@ block destination s3(
     bucket()
     access_key("")
     secret_key("")
+    role("")
     object_key()
     object_key_timestamp("")
     template("${MESSAGE}\n")
@@ -48,6 +49,7 @@ block destination s3(
             "bucket" => `bucket`
             "access_key" => "`access_key`"
             "secret_key" => "`secret_key`"
+            "role" => "`role`"
             "object_key" => LogTemplate(`object_key`)
             "object_key_timestamp" => LogTemplate(`object_key_timestamp`)
             "template" => LogTemplate(`template`)


### PR DESCRIPTION
By setting role() option syslog-ng will assume the given role and use that to interact with the S3. This is a common pattern for running in AWS and accessing a bucket in another account.

NOTE: If you use only S3 calls then you might avoid this by setting a policy on the bucket but it is also common that you want to use SSE-KMS which requires an access to a KMS key. Syslog-ng does not support it, yet, but that could easily change soon.

The session will be automatically refreshed when needed.

For example:
```
destination d_s3 {
        s3(
                bucket( "mycompany-log-archive" )
                role( "arn:aws:iam::1234567890:role/log-archiver-XXXXXXXX" )
                object-key( "logs/${HOST}/year=${YEAR}/month=${MONTH}/day=${DAY}/syslog" )
                object-key-timestamp( "${YEAR}-${MONTH}-${DAY}" )
        );
};
```

The documentation also should be updated but I am uncertain where to do that and who should do that.

A few takeaways on the code:
- I chose `role()` but if you prefer it can be modified to `role-arn()` or `assume-role()` or `assume-role-arn()`. I saw examples of all of those.
- I actually tested the credential refresh procedure and it works as intended. It is not well documented but I saw this approach in many articles.
- The first assume role operation will be executed when you create the first client. In this case this is the get-caller-identity call. That will fail and the whole process will be restarted by syslog-ng(?).
- It could be a good idea to make RoleSessionName configurable, to make CloudTrail (or other audit trail solutions) more usable. It is common that a Role is used by multiple services. I thought that should be included in another PR to minimize the size. If you disagree I can add add a `role-session-name()` option.
- When you assume a role you receive temporal session credentials valid only for a short time. This time is by default 1 hour. I didn't make it configurable to keep the size of the PR low but it can be added that later in another PR.
- The whoami lines can be compacted into one, albeit longer line. I kept in 3 different lines to make it easier to read. If you disagree I can make it into one line or delete it completely.
- The boto3 library uses different naming schemes even in the same file (PascalCase and snake_case in this case). I intentionally kept the original names during the import.

This solves #4859.
