### PR TITLE
Filterx fix memory leak and unit tests

### DIFF
--- a/lib/filterx/expr-condition.c
+++ b/lib/filterx/expr-condition.c
@@ -82,6 +82,7 @@ _free (FilterXExpr *s)
   g_list_free_full(self->statements, (GDestroyNotify) filterx_expr_unref);
   if (self->false_branch != NULL)
     filterx_expr_unref(&self->false_branch->super);
+  filterx_expr_free_method(s);
 }
 
 static FilterXObject *

--- a/lib/filterx/expr-dict.c
+++ b/lib/filterx/expr-dict.c
@@ -101,6 +101,7 @@ _free(FilterXExpr *s)
 
   g_list_free_full(self->key_values, (GDestroyNotify) filterx_kv_free);
   filterx_expr_unref(self->fillable);
+  filterx_expr_free_method(s);
 }
 
 FilterXExpr *

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -100,6 +100,7 @@ _free(FilterXExpr *s)
   FilterXGetSubscript *self = (FilterXGetSubscript *) s;
   filterx_expr_unref(self->key);
   filterx_expr_unref(self->operand);
+  filterx_expr_free_method(s);
 }
 
 /* NOTE: takes the object reference */

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -53,6 +53,7 @@ _free(FilterXExpr *s)
   FilterXGetAttr *self = (FilterXGetAttr *) s;
   g_free(self->attr_name);
   filterx_expr_unref(self->operand);
+  filterx_expr_free_method(s);
 }
 
 /* NOTE: takes the object reference */

--- a/lib/filterx/expr-list.c
+++ b/lib/filterx/expr-list.c
@@ -80,6 +80,7 @@ _free(FilterXExpr *s)
 
   g_list_free_full(self->values, (GDestroyNotify) filterx_expr_unref);
   filterx_expr_unref(self->fillable);
+  filterx_expr_free_method(s);
 }
 
 FilterXExpr *

--- a/lib/filterx/expr-literal.c
+++ b/lib/filterx/expr-literal.c
@@ -40,6 +40,7 @@ _free(FilterXExpr *s)
 {
   FilterXLiteral *self = (FilterXLiteral *) s;
   filterx_object_unref(self->object);
+  filterx_expr_free_method(s);
 }
 
 /* NOTE: takes the object reference */

--- a/lib/filterx/expr-message-ref.c
+++ b/lib/filterx/expr-message-ref.c
@@ -136,12 +136,6 @@ _unset(FilterXExpr *s)
   return TRUE;
 }
 
-static void
-_free(FilterXExpr *s)
-{
-//  FilterXMessageRefExpr *self = (FilterXMessageRefExpr *) s;
-}
-
 FilterXExpr *
 filterx_message_ref_expr_new(NVHandle handle)
 {
@@ -153,7 +147,6 @@ filterx_message_ref_expr_new(NVHandle handle)
   self->super.assign = _assign;
   self->super.isset = _isset;
   self->super.unset = _unset;
-  self->super.free_fn = _free;
   self->handle = handle;
   return &self->super;
 }

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -80,6 +80,7 @@ _free(FilterXExpr *s)
   filterx_expr_unref(self->key);
   filterx_expr_unref(self->object);
   filterx_expr_unref(self->new_value);
+  filterx_expr_free_method(s);
 }
 
 FilterXExpr *

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -66,6 +66,7 @@ _free(FilterXExpr *s)
   g_free(self->attr_name);
   filterx_expr_unref(self->object);
   filterx_expr_unref(self->new_value);
+  filterx_expr_free_method(s);
 }
 
 FilterXExpr *

--- a/lib/filterx/expr-template.c
+++ b/lib/filterx/expr-template.c
@@ -59,6 +59,7 @@ _free(FilterXExpr *s)
 {
   FilterXTemplate *self = (FilterXTemplate *) s;
   log_template_unref(self->template);
+  filterx_expr_free_method(s);
 }
 
 /* NOTE: takes the object reference */

--- a/lib/filterx/filterx-expr.c
+++ b/lib/filterx/filterx-expr.c
@@ -84,6 +84,7 @@ filterx_unary_op_free_method(FilterXExpr *s)
   FilterXUnaryOp *self = (FilterXUnaryOp *) s;
 
   filterx_expr_unref(self->operand);
+  filterx_expr_free_method(s);
 }
 
 void
@@ -101,6 +102,7 @@ filterx_binary_op_free_method(FilterXExpr *s)
 
   filterx_expr_unref(self->lhs);
   filterx_expr_unref(self->rhs);
+  filterx_expr_free_method(s);
 }
 
 void

--- a/lib/filterx/tests/Makefile.am
+++ b/lib/filterx/tests/Makefile.am
@@ -5,6 +5,11 @@ lib_filterx_tests_TESTS		 =              \
 		lib/filterx/tests/test_object_json	\
 		lib/filterx/tests/test_object_null	\
 		lib/filterx/tests/test_object_string	\
+		lib/filterx/tests/test_object_protobuf	\
+		lib/filterx/tests/test_object_double	\
+		lib/filterx/tests/test_object_boolean	\
+		lib/filterx/tests/test_object_integer	\
+		lib/filterx/tests/test_object_bytes	\
 		lib/filterx/tests/test_filterx_expr	\
 		lib/filterx/tests/test_expr_comparison \
 		lib/filterx/tests/test_expr_condition \


### PR DESCRIPTION
This branch fixes up the Makefile.am version of the filterx unit tests as well as fix a memory leak caused by the missing filterx_expr_free_method() calls in derived classes.

