### PR TITLE
inrduce Filterx istype builtin function

### DIFF
--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -33,7 +33,7 @@ set(FILTERX_HEADERS
     filterx/expr-condition.h
     filterx/expr-isset.h
     filterx/expr-unset.h
-    filterx/filterx-globals-tests.h
+    filterx/filterx-private.h
     PARENT_SCOPE
     )
 
@@ -73,6 +73,7 @@ set(FILTERX_SOURCES
     filterx/expr-condition.c
     filterx/expr-isset.c
     filterx/expr-unset.c
+    filterx/filterx-private.c
     PARENT_SCOPE
     )
 

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -35,7 +35,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/expr-condition.h \
 	lib/filterx/expr-isset.h \
 	lib/filterx/expr-unset.h		\
-	lib/filterx/filterx-globals-tests.h
+	lib/filterx/filterx-private.h
 
 
 filterx_sources = 				\
@@ -74,6 +74,7 @@ filterx_sources = 				\
 	lib/filterx/expr-condition.c		\
 	lib/filterx/expr-isset.c		\
 	lib/filterx/expr-unset.c		\
+	lib/filterx/filterx-private.c	\
 	lib/filterx/filterx-grammar.y
 
 BUILT_SOURCES += 				\

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -63,6 +63,7 @@ filterx_builtin_functions_init(void)
   g_assert(filterx_builtin_function_register("int", filterx_typecast_integer));
   g_assert(filterx_builtin_function_register("double", filterx_typecast_double));
   g_assert(filterx_builtin_function_register("strptime", filterx_datetime_strptime));
+  g_assert(filterx_builtin_function_register("istype", filterx_object_is_type_builtin));
 }
 
 void

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -21,6 +21,7 @@
  *
  */
 #include "filterx/filterx-globals.h"
+#include "filterx/filterx-private.h"
 #include "filterx/object-primitive.h"
 #include "filterx/object-null.h"
 #include "filterx/object-string.h"
@@ -33,39 +34,21 @@
 static GHashTable *filterx_builtin_functions = NULL;
 
 gboolean
-filterx_builtin_function_register_inner(GHashTable *ht, const gchar *fn_name, FilterXFunctionProto func)
-{
-  return g_hash_table_insert(ht, g_strdup(fn_name), func);
-}
-
-gboolean
 filterx_builtin_function_register(const gchar *fn_name, FilterXFunctionProto func)
 {
-  return filterx_builtin_function_register_inner(filterx_builtin_functions, fn_name, func);
-}
-
-FilterXFunctionProto
-filterx_builtin_function_lookup_inner(GHashTable *ht, const gchar *fn_name)
-{
-  return (FilterXFunctionProto)g_hash_table_lookup(ht, fn_name);
+  return filterx_builtin_function_register_private(filterx_builtin_functions, fn_name, func);
 }
 
 FilterXFunctionProto
 filterx_builtin_function_lookup(const gchar *fn_name)
 {
-  return filterx_builtin_function_lookup_inner(filterx_builtin_functions, fn_name);
-}
-
-void
-filterx_builtin_functions_init_inner(GHashTable **ht)
-{
-  *ht = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, (GDestroyNotify) NULL);
+  return filterx_builtin_function_lookup_private(filterx_builtin_functions, fn_name);
 }
 
 void
 filterx_builtin_functions_init(void)
 {
-  filterx_builtin_functions_init_inner(&filterx_builtin_functions);
+  filterx_builtin_functions_init_private(&filterx_builtin_functions);
   filterx_builtin_function_register("json", filterx_json_new_from_args);
   filterx_builtin_function_register("json_array", filterx_json_array_new_from_args);
   g_assert(filterx_builtin_function_register("datetime", filterx_typecast_datetime));
@@ -80,15 +63,9 @@ filterx_builtin_functions_init(void)
 }
 
 void
-filterx_builtin_functions_deinit_inner(GHashTable *ht)
-{
-  g_hash_table_destroy(ht);
-}
-
-void
 filterx_builtin_functions_deinit(void)
 {
-  filterx_builtin_functions_deinit_inner(filterx_builtin_functions);
+  filterx_builtin_functions_deinit_private(filterx_builtin_functions);
 }
 
 void

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -32,6 +32,9 @@
 #include "filterx/object-dict-interface.h"
 
 static GHashTable *filterx_builtin_functions = NULL;
+static GHashTable *filterx_types = NULL;
+
+// Builtin functions
 
 gboolean
 filterx_builtin_function_register(const gchar *fn_name, FilterXFunctionProto func)
@@ -68,9 +71,40 @@ filterx_builtin_functions_deinit(void)
   filterx_builtin_functions_deinit_private(filterx_builtin_functions);
 }
 
+// FilterX types
+
+FilterXType *
+filterx_type_lookup(const gchar *type_name)
+{
+  return filterx_type_lookup_private(filterx_types, type_name);
+}
+
+gboolean
+filterx_type_register(const gchar *type_name, FilterXType *fxtype)
+{
+  return filterx_type_register_private(filterx_types, type_name, fxtype);
+}
+
+void
+filterx_types_init(void)
+{
+  filterx_types_init_private(&filterx_types);
+  filterx_type_register("object", &FILTERX_TYPE_NAME(object));
+}
+
+void
+filterx_types_deinit(void)
+{
+  filterx_types_deinit_private(filterx_types);
+}
+
+// Globals
+
 void
 filterx_global_init(void)
 {
+  filterx_types_init();
+
   filterx_type_init(&FILTERX_TYPE_NAME(list));
   filterx_type_init(&FILTERX_TYPE_NAME(dict));
 
@@ -95,6 +129,7 @@ void
 filterx_global_deinit(void)
 {
   filterx_builtin_functions_deinit();
+  filterx_types_deinit();
 }
 
 FilterXObject *filterx_typecast_get_arg(GPtrArray *args, gchar *alt_msg)

--- a/lib/filterx/filterx-globals.h
+++ b/lib/filterx/filterx-globals.h
@@ -28,7 +28,12 @@
 
 void filterx_global_init(void);
 void filterx_global_deinit(void);
+// Builtin functions
 FilterXFunctionProto filterx_builtin_function_lookup(const gchar *);
+// FilterX types
+FilterXType *filterx_type_lookup(const gchar *type_name);
+gboolean filterx_type_register(const gchar *type_name, FilterXType *fxtype);
+// Helpers
 FilterXObject *filterx_typecast_get_arg(GPtrArray *args, gchar *alt_msg);
 
 #endif

--- a/lib/filterx/filterx-object.c
+++ b/lib/filterx/filterx-object.c
@@ -23,6 +23,7 @@
 #include "filterx-object.h"
 #include "filterx-eval.h"
 #include "mainloop-worker.h"
+#include "filterx/filterx-globals.h"
 
 #define INIT_TYPE_METHOD(type, method_name) do { \
     if (type->method_name) \
@@ -57,6 +58,7 @@ filterx_type_init(FilterXType *type)
   INIT_TYPE_METHOD(type, dict_factory);
   INIT_TYPE_METHOD(type, repr);
   INIT_TYPE_METHOD(type, free_fn);
+  g_assert(filterx_type_register(type->name, type));
 }
 
 #define FILTERX_OBJECT_MAGIC_BIAS G_MAXINT32

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -96,6 +96,7 @@ gboolean filterx_object_freeze(FilterXObject *self);
 void filterx_object_unfreeze_and_free(FilterXObject *self);
 void filterx_object_init_instance(FilterXObject *self, FilterXType *type);
 void filterx_object_free_method(FilterXObject *self);
+FilterXObject *filterx_object_is_type_builtin(GPtrArray *args);
 
 static inline gboolean
 filterx_object_is_type(FilterXObject *object, FilterXType *type)

--- a/lib/filterx/filterx-private.c
+++ b/lib/filterx/filterx-private.c
@@ -30,6 +30,8 @@
 #include "filterx/object-list-interface.h"
 #include "filterx/object-dict-interface.h"
 
+// Builtin functions
+
 gboolean
 filterx_builtin_function_register_private(GHashTable *ht, const gchar *fn_name, FilterXFunctionProto func)
 {
@@ -50,6 +52,32 @@ filterx_builtin_functions_init_private(GHashTable **ht)
 
 void
 filterx_builtin_functions_deinit_private(GHashTable *ht)
+{
+  g_hash_table_destroy(ht);
+}
+
+// FilterX Types
+
+gboolean
+filterx_type_register_private(GHashTable *ht, const gchar *type_name, FilterXType *fxtype)
+{
+  return g_hash_table_insert(ht, g_strdup(type_name), fxtype);
+}
+
+FilterXType *
+filterx_type_lookup_private(GHashTable *ht, const gchar *type_name)
+{
+  return (FilterXType *)g_hash_table_lookup(ht, type_name);
+}
+
+void
+filterx_types_init_private(GHashTable **ht)
+{
+  *ht = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, (GDestroyNotify) NULL);
+}
+
+void
+filterx_types_deinit_private(GHashTable *ht)
 {
   g_hash_table_destroy(ht);
 }

--- a/lib/filterx/filterx-private.c
+++ b/lib/filterx/filterx-private.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 shifter <shifter@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "filterx/filterx-private.h"
+#include "filterx/object-primitive.h"
+#include "filterx/object-null.h"
+#include "filterx/object-string.h"
+#include "filterx/object-json.h"
+#include "filterx/object-datetime.h"
+#include "filterx/object-message-value.h"
+#include "filterx/object-list-interface.h"
+#include "filterx/object-dict-interface.h"
+
+gboolean
+filterx_builtin_function_register_private(GHashTable *ht, const gchar *fn_name, FilterXFunctionProto func)
+{
+  return g_hash_table_insert(ht, g_strdup(fn_name), func);
+}
+
+FilterXFunctionProto
+filterx_builtin_function_lookup_private(GHashTable *ht, const gchar *fn_name)
+{
+  return (FilterXFunctionProto)g_hash_table_lookup(ht, fn_name);
+}
+
+void
+filterx_builtin_functions_init_private(GHashTable **ht)
+{
+  *ht = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, (GDestroyNotify) NULL);
+}
+
+void
+filterx_builtin_functions_deinit_private(GHashTable *ht)
+{
+  g_hash_table_destroy(ht);
+}

--- a/lib/filterx/filterx-private.h
+++ b/lib/filterx/filterx-private.h
@@ -26,9 +26,17 @@
 #include "filterx-object.h"
 #include "filterx/expr-function.h"
 
+// Builtin functions
 gboolean filterx_builtin_function_register_private(GHashTable *ht, const gchar *fn_name, FilterXFunctionProto func);
 FilterXFunctionProto filterx_builtin_function_lookup_private(GHashTable *ht, const gchar *fn_name);
 void filterx_builtin_functions_init_private(GHashTable **ht);
 void filterx_builtin_functions_deinit_private(GHashTable *ht);
+// Types
+gboolean filterx_type_register_private(GHashTable *ht, const gchar *type_name, FilterXType *fxtype);
+FilterXType *filterx_type_lookup_private(GHashTable *ht, const gchar *type_name);
+void filterx_types_init_private(GHashTable **ht);
+void filterx_types_deinit_private(GHashTable *ht);
+
+
 
 #endif

--- a/lib/filterx/filterx-private.h
+++ b/lib/filterx/filterx-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ * Copyright (c) 2024 shifter <shifter@axoflow.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -20,15 +20,15 @@
  * COPYING for details.
  *
  */
-#ifndef FILTERX_GLOBALS_TESTS_H_INCLUDED
-#define FILTERX_GLOBALS_TESTS_H_INCLUDED
+#ifndef FILTERX_PRIVATE_H_INCLUDED
+#define FILTERX_PRIVATE_H_INCLUDED
 
 #include "filterx-object.h"
 #include "filterx/expr-function.h"
 
-gboolean filterx_builtin_function_register_inner(GHashTable *ht, const gchar *fn_name, FilterXFunctionProto func);
-FilterXFunctionProto filterx_builtin_function_lookup_inner(GHashTable *ht, const gchar *fn_name);
-void filterx_builtin_functions_init_inner(GHashTable **ht);
-void filterx_builtin_functions_deinit_inner(GHashTable *ht);
+gboolean filterx_builtin_function_register_private(GHashTable *ht, const gchar *fn_name, FilterXFunctionProto func);
+FilterXFunctionProto filterx_builtin_function_lookup_private(GHashTable *ht, const gchar *fn_name);
+void filterx_builtin_functions_init_private(GHashTable **ht);
+void filterx_builtin_functions_deinit_private(GHashTable *ht);
 
 #endif

--- a/lib/filterx/tests/CMakeLists.txt
+++ b/lib/filterx/tests/CMakeLists.txt
@@ -14,3 +14,4 @@ add_unit_test(LIBTEST CRITERION TARGET test_object_boolean DEPENDS json-plugin $
 add_unit_test(LIBTEST CRITERION TARGET test_object_integer DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_object_double DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_type_registry DEPENDS json-plugin ${JSONC_LIBRARY})
+add_unit_test(LIBTEST CRITERION TARGET test_filterx_object DEPENDS json-plugin ${JSONC_LIBRARY})

--- a/lib/filterx/tests/CMakeLists.txt
+++ b/lib/filterx/tests/CMakeLists.txt
@@ -13,3 +13,4 @@ add_unit_test(LIBTEST CRITERION TARGET test_object_protobuf DEPENDS json-plugin 
 add_unit_test(LIBTEST CRITERION TARGET test_object_boolean DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_object_integer DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_object_double DEPENDS json-plugin ${JSONC_LIBRARY})
+add_unit_test(LIBTEST CRITERION TARGET test_type_registry DEPENDS json-plugin ${JSONC_LIBRARY})

--- a/lib/filterx/tests/Makefile.am
+++ b/lib/filterx/tests/Makefile.am
@@ -14,7 +14,8 @@ lib_filterx_tests_TESTS		 =              \
 		lib/filterx/tests/test_expr_comparison \
 		lib/filterx/tests/test_expr_condition \
 		lib/filterx/tests/test_builtin_functions \
-		lib/filterx/tests/test_type_registry
+		lib/filterx/tests/test_type_registry \
+		lib/filterx/tests/test_filterx_object
 
 EXTRA_DIST += lib/filterx/tests/CMakeLists.txt \
 	lib/filterx/tests/filterx-lib.h
@@ -68,3 +69,6 @@ lib_filterx_tests_test_object_double_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
 
 lib_filterx_tests_test_type_registry_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_type_registry_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
+
+lib_filterx_tests_test_filterx_object_CFLAGS  = $(TEST_CFLAGS)
+lib_filterx_tests_test_filterx_object_LDADD   = $(TEST_LDADD) $(JSON_LIBS)

--- a/lib/filterx/tests/Makefile.am
+++ b/lib/filterx/tests/Makefile.am
@@ -13,7 +13,8 @@ lib_filterx_tests_TESTS		 =              \
 		lib/filterx/tests/test_filterx_expr	\
 		lib/filterx/tests/test_expr_comparison \
 		lib/filterx/tests/test_expr_condition \
-		lib/filterx/tests/test_builtin_functions
+		lib/filterx/tests/test_builtin_functions \
+		lib/filterx/tests/test_type_registry
 
 EXTRA_DIST += lib/filterx/tests/CMakeLists.txt \
 	lib/filterx/tests/filterx-lib.h
@@ -64,3 +65,6 @@ lib_filterx_tests_test_object_integer_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
 
 lib_filterx_tests_test_object_double_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_object_double_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
+
+lib_filterx_tests_test_type_registry_CFLAGS  = $(TEST_CFLAGS)
+lib_filterx_tests_test_type_registry_LDADD   = $(TEST_LDADD) $(JSON_LIBS)

--- a/lib/filterx/tests/test_builtin_functions.c
+++ b/lib/filterx/tests/test_builtin_functions.c
@@ -37,7 +37,7 @@
 #include "filterx/expr-assign.h"
 #include "filterx/expr-template.h"
 #include "filterx/expr-message-ref.h"
-#include "filterx/filterx-globals-tests.h"
+#include "filterx/filterx-private.h"
 
 #include "apphook.h"
 #include "scratch-buffers.h"
@@ -54,28 +54,28 @@ test_builtin_dummy_function(GPtrArray *args)
 Test(builtin_functions, test_builtin_functions_registering_existing_key_returns_false)
 {
   GHashTable *ht;
-  filterx_builtin_functions_init_inner(&ht);
+  filterx_builtin_functions_init_private(&ht);
   // first register returns TRUE
-  cr_assert(filterx_builtin_function_register_inner(ht, TEST_BUILTIN_FUNCTION_NAME, test_builtin_dummy_function));
+  cr_assert(filterx_builtin_function_register_private(ht, TEST_BUILTIN_FUNCTION_NAME, test_builtin_dummy_function));
   // second attampt of register must return FALSE
-  cr_assert(!filterx_builtin_function_register_inner(ht, TEST_BUILTIN_FUNCTION_NAME, test_builtin_dummy_function));
-  filterx_builtin_functions_deinit_inner(ht);
+  cr_assert(!filterx_builtin_function_register_private(ht, TEST_BUILTIN_FUNCTION_NAME, test_builtin_dummy_function));
+  filterx_builtin_functions_deinit_private(ht);
 }
 
 Test(builtin_functions, test_builtin_functions_lookup)
 {
   GHashTable *ht;
-  filterx_builtin_functions_init_inner(&ht);
+  filterx_builtin_functions_init_private(&ht);
 
   // func not found
-  FilterXFunctionProto func = filterx_builtin_function_lookup_inner(ht, TEST_BUILTIN_FUNCTION_NAME);
+  FilterXFunctionProto func = filterx_builtin_function_lookup_private(ht, TEST_BUILTIN_FUNCTION_NAME);
   cr_assert(func == NULL);
 
   // add dummy function
-  cr_assert(filterx_builtin_function_register_inner(ht, TEST_BUILTIN_FUNCTION_NAME, test_builtin_dummy_function));
+  cr_assert(filterx_builtin_function_register_private(ht, TEST_BUILTIN_FUNCTION_NAME, test_builtin_dummy_function));
 
   // lookup returns dummy function
-  func = filterx_builtin_function_lookup_inner(ht, TEST_BUILTIN_FUNCTION_NAME);
+  func = filterx_builtin_function_lookup_private(ht, TEST_BUILTIN_FUNCTION_NAME);
   cr_assert(func != NULL);
 
   // check dummy function as result
@@ -88,7 +88,7 @@ Test(builtin_functions, test_builtin_functions_lookup)
 
   cr_assert(strcmp(str, "test-builtin-functions") == 0);
 
-  filterx_builtin_functions_deinit_inner(ht);
+  filterx_builtin_functions_deinit_private(ht);
   filterx_object_unref(res);
 }
 

--- a/lib/filterx/tests/test_filterx_object.c
+++ b/lib/filterx/tests/test_filterx_object.c
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2024 shifter <shifter@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include "libtest/cr_template.h"
+
+#include "filterx/filterx-object.h"
+#include "filterx/filterx-globals.h"
+#include "filterx/object-string.h"
+#include "filterx/object-primitive.h"
+
+#include "apphook.h"
+
+FILTERX_DECLARE_TYPE(dummy_base);
+FILTERX_DECLARE_TYPE(dummy);
+FILTERX_DEFINE_TYPE(dummy_base, FILTERX_TYPE_NAME(object));
+FILTERX_DEFINE_TYPE(dummy, FILTERX_TYPE_NAME(dummy_base));
+
+Test(filterx_object, test_filterx_object_is_type_builtin_null_args)
+{
+  FilterXObject *out = filterx_object_is_type_builtin(NULL);
+  cr_assert_null(out);
+}
+
+Test(filterx_object, test_filterx_object_is_type_builtin_empty_args)
+{
+  GPtrArray *args = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
+  FilterXObject *out = filterx_object_is_type_builtin(args);
+  cr_assert_null(out);
+  g_ptr_array_free(args, TRUE);
+}
+
+Test(filterx_object, test_filterx_object_is_type_builtin_null_object_arg)
+{
+  GPtrArray *args = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
+  g_ptr_array_add(args, NULL);
+  g_ptr_array_add(args, filterx_string_new("json_object", -1));
+  FilterXObject *out = filterx_object_is_type_builtin(args);
+  cr_assert_null(out);
+  g_ptr_array_free(args, TRUE);
+}
+
+Test(filterx_object, test_filterx_object_is_type_builtin_null_type_arg)
+{
+  GPtrArray *args = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
+
+  g_ptr_array_add(args, filterx_object_new(&FILTERX_TYPE_NAME(dummy)));
+  g_ptr_array_add(args, NULL);
+  FilterXObject *out = filterx_object_is_type_builtin(args);
+  cr_assert_null(out);
+  g_ptr_array_free(args, TRUE);
+}
+
+Test(filterx_object, test_filterx_object_is_type_builtin_invalid_type_arg)
+{
+  GPtrArray *args = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
+  g_ptr_array_add(args, filterx_object_new(&FILTERX_TYPE_NAME(dummy)));
+  g_ptr_array_add(args, filterx_integer_new(33));
+  FilterXObject *out = filterx_object_is_type_builtin(args);
+  cr_assert_null(out);
+  g_ptr_array_free(args, TRUE);
+}
+
+Test(filterx_object, test_filterx_object_is_type_builtin_too_many_args)
+{
+  GPtrArray *args = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
+  g_ptr_array_add(args, filterx_object_new(&FILTERX_TYPE_NAME(dummy)));
+  g_ptr_array_add(args, filterx_string_new("dummy", -1));
+  g_ptr_array_add(args, filterx_string_new("dummy_base", -1));
+  FilterXObject *out = filterx_object_is_type_builtin(args);
+  cr_assert_null(out);
+  g_ptr_array_free(args, TRUE);
+}
+
+Test(filterx_object, test_filterx_object_is_type_builtin_non_matching_type)
+{
+  GPtrArray *args = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
+  g_ptr_array_add(args, filterx_object_new(&FILTERX_TYPE_NAME(dummy)));
+  g_ptr_array_add(args, filterx_string_new("string", -1));
+  FilterXObject *out = filterx_object_is_type_builtin(args);
+  cr_assert_not_null(out);
+  cr_assert(filterx_object_is_type(out, &FILTERX_TYPE_NAME(boolean)));
+  cr_assert(filterx_object_falsy(out));
+  g_ptr_array_free(args, TRUE);
+  filterx_object_unref(out);
+}
+
+Test(filterx_object, test_filterx_object_is_type_builtin_matching_type)
+{
+  GPtrArray *args = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
+  g_ptr_array_add(args, filterx_object_new(&FILTERX_TYPE_NAME(dummy)));
+  g_ptr_array_add(args, filterx_string_new("dummy", -1));
+  FilterXObject *out = filterx_object_is_type_builtin(args);
+  cr_assert_not_null(out);
+  cr_assert(filterx_object_is_type(out, &FILTERX_TYPE_NAME(boolean)));
+  cr_assert(filterx_object_truthy(out));
+  g_ptr_array_free(args, TRUE);
+  filterx_object_unref(out);
+}
+
+Test(filterx_object, test_filterx_object_is_type_builtin_matching_type_for_super_type)
+{
+  GPtrArray *args = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
+  g_ptr_array_add(args, filterx_object_new(&FILTERX_TYPE_NAME(dummy)));
+  g_ptr_array_add(args, filterx_string_new("dummy_base", -1));
+  FilterXObject *out = filterx_object_is_type_builtin(args);
+  cr_assert_not_null(out);
+  cr_assert(filterx_object_is_type(out, &FILTERX_TYPE_NAME(boolean)));
+  cr_assert(filterx_object_truthy(out));
+  g_ptr_array_free(args, TRUE);
+  filterx_object_unref(out);
+}
+
+Test(filterx_object, test_filterx_object_is_type_builtin_matching_type_for_root_type)
+{
+  GPtrArray *args = g_ptr_array_new_with_free_func((GDestroyNotify) filterx_object_unref);
+  g_ptr_array_add(args, filterx_object_new(&FILTERX_TYPE_NAME(dummy)));
+  g_ptr_array_add(args, filterx_string_new("object", -1));
+  FilterXObject *out = filterx_object_is_type_builtin(args);
+  cr_assert_not_null(out);
+  cr_assert(filterx_object_is_type(out, &FILTERX_TYPE_NAME(boolean)));
+  cr_assert(filterx_object_truthy(out));
+  g_ptr_array_free(args, TRUE);
+  filterx_object_unref(out);
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  filterx_type_init(&FILTERX_TYPE_NAME(dummy_base));
+  filterx_type_init(&FILTERX_TYPE_NAME(dummy));
+}
+
+static void
+teardown(void)
+{
+  app_shutdown();
+}
+
+TestSuite(filterx_object, .init = setup, .fini = teardown);

--- a/lib/filterx/tests/test_type_registry.c
+++ b/lib/filterx/tests/test_type_registry.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024 shifter <shifter@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include "libtest/cr_template.h"
+
+#include "filterx/filterx-object.h"
+#include "filterx/filterx-private.h"
+
+#include "apphook.h"
+
+
+FILTERX_DEFINE_TYPE(dummy_base, FILTERX_TYPE_NAME(object));
+
+Test(type_registry, test_type_registry_registering_existing_key_returns_false)
+{
+  GHashTable *ht;
+  filterx_types_init_private(&ht);
+  // first register returns TRUE
+  cr_assert(filterx_type_register_private(ht, "base", &FILTERX_TYPE_NAME(dummy_base)));
+  // second attampt of register must return FALSE
+  cr_assert(!filterx_type_register_private(ht, "base", &FILTERX_TYPE_NAME(dummy_base)));
+  filterx_types_deinit_private(ht);
+}
+
+Test(type_registry, test_type_registry_lookup)
+{
+  GHashTable *ht;
+  filterx_types_init_private(&ht);
+
+  // type not found
+  FilterXType *fxtype = filterx_type_lookup_private(ht, "base");
+  cr_assert(fxtype == NULL);
+
+  // add dummy function
+  cr_assert(filterx_type_register_private(ht, "base", &FILTERX_TYPE_NAME(dummy_base)));
+
+  // lookup returns dummy function
+  fxtype = filterx_type_lookup_private(ht, "base");
+  cr_assert(fxtype != NULL);
+
+  cr_assert_eq(&FILTERX_TYPE_NAME(dummy_base), fxtype);
+
+  filterx_types_deinit_private(ht);
+}
+
+static void
+setup(void)
+{
+  app_startup();
+}
+
+static void
+teardown(void)
+{
+  app_shutdown();
+}
+
+TestSuite(type_registry, .init = setup, .fini = teardown);


### PR DESCRIPTION
`istype` required to match to super types as well, this way the type check must be recursive/iterative. matching the type name strings with the type_str arguments could be a really slow operation. however filterx already has it's own effective recursive type matcher function, the `filterx_object_is_type(FilterXObject*, FilterXType*)`. to get the proper FilterXType parameter for this function we introduce the type registry in filterx-globals, which is able to lookup for a type name and returns a FilterXType for it.

usage example:
```
filterx {
		$j = json();
		if (istype($j, "dict")) {
                  do things...
                };
}
```
