### PR TITLE
Filterx function memleak fix + unit tests

### DIFF
--- a/lib/filterx/expr-function.c
+++ b/lib/filterx/expr-function.c
@@ -36,6 +36,7 @@ filterx_function_eval_expressions(GList *expressions)
       return NULL;
     }
   GPtrArray *res = g_ptr_array_sized_new(g_list_length(expressions));
+  g_ptr_array_set_free_func(res, (GDestroyNotify) filterx_object_unref);
   for (GList *head = expressions; head; head = head->next)
     {
       FilterXObject *fxo = filterx_expr_eval(head->data);

--- a/lib/filterx/tests/CMakeLists.txt
+++ b/lib/filterx/tests/CMakeLists.txt
@@ -15,3 +15,4 @@ add_unit_test(LIBTEST CRITERION TARGET test_object_integer DEPENDS json-plugin $
 add_unit_test(LIBTEST CRITERION TARGET test_object_double DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_type_registry DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_filterx_object DEPENDS json-plugin ${JSONC_LIBRARY})
+add_unit_test(LIBTEST CRITERION TARGET test_expr_function DEPENDS json-plugin ${JSONC_LIBRARY})

--- a/lib/filterx/tests/Makefile.am
+++ b/lib/filterx/tests/Makefile.am
@@ -72,3 +72,5 @@ lib_filterx_tests_test_type_registry_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
 
 lib_filterx_tests_test_filterx_object_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_filterx_object_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
+lib_filterx_tests_test_expr_function_CFLAGS	= $(TEST_CFLAGS)
+lib_filterx_tests_test_expr_function_LDADD	= $(TEST_LDADD) $(JSON_LIBS)

--- a/lib/filterx/tests/test_expr_function.c
+++ b/lib/filterx/tests/test_expr_function.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2024 shifter <shifter@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include "libtest/cr_template.h"
+
+#include "filterx/filterx-object.h"
+#include "filterx/object-primitive.h"
+#include "filterx/expr-comparison.h"
+#include "filterx/expr-condition.h"
+#include "filterx/filterx-expr.h"
+#include "filterx/expr-literal.h"
+#include "filterx/object-string.h"
+#include "filterx/object-null.h"
+#include "filterx/object-datetime.h"
+#include "filterx/object-message-value.h"
+#include "filterx/expr-assign.h"
+#include "filterx/expr-template.h"
+#include "filterx/expr-message-ref.h"
+#include "filterx/expr-function.h"
+
+#include "apphook.h"
+#include "scratch-buffers.h"
+
+FilterXObject *test_dummy_function(GPtrArray *args)
+{
+  GString *repr = scratch_buffers_alloc();
+  GString *out = scratch_buffers_alloc();
+  for (int i = 0; i < args->len; i++)
+    {
+      FilterXObject *object = g_ptr_array_index(args, i);
+      cr_assert_not_null(object);
+      cr_assert(filterx_object_repr(object, repr));
+      g_string_append(out, repr->str);
+    }
+
+  return filterx_string_new(out->str, out->len);
+}
+
+Test(expr_function, test_function_null_args)
+{
+  FilterXExpr *func = filterx_function_new("test_dummy", NULL, test_dummy_function);
+  cr_assert_not_null(func);
+  filterx_expr_unref(func);
+}
+
+Test(expr_function, test_function_null_arg)
+{
+  GList *args = NULL;
+  args = g_list_append(args, NULL);
+  FilterXExpr *func = filterx_function_new("test_dummy", args, test_dummy_function);
+  cr_assert_not_null(func);
+  filterx_expr_unref(func);
+}
+
+Test(expr_function, test_function_valid_arg)
+{
+  GList *args = NULL;
+  args = g_list_append(args, filterx_literal_new(filterx_string_new("bad format 1", -1)));
+
+  FilterXExpr *func = filterx_function_new("test_dummy", args, test_dummy_function);
+  cr_assert_not_null(func);
+
+  FilterXObject *res = filterx_expr_eval(func);
+  cr_assert_not_null(res);
+  cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(string)));
+  const gchar *str = filterx_string_get_value(res, NULL);
+  cr_assert_str_eq(str, "bad format 1");
+  filterx_expr_unref(func);
+  filterx_object_unref(res);
+}
+
+Test(expr_function, test_function_multiple_args)
+{
+  GList *args = NULL;
+  args = g_list_append(args, filterx_literal_new(filterx_null_new()));
+  args = g_list_append(args, filterx_literal_new(filterx_integer_new(443)));
+  args = g_list_append(args, filterx_literal_new(filterx_string_new("foobar", -1)));
+  FilterXExpr *func = filterx_function_new("test_dummy", args, test_dummy_function);
+  cr_assert_not_null(func);
+  FilterXObject *res = filterx_expr_eval(func);
+  cr_assert_not_null(res);
+  cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(string)));
+  const gchar *str = filterx_string_get_value(res, NULL);
+  cr_assert_str_eq(str, "null443foobar");
+  filterx_expr_unref(func);
+  filterx_object_unref(res);
+}
+
+static void
+setup(void)
+{
+  app_startup();
+}
+
+static void
+teardown(void)
+{
+  scratch_buffers_explicit_gc();
+  app_shutdown();
+}
+
+TestSuite(expr_function, .init = setup, .fini = teardown);


### PR DESCRIPTION
Add missing filterx function unit tests and fixes memory leak issue discovered by unit tests.
Add extended unit test for one of the most complex, existing filterx builtin function to check the new memory leak issue fix (strptime).
