### PR TITLE
Filterx fix tenary

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -157,15 +157,16 @@
 
 /* operators in the filter language, the order of this determines precedence */
 %right KW_ASSIGN 9000
-%left  KW_OR 9001
-%left  KW_AND 9002
-%left  KW_STR_EQ 9003 KW_STR_NE 9004, KW_TA_EQ 9005, KW_TA_NE 9006, KW_TAV_EQ 9007, KW_TAV_NE 9008
-%left  KW_STR_LT 9009, KW_STR_LE 9010, KW_STR_GE, 9011 KW_STR_GT, 9012, KW_TA_LT 9013, KW_TA_LE 9014, KW_TA_GE 9015, KW_TA_GT 9016
-%right KW_PLUS_ASSIGN 9018
+%right '?' ':'
+%left  KW_OR 9010
+%left  KW_AND 9020
+%left  KW_STR_EQ 9030 KW_STR_NE 9031, KW_TA_EQ 9032, KW_TA_NE 9033, KW_TAV_EQ 9034, KW_TAV_NE 9035
+%left  KW_STR_LT 9040, KW_STR_LE 9041, KW_STR_GE, 9042 KW_STR_GT, 9043, KW_TA_LT 9044, KW_TA_LE 9045, KW_TA_GE 9046, KW_TA_GT 9047
+%right KW_PLUS_ASSIGN 9050
 
 %left  '+' '-'
 %left  '*' '/'
-%left '.' '[' ']' KW_NOT 9017
+%left '.' '[' ']' KW_NOT 9049
 
 /* statements */
 %token KW_SOURCE                      10000

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -114,7 +114,7 @@ construct_template_expr(LogTemplate *template)
 %type <ptr> conditional
 %type <ptr> if
 %type <ptr> codeblock
-%type <ptr> tenary
+%type <ptr> ternary
 
 %%
 
@@ -164,7 +164,7 @@ expr
         | expr KW_TAV_EQ expr			{ $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AND_VALUE_BASED | FCMPX_EQ); }
         | expr KW_TAV_NE expr			{ $$ = filterx_comparison_new($1, $3, FCMPX_TYPE_AND_VALUE_BASED | FCMPX_NE ); }
 	| '(' expr ')'				{ $$ = $2; }
-	| tenary				{ $$ = $1; }
+	| ternary				{ $$ = $1; }
 	| KW_ISSET '(' expr ')'			{ $$ = filterx_isset_new($3); }
 	| KW_UNSET '(' expr ')'			{ $$ = filterx_unset_new($3); }
 	;
@@ -302,7 +302,7 @@ codeblock
 	: '{' stmts '}'				{ $$ = $2; }
 	;
 
-tenary
+ternary
 	: expr '?' expr ':' expr
 	  {
 	    FilterXConditional *cond = (FilterXConditional*)filterx_conditional_new_conditional_codeblock($1, g_list_append(NULL, $3));

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -303,15 +303,15 @@ codeblock
 	;
 
 tenary
-	: '(' expr '?' expr ':' expr ')'
+	: expr '?' expr ':' expr
 	  {
-	    FilterXConditional *cond = (FilterXConditional*)filterx_conditional_new_conditional_codeblock($2, g_list_append(NULL, $4));
-	    $$ = filterx_conditional_add_false_branch(cond, (FilterXConditional*)filterx_conditional_new_codeblock(g_list_append(NULL, $6)));
-	  }
-	| '(' expr '?' ':' expr ')'
-	  {
-	    FilterXConditional *cond = (FilterXConditional*)filterx_conditional_new_conditional_codeblock($2, NULL);
+	    FilterXConditional *cond = (FilterXConditional*)filterx_conditional_new_conditional_codeblock($1, g_list_append(NULL, $3));
 	    $$ = filterx_conditional_add_false_branch(cond, (FilterXConditional*)filterx_conditional_new_codeblock(g_list_append(NULL, $5)));
+	  }
+	| expr '?' ':' expr
+	  {
+	    FilterXConditional *cond = (FilterXConditional*)filterx_conditional_new_conditional_codeblock($1, NULL);
+	    $$ = filterx_conditional_add_false_branch(cond, (FilterXConditional*)filterx_conditional_new_codeblock(g_list_append(NULL, $4)));
 	  }
 	;
 

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -308,6 +308,11 @@ tenary
 	    FilterXConditional *cond = (FilterXConditional*)filterx_conditional_new_conditional_codeblock($2, g_list_append(NULL, $4));
 	    $$ = filterx_conditional_add_false_branch(cond, (FilterXConditional*)filterx_conditional_new_codeblock(g_list_append(NULL, $6)));
 	  }
+	| '(' expr '?' ':' expr ')'
+	  {
+	    FilterXConditional *cond = (FilterXConditional*)filterx_conditional_new_conditional_codeblock($2, NULL);
+	    $$ = filterx_conditional_add_false_branch(cond, (FilterXConditional*)filterx_conditional_new_codeblock(g_list_append(NULL, $5)));
+	  }
 	;
 
 /* INCLUDE_RULES */

--- a/lib/filterx/tests/test_expr_condition.c
+++ b/lib/filterx/tests/test_expr_condition.c
@@ -569,6 +569,28 @@ Test(expr_condition, test_condition_must_not_fail_on_empty_else_block)
   deinit_test(&env);
 }
 
+Test(expr_condition, test_condition_with_complex_expression_to_check_memory_leaks)
+{
+  TestEnv env;
+  init_test(&env);
+
+  GList *stmts = NULL;
+  stmts = g_list_append(stmts, filterx_literal_new(filterx_string_new("foobar", -1)));
+
+  FilterXExpr *cond = filterx_conditional_new_conditional_codeblock(filterx_literal_new(filterx_integer_new(0)), NULL);
+  cond = filterx_conditional_add_false_branch((FilterXConditional *)cond,
+                                              (FilterXConditional *)filterx_conditional_new_codeblock(stmts));
+  FilterXObject *res = filterx_expr_eval(cond);
+  cr_assert_not_null(res);
+  cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(string)));
+  const gchar *str = filterx_string_get_value(res, NULL);
+  cr_assert_str_eq(str, "foobar");
+
+  filterx_expr_unref(cond);
+  filterx_object_unref(res);
+
+  deinit_test(&env);
+}
 
 static void
 setup(void)

--- a/lib/filterx/tests/test_expr_condition.c
+++ b/lib/filterx/tests/test_expr_condition.c
@@ -37,6 +37,7 @@
 #include "filterx/expr-assign.h"
 #include "filterx/expr-template.h"
 #include "filterx/expr-message-ref.h"
+#include "filterx/expr-function.h"
 
 #include "apphook.h"
 #include "scratch-buffers.h"
@@ -497,6 +498,77 @@ Test(expr_condition, test_condition_do_not_allow_to_add_else_into_else, .signal=
 
   deinit_test(&env);
 }
+
+FilterXObject *
+_fail_func(GPtrArray *args)
+{
+  return NULL;
+}
+
+Test(expr_condition, test_condition_return_null_on_illegal_expr)
+{
+  TestEnv env;
+  init_test(&env);
+
+  GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
+
+  FilterXExpr *func = filterx_function_new("test_fn", NULL, _fail_func);
+
+  FilterXExpr *cond = filterx_conditional_new_conditional_codeblock(func, stmts);
+  FilterXObject *res = filterx_expr_eval(cond);
+  cr_assert_null(res);
+
+  filterx_expr_unref(cond);
+
+  deinit_test(&env);
+}
+
+FilterXObject *
+_dummy_func(GPtrArray *args)
+{
+  return filterx_string_new("foobar", -1);
+}
+
+Test(expr_condition, test_condition_return_expr_result_on_missing_stmts)
+{
+  TestEnv env;
+  init_test(&env);
+
+  FilterXExpr *func = filterx_function_new("test_fn", NULL, _dummy_func);
+
+  FilterXExpr *cond = filterx_conditional_new_conditional_codeblock(func, NULL);
+  FilterXObject *res = filterx_expr_eval(cond);
+  cr_assert_not_null(res);
+  cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(string)));
+  const gchar *strval = filterx_string_get_value(res, NULL);
+  cr_assert_str_eq(strval, "foobar");
+
+  filterx_expr_unref(cond);
+  filterx_object_unref(res);
+
+  deinit_test(&env);
+}
+
+Test(expr_condition, test_condition_must_not_fail_on_empty_else_block)
+{
+  TestEnv env;
+  init_test(&env);
+
+  FilterXExpr *cond = filterx_conditional_new_conditional_codeblock(filterx_literal_new(filterx_boolean_new(FALSE)),
+                      NULL);
+  cond = filterx_conditional_add_false_branch((FilterXConditional *)cond,
+                                              (FilterXConditional *)filterx_conditional_new_codeblock(NULL));
+  FilterXObject *res = filterx_expr_eval(cond);
+  cr_assert_not_null(res);
+  cr_assert(filterx_object_is_type(res, &FILTERX_TYPE_NAME(boolean)));
+  cr_assert(filterx_object_truthy(res));
+
+  filterx_expr_unref(cond);
+  filterx_object_unref(res);
+
+  deinit_test(&env);
+}
+
 
 static void
 setup(void)

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -536,7 +536,7 @@ $MSG = example_echo($list);
     assert file_true.read_log() == """foo,bar,baz\n"""
 
 
-def test_tenary_operator_true(config, syslog_ng):
+def test_ternary_operator_true(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, """
     $MSG = true?${values.true_string}:${values.false_string};
@@ -549,7 +549,7 @@ def test_tenary_operator_true(config, syslog_ng):
     assert file_true.read_log() == "boolean:true\n"
 
 
-def test_tenary_operator_false(config, syslog_ng):
+def test_ternary_operator_false(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, """
     $MSG = false?${values.true_string}:${values.false_string};
@@ -562,7 +562,7 @@ def test_tenary_operator_false(config, syslog_ng):
     assert file_true.read_log() == "boolean:false\n"
 
 
-def test_tenary_operator_expression_true(config, syslog_ng):
+def test_ternary_operator_expression_true(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, """
     $MSG = (0 === 0)?${values.true_string}:${values.false_string};
@@ -575,7 +575,7 @@ def test_tenary_operator_expression_true(config, syslog_ng):
     assert file_true.read_log() == "boolean:true\n"
 
 
-def test_tenary_operator_expression_false(config, syslog_ng):
+def test_ternary_operator_expression_false(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, """
     $MSG = (0 === 1)?${values.true_string}:${values.false_string};
@@ -588,7 +588,7 @@ def test_tenary_operator_expression_false(config, syslog_ng):
     assert file_true.read_log() == "boolean:false\n"
 
 
-def test_tenary_operator_inline_tenary_expression_true(config, syslog_ng):
+def test_ternary_operator_inline_ternary_expression_true(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, """
     $MSG = (0 === 0)?("foo" eq "foo"? ${values.true_string} : "inner:false"):${values.false_string};
@@ -601,7 +601,7 @@ def test_tenary_operator_inline_tenary_expression_true(config, syslog_ng):
     assert file_true.read_log() == "boolean:true\n"
 
 
-def test_tenary_operator_inline_tenary_expression_false(config, syslog_ng):
+def test_ternary_operator_inline_ternary_expression_false(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, """
     $MSG = (0 === 0)?("foo" eq "bar"? ${values.true_string} : "inner:false"):${values.false_string};
@@ -614,7 +614,7 @@ def test_tenary_operator_inline_tenary_expression_false(config, syslog_ng):
     assert file_true.read_log() == "inner:false\n"
 
 
-def test_tenary_return_condition_expression_value_without_true_branch(config, syslog_ng):
+def test_ternary_return_condition_expression_value_without_true_branch(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, """
     $MSG = ${values.true_string}?:${values.false_string};

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -539,7 +539,7 @@ $MSG = example_echo($list);
 def test_tenary_operator_true(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, """
-    $MSG = (true?${values.true_string}:${values.false_string});
+    $MSG = true?${values.true_string}:${values.false_string};
 """,
     )
     syslog_ng.start(config)
@@ -552,7 +552,7 @@ def test_tenary_operator_true(config, syslog_ng):
 def test_tenary_operator_false(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, """
-    $MSG = (false?${values.true_string}:${values.false_string});
+    $MSG = false?${values.true_string}:${values.false_string};
 """,
     )
     syslog_ng.start(config)
@@ -565,7 +565,7 @@ def test_tenary_operator_false(config, syslog_ng):
 def test_tenary_operator_expression_true(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, """
-    $MSG = ((0 === 0)?${values.true_string}:${values.false_string});
+    $MSG = (0 === 0)?${values.true_string}:${values.false_string};
 """,
     )
     syslog_ng.start(config)
@@ -578,7 +578,7 @@ def test_tenary_operator_expression_true(config, syslog_ng):
 def test_tenary_operator_expression_false(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, """
-    $MSG = ((0 === 1)?${values.true_string}:${values.false_string});
+    $MSG = (0 === 1)?${values.true_string}:${values.false_string};
 """,
     )
     syslog_ng.start(config)
@@ -591,7 +591,7 @@ def test_tenary_operator_expression_false(config, syslog_ng):
 def test_tenary_operator_inline_tenary_expression_true(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, """
-    $MSG = ((0 === 0)?("foo" eq "foo"? ${values.true_string} : "inner:false"):${values.false_string});
+    $MSG = (0 === 0)?("foo" eq "foo"? ${values.true_string} : "inner:false"):${values.false_string};
 """,
     )
     syslog_ng.start(config)
@@ -604,7 +604,7 @@ def test_tenary_operator_inline_tenary_expression_true(config, syslog_ng):
 def test_tenary_operator_inline_tenary_expression_false(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, """
-    $MSG = ((0 === 0)?("foo" eq "bar"? ${values.true_string} : "inner:false"):${values.false_string});
+    $MSG = (0 === 0)?("foo" eq "bar"? ${values.true_string} : "inner:false"):${values.false_string};
 """,
     )
     syslog_ng.start(config)
@@ -617,7 +617,7 @@ def test_tenary_operator_inline_tenary_expression_false(config, syslog_ng):
 def test_tenary_return_condition_expression_value_without_true_branch(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, """
-    $MSG = (${values.true_string}?:${values.false_string});
+    $MSG = ${values.true_string}?:${values.false_string};
 """,
     )
 

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -614,6 +614,20 @@ def test_tenary_operator_inline_tenary_expression_false(config, syslog_ng):
     assert file_true.read_log() == "inner:false\n"
 
 
+def test_tenary_return_condition_expression_value_without_true_branch(config, syslog_ng):
+    (file_true, file_false) = create_config(
+        config, """
+    $MSG = (${values.true_string}?:${values.false_string});
+""",
+    )
+
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "boolean:true\n"
+
+
 def test_if_condition_without_else_branch_match(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, """


### PR DESCRIPTION
ternary operator changes

- ternary operator is now able to return condition-expression's value when no expressions presented in true branch
i.e.:
```
filterx {
		$res = "my expression" ? : "bad";
}
// res will be 'my expression'. it's useful to handle default-value like issues
```
- ternary operator now returns hard NULL (error) on condition-expression evaluation errors, this way interrupts the filterx block's running
- ternary now can be used without brackets
- 'tenary' naming typo fixed
