### PR TITLE
Filterx error handling

### DIFF
--- a/lib/filterx/expr-boolalg.c
+++ b/lib/filterx/expr-boolalg.c
@@ -29,6 +29,9 @@ _eval_not(FilterXExpr *s)
   FilterXUnaryOp *self = (FilterXUnaryOp *) s;
 
   FilterXObject *result = filterx_expr_eval(self->operand);
+  if (!result)
+    return NULL;
+
   gboolean truthy = filterx_object_truthy(result);
   filterx_object_unref(result);
 
@@ -57,6 +60,9 @@ _eval_and(FilterXExpr *s)
    * evaluation just like most languages */
 
   FilterXObject *result = filterx_expr_eval(self->lhs);
+  if (!result)
+    return NULL;
+
   gboolean lhs_truthy = filterx_object_truthy(result);
   filterx_object_unref(result);
 
@@ -64,6 +70,9 @@ _eval_and(FilterXExpr *s)
     return filterx_boolean_new(FALSE);
 
   result = filterx_expr_eval(self->rhs);
+  if (!result)
+    return NULL;
+
   gboolean rhs_truthy = filterx_object_truthy(result);
   filterx_object_unref(result);
 
@@ -92,6 +101,9 @@ _eval_or(FilterXExpr *s)
    * evaluation just like most languages */
 
   FilterXObject *result = filterx_expr_eval(self->lhs);
+  if (!result)
+    return NULL;
+
   gboolean lhs_truthy = filterx_object_truthy(result);
   filterx_object_unref(result);
 
@@ -99,6 +111,9 @@ _eval_or(FilterXExpr *s)
     return filterx_boolean_new(TRUE);
 
   result = filterx_expr_eval(self->rhs);
+  if (!result)
+    return NULL;
+
   gboolean rhs_truthy = filterx_object_truthy(result);
   filterx_object_unref(result);
 

--- a/lib/filterx/expr-function.c
+++ b/lib/filterx/expr-function.c
@@ -25,6 +25,7 @@
 #include "filterx/expr-function.h"
 #include "filterx/filterx-grammar.h"
 #include "filterx/filterx-globals.h"
+#include "filterx/filterx-eval.h"
 #include "plugin.h"
 #include "cfg.h"
 
@@ -65,6 +66,9 @@ _eval(FilterXExpr *s)
 
   if (args != NULL)
     g_ptr_array_free(args, TRUE);
+  if (!res)
+    filterx_eval_push_error("Function call failed", s, NULL);
+
   return res;
 }
 

--- a/lib/filterx/expr-get-subscript.c
+++ b/lib/filterx/expr-get-subscript.c
@@ -21,6 +21,7 @@
  *
  */
 #include "filterx/expr-get-subscript.h"
+#include "filterx/filterx-eval.h"
 
 typedef struct _FilterXGetSubscript
 {
@@ -43,6 +44,8 @@ _eval(FilterXExpr *s)
   if (!key)
     goto exit;
   result = filterx_object_get_subscript(variable, key);
+  if (!result)
+    filterx_eval_push_error("Object get-subscript failed", s, key);
 exit:
   filterx_object_unref(key);
   filterx_object_unref(variable);

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -21,12 +21,13 @@
  *
  */
 #include "filterx/expr-getattr.h"
+#include "filterx/object-string.h"
 
 typedef struct _FilterXGetAttr
 {
   FilterXExpr super;
   FilterXExpr *operand;
-  gchar *attr_name;
+  FilterXObject *attr;
 } FilterXGetAttr;
 
 static FilterXObject *
@@ -39,7 +40,7 @@ _eval(FilterXExpr *s)
   if (!variable)
     return NULL;
 
-  FilterXObject *attr = filterx_object_getattr(variable, self->attr_name);
+  FilterXObject *attr = filterx_object_getattr(variable, self->attr);
   if (!attr)
     goto exit;
 exit:
@@ -51,7 +52,7 @@ static void
 _free(FilterXExpr *s)
 {
   FilterXGetAttr *self = (FilterXGetAttr *) s;
-  g_free(self->attr_name);
+  filterx_object_unref(self->attr);
   filterx_expr_unref(self->operand);
   filterx_expr_free_method(s);
 }
@@ -66,6 +67,6 @@ filterx_getattr_new(FilterXExpr *operand, const gchar *attr_name)
   self->super.eval = _eval;
   self->super.free_fn = _free;
   self->operand = operand;
-  self->attr_name = g_strdup(attr_name);
+  self->attr = filterx_string_new(attr_name, -1);
   return &self->super;
 }

--- a/lib/filterx/expr-getattr.c
+++ b/lib/filterx/expr-getattr.c
@@ -22,6 +22,7 @@
  */
 #include "filterx/expr-getattr.h"
 #include "filterx/object-string.h"
+#include "filterx/filterx-eval.h"
 
 typedef struct _FilterXGetAttr
 {
@@ -42,7 +43,10 @@ _eval(FilterXExpr *s)
 
   FilterXObject *attr = filterx_object_getattr(variable, self->attr);
   if (!attr)
-    goto exit;
+    {
+      filterx_eval_push_error("Attribute lookup failed", s, self->attr);
+      goto exit;
+    }
 exit:
   filterx_object_unref(variable);
   return attr;

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -22,6 +22,7 @@
  */
 #include "filterx/expr-set-subscript.h"
 #include "filterx/object-primitive.h"
+#include "filterx/filterx-eval.h"
 #include "scratch-buffers.h"
 
 typedef struct _FilterXSetSubscript
@@ -91,6 +92,10 @@ _eval(FilterXExpr *s)
                     evt_tag_mem("key", key_buf->str, key_buf->len),
                     evt_tag_mem("value", buf->str, buf->len));
         }
+    }
+  else
+    {
+      filterx_eval_push_error("Object set-subscript failed", s, key);
     }
 
   filterx_object_unref(cloned);

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -23,6 +23,7 @@
 #include "filterx/expr-setattr.h"
 #include "filterx/object-primitive.h"
 #include "filterx/object-string.h"
+#include "filterx/filterx-eval.h"
 #include "scratch-buffers.h"
 
 typedef struct _FilterXSetAttr
@@ -66,6 +67,10 @@ _eval(FilterXExpr *s)
                     evt_tag_str("attr", filterx_string_get_value(self->attr, NULL)),
                     evt_tag_mem("value", buf->str, buf->len));
         }
+    }
+  else
+    {
+      filterx_eval_push_error("Attribute set failed", s, self->attr);
     }
 
   filterx_object_unref(cloned);

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -22,13 +22,14 @@
  */
 #include "filterx/expr-setattr.h"
 #include "filterx/object-primitive.h"
+#include "filterx/object-string.h"
 #include "scratch-buffers.h"
 
 typedef struct _FilterXSetAttr
 {
   FilterXExpr super;
   FilterXExpr *object;
-  gchar *attr_name;
+  FilterXObject *attr;
   FilterXExpr *new_value;
 } FilterXSetAttr;
 
@@ -49,7 +50,7 @@ _eval(FilterXExpr *s)
   FilterXObject *cloned = filterx_object_clone(new_value);
   filterx_object_unref(new_value);
 
-  if (filterx_object_setattr(object, self->attr_name, cloned))
+  if (filterx_object_setattr(object, self->attr, cloned))
     {
       result = filterx_boolean_new(TRUE);
       if (trace_flag)
@@ -62,7 +63,7 @@ _eval(FilterXExpr *s)
                 g_assert_not_reached();
             }
           msg_trace("Filterx setattr",
-                    evt_tag_str("attr_name", self->attr_name),
+                    evt_tag_str("attr", filterx_string_get_value(self->attr, NULL)),
                     evt_tag_mem("value", buf->str, buf->len));
         }
     }
@@ -79,7 +80,7 @@ _free(FilterXExpr *s)
 {
   FilterXSetAttr *self = (FilterXSetAttr *) s;
 
-  g_free(self->attr_name);
+  filterx_object_unref(self->attr);
   filterx_expr_unref(self->object);
   filterx_expr_unref(self->new_value);
   filterx_expr_free_method(s);
@@ -94,7 +95,7 @@ filterx_setattr_new(FilterXExpr *object, const gchar *attr_name, FilterXExpr *ne
   self->super.eval = _eval;
   self->super.free_fn = _free;
   self->object = object;
-  self->attr_name = g_strdup(attr_name);
+  self->attr = filterx_string_new(attr_name, -1);
   self->new_value = new_value;
   return &self->super;
 }

--- a/lib/filterx/expr-template.c
+++ b/lib/filterx/expr-template.c
@@ -22,6 +22,7 @@
  */
 #include "filterx/expr-template.h"
 #include "filterx/object-message-value.h"
+#include "filterx/filterx-eval.h"
 #include "template/templates.h"
 #include "scratch-buffers.h"
 

--- a/lib/filterx/expr-template.h
+++ b/lib/filterx/expr-template.h
@@ -24,6 +24,7 @@
 #define FILTERX_TEMPLATE_H_INCLUDED
 
 #include "filterx/filterx-expr.h"
+#include "template/templates.h"
 
 FilterXExpr *filterx_template_new(LogTemplate *template);
 

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -23,6 +23,7 @@
 #include "filterx/expr-variable.h"
 #include "filterx/object-message-value.h"
 #include "filterx/filterx-scope.h"
+#include "filterx/filterx-eval.h"
 #include "logmsg/logmsg.h"
 
 typedef struct _FilterXVariableExpr

--- a/lib/filterx/expr-variable.c
+++ b/lib/filterx/expr-variable.c
@@ -22,6 +22,7 @@
  */
 #include "filterx/expr-variable.h"
 #include "filterx/object-message-value.h"
+#include "filterx/object-string.h"
 #include "filterx/filterx-scope.h"
 #include "filterx/filterx-eval.h"
 #include "logmsg/logmsg.h"
@@ -29,6 +30,7 @@
 typedef struct _FilterXVariableExpr
 {
   FilterXExpr super;
+  FilterXObject *variable_name;
   NVHandle handle;
   gboolean declared;
 } FilterXVariableExpr;
@@ -41,7 +43,7 @@ _pull_variable_from_message(FilterXVariableExpr *self, FilterXEvalContext *conte
   const gchar *value = log_msg_get_value_if_set_with_type(msg, self->handle, &value_len, &t);
   if (!value)
     {
-      filterx_eval_push_error("Missing name-value pair in log message", &self->super, NULL);
+      filterx_eval_push_error("No such name-value pair in the log message", &self->super, self->variable_name);
       return NULL;
     }
 
@@ -70,14 +72,14 @@ _eval(FilterXExpr *s)
       FilterXObject *value = filterx_variable_get_value(variable);
       if (!value)
         {
-          filterx_eval_push_error("No value set for variable", &self->super, NULL);
+          filterx_eval_push_error("Variable is unset", &self->super, self->variable_name);
         }
       return value;
     }
 
   if (!filterx_variable_handle_is_floating(self->handle))
     return _pull_variable_from_message(self, context, context->msgs[0]);
-  filterx_eval_push_error("Undeclared floating variable", s, NULL);
+  filterx_eval_push_error("No such variable", s, self->variable_name);
   return NULL;
 }
 
@@ -151,18 +153,37 @@ _unset(FilterXExpr *s)
   return TRUE;
 }
 
+static void
+_free(FilterXExpr *s)
+{
+  FilterXVariableExpr *self = (FilterXVariableExpr *) s;
+
+  filterx_object_unref(self->variable_name);
+  filterx_expr_free_method(s);
+}
+
 static FilterXExpr *
 filterx_variable_expr_new(const gchar *name, FilterXVariableType type)
 {
   FilterXVariableExpr *self = g_new0(FilterXVariableExpr, 1);
 
   filterx_expr_init_instance(&self->super);
+  self->super.free_fn = _free;
   self->super.eval = _eval;
   self->super._update_repr = _update_repr;
   self->super.assign = _assign;
   self->super.isset = _isset;
   self->super.unset = _unset;
   self->handle = filterx_scope_map_variable_to_handle(name, type);
+  if (type == FX_VAR_MESSAGE)
+    {
+      gchar *dollar_name = g_strdup_printf("$%s", name);
+      self->variable_name = filterx_string_new(dollar_name, -1);
+      g_free(dollar_name);
+    }
+  else
+    self->variable_name = filterx_string_new(name, -1);
+
   return &self->super;
 }
 

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -53,6 +53,37 @@ filterx_eval_set_context(FilterXEvalContext *context)
   eval_context = context;
 }
 
+void
+filterx_eval_push_error(const gchar *message, FilterXExpr *expr, FilterXObject *object)
+{
+  FilterXEvalContext *context = filterx_eval_get_context();
+
+  filterx_object_unref(context->error.object);
+  context->error.message = message;
+  context->error.expr = expr;
+  context->error.object = filterx_object_ref(object);
+}
+
+const gchar *
+filterx_eval_get_last_error(void)
+{
+  FilterXEvalContext *context = filterx_eval_get_context();
+
+  return context->error.message;
+}
+
+void
+filterx_eval_clear_errors(void)
+{
+  FilterXEvalContext *context = filterx_eval_get_context();
+
+  filterx_object_unref(context->error.object);
+  context->error = ((FilterXError )
+  {
+    0
+  });
+}
+
 static gboolean
 _evaluate_statement(FilterXExpr *expr)
 {

--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -24,6 +24,7 @@
 #define FILTERX_EVAL_H_INCLUDED
 
 #include "filterx/filterx-scope.h"
+#include "filterx/filterx-expr.h"
 #include "template/eval.h"
 
 typedef struct _FilterXEvalContext FilterXEvalContext;

--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -27,18 +27,26 @@
 #include "filterx/filterx-expr.h"
 #include "template/eval.h"
 
-typedef struct _FilterXEvalContext FilterXEvalContext;
+typedef struct _FilterXError
+{
+  const gchar *message;
+  FilterXExpr *expr;
+  FilterXObject *object;
+} FilterXError;
 
+typedef struct _FilterXEvalContext FilterXEvalContext;
 struct _FilterXEvalContext
 {
   LogMessage **msgs;
   gint num_msg;
   FilterXScope *scope;
+  FilterXError error;
   LogTemplateEvalOptions *template_eval_options;
 };
 
 FilterXEvalContext *filterx_eval_get_context(void);
 FilterXScope *filterx_eval_get_scope(void);
+void filterx_eval_push_error(const gchar *message, FilterXExpr *expr, FilterXObject *object);
 void filterx_eval_set_context(FilterXEvalContext *context);
 gboolean filterx_eval_exec_statements(FilterXScope *scope, GList *statements, LogMessage *msg);
 void filterx_eval_sync_scope_and_message(FilterXScope *scope, LogMessage *msg);

--- a/lib/filterx/filterx-expr.c
+++ b/lib/filterx/filterx-expr.c
@@ -37,6 +37,14 @@ filterx_expr_set_location(FilterXExpr *self, CfgLexer *lexer, CFG_LTYPE *lloc)
     }
 }
 
+EVTTAG *
+filterx_expr_format_location_tag(FilterXExpr *self)
+{
+  return evt_tag_printf("expr", "%s:%d:%d| %s",
+                        self->lloc.name, self->lloc.first_line, self->lloc.first_column,
+                        self->expr_text ? : "n/a");
+}
+
 void
 filterx_expr_free_method(FilterXExpr *self)
 {

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -25,7 +25,6 @@
 #define FILTERX_EXPR_H_INCLUDED
 
 #include "filterx-object.h"
-#include "filterx-eval.h"
 #include "cfg-lexer.h"
 
 typedef struct _FilterXExpr FilterXExpr;

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -132,6 +132,7 @@ filterx_expr_unset(FilterXExpr *self)
 }
 
 void filterx_expr_set_location(FilterXExpr *self, CfgLexer *lexer, CFG_LTYPE *lloc);
+EVTTAG *filterx_expr_format_location_tag(FilterXExpr *self);
 void filterx_expr_init_instance(FilterXExpr *self);
 FilterXExpr *filterx_expr_new(void);
 FilterXExpr *filterx_expr_ref(FilterXExpr *self);

--- a/lib/filterx/filterx-object.c
+++ b/lib/filterx/filterx-object.c
@@ -27,6 +27,24 @@
 #include "filterx/object-string.h"
 #include "filterx/filterx-globals.h"
 
+FilterXObject *
+filterx_object_getattr_string(FilterXObject *self, const gchar *attr_name)
+{
+  FilterXObject *attr = filterx_string_new(attr_name, -1);
+  FilterXObject *res = filterx_object_getattr(self, attr);
+  filterx_object_unref(attr);
+  return res;
+}
+
+gboolean
+filterx_object_setattr_string(FilterXObject *self, const gchar *attr_name, FilterXObject *new_value)
+{
+  FilterXObject *attr = filterx_string_new(attr_name, -1);
+  gboolean res = filterx_object_setattr(self, attr, new_value);
+  filterx_object_unref(attr);
+  return res;
+}
+
 #define INIT_TYPE_METHOD(type, method_name) do { \
     if (type->method_name) \
       break; \

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -40,8 +40,8 @@ struct _FilterXType
   FilterXObject *(*clone)(FilterXObject *self);
   gboolean (*map_to_json)(FilterXObject *self, struct json_object **object);
   gboolean (*truthy)(FilterXObject *self);
-  FilterXObject *(*getattr)(FilterXObject *self, const gchar *attr_name);
-  gboolean (*setattr)(FilterXObject *self, const gchar *attr_name, FilterXObject *new_value);
+  FilterXObject *(*getattr)(FilterXObject *self, FilterXObject *attr);
+  gboolean (*setattr)(FilterXObject *self, FilterXObject *attr, FilterXObject *new_value);
   FilterXObject *(*get_subscript)(FilterXObject *self, FilterXObject *key);
   gboolean (*set_subscript)(FilterXObject *self, FilterXObject *key, FilterXObject *new_value);
   gboolean (*is_key_set)(FilterXObject *self, FilterXObject *key);
@@ -88,6 +88,9 @@ struct _FilterXObject
   guint thread_index:16, modified_in_place:1;
   FilterXType *type;
 };
+
+FilterXObject *filterx_object_getattr_string(FilterXObject *self, const gchar *attr_name);
+gboolean filterx_object_setattr_string(FilterXObject *self, const gchar *attr_name, FilterXObject *new_value);
 
 FilterXObject *filterx_object_new(FilterXType *type);
 FilterXObject *filterx_object_ref(FilterXObject *self);
@@ -182,18 +185,18 @@ filterx_object_falsy(FilterXObject *self)
 }
 
 static inline FilterXObject *
-filterx_object_getattr(FilterXObject *self, const gchar *attr_name)
+filterx_object_getattr(FilterXObject *self, FilterXObject *attr)
 {
   if (self->type->getattr)
-    return self->type->getattr(self, attr_name);
+    return self->type->getattr(self, attr);
   return NULL;
 }
 
 static inline gboolean
-filterx_object_setattr(FilterXObject *self, const gchar *attr_name, FilterXObject *new_value)
+filterx_object_setattr(FilterXObject *self, FilterXObject *attr, FilterXObject *new_value)
 {
   if (self->type->setattr)
-    return self->type->setattr(self, attr_name, new_value);
+    return self->type->setattr(self, attr, new_value);
   return FALSE;
 }
 

--- a/lib/filterx/object-dict-interface.c
+++ b/lib/filterx/object-dict-interface.c
@@ -102,30 +102,26 @@ _unset_key(FilterXObject *s, FilterXObject *key)
 }
 
 static FilterXObject *
-_getattr(FilterXObject *s, const gchar *attr_name)
+_getattr(FilterXObject *s, FilterXObject *attr)
 {
   FilterXDict *self = (FilterXDict *) s;
 
   if (!self->support_attr)
     return NULL;
 
-  FilterXObject *key = filterx_string_new(attr_name, -1);
-  FilterXObject *result = self->get_subscript(self, key);
-  filterx_object_unref(key);
+  FilterXObject *result = self->get_subscript(self, attr);
   return result;
 }
 
 static gboolean
-_setattr(FilterXObject *s, const gchar *attr_name, FilterXObject *new_value)
+_setattr(FilterXObject *s, FilterXObject *attr, FilterXObject *new_value)
 {
   FilterXDict *self = (FilterXDict *) s;
 
   if (!self->support_attr)
     return FALSE;
 
-  FilterXObject *key = filterx_string_new(attr_name, -1);
-  gboolean result = self->set_subscript(self, key, new_value);
-  filterx_object_unref(key);
+  gboolean result = self->set_subscript(self, attr, new_value);
   return result;
 }
 

--- a/lib/filterx/tests/test_expr_condition.c
+++ b/lib/filterx/tests/test_expr_condition.c
@@ -24,7 +24,7 @@
 #include <criterion/criterion.h>
 #include "libtest/cr_template.h"
 
-#include "filterx/filterx-object.h"
+#include "filterx/filterx-eval.h"
 #include "filterx/object-primitive.h"
 #include "filterx/expr-comparison.h"
 #include "filterx/expr-condition.h"

--- a/lib/filterx/tests/test_filterx_expr.c
+++ b/lib/filterx/tests/test_filterx_expr.c
@@ -24,6 +24,8 @@
 #include <criterion/criterion.h>
 #include "libtest/cr_template.h"
 
+#include "filterx/filterx-scope.h"
+#include "filterx/filterx-eval.h"
 #include "filterx/expr-literal.h"
 #include "filterx/expr-template.h"
 #include "filterx/expr-literal-generator.h"

--- a/modules/grpc/otel/filterx/object-otel-logrecord.cpp
+++ b/modules/grpc/otel/filterx/object-otel-logrecord.cpp
@@ -149,19 +149,19 @@ _free(FilterXObject *s)
 }
 
 static gboolean
-_setattr(FilterXObject *s, const gchar *attr_name, FilterXObject *new_value)
+_setattr(FilterXObject *s, FilterXObject *attr, FilterXObject *new_value)
 {
   FilterXOtelLogRecord *self = (FilterXOtelLogRecord *) s;
 
-  return self->cpp->SetField(attr_name, new_value);
+  return self->cpp->SetField(filterx_string_get_value(attr, NULL), new_value);
 }
 
 static FilterXObject *
-_getattr(FilterXObject *s, const gchar *attr_name)
+_getattr(FilterXObject *s, FilterXObject *attr)
 {
   FilterXOtelLogRecord *self = (FilterXOtelLogRecord *) s;
 
-  return self->cpp->GetField(attr_name);
+  return self->cpp->GetField(filterx_string_get_value(attr, NULL));
 }
 
 static gboolean

--- a/modules/grpc/otel/filterx/object-otel-resource.cpp
+++ b/modules/grpc/otel/filterx/object-otel-resource.cpp
@@ -131,19 +131,19 @@ _free(FilterXObject *s)
 }
 
 static gboolean
-_setattr(FilterXObject *s, const gchar *attr_name, FilterXObject *new_value)
+_setattr(FilterXObject *s, FilterXObject *attr, FilterXObject *new_value)
 {
   FilterXOtelResource *self = (FilterXOtelResource *) s;
 
-  return self->cpp->set_field(attr_name, new_value);
+  return self->cpp->set_field(filterx_string_get_value(attr, NULL), new_value);
 }
 
 static FilterXObject *
-_getattr(FilterXObject *s, const gchar *attr_name)
+_getattr(FilterXObject *s, FilterXObject *attr)
 {
   FilterXOtelResource *self = (FilterXOtelResource *) s;
 
-  return self->cpp->get_field(attr_name);
+  return self->cpp->get_field(filterx_string_get_value(attr, NULL));
 }
 
 static gboolean

--- a/modules/grpc/otel/filterx/object-otel-scope.cpp
+++ b/modules/grpc/otel/filterx/object-otel-scope.cpp
@@ -131,19 +131,19 @@ _free(FilterXObject *s)
 }
 
 static gboolean
-_setattr(FilterXObject *s, const gchar *attr_name, FilterXObject *new_value)
+_setattr(FilterXObject *s, FilterXObject *attr, FilterXObject *new_value)
 {
   FilterXOtelScope *self = (FilterXOtelScope *) s;
 
-  return self->cpp->set_field(attr_name, new_value);
+  return self->cpp->set_field(filterx_string_get_value(attr, NULL), new_value);
 }
 
 static FilterXObject *
-_getattr(FilterXObject *s, const gchar *attr_name)
+_getattr(FilterXObject *s, FilterXObject *attr)
 {
   FilterXOtelScope *self = (FilterXOtelScope *) s;
 
-  return self->cpp->get_field(attr_name);
+  return self->cpp->get_field(filterx_string_get_value(attr, NULL));
 }
 
 static gboolean

--- a/modules/grpc/otel/tests/test-otel-filterx.cpp
+++ b/modules/grpc/otel/tests/test-otel-filterx.cpp
@@ -46,7 +46,7 @@ using namespace google::protobuf::util;
 static void
 _assert_filterx_integer_attribute(FilterXObject *obj, const std::string &attribute_name, gint64 expected_value)
 {
-  FilterXObject *filterx_integer = filterx_object_getattr(obj, attribute_name.c_str());
+  FilterXObject *filterx_integer = filterx_object_getattr_string(obj, attribute_name.c_str());
   cr_assert(filterx_object_is_type(filterx_integer, &FILTERX_TYPE_NAME(integer)));
 
   GenericNumber value = filterx_primitive_get_value(filterx_integer);
@@ -59,7 +59,7 @@ static void
 _assert_filterx_string_attribute(FilterXObject *obj, const std::string &attribute_name,
                                  const std::string &expected_value)
 {
-  FilterXObject *filterx_string = filterx_object_getattr(obj, attribute_name.c_str());
+  FilterXObject *filterx_string = filterx_object_getattr_string(obj, attribute_name.c_str());
   cr_assert(filterx_object_is_type(filterx_string, &FILTERX_TYPE_NAME(string)));
 
   gsize len;
@@ -84,7 +84,7 @@ static void
 _assert_filterx_repeated_kv_attribute(FilterXObject *obj, const std::string &attribute_name,
                                       const google::protobuf::RepeatedPtrField<KeyValue> &expected_repeated_kv)
 {
-  FilterXObject *filterx_otel_kvlist = filterx_object_getattr(obj, attribute_name.c_str());
+  FilterXObject *filterx_otel_kvlist = filterx_object_getattr_string(obj, attribute_name.c_str());
   cr_assert(filterx_object_is_type(filterx_otel_kvlist, &FILTERX_TYPE_NAME(otel_kvlist)));
 
   const google::protobuf::RepeatedPtrField<KeyValue> &kvlist = ((FilterXOtelKVList *)
@@ -305,7 +305,7 @@ Test(otel_filterx, resource_get_field)
   _assert_filterx_integer_attribute(filterx_otel_resource, "dropped_attributes_count", 42);
   _assert_filterx_repeated_kv_attribute(filterx_otel_resource, "attributes", resource.attributes());
 
-  FilterXObject *filterx_invalid = filterx_object_getattr(filterx_otel_resource, "invalid_attr");
+  FilterXObject *filterx_invalid = filterx_object_getattr_string(filterx_otel_resource, "invalid_attr");
   cr_assert_not(filterx_invalid);
 
   filterx_object_unref(filterx_otel_resource);
@@ -318,7 +318,7 @@ Test(otel_filterx, resource_set_field)
   cr_assert(filterx_otel_resource);
 
   FilterXObject *filterx_integer = filterx_integer_new(42);
-  cr_assert(filterx_object_setattr(filterx_otel_resource, "dropped_attributes_count", filterx_integer));
+  cr_assert(filterx_object_setattr_string(filterx_otel_resource, "dropped_attributes_count", filterx_integer));
 
   KeyValueList attributes;
   KeyValue *attribute_1 = attributes.add_values();
@@ -329,9 +329,9 @@ Test(otel_filterx, resource_set_field)
   g_ptr_array_insert(attributes_kvlist_args, 0, filterx_protobuf_new(serialized_attributes.c_str(),
                      serialized_attributes.length()));
   FilterXObject *filterx_kvlist = filterx_otel_kvlist_new_from_args(attributes_kvlist_args);
-  cr_assert(filterx_object_setattr(filterx_otel_resource, "attributes", filterx_kvlist));
+  cr_assert(filterx_object_setattr_string(filterx_otel_resource, "attributes", filterx_kvlist));
 
-  cr_assert_not(filterx_object_setattr(filterx_otel_resource, "invalid_attr", filterx_integer));
+  cr_assert_not(filterx_object_setattr_string(filterx_otel_resource, "invalid_attr", filterx_integer));
 
   GString *serialized = g_string_new(NULL);
   LogMessageValueType type;
@@ -442,7 +442,7 @@ Test(otel_filterx, scope_get_field)
   _assert_filterx_string_attribute(filterx_otel_scope, "name", "foobar");
   _assert_filterx_repeated_kv_attribute(filterx_otel_scope, "attributes", scope.attributes());
 
-  FilterXObject *filterx_invalid = filterx_object_getattr(filterx_otel_scope, "invalid_attr");
+  FilterXObject *filterx_invalid = filterx_object_getattr_string(filterx_otel_scope, "invalid_attr");
   cr_assert_not(filterx_invalid);
 
   filterx_object_unref(filterx_otel_scope);
@@ -455,10 +455,10 @@ Test(otel_filterx, scope_set_field)
   cr_assert(filterx_otel_scope);
 
   FilterXObject *filterx_integer = filterx_integer_new(42);
-  cr_assert(filterx_object_setattr(filterx_otel_scope, "dropped_attributes_count", filterx_integer));
+  cr_assert(filterx_object_setattr_string(filterx_otel_scope, "dropped_attributes_count", filterx_integer));
 
   FilterXObject *filterx_string = filterx_string_new("foobar", -1);
-  cr_assert(filterx_object_setattr(filterx_otel_scope, "name", filterx_string));
+  cr_assert(filterx_object_setattr_string(filterx_otel_scope, "name", filterx_string));
 
   KeyValueList attributes;
   KeyValue *attribute_1 = attributes.add_values();
@@ -469,9 +469,9 @@ Test(otel_filterx, scope_set_field)
   g_ptr_array_insert(attributes_kvlist_args, 0, filterx_protobuf_new(serialized_attributes.c_str(),
                      serialized_attributes.length()));
   FilterXObject *filterx_kvlist = filterx_otel_kvlist_new_from_args(attributes_kvlist_args);
-  cr_assert(filterx_object_setattr(filterx_otel_scope, "attributes", filterx_kvlist));
+  cr_assert(filterx_object_setattr_string(filterx_otel_scope, "attributes", filterx_kvlist));
 
-  cr_assert_not(filterx_object_setattr(filterx_otel_scope, "invalid_attr", filterx_integer));
+  cr_assert_not(filterx_object_setattr_string(filterx_otel_scope, "invalid_attr", filterx_integer));
 
   GString *serialized = g_string_new(NULL);
   LogMessageValueType type;
@@ -682,11 +682,11 @@ Test(otel_filterx, kvlist_through_logrecord)
 
   /* $log.attributes = $kvlist; */
   FilterXObject *fx_kvlist_clone = filterx_object_clone(fx_kvlist);
-  cr_assert(filterx_object_setattr(fx_logrecord, "attributes", fx_kvlist_clone));
+  cr_assert(filterx_object_setattr_string(fx_logrecord, "attributes", fx_kvlist_clone));
   filterx_object_unref(fx_kvlist_clone);
 
   /* $log.attributes["key_1"] = "bar"; */
-  fx_get_1 = filterx_object_getattr(fx_logrecord, "attributes");
+  fx_get_1 = filterx_object_getattr_string(fx_logrecord, "attributes");
   cr_assert(fx_get_1);
   cr_assert(filterx_object_set_subscript(fx_get_1, fx_key_1, fx_bar));
 
@@ -695,7 +695,7 @@ Test(otel_filterx, kvlist_through_logrecord)
 
   /* $log.attributes["key_3"] = $inner_kvlist; */
   filterx_object_unref(fx_get_1);
-  fx_get_1 = filterx_object_getattr(fx_logrecord, "attributes");
+  fx_get_1 = filterx_object_getattr_string(fx_logrecord, "attributes");
   cr_assert(fx_get_1);
   FilterXObject *fx_inner_kvlist_clone = filterx_object_clone(fx_inner_kvlist);
   cr_assert(filterx_object_set_subscript(fx_get_1, fx_key_3, fx_inner_kvlist_clone));
@@ -706,7 +706,7 @@ Test(otel_filterx, kvlist_through_logrecord)
 
   /* $log.attributes["key_3"]["key_2"] = "baz"; */
   filterx_object_unref(fx_get_1);
-  fx_get_1 = filterx_object_getattr(fx_logrecord, "attributes");
+  fx_get_1 = filterx_object_getattr_string(fx_logrecord, "attributes");
   cr_assert(fx_get_1);
   filterx_object_unref(fx_get_2);
   fx_get_2 = filterx_object_get_subscript(fx_get_1, fx_key_3);
@@ -936,11 +936,11 @@ Test(otel_filterx, array_through_logrecord)
 
   /* $log.body = $array; */
   FilterXObject *fx_array_clone = filterx_object_clone(fx_array);
-  cr_assert(filterx_object_setattr(fx_logrecord, "body", fx_array_clone));
+  cr_assert(filterx_object_setattr_string(fx_logrecord, "body", fx_array_clone));
   filterx_object_unref(fx_array_clone);
 
   /* $log.body[] = "bar"; */
-  fx_get_1 = filterx_object_getattr(fx_logrecord, "body");
+  fx_get_1 = filterx_object_getattr_string(fx_logrecord, "body");
   cr_assert(fx_get_1);
   cr_assert(filterx_object_set_subscript(fx_get_1, nullptr, fx_bar));
 
@@ -949,7 +949,7 @@ Test(otel_filterx, array_through_logrecord)
 
   /* $log.body[] = $inner_array; */
   filterx_object_unref(fx_get_1);
-  fx_get_1 = filterx_object_getattr(fx_logrecord, "body");
+  fx_get_1 = filterx_object_getattr_string(fx_logrecord, "body");
   cr_assert(fx_get_1);
   FilterXObject *fx_inner_array_clone = filterx_object_clone(fx_inner_array);
   cr_assert(filterx_object_set_subscript(fx_get_1, nullptr, fx_inner_array_clone));
@@ -960,7 +960,7 @@ Test(otel_filterx, array_through_logrecord)
 
   /* $log.body[2][] = "baz"; */
   filterx_object_unref(fx_get_1);
-  fx_get_1 = filterx_object_getattr(fx_logrecord, "body");
+  fx_get_1 = filterx_object_getattr_string(fx_logrecord, "body");
   cr_assert(fx_get_1);
   filterx_object_unref(fx_get_2);
   fx_get_2 = filterx_object_get_subscript(fx_get_1, fx_2);


### PR DESCRIPTION
This PR implements an error handling for filterx expressions, so the key "error" cases are reported as statements
are evaluated.

It just covers variables/setattr/getattr/set-subscript/get-subscript

Functions are not covered yet.

This sits on top of #4885 
