### PR TITLE
Filterx message_value repr

### DIFF
--- a/lib/filterx/object-datetime.c
+++ b/lib/filterx/object-datetime.c
@@ -189,17 +189,20 @@ filterx_typecast_datetime_isodate(GPtrArray *args)
   return filterx_datetime_new(&ut);
 }
 
+gboolean
+datetime_repr(const UnixTime *ut, GString *repr)
+{
+  WallClockTime wct = WALL_CLOCK_TIME_INIT;
+  convert_unix_time_to_wall_clock_time(ut, &wct);
+  append_format_wall_clock_time(&wct, repr, TS_FMT_ISO, 3);
+  return TRUE;
+}
+
 static gboolean
 _repr(FilterXObject *s, GString *repr)
 {
   UnixTime ut = filterx_datetime_get_value(s);
-
-  WallClockTime wct = WALL_CLOCK_TIME_INIT;
-  convert_unix_time_to_wall_clock_time(&ut, &wct);
-
-  append_format_wall_clock_time(&wct, repr, TS_FMT_ISO, 3);
-
-  return TRUE;
+  return datetime_repr(&ut, repr);
 }
 
 const gchar *

--- a/lib/filterx/object-datetime.h
+++ b/lib/filterx/object-datetime.h
@@ -35,4 +35,6 @@ FilterXObject *filterx_typecast_datetime(GPtrArray *args);
 FilterXObject *filterx_typecast_datetime_isodate(GPtrArray *args);
 FilterXObject *filterx_datetime_strptime(GPtrArray *args);
 
+gboolean datetime_repr(const UnixTime *ut, GString *repr);
+
 #endif

--- a/lib/filterx/object-null.c
+++ b/lib/filterx/object-null.c
@@ -42,11 +42,17 @@ _map_to_json(FilterXObject *s, struct json_object **object)
   return TRUE;
 }
 
-static gboolean
-_null_repr(FilterXObject *s, GString *repr)
+gboolean
+null_repr(GString *repr)
 {
   g_string_append_len(repr, "null", 4);
   return TRUE;
+}
+
+static gboolean
+_null_repr(FilterXObject *s, GString *repr)
+{
+  return null_repr(repr);
 }
 
 FilterXObject *

--- a/lib/filterx/object-null.h
+++ b/lib/filterx/object-null.h
@@ -29,4 +29,6 @@ FILTERX_DECLARE_TYPE(null);
 
 FilterXObject *filterx_null_new(void);
 
+gboolean null_repr(GString *repr);
+
 #endif

--- a/lib/filterx/object-primitive.c
+++ b/lib/filterx/object-primitive.c
@@ -57,14 +57,19 @@ _integer_map_to_json(FilterXObject *s, struct json_object **object)
   return TRUE;
 }
 
+gboolean
+integer_repr(gint64 val, GString *repr)
+{
+  format_int64_padded(repr, 0, 0, 10, val);
+  return TRUE;
+}
+
 static gboolean
 _integer_marshal(FilterXObject *s, GString *repr, LogMessageValueType *t)
 {
   FilterXPrimitive *self = (FilterXPrimitive *) s;
-
-  format_int64_padded(repr, 0, 0, 10, gn_as_int64(&self->value));
   *t = LM_VT_INTEGER;
-  return TRUE;
+  return integer_repr(gn_as_int64(&self->value), repr);
 }
 
 FilterXObject *
@@ -84,16 +89,21 @@ _double_map_to_json(FilterXObject *s, struct json_object **object)
   return TRUE;
 }
 
+gboolean
+double_repr(double val, GString *repr)
+{
+  gchar buf[G_ASCII_DTOSTR_BUF_SIZE];
+  g_ascii_dtostr(buf, sizeof(buf), val);
+  g_string_append(repr, buf);
+  return TRUE;
+}
+
 static gboolean
 _double_marshal(FilterXObject *s, GString *repr, LogMessageValueType *t)
 {
   FilterXPrimitive *self = (FilterXPrimitive *) s;
-  gchar buf[32];
-
-  g_ascii_dtostr(buf, sizeof(buf), gn_as_double(&self->value));
-  g_string_append(repr, buf);
   *t = LM_VT_DOUBLE;
-  return TRUE;
+  return double_repr(gn_as_double(&self->value), repr);
 }
 
 FilterXObject *
@@ -104,17 +114,22 @@ filterx_double_new(gdouble value)
   return &self->super;
 }
 
+gboolean
+bool_repr(gboolean bool_val, GString *repr)
+{
+  if (bool_val)
+    g_string_append(repr, "true");
+  else
+    g_string_append(repr, "false");
+  return TRUE;
+}
+
 static gboolean
 _bool_marshal(FilterXObject *s, GString *repr, LogMessageValueType *t)
 {
   FilterXPrimitive *self = (FilterXPrimitive *) s;
-
-  if (!gn_is_zero(&self->value))
-    g_string_append(repr, "true");
-  else
-    g_string_append(repr, "false");
   *t = LM_VT_BOOLEAN;
-  return TRUE;
+  return bool_repr(!gn_is_zero(&self->value), repr);
 }
 
 static gboolean

--- a/lib/filterx/object-primitive.h
+++ b/lib/filterx/object-primitive.h
@@ -52,6 +52,10 @@ FilterXObject *filterx_typecast_boolean(GPtrArray *args);
 FilterXObject *filterx_typecast_integer(GPtrArray *args);
 FilterXObject *filterx_typecast_double(GPtrArray *args);
 
+gboolean bool_repr(gboolean bool_val, GString *repr);
+gboolean double_repr(double val, GString *repr);
+gboolean integer_repr(gint64 val, GString *repr);
+
 static inline gboolean
 filterx_integer_unwrap(FilterXObject *s, gint64 *value)
 {

--- a/lib/filterx/tests/test_object_message.c
+++ b/lib/filterx/tests/test_object_message.c
@@ -24,6 +24,7 @@
 #include "filterx/object-message-value.h"
 #include "apphook.h"
 #include "filterx-lib.h"
+#include "scratch-buffers.h"
 
 static void
 assert_object_json_equals(FilterXObject *obj, const gchar *expected_json_repr)
@@ -83,6 +84,100 @@ Test(filterx_message, test_filterx_object_value_maps_to_the_right_json_value)
   filterx_object_unref(fobj);
 }
 
+Test(filterx_message, test_filterx_message_type_null_repr)
+{
+  FilterXObject *fobj = filterx_message_value_new(NULL, 0, LM_VT_NULL);
+  GString *repr = scratch_buffers_alloc();
+  cr_assert(filterx_object_repr(fobj, repr));
+  cr_assert_str_eq("null", repr->str);
+  filterx_object_unref(fobj);
+}
+
+Test(filterx_message, test_filterx_message_type_string_repr)
+{
+  gchar *test_str = "any string";
+
+  FilterXObject *fobj = filterx_message_value_new(test_str, -1, LM_VT_STRING);
+  GString *repr = scratch_buffers_alloc();
+  cr_assert(filterx_object_repr(fobj, repr));
+  cr_assert_str_eq(test_str, repr->str);
+  filterx_object_unref(fobj);
+}
+
+Test(filterx_message, test_filterx_message_type_bytes_repr)
+{
+  gchar *test_str = "any bytes";
+
+  FilterXObject *fobj = filterx_message_value_new(test_str, -1, LM_VT_BYTES);
+  GString *repr = scratch_buffers_alloc();
+  cr_assert(filterx_object_repr(fobj, repr));
+  cr_assert_str_eq(test_str, repr->str);
+  filterx_object_unref(fobj);
+}
+
+Test(filterx_message, test_filterx_message_type_protobuf_repr)
+{
+  gchar *test_str = "not a valid protobuf!";
+
+  FilterXObject *fobj = filterx_message_value_new(test_str, -1, LM_VT_PROTOBUF);
+  GString *repr = scratch_buffers_alloc();
+  cr_assert(filterx_object_repr(fobj, repr));
+  cr_assert_str_eq(test_str, repr->str);
+  filterx_object_unref(fobj);
+}
+
+Test(filterx_message, test_filterx_message_type_json_repr)
+{
+  gchar *test_str = "{\"test\":\"json\"}";
+
+  FilterXObject *fobj = filterx_message_value_new(test_str, -1, LM_VT_JSON);
+  GString *repr = scratch_buffers_alloc();
+  cr_assert(filterx_object_repr(fobj, repr));
+  cr_assert_str_eq(test_str, repr->str);
+  filterx_object_unref(fobj);
+}
+
+Test(filterx_message, test_filterx_message_type_boolean_repr)
+{
+  gchar *val = "T";
+  FilterXObject *fobj = filterx_message_value_new(val, -1, LM_VT_BOOLEAN);
+  GString *repr = scratch_buffers_alloc();
+  cr_assert(filterx_object_repr(fobj, repr));
+  cr_assert_str_eq("true", repr->str);
+  filterx_object_unref(fobj);
+}
+
+Test(filterx_message, test_filterx_message_type_int_repr)
+{
+  gchar *val = "443";
+  FilterXObject *fobj = filterx_message_value_new(val, -1, LM_VT_INTEGER);
+  GString *repr = scratch_buffers_alloc();
+  cr_assert(filterx_object_repr(fobj, repr));
+  cr_assert_str_eq("443", repr->str);
+  filterx_object_unref(fobj);
+}
+
+Test(filterx_message, test_filterx_message_type_double_repr)
+{
+  gchar *val = "17.756";
+  FilterXObject *fobj = filterx_message_value_new(val, -1, LM_VT_DOUBLE);
+  GString *repr = scratch_buffers_alloc();
+  cr_assert(filterx_object_repr(fobj, repr));
+  cr_assert_str_eq("17.756", repr->str);
+  filterx_object_unref(fobj);
+}
+
+Test(filterx_message, test_filterx_message_type_datetime_repr)
+{
+  gchar *val = "1713520972.000000+02:00";
+  FilterXObject *fobj = filterx_message_value_new(val, -1, LM_VT_DATETIME);
+  GString *repr = scratch_buffers_alloc();
+  cr_assert(filterx_object_repr(fobj, repr));
+  cr_assert_str_eq("2024-04-19T12:02:52.000+02:00", repr->str);
+  filterx_object_unref(fobj);
+}
+
+
 static void
 setup(void)
 {
@@ -92,6 +187,7 @@ setup(void)
 static void
 teardown(void)
 {
+  scratch_buffers_explicit_gc();
   app_shutdown();
 }
 


### PR DESCRIPTION
- repr method implemented for message-value type, this way string() typecast is able to handle message-value types
- add unit tests