### PR TITLE
Fix otel config revert

### DIFF
--- a/modules/grpc/otel/otel-source.hpp
+++ b/modules/grpc/otel/otel-source.hpp
@@ -57,9 +57,9 @@ public:
   void add_extra_channel_arg(std::string name, std::string value);
   GrpcServerCredentialsBuilderW *get_credentials_builder_wrapper();
 
-  TraceService::AsyncService trace_service;
-  LogsService::AsyncService logs_service;
-  MetricsService::AsyncService metrics_service;
+  std::unique_ptr<TraceService::AsyncService> trace_service;
+  std::unique_ptr<LogsService::AsyncService> logs_service;
+  std::unique_ptr<MetricsService::AsyncService> metrics_service;
 
 private:
   friend SourceWorker;

--- a/news/bugfix-4910.md
+++ b/news/bugfix-4910.md
@@ -1,0 +1,1 @@
+`opentelemetry()`: fix crash when an invalid configuration needs to be reverted


### PR DESCRIPTION
Each service belongs to a single server.

This patch fixes the following assert by recreating
the service instances:

"Can only register an asynchronous service against one server."