### PR TITLE
Fix MQTT destination module loosing its connection to the broker regulary.

### DIFF
--- a/modules/mqtt/destination/mqtt-worker.h
+++ b/modules/mqtt/destination/mqtt-worker.h
@@ -26,6 +26,8 @@
 #include "logthrdest/logthrdestdrv.h"
 #include "thread-utils.h"
 
+#include <iv.h>
+
 #include <MQTTClient.h>
 
 typedef struct _MQTTDestinationWorker
@@ -36,6 +38,8 @@ typedef struct _MQTTDestinationWorker
 
   GString *string_to_write;
   GString *topic_name_buffer;
+
+  struct iv_timer yield_timer;
 } MQTTDestinationWorker;
 
 LogThreadedDestWorker *mqtt_dw_new(LogThreadedDestDriver *o, gint worker_index);


### PR DESCRIPTION
The current MQTT destination implementation does not answer to MQTT ping requests in time when only a low volume of messages are send to the MQTT broker.

MQTT broker might close the connection because of the missing responses, causing error messages in syslog-ng and even lost messages. One example is the broker operated by AWS as part of their "IoT Core Broker" service.

This patch adds regular calls to MQTTClient_yield every 0.5 seconds. These calls allow the MQTT client library to answer the ping requests.

The requirement for these calls is documented in the Paho MQTT C Client Library documentation in the comparision between synchronous and asynchronous clients:

"Client applications must call either MQTTClient_receive() or MQTTClient_yield() relatively frequently in order to allow processing of acknowledgements and the MQTT "pings" that keep the network connection to the server alive."

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
