### PR TITLE
stats: do not show orphan metrics for `stats prometheus`

### DIFF
--- a/lib/stats/stats-prometheus.c
+++ b/lib/stats/stats-prometheus.c
@@ -257,6 +257,9 @@ stats_format_prometheus(StatsCluster *sc, gint type, StatsCounterItem *counter, 
   if (!sc->key.name && !with_legacy)
     return;
 
+  if (stats_cluster_is_orphaned(sc))
+    return;
+
   ScratchBuffersMarker marker;
   scratch_buffers_mark(&marker);
 

--- a/news/other-4921.md
+++ b/news/other-4921.md
@@ -1,0 +1,9 @@
+`syslog-ng-ctl`: do not show orphan metrics for `stats prometheus`
+
+As the `stats prometheus` command is intended to be used to forward metrics
+to Prometheus or any other time-series database, displaying orphaned metrics
+should be avoided in order not to insert new data points when a given metric
+is no longer alive.
+
+In case you are interested in the last known value of orphaned counters, use
+the `stats` or `query` subcommands.


### PR DESCRIPTION
As the `stats prometheus` command is intended to be used to forward metrics to Prometheus or any other time-series database, displaying orphaned metrics should be avoided in order not to insert new data points when a given metric is no longer alive.

In case you are interested in the last known value of orphaned counters, use the `stats` or `query` subcommands.