### PR TITLE
Fix s3 destination compatibility with services like MinIO

### DIFF
--- a/modules/python-modules/syslogng/modules/s3/s3_destination.py
+++ b/modules/python-modules/syslogng/modules/s3/s3_destination.py
@@ -257,9 +257,9 @@ class S3Destination(LogDestination):
                 method="sts-assume-role",
             )
 
-        sts = self.session.client("sts")
-        whoami = sts.get_caller_identity().get("Arn")
-        self.logger.info(f"Using {whoami} to access the bucket")
+            sts = self.session.client("sts")
+            whoami = sts.get_caller_identity().get("Arn")
+            self.logger.info(f"Using {whoami} to access the bucket")
 
         self.client = self.session.client(
             service_name="s3",


### PR DESCRIPTION
A regression happened with the introduction of role support in the s3 destination: you can't use it with Minio anymore. This PR makes an attempt to fix that.



Calling sts.get_caller_identity() will fail with endpoints that are advertised as S3 compatible but provide no other AWS services, for example Minio:

> syslog-ng[80]: Exception while calling a Python function; caller='minio#0', class='syslogng.modules.s3.S3Destination', function='open', exception='ClientError: An error occurred (InvalidClientTokenId) when calling the GetCallerIdentity operation: The security token included in the request is invalid.'

This patch moves the call that's not used for anything but for displaying a log message about the assumed identity, inside the condition checking for a `role` option.

However, we can safely call get_caller_identity if we use/have sts anyway, because according to AWS Docs, you don't need any permissions for that. I'm not sure about the effectiveness and necessity of this though.

> No permissions are required to perform this operation. If an administrator attaches a policy to your identity that explicitly denies access to the sts:GetCallerIdentity action, you can still perform this operation.