### PR TITLE
filterx: OTel <-> JSON conversion

### DIFF
--- a/lib/filterx/expr-literal-generator.c
+++ b/lib/filterx/expr-literal-generator.c
@@ -97,7 +97,7 @@ _eval_elements(FilterXObject *fillable, GList *elements)
           value = cloned_value;
         }
 
-      gboolean success = filterx_object_set_subscript(fillable, key, value);
+      gboolean success = filterx_object_set_subscript(fillable, key, &value);
 
       filterx_object_unref(key);
       filterx_object_unref(value);

--- a/lib/filterx/expr-regexp.c
+++ b/lib/filterx/expr-regexp.c
@@ -167,7 +167,7 @@ _store_matches_to_list(pcre2_code_8 *pattern, const FilterXReMatchState *state, 
         continue;
 
       FilterXObject *value = filterx_string_new(state->lhs_str + begin_index, end_index - begin_index);
-      gboolean success = filterx_list_append(fillable, value);
+      gboolean success = filterx_list_append(fillable, &value);
       filterx_object_unref(value);
 
       if (!success)
@@ -199,7 +199,7 @@ _store_matches_to_dict(pcre2_code_8 *pattern, const FilterXReMatchState *state, 
       FilterXObject *key = filterx_string_new(num_str_buf, -1);
       FilterXObject *value = filterx_string_new(state->lhs_str + begin_index, end_index - begin_index);
 
-      gboolean success = filterx_object_set_subscript(fillable, key, value);
+      gboolean success = filterx_object_set_subscript(fillable, key, &value);
 
       filterx_object_unref(key);
       filterx_object_unref(value);
@@ -234,7 +234,7 @@ _store_matches_to_dict(pcre2_code_8 *pattern, const FilterXReMatchState *state, 
       FilterXObject *key = filterx_string_new(namedgroup_name, -1);
       FilterXObject *value = filterx_object_get_subscript(fillable, num_key);
 
-      gboolean success = filterx_object_set_subscript(fillable, key, value);
+      gboolean success = filterx_object_set_subscript(fillable, key, &value);
       g_assert(filterx_object_unset_key(fillable, num_key));
 
       filterx_object_unref(key);

--- a/lib/filterx/expr-set-subscript.c
+++ b/lib/filterx/expr-set-subscript.c
@@ -69,7 +69,7 @@ _eval(FilterXExpr *s)
   FilterXObject *cloned = filterx_object_clone(new_value);
   filterx_object_unref(new_value);
 
-  if (filterx_object_set_subscript(object, key, cloned))
+  if (filterx_object_set_subscript(object, key, &cloned))
     {
       result = filterx_boolean_new(TRUE);
       if (trace_flag)

--- a/lib/filterx/expr-setattr.c
+++ b/lib/filterx/expr-setattr.c
@@ -57,7 +57,7 @@ _eval(FilterXExpr *s)
   FilterXObject *cloned = filterx_object_clone(new_value);
   filterx_object_unref(new_value);
 
-  if (filterx_object_setattr(object, self->attr, cloned))
+  if (filterx_object_setattr(object, self->attr, &cloned))
     {
       result = filterx_boolean_new(TRUE);
       if (trace_flag)

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -142,11 +142,13 @@ _evaluate_statement(FilterXExpr *expr)
       if (!success)
         msg_debug("FILTERX  FALSY",
                   filterx_expr_format_location_tag(expr),
-                  evt_tag_mem("value", buf->str, buf->len));
+                  evt_tag_mem("value", buf->str, buf->len),
+                  evt_tag_str("type", res->type->name));
       else
         msg_trace("FILTERX TRUTHY",
                   filterx_expr_format_location_tag(expr),
-                  evt_tag_mem("value", buf->str, buf->len));
+                  evt_tag_mem("value", buf->str, buf->len),
+                  evt_tag_str("type", res->type->name));
     }
 
   filterx_object_unref(res);

--- a/lib/filterx/filterx-object.c
+++ b/lib/filterx/filterx-object.c
@@ -37,7 +37,7 @@ filterx_object_getattr_string(FilterXObject *self, const gchar *attr_name)
 }
 
 gboolean
-filterx_object_setattr_string(FilterXObject *self, const gchar *attr_name, FilterXObject *new_value)
+filterx_object_setattr_string(FilterXObject *self, const gchar *attr_name, FilterXObject **new_value)
 {
   FilterXObject *attr = filterx_string_new(attr_name, -1);
   gboolean res = filterx_object_setattr(self, attr, new_value);

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -178,8 +178,14 @@ filterx_object_clone(FilterXObject *self)
 static inline gboolean
 filterx_object_map_to_json(FilterXObject *self, struct json_object **object, FilterXObject **assoc_object)
 {
+  *assoc_object = NULL;
   if (self->type->map_to_json)
-    return self->type->map_to_json(self, object, assoc_object);
+    {
+      gboolean result = self->type->map_to_json(self, object, assoc_object);
+      if (!(*assoc_object))
+        *assoc_object = filterx_object_ref(self);
+      return result;
+    }
   return FALSE;
 }
 

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -38,12 +38,12 @@ struct _FilterXType
   FilterXObject *(*unmarshal)(FilterXObject *self);
   gboolean (*marshal)(FilterXObject *self, GString *repr, LogMessageValueType *t);
   FilterXObject *(*clone)(FilterXObject *self);
-  gboolean (*map_to_json)(FilterXObject *self, struct json_object **object);
+  gboolean (*map_to_json)(FilterXObject *self, struct json_object **object, FilterXObject **assoc_object);
   gboolean (*truthy)(FilterXObject *self);
   FilterXObject *(*getattr)(FilterXObject *self, FilterXObject *attr);
-  gboolean (*setattr)(FilterXObject *self, FilterXObject *attr, FilterXObject *new_value);
+  gboolean (*setattr)(FilterXObject *self, FilterXObject *attr, FilterXObject **new_value);
   FilterXObject *(*get_subscript)(FilterXObject *self, FilterXObject *key);
-  gboolean (*set_subscript)(FilterXObject *self, FilterXObject *key, FilterXObject *new_value);
+  gboolean (*set_subscript)(FilterXObject *self, FilterXObject *key, FilterXObject **new_value);
   gboolean (*is_key_set)(FilterXObject *self, FilterXObject *key);
   gboolean (*unset_key)(FilterXObject *self, FilterXObject *key);
   FilterXObject *(*list_factory)(void);
@@ -92,7 +92,7 @@ struct _FilterXObject
 };
 
 FilterXObject *filterx_object_getattr_string(FilterXObject *self, const gchar *attr_name);
-gboolean filterx_object_setattr_string(FilterXObject *self, const gchar *attr_name, FilterXObject *new_value);
+gboolean filterx_object_setattr_string(FilterXObject *self, const gchar *attr_name, FilterXObject **new_value);
 
 FilterXObject *filterx_object_new(FilterXType *type);
 FilterXObject *filterx_object_ref(FilterXObject *self);
@@ -176,10 +176,10 @@ filterx_object_clone(FilterXObject *self)
 }
 
 static inline gboolean
-filterx_object_map_to_json(FilterXObject *self, struct json_object **object)
+filterx_object_map_to_json(FilterXObject *self, struct json_object **object, FilterXObject **assoc_object)
 {
   if (self->type->map_to_json)
-    return self->type->map_to_json(self, object);
+    return self->type->map_to_json(self, object, assoc_object);
   return FALSE;
 }
 
@@ -208,7 +208,7 @@ filterx_object_getattr(FilterXObject *self, FilterXObject *attr)
 }
 
 static inline gboolean
-filterx_object_setattr(FilterXObject *self, FilterXObject *attr, FilterXObject *new_value)
+filterx_object_setattr(FilterXObject *self, FilterXObject *attr, FilterXObject **new_value)
 {
   g_assert(!self->readonly);
 
@@ -230,7 +230,7 @@ filterx_object_get_subscript(FilterXObject *self, FilterXObject *key)
 }
 
 static inline gboolean
-filterx_object_set_subscript(FilterXObject *self, FilterXObject *key, FilterXObject *new_value)
+filterx_object_set_subscript(FilterXObject *self, FilterXObject *key, FilterXObject **new_value)
 {
   g_assert(!self->readonly);
 

--- a/lib/filterx/object-datetime.c
+++ b/lib/filterx/object-datetime.c
@@ -84,7 +84,7 @@ _marshal(FilterXObject *s, GString *repr, LogMessageValueType *t)
 }
 
 static gboolean
-_map_to_json(FilterXObject *s, struct json_object **object)
+_map_to_json(FilterXObject *s, struct json_object **object, FilterXObject **assoc_object)
 {
   FilterXDateTime *self = (FilterXDateTime *) s;
   GString *time_stamp = scratch_buffers_alloc();
@@ -92,6 +92,7 @@ _map_to_json(FilterXObject *s, struct json_object **object)
   _convert_unix_time_to_string(&self->ut, time_stamp);
 
   *object = json_object_new_string_len(time_stamp->str, time_stamp->len);
+  *assoc_object = filterx_object_ref(s);
   return TRUE;
 }
 

--- a/lib/filterx/object-datetime.c
+++ b/lib/filterx/object-datetime.c
@@ -92,7 +92,6 @@ _map_to_json(FilterXObject *s, struct json_object **object, FilterXObject **asso
   _convert_unix_time_to_string(&self->ut, time_stamp);
 
   *object = json_object_new_string_len(time_stamp->str, time_stamp->len);
-  *assoc_object = filterx_object_ref(s);
   return TRUE;
 }
 

--- a/lib/filterx/object-dict-interface.c
+++ b/lib/filterx/object-dict-interface.c
@@ -56,7 +56,7 @@ _get_subscript(FilterXObject *s, FilterXObject *key)
 }
 
 static gboolean
-_set_subscript(FilterXObject *s, FilterXObject *key, FilterXObject *new_value)
+_set_subscript(FilterXObject *s, FilterXObject *key, FilterXObject **new_value)
 {
   FilterXDict *self = (FilterXDict *) s;
 
@@ -115,7 +115,7 @@ _getattr(FilterXObject *s, FilterXObject *attr)
 }
 
 static gboolean
-_setattr(FilterXObject *s, FilterXObject *attr, FilterXObject *new_value)
+_setattr(FilterXObject *s, FilterXObject *attr, FilterXObject **new_value)
 {
   FilterXDict *self = (FilterXDict *) s;
 

--- a/lib/filterx/object-dict-interface.h
+++ b/lib/filterx/object-dict-interface.h
@@ -36,7 +36,7 @@ struct FilterXDict_
   gboolean support_attr;
 
   FilterXObject *(*get_subscript)(FilterXDict *s, FilterXObject *key);
-  gboolean (*set_subscript)(FilterXDict *s, FilterXObject *key, FilterXObject *new_value);
+  gboolean (*set_subscript)(FilterXDict *s, FilterXObject *key, FilterXObject **new_value);
   gboolean (*is_key_set)(FilterXDict *s, FilterXObject *key);
   gboolean (*unset_key)(FilterXDict *s, FilterXObject *key);
   guint64 (*len)(FilterXDict *s);

--- a/lib/filterx/object-json-array.c
+++ b/lib/filterx/object-json-array.c
@@ -84,7 +84,6 @@ _map_to_json(FilterXObject *s, struct json_object **object, FilterXObject **asso
   FilterXJsonArray *self = (FilterXJsonArray *) s;
 
   *object = json_object_get(self->object);
-  *assoc_object = filterx_object_ref(s);
   return TRUE;
 }
 

--- a/lib/filterx/object-json-internal.h
+++ b/lib/filterx/object-json-internal.h
@@ -27,7 +27,6 @@
 #include "object-json.h"
 #include "filterx/filterx-weakrefs.h"
 
-void filterx_json_associate_cached_object(struct json_object *json_obj, FilterXObject *filterx_object);
 FilterXObject *filterx_json_convert_json_to_object_cached(FilterXObject *self, FilterXWeakRef *root_container,
                                                           struct json_object *json_obj);
 

--- a/lib/filterx/object-json-object.c
+++ b/lib/filterx/object-json-object.c
@@ -59,7 +59,6 @@ _map_to_json(FilterXObject *s, struct json_object **json_obj, FilterXObject **as
   FilterXJsonObject *self = (FilterXJsonObject *) s;
 
   *json_obj = json_object_get(self->object);
-  *assoc_object = filterx_object_ref(s);
   return TRUE;
 }
 

--- a/lib/filterx/object-json-object.c
+++ b/lib/filterx/object-json-object.c
@@ -54,11 +54,12 @@ _marshal(FilterXObject *s, GString *repr, LogMessageValueType *t)
 }
 
 static gboolean
-_map_to_json(FilterXObject *s, struct json_object **json_obj)
+_map_to_json(FilterXObject *s, struct json_object **json_obj, FilterXObject **assoc_object)
 {
   FilterXJsonObject *self = (FilterXJsonObject *) s;
 
   *json_obj = json_object_get(self->object);
+  *assoc_object = filterx_object_ref(s);
   return TRUE;
 }
 
@@ -91,7 +92,7 @@ _get_subscript(FilterXDict *s, FilterXObject *key)
 }
 
 static gboolean
-_set_subscript(FilterXDict *s, FilterXObject *key, FilterXObject *new_value)
+_set_subscript(FilterXDict *s, FilterXObject *key, FilterXObject **new_value)
 {
   FilterXJsonObject *self = (FilterXJsonObject *) s;
 
@@ -100,13 +101,15 @@ _set_subscript(FilterXDict *s, FilterXObject *key, FilterXObject *new_value)
     return FALSE;
 
   struct json_object *new_json_value = NULL;
-  if (!filterx_object_map_to_json(new_value, &new_json_value))
+  FilterXObject *assoc_object = NULL;
+  if (!filterx_object_map_to_json(*new_value, &new_json_value, &assoc_object))
     return FALSE;
 
-  filterx_json_associate_cached_object(new_json_value, new_value);
+  filterx_json_associate_cached_object(new_json_value, assoc_object);
 
   if (json_object_object_add(self->object, key_str, new_json_value) != 0)
     {
+      filterx_object_unref(assoc_object);
       json_object_put(new_json_value);
       return FALSE;
     }
@@ -118,6 +121,9 @@ _set_subscript(FilterXDict *s, FilterXObject *key, FilterXObject *new_value)
       root_container->modified_in_place = TRUE;
       filterx_object_unref(root_container);
     }
+
+  filterx_object_unref(*new_value);
+  *new_value = assoc_object;
 
   return TRUE;
 }

--- a/lib/filterx/object-json.h
+++ b/lib/filterx/object-json.h
@@ -49,4 +49,6 @@ const gchar *filterx_json_to_json_literal(FilterXObject *s);
 const gchar *filterx_json_object_to_json_literal(FilterXObject *s);
 const gchar *filterx_json_array_to_json_literal(FilterXObject *s);
 
+void filterx_json_associate_cached_object(struct json_object *json_obj, FilterXObject *filterx_object);
+
 #endif

--- a/lib/filterx/object-list-interface.c
+++ b/lib/filterx/object-list-interface.c
@@ -35,7 +35,7 @@ filterx_list_get_subscript(FilterXObject *s, gint64 index)
 }
 
 gboolean
-filterx_list_set_subscript(FilterXObject *s, gint64 index, FilterXObject *new_value)
+filterx_list_set_subscript(FilterXObject *s, gint64 index, FilterXObject **new_value)
 {
   FilterXObject *index_obj = filterx_integer_new(index);
   gboolean result = filterx_object_set_subscript(s, index_obj, new_value);
@@ -45,7 +45,7 @@ filterx_list_set_subscript(FilterXObject *s, gint64 index, FilterXObject *new_va
 }
 
 gboolean
-filterx_list_append(FilterXObject *s, FilterXObject *new_value)
+filterx_list_append(FilterXObject *s, FilterXObject **new_value)
 {
   return filterx_object_set_subscript(s, NULL, new_value);
 }
@@ -130,7 +130,7 @@ _get_subscript(FilterXObject *s, FilterXObject *key)
 }
 
 static gboolean
-_set_subscript(FilterXObject *s, FilterXObject *key, FilterXObject *new_value)
+_set_subscript(FilterXObject *s, FilterXObject *key, FilterXObject **new_value)
 {
   FilterXList *self = (FilterXList *) s;
 

--- a/lib/filterx/object-list-interface.h
+++ b/lib/filterx/object-list-interface.h
@@ -33,15 +33,15 @@ struct FilterXList_
   FilterXObject super;
 
   FilterXObject *(*get_subscript)(FilterXList *s, guint64 index);
-  gboolean (*set_subscript)(FilterXList *s, guint64 index, FilterXObject *new_value);
-  gboolean (*append)(FilterXList *s, FilterXObject *new_value);
+  gboolean (*set_subscript)(FilterXList *s, guint64 index, FilterXObject **new_value);
+  gboolean (*append)(FilterXList *s, FilterXObject **new_value);
   gboolean (*unset_index)(FilterXList *s, guint64 index);
   guint64 (*len)(FilterXList *s);
 };
 
 FilterXObject *filterx_list_get_subscript(FilterXObject *s, gint64 index);
-gboolean filterx_list_set_subscript(FilterXObject *s, gint64 index, FilterXObject *new_value);
-gboolean filterx_list_append(FilterXObject *s, FilterXObject *new_value);
+gboolean filterx_list_set_subscript(FilterXObject *s, gint64 index, FilterXObject **new_value);
+gboolean filterx_list_append(FilterXObject *s, FilterXObject **new_value);
 gboolean filterx_list_unset_index(FilterXObject *s, gint64 index);
 
 void filterx_list_init_instance(FilterXList *self, FilterXType *type);

--- a/lib/filterx/object-message-value.c
+++ b/lib/filterx/object-message-value.c
@@ -125,13 +125,13 @@ _unmarshal_repr(const gchar *repr, gssize repr_len, LogMessageValueType t)
  * and call map_to_json on the unmarshalled object.
  */
 static gboolean
-_map_to_json(FilterXObject *s, struct json_object **jso)
+_map_to_json(FilterXObject *s, struct json_object **jso, FilterXObject **assoc_object)
 {
   FilterXObject *unmarshalled_object = filterx_object_unmarshal(filterx_object_ref(s));
 
   if (unmarshalled_object)
     {
-      gboolean result = filterx_object_map_to_json(unmarshalled_object, jso);
+      gboolean result = filterx_object_map_to_json(unmarshalled_object, jso, assoc_object);
       filterx_object_unref(unmarshalled_object);
       return result;
     }

--- a/lib/filterx/object-null.c
+++ b/lib/filterx/object-null.c
@@ -42,7 +42,6 @@ static gboolean
 _map_to_json(FilterXObject *s, struct json_object **object, FilterXObject **assoc_object)
 {
   *object = NULL;
-  *assoc_object = filterx_object_ref(s);
   return TRUE;
 }
 

--- a/lib/filterx/object-null.c
+++ b/lib/filterx/object-null.c
@@ -39,9 +39,10 @@ _marshal(FilterXObject *s, GString *repr, LogMessageValueType *t)
 }
 
 static gboolean
-_map_to_json(FilterXObject *s, struct json_object **object)
+_map_to_json(FilterXObject *s, struct json_object **object, FilterXObject **assoc_object)
 {
   *object = NULL;
+  *assoc_object = filterx_object_ref(s);
   return TRUE;
 }
 

--- a/lib/filterx/object-primitive.c
+++ b/lib/filterx/object-primitive.c
@@ -60,7 +60,6 @@ _integer_map_to_json(FilterXObject *s, struct json_object **object, FilterXObjec
   FilterXPrimitive *self = (FilterXPrimitive *) s;
 
   *object = json_object_new_int64(gn_as_int64(&self->value));
-  *assoc_object = filterx_object_ref(s);
   return TRUE;
 }
 
@@ -101,7 +100,6 @@ _double_map_to_json(FilterXObject *s, struct json_object **object, FilterXObject
   FilterXPrimitive *self = (FilterXPrimitive *) s;
 
   *object = json_object_new_double(gn_as_double(&self->value));
-  *assoc_object = filterx_object_ref(s);
   return TRUE;
 }
 
@@ -154,7 +152,6 @@ _bool_map_to_json(FilterXObject *s, struct json_object **object, FilterXObject *
   FilterXPrimitive *self = (FilterXPrimitive *) s;
 
   *object = json_object_new_boolean(gn_as_int64(&self->value));
-  *assoc_object = filterx_object_ref(s);
   return TRUE;
 }
 

--- a/lib/filterx/object-primitive.c
+++ b/lib/filterx/object-primitive.c
@@ -55,11 +55,12 @@ filterx_primitive_new(FilterXType *type)
 }
 
 static gboolean
-_integer_map_to_json(FilterXObject *s, struct json_object **object)
+_integer_map_to_json(FilterXObject *s, struct json_object **object, FilterXObject **assoc_object)
 {
   FilterXPrimitive *self = (FilterXPrimitive *) s;
 
   *object = json_object_new_int64(gn_as_int64(&self->value));
+  *assoc_object = filterx_object_ref(s);
   return TRUE;
 }
 
@@ -95,11 +96,12 @@ filterx_integer_new(gint64 value)
 }
 
 static gboolean
-_double_map_to_json(FilterXObject *s, struct json_object **object)
+_double_map_to_json(FilterXObject *s, struct json_object **object, FilterXObject **assoc_object)
 {
   FilterXPrimitive *self = (FilterXPrimitive *) s;
 
   *object = json_object_new_double(gn_as_double(&self->value));
+  *assoc_object = filterx_object_ref(s);
   return TRUE;
 }
 
@@ -147,11 +149,12 @@ _bool_marshal(FilterXObject *s, GString *repr, LogMessageValueType *t)
 }
 
 static gboolean
-_bool_map_to_json(FilterXObject *s, struct json_object **object)
+_bool_map_to_json(FilterXObject *s, struct json_object **object, FilterXObject **assoc_object)
 {
   FilterXPrimitive *self = (FilterXPrimitive *) s;
 
   *object = json_object_new_boolean(gn_as_int64(&self->value));
+  *assoc_object = filterx_object_ref(s);
   return TRUE;
 }
 

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -104,11 +104,12 @@ _len(FilterXObject *s, guint64 *len)
 }
 
 static gboolean
-_map_to_json(FilterXObject *s, struct json_object **object)
+_map_to_json(FilterXObject *s, struct json_object **object, FilterXObject **assoc_object)
 {
   FilterXString *self = (FilterXString *) s;
 
   *object = json_object_new_string_len(self->str, self->str_len);
+  *assoc_object = filterx_object_ref(s);
   return TRUE;
 }
 
@@ -141,7 +142,7 @@ _get_base64_encoded_size(gsize len)
 }
 
 static gboolean
-_bytes_map_to_json(FilterXObject *s, struct json_object **object)
+_bytes_map_to_json(FilterXObject *s, struct json_object **object, FilterXObject **assoc_object)
 {
   FilterXString *self = (FilterXString *) s;
   GString *encode_buffer = scratch_buffers_alloc();
@@ -165,6 +166,7 @@ _bytes_map_to_json(FilterXObject *s, struct json_object **object)
   g_string_set_size(encode_buffer, out_len);
 
   *object = json_object_new_string_len(encode_buffer->str, encode_buffer->len);
+  *assoc_object = filterx_object_ref(s);
   return TRUE;
 }
 

--- a/lib/filterx/object-string.c
+++ b/lib/filterx/object-string.c
@@ -109,7 +109,6 @@ _map_to_json(FilterXObject *s, struct json_object **object, FilterXObject **asso
   FilterXString *self = (FilterXString *) s;
 
   *object = json_object_new_string_len(self->str, self->str_len);
-  *assoc_object = filterx_object_ref(s);
   return TRUE;
 }
 
@@ -166,7 +165,6 @@ _bytes_map_to_json(FilterXObject *s, struct json_object **object, FilterXObject 
   g_string_set_size(encode_buffer, out_len);
 
   *object = json_object_new_string_len(encode_buffer->str, encode_buffer->len);
-  *assoc_object = filterx_object_ref(s);
   return TRUE;
 }
 

--- a/lib/filterx/tests/test_filterx_expr.c
+++ b/lib/filterx/tests/test_filterx_expr.c
@@ -450,7 +450,7 @@ Test(filterx_expr, test_filterx_readonly)
   FilterXObject *dict = filterx_test_dict_new();
 
   FilterXObject *inner_dict = filterx_test_dict_new();
-  cr_assert(filterx_object_set_subscript(dict, foo, inner_dict));
+  cr_assert(filterx_object_set_subscript(dict, foo, &inner_dict));
   filterx_object_unref(inner_dict);
 
   filterx_object_make_readonly(dict);

--- a/lib/filterx/tests/test_func_istype.c
+++ b/lib/filterx/tests/test_func_istype.c
@@ -87,7 +87,7 @@ Test(filterx_func_istype, non_literal_type_arg)
 {
   FilterXObject *list = filterx_test_list_new();
   FilterXObject *type_str = filterx_string_new("dummy", -1);
-  filterx_list_append(list, type_str);
+  filterx_list_append(list, &type_str);
   filterx_object_unref(type_str);
 
   FilterXExpr *type_expr = filterx_get_subscript_new(filterx_literal_new(list),

--- a/lib/filterx/tests/test_object_datetime.c
+++ b/lib/filterx/tests/test_object_datetime.c
@@ -337,7 +337,7 @@ Test(filterx_datetime, test_filterx_datetime_strptime_with_non_literal_format)
 {
   FilterXObject *list = filterx_test_list_new();
   FilterXObject *format = filterx_string_new(datefmt_isodate, -1);
-  cr_assert(filterx_list_append(list, format));
+  cr_assert(filterx_list_append(list, &format));
   filterx_object_unref(format);
   FilterXExpr *format_expr = filterx_get_subscript_new(filterx_literal_new(list),
                                                        filterx_literal_new(filterx_integer_new(-1)));

--- a/libtest/filterx-lib.c
+++ b/libtest/filterx-lib.c
@@ -25,6 +25,7 @@
 #include "filterx-lib.h"
 #include "cr_template.h"
 #include "filterx/object-json.h"
+#include "filterx/object-string.h"
 #include "filterx/filterx-eval.h"
 
 void
@@ -46,12 +47,14 @@ void
 assert_object_json_equals(FilterXObject *obj, const gchar *expected_json_repr)
 {
   struct json_object *jso = NULL;
+  FilterXObject *assoc_object = NULL;
 
-  cr_assert(filterx_object_map_to_json(obj, &jso) == TRUE, "error mapping to json, expected json was: %s",
+  cr_assert(filterx_object_map_to_json(obj, &jso, &assoc_object) == TRUE, "error mapping to json, expected json was: %s",
             expected_json_repr);
   const gchar *json_repr = json_object_to_json_string_ext(jso, JSON_C_TO_STRING_PLAIN);
   cr_assert_str_eq(json_repr, expected_json_repr);
   json_object_put(jso);
+  filterx_object_unref(assoc_object);
 }
 
 
@@ -111,11 +114,12 @@ _unknown_truthy(FilterXObject *s)
 }
 
 static gboolean
-_unknown_map_to_json(FilterXObject *s, struct json_object **object)
+_unknown_map_to_json(FilterXObject *s, struct json_object **object, FilterXObject **assoc_object)
 {
   gssize len;
   const gchar *repr = filterx_test_unknown_object_marshaled_repr(&len);
   *object = json_object_new_string_len(repr, len);
+  *assoc_object = filterx_string_new(repr, len);
   return TRUE;
 }
 

--- a/modules/grpc/otel/filterx/object-otel-array.hpp
+++ b/modules/grpc/otel/filterx/object-otel-array.hpp
@@ -55,9 +55,9 @@ public:
   ~Array();
 
   std::string marshal();
-  bool set_subscript(uint64_t index, FilterXObject *value);
+  bool set_subscript(uint64_t index, FilterXObject **value);
   FilterXObject *get_subscript(uint64_t index);
-  bool append(FilterXObject *value);
+  bool append(FilterXObject **value);
   bool unset_index(uint64_t index);
   uint64_t len() const;
   const ArrayValue &get_value() const;
@@ -78,7 +78,8 @@ class OtelArrayField : public ProtobufField
 {
 public:
   FilterXObject *FilterXObjectGetter(google::protobuf::Message *message, ProtoReflectors reflectors);
-  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object);
+  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object,
+                           FilterXObject **assoc_object);
 };
 
 extern OtelArrayField otel_array_converter;

--- a/modules/grpc/otel/filterx/object-otel-kvlist.cpp
+++ b/modules/grpc/otel/filterx/object-otel-kvlist.cpp
@@ -408,20 +408,9 @@ OtelKVListField::FilterXObjectGetter(google::protobuf::Message *message, ProtoRe
     }
 }
 
-bool
-OtelKVListField::FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors,
-                                     FilterXObject *object, FilterXObject **assoc_object)
+static RepeatedPtrField<KeyValue> *
+_get_repeated_kv(google::protobuf::Message *message, syslogng::grpc::otel::ProtoReflectors reflectors)
 {
-  if (!filterx_object_is_type(object, &FILTERX_TYPE_NAME(otel_kvlist)))
-    {
-      msg_error("otel-kvlist: Failed to convert field, type is unsupported",
-                evt_tag_str("field", reflectors.fieldDescriptor->name().c_str()),
-                evt_tag_str("expected_type", reflectors.fieldDescriptor->type_name()),
-                evt_tag_str("type", object->type->name));
-      return false;
-    }
-
-  FilterXOtelKVList *filterx_kvlist = (FilterXOtelKVList *) object;
   RepeatedPtrField<KeyValue> *repeated_kv;
 
   if (reflectors.fieldDescriptor->is_repeated())
@@ -449,6 +438,61 @@ OtelKVListField::FilterXObjectSetter(google::protobuf::Message *message, ProtoRe
         }
     }
 
+  return repeated_kv;
+}
+
+static gboolean
+_add_elem_to_repeated_kv(FilterXObject *key_obj, FilterXObject *value_obj, gpointer user_data)
+{
+  RepeatedPtrField<KeyValue> *repeated_kv = (RepeatedPtrField<KeyValue> *) user_data;
+
+  /* FilterX strings are always NUL terminated. */
+  const gchar *key = filterx_string_get_value(key_obj, NULL);
+  if (!key)
+    return FALSE;
+
+  KeyValue *kv = repeated_kv->Add();
+  kv->set_key(key);
+
+  FilterXObject *assoc_object = NULL;
+  if (!syslogng::grpc::otel::any_field_converter.FilterXObjectDirectSetter(kv->mutable_value(), value_obj, &assoc_object))
+    return false;
+
+  filterx_object_unref(assoc_object);
+  return true;
+}
+
+static bool
+_set_kvlist_field_from_dict(google::protobuf::Message *message, syslogng::grpc::otel::ProtoReflectors reflectors,
+                            FilterXObject *object, FilterXObject **assoc_object)
+{
+  RepeatedPtrField<KeyValue> *repeated_kv = _get_repeated_kv(message, reflectors);
+  if (!filterx_dict_iter(object, _add_elem_to_repeated_kv, repeated_kv))
+    return false;
+
+  *assoc_object = _new_borrowed(repeated_kv);
+  return true;
+}
+
+bool
+OtelKVListField::FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors,
+                                     FilterXObject *object, FilterXObject **assoc_object)
+{
+  if (!filterx_object_is_type(object, &FILTERX_TYPE_NAME(otel_kvlist)))
+    {
+      if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(dict)))
+        return _set_kvlist_field_from_dict(message, reflectors, object, assoc_object);
+
+      msg_error("otel-kvlist: Failed to convert field, type is unsupported",
+                evt_tag_str("field", reflectors.fieldDescriptor->name().c_str()),
+                evt_tag_str("expected_type", reflectors.fieldDescriptor->type_name()),
+                evt_tag_str("type", object->type->name));
+      return false;
+    }
+
+  FilterXOtelKVList *filterx_kvlist = (FilterXOtelKVList *) object;
+
+  RepeatedPtrField<KeyValue> *repeated_kv = _get_repeated_kv(message, reflectors);
   repeated_kv->CopyFrom(filterx_kvlist->cpp->get_value());
 
   KVList *new_kvlist;

--- a/modules/grpc/otel/filterx/object-otel-kvlist.hpp
+++ b/modules/grpc/otel/filterx/object-otel-kvlist.hpp
@@ -57,7 +57,7 @@ public:
   ~KVList();
 
   std::string marshal();
-  bool set_subscript(FilterXObject *key, FilterXObject *value);
+  bool set_subscript(FilterXObject *key, FilterXObject **value);
   bool is_key_set(FilterXObject *key) const;
   FilterXObject *get_subscript(FilterXObject *key);
   bool unset_key(FilterXObject *key);
@@ -82,7 +82,8 @@ class OtelKVListField : public ProtobufField
 {
 public:
   FilterXObject *FilterXObjectGetter(google::protobuf::Message *message, ProtoReflectors reflectors);
-  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object);
+  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object,
+                           FilterXObject **assoc_object);
 };
 
 extern OtelKVListField otel_kvlist_converter;

--- a/modules/grpc/otel/filterx/object-otel-logrecord.hpp
+++ b/modules/grpc/otel/filterx/object-otel-logrecord.hpp
@@ -48,7 +48,7 @@ public:
   LogRecord(FilterXOtelLogRecord *super, FilterXObject *protobuf_object);
   LogRecord(LogRecord &o) = delete;
   LogRecord(LogRecord &&o) = delete;
-  bool SetField(const gchar *attribute, FilterXObject *value);
+  bool SetField(const gchar *attribute, FilterXObject **value);
   std::string Marshal(void);
   FilterXObject *GetField(const gchar *attribute);
   const opentelemetry::proto::logs::v1::LogRecord &GetValue() const;

--- a/modules/grpc/otel/filterx/object-otel-resource.cpp
+++ b/modules/grpc/otel/filterx/object-otel-resource.cpp
@@ -60,12 +60,18 @@ Resource::marshal(void)
 }
 
 bool
-Resource::set_field(const gchar *attribute, FilterXObject *value)
+Resource::set_field(const gchar *attribute, FilterXObject **value)
 {
   try
     {
       ProtoReflectors reflectors(resource, attribute);
-      return otel_converter_by_field_descriptor(reflectors.fieldDescriptor)->Set(&resource, attribute, value);
+      FilterXObject *assoc_object = NULL;
+      if (!otel_converter_by_field_descriptor(reflectors.fieldDescriptor)->Set(&resource, attribute, *value, &assoc_object))
+        return false;
+
+      filterx_object_unref(*value);
+      *value = assoc_object;
+      return true;
     }
   catch (const std::invalid_argument &e)
     {
@@ -131,7 +137,7 @@ _free(FilterXObject *s)
 }
 
 static gboolean
-_setattr(FilterXObject *s, FilterXObject *attr, FilterXObject *new_value)
+_setattr(FilterXObject *s, FilterXObject *attr, FilterXObject **new_value)
 {
   FilterXOtelResource *self = (FilterXOtelResource *) s;
 

--- a/modules/grpc/otel/filterx/object-otel-resource.hpp
+++ b/modules/grpc/otel/filterx/object-otel-resource.hpp
@@ -50,7 +50,7 @@ public:
   Resource(Resource &&o) = delete;
 
   std::string marshal();
-  bool set_field(const gchar *attribute, FilterXObject *value);
+  bool set_field(const gchar *attribute, FilterXObject **value);
   FilterXObject *get_field(const gchar *attribute);
   const opentelemetry::proto::resource::v1::Resource &get_value() const;
 

--- a/modules/grpc/otel/filterx/object-otel-scope.hpp
+++ b/modules/grpc/otel/filterx/object-otel-scope.hpp
@@ -50,7 +50,7 @@ public:
   Scope(Scope &&o) = delete;
 
   std::string marshal();
-  bool set_field(const gchar *attribute, FilterXObject *value);
+  bool set_field(const gchar *attribute, FilterXObject **value);
   FilterXObject *get_field(const gchar *attribute);
   const opentelemetry::proto::common::v1::InstrumentationScope &get_value() const;
 

--- a/modules/grpc/otel/filterx/otel-field.cpp
+++ b/modules/grpc/otel/filterx/otel-field.cpp
@@ -204,21 +204,15 @@ AnyField::FilterXObjectDirectSetter(AnyValue *anyValue, FilterXObject *object, F
       converter = protobuf_converter_by_type(FieldDescriptor::TYPE_BYTES);
       typeFieldName = "bytes_value";
     }
-  else if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(otel_kvlist)))
+  else if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(dict)))
     {
       converter = &filterx::otel_kvlist_converter;
       typeFieldName = "kvlist_value";
     }
-  else if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(otel_array)))
+  else if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(list)))
     {
       converter = &filterx::otel_array_converter;
       typeFieldName = "array_value";
-    }
-  else if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(json_object)) ||
-           filterx_object_is_type(object, &FILTERX_TYPE_NAME(json_array)))
-    {
-      converter = protobuf_converter_by_type(FieldDescriptor::TYPE_STRING);
-      typeFieldName = "string_value";
     }
   else if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(datetime)))
     {

--- a/modules/grpc/otel/filterx/otel-field.hpp
+++ b/modules/grpc/otel/filterx/otel-field.hpp
@@ -38,10 +38,11 @@ class AnyField : public ProtobufField
 
 public:
   FilterXObject *FilterXObjectGetter(Message *message, ProtoReflectors reflectors);
-  bool FilterXObjectSetter(Message *message, ProtoReflectors reflectors, FilterXObject *object);
+  bool FilterXObjectSetter(Message *message, ProtoReflectors reflectors, FilterXObject *object,
+                           FilterXObject **assoc_object);
 
   FilterXObject *FilterXObjectDirectGetter(AnyValue *anyValue);
-  bool FilterXObjectDirectSetter(AnyValue *anyValue, FilterXObject *object);
+  bool FilterXObjectDirectSetter(AnyValue *anyValue, FilterXObject *object, FilterXObject **assoc_object);
 };
 
 extern AnyField any_field_converter;

--- a/modules/grpc/otel/filterx/protobuf-field.cpp
+++ b/modules/grpc/otel/filterx/protobuf-field.cpp
@@ -68,10 +68,12 @@ public:
   {
     return filterx_boolean_new(reflectors.reflection->GetBool(*message, reflectors.fieldDescriptor));
   }
-  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object)
+  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object,
+                           FilterXObject **assoc_object)
   {
     gboolean truthy = filterx_object_truthy(object);
     reflectors.reflection->SetBool(message, reflectors.fieldDescriptor, truthy);
+    *assoc_object = filterx_object_ref(object);
     return true;
   }
 };
@@ -83,7 +85,8 @@ public:
   {
     return filterx_integer_new(gint32(reflectors.reflection->GetInt32(*message, reflectors.fieldDescriptor)));
   }
-  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object)
+  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object,
+                           FilterXObject **assoc_object)
   {
     if (!filterx_object_is_type(object, &FILTERX_TYPE_NAME(integer)))
       {
@@ -93,6 +96,7 @@ public:
     GenericNumber gn = filterx_primitive_get_value(object);
     int32_t val = MAX(INT32_MIN, MIN(INT32_MAX, gn_as_int64(&gn)));
     reflectors.reflection->SetInt32(message, reflectors.fieldDescriptor, val);
+    *assoc_object = filterx_object_ref(object);
     return true;
   }
 };
@@ -104,13 +108,15 @@ public:
   {
     return filterx_integer_new(gint64(reflectors.reflection->GetInt64(*message, reflectors.fieldDescriptor)));
   }
-  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object)
+  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object,
+                           FilterXObject **assoc_object)
   {
     if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(integer)))
       {
         GenericNumber gn = filterx_primitive_get_value(object);
         int64_t val = gn_as_int64(&gn);
         reflectors.reflection->SetInt64(message, reflectors.fieldDescriptor, val);
+        *assoc_object = filterx_object_ref(object);
         return true;
       }
     else if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(datetime)))
@@ -118,6 +124,7 @@ public:
         const UnixTime utime = filterx_datetime_get_value(object);
         uint64_t unix_epoch = unix_time_to_unix_epoch(utime);
         reflectors.reflection->SetInt64(message, reflectors.fieldDescriptor, (int64_t)(unix_epoch));
+        *assoc_object = filterx_object_ref(object);
         return true;
       }
 
@@ -133,7 +140,8 @@ public:
   {
     return filterx_integer_new(guint32(reflectors.reflection->GetUInt32(*message, reflectors.fieldDescriptor)));
   }
-  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object)
+  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object,
+                           FilterXObject **assoc_object)
   {
     if (!filterx_object_is_type(object, &FILTERX_TYPE_NAME(integer)))
       {
@@ -143,6 +151,7 @@ public:
     GenericNumber gn = filterx_primitive_get_value(object);
     uint32_t val = MAX(0, MIN(UINT32_MAX, gn_as_int64(&gn)));
     reflectors.reflection->SetUInt32(message, reflectors.fieldDescriptor, val);
+    *assoc_object = filterx_object_ref(object);
     return true;
   }
 };
@@ -164,13 +173,15 @@ public:
       }
     return filterx_integer_new(guint64(val));
   }
-  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object)
+  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object,
+                           FilterXObject **assoc_object)
   {
     if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(integer)))
       {
         GenericNumber gn = filterx_primitive_get_value(object);
         uint64_t val = MAX(0, MIN(UINT64_MAX, (uint64_t) gn_as_int64(&gn)));
         reflectors.reflection->SetUInt64(message, reflectors.fieldDescriptor, val);
+        *assoc_object = filterx_object_ref(object);
         return true;
       }
     else if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(datetime)))
@@ -178,6 +189,7 @@ public:
         const UnixTime utime = filterx_datetime_get_value(object);
         uint64_t unix_epoch = unix_time_to_unix_epoch(utime);
         reflectors.reflection->SetUInt64(message, reflectors.fieldDescriptor, unix_epoch);
+        *assoc_object = filterx_object_ref(object);
         return true;
       }
 
@@ -196,7 +208,8 @@ public:
                                   &bytesBuffer);
     return filterx_string_new(bytesRef.c_str(), bytesRef.length());
   }
-  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object)
+  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object,
+                           FilterXObject **assoc_object)
   {
     if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(string)))
       {
@@ -204,6 +217,7 @@ public:
         const gchar *str = filterx_string_get_value(object, &value_len);
         std::string stdString(str, value_len);
         reflectors.reflection->SetString(message, reflectors.fieldDescriptor, stdString);
+        *assoc_object = filterx_object_ref(object);
         return true;
       }
     else if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(json_object)) ||
@@ -217,6 +231,7 @@ public:
             return false;
           }
         reflectors.reflection->SetString(message, reflectors.fieldDescriptor, json_literal);
+        *assoc_object = filterx_object_ref(object);
         return true;
       }
     log_type_error(reflectors, object->type->name);
@@ -231,7 +246,8 @@ public:
   {
     return filterx_double_new(gdouble(reflectors.reflection->GetDouble(*message, reflectors.fieldDescriptor)));
   }
-  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object)
+  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object,
+                           FilterXObject **assoc_object)
   {
     GenericNumber gn = filterx_primitive_get_value(object);
     double val;
@@ -251,8 +267,8 @@ public:
       }
 
     reflectors.reflection->SetDouble(message, reflectors.fieldDescriptor, val);
+    *assoc_object = filterx_object_ref(object);
     return true;
-
   }
 };
 
@@ -263,7 +279,8 @@ public:
   {
     return filterx_double_new(gdouble(reflectors.reflection->GetFloat(*message, reflectors.fieldDescriptor)));
   }
-  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object)
+  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object,
+                           FilterXObject **assoc_object)
   {
     GenericNumber gn = filterx_primitive_get_value(object);
     double val;
@@ -284,6 +301,7 @@ public:
 
     float floatVal = double_to_float_safe(val);
     reflectors.reflection->SetFloat(message, reflectors.fieldDescriptor, floatVal);
+    *assoc_object = filterx_object_ref(object);
     return true;
   }
 };
@@ -298,7 +316,8 @@ public:
                                   &bytesBuffer);
     return filterx_bytes_new(bytesRef.c_str(), bytesRef.length());
   }
-  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object)
+  bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors, FilterXObject *object,
+                           FilterXObject **assoc_object)
   {
     if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(bytes)))
       {
@@ -306,6 +325,7 @@ public:
         const gchar *str = filterx_bytes_get_value(object, &value_len);
         std::string stdString(str, value_len);
         reflectors.reflection->SetString(message, reflectors.fieldDescriptor, stdString);
+        *assoc_object = filterx_object_ref(object);
         return true;
       }
     else if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(protobuf)))
@@ -314,6 +334,7 @@ public:
         const gchar *str = filterx_protobuf_get_value(object, &value_len);
         std::string stdString(str, value_len);
         reflectors.reflection->SetString(message, reflectors.fieldDescriptor, stdString);
+        *assoc_object = filterx_object_ref(object);
         return true;
       }
     log_type_error(reflectors, object->type->name);

--- a/modules/grpc/otel/filterx/protobuf-field.hpp
+++ b/modules/grpc/otel/filterx/protobuf-field.hpp
@@ -84,12 +84,12 @@ public:
         return nullptr;
       }
   };
-  bool Set(google::protobuf::Message *message, std::string fieldName, FilterXObject *object)
+  bool Set(google::protobuf::Message *message, std::string fieldName, FilterXObject *object, FilterXObject **assoc_object)
   {
     try
       {
         ProtoReflectors reflectors(*message, fieldName);
-        return this->FilterXObjectSetter(message, reflectors, object);
+        return this->FilterXObjectSetter(message, reflectors, object, assoc_object);
       }
     catch(const std::exception &ex)
       {
@@ -102,7 +102,7 @@ public:
 protected:
   virtual FilterXObject *FilterXObjectGetter(google::protobuf::Message *message, ProtoReflectors reflectors) = 0;
   virtual bool FilterXObjectSetter(google::protobuf::Message *message, ProtoReflectors reflectors,
-                                   FilterXObject *object) = 0;
+                                   FilterXObject *object, FilterXObject **assoc_object) = 0;
 };
 
 std::unique_ptr<ProtobufField> *all_protobuf_converters();

--- a/modules/grpc/otel/tests/test-otel-filterx.cpp
+++ b/modules/grpc/otel/tests/test-otel-filterx.cpp
@@ -318,7 +318,7 @@ Test(otel_filterx, resource_set_field)
   cr_assert(filterx_otel_resource);
 
   FilterXObject *filterx_integer = filterx_integer_new(42);
-  cr_assert(filterx_object_setattr_string(filterx_otel_resource, "dropped_attributes_count", filterx_integer));
+  cr_assert(filterx_object_setattr_string(filterx_otel_resource, "dropped_attributes_count", &filterx_integer));
 
   KeyValueList attributes;
   KeyValue *attribute_1 = attributes.add_values();
@@ -329,9 +329,9 @@ Test(otel_filterx, resource_set_field)
   g_ptr_array_insert(attributes_kvlist_args, 0, filterx_protobuf_new(serialized_attributes.c_str(),
                      serialized_attributes.length()));
   FilterXObject *filterx_kvlist = filterx_otel_kvlist_new_from_args(attributes_kvlist_args);
-  cr_assert(filterx_object_setattr_string(filterx_otel_resource, "attributes", filterx_kvlist));
+  cr_assert(filterx_object_setattr_string(filterx_otel_resource, "attributes", &filterx_kvlist));
 
-  cr_assert_not(filterx_object_setattr_string(filterx_otel_resource, "invalid_attr", filterx_integer));
+  cr_assert_not(filterx_object_setattr_string(filterx_otel_resource, "invalid_attr", &filterx_integer));
 
   GString *serialized = g_string_new(NULL);
   LogMessageValueType type;
@@ -455,10 +455,10 @@ Test(otel_filterx, scope_set_field)
   cr_assert(filterx_otel_scope);
 
   FilterXObject *filterx_integer = filterx_integer_new(42);
-  cr_assert(filterx_object_setattr_string(filterx_otel_scope, "dropped_attributes_count", filterx_integer));
+  cr_assert(filterx_object_setattr_string(filterx_otel_scope, "dropped_attributes_count", &filterx_integer));
 
   FilterXObject *filterx_string = filterx_string_new("foobar", -1);
-  cr_assert(filterx_object_setattr_string(filterx_otel_scope, "name", filterx_string));
+  cr_assert(filterx_object_setattr_string(filterx_otel_scope, "name", &filterx_string));
 
   KeyValueList attributes;
   KeyValue *attribute_1 = attributes.add_values();
@@ -469,9 +469,9 @@ Test(otel_filterx, scope_set_field)
   g_ptr_array_insert(attributes_kvlist_args, 0, filterx_protobuf_new(serialized_attributes.c_str(),
                      serialized_attributes.length()));
   FilterXObject *filterx_kvlist = filterx_otel_kvlist_new_from_args(attributes_kvlist_args);
-  cr_assert(filterx_object_setattr_string(filterx_otel_scope, "attributes", filterx_kvlist));
+  cr_assert(filterx_object_setattr_string(filterx_otel_scope, "attributes", &filterx_kvlist));
 
-  cr_assert_not(filterx_object_setattr_string(filterx_otel_scope, "invalid_attr", filterx_integer));
+  cr_assert_not(filterx_object_setattr_string(filterx_otel_scope, "invalid_attr", &filterx_integer));
 
   GString *serialized = g_string_new(NULL);
   LogMessageValueType type;
@@ -620,13 +620,13 @@ Test(otel_filterx, kvlist_set_subscript)
   FilterXObject *element_3_value = filterx_otel_kvlist_new_from_args(NULL);
   FilterXObject *element_4_key = filterx_string_new("element_4_key", -1);
   FilterXObject *element_4_value = filterx_otel_array_new_from_args(NULL);
-  cr_assert(filterx_object_set_subscript(filterx_otel_kvlist, element_1_key, element_1_value));
-  cr_assert(filterx_object_set_subscript(filterx_otel_kvlist, element_2_key, element_2_value));
-  cr_assert(filterx_object_set_subscript(filterx_otel_kvlist, element_3_key, element_3_value));
-  cr_assert(filterx_object_set_subscript(filterx_otel_kvlist, element_4_key, element_4_value));
+  cr_assert(filterx_object_set_subscript(filterx_otel_kvlist, element_1_key, &element_1_value));
+  cr_assert(filterx_object_set_subscript(filterx_otel_kvlist, element_2_key, &element_2_value));
+  cr_assert(filterx_object_set_subscript(filterx_otel_kvlist, element_3_key, &element_3_value));
+  cr_assert(filterx_object_set_subscript(filterx_otel_kvlist, element_4_key, &element_4_value));
 
   FilterXObject *invalid_element_key = filterx_integer_new(1234);
-  cr_assert_not(filterx_object_set_subscript(filterx_otel_kvlist, invalid_element_key, element_1_value));
+  cr_assert_not(filterx_object_set_subscript(filterx_otel_kvlist, invalid_element_key, &element_1_value));
 
   GString *serialized = g_string_new(NULL);
   LogMessageValueType type;
@@ -678,31 +678,31 @@ Test(otel_filterx, kvlist_through_logrecord)
   FilterXObject *fx_get_2 = nullptr;
 
   /* $kvlist["key_0"] = "foo"; */
-  cr_assert(filterx_object_set_subscript(fx_kvlist, fx_key_0, fx_foo));
+  cr_assert(filterx_object_set_subscript(fx_kvlist, fx_key_0, &fx_foo));
 
   /* $log.attributes = $kvlist; */
   FilterXObject *fx_kvlist_clone = filterx_object_clone(fx_kvlist);
-  cr_assert(filterx_object_setattr_string(fx_logrecord, "attributes", fx_kvlist_clone));
+  cr_assert(filterx_object_setattr_string(fx_logrecord, "attributes", &fx_kvlist_clone));
   filterx_object_unref(fx_kvlist_clone);
 
   /* $log.attributes["key_1"] = "bar"; */
   fx_get_1 = filterx_object_getattr_string(fx_logrecord, "attributes");
   cr_assert(fx_get_1);
-  cr_assert(filterx_object_set_subscript(fx_get_1, fx_key_1, fx_bar));
+  cr_assert(filterx_object_set_subscript(fx_get_1, fx_key_1, &fx_bar));
 
   /* $kvlist["key_2"] = "baz"; */
-  cr_assert(filterx_object_set_subscript(fx_kvlist, fx_key_2, fx_baz));
+  cr_assert(filterx_object_set_subscript(fx_kvlist, fx_key_2, &fx_baz));
 
   /* $log.attributes["key_3"] = $inner_kvlist; */
   filterx_object_unref(fx_get_1);
   fx_get_1 = filterx_object_getattr_string(fx_logrecord, "attributes");
   cr_assert(fx_get_1);
   FilterXObject *fx_inner_kvlist_clone = filterx_object_clone(fx_inner_kvlist);
-  cr_assert(filterx_object_set_subscript(fx_get_1, fx_key_3, fx_inner_kvlist_clone));
+  cr_assert(filterx_object_set_subscript(fx_get_1, fx_key_3, &fx_inner_kvlist_clone));
   filterx_object_unref(fx_inner_kvlist_clone);
 
   /* $inner_kvlist["key_0"] = "foo"; */
-  cr_assert(filterx_object_set_subscript(fx_inner_kvlist, fx_key_0, fx_foo));
+  cr_assert(filterx_object_set_subscript(fx_inner_kvlist, fx_key_0, &fx_foo));
 
   /* $log.attributes["key_3"]["key_2"] = "baz"; */
   filterx_object_unref(fx_get_1);
@@ -711,7 +711,7 @@ Test(otel_filterx, kvlist_through_logrecord)
   filterx_object_unref(fx_get_2);
   fx_get_2 = filterx_object_get_subscript(fx_get_1, fx_key_3);
   cr_assert(fx_get_2);
-  cr_assert(filterx_object_set_subscript(fx_get_2, fx_key_2, fx_baz));
+  cr_assert(filterx_object_set_subscript(fx_get_2, fx_key_2, &fx_baz));
 
   LogRecord expected_logrecord;
   KeyValue *expected_logrecord_attr_0 = expected_logrecord.add_attributes();
@@ -881,13 +881,13 @@ Test(otel_filterx, array_set_subscript)
   FilterXObject *element_2_value = filterx_string_new("foobar", -1);
   FilterXObject *element_3_value = filterx_otel_kvlist_new_from_args(NULL);
   FilterXObject *element_4_value = filterx_otel_array_new_from_args(NULL);
-  cr_assert(filterx_object_set_subscript(filterx_otel_array, NULL, element_1_value));
-  cr_assert(filterx_object_set_subscript(filterx_otel_array, NULL, element_2_value));
-  cr_assert(filterx_object_set_subscript(filterx_otel_array, NULL, element_3_value));
-  cr_assert(filterx_object_set_subscript(filterx_otel_array, NULL, element_4_value));
+  cr_assert(filterx_object_set_subscript(filterx_otel_array, NULL, &element_1_value));
+  cr_assert(filterx_object_set_subscript(filterx_otel_array, NULL, &element_2_value));
+  cr_assert(filterx_object_set_subscript(filterx_otel_array, NULL, &element_3_value));
+  cr_assert(filterx_object_set_subscript(filterx_otel_array, NULL, &element_4_value));
 
   FilterXObject *invalid_element_key = filterx_string_new("invalid_key", -1);
-  cr_assert_not(filterx_object_set_subscript(filterx_otel_array, invalid_element_key, element_1_value));
+  cr_assert_not(filterx_object_set_subscript(filterx_otel_array, invalid_element_key, &element_1_value));
 
   GString *serialized = g_string_new(NULL);
   LogMessageValueType type;
@@ -932,31 +932,31 @@ Test(otel_filterx, array_through_logrecord)
   FilterXObject *fx_get_2 = nullptr;
 
   /* $array[] = "foo"; */
-  cr_assert(filterx_object_set_subscript(fx_array, nullptr, fx_foo));
+  cr_assert(filterx_object_set_subscript(fx_array, nullptr, &fx_foo));
 
   /* $log.body = $array; */
   FilterXObject *fx_array_clone = filterx_object_clone(fx_array);
-  cr_assert(filterx_object_setattr_string(fx_logrecord, "body", fx_array_clone));
+  cr_assert(filterx_object_setattr_string(fx_logrecord, "body", &fx_array_clone));
   filterx_object_unref(fx_array_clone);
 
   /* $log.body[] = "bar"; */
   fx_get_1 = filterx_object_getattr_string(fx_logrecord, "body");
   cr_assert(fx_get_1);
-  cr_assert(filterx_object_set_subscript(fx_get_1, nullptr, fx_bar));
+  cr_assert(filterx_object_set_subscript(fx_get_1, nullptr, &fx_bar));
 
   /* $array[] = "baz"; */
-  cr_assert(filterx_object_set_subscript(fx_array, nullptr, fx_baz));
+  cr_assert(filterx_object_set_subscript(fx_array, nullptr, &fx_baz));
 
   /* $log.body[] = $inner_array; */
   filterx_object_unref(fx_get_1);
   fx_get_1 = filterx_object_getattr_string(fx_logrecord, "body");
   cr_assert(fx_get_1);
   FilterXObject *fx_inner_array_clone = filterx_object_clone(fx_inner_array);
-  cr_assert(filterx_object_set_subscript(fx_get_1, nullptr, fx_inner_array_clone));
+  cr_assert(filterx_object_set_subscript(fx_get_1, nullptr, &fx_inner_array_clone));
   filterx_object_unref(fx_inner_array_clone);
 
   /* $inner_array[] = "foo"; */
-  cr_assert(filterx_object_set_subscript(fx_inner_array, nullptr, fx_foo));
+  cr_assert(filterx_object_set_subscript(fx_inner_array, nullptr, &fx_foo));
 
   /* $log.body[2][] = "baz"; */
   filterx_object_unref(fx_get_1);
@@ -965,7 +965,7 @@ Test(otel_filterx, array_through_logrecord)
   filterx_object_unref(fx_get_2);
   fx_get_2 = filterx_object_get_subscript(fx_get_1, fx_2);
   cr_assert(fx_get_2);
-  cr_assert(filterx_object_set_subscript(fx_get_2, nullptr, fx_baz));
+  cr_assert(filterx_object_set_subscript(fx_get_2, nullptr, &fx_baz));
 
   LogRecord expected_logrecord;
   ArrayValue *expected_logrecord_array = expected_logrecord.mutable_body()->mutable_array_value();

--- a/modules/json/tests/test_filterx_format_json.c
+++ b/modules/json/tests/test_filterx_format_json.c
@@ -139,14 +139,14 @@ Test(filterx_format_json, test_filterx_format_json)
 
   /* dict */
   FilterXObject *dict = filterx_test_dict_new();
-  cr_assert(filterx_object_set_subscript(dict, foo, fx_42));
-  cr_assert(filterx_object_set_subscript(dict, bar, fx_1337));
+  cr_assert(filterx_object_set_subscript(dict, foo, &fx_42));
+  cr_assert(filterx_object_set_subscript(dict, bar, &fx_1337));
   _assert_filterx_format_json_and_unref(dict, "{\"foo\":42,\"bar\":1337}");
 
   /* list */
   FilterXObject *list = filterx_test_list_new();
-  cr_assert(filterx_list_append(list, foo));
-  cr_assert(filterx_list_append(list, bar));
+  cr_assert(filterx_list_append(list, &foo));
+  cr_assert(filterx_list_append(list, &bar));
   _assert_filterx_format_json_and_unref(list, "[\"foo\",\"bar\"]");
 
   filterx_object_unref(foo);

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -268,7 +268,8 @@ def test_otel_logrecord_body_json_setter_getter(config, syslog_ng):
         config, """
                                             $olr = otel_logrecord();
                                             $olr.body = ${values.json};
-                                            $MSG = $olr.body; """,
+                                            istype($olr.body, "otel_kvlist");
+                                            $MSG = format_json($olr.body); """,
     )
     syslog_ng.start(config)
 


### PR DESCRIPTION
Now supports:

```
    otel_kvl = otel_kvlist({"foo": 42});
    otel_arr = otel_array([1, 2]);

    js = json();

    js.otel_kvl = otel_kvl;
    istype(js.otel_kvl, "json_object");
    js.otel_kvl += {"bar": 1337};

    js.otel_arr = otel_arr;
    istype(js.otel_arr, "json_array");
    js.otel_arr += [3, 4];
```
and
```
    js = json({"foo": 42});
    js_arr = json_array([1, 2]);

    otel_kvl = otel_kvlist();

    otel_kvl.js = js;
    istype(otel_kvl.js, "otel_kvlist");
    otel_kvl.js += {"bar": 1337};

    otel_kvl.js_arr = js_arr;
    istype(otel_kvl.js_arr, "otel_array");
    otel_kvl.js_arr += [3, 4];
```