### PR TITLE
C++ modules: remove direct libstdc++ linkage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -126,7 +126,7 @@ endif
 
 TEST_CFLAGS		= -DTOP_SRCDIR=\"$(abs_top_srcdir)\" $(AM_CFLAGS) $(CRITERION_CFLAGS)
 
-TEST_CXXFLAGS		= -DTOP_SRCDIR=\"$(abs_top_srcdir)\" $(AM_CXXFLAGS) $(CRITERION_CFLAGS) -lstdc++
+TEST_CXXFLAGS		= -DTOP_SRCDIR=\"$(abs_top_srcdir)\" $(AM_CXXFLAGS) $(CRITERION_CFLAGS)
 
 TEST_LDADD		= $(LIBTEST_LIBS) $(CRITERION_LIBS) \
 			  $(top_builddir)/lib/libsyslog-ng.la \

--- a/lib/compat/cpp-start.h
+++ b/lib/compat/cpp-start.h
@@ -49,9 +49,10 @@
  *     and plugin.c.  This minimizes the chance of including an incompatible
  *     C header.
  *   - Build/link the C++ code as C++ separately and link to that from your
- *     C lib.  Adding -lstdc++ to LIBADD is neccessary in this case as it is
- *     automatically added while linking the C++ object itself, but not when
- *     linking to the C++ object from a C lib.
+ *     C lib. In case your C++ library is static, add the following to the
+ *     the C lib to force linking against the appropriate C++ standard
+ *     library (libc++, libstdc++):
+ *       nodist_EXTRA_*_SOURCES = force-cpp-linker-with-default-stdlib.cpp
  *   - In your C++ code it is not possible to derive from a C class in the
  *     usual C way by adding a super field and filling its free_fn, because
  *     we do our own reference counting and freeing logic and we cannot rely

--- a/modules/cloud-auth/Makefile.am
+++ b/modules/cloud-auth/Makefile.am
@@ -40,6 +40,8 @@ modules_cloud_auth_libcloud_auth_la_LIBADD = \
   $(MODULE_DEPS_LIBS) \
   $(top_builddir)/modules/cloud-auth/libcloud_auth_cpp.la
 
+nodist_EXTRA_modules_cloud_auth_libcloud_auth_la_SOURCES = force-cpp-linker-with-default-stdlib.cpp
+
 modules_cloud_auth_libcloud_auth_la_LDFLAGS = \
   $(MODULE_LDFLAGS)
 

--- a/modules/examples/Makefile.am
+++ b/modules/examples/Makefile.am
@@ -35,7 +35,7 @@ EXTRA_modules_examples_libexamples_la_DEPENDENCIES = $(MODULE_DEPS_LIBS) $(EXAMP
 modules_examples_libexamples_la_LDFLAGS = $(MODULE_LDFLAGS)
 
 if ENABLE_CPP
-modules_examples_libexamples_la_LIBADD += -lstdc++
+nodist_EXTRA_modules_examples_libexamples_la_SOURCES = force-cpp-linker-with-default-stdlib.cpp
 endif
 
 EXTRA_DIST += modules/examples/CMakeLists.txt

--- a/modules/grpc/bigquery/Makefile.am
+++ b/modules/grpc/bigquery/Makefile.am
@@ -41,8 +41,9 @@ modules_grpc_bigquery_libbigquery_la_CPPFLAGS = \
 modules_grpc_bigquery_libbigquery_la_LIBADD = \
   $(MODULE_DEPS_LIBS) \
   $(top_builddir)/modules/grpc/protos/libgrpc-protos.la \
-  $(top_builddir)/modules/grpc/bigquery/libbigquery_cpp.la \
-  -lstdc++
+  $(top_builddir)/modules/grpc/bigquery/libbigquery_cpp.la
+
+nodist_EXTRA_modules_grpc_bigquery_libbigquery_la_SOURCES = force-cpp-linker-with-default-stdlib.cpp
 
 modules_grpc_bigquery_libbigquery_la_LDFLAGS = $(MODULE_LDFLAGS)
 EXTRA_modules_grpc_bigquery_libbigquery_la_DEPENDENCIES = \

--- a/modules/grpc/loki/Makefile.am
+++ b/modules/grpc/loki/Makefile.am
@@ -43,8 +43,9 @@ modules_grpc_loki_libloki_la_CPPFLAGS = \
 modules_grpc_loki_libloki_la_LIBADD = \
   $(MODULE_DEPS_LIBS) \
   $(top_builddir)/modules/grpc/protos/libgrpc-protos.la \
-  $(top_builddir)/modules/grpc/loki/libloki_cpp.la \
-  -lstdc++
+  $(top_builddir)/modules/grpc/loki/libloki_cpp.la
+
+nodist_EXTRA_modules_grpc_loki_libloki_la_SOURCES = force-cpp-linker-with-default-stdlib.cpp
 
 modules_grpc_loki_libloki_la_LDFLAGS = $(MODULE_LDFLAGS)
 EXTRA_modules_grpc_loki_libloki_la_DEPENDENCIES = \

--- a/modules/grpc/otel/Makefile.am
+++ b/modules/grpc/otel/Makefile.am
@@ -61,8 +61,9 @@ modules_grpc_otel_libotel_la_LIBADD = \
   $(MODULE_DEPS_LIBS) \
   $(top_builddir)/modules/grpc/protos/libgrpc-protos.la \
   $(top_builddir)/modules/grpc/otel/libotel_cpp.la \
-  $(top_builddir)/modules/grpc/otel/filterx/libfilterx.la \
-  -lstdc++
+  $(top_builddir)/modules/grpc/otel/filterx/libfilterx.la
+
+nodist_EXTRA_modules_grpc_otel_libotel_la_SOURCES = force-cpp-linker-with-default-stdlib.cpp
 
 modules_grpc_otel_libotel_la_LDFLAGS = $(MODULE_LDFLAGS)
 

--- a/modules/grpc/protos/Makefile.am
+++ b/modules/grpc/protos/Makefile.am
@@ -128,7 +128,8 @@ if ENABLE_EXTRA_WARNINGS
 modules_grpc_protos_libgrpc_protos_la_CXXFLAGS += -Wno-switch-default
 endif
 
-modules_grpc_protos_libgrpc_protos_la_LIBADD = $(MODULE_DEPS_LIBS) $(PROTOBUF_LIBS) $(GRPCPP_LIBS) -lstdc++
+modules_grpc_protos_libgrpc_protos_la_LIBADD = $(MODULE_DEPS_LIBS) $(PROTOBUF_LIBS) $(GRPCPP_LIBS)
+nodist_EXTRA_modules_grpc_protos_libgrpc_protos_la_SOURCES = force-cpp-linker-with-default-stdlib.cpp
 EXTRA_modules_grpc_protos_libgrpc_protos_la_DEPENDENCIES = $(MODULE_DEPS_LIBS)
 
 CLEANFILES += \

--- a/news/other-4933.md
+++ b/news/other-4933.md
@@ -1,0 +1,3 @@
+`bigquery()`, `loki()`, `opentelemetry()`, `cloud-auth()`: C++ modules can be compiled with clang
+
+Compiling and using these C++ modules are now easier on FreeBSD and macOS.


### PR DESCRIPTION
libtool should follow transitive dependencies and link against the appropriate C++ standard lib (libc++ or libstdc++) automatically.

Fixes #4932, but let's wait for @alltilla's review because something doesn't seem right here.