### PR TITLE
Logproto remove handshake in progress

### DIFF
--- a/lib/logproto/CMakeLists.txt
+++ b/lib/logproto/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LOGPROTO_HEADERS
     logproto/logproto-server.h
     logproto/logproto-text-client.h
     logproto/logproto-text-server.h
+    logproto/logproto-auto-server.h
     logproto/logproto-proxied-text-server.h
     PARENT_SCOPE)
 
@@ -26,6 +27,7 @@ set(LOGPROTO_SOURCES
     logproto/logproto-server.c
     logproto/logproto-text-client.c
     logproto/logproto-text-server.c
+    logproto/logproto-auto-server.c
     logproto/logproto-proxied-text-server.c
     PARENT_SCOPE)
 

--- a/lib/logproto/Makefile.am
+++ b/lib/logproto/Makefile.am
@@ -11,6 +11,7 @@ logprotoinclude_HEADERS = \
 	lib/logproto/logproto-framed-server.h	\
 	lib/logproto/logproto-text-client.h  \
 	lib/logproto/logproto-text-server.h	\
+	lib/logproto/logproto-auto-server.h	\
 	lib/logproto/logproto-proxied-text-server.h	\
 	lib/logproto/logproto-multiline-server.h \
 	lib/logproto/logproto-record-server.h \
@@ -26,6 +27,7 @@ logproto_sources = \
 	lib/logproto/logproto-framed-server.c	\
 	lib/logproto/logproto-text-client.c  \
 	lib/logproto/logproto-text-server.c	\
+	lib/logproto/logproto-auto-server.c	\
 	lib/logproto/logproto-proxied-text-server.c	\
 	lib/logproto/logproto-multiline-server.c \
 	lib/logproto/logproto-record-server.c \

--- a/lib/logproto/logproto-auto-server.c
+++ b/lib/logproto/logproto-auto-server.c
@@ -83,25 +83,13 @@ log_proto_auto_server_fetch(LogProtoServer *s, const guchar **msg, gsize *msg_le
   g_assert_not_reached();
 }
 
-static gboolean
-log_proto_auto_handshake_in_progress(LogProtoServer *s)
-{
-  LogProtoAutoServer *self = (LogProtoAutoServer *) s;
-
-  if (self->proto_impl)
-    return log_proto_server_handshake_in_progress(self->proto_impl);
-
-  /* as long as the auto detection is not yet finished we are in handshake mode */
-  return TRUE;
-}
-
 static LogProtoStatus
-log_proto_auto_handshake(LogProtoServer *s)
+log_proto_auto_handshake(LogProtoServer *s, gboolean *handshake_finished)
 {
   LogProtoAutoServer *self = (LogProtoAutoServer *) s;
   /* allow the impl to do its handshake */
   if (self->proto_impl)
-    return log_proto_server_handshake(self->proto_impl);
+    return log_proto_server_handshake(self->proto_impl, handshake_finished);
 
   gchar detect_buffer[8];
   gint rc;
@@ -138,7 +126,6 @@ log_proto_auto_server_new(LogTransport *transport, const LogProtoServerOptions *
   LogProtoAutoServer *self = g_new0(LogProtoAutoServer, 1);
 
   log_proto_server_init(&self->super, transport, options);
-  self->super.handshake_in_progess = log_proto_auto_handshake_in_progress;
   self->super.handshake = log_proto_auto_handshake;
   self->super.prepare = log_proto_auto_server_prepare;
   self->super.fetch = log_proto_auto_server_fetch;

--- a/lib/logproto/logproto-auto-server.c
+++ b/lib/logproto/logproto-auto-server.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2024 Balázs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "logproto-auto-server.h"
+#include "logproto-text-server.h"
+#include "logproto-framed-server.h"
+#include "messages.h"
+
+typedef struct _LogProtoAutoServer
+{
+  LogProtoServer super;
+
+  /* the actual LogProto instance that we run after auto-detecting the protocol */
+  LogProtoServer *proto_impl;
+} LogProtoAutoServer;
+
+static LogProtoServer *
+_construct_detected_proto(LogProtoAutoServer *self, const gchar *detect_buffer, gsize detect_buffer_len)
+{
+  if (g_ascii_isdigit(detect_buffer[0]))
+    {
+      msg_debug("Auto-detected octet-counted-framing on RFC6587 connection, using framed transport",
+                evt_tag_int("fd", self->super.transport->fd));
+      return log_proto_framed_server_new(self->super.transport, self->super.options);
+    }
+  if (detect_buffer[0] == '<')
+    {
+      msg_debug("Auto-detected non-transparent-framing on RFC6587 connection, using simple text transport",
+                evt_tag_int("fd", self->super.transport->fd));
+    }
+  else
+    {
+      msg_debug("Unable to detect framing on RFC6587 connection, falling back to simple text transport",
+                evt_tag_int("fd", self->super.transport->fd),
+                evt_tag_mem("detect_buffer", detect_buffer, detect_buffer_len));
+    }
+  return log_proto_text_server_new(self->super.transport, self->super.options);
+}
+
+static LogProtoPrepareAction
+log_proto_auto_server_prepare(LogProtoServer *s, GIOCondition *cond, gint *timeout G_GNUC_UNUSED)
+{
+  LogProtoAutoServer *self = (LogProtoAutoServer *) s;
+
+  if (self->proto_impl)
+    return log_proto_server_prepare(self->proto_impl, cond, timeout);
+
+  *cond = self->super.transport->cond;
+  if (*cond == 0)
+    *cond = G_IO_IN;
+
+  return LPPA_POLL_IO;
+}
+
+static LogProtoStatus
+log_proto_auto_server_fetch(LogProtoServer *s, const guchar **msg, gsize *msg_len, gboolean *may_read,
+                            LogTransportAuxData *aux, Bookmark *bookmark)
+{
+  LogProtoAutoServer *self = (LogProtoAutoServer *) s;
+
+  if (self->proto_impl)
+    return log_proto_server_fetch(self->proto_impl, msg, msg_len, may_read, aux, bookmark);
+
+  g_assert_not_reached();
+}
+
+static gboolean
+log_proto_auto_handshake_in_progress(LogProtoServer *s)
+{
+  LogProtoAutoServer *self = (LogProtoAutoServer *) s;
+
+  if (self->proto_impl)
+    return log_proto_server_handshake_in_progress(self->proto_impl);
+
+  /* as long as the auto detection is not yet finished we are in handshake mode */
+  return TRUE;
+}
+
+static LogProtoStatus
+log_proto_auto_handshake(LogProtoServer *s)
+{
+  LogProtoAutoServer *self = (LogProtoAutoServer *) s;
+  /* allow the impl to do its handshake */
+  if (self->proto_impl)
+    return log_proto_server_handshake(self->proto_impl);
+
+  gchar detect_buffer[8];
+  gint rc;
+
+  rc = log_transport_read_ahead(self->super.transport, detect_buffer, sizeof(detect_buffer));
+  if (rc == 0)
+    return LPS_EOF;
+  else if (rc < 0)
+    return LPS_ERROR;
+
+  self->proto_impl = _construct_detected_proto(self, detect_buffer, rc);
+  if (self->proto_impl)
+    {
+      /* transport is handed over to the new proto */
+      self->super.transport = NULL;
+      return LPS_SUCCESS;
+    }
+  return LPS_ERROR;
+}
+
+static void
+log_proto_auto_server_free(LogProtoServer *s)
+{
+  LogProtoAutoServer *self = (LogProtoAutoServer *) s;
+
+  if (self->proto_impl)
+    log_proto_server_free(self->proto_impl);
+  log_proto_server_free_method(s);
+}
+
+LogProtoServer *
+log_proto_auto_server_new(LogTransport *transport, const LogProtoServerOptions *options)
+{
+  LogProtoAutoServer *self = g_new0(LogProtoAutoServer, 1);
+
+  log_proto_server_init(&self->super, transport, options);
+  self->super.handshake_in_progess = log_proto_auto_handshake_in_progress;
+  self->super.handshake = log_proto_auto_handshake;
+  self->super.prepare = log_proto_auto_server_prepare;
+  self->super.fetch = log_proto_auto_server_fetch;
+  self->super.free_fn = log_proto_auto_server_free;
+  return &self->super;
+}

--- a/lib/logproto/logproto-auto-server.h
+++ b/lib/logproto/logproto-auto-server.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 Balázs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef LOGPROTO_AUTO_SERVER_H_INCLUDED
+#define LOGPROTO_AUTO_SERVER_H_INCLUDED
+
+#include "logproto-server.h"
+
+LogProtoServer *log_proto_auto_server_new(LogTransport *transport, const LogProtoServerOptions *options);
+
+#endif

--- a/lib/logproto/logproto-builtins.c
+++ b/lib/logproto/logproto-builtins.c
@@ -27,6 +27,7 @@
 #include "logproto-proxied-text-server.h"
 #include "logproto-framed-client.h"
 #include "logproto-framed-server.h"
+#include "logproto-auto-server.h"
 #include "plugin.h"
 #include "plugin-types.h"
 
@@ -42,6 +43,7 @@ DEFINE_LOG_PROTO_SERVER(log_proto_proxied_text);
 DEFINE_LOG_PROTO_SERVER(log_proto_proxied_text_tls_passthrough, .use_multitransport = TRUE);
 DEFINE_LOG_PROTO_CLIENT(log_proto_framed);
 DEFINE_LOG_PROTO_SERVER(log_proto_framed);
+DEFINE_LOG_PROTO_SERVER(log_proto_auto);
 
 static Plugin framed_server_plugins[] =
 {
@@ -54,7 +56,8 @@ static Plugin framed_server_plugins[] =
   LOG_PROTO_SERVER_PLUGIN(log_proto_proxied_text, "proxied-tcp"),
   LOG_PROTO_SERVER_PLUGIN(log_proto_proxied_text_tls_passthrough, "proxied-tls-passthrough"),
   LOG_PROTO_CLIENT_PLUGIN(log_proto_framed, "framed"),
-  LOG_PROTO_SERVER_PLUGIN(log_proto_framed, "framed"),
+  LOG_PROTO_SERVER_PLUGIN(log_proto_framed, "force-framed"),
+  LOG_PROTO_SERVER_PLUGIN(log_proto_auto, "framed"),
 };
 
 void

--- a/lib/logproto/logproto-client.h
+++ b/lib/logproto/logproto-client.h
@@ -73,8 +73,7 @@ struct _LogProtoClient
   LogProtoStatus (*process_in)(LogProtoClient *s);
   LogProtoStatus (*flush)(LogProtoClient *s);
   gboolean (*validate_options)(LogProtoClient *s);
-  gboolean (*handshake_in_progess)(LogProtoClient *s);
-  LogProtoStatus (*handshake)(LogProtoClient *s);
+  LogProtoStatus (*handshake)(LogProtoClient *s, gboolean *handshake_finished);
   gboolean (*restart_with_state)(LogProtoClient *s, PersistState *state, const gchar *persist_name);
   void (*free_fn)(LogProtoClient *s);
   LogProtoClientFlowControlFuncs flow_control_funcs;
@@ -113,23 +112,14 @@ log_proto_client_validate_options(LogProtoClient *self)
   return self->validate_options(self);
 }
 
-static inline gboolean
-log_proto_client_handshake_in_progress(LogProtoClient *s)
-{
-  if (s->handshake_in_progess)
-    {
-      return s->handshake_in_progess(s);
-    }
-  return FALSE;
-}
-
 static inline LogProtoStatus
-log_proto_client_handshake(LogProtoClient *s)
+log_proto_client_handshake(LogProtoClient *s, gboolean *handshake_finished)
 {
   if (s->handshake)
     {
-      return s->handshake(s);
+      return s->handshake(s, handshake_finished);
     }
+  *handshake_finished = TRUE;
   return LPS_SUCCESS;
 }
 

--- a/lib/logproto/logproto-proxied-text-server.c
+++ b/lib/logproto/logproto-proxied-text-server.c
@@ -524,13 +524,13 @@ log_proto_proxied_text_server_prepare(LogProtoServer *s, GIOCondition *cond, gin
 }
 
 static LogProtoStatus
-log_proto_proxied_text_server_handshake(LogProtoServer *s)
+log_proto_proxied_text_server_handshake(LogProtoServer *s, gboolean *handshake_finished)
 {
   LogProtoProxiedTextServer *self = (LogProtoProxiedTextServer *) s;
 
   LogProtoStatus status = _fetch_into_proxy_buffer(self);
 
-  self->handshake_done = (status == LPS_SUCCESS);
+  self->handshake_done = *handshake_finished = (status == LPS_SUCCESS);
   if (status != LPS_SUCCESS)
     return status;
 
@@ -556,13 +556,6 @@ log_proto_proxied_text_server_handshake(LogProtoServer *s)
       msg_error("Error parsing PROXY protocol header");
       return LPS_ERROR;
     }
-}
-
-static gboolean
-log_proto_proxied_text_server_handshake_in_progress(LogProtoServer *s)
-{
-  LogProtoProxiedTextServer *self = (LogProtoProxiedTextServer *) s;
-  return !self->handshake_done;
 }
 
 static void
@@ -626,7 +619,6 @@ log_proto_proxied_text_server_init(LogProtoProxiedTextServer *self, LogTransport
   log_proto_text_server_init(&self->super, transport, options);
 
   self->super.super.super.prepare = log_proto_proxied_text_server_prepare;
-  self->super.super.super.handshake_in_progess = log_proto_proxied_text_server_handshake_in_progress;
   self->super.super.super.handshake = log_proto_proxied_text_server_handshake;
   self->super.super.super.fetch = log_proto_proxied_text_server_fetch;
   self->super.super.super.free_fn = log_proto_proxied_text_server_free;

--- a/lib/logproto/logproto-server.c
+++ b/lib/logproto/logproto-server.c
@@ -124,7 +124,8 @@ log_proto_server_validate_options_method(LogProtoServer *s)
 void
 log_proto_server_free_method(LogProtoServer *s)
 {
-  log_transport_free(s->transport);
+  if (s->transport)
+    log_transport_free(s->transport);
 }
 
 void

--- a/lib/logproto/logproto-server.h
+++ b/lib/logproto/logproto-server.h
@@ -88,8 +88,7 @@ struct _LogProtoServer
   LogProtoStatus (*fetch)(LogProtoServer *s, const guchar **msg, gsize *msg_len, gboolean *may_read,
                           LogTransportAuxData *aux, Bookmark *bookmark);
   gboolean (*validate_options)(LogProtoServer *s);
-  gboolean (*handshake_in_progess)(LogProtoServer *s);
-  LogProtoStatus (*handshake)(LogProtoServer *s);
+  LogProtoStatus (*handshake)(LogProtoServer *s, gboolean *handshake_finished);
   void (*free_fn)(LogProtoServer *s);
 };
 
@@ -99,23 +98,14 @@ log_proto_server_validate_options(LogProtoServer *self)
   return self->validate_options(self);
 }
 
-static inline gboolean
-log_proto_server_handshake_in_progress(LogProtoServer *s)
-{
-  if (s->handshake_in_progess)
-    {
-      return s->handshake_in_progess(s);
-    }
-  return FALSE;
-}
-
 static inline LogProtoStatus
-log_proto_server_handshake(LogProtoServer *s)
+log_proto_server_handshake(LogProtoServer *s, gboolean *handshake_finished)
 {
   if (s->handshake)
     {
-      return s->handshake(s);
+      return s->handshake(s, handshake_finished);
     }
+  *handshake_finished = TRUE;
   return LPS_SUCCESS;
 }
 

--- a/lib/logproto/tests/CMakeLists.txt
+++ b/lib/logproto/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ set(TEST_LOGPROTO_SOURCES
   test-text-server.c
   test-dgram-server.c
   test-framed-server.c
+  test-auto-server.c
   test-indented-multiline-server.c
   test-regexp-multiline-server.c
   test-proxy-proto.c)

--- a/lib/logproto/tests/Makefile.am
+++ b/lib/logproto/tests/Makefile.am
@@ -17,6 +17,7 @@ lib_logproto_tests_test_logproto_SOURCES = 			\
 	lib/logproto/tests/test-text-server.c			\
 	lib/logproto/tests/test-dgram-server.c			\
 	lib/logproto/tests/test-framed-server.c			\
+	lib/logproto/tests/test-auto-server.c			\
 	lib/logproto/tests/test-indented-multiline-server.c	\
 	lib/logproto/tests/test-regexp-multiline-server.c	\
 	lib/logproto/tests/test-proxy-proto.c

--- a/lib/logproto/tests/test-auto-server.c
+++ b/lib/logproto/tests/test-auto-server.c
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2012-2019 Balabit
+ * Copyright (c) 2012-2013 Balázs Scheidler
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include "libtest/mock-transport.h"
+#include "libtest/proto_lib.h"
+#include "libtest/msg_parse_lib.h"
+
+#include "logproto/logproto-auto-server.h"
+
+#include <errno.h>
+
+Test(log_proto, test_log_proto_initial_framing_too_long)
+{
+  LogProtoServer *proto;
+
+  proto = log_proto_auto_server_new(
+            log_transport_mock_stream_new(
+              "100000000 too long\n", -1,
+              LTM_EOF),
+            get_inited_proto_server_options());
+
+  assert_proto_server_handshake_failure(proto, LPS_SUCCESS);
+  assert_proto_server_fetch_failure(proto, LPS_ERROR, NULL);
+  log_proto_server_free(proto);
+}
+
+Test(log_proto, test_log_proto_error_in_initial_frame)
+{
+  LogProtoServer *proto;
+
+  proto = log_proto_auto_server_new(
+            log_transport_mock_stream_new(
+              LTM_INJECT_ERROR(EIO)),
+            get_inited_proto_server_options());
+
+  assert_proto_server_handshake_failure(proto, LPS_ERROR);
+  log_proto_server_free(proto);
+}
+
+Test(log_proto, test_log_proto_auto_server_no_framing)
+{
+  LogProtoServer *proto;
+
+  proto = log_proto_auto_server_new(
+            log_transport_mock_stream_new(
+              "abcdefghijklmnopqstuvwxyz\n", -1,
+              "01234567\n", -1,
+              "01234567\0", 9,
+              "abcdef", -1,
+              LTM_EOF),
+            get_inited_proto_server_options());
+
+  assert_proto_server_handshake(proto);
+  assert_proto_server_fetch(proto, "abcdefghijklmnopqstuvwxyz", -1);
+  assert_proto_server_fetch(proto, "01234567", -1);
+  assert_proto_server_fetch(proto, "01234567", 8);
+  assert_proto_server_fetch(proto, "abcdef", -1);
+  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+  log_proto_server_free(proto);
+}
+
+Test(log_proto, test_log_proto_auto_server_opening_bracket)
+{
+  LogProtoServer *proto;
+
+  proto = log_proto_auto_server_new(
+            log_transport_mock_stream_new(
+              "<55> abcdefghijklmnopqstuvwxyz\n", -1,
+              "01234567\n", -1,
+              "01234567\0", 9,
+              "abcdef", -1,
+              LTM_EOF),
+            get_inited_proto_server_options());
+
+  assert_proto_server_handshake(proto);
+  assert_proto_server_fetch(proto, "<55> abcdefghijklmnopqstuvwxyz", -1);
+  assert_proto_server_fetch(proto, "01234567", -1);
+  assert_proto_server_fetch(proto, "01234567", 8);
+  assert_proto_server_fetch(proto, "abcdef", -1);
+  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+  log_proto_server_free(proto);
+}
+
+Test(log_proto, test_log_proto_auto_server_with_framing)
+{
+  LogProtoServer *proto;
+
+  proto = log_proto_auto_server_new(
+            log_transport_mock_stream_new(
+              "32 0123456789ABCDEF0123456789ABCDEF", -1,
+              "10 01234567\n\n", -1,
+              "10 01234567\0\0", 13,
+              /* utf8 */
+              "30 árvíztűrőtükörfúrógép", -1,
+              /* iso-8859-2 */
+              "21 \xe1\x72\x76\xed\x7a\x74\xfb\x72\xf5\x74\xfc\x6b\xf6\x72\x66\xfa"      /*  |árvíztűrőtükörfú| */
+              "\x72\xf3\x67\xe9\x70", -1,                                                /*  |rógép|            */
+              /* ucs4 */
+              "32 \x00\x00\x00\xe1\x00\x00\x00\x72\x00\x00\x00\x76\x00\x00\x00\xed"      /* |...á...r...v...í| */
+              "\x00\x00\x00\x7a\x00\x00\x00\x74\x00\x00\x01\x71\x00\x00\x00\x72", 35,    /* |...z...t...ű...r|  */
+              LTM_EOF),
+            get_inited_proto_server_options());
+
+  assert_proto_server_handshake(proto);
+  assert_proto_server_fetch(proto, "0123456789ABCDEF0123456789ABCDEF", -1);
+  assert_proto_server_fetch(proto, "01234567\n\n", -1);
+  assert_proto_server_fetch(proto, "01234567\0\0", 10);
+  assert_proto_server_fetch(proto, "árvíztűrőtükörfúrógép", -1);
+  assert_proto_server_fetch(proto,
+                            "\xe1\x72\x76\xed\x7a\x74\xfb\x72\xf5\x74\xfc\x6b\xf6\x72\x66\xfa"        /*  |.rv.zt.r.t.k.rf.| */
+                            "\x72\xf3\x67\xe9\x70", -1);                                              /*  |r.g.p|            */
+  assert_proto_server_fetch(proto,
+                            "\x00\x00\x00\xe1\x00\x00\x00\x72\x00\x00\x00\x76\x00\x00\x00\xed"        /* |...á...r...v...í| */
+                            "\x00\x00\x00\x7a\x00\x00\x00\x74\x00\x00\x01\x71\x00\x00\x00\x72", 32);  /* |...z...t...q...r|  */
+  assert_proto_server_fetch_failure(proto, LPS_EOF, NULL);
+  log_proto_server_free(proto);
+}

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -60,7 +60,7 @@ struct _LogReader
 {
   LogSource super;
   LogProtoServer *proto;
-  gboolean immediate_check;
+  gboolean immediate_check, handshake_in_progress;
   LogPipe *control;
   LogReaderOptions *options;
   PollEvents *poll_events;

--- a/lib/transport/tests/Makefile.am
+++ b/lib/transport/tests/Makefile.am
@@ -1,5 +1,6 @@
 lib_transport_tests_TESTS		 = \
 	lib/transport/tests/test_aux_data \
+	lib/transport/tests/test_transport \
 	lib/transport/tests/test_transport_factory_id \
 	lib/transport/tests/test_transport_factory \
 	lib/transport/tests/test_transport_factory_registry \
@@ -14,6 +15,12 @@ lib_transport_tests_test_aux_data_CFLAGS  = $(TEST_CFLAGS) \
 lib_transport_tests_test_aux_data_LDADD	 = $(TEST_LDADD)
 lib_transport_tests_test_aux_data_SOURCES = 			\
 	lib/transport/tests/test_aux_data.c
+
+lib_transport_tests_test_transport_CFLAGS  = $(TEST_CFLAGS) \
+	-I${top_srcdir}/lib/transport/tests
+lib_transport_tests_test_transport_LDADD	 = $(TEST_LDADD)
+lib_transport_tests_test_transport_SOURCES = 			\
+	lib/transport/tests/test_transport.c
 
 lib_transport_tests_test_transport_factory_id_CFLAGS  = $(TEST_CFLAGS) \
 	-I${top_srcdir}/lib/transport/tests

--- a/lib/transport/tests/test_transport.c
+++ b/lib/transport/tests/test_transport.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2024 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include "libtest/mock-transport.h"
+
+#include "transport/logtransport.h"
+#include "apphook.h"
+
+#include <errno.h>
+
+Test(transport, test_read_ahead_bytes_get_shifted_into_the_actual_read)
+{
+  LogTransport *t = log_transport_mock_stream_new("readahead", -1, LTM_EOF);
+
+  gchar buf[12] = {0};
+  memset(buf, 0, sizeof(buf));
+  gint rc = log_transport_read_ahead(t, buf, 4);
+  cr_assert(rc == 4, "unexpected rc = %d", rc);
+  cr_assert_str_eq(buf, "read");
+
+  /* the read() returns the bytes that were read in advance */
+
+  memset(buf, 0, sizeof(buf));
+  rc = log_transport_read(t, buf, 4, NULL);
+  cr_assert(rc == 4, "unexpected rc = %d", rc);
+  cr_assert_str_eq(buf, "read");
+
+}
+
+Test(transport, test_read_ahead_bytes_and_new_read_is_combined)
+{
+  LogTransport *t = log_transport_mock_stream_new("readahead", -1, LTM_EOF);
+
+  gchar buf[12] = {0};
+  memset(buf, 0, sizeof(buf));
+  gint rc = log_transport_read_ahead(t, buf, 4);
+  cr_assert(rc == 4, "unexpected rc = %d", rc);
+  cr_assert_str_eq(buf, "read");
+
+  /* NOTE: the mock will return only a single byte for every read to
+   * exercise retry mechanisms, so only read a single character here */
+
+  memset(buf, 0, sizeof(buf));
+  rc = log_transport_read(t, buf, 5, NULL);
+  cr_assert(rc == 5, "unexpected rc = %d", rc);
+  cr_assert_str_eq(buf, "reada");
+
+}
+
+Test(transport, test_read_ahead_returns_the_same_buffer_any_number_of_times)
+{
+  LogTransport *t = log_transport_mock_stream_new("readahead", -1, LTM_EOF);
+
+  gchar buf[12];
+
+  memset(buf, 0, sizeof(buf));
+  cr_assert(log_transport_read_ahead(t, buf, 1) == 1);
+  cr_assert_str_eq(buf, "r");
+  memset(buf, 0, sizeof(buf));
+  cr_assert(log_transport_read_ahead(t, buf, 2) == 2);
+  cr_assert_str_eq(buf, "re");
+  memset(buf, 0, sizeof(buf));
+  cr_assert(log_transport_read_ahead(t, buf, 8) == 8);
+  cr_assert_str_eq(buf, "readahea");
+  memset(buf, 0, sizeof(buf));
+  cr_assert(log_transport_read_ahead(t, buf, 4) == 4);
+  cr_assert_str_eq(buf, "read");
+
+  /* the read() returns the bytes that were read in advance */
+  cr_assert(log_transport_read(t, buf, 9, NULL) == 9);
+  cr_assert_str_eq(buf, "readahead");
+
+}
+
+Test(transport, test_read_ahead_more_than_the_internal_buffer, .signal = SIGABRT)
+{
+  LogTransport *t = log_transport_mock_stream_new("12345678901234567890", -1, LTM_EOF);
+
+  /* 20 bytes, the internal look ahead buffer in LogTransport is 16 bytes which we are overflowing here */
+  cr_assert(sizeof(t->read_ahead_buf) == 16);
+
+  gchar buf[32];
+
+  memset(buf, 0, sizeof(buf));
+  cr_assert(log_transport_read_ahead(t, buf, 20) == 20);
+}
+
+Test(transport, test_read_ahead_with_packets_split_in_half)
+{
+  LogTransport *t = log_transport_mock_stream_new("1234", -1, LTM_INJECT_ERROR(EAGAIN), "5678", -1, LTM_EOF);
+
+  gchar buf[32];
+  memset(buf, 0, sizeof(buf));
+  gint rc = log_transport_read_ahead(t, buf, 8);
+  cr_assert(rc == 4, "unexpected rc = %d", rc);
+  cr_assert_str_eq(buf, "1234");
+
+  memset(buf, 0, sizeof(buf));
+  rc = log_transport_read_ahead(t, buf, 8);
+  cr_assert(rc == 8, "unexpected rc = %d", rc);
+  cr_assert_str_eq(buf, "12345678");
+}
+
+TestSuite(transport, .init = app_startup, .fini = app_shutdown);

--- a/libtest/mock-transport.c
+++ b/libtest/mock-transport.c
@@ -211,7 +211,7 @@ log_transport_mock_read_method(LogTransport *s, gpointer buf, gsize count, LogTr
   switch (g_array_index(self->value, data_t, self->current_value_ndx).type)
     {
     case DATA_STRING:
-      if (self->input_is_a_stream)
+      if (self->input_is_a_stream && count > 0)
         count = 1;
 
       current_iov = &g_array_index(self->value, data_t, self->current_value_ndx).iov;

--- a/libtest/proto_lib.c
+++ b/libtest/proto_lib.c
@@ -38,6 +38,24 @@ assert_proto_server_status(LogProtoServer *proto, LogProtoStatus status, LogProt
 }
 
 LogProtoStatus
+proto_server_handshake(LogProtoServer *proto)
+{
+  gboolean handshake_finished = FALSE;
+  LogProtoStatus status;
+
+  start_grabbing_messages();
+  do
+    {
+      status = log_proto_server_handshake(proto, &handshake_finished);
+      if (status == LPS_AGAIN)
+        status = LPS_SUCCESS;
+    }
+  while (status == LPS_SUCCESS && handshake_finished == FALSE);
+  stop_grabbing_messages();
+  return status;
+}
+
+LogProtoStatus
 proto_server_fetch(LogProtoServer *proto, const guchar **msg, gsize *msg_len)
 {
   Bookmark bookmark;
@@ -78,6 +96,16 @@ construct_server_proto_plugin(const gchar *name, LogTransport *transport)
   proto_factory = log_proto_server_get_factory(&configuration->plugin_context, name);
   cr_assert_not_null(proto_factory, "error looking up proto factory");
   return log_proto_server_factory_construct(proto_factory, transport, &proto_server_options);
+}
+
+void
+assert_proto_server_handshake(LogProtoServer *proto)
+{
+  LogProtoStatus status;
+
+  status = proto_server_handshake(proto);
+
+  assert_proto_server_status(proto, status, LPS_SUCCESS);
 }
 
 void
@@ -144,6 +172,16 @@ assert_proto_server_fetch_failure(LogProtoServer *proto, LogProtoStatus expected
   assert_proto_server_status(proto, status, expected_status);
   if (error_message)
     assert_grabbed_log_contains(error_message);
+}
+
+void
+assert_proto_server_handshake_failure(LogProtoServer *proto, LogProtoStatus expected_status)
+{
+  LogProtoStatus status;
+
+  status = proto_server_handshake(proto);
+
+  assert_proto_server_status(proto, status, expected_status);
 }
 
 void

--- a/libtest/proto_lib.h
+++ b/libtest/proto_lib.h
@@ -29,6 +29,9 @@
 
 extern LogProtoServerOptions proto_server_options;
 
+
+void assert_proto_server_handshake(LogProtoServer *proto);
+void assert_proto_server_handshake_failure(LogProtoServer *proto, LogProtoStatus expected_status);
 void assert_proto_server_status(LogProtoServer *proto, LogProtoStatus status, LogProtoStatus expected_status);
 void assert_proto_server_fetch(LogProtoServer *proto, const gchar *expected_msg, gssize expected_msg_len);
 void assert_proto_server_fetch_single_read(LogProtoServer *proto, const gchar *expected_msg, gssize expected_msg_len);

--- a/news/feature-4814.md
+++ b/news/feature-4814.md
@@ -1,0 +1,5 @@
+`syslog()` source driver: add support for RFC6587 style auto-detection of
+octet-count based framing to avoid confusion that stems from the sender
+using a different protocol to the server.  This is automatically enabled for
+both the `transport(tcp)` and the `transport(tls)` settings.  You can disable
+auto-detection by using `transport(text)` or `transport(framed)`.

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -128,6 +128,8 @@ modules/python/python-confgen\.[ch]
 lib/tests/test_logscheduler\.c
 lib/filterx/.*\.[ch]
 lib/filterx/filterx-grammar\.ym
+lib/logproto/logproto-auto-server\.[ch]
+lib/transport/tests/test_transport\.c
 
 ###########################################################################
 # These tests are GPLd even though they reside under lib/ and are excluded


### PR DESCRIPTION

This is the remainder of #4814 which was crashing under Kira which were probably caused by these patches. I made an attempt to fix these up and hope they can go in once #4814 lands.

The branch itself simplifies the LogProto handshake API and adds a unit test for the LogProtoAutoServer class (rfc6587)
