### PR TITLE
stats: fix a memory leak of StatsCounter->name

### DIFF
--- a/lib/stats/stats-cluster.c
+++ b/lib/stats/stats-cluster.c
@@ -358,8 +358,7 @@ stats_cluster_untrack_counter(StatsCluster *self, gint type, StatsCounterItem **
 
   if (self->use_count == 0 && (*counter)->external)
     {
-      (*counter)->external = FALSE;
-      (*counter)->value_ref = NULL;
+      stats_counter_clear(*counter);
       gint type_mask = 1 << type;
       self->live_mask &= ~type_mask;
     }
@@ -450,7 +449,7 @@ stats_counter_group_free(StatsCounterGroup *self)
 static void
 stats_cluster_free_counter(StatsCluster *self, gint type, StatsCounterItem *item, gpointer user_data)
 {
-  stats_counter_free(item);
+  stats_counter_clear(item);
 }
 
 void

--- a/lib/stats/stats-counter.h
+++ b/lib/stats/stats-counter.h
@@ -128,9 +128,10 @@ stats_counter_get_name(StatsCounterItem *counter)
 }
 
 static inline void
-stats_counter_free(StatsCounterItem *counter)
+stats_counter_clear(StatsCounterItem *counter)
 {
   g_free(counter->name);
+  memset(counter, 0, sizeof(*counter));
 }
 
 #endif


### PR DESCRIPTION
The "unregister" path was not properly calling the cleanup function of StatsCounter, added it now.

PS: our stats subsystem is still a mess. This is not trying to remedy that.

