### PR TITLE
Filterx expr list eval

### DIFF
--- a/lib/filterx/expr-condition.c
+++ b/lib/filterx/expr-condition.c
@@ -65,17 +65,10 @@ _eval_condition(FilterXConditional *c)
       goto exit;
     }
 
-  for (GList *l = c->statements; l; l = l->next)
+  if (!filterx_expr_list_eval(c->statements, &result))
     {
-      FilterXExpr *expr = l->data;
-      result = filterx_expr_eval(expr);
-      if (!result || !filterx_object_truthy(result))
-        {
-          filterx_object_unref(result);
-          return filterx_boolean_new(FALSE);
-        }
-      if (l->next != NULL)
-        filterx_object_unref(result);
+      filterx_object_unref(result);
+      return filterx_boolean_new(FALSE);
     }
 exit:
   filterx_object_unref(condition_value);

--- a/lib/filterx/expr-generator.c
+++ b/lib/filterx/expr-generator.c
@@ -36,6 +36,7 @@ void
 filterx_generator_init_instance(FilterXExpr *s)
 {
   filterx_expr_init_instance(s);
+  s->ignore_falsy_result = TRUE;
 }
 
 void

--- a/lib/filterx/expr-generator.c
+++ b/lib/filterx/expr-generator.c
@@ -32,10 +32,27 @@ filterx_generator_set_fillable(FilterXExpr *s, FilterXExpr *fillable)
   self->fillable = fillable;
 }
 
+static FilterXObject *
+_eval(FilterXExpr *s)
+{
+  FilterXExprGenerator *self = (FilterXExprGenerator *) s;
+
+  FilterXObject *fillable = filterx_expr_eval_typed(self->fillable);
+  if (!fillable)
+    return NULL;
+
+  if (self->generate(self, fillable))
+    return fillable;
+
+  filterx_object_unref(fillable);
+  return NULL;
+}
+
 void
 filterx_generator_init_instance(FilterXExpr *s)
 {
   filterx_expr_init_instance(s);
+  s->eval = _eval;
   s->ignore_falsy_result = TRUE;
 }
 

--- a/lib/filterx/expr-generator.h
+++ b/lib/filterx/expr-generator.h
@@ -31,6 +31,7 @@ struct FilterXExprGenerator_
 {
   FilterXExpr super;
   FilterXExpr *fillable;
+  gboolean (*generate)(FilterXExprGenerator *self, FilterXObject *fillable);
   FilterXObject *(*create_container)(FilterXExprGenerator *self, FilterXExpr *fillable_parent);
 };
 

--- a/lib/filterx/expr-literal-generator.c
+++ b/lib/filterx/expr-literal-generator.c
@@ -142,9 +142,10 @@ _literal_generator_eval(FilterXExpr *s)
   if (!fillable)
     return NULL;
 
-  FilterXObject *result = _eval_elements(fillable, self->elements) ? filterx_boolean_new(TRUE) : NULL;
-  filterx_object_unref(fillable);
-  return result;
+  if (!_eval_elements(fillable, self->elements))
+    return NULL;
+
+  return fillable;
 }
 
 void

--- a/lib/filterx/expr-literal-generator.c
+++ b/lib/filterx/expr-literal-generator.c
@@ -133,19 +133,12 @@ _list_generator_create_container(FilterXExprGenerator *s, FilterXExpr *fillable_
   return result;
 }
 
-static FilterXObject *
-_literal_generator_eval(FilterXExpr *s)
+static gboolean
+_literal_generator_generate(FilterXExprGenerator *s, FilterXObject *fillable)
 {
   FilterXExprLiteralGenerator *self = (FilterXExprLiteralGenerator *) s;
 
-  FilterXObject *fillable = filterx_expr_eval_typed(self->super.fillable);
-  if (!fillable)
-    return NULL;
-
-  if (!_eval_elements(fillable, self->elements))
-    return NULL;
-
-  return fillable;
+  return _eval_elements(fillable, self->elements);
 }
 
 void
@@ -161,7 +154,7 @@ static void
 _literal_generator_init_instance(FilterXExprLiteralGenerator *self)
 {
   filterx_generator_init_instance(&self->super.super);
-  self->super.super.eval = _literal_generator_eval;
+  self->super.generate = _literal_generator_generate;
   self->super.super.free_fn = _literal_generator_free;
 }
 

--- a/lib/filterx/expr-regexp.c
+++ b/lib/filterx/expr-regexp.c
@@ -359,14 +359,16 @@ _regexp_search_generator_eval(FilterXExpr *s)
   if (matched)
     {
       if (!_store_matches(self->pattern, &state, fillable))
-        goto exit;
+        {
+          filterx_object_unref(fillable);
+          goto exit;
+        }
     }
 
-  result = filterx_boolean_new(TRUE);
+  result = fillable;
 
 exit:
   _state_cleanup(&state);
-  filterx_object_unref(fillable);
   return result;
 }
 

--- a/lib/filterx/expr-shorthand.c
+++ b/lib/filterx/expr-shorthand.c
@@ -33,19 +33,9 @@ static FilterXObject *
 _eval(FilterXExpr *s)
 {
   FilterXShorthand *self = (FilterXShorthand *) s;
-
   FilterXObject *result = NULL;
-  for (GList *elem = self->exprs; elem; elem = elem->next)
-    {
-      filterx_object_unref(result);
 
-      FilterXExpr *expr = elem->data;
-      result = filterx_expr_eval(expr);
-
-      if (!result || filterx_object_falsy(result))
-        break;
-    }
-
+  filterx_expr_list_eval(self->exprs, &result);
   return result;
 }
 

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -155,7 +155,6 @@ _evaluate_statement(FilterXExpr *expr)
   return success;
 }
 
-
 gboolean
 filterx_eval_exec_statements(FilterXScope *scope, GList *statements, LogMessage *msg)
 {

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -120,14 +120,14 @@ _evaluate_statement(FilterXExpr *expr)
 
   if (!res)
     {
-      msg_debug("FILTERX  ERROR",
+      msg_debug("FILTERX ERROR",
                 filterx_expr_format_location_tag(expr),
                 filterx_format_last_error());
       return FALSE;
     }
   filterx_eval_clear_errors();
 
-  success = filterx_object_truthy(res);
+  success = expr->ignore_falsy_result || filterx_object_truthy(res);
   if (!success || trace_flag)
     {
       GString *buf = scratch_buffers_alloc();
@@ -140,14 +140,15 @@ _evaluate_statement(FilterXExpr *expr)
         }
 
       if (!success)
-        msg_debug("FILTERX  FALSY",
+        msg_debug("FILTERX FALSY",
                   filterx_expr_format_location_tag(expr),
                   evt_tag_mem("value", buf->str, buf->len),
                   evt_tag_str("type", res->type->name));
       else
-        msg_trace("FILTERX TRUTHY",
+        msg_trace("FILTERX ESTEP",
                   filterx_expr_format_location_tag(expr),
                   evt_tag_mem("value", buf->str, buf->len),
+                  evt_tag_int("truthy", filterx_object_truthy(res)),
                   evt_tag_str("type", res->type->name));
     }
 

--- a/lib/filterx/filterx-expr.c
+++ b/lib/filterx/filterx-expr.c
@@ -136,7 +136,8 @@ filterx_expr_list_eval(GList *expressions, FilterXObject **result)
       FilterXExpr *expr = elem->data;
       *result = filterx_expr_eval(expr);
 
-      if (!(*result) || filterx_object_falsy(*result))
+      if (!(*result) ||
+          (!expr->ignore_falsy_result && filterx_object_falsy(*result)))
         return FALSE;
     }
 

--- a/lib/filterx/filterx-expr.c
+++ b/lib/filterx/filterx-expr.c
@@ -124,3 +124,21 @@ filterx_binary_op_init_instance(FilterXBinaryOp *self, FilterXExpr *lhs, FilterX
   self->lhs = lhs;
   self->rhs = rhs;
 }
+
+gboolean
+filterx_expr_list_eval(GList *expressions, FilterXObject **result)
+{
+  *result = NULL;
+  for (GList *elem = expressions; elem; elem = elem->next)
+    {
+      filterx_object_unref(*result);
+
+      FilterXExpr *expr = elem->data;
+      *result = filterx_expr_eval(expr);
+
+      if (!(*result) || filterx_object_falsy(*result))
+        return FALSE;
+    }
+
+  return TRUE;
+}

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -157,4 +157,6 @@ typedef struct _FilterXBinaryOp
 void filterx_binary_op_free_method(FilterXExpr *s);
 void filterx_binary_op_init_instance(FilterXBinaryOp *self, FilterXExpr *lhs, FilterXExpr *rhs);
 
+gboolean filterx_expr_list_eval(GList *expressions, FilterXObject **result);
+
 #endif

--- a/lib/filterx/filterx-expr.h
+++ b/lib/filterx/filterx-expr.h
@@ -33,6 +33,7 @@ struct _FilterXExpr
 {
   guint32 ref_cnt;
   const gchar *type;
+  guint32 ignore_falsy_result:1;
 
   /* evaluate expression */
   FilterXObject *(*eval)(FilterXExpr *self);

--- a/lib/filterx/tests/test_expr_regexp.c
+++ b/lib/filterx/tests/test_expr_regexp.c
@@ -86,9 +86,7 @@ _search(const gchar *lhs, const gchar *pattern)
 
   FilterXObject *result_obj = filterx_expr_eval(expr);
   cr_assert(result_obj);
-  gboolean result;
-  cr_assert(filterx_boolean_unwrap(result_obj, &result));
-  cr_assert(result);
+  cr_assert(filterx_object_truthy(result_obj));
 
   FilterXObject *fillable = filterx_expr_eval(fillable_expr);
   cr_assert(fillable);
@@ -109,9 +107,7 @@ _search_with_fillable(const gchar *lhs, const gchar *pattern, FilterXObject *fil
 
   FilterXObject *result_obj = filterx_expr_eval(expr);
   cr_assert(result_obj);
-  gboolean result;
-  cr_assert(filterx_boolean_unwrap(result_obj, &result));
-  cr_assert(result);
+  cr_assert(filterx_object_truthy(result_obj));
 
   filterx_object_unref(result_obj);
   filterx_expr_unref(expr);

--- a/lib/filterx/tests/test_filterx_expr.c
+++ b/lib/filterx/tests/test_filterx_expr.c
@@ -124,7 +124,6 @@ Test(filterx_expr, test_filterx_list_merge)
   FilterXExpr *fillable = filterx_literal_new(json_array);
   FilterXExpr *list_expr = NULL;
   FilterXObject *result = NULL;
-  gboolean success = FALSE;
   GList *values = NULL, *inner_values = NULL;
   guint64 len;
 
@@ -140,8 +139,7 @@ Test(filterx_expr, test_filterx_list_merge)
   // $fillable += [42];
   result = filterx_expr_eval(list_expr);
   cr_assert(result);
-  cr_assert(filterx_boolean_unwrap(result, &success));
-  cr_assert(success);
+  cr_assert(filterx_object_truthy(result));
   cr_assert(filterx_object_len(json_array, &len));
   cr_assert_eq(len, 1);
   _assert_int_value_and_unref(filterx_list_get_subscript(json_array, 0), 42);
@@ -150,8 +148,7 @@ Test(filterx_expr, test_filterx_list_merge)
   // $fillable += [42];
   result = filterx_expr_eval(list_expr);
   cr_assert(result);
-  cr_assert(filterx_boolean_unwrap(result, &success));
-  cr_assert(success);
+  cr_assert(filterx_object_truthy(result));
   cr_assert(filterx_object_len(json_array, &len));
   cr_assert_eq(len, 2);
   _assert_int_value_and_unref(filterx_list_get_subscript(json_array, 0), 42);
@@ -175,8 +172,7 @@ Test(filterx_expr, test_filterx_list_merge)
   // $fillable += [[1337]];
   result = filterx_expr_eval(list_expr);
   cr_assert(result);
-  cr_assert(filterx_boolean_unwrap(result, &success));
-  cr_assert(success);
+  cr_assert(filterx_object_truthy(result));
   cr_assert(filterx_object_len(json_array, &len));
   cr_assert_eq(len, 3);
 
@@ -217,7 +213,6 @@ Test(filterx_expr, test_filterx_dict_merge)
   FilterXExpr *fillable = filterx_literal_new(json);
   FilterXExpr *dict_expr = NULL;
   FilterXObject *result = NULL;
-  gboolean success = FALSE;
   GList *values = NULL, *inner_values = NULL;
   guint64 len;
 
@@ -237,8 +232,7 @@ Test(filterx_expr, test_filterx_dict_merge)
   // $fillable += {"foo": 42};
   result = filterx_expr_eval(dict_expr);
   cr_assert(result);
-  cr_assert(filterx_boolean_unwrap(result, &success));
-  cr_assert(success);
+  cr_assert(filterx_object_truthy(result));
   cr_assert(filterx_object_len(json, &len));
   cr_assert_eq(len, 1);
   _assert_int_value_and_unref(filterx_object_get_subscript(json, foo), 42);
@@ -247,8 +241,7 @@ Test(filterx_expr, test_filterx_dict_merge)
   // $fillable += {"foo": 42};
   result = filterx_expr_eval(dict_expr);
   cr_assert(result);
-  cr_assert(filterx_boolean_unwrap(result, &success));
-  cr_assert(success);
+  cr_assert(filterx_object_truthy(result));
   cr_assert(filterx_object_len(json, &len));
   cr_assert_eq(len, 1);
   _assert_int_value_and_unref(filterx_object_get_subscript(json, foo), 42);
@@ -268,8 +261,7 @@ Test(filterx_expr, test_filterx_dict_merge)
   // $fillable += {"foo": 420};
   result = filterx_expr_eval(dict_expr);
   cr_assert(result);
-  cr_assert(filterx_boolean_unwrap(result, &success));
-  cr_assert(success);
+  cr_assert(filterx_object_truthy(result));
   cr_assert(filterx_object_len(json, &len));
   cr_assert_eq(len, 1);
   _assert_int_value_and_unref(filterx_object_get_subscript(json, foo), 420);
@@ -289,8 +281,7 @@ Test(filterx_expr, test_filterx_dict_merge)
   // $fillable += {"bar": 1337};
   result = filterx_expr_eval(dict_expr);
   cr_assert(result);
-  cr_assert(filterx_boolean_unwrap(result, &success));
-  cr_assert(success);
+  cr_assert(filterx_object_truthy(result));
   cr_assert(filterx_object_len(json, &len));
   cr_assert_eq(len, 2);
   _assert_int_value_and_unref(filterx_object_get_subscript(json, foo), 420);
@@ -314,8 +305,7 @@ Test(filterx_expr, test_filterx_dict_merge)
   // $fillable += {"baz": {"foo": 1}};
   result = filterx_expr_eval(dict_expr);
   cr_assert(result);
-  cr_assert(filterx_boolean_unwrap(result, &success));
-  cr_assert(success);
+  cr_assert(filterx_object_truthy(result));
   cr_assert(filterx_object_len(json, &len));
   cr_assert_eq(len, 3);
 
@@ -332,8 +322,7 @@ Test(filterx_expr, test_filterx_dict_merge)
   // Shallow merge.
   result = filterx_expr_eval(dict_expr);
   cr_assert(result);
-  cr_assert(filterx_boolean_unwrap(result, &success));
-  cr_assert(success);
+  cr_assert(filterx_object_truthy(result));
   cr_assert(filterx_object_len(json, &len));
   cr_assert_eq(len, 3);
 

--- a/modules/grpc/otel/filterx/object-otel-array.cpp
+++ b/modules/grpc/otel/filterx/object-otel-array.cpp
@@ -376,7 +376,6 @@ OtelArrayField::FilterXObjectSetter(google::protobuf::Message *message, ProtoRef
 
   delete filterx_array->cpp;
   filterx_array->cpp = new_array;
-  *assoc_object = filterx_object_ref(object);
 
   return true;
 }

--- a/modules/grpc/otel/filterx/object-otel-kvlist.cpp
+++ b/modules/grpc/otel/filterx/object-otel-kvlist.cpp
@@ -507,7 +507,6 @@ OtelKVListField::FilterXObjectSetter(google::protobuf::Message *message, ProtoRe
 
   delete filterx_kvlist->cpp;
   filterx_kvlist->cpp = new_kvlist;
-  *assoc_object = filterx_object_ref(object);
 
   return true;
 }

--- a/modules/grpc/otel/filterx/otel-field.cpp
+++ b/modules/grpc/otel/filterx/otel-field.cpp
@@ -289,7 +289,6 @@ public:
           }
 
         reflectors.reflection->SetEnumValue(message, reflectors.fieldDescriptor, (int) value);
-        *assoc_object = object;
         return true;
       }
 

--- a/modules/grpc/otel/filterx/protobuf-field.cpp
+++ b/modules/grpc/otel/filterx/protobuf-field.cpp
@@ -73,7 +73,6 @@ public:
   {
     gboolean truthy = filterx_object_truthy(object);
     reflectors.reflection->SetBool(message, reflectors.fieldDescriptor, truthy);
-    *assoc_object = filterx_object_ref(object);
     return true;
   }
 };
@@ -96,7 +95,6 @@ public:
     GenericNumber gn = filterx_primitive_get_value(object);
     int32_t val = MAX(INT32_MIN, MIN(INT32_MAX, gn_as_int64(&gn)));
     reflectors.reflection->SetInt32(message, reflectors.fieldDescriptor, val);
-    *assoc_object = filterx_object_ref(object);
     return true;
   }
 };
@@ -116,7 +114,6 @@ public:
         GenericNumber gn = filterx_primitive_get_value(object);
         int64_t val = gn_as_int64(&gn);
         reflectors.reflection->SetInt64(message, reflectors.fieldDescriptor, val);
-        *assoc_object = filterx_object_ref(object);
         return true;
       }
     else if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(datetime)))
@@ -124,7 +121,6 @@ public:
         const UnixTime utime = filterx_datetime_get_value(object);
         uint64_t unix_epoch = unix_time_to_unix_epoch(utime);
         reflectors.reflection->SetInt64(message, reflectors.fieldDescriptor, (int64_t)(unix_epoch));
-        *assoc_object = filterx_object_ref(object);
         return true;
       }
 
@@ -151,7 +147,6 @@ public:
     GenericNumber gn = filterx_primitive_get_value(object);
     uint32_t val = MAX(0, MIN(UINT32_MAX, gn_as_int64(&gn)));
     reflectors.reflection->SetUInt32(message, reflectors.fieldDescriptor, val);
-    *assoc_object = filterx_object_ref(object);
     return true;
   }
 };
@@ -181,7 +176,6 @@ public:
         GenericNumber gn = filterx_primitive_get_value(object);
         uint64_t val = MAX(0, MIN(UINT64_MAX, (uint64_t) gn_as_int64(&gn)));
         reflectors.reflection->SetUInt64(message, reflectors.fieldDescriptor, val);
-        *assoc_object = filterx_object_ref(object);
         return true;
       }
     else if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(datetime)))
@@ -189,7 +183,6 @@ public:
         const UnixTime utime = filterx_datetime_get_value(object);
         uint64_t unix_epoch = unix_time_to_unix_epoch(utime);
         reflectors.reflection->SetUInt64(message, reflectors.fieldDescriptor, unix_epoch);
-        *assoc_object = filterx_object_ref(object);
         return true;
       }
 
@@ -217,7 +210,6 @@ public:
         const gchar *str = filterx_string_get_value(object, &value_len);
         std::string stdString(str, value_len);
         reflectors.reflection->SetString(message, reflectors.fieldDescriptor, stdString);
-        *assoc_object = filterx_object_ref(object);
         return true;
       }
     else if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(json_object)) ||
@@ -231,7 +223,6 @@ public:
             return false;
           }
         reflectors.reflection->SetString(message, reflectors.fieldDescriptor, json_literal);
-        *assoc_object = filterx_object_ref(object);
         return true;
       }
     log_type_error(reflectors, object->type->name);
@@ -267,7 +258,6 @@ public:
       }
 
     reflectors.reflection->SetDouble(message, reflectors.fieldDescriptor, val);
-    *assoc_object = filterx_object_ref(object);
     return true;
   }
 };
@@ -301,7 +291,6 @@ public:
 
     float floatVal = double_to_float_safe(val);
     reflectors.reflection->SetFloat(message, reflectors.fieldDescriptor, floatVal);
-    *assoc_object = filterx_object_ref(object);
     return true;
   }
 };
@@ -325,7 +314,7 @@ public:
         const gchar *str = filterx_bytes_get_value(object, &value_len);
         std::string stdString(str, value_len);
         reflectors.reflection->SetString(message, reflectors.fieldDescriptor, stdString);
-        *assoc_object = filterx_object_ref(object);
+
         return true;
       }
     else if (filterx_object_is_type(object, &FILTERX_TYPE_NAME(protobuf)))
@@ -334,7 +323,6 @@ public:
         const gchar *str = filterx_protobuf_get_value(object, &value_len);
         std::string stdString(str, value_len);
         reflectors.reflection->SetString(message, reflectors.fieldDescriptor, stdString);
-        *assoc_object = filterx_object_ref(object);
         return true;
       }
     log_type_error(reflectors, object->type->name);

--- a/modules/grpc/otel/filterx/protobuf-field.hpp
+++ b/modules/grpc/otel/filterx/protobuf-field.hpp
@@ -89,7 +89,13 @@ public:
     try
       {
         ProtoReflectors reflectors(*message, fieldName);
-        return this->FilterXObjectSetter(message, reflectors, object, assoc_object);
+        if (this->FilterXObjectSetter(message, reflectors, object, assoc_object))
+          {
+            if (!(*assoc_object))
+              *assoc_object = filterx_object_ref(object);
+            return true;
+          }
+        return false;
       }
     catch(const std::exception &ex)
       {


### PR DESCRIPTION
This PR consolidates the evaluation loop for expression lists and then introduces a new property "ignore_falsy_return" for expressions. If this is set, then the expression evaluation continues _even_ if the current one returns a falsy result.

This would make it possible to bring assignments back to normal expressions and would also allow chaining. That is not added back though.
