### PR TITLE
Filterx refactor eval context management

### DIFF
--- a/lib/driver.c
+++ b/lib/driver.c
@@ -142,7 +142,7 @@ static void
 log_driver_init_instance(LogDriver *self, GlobalConfig *cfg)
 {
   log_pipe_init_instance(&self->super, cfg);
-  self->super.flags |= PIF_CONFIG_RELATED;
+  self->super.flags |= PIF_CONFIG_RELATED + PIF_SYNC_FILTERX;
   self->super.free_fn = log_driver_free;
   self->super.pre_init = log_driver_pre_init_method;
   self->super.init = log_driver_init_method;

--- a/lib/filter/filter-pipe.c
+++ b/lib/filter/filter-pipe.c
@@ -122,7 +122,7 @@ log_filter_pipe_new(FilterExprNode *expr, GlobalConfig *cfg)
   LogFilterPipe *self = g_new0(LogFilterPipe, 1);
 
   log_pipe_init_instance(&self->super, cfg);
-  self->super.flags |= PIF_CONFIG_RELATED;
+  self->super.flags |= PIF_CONFIG_RELATED + PIF_SYNC_FILTERX;
   self->super.init = log_filter_pipe_init;
   self->super.queue = log_filter_pipe_queue;
   self->super.free_fn = log_filter_pipe_free;

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -22,6 +22,7 @@
  */
 #include "filterx/filterx-eval.h"
 #include "filterx/filterx-expr.h"
+#include "logpipe.h"
 #include "scratch-buffers.h"
 #include "tls-support.h"
 
@@ -182,4 +183,21 @@ fail:
   filterx_scope_set_dirty(scope);
   filterx_eval_set_context(NULL);
   return success;
+}
+
+
+FilterXScope *
+filterx_eval_begin_scope(const LogPathOptions *path_options)
+{
+  FilterXScope *scope = filterx_scope_ref(path_options->filterx_scope);
+  if (!scope)
+    scope = filterx_scope_new();
+  filterx_scope_make_writable(&scope);
+  return scope;
+}
+
+void
+filterx_eval_end_scope(FilterXScope *scope)
+{
+  filterx_scope_unref(scope);
 }

--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -42,16 +42,19 @@ struct _FilterXEvalContext
   FilterXScope *scope;
   FilterXError error;
   LogTemplateEvalOptions *template_eval_options;
+  FilterXEvalContext *previous_context;
 };
 
 FilterXEvalContext *filterx_eval_get_context(void);
 FilterXScope *filterx_eval_get_scope(void);
 void filterx_eval_push_error(const gchar *message, FilterXExpr *expr, FilterXObject *object);
 void filterx_eval_set_context(FilterXEvalContext *context);
-gboolean filterx_eval_exec_statements(FilterXScope *scope, GList *statements, LogMessage *msg);
+gboolean filterx_eval_exec_statements(FilterXEvalContext *context, GList *statements, LogMessage *msg);
 void filterx_eval_sync_scope_and_message(FilterXScope *scope, LogMessage *msg);
 const gchar *filterx_eval_get_last_error(void);
 void filterx_eval_clear_errors(void);
 
+void filterx_eval_init_context(FilterXEvalContext *context, FilterXEvalContext *previous_context);
+void filterx_eval_deinit_context(FilterXEvalContext *context);
 
 #endif

--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -60,4 +60,26 @@ void filterx_eval_store_weak_ref(FilterXObject *object);
 void filterx_eval_init_context(FilterXEvalContext *context, FilterXEvalContext *previous_context);
 void filterx_eval_deinit_context(FilterXEvalContext *context);
 
+static inline void
+filterx_eval_sync_message(FilterXEvalContext *context, LogMessage **pmsg, const LogPathOptions *path_options)
+{
+  if (!context)
+    return;
+
+  if (!filterx_scope_is_dirty(context->scope))
+    return;
+
+  log_msg_make_writable(pmsg, path_options);
+  filterx_scope_sync(context->scope, *pmsg);
+}
+
+static inline void
+filterx_eval_prepare_for_fork(FilterXEvalContext *context, LogMessage **pmsg, const LogPathOptions *path_options)
+{
+  filterx_eval_sync_message(context, pmsg, path_options);
+  if (context)
+    filterx_scope_write_protect(context->scope);
+  log_msg_write_protect(*pmsg);
+}
+
 #endif

--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -42,6 +42,7 @@ struct _FilterXEvalContext
   FilterXScope *scope;
   FilterXError error;
   LogTemplateEvalOptions *template_eval_options;
+  GPtrArray *weak_refs;
   FilterXEvalContext *previous_context;
 };
 
@@ -53,6 +54,8 @@ gboolean filterx_eval_exec_statements(FilterXEvalContext *context, GList *statem
 void filterx_eval_sync_scope_and_message(FilterXScope *scope, LogMessage *msg);
 const gchar *filterx_eval_get_last_error(void);
 void filterx_eval_clear_errors(void);
+
+void filterx_eval_store_weak_ref(FilterXObject *object);
 
 void filterx_eval_init_context(FilterXEvalContext *context, FilterXEvalContext *previous_context);
 void filterx_eval_deinit_context(FilterXEvalContext *context);

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -87,7 +87,7 @@ struct _FilterXObject
    *                          propagates to the inner elements lazily
    *
    */
-  guint thread_index:16, modified_in_place:1, readonly:1;
+  guint thread_index:16, modified_in_place:1, readonly:1, weak_referenced:1;
   FilterXType *type;
 };
 

--- a/lib/filterx/filterx-pipe.c
+++ b/lib/filterx/filterx-pipe.c
@@ -49,32 +49,29 @@ static void
 log_filterx_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
   LogFilterXPipe *self = (LogFilterXPipe *) s;
+  FilterXEvalContext eval_context;
   LogPathOptions local_path_options;
   gboolean res;
 
   path_options = log_path_options_chain(&local_path_options, path_options);
-
-  FilterXScope *scope = filterx_eval_begin_scope(path_options);
+  filterx_eval_init_context(&eval_context, path_options->filterx_context);
 
   msg_trace(">>>>>> filterx rule evaluation begin",
             evt_tag_str("rule", self->name),
             log_pipe_location_tag(s),
-            evt_tag_printf("path_scope", "%p", path_options->filterx_scope),
-            evt_tag_printf("scope", "%p", scope),
             evt_tag_msg_reference(msg));
 
   NVTable *payload = nv_table_ref(msg->payload);
-  res = filterx_eval_exec_statements(scope, self->stmts, msg);
+  res = filterx_eval_exec_statements(&eval_context, self->stmts, msg);
 
   msg_trace("<<<<<< filterx rule evaluation result",
             evt_tag_str("result", res ? "matched" : "unmatched"),
             evt_tag_str("rule", self->name),
             log_pipe_location_tag(s),
-            evt_tag_printf("scope", "%p", scope),
-            evt_tag_int("dirty", filterx_scope_is_dirty(scope)),
+            evt_tag_int("dirty", filterx_scope_is_dirty(eval_context.scope)),
             evt_tag_msg_reference(msg));
 
-  local_path_options.filterx_scope = scope;
+  local_path_options.filterx_context = &eval_context;
   if (res)
     {
       log_pipe_forward_msg(s, msg, path_options);
@@ -86,7 +83,7 @@ log_filterx_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_o
       log_msg_drop(msg, path_options, AT_PROCESSED);
     }
 
-  filterx_eval_end_scope(scope);
+  filterx_eval_deinit_context(&eval_context);
   nv_table_unref(payload);
 }
 

--- a/lib/filterx/filterx-pipe.c
+++ b/lib/filterx/filterx-pipe.c
@@ -54,10 +54,7 @@ log_filterx_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_o
 
   path_options = log_path_options_chain(&local_path_options, path_options);
 
-  FilterXScope *scope = filterx_scope_ref(path_options->filterx_scope);
-  if (!scope)
-    scope = filterx_scope_new();
-  filterx_scope_make_writable(&scope);
+  FilterXScope *scope = filterx_eval_begin_scope(path_options);
 
   msg_trace(">>>>>> filterx rule evaluation begin",
             evt_tag_str("rule", self->name),
@@ -89,7 +86,7 @@ log_filterx_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_o
       log_msg_drop(msg, path_options, AT_PROCESSED);
     }
 
-  filterx_scope_unref(scope);
+  filterx_eval_end_scope(scope);
   nv_table_unref(payload);
 }
 

--- a/lib/filterx/filterx-pipe.c
+++ b/lib/filterx/filterx-pipe.c
@@ -114,7 +114,7 @@ log_filterx_pipe_new(GList *stmts, GlobalConfig *cfg)
   LogFilterXPipe *self = g_new0(LogFilterXPipe, 1);
 
   log_pipe_init_instance(&self->super, cfg);
-  self->super.flags = (self->super.flags | PIF_CONFIG_RELATED) & ~PIF_SYNC_SCOPE;
+  self->super.flags = (self->super.flags | PIF_CONFIG_RELATED);
   self->super.init = log_filterx_pipe_init;
   self->super.queue = log_filterx_pipe_queue;
   self->super.free_fn = log_filterx_pipe_free;

--- a/lib/filterx/filterx-scope.h
+++ b/lib/filterx/filterx-scope.h
@@ -66,9 +66,6 @@ FilterXVariable *filterx_scope_register_variable(FilterXScope *self,
                                                  FilterXVariableHandle handle,
                                                  FilterXObject *initial_value);
 
-void filterx_scope_store_weak_ref(FilterXScope *self, FilterXObject *object);
-
-
 /* copy on write */
 void filterx_scope_write_protect(FilterXScope *self);
 FilterXScope *filterx_scope_make_writable(FilterXScope **pself);

--- a/lib/filterx/filterx-weakrefs.c
+++ b/lib/filterx/filterx-weakrefs.c
@@ -54,9 +54,7 @@
 void
 filterx_weakref_set(FilterXWeakRef *self, FilterXObject *object)
 {
-  FilterXScope *scope = filterx_eval_get_scope();
-  if (scope)
-    filterx_scope_store_weak_ref(scope, object);
+  filterx_eval_store_weak_ref(object);
   self->object = object;
 }
 

--- a/lib/filterx/object-json.c
+++ b/lib/filterx/object-json.c
@@ -131,9 +131,7 @@ filterx_json_convert_json_to_object_cached(FilterXObject *self, FilterXWeakRef *
 void
 filterx_json_associate_cached_object(struct json_object *json_obj, FilterXObject *filterx_obj)
 {
-  FilterXScope *scope = filterx_eval_get_scope();
-
-  filterx_scope_store_weak_ref(scope, filterx_obj);
+  filterx_eval_store_weak_ref(filterx_obj);
 
   /* we are not storing a reference in userdata to avoid circular
    * references.  That ref is retained by the filterx_scope_store_weak_ref()

--- a/lib/logmpx.c
+++ b/lib/logmpx.c
@@ -219,7 +219,6 @@ log_multiplexer_new(GlobalConfig *cfg)
   LogMultiplexer *self = g_new0(LogMultiplexer, 1);
 
   log_pipe_init_instance(&self->super, cfg);
-  self->super.flags = self->super.flags & ~PIF_SYNC_SCOPE;
   self->super.init = log_multiplexer_init;
   self->super.deinit = log_multiplexer_deinit;
   self->super.queue = log_multiplexer_queue;

--- a/lib/logpipe.c
+++ b/lib/logpipe.c
@@ -82,7 +82,6 @@ log_pipe_init_instance(LogPipe *self, GlobalConfig *cfg)
   self->queue = NULL;
   self->free_fn = log_pipe_free_method;
   self->arcs = _arcs;
-  self->flags = PIF_SYNC_SCOPE;
 }
 
 LogPipe *

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -72,7 +72,8 @@
 /* node created directly by the user */
 #define PIF_CONFIG_RELATED    0x0100
 
-#define PIF_SYNC_SCOPE        0x0200
+/* sync filterx state and message in right before calling queue() */
+#define PIF_SYNC_FILTERX      0x0200
 
 /* private flags range, to be used by other LogPipe instances for their own purposes */
 
@@ -458,7 +459,7 @@ log_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
         }
     }
 
-  if ((s->flags & PIF_SYNC_SCOPE))
+  if ((s->flags & PIF_SYNC_FILTERX))
     filterx_eval_sync_message(path_options->filterx_context, &msg, path_options);
 
   if (G_UNLIKELY(s->flags & (PIF_HARD_FLOW_CONTROL | PIF_JUNCTION_END | PIF_CONDITIONAL_MIDPOINT)))

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -458,13 +458,8 @@ log_pipe_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
         }
     }
 
-  if ((s->flags & PIF_SYNC_SCOPE) &&
-      path_options->filterx_scope &&
-      filterx_scope_is_dirty(path_options->filterx_scope))
-    {
-      log_msg_make_writable(&msg, path_options);
-      filterx_scope_sync(path_options->filterx_scope, msg);
-    }
+  if ((s->flags & PIF_SYNC_SCOPE))
+    filterx_eval_sync_message(path_options->filterx_context, &msg, path_options);
 
   if (G_UNLIKELY(s->flags & (PIF_HARD_FLOW_CONTROL | PIF_JUNCTION_END | PIF_CONDITIONAL_MIDPOINT)))
     {

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -27,7 +27,7 @@
 
 #include "syslog-ng.h"
 #include "logmsg/logmsg.h"
-#include "filterx/filterx-scope.h"
+#include "filterx/filterx-eval.h"
 #include "cfg.h"
 #include "atomic.h"
 #include "messages.h"
@@ -218,7 +218,7 @@ struct _LogPathOptions
 
   gboolean *matched;
   const LogPathOptions *lpo_parent_junction;
-  FilterXScope *filterx_scope;
+  FilterXEvalContext *filterx_context;
 };
 
 #define LOG_PATH_OPTIONS_INIT { TRUE, FALSE, NULL, NULL }

--- a/lib/parser/parser-expr.c
+++ b/lib/parser/parser-expr.c
@@ -182,7 +182,7 @@ void
 log_parser_init_instance(LogParser *self, GlobalConfig *cfg)
 {
   log_pipe_init_instance(&self->super, cfg);
-  self->super.flags |= PIF_CONFIG_RELATED;
+  self->super.flags |= PIF_CONFIG_RELATED + PIF_SYNC_FILTERX;
   self->super.init = log_parser_init_method;
   self->super.deinit = log_parser_deinit_method;
   self->super.free_fn = log_parser_free_method;

--- a/lib/rewrite/rewrite-expr.c
+++ b/lib/rewrite/rewrite-expr.c
@@ -98,7 +98,7 @@ log_rewrite_init_instance(LogRewrite *self, GlobalConfig *cfg)
 {
   log_pipe_init_instance(&self->super, cfg);
   /* indicate that the rewrite rule is changing the message */
-  self->super.flags |= PIF_CONFIG_RELATED;
+  self->super.flags |= PIF_CONFIG_RELATED + PIF_SYNC_FILTERX;
   self->super.free_fn = log_rewrite_free_method;
   self->super.queue = log_rewrite_queue;
   self->super.init = log_rewrite_init_method;


### PR DESCRIPTION
This PR is  a fix for a crash I introduced when I fixed a filterx memory leak in #4927  by using weakrefs in our object-json implementations. This branch starts with a light testcase to reproduce the issue.

The trigger for the crash is that when filterx_scope_clone() is called, it now adds weakrefs, but the clone will happen outside of the main filterx evaluation loop. Outside of that loop we don't have a scope, and without the scope we don't have weakrefs.

The solution implemented in this branch are:
* I moved the weakref tracking data structure from FilterXScope to FilterXEvalContext
* all filterx blocks (e.g. all filterx-pipe instances), share the weakref array (previously all of them had their own)

To make all of the above possible and simple, I made a  few refactors:
* I split the filterx_eval_exec_statements() to 3 functions, 1) init_context, 2) exec_statements, 3) deinit_context
* the EvalContext now lives as a local variable in filterx-pipe's queue function and they are chained up in a linked list (e.g. an eval_context has a pointer to the previous eval_context)
* I tried to encapsulate open-coded filterx/logpipe integration code into functions on the filterx side to make the code easier to read.

