### PR TITLE
csv-scanner: fix escape-backslash-with-sequences on ARM

### DIFF
--- a/lib/scanner/csv-scanner/csv-scanner.c
+++ b/lib/scanner/csv-scanner/csv-scanner.c
@@ -251,9 +251,12 @@ _parse_character_with_quotation(CSVScanner *self)
             case 'x':
               if (*(self->src+1) && *(self->src+2))
                 {
-                  ch = _decode_xbyte(*(self->src+1), *(self->src+2));
-                  if (ch >= 0)
-                    self->src += 2;
+                  gint decoded = _decode_xbyte(*(self->src+1), *(self->src+2));
+                  if (decoded >= 0)
+                    {
+                      self->src += 2;
+                      ch = decoded;
+                    }
                   else
                     ch = 'x';
                 }

--- a/news/bugfix-4947.md
+++ b/news/bugfix-4947.md
@@ -1,0 +1,3 @@
+`csv-parser()`: fix escape-backslash-with-sequences dialect on ARM
+
+`csv-parser()` produced invalid output on platforms where char is an unsigned type.


### PR DESCRIPTION
On ARM, gchar is unsigned.