### PR TITLE
cfg-block-generator: fix generating multi-line args

### DIFF
--- a/lib/cfg-block-generator.c
+++ b/lib/cfg-block-generator.c
@@ -38,7 +38,16 @@ static void
 _report_generator_args(gpointer key, gpointer value, gpointer user_data)
 {
   GString *result = (GString *) user_data;
-  g_string_append_printf(result, "## %s=%s\n", (gchar *) key, (gchar *) value);
+  g_string_append_printf(result, "## %s=", (gchar *) key);
+  for (const gchar *c = (const gchar *) value; *c; c++)
+    {
+      if (*c == '\n' && *(c + 1))
+        g_string_append(result, "\n## ");
+      else
+        g_string_append_c(result, *c);
+    }
+
+  g_string_append_c(result, '\n');
 }
 
 gboolean


### PR DESCRIPTION
No news file needed as the bug was introduced recently in #4929.