### PR TITLE
filterx: fix template evaluation

### DIFF
--- a/lib/filterx/expr-template.c
+++ b/lib/filterx/expr-template.c
@@ -45,7 +45,7 @@ _eval(FilterXExpr *s)
   /* FIXME/2: let's make this handle literal and trivial templates */
 
   log_template_format_value_and_type_with_context(self->template, context->msgs, context->num_msg,
-                                                  context->template_eval_options, value, &t);
+                                                  &context->template_eval_options, value, &t);
 
   /* NOTE: we borrow value->str here which is stored in a scratch buffer
    * that should be valid as long as we are traversing the filter

--- a/lib/filterx/filterx-eval.c
+++ b/lib/filterx/filterx-eval.c
@@ -217,7 +217,7 @@ filterx_eval_init_context(FilterXEvalContext *context, FilterXEvalContext *previ
   filterx_scope_make_writable(&scope);
 
   memset(context, 0, sizeof(*context));
-  context->template_eval_options = &DEFAULT_TEMPLATE_EVAL_OPTIONS;
+  context->template_eval_options = DEFAULT_TEMPLATE_EVAL_OPTIONS;
   context->scope = scope;
 
   if (previous_context)

--- a/lib/filterx/filterx-eval.h
+++ b/lib/filterx/filterx-eval.h
@@ -41,7 +41,7 @@ struct _FilterXEvalContext
   gint num_msg;
   FilterXScope *scope;
   FilterXError error;
-  LogTemplateEvalOptions *template_eval_options;
+  LogTemplateEvalOptions template_eval_options;
   GPtrArray *weak_refs;
   FilterXEvalContext *previous_context;
 };

--- a/lib/filterx/tests/test_filterx_expr.c
+++ b/lib/filterx/tests/test_filterx_expr.c
@@ -82,7 +82,7 @@ Test(filterx_expr, test_filterx_template_evaluates_to_the_expanded_value)
   {
     .msgs = &msg,
     .num_msg = 1,
-    .template_eval_options = &DEFAULT_TEMPLATE_EVAL_OPTIONS,
+    .template_eval_options = DEFAULT_TEMPLATE_EVAL_OPTIONS,
     .scope = scope,
   };
 
@@ -114,7 +114,7 @@ Test(filterx_expr, test_filterx_list_merge)
   {
     .msgs = &msg,
     .num_msg = 1,
-    .template_eval_options = &DEFAULT_TEMPLATE_EVAL_OPTIONS,
+    .template_eval_options = DEFAULT_TEMPLATE_EVAL_OPTIONS,
     .scope = scope,
   };
   filterx_eval_set_context(&context);
@@ -203,7 +203,7 @@ Test(filterx_expr, test_filterx_dict_merge)
   {
     .msgs = &msg,
     .num_msg = 1,
-    .template_eval_options = &DEFAULT_TEMPLATE_EVAL_OPTIONS,
+    .template_eval_options = DEFAULT_TEMPLATE_EVAL_OPTIONS,
     .scope = scope,
   };
   filterx_eval_set_context(&context);
@@ -356,7 +356,7 @@ Test(filterx_expr, test_filterx_assign)
   {
     .msgs = &msg,
     .num_msg = 1,
-    .template_eval_options = &DEFAULT_TEMPLATE_EVAL_OPTIONS,
+    .template_eval_options = DEFAULT_TEMPLATE_EVAL_OPTIONS,
     .scope = scope,
   };
   filterx_eval_set_context(&context);
@@ -397,7 +397,7 @@ Test(filterx_expr, test_filterx_setattr)
   {
     .msgs = &msg,
     .num_msg = 1,
-    .template_eval_options = &DEFAULT_TEMPLATE_EVAL_OPTIONS,
+    .template_eval_options = DEFAULT_TEMPLATE_EVAL_OPTIONS,
     .scope = scope,
   };
   filterx_eval_set_context(&context);
@@ -432,7 +432,7 @@ Test(filterx_expr, test_filterx_set_subscript)
   {
     .msgs = &msg,
     .num_msg = 1,
-    .template_eval_options = &DEFAULT_TEMPLATE_EVAL_OPTIONS,
+    .template_eval_options = DEFAULT_TEMPLATE_EVAL_OPTIONS,
     .scope = scope,
   };
   filterx_eval_set_context(&context);
@@ -469,7 +469,7 @@ Test(filterx_expr, test_filterx_readonly)
   {
     .msgs = &msg,
     .num_msg = 1,
-    .template_eval_options = &DEFAULT_TEMPLATE_EVAL_OPTIONS,
+    .template_eval_options = DEFAULT_TEMPLATE_EVAL_OPTIONS,
     .scope = scope,
   };
   filterx_eval_set_context(&context);

--- a/libtest/filterx-lib.c
+++ b/libtest/filterx-lib.c
@@ -155,7 +155,7 @@ init_libtest_filterx(void)
   {
     .msgs = &filterx_env.msg,
     .num_msg = 1,
-    .template_eval_options = &DEFAULT_TEMPLATE_EVAL_OPTIONS,
+    .template_eval_options = DEFAULT_TEMPLATE_EVAL_OPTIONS,
     .scope = filterx_env.scope,
   };
   filterx_eval_set_context(&filterx_env.context);


### PR DESCRIPTION
FilterXEvalContext->template_eval_options was stored on an unrolled stack location.


