### PR TITLE
filterx: `cached_json_file()` refcount fix

### DIFF
--- a/lib/filterx/filterx-object.c
+++ b/lib/filterx/filterx-object.c
@@ -112,17 +112,23 @@ filterx_object_new(FilterXType *type)
 gboolean
 filterx_object_freeze(FilterXObject *self)
 {
-  if (self->ref_cnt == FILTERX_OBJECT_MAGIC_BIAS)
+  if (filterx_object_is_frozen(self))
     return FALSE;
   g_assert(self->ref_cnt == 1);
   self->ref_cnt = FILTERX_OBJECT_MAGIC_BIAS;
   return TRUE;
 }
 
+gboolean
+filterx_object_is_frozen(FilterXObject *self)
+{
+  return self->ref_cnt == FILTERX_OBJECT_MAGIC_BIAS;
+}
+
 void
 filterx_object_unfreeze_and_free(FilterXObject *self)
 {
-  g_assert(self->ref_cnt == FILTERX_OBJECT_MAGIC_BIAS);
+  g_assert(filterx_object_is_frozen(self));
   self->ref_cnt = 1;
   filterx_object_unref(self);
 }
@@ -133,7 +139,7 @@ filterx_object_ref(FilterXObject *self)
   if (!self)
     return NULL;
 
-  if (self->ref_cnt == FILTERX_OBJECT_MAGIC_BIAS)
+  if (filterx_object_is_frozen(self))
     return self;
   self->ref_cnt++;
   return self;
@@ -145,7 +151,7 @@ filterx_object_unref(FilterXObject *self)
   if (!self)
     return;
 
-  if (self->ref_cnt == FILTERX_OBJECT_MAGIC_BIAS)
+  if (filterx_object_is_frozen(self))
     return;
 
   /* this asserts that the 16 bit wide thread_index suffices to hold a

--- a/lib/filterx/filterx-object.h
+++ b/lib/filterx/filterx-object.h
@@ -98,6 +98,7 @@ FilterXObject *filterx_object_new(FilterXType *type);
 FilterXObject *filterx_object_ref(FilterXObject *self);
 void filterx_object_unref(FilterXObject *self);
 gboolean filterx_object_freeze(FilterXObject *self);
+gboolean filterx_object_is_frozen(FilterXObject *self);
 void filterx_object_unfreeze_and_free(FilterXObject *self);
 void filterx_object_init_instance(FilterXObject *self, FilterXType *type);
 void filterx_object_free_method(FilterXObject *self);

--- a/lib/filterx/object-json.c
+++ b/lib/filterx/object-json.c
@@ -124,7 +124,8 @@ filterx_json_convert_json_to_object_cached(FilterXObject *self, FilterXWeakRef *
     return filterx_object_ref(filterx_obj);
 
   filterx_obj = _convert_json_to_object(self, root_container, jso);
-  filterx_json_associate_cached_object(jso, filterx_obj);
+  if (!filterx_object_is_frozen(self))
+    filterx_json_associate_cached_object(jso, filterx_obj);
   return filterx_obj;
 }
 


### PR DESCRIPTION
Fixes
```
log "cache-json-file" {
  source { example-msg-generator(); };

  filterx {
    js = cache_json_file("/tmp/test.json");
    js.foo;
  };

  destination { stdout(template("$MSG\n")); };
};
```