### PR TITLE
otel: hostname handling

### DIFF
--- a/modules/grpc/otel/otel-grammar.ym
+++ b/modules/grpc/otel/otel-grammar.ym
@@ -74,6 +74,7 @@ GrpcClientCredentialsBuilderW *last_grpc_client_credentials_builder;
 %token KW_BATCH_BYTES
 %token KW_CONCURRENT_REQUESTS
 %token KW_CHANNEL_ARGS
+%token KW_SET_HOSTNAME
 
 %type <ptr> source_otel
 %type <ptr> parser_otel
@@ -143,6 +144,7 @@ parser_otel_options
 
 parser_otel_option
   : parser_opt
+  | KW_SET_HOSTNAME '(' yesno ')' { otel_protobuf_parser_set_hostname(last_parser, $3); }
   ;
 
 destination_otel
@@ -294,4 +296,3 @@ grpc_client_credentials_builder_alts_target_service_accounts
 /* INCLUDE_RULES */
 
 %%
-

--- a/modules/grpc/otel/otel-parser.c
+++ b/modules/grpc/otel/otel-parser.c
@@ -52,6 +52,7 @@ static CfgLexerKeyword otel_keywords[] =
   { "batch_bytes",               KW_BATCH_BYTES },
   { "concurrent_requests",       KW_CONCURRENT_REQUESTS },
   { "channel_args",              KW_CHANNEL_ARGS },
+  { "set_hostname",              KW_SET_HOSTNAME },
   { NULL }
 };
 

--- a/modules/grpc/otel/otel-protobuf-parser.cpp
+++ b/modules/grpc/otel/otel-protobuf-parser.cpp
@@ -218,18 +218,6 @@ _add_repeated_KeyValue_fields(LogMessage *msg, const char *key, const RepeatedPt
   _add_repeated_KeyValue_fields_with_prefix(msg, key_buffer, 0, key, key_values);
 }
 
-static std::string
-_extract_hostname(const grpc::string &peer)
-{
-  size_t first = peer.find_first_of(':');
-  size_t last = peer.find_last_of(':');
-
-  if (first != grpc::string::npos && last != grpc::string::npos)
-    return peer.substr(first + 1, last - first - 1);
-
-  return "";
-}
-
 static GSockAddr *
 _extract_saddr(const grpc::string &peer)
 {
@@ -1112,11 +1100,6 @@ syslogng::grpc::otel::ProtobufParser::store_raw_metadata(LogMessage *msg, const 
                                                          const std::string &scope_schema_url)
 {
   std::string serialized;
-
-  /* HOST */
-  std::string hostname = _extract_hostname(peer);
-  if (hostname.length())
-    log_msg_set_value(msg, LM_V_HOST, hostname.c_str(), hostname.length());
 
   msg->saddr = _extract_saddr(peer);
 

--- a/modules/grpc/otel/otel-protobuf-parser.h
+++ b/modules/grpc/otel/otel-protobuf-parser.h
@@ -32,6 +32,7 @@
 typedef struct OtelProtobufParser_ OtelProtobufParser;
 
 LogParser *otel_protobuf_parser_new(GlobalConfig *cfg);
+void otel_protobuf_parser_set_hostname(LogParser *s, gboolean set_hostname);
 
 #include "compat/cpp-end.h"
 

--- a/modules/grpc/otel/otel-protobuf-parser.hpp
+++ b/modules/grpc/otel/otel-protobuf-parser.hpp
@@ -53,6 +53,11 @@ class ProtobufParser
 public:
   bool process(LogMessage *msg);
 
+  void set_hostname(bool s)
+  {
+    this->set_host = s;
+  }
+
   static void store_raw_metadata(LogMessage *msg, const ::grpc::string &peer,
                                  const Resource &resource, const std::string &resource_schema_url,
                                  const InstrumentationScope &scope, const std::string &scope_schema_url);
@@ -69,6 +74,9 @@ private:
   static void set_syslog_ng_macros(LogMessage *msg, const KeyValueList &macros);
   static void set_syslog_ng_address(LogMessage *msg, GSockAddr **sa, const KeyValueList &addr);
   static void parse_syslog_ng_tags(LogMessage *msg, const std::string &tags_as_str);
+
+private:
+  bool set_host = true;
 };
 
 }

--- a/modules/grpc/otel/otel-source.cpp
+++ b/modules/grpc/otel/otel-source.cpp
@@ -121,6 +121,12 @@ syslogng::grpc::otel::SourceDriver::init()
   if (fetch_limit == -1)
     fetch_limit = super->super.worker_options.super.init_window_size;
 
+  /*
+   * syslog-ng-otlp(): the original HOST is always kept
+   * opentelemetry(): there is no parsing in this source, HOST always falls back to saddr (LogSource)
+   */
+  super->super.worker_options.super.keep_hostname = TRUE;
+
   return log_threaded_source_driver_init_method(&super->super.super.super.super);
 }
 

--- a/modules/grpc/otel/tests/test-otel-protobuf-parser.cpp
+++ b/modules/grpc/otel/tests/test-otel-protobuf-parser.cpp
@@ -143,6 +143,10 @@ Test(otel_protobuf_parser, metadata)
   bytes_attr->set_key("bytes_key");
   bytes_attr->mutable_value()->set_bytes_value({0, 1, 2, 3, 4, 5, 6, 7});
 
+  KeyValue *hostname = resource.add_attributes();
+  hostname->set_key("host.name");
+  hostname->mutable_value()->set_string_value("myhost");
+
   std::string scope_schema_url = "my_scope_schema_url";
 
   LogMessage *msg = log_msg_new_empty();
@@ -152,6 +156,7 @@ Test(otel_protobuf_parser, metadata)
 
   cr_assert(msg->saddr != NULL);
   _assert_log_msg_value(msg, "SOURCEIP", "::1", -1, LM_VT_STRING);
+  _assert_log_msg_value(msg, "HOST", "myhost", -1, LM_VT_STRING);
 
   _assert_log_msg_value(msg, ".otel.resource.attributes.null_key", "", -1, LM_VT_NULL);
   _assert_log_msg_value(msg, ".otel.resource.attributes.string_key", "string_attribute", -1, LM_VT_STRING);


### PR DESCRIPTION
`keep-hostname(yes/no)` won't work in `opentelemetry()`/`syslog-ng-otlp()`, because
  - we want to allow the same port (driver) to be used for `syslog-ng-otlp()` and `opentelemetry()`
  - we always want to store the original hostname in `syslog-ng-otlp()`
  - we don't want to parse anything in `opentelemetry()`, we have a separate parser for that

Instead of implementing `keep-hostname(yes/no)` scenarios for these 2 sources, we ignore this flag. `syslog-ng-otlp()` keeps the original hostname, `opentelemetry()` doesn't do anything, so it falls back to using the peer address (saddr) as HOST. 

(The code forces `keep-hostname(yes)` on both sources, but in practice the above is done due to the fallback mechanism.)
 
For the `opentelemetry()` parser, the `set-hostname(yes/no)` option is introduced, `yes` is the default.
It extracts the `host.name` attribute if available, or leaves the HOST field as-is (https://opentelemetry.io/docs/specs/semconv/attributes-registry/host/).

With these defaults the `syslog-ng-otlp() + opentelemetry()` parser scenario ends up being correct, we'll get the original hostname regardless of where the message originally came from (OTLP, syslog, etc.).