### PR TITLE
filterx: fix ${variable} references in lexer

### DIFF
--- a/lib/cfg-lex.l
+++ b/lib/cfg-lex.l
@@ -348,7 +348,7 @@ filterx_word	[^ \#'"/\(\)\{\}\[\]\\;\r\n\t,|\.@:]
 
     /* and this is the version in filterx, which only allows "traditional" identifiers */
 <filterx>[a-zA-Z][_a-zA-Z0-9]* 	   { return cfg_lexer_map_word_to_token(yyextra, yylval, yylloc, yytext); }
-<filterx>\$\{({filterx_word}+(\.)?)*{filterx_word}+\}   { yylval->cptr = strndup(yytext+2, strlen(yytext) - 3); return LL_MESSAGE_REF; }
+<filterx>\$\{([^}]+)\}   { yylval->cptr = strndup(yytext+2, strlen(yytext) - 3); return LL_MESSAGE_REF; }
 <INITIAL>\,	   	   ;
 
 <INITIAL,filterx>\"        {

--- a/tests/light/functional_tests/filterx/test_filterx_scope.py
+++ b/tests/light/functional_tests/filterx/test_filterx_scope.py
@@ -111,6 +111,26 @@ def test_message_tied_variables_are_propagated_to_the_output(config, syslog_ng):
     assert file_true.read_log() == "kecske\n"
 
 
+def test_message_tied_variables_in_braces_are_propagated_to_the_output(config, syslog_ng):
+    (file_true, file_false, _) = create_config(
+        config, [
+            """
+                ${.foo.bar.baz} = "kecske";
+                isset(${.foo.bar.baz});
+            """,
+            """
+                isset(${.foo.bar.baz});
+                $MSG = ${.foo.bar.baz};
+            """,
+        ],
+    )
+    syslog_ng.start(config)
+
+    assert file_true.get_stats()["processed"] == 1
+    assert "processed" not in file_false.get_stats()
+    assert file_true.read_log() == "kecske\n"
+
+
 def test_message_tied_variables_are_propagated_to_the_output_in_junctions(config, syslog_ng):
     (file_true, file_false, _) = create_config(
         config, init_exprs=[


### PR DESCRIPTION
Message-tied variables in braces were not processed properly in filterx expressions as the lexer regexp was incorrect.

This branch fixes that.
