### PR TITLE
filterx: named function arguments

### DIFF
--- a/lib/filterx/expr-function.h
+++ b/lib/filterx/expr-function.h
@@ -37,7 +37,7 @@ typedef struct _FilterXFunction
 
 typedef struct _FilterXFunctionArgs FilterXFunctionArgs;
 
-typedef FilterXFunction *(*FilterXFunctionCtor)(const gchar *, GList *, GError **);
+typedef FilterXFunction *(*FilterXFunctionCtor)(const gchar *, FilterXFunctionArgs *, GError **);
 
 #define FILTERX_FUNCTION_ERROR filterx_function_error_quark()
 GQuark filterx_function_error_quark(void);

--- a/lib/filterx/expr-function.h
+++ b/lib/filterx/expr-function.h
@@ -35,6 +35,8 @@ typedef struct _FilterXFunction
   gchar *function_name;
 } FilterXFunction;
 
+typedef struct _FilterXFunctionArgs FilterXFunctionArgs;
+
 typedef FilterXFunction *(*FilterXFunctionCtor)(const gchar *, GList *, GError **);
 
 #define FILTERX_FUNCTION_ERROR filterx_function_error_quark()
@@ -49,6 +51,15 @@ enum FilterXFunctionError
 void filterx_function_init_instance(FilterXFunction *s, const gchar *function_name);
 void filterx_function_free_method(FilterXFunction *s);
 
-FilterXExpr *filterx_function_lookup(GlobalConfig *cfg, const gchar *function_name, GList *arguments, GError **error);
+FilterXFunctionArgs *filterx_function_args_new(GList *positional_exprs);
+guint64 filterx_function_args_len(FilterXFunctionArgs *self);
+FilterXExpr *filterx_function_args_get_expr(FilterXFunctionArgs *self, guint64 index);
+FilterXObject *filterx_function_args_get_object(FilterXFunctionArgs *self, guint64 index);
+const gchar *filterx_function_args_get_literal_string(FilterXFunctionArgs *self, guint64 index, gsize *len);
+gboolean filterx_function_args_is_literal_null(FilterXFunctionArgs *self, guint64 index);
+void filterx_function_args_free(FilterXFunctionArgs *self);
+
+FilterXExpr *filterx_function_lookup(GlobalConfig *cfg, const gchar *function_name, GList *positional_args,
+                                     GError **error);
 
 #endif

--- a/lib/filterx/expr-function.h
+++ b/lib/filterx/expr-function.h
@@ -36,6 +36,11 @@ typedef struct _FilterXFunction
 } FilterXFunction;
 
 typedef struct _FilterXFunctionArgs FilterXFunctionArgs;
+typedef struct _FilterXFunctionArg
+{
+  gchar *name;
+  FilterXExpr *value;
+} FilterXFunctionArg;
 
 typedef FilterXFunction *(*FilterXFunctionCtor)(const gchar *, FilterXFunctionArgs *, GError **);
 
@@ -51,15 +56,19 @@ enum FilterXFunctionError
 void filterx_function_init_instance(FilterXFunction *s, const gchar *function_name);
 void filterx_function_free_method(FilterXFunction *s);
 
-FilterXFunctionArgs *filterx_function_args_new(GList *positional_exprs);
+FilterXFunctionArg *filterx_function_arg_new(const gchar *name, FilterXExpr *value);
+FilterXFunctionArgs *filterx_function_args_new(GList *args, GError **error);
 guint64 filterx_function_args_len(FilterXFunctionArgs *self);
 FilterXExpr *filterx_function_args_get_expr(FilterXFunctionArgs *self, guint64 index);
 FilterXObject *filterx_function_args_get_object(FilterXFunctionArgs *self, guint64 index);
 const gchar *filterx_function_args_get_literal_string(FilterXFunctionArgs *self, guint64 index, gsize *len);
 gboolean filterx_function_args_is_literal_null(FilterXFunctionArgs *self, guint64 index);
+FilterXExpr *filterx_function_args_get_named_expr(FilterXFunctionArgs *self, const gchar *name);
+FilterXObject *filterx_function_args_get_named_object(FilterXFunctionArgs *self, const gchar *name, gboolean *exists);
+const gchar *filterx_function_args_get_named_literal_string(FilterXFunctionArgs *self, const gchar *name,
+                                                            gsize *len, gboolean *exists);
 void filterx_function_args_free(FilterXFunctionArgs *self);
 
-FilterXExpr *filterx_function_lookup(GlobalConfig *cfg, const gchar *function_name, GList *positional_args,
-                                     GError **error);
+FilterXExpr *filterx_function_lookup(GlobalConfig *cfg, const gchar *function_name, GList *args, GError **error);
 
 #endif

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -336,7 +336,8 @@ arguments
 	;
 
 argument
-	: expr
+	: expr					{ $$ = filterx_function_arg_new(NULL, $1); }
+	| string KW_ASSIGN expr			{ $$ = filterx_function_arg_new($1, $3); free($1); }
 	;
 
 literal: literal_object				{ $$ = filterx_literal_new(filterx_config_freeze_object(configuration, $1)); }

--- a/lib/filterx/filterx-private.h
+++ b/lib/filterx/filterx-private.h
@@ -27,7 +27,7 @@
 #include "filterx/expr-function.h"
 
 // Builtin functions
-FilterXExpr *filterx_simple_function_new(const gchar *function_name, GList *arguments,
+FilterXExpr *filterx_simple_function_new(const gchar *function_name, FilterXFunctionArgs *args,
                                          FilterXSimpleFunctionProto function_proto);
 
 gboolean filterx_builtin_simple_function_register_private(GHashTable *ht, const gchar *fn_name,

--- a/lib/filterx/func-istype.h
+++ b/lib/filterx/func-istype.h
@@ -27,6 +27,6 @@
 
 #include "filterx/expr-function.h"
 
-FilterXFunction *filterx_function_istype_new(const gchar *function_name, GList *argument_expressions, GError **error);
+FilterXFunction *filterx_function_istype_new(const gchar *function_name, FilterXFunctionArgs *args, GError **error);
 
 #endif

--- a/lib/filterx/object-datetime.h
+++ b/lib/filterx/object-datetime.h
@@ -34,8 +34,7 @@ FilterXObject *filterx_datetime_new(const UnixTime *ut);
 UnixTime filterx_datetime_get_value(FilterXObject *s);
 FilterXObject *filterx_typecast_datetime(GPtrArray *args);
 FilterXObject *filterx_typecast_datetime_isodate(GPtrArray *args);
-FilterXFunction *filterx_function_strptime_new(const gchar *function_name, GList *argument_expressions,
-                                               GError **error);
+FilterXFunction *filterx_function_strptime_new(const gchar *function_name, FilterXFunctionArgs *args, GError **error);
 
 gboolean datetime_repr(const UnixTime *ut, GString *repr);
 

--- a/lib/filterx/tests/test_builtin_functions.c
+++ b/lib/filterx/tests/test_builtin_functions.c
@@ -143,7 +143,7 @@ Test(builtin_functions, test_builtin_function_ctors_lookup)
   cr_assert(ctor != NULL);
 
   // check dummy ctor as result
-  FilterXFunction *func_expr = ctor(TEST_BUILTIN_FUNCTION_NAME, filterx_function_args_new(NULL), NULL);
+  FilterXFunction *func_expr = ctor(TEST_BUILTIN_FUNCTION_NAME, filterx_function_args_new(NULL, NULL), NULL);
   cr_assert(func_expr != NULL);
 
   FilterXObject *res = filterx_expr_eval(&func_expr->super);

--- a/lib/filterx/tests/test_builtin_functions.c
+++ b/lib/filterx/tests/test_builtin_functions.c
@@ -102,13 +102,13 @@ _dummy_eval(FilterXExpr *s)
 }
 
 static FilterXFunction *
-_test_builtin_dummy_function_ctor(const gchar *function_name, GList *argument_expressions, GError **error)
+_test_builtin_dummy_function_ctor(const gchar *function_name, FilterXFunctionArgs *args, GError **error)
 {
   FilterXFunction *self = g_new0(FilterXFunction, 1);
   filterx_function_init_instance(self, function_name);
   self->super.eval = _dummy_eval;
 
-  g_list_free_full(argument_expressions, (GDestroyNotify) filterx_expr_unref);
+  filterx_function_args_free(args);
   return self;
 }
 
@@ -143,7 +143,7 @@ Test(builtin_functions, test_builtin_function_ctors_lookup)
   cr_assert(ctor != NULL);
 
   // check dummy ctor as result
-  FilterXFunction *func_expr = ctor(TEST_BUILTIN_FUNCTION_NAME, NULL, NULL);
+  FilterXFunction *func_expr = ctor(TEST_BUILTIN_FUNCTION_NAME, filterx_function_args_new(NULL), NULL);
   cr_assert(func_expr != NULL);
 
   FilterXObject *res = filterx_expr_eval(&func_expr->super);

--- a/lib/filterx/tests/test_expr_condition.c
+++ b/lib/filterx/tests/test_expr_condition.c
@@ -355,7 +355,7 @@ Test(expr_condition, test_condition_return_null_on_illegal_expr)
 {
   GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
 
-  FilterXExpr *func = filterx_simple_function_new("test_fn", filterx_function_args_new(NULL), _fail_func);
+  FilterXExpr *func = filterx_simple_function_new("test_fn", filterx_function_args_new(NULL, NULL), _fail_func);
 
   FilterXExpr *cond = filterx_conditional_new_conditional_codeblock(func, stmts);
   FilterXObject *res = filterx_expr_eval(cond);
@@ -372,7 +372,7 @@ _dummy_func(GPtrArray *args)
 
 Test(expr_condition, test_condition_return_expr_result_on_missing_stmts)
 {
-  FilterXExpr *func = filterx_simple_function_new("test_fn", filterx_function_args_new(NULL), _dummy_func);
+  FilterXExpr *func = filterx_simple_function_new("test_fn", filterx_function_args_new(NULL, NULL), _dummy_func);
 
   FilterXExpr *cond = filterx_conditional_new_conditional_codeblock(func, NULL);
   FilterXObject *res = filterx_expr_eval(cond);

--- a/lib/filterx/tests/test_expr_condition.c
+++ b/lib/filterx/tests/test_expr_condition.c
@@ -355,7 +355,7 @@ Test(expr_condition, test_condition_return_null_on_illegal_expr)
 {
   GList *stmts = g_list_append(NULL, _assert_assign_var("$control-value", _string_to_filterXExpr("matching")));
 
-  FilterXExpr *func = filterx_simple_function_new("test_fn", NULL, _fail_func);
+  FilterXExpr *func = filterx_simple_function_new("test_fn", filterx_function_args_new(NULL), _fail_func);
 
   FilterXExpr *cond = filterx_conditional_new_conditional_codeblock(func, stmts);
   FilterXObject *res = filterx_expr_eval(cond);
@@ -372,7 +372,7 @@ _dummy_func(GPtrArray *args)
 
 Test(expr_condition, test_condition_return_expr_result_on_missing_stmts)
 {
-  FilterXExpr *func = filterx_simple_function_new("test_fn", NULL, _dummy_func);
+  FilterXExpr *func = filterx_simple_function_new("test_fn", filterx_function_args_new(NULL), _dummy_func);
 
   FilterXExpr *cond = filterx_conditional_new_conditional_codeblock(func, NULL);
   FilterXObject *res = filterx_expr_eval(cond);

--- a/lib/filterx/tests/test_expr_function.c
+++ b/lib/filterx/tests/test_expr_function.c
@@ -60,7 +60,8 @@ FilterXObject *test_dummy_function(GPtrArray *args)
 
 Test(expr_function, test_function_null_args)
 {
-  FilterXExpr *func = filterx_simple_function_new("test_dummy", filterx_function_args_new(NULL), test_dummy_function);
+  FilterXExpr *func = filterx_simple_function_new("test_dummy", filterx_function_args_new(NULL, NULL),
+                                                  test_dummy_function);
   cr_assert_not_null(func);
   filterx_expr_unref(func);
 }
@@ -68,8 +69,9 @@ Test(expr_function, test_function_null_args)
 Test(expr_function, test_function_null_arg)
 {
   GList *args = NULL;
-  args = g_list_append(args, NULL);
-  FilterXExpr *func = filterx_simple_function_new("test_dummy", filterx_function_args_new(args), test_dummy_function);
+  args = g_list_append(args, filterx_function_arg_new(NULL, NULL));
+  FilterXExpr *func = filterx_simple_function_new("test_dummy", filterx_function_args_new(args, NULL),
+                                                  test_dummy_function);
   cr_assert_not_null(func);
   filterx_expr_unref(func);
 }
@@ -77,9 +79,10 @@ Test(expr_function, test_function_null_arg)
 Test(expr_function, test_function_valid_arg)
 {
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("bad format 1", -1)));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("bad format 1", -1))));
 
-  FilterXExpr *func = filterx_simple_function_new("test_dummy", filterx_function_args_new(args), test_dummy_function);
+  FilterXExpr *func = filterx_simple_function_new("test_dummy", filterx_function_args_new(args, NULL),
+                                                  test_dummy_function);
   cr_assert_not_null(func);
 
   FilterXObject *res = filterx_expr_eval(func);
@@ -94,10 +97,11 @@ Test(expr_function, test_function_valid_arg)
 Test(expr_function, test_function_multiple_args)
 {
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_null_new()));
-  args = g_list_append(args, filterx_literal_new(filterx_integer_new(443)));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("foobar", -1)));
-  FilterXExpr *func = filterx_simple_function_new("test_dummy", filterx_function_args_new(args), test_dummy_function);
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_null_new())));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_integer_new(443))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("foobar", -1))));
+  FilterXExpr *func = filterx_simple_function_new("test_dummy", filterx_function_args_new(args, NULL),
+                                                  test_dummy_function);
   cr_assert_not_null(func);
   FilterXObject *res = filterx_expr_eval(func);
   cr_assert_not_null(res);

--- a/lib/filterx/tests/test_expr_function.c
+++ b/lib/filterx/tests/test_expr_function.c
@@ -60,7 +60,7 @@ FilterXObject *test_dummy_function(GPtrArray *args)
 
 Test(expr_function, test_function_null_args)
 {
-  FilterXExpr *func = filterx_simple_function_new("test_dummy", NULL, test_dummy_function);
+  FilterXExpr *func = filterx_simple_function_new("test_dummy", filterx_function_args_new(NULL), test_dummy_function);
   cr_assert_not_null(func);
   filterx_expr_unref(func);
 }
@@ -69,7 +69,7 @@ Test(expr_function, test_function_null_arg)
 {
   GList *args = NULL;
   args = g_list_append(args, NULL);
-  FilterXExpr *func = filterx_simple_function_new("test_dummy", args, test_dummy_function);
+  FilterXExpr *func = filterx_simple_function_new("test_dummy", filterx_function_args_new(args), test_dummy_function);
   cr_assert_not_null(func);
   filterx_expr_unref(func);
 }
@@ -79,7 +79,7 @@ Test(expr_function, test_function_valid_arg)
   GList *args = NULL;
   args = g_list_append(args, filterx_literal_new(filterx_string_new("bad format 1", -1)));
 
-  FilterXExpr *func = filterx_simple_function_new("test_dummy", args, test_dummy_function);
+  FilterXExpr *func = filterx_simple_function_new("test_dummy", filterx_function_args_new(args), test_dummy_function);
   cr_assert_not_null(func);
 
   FilterXObject *res = filterx_expr_eval(func);
@@ -97,7 +97,7 @@ Test(expr_function, test_function_multiple_args)
   args = g_list_append(args, filterx_literal_new(filterx_null_new()));
   args = g_list_append(args, filterx_literal_new(filterx_integer_new(443)));
   args = g_list_append(args, filterx_literal_new(filterx_string_new("foobar", -1)));
-  FilterXExpr *func = filterx_simple_function_new("test_dummy", args, test_dummy_function);
+  FilterXExpr *func = filterx_simple_function_new("test_dummy", filterx_function_args_new(args), test_dummy_function);
   cr_assert_not_null(func);
   FilterXObject *res = filterx_expr_eval(func);
   cr_assert_not_null(res);

--- a/lib/filterx/tests/test_func_istype.c
+++ b/lib/filterx/tests/test_func_istype.c
@@ -43,7 +43,7 @@ FILTERX_DEFINE_TYPE(dummy, FILTERX_TYPE_NAME(dummy_base));
 
 Test(filterx_func_istype, null_args)
 {
-  cr_assert_not(filterx_function_istype_new("istype", NULL, NULL));
+  cr_assert_not(filterx_function_istype_new("istype", filterx_function_args_new(NULL), NULL));
 }
 
 Test(filterx_func_istype, null_object_arg)
@@ -52,7 +52,7 @@ Test(filterx_func_istype, null_object_arg)
   args = g_list_append(args, NULL);
   args = g_list_append(args, filterx_literal_new(filterx_string_new("json_object", -1)));
 
-  cr_assert_not(filterx_function_istype_new("istype", args, NULL));
+  cr_assert_not(filterx_function_istype_new("istype", filterx_function_args_new(args), NULL));
 }
 
 Test(filterx_func_istype, null_type_arg)
@@ -61,7 +61,7 @@ Test(filterx_func_istype, null_type_arg)
   args = g_list_append(args, filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy))));
   args = g_list_append(args, NULL);
 
-  cr_assert_not(filterx_function_istype_new("istype", args, NULL));
+  cr_assert_not(filterx_function_istype_new("istype", filterx_function_args_new(args), NULL));
 }
 
 Test(filterx_func_istype, invalid_type_arg)
@@ -70,7 +70,7 @@ Test(filterx_func_istype, invalid_type_arg)
   args = g_list_append(args, filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy))));
   args = g_list_append(args, filterx_literal_new(filterx_integer_new(33)));
 
-  cr_assert_not(filterx_function_istype_new("istype", args, NULL));
+  cr_assert_not(filterx_function_istype_new("istype", filterx_function_args_new(args), NULL));
 }
 
 Test(filterx_func_istype, too_many_args)
@@ -80,7 +80,7 @@ Test(filterx_func_istype, too_many_args)
   args = g_list_append(args, filterx_literal_new(filterx_string_new("dummy", -1)));
   args = g_list_append(args, filterx_literal_new(filterx_string_new("dummy_base", -1)));
 
-  cr_assert_not(filterx_function_istype_new("istype", args, NULL));
+  cr_assert_not(filterx_function_istype_new("istype", filterx_function_args_new(args), NULL));
 }
 
 Test(filterx_func_istype, non_literal_type_arg)
@@ -97,7 +97,7 @@ Test(filterx_func_istype, non_literal_type_arg)
   args = g_list_append(args, filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy))));
   args = g_list_append(args, type_expr);
 
-  cr_assert_not(filterx_function_istype_new("istype", args, NULL));
+  cr_assert_not(filterx_function_istype_new("istype", filterx_function_args_new(args), NULL));
 }
 
 Test(filterx_func_istype, non_matching_type)
@@ -106,7 +106,7 @@ Test(filterx_func_istype, non_matching_type)
   args = g_list_append(args, filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy))));
   args = g_list_append(args, filterx_literal_new(filterx_string_new("string", -1)));
 
-  FilterXFunction *func_expr = filterx_function_istype_new("istype", args, NULL);
+  FilterXFunction *func_expr = filterx_function_istype_new("istype", filterx_function_args_new(args), NULL);
   cr_assert(func_expr);
 
   FilterXObject *result_obj = filterx_expr_eval(&func_expr->super);
@@ -126,7 +126,7 @@ Test(filterx_func_istype, matching_type)
   args = g_list_append(args, filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy))));
   args = g_list_append(args, filterx_literal_new(filterx_string_new("dummy", -1)));
 
-  FilterXFunction *func_expr = filterx_function_istype_new("istype", args, NULL);
+  FilterXFunction *func_expr = filterx_function_istype_new("istype", filterx_function_args_new(args), NULL);
   cr_assert(func_expr);
 
   FilterXObject *result_obj = filterx_expr_eval(&func_expr->super);
@@ -146,7 +146,7 @@ Test(filterx_func_istype, matching_type_for_super_type)
   args = g_list_append(args, filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy))));
   args = g_list_append(args, filterx_literal_new(filterx_string_new("dummy_base", -1)));
 
-  FilterXFunction *func_expr = filterx_function_istype_new("istype", args, NULL);
+  FilterXFunction *func_expr = filterx_function_istype_new("istype", filterx_function_args_new(args), NULL);
   cr_assert(func_expr);
 
   FilterXObject *result_obj = filterx_expr_eval(&func_expr->super);
@@ -166,7 +166,7 @@ Test(filterx_func_istype, matching_type_for_root_type)
   args = g_list_append(args, filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy))));
   args = g_list_append(args, filterx_literal_new(filterx_string_new("object", -1)));
 
-  FilterXFunction *func_expr = filterx_function_istype_new("istype", args, NULL);
+  FilterXFunction *func_expr = filterx_function_istype_new("istype", filterx_function_args_new(args), NULL);
   cr_assert(func_expr);
 
   FilterXObject *result_obj = filterx_expr_eval(&func_expr->super);

--- a/lib/filterx/tests/test_func_istype.c
+++ b/lib/filterx/tests/test_func_istype.c
@@ -43,44 +43,47 @@ FILTERX_DEFINE_TYPE(dummy, FILTERX_TYPE_NAME(dummy_base));
 
 Test(filterx_func_istype, null_args)
 {
-  cr_assert_not(filterx_function_istype_new("istype", filterx_function_args_new(NULL), NULL));
+  cr_assert_not(filterx_function_istype_new("istype", filterx_function_args_new(NULL, NULL), NULL));
 }
 
 Test(filterx_func_istype, null_object_arg)
 {
   GList *args = NULL;
-  args = g_list_append(args, NULL);
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("json_object", -1)));
+  args = g_list_append(args, filterx_function_arg_new(NULL, NULL));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("json_object", -1))));
 
-  cr_assert_not(filterx_function_istype_new("istype", filterx_function_args_new(args), NULL));
+  cr_assert_not(filterx_function_istype_new("istype", filterx_function_args_new(args, NULL), NULL));
 }
 
 Test(filterx_func_istype, null_type_arg)
 {
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy))));
-  args = g_list_append(args, NULL);
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy)))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, NULL));
 
-  cr_assert_not(filterx_function_istype_new("istype", filterx_function_args_new(args), NULL));
+  cr_assert_not(filterx_function_istype_new("istype", filterx_function_args_new(args, NULL), NULL));
 }
 
 Test(filterx_func_istype, invalid_type_arg)
 {
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy))));
-  args = g_list_append(args, filterx_literal_new(filterx_integer_new(33)));
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy)))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_integer_new(33))));
 
-  cr_assert_not(filterx_function_istype_new("istype", filterx_function_args_new(args), NULL));
+  cr_assert_not(filterx_function_istype_new("istype", filterx_function_args_new(args, NULL), NULL));
 }
 
 Test(filterx_func_istype, too_many_args)
 {
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy))));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("dummy", -1)));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("dummy_base", -1)));
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy)))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("dummy", -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("dummy_base", -1))));
 
-  cr_assert_not(filterx_function_istype_new("istype", filterx_function_args_new(args), NULL));
+  cr_assert_not(filterx_function_istype_new("istype", filterx_function_args_new(args, NULL), NULL));
 }
 
 Test(filterx_func_istype, non_literal_type_arg)
@@ -94,19 +97,21 @@ Test(filterx_func_istype, non_literal_type_arg)
                                                      filterx_literal_new(filterx_integer_new(-1)));
 
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy))));
-  args = g_list_append(args, type_expr);
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy)))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, type_expr));
 
-  cr_assert_not(filterx_function_istype_new("istype", filterx_function_args_new(args), NULL));
+  cr_assert_not(filterx_function_istype_new("istype", filterx_function_args_new(args, NULL), NULL));
 }
 
 Test(filterx_func_istype, non_matching_type)
 {
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy))));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("string", -1)));
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy)))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("string", -1))));
 
-  FilterXFunction *func_expr = filterx_function_istype_new("istype", filterx_function_args_new(args), NULL);
+  FilterXFunction *func_expr = filterx_function_istype_new("istype", filterx_function_args_new(args, NULL), NULL);
   cr_assert(func_expr);
 
   FilterXObject *result_obj = filterx_expr_eval(&func_expr->super);
@@ -123,10 +128,11 @@ Test(filterx_func_istype, non_matching_type)
 Test(filterx_func_istype, matching_type)
 {
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy))));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("dummy", -1)));
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy)))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("dummy", -1))));
 
-  FilterXFunction *func_expr = filterx_function_istype_new("istype", filterx_function_args_new(args), NULL);
+  FilterXFunction *func_expr = filterx_function_istype_new("istype", filterx_function_args_new(args, NULL), NULL);
   cr_assert(func_expr);
 
   FilterXObject *result_obj = filterx_expr_eval(&func_expr->super);
@@ -143,10 +149,11 @@ Test(filterx_func_istype, matching_type)
 Test(filterx_func_istype, matching_type_for_super_type)
 {
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy))));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("dummy_base", -1)));
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy)))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("dummy_base", -1))));
 
-  FilterXFunction *func_expr = filterx_function_istype_new("istype", filterx_function_args_new(args), NULL);
+  FilterXFunction *func_expr = filterx_function_istype_new("istype", filterx_function_args_new(args, NULL), NULL);
   cr_assert(func_expr);
 
   FilterXObject *result_obj = filterx_expr_eval(&func_expr->super);
@@ -163,10 +170,11 @@ Test(filterx_func_istype, matching_type_for_super_type)
 Test(filterx_func_istype, matching_type_for_root_type)
 {
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy))));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("object", -1)));
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_object_new(&FILTERX_TYPE_NAME(dummy)))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("object", -1))));
 
-  FilterXFunction *func_expr = filterx_function_istype_new("istype", filterx_function_args_new(args), NULL);
+  FilterXFunction *func_expr = filterx_function_istype_new("istype", filterx_function_args_new(args, NULL), NULL);
   cr_assert(func_expr);
 
   FilterXObject *result_obj = filterx_expr_eval(&func_expr->super);

--- a/lib/filterx/tests/test_object_datetime.c
+++ b/lib/filterx/tests/test_object_datetime.c
@@ -212,7 +212,7 @@ Test(filterx_datetime, test_filterx_datetime_repr_isodate_Z)
 
 Test(filterx_datetime, test_filterx_datetime_strptime_with_null_args)
 {
-  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", NULL, NULL);
+  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(NULL), NULL);
   cr_assert_null(func_expr);
 }
 
@@ -222,7 +222,7 @@ Test(filterx_datetime, test_filterx_datetime_strptime_without_args)
   args = g_list_append(args, NULL);
   args = g_list_append(args, NULL);
 
-  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", args, NULL);
+  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args), NULL);
   cr_assert_null(func_expr);
 }
 
@@ -232,7 +232,7 @@ Test(filterx_datetime, test_filterx_datetime_strptime_without_timefmt)
   GList *args = NULL;
   args = g_list_append(args, filterx_literal_new(filterx_string_new(test_time_str, -1)));
 
-  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", args, NULL);
+  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args), NULL);
   cr_assert_null(func_expr);
 }
 
@@ -243,7 +243,7 @@ Test(filterx_datetime, test_filterx_datetime_strptime_non_matching_timefmt)
   args = g_list_append(args, filterx_literal_new(filterx_string_new(test_time_str, -1)));
   args = g_list_append(args, filterx_literal_new(filterx_string_new("non matching timefmt", -1)));
 
-  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", args, NULL);
+  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args), NULL);
   cr_assert(func_expr);
 
   FilterXObject *obj = filterx_expr_eval(&func_expr->super);
@@ -261,7 +261,7 @@ Test(filterx_datetime, test_filterx_datetime_strptime_matching_timefmt)
   args = g_list_append(args, filterx_literal_new(filterx_string_new(test_time_str, -1)));
   args = g_list_append(args, filterx_literal_new(filterx_string_new(datefmt_isodate, -1)));
 
-  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", args, NULL);
+  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args), NULL);
   cr_assert(func_expr);
 
   FilterXObject *obj = filterx_expr_eval(&func_expr->super);
@@ -285,7 +285,7 @@ Test(filterx_datetime, test_filterx_datetime_strptime_matching_nth_timefmt)
   args = g_list_append(args, filterx_literal_new(filterx_string_new("bad format 2", -1)));
   args = g_list_append(args, filterx_literal_new(filterx_string_new(datefmt_isodate, -1)));
 
-  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", args, NULL);
+  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args), NULL);
   cr_assert(func_expr);
 
   FilterXObject *obj = filterx_expr_eval(&func_expr->super);
@@ -309,7 +309,7 @@ Test(filterx_datetime, test_filterx_datetime_strptime_non_matching_nth_timefmt)
   args = g_list_append(args, filterx_literal_new(filterx_string_new("bad format 2", -1)));
   args = g_list_append(args, filterx_literal_new(filterx_string_new("non matching fmt", -1)));
 
-  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", args, NULL);
+  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args), NULL);
   cr_assert(func_expr);
 
   FilterXObject *obj = filterx_expr_eval(&func_expr->super);
@@ -328,7 +328,7 @@ Test(filterx_datetime, test_filterx_datetime_strptime_invalid_arg_type)
   args = g_list_append(args, filterx_literal_new(filterx_integer_new(1337)));
   args = g_list_append(args, filterx_literal_new(filterx_string_new(datefmt_isodate, -1)));
 
-  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", args, NULL);
+  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args), NULL);
   cr_assert_null(func_expr);
 }
 
@@ -347,7 +347,7 @@ Test(filterx_datetime, test_filterx_datetime_strptime_with_non_literal_format)
   args = g_list_append(args, filterx_literal_new(filterx_string_new(test_time_str, -1)));
   args = g_list_append(args, format_expr);
 
-  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", args, NULL);
+  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args), NULL);
   cr_assert_null(func_expr);
 }
 

--- a/lib/filterx/tests/test_object_datetime.c
+++ b/lib/filterx/tests/test_object_datetime.c
@@ -212,17 +212,18 @@ Test(filterx_datetime, test_filterx_datetime_repr_isodate_Z)
 
 Test(filterx_datetime, test_filterx_datetime_strptime_with_null_args)
 {
-  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(NULL), NULL);
+  GError *error = NULL;
+  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(NULL, &error), NULL);
   cr_assert_null(func_expr);
 }
 
 Test(filterx_datetime, test_filterx_datetime_strptime_without_args)
 {
   GList *args = NULL;
-  args = g_list_append(args, NULL);
-  args = g_list_append(args, NULL);
+  args = g_list_append(args, filterx_function_arg_new(NULL, NULL));
+  args = g_list_append(args, filterx_function_arg_new(NULL, NULL));
 
-  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args), NULL);
+  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args, NULL), NULL);
   cr_assert_null(func_expr);
 }
 
@@ -230,9 +231,9 @@ Test(filterx_datetime, test_filterx_datetime_strptime_without_timefmt)
 {
   const gchar *test_time_str = "2024-04-08T10:11:12Z";
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_string_new(test_time_str, -1)));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new(test_time_str, -1))));
 
-  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args), NULL);
+  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args, NULL), NULL);
   cr_assert_null(func_expr);
 }
 
@@ -240,10 +241,11 @@ Test(filterx_datetime, test_filterx_datetime_strptime_non_matching_timefmt)
 {
   const gchar *test_time_str = "2024-04-08T10:11:12Z";
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_string_new(test_time_str, -1)));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("non matching timefmt", -1)));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new(test_time_str, -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("non matching timefmt",
+                                                      -1))));
 
-  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args), NULL);
+  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args, NULL), NULL);
   cr_assert(func_expr);
 
   FilterXObject *obj = filterx_expr_eval(&func_expr->super);
@@ -258,10 +260,11 @@ Test(filterx_datetime, test_filterx_datetime_strptime_matching_timefmt)
 {
   const gchar *test_time_str = "2024-04-08T10:11:12Z";
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_string_new(test_time_str, -1)));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new(datefmt_isodate, -1)));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new(test_time_str, -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new(datefmt_isodate,
+                                                      -1))));
 
-  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args), NULL);
+  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args, NULL), NULL);
   cr_assert(func_expr);
 
   FilterXObject *obj = filterx_expr_eval(&func_expr->super);
@@ -280,12 +283,13 @@ Test(filterx_datetime, test_filterx_datetime_strptime_matching_nth_timefmt)
 {
   const gchar *test_time_str = "2024-04-08T10:11:12+01:00";
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_string_new(test_time_str, -1)));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("bad format 1", -1)));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("bad format 2", -1)));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new(datefmt_isodate, -1)));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new(test_time_str, -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("bad format 1", -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("bad format 2", -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new(datefmt_isodate,
+                                                      -1))));
 
-  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args), NULL);
+  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args, NULL), NULL);
   cr_assert(func_expr);
 
   FilterXObject *obj = filterx_expr_eval(&func_expr->super);
@@ -304,12 +308,13 @@ Test(filterx_datetime, test_filterx_datetime_strptime_non_matching_nth_timefmt)
 {
   const gchar *test_time_str = "2024-04-08T10:11:12Z";
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_string_new(test_time_str, -1)));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("bad format 1", -1)));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("bad format 2", -1)));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("non matching fmt", -1)));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new(test_time_str, -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("bad format 1", -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("bad format 2", -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("non matching fmt",
+                                                      -1))));
 
-  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args), NULL);
+  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args, NULL), NULL);
   cr_assert(func_expr);
 
   FilterXObject *obj = filterx_expr_eval(&func_expr->super);
@@ -324,11 +329,12 @@ Test(filterx_datetime, test_filterx_datetime_strptime_invalid_arg_type)
 {
   const gchar *test_time_str = "2024-04-08T10:11:12Z";
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_string_new(test_time_str, -1)));
-  args = g_list_append(args, filterx_literal_new(filterx_integer_new(1337)));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new(datefmt_isodate, -1)));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new(test_time_str, -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_integer_new(1337))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new(datefmt_isodate,
+                                                      -1))));
 
-  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args), NULL);
+  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args, NULL), NULL);
   cr_assert_null(func_expr);
 }
 
@@ -344,11 +350,11 @@ Test(filterx_datetime, test_filterx_datetime_strptime_with_non_literal_format)
 
   const gchar *test_time_str = "2024-04-08T10:11:12Z";
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_string_new(test_time_str, -1)));
-  args = g_list_append(args, format_expr);
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new(test_time_str, -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, format_expr));
 
-  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args), NULL);
-  cr_assert_null(func_expr);
+  FilterXFunction *func_expr = filterx_function_strptime_new("strptime", filterx_function_args_new(args, NULL), NULL);
+  cr_assert_null(func_expr, "%p", func_expr);
 }
 
 static void

--- a/modules/json/filterx-cache-json-file.h
+++ b/modules/json/filterx-cache-json-file.h
@@ -24,7 +24,7 @@
 #include "filterx/expr-function.h"
 #include "plugin.h"
 
-FilterXFunction *filterx_function_cache_json_file_new(const gchar *function_name, GList *argument_expressions,
+FilterXFunction *filterx_function_cache_json_file_new(const gchar *function_name, FilterXFunctionArgs *args,
                                                       GError **error);
 gpointer filterx_function_cache_json_file_new_construct(Plugin *self);
 

--- a/modules/kvformat/filterx-func-format-kv.c
+++ b/modules/kvformat/filterx-func-format-kv.c
@@ -123,92 +123,63 @@ _free(FilterXExpr *s)
 }
 
 static gboolean
-_extract_value_separator_arg(FilterXFunctionFormatKV *self, FilterXExpr *value_separator_expr, GError **error)
+_extract_value_separator_arg(FilterXFunctionFormatKV *self, FilterXFunctionArgs *args, GError **error)
 {
-  FilterXObject *value_separator_obj = filterx_expr_eval_typed(value_separator_expr);
+  if (filterx_function_args_is_literal_null(args, 1))
+    return TRUE;
 
-  if (!value_separator_obj ||
-      !(filterx_object_is_type(value_separator_obj, &FILTERX_TYPE_NAME(null)) ||
-        filterx_object_is_type(value_separator_obj, &FILTERX_TYPE_NAME(string))) ||
-      !filterx_expr_is_literal(value_separator_expr))
+  gsize value_separator_len;
+  const gchar *value_separator = filterx_function_args_get_literal_string(args, 1, &value_separator_len);
+  if (!value_separator)
     {
       g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
                   "value_separator must be a string literal or null. " FILTERX_FUNC_FORMAT_KV_USAGE);
-      filterx_object_unref(value_separator_obj);
       return FALSE;
     }
 
-  if (filterx_object_is_type(value_separator_obj, &FILTERX_TYPE_NAME(null)))
-    {
-      filterx_object_unref(value_separator_obj);
-      return TRUE;
-    }
-
-  gsize value_separator_len;
-  const gchar *value_separator_str = filterx_string_get_value(value_separator_obj, &value_separator_len);
   if (value_separator_len != 1)
     {
       g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
                   "value_separator must be a single character. " FILTERX_FUNC_FORMAT_KV_USAGE);
-      filterx_object_unref(value_separator_obj);
       return FALSE;
     }
 
-  self->value_separator = value_separator_str[0];
-  filterx_object_unref(value_separator_obj);
+  self->value_separator = value_separator[0];
   return TRUE;
 }
 
 static gboolean
-_extract_pair_separator_arg(FilterXFunctionFormatKV *self, FilterXExpr *pair_separator_expr, GError **error)
+_extract_pair_separator_arg(FilterXFunctionFormatKV *self, FilterXFunctionArgs *args, GError **error)
 {
-  FilterXObject *pair_separator_obj = filterx_expr_eval_typed(pair_separator_expr);
+  if (filterx_function_args_is_literal_null(args, 2))
+    return TRUE;
 
-  if (!pair_separator_obj ||
-      !(filterx_object_is_type(pair_separator_obj, &FILTERX_TYPE_NAME(null)) ||
-        filterx_object_is_type(pair_separator_obj, &FILTERX_TYPE_NAME(string))) ||
-      !filterx_expr_is_literal(pair_separator_expr))
-    {
-      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
-                  "pair_separator must be a string literal or null. " FILTERX_FUNC_FORMAT_KV_USAGE);
-      filterx_object_unref(pair_separator_obj);
-      return FALSE;
-    }
-
-  if (filterx_object_is_type(pair_separator_obj, &FILTERX_TYPE_NAME(null)))
-    {
-      filterx_object_unref(pair_separator_obj);
-      return TRUE;
-    }
-
-  gsize pair_separator_len;
-  const gchar *pair_separator_str = filterx_string_get_value(pair_separator_obj, &pair_separator_len);
+  gsize pair_separator_len = 0;
+  const gchar *pair_separator = filterx_function_args_get_literal_string(args, 2, &pair_separator_len);
   if (pair_separator_len == 0)
     {
       g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
                   "pair_separator must be non-zero length. " FILTERX_FUNC_FORMAT_KV_USAGE);
-      filterx_object_unref(pair_separator_obj);
       return FALSE;
     }
 
   g_free(self->pair_separator);
-  self->pair_separator = g_strdup(pair_separator_str);
-  filterx_object_unref(pair_separator_obj);
+  self->pair_separator = g_strdup(pair_separator);
   return TRUE;
 }
 
 static gboolean
-_extract_arguments(FilterXFunctionFormatKV *self, GList *argument_expressions, GError **error)
+_extract_arguments(FilterXFunctionFormatKV *self, FilterXFunctionArgs *args, GError **error)
 {
-  gsize arguments_len = argument_expressions ? g_list_length(argument_expressions) : 0;
-  if (arguments_len < 1 || arguments_len > 3)
+  gsize args_len = filterx_function_args_len(args);
+  if (args_len < 1 || args_len > 3)
     {
       g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
                   "invalid number of arguments. " FILTERX_FUNC_FORMAT_KV_USAGE);
       return FALSE;
     }
 
-  self->kvs = filterx_expr_ref((FilterXExpr *) argument_expressions->data);
+  self->kvs = filterx_function_args_get_expr(args, 0);
   if (!self->kvs)
     {
       g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
@@ -216,27 +187,23 @@ _extract_arguments(FilterXFunctionFormatKV *self, GList *argument_expressions, G
       return FALSE;
     }
 
-  if (!argument_expressions->next)
+  if (args_len < 2)
     return TRUE;
 
-  FilterXExpr *value_separator_expr = (FilterXExpr *) argument_expressions->next->data;
-  if (value_separator_expr && !_extract_value_separator_arg(self, value_separator_expr, error))
+  if (!_extract_value_separator_arg(self, args, error))
     return FALSE;
 
-  if (!argument_expressions->next->next)
+  if (args_len < 3)
     return TRUE;
 
-  FilterXExpr *pair_separator_expr = (FilterXExpr *) argument_expressions->next->next->data;
-  if (pair_separator_expr && !_extract_pair_separator_arg(self, pair_separator_expr, error))
+  if (!_extract_pair_separator_arg(self, args, error))
     return FALSE;
-
-  g_assert(!argument_expressions->next->next->next);
 
   return TRUE;
 }
 
 FilterXFunction *
-filterx_function_format_kv_new(const gchar *function_name, GList *argument_expressions, GError **error)
+filterx_function_format_kv_new(const gchar *function_name, FilterXFunctionArgs *args, GError **error)
 {
   FilterXFunctionFormatKV *self = g_new0(FilterXFunctionFormatKV, 1);
   filterx_function_init_instance(&self->super, function_name);
@@ -246,14 +213,14 @@ filterx_function_format_kv_new(const gchar *function_name, GList *argument_expre
   self->value_separator = '=';
   self->pair_separator = g_strdup(", ");
 
-  if (!_extract_arguments(self, argument_expressions, error))
+  if (!_extract_arguments(self, args, error))
     goto error;
 
-  g_list_free_full(argument_expressions, (GDestroyNotify) filterx_expr_unref);
+  filterx_function_args_free(args);
   return &self->super;
 
 error:
-  g_list_free_full(argument_expressions, (GDestroyNotify) filterx_expr_unref);
+  filterx_function_args_free(args);
   filterx_expr_unref(&self->super.super);
   return NULL;
 }

--- a/modules/kvformat/filterx-func-format-kv.h
+++ b/modules/kvformat/filterx-func-format-kv.h
@@ -26,8 +26,7 @@
 #include "plugin.h"
 #include "filterx/expr-function.h"
 
-FilterXFunction *filterx_function_format_kv_new(const gchar *function_name, GList *argument_expressions,
-                                                GError **error);
+FilterXFunction *filterx_function_format_kv_new(const gchar *function_name, FilterXFunctionArgs *args, GError **error);
 gpointer filterx_function_construct_format_kv(Plugin *self);
 
 #endif

--- a/modules/kvformat/filterx-func-parse-kv.c
+++ b/modules/kvformat/filterx-func-parse-kv.c
@@ -34,17 +34,19 @@
 #include "parser/parser-expr.h"
 #include "scratch-buffers.h"
 
-#define PARSE_KV_OPTS_COUNT 3
+#define PARSE_KV_OPTS_COUNT (4)
 
 enum parse_kv_opts
 {
-  PARSE_KV_OPTS_VALUE_SEP = 0,
-  PARSE_KV_OPTS_PAIR_SEP = 1,
-  PARSE_KV_OPTS_STRAY_WORDS_KEY = 2,
+  PARSE_KV_OPTS_MSG = 0,
+  PARSE_KV_OPTS_VALUE_SEP = 1,
+  PARSE_KV_OPTS_PAIR_SEP = 2,
+  PARSE_KV_OPTS_STRAY_WORDS_KEY = 3,
 };
 
 static const gchar *parse_kv_opts_names[PARSE_KV_OPTS_COUNT] =
 {
+  "msg",
   "value_separator",
   "pair_separator",
   "stray_words_key"
@@ -215,9 +217,9 @@ _free(FilterXExpr *s)
 }
 
 static FilterXExpr *
-_extract_parse_kv_msg_expr(GList *argument_expressions, GError **error)
+_extract_parse_kv_msg_expr(FilterXFunctionArgs *args, GError **error)
 {
-  FilterXExpr *msg_expr = filterx_expr_ref(((FilterXExpr *) argument_expressions->data));
+  FilterXExpr *msg_expr = filterx_function_args_get_expr(args, 0);
   if (!msg_expr)
     {
       g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
@@ -229,72 +231,56 @@ _extract_parse_kv_msg_expr(GList *argument_expressions, GError **error)
 }
 
 static gboolean
-_extract_parse_kv_opts(FilterXFunctionParseKV *self, GList *argument_expressions, GError **error)
+_extract_parse_kv_opts(FilterXFunctionParseKV *self, FilterXFunctionArgs *args, GError **error)
 {
-  gsize arguments_len = argument_expressions ? g_list_length(argument_expressions) : 0;
-  if (arguments_len < 1)
+  guint64 args_len = filterx_function_args_len(args);
+
+  for (guint i = 1; i < args_len; i++)
+    {
+      g_assert(i < PARSE_KV_OPTS_COUNT);
+
+      if (filterx_function_args_is_literal_null(args, i))
+        continue;
+
+      const gchar *arg_str = filterx_function_args_get_literal_string(args, i, NULL);
+      if (!arg_str)
+        {
+          g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                      "%s argument must be string literal or null. " FILTERX_FUNC_PARSE_KV_USAGE,
+                      parse_kv_opts_names[i]);
+          return FALSE;
+        }
+
+      if (!_apply_parse_kv_option(self, i, arg_str, error))
+        return FALSE;
+    }
+
+  return TRUE;
+}
+
+static gboolean
+_extract_args(FilterXFunctionParseKV *self, FilterXFunctionArgs *args, GError **error)
+{
+  gsize args_len = filterx_function_args_len(args);
+  if (args_len < 1 || args_len > PARSE_KV_OPTS_COUNT)
     {
       g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
                   "invalid number of arguments. " FILTERX_FUNC_PARSE_KV_USAGE);
       return FALSE;
     }
 
-  FilterXObject *format_obj = NULL;
-  guint32 i = 0;
-  for (GList *elem = argument_expressions->next; elem; elem = elem->next)
-    {
-      if (i >= PARSE_KV_OPTS_COUNT)
-        break;
+  self->msg = _extract_parse_kv_msg_expr(args, error);
+  if (!self->msg)
+    return FALSE;
 
-      FilterXExpr *argument_expr = (FilterXExpr *) elem->data;
-
-      if (!argument_expr || !filterx_expr_is_literal(argument_expr))
-        {
-          g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
-                      "%s argument must be string literal. " FILTERX_FUNC_PARSE_KV_USAGE,
-                      parse_kv_opts_names[i]);
-          return FALSE;
-        }
-
-      format_obj = filterx_expr_eval(argument_expr);
-      if (!format_obj)
-        {
-          g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
-                      "%s argument. " FILTERX_FUNC_PARSE_KV_USAGE, parse_kv_opts_names[i]);
-          goto error;
-        }
-
-      if (filterx_object_is_type(format_obj, &FILTERX_TYPE_NAME(string)))
-        {
-          gsize format_len;
-          const gchar *opt = filterx_string_get_value(format_obj, &format_len);
-
-          if (!opt)
-            {
-              g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
-                          "%s argument must be string literal. " FILTERX_FUNC_PARSE_KV_USAGE,
-                          parse_kv_opts_names[i]);
-              goto error;
-            }
-
-          if (!_apply_parse_kv_option(self, i, opt, error))
-            goto error;
-        }
-
-      filterx_object_unref(format_obj);
-      i++;
-    }
+  if (!_extract_parse_kv_opts(self, args, error))
+    return FALSE;
 
   return TRUE;
-
-error:
-  filterx_object_unref(format_obj);
-  return FALSE  ;
 }
 
-FilterXExpr *
-filterx_function_parse_kv_new(const gchar *function_name, GList *argument_expressions, GError **error)
-
+FilterXFunction *
+filterx_function_parse_kv_new(const gchar *function_name, FilterXFunctionArgs *args, GError **error)
 {
   FilterXFunctionParseKV *self = g_new0(FilterXFunctionParseKV, 1);
   filterx_function_init_instance(&self->super, function_name);
@@ -303,18 +289,14 @@ filterx_function_parse_kv_new(const gchar *function_name, GList *argument_expres
   self->value_separator = '=';
   self->pair_separator = g_strdup(", ");
 
-  if (!_extract_parse_kv_opts(self, argument_expressions, error))
+  if (!_extract_args(self, args, error))
     goto error;
 
-  self->msg = _extract_parse_kv_msg_expr(argument_expressions, error);
-  if (!self->msg)
-    goto error;
-
-  g_list_free_full(argument_expressions, (GDestroyNotify) filterx_expr_unref);
-  return &self->super.super;
+  filterx_function_args_free(args);
+  return &self->super;
 
 error:
-  g_list_free_full(argument_expressions, (GDestroyNotify) filterx_expr_unref);
+  filterx_function_args_free(args);
   filterx_expr_unref(&self->super.super);
   return NULL;
 }

--- a/modules/kvformat/filterx-func-parse-kv.h
+++ b/modules/kvformat/filterx-func-parse-kv.h
@@ -28,7 +28,7 @@
 
 #define FILTERX_FUNC_PARSE_KV_USAGE "Usage: parse_kv(msg, value_separator, pair_separator, stray_words_key)"
 
-FilterXExpr *filterx_function_parse_kv_new(const gchar *function_name, GList *argument_expressions, GError **error);
+FilterXFunction *filterx_function_parse_kv_new(const gchar *function_name, FilterXFunctionArgs *args, GError **error);
 gpointer filterx_function_construct_parse_kv(Plugin *self);
 
 #endif

--- a/modules/kvformat/filterx-func-parse-kv.h
+++ b/modules/kvformat/filterx-func-parse-kv.h
@@ -26,7 +26,7 @@
 #include "plugin.h"
 #include "filterx/expr-function.h"
 
-#define FILTERX_FUNC_PARSE_KV_USAGE "Usage: parse_kv(msg, value_separator, pair_separator, stray_words_key)"
+#define FILTERX_FUNC_PARSE_KV_USAGE "Usage: parse_kv(msg, value_separator=\"=\", pair_separator=\", \", stray_words_key=\"stray_words\")"
 
 FilterXFunction *filterx_function_parse_kv_new(const gchar *function_name, FilterXFunctionArgs *args, GError **error);
 gpointer filterx_function_construct_parse_kv(Plugin *self);

--- a/modules/kvformat/tests/test_filterx_func_format_kv.c
+++ b/modules/kvformat/tests/test_filterx_func_format_kv.c
@@ -72,92 +72,67 @@ Test(filterx_func_format_kv, test_invalid_args)
 
   /* empty value_separator */
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("", -1))));
+  args = g_list_append(args, filterx_function_arg_new("value_separator", filterx_literal_new(filterx_string_new("",
+                                                      -1))));
   _assert_format_kv_init_fail(args);
   args = NULL;
 
   /* too long value_separator */
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("->", -1))));
+  args = g_list_append(args, filterx_function_arg_new("value_separator", filterx_literal_new(filterx_string_new("->",
+                                                      -1))));
   _assert_format_kv_init_fail(args);
   args = NULL;
 
   /* non-literal value_separator */
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_non_literal_new(filterx_string_new("=", -1))));
+  args = g_list_append(args, filterx_function_arg_new("value_separator", filterx_non_literal_new(filterx_string_new("=",
+                                                      -1))));
   _assert_format_kv_init_fail(args);
   args = NULL;
 
   /* non-string value_separator */
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_integer_new(42))));
+  args = g_list_append(args, filterx_function_arg_new("value_separator", filterx_literal_new(filterx_integer_new(42))));
   _assert_format_kv_init_fail(args);
   args = NULL;
 
   /* error value_separator */
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_error_expr_new()));
+  args = g_list_append(args, filterx_function_arg_new("value_separator", filterx_error_expr_new()));
   _assert_format_kv_init_fail(args);
   args = NULL;
 
   /* empty pair_separator */
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("=", -1))));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("", -1))));
+  args = g_list_append(args, filterx_function_arg_new("pair_separator", filterx_literal_new(filterx_string_new("", -1))));
   _assert_format_kv_init_fail(args);
   args = NULL;
 
   /* non-literal pair_separator */
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("=", -1))));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_non_literal_new(filterx_string_new("", -1))));
+  args = g_list_append(args, filterx_function_arg_new("pair_separator", filterx_non_literal_new(filterx_string_new("",
+                                                      -1))));
   _assert_format_kv_init_fail(args);
   args = NULL;
 
   /* non-string pair_separator */
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("=", -1))));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_integer_new(42))));
+  args = g_list_append(args, filterx_function_arg_new("pair_separator", filterx_literal_new(filterx_integer_new(42))));
   _assert_format_kv_init_fail(args);
   args = NULL;
 
   /* error pair_separator */
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("=", -1))));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_error_expr_new()));
+  args = g_list_append(args, filterx_function_arg_new("pair_separator", filterx_error_expr_new()));
   _assert_format_kv_init_fail(args);
   args = NULL;
 
   /* too_many_args */
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("=", -1))));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new(", ", -1))));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("foobar", -1))));
   _assert_format_kv_init_fail(args);
   args = NULL;
-}
-
-Test(filterx_func_format_kv, test_optional_arguments)
-{
-  FilterXExpr *kvs = filterx_literal_new(filterx_json_object_new_from_repr("{\"foo\":\"bar\",\"bar\":\"baz\"}", -1));
-  GList *args = NULL;
-
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_expr_ref(kvs)));
-  _assert_format_kv(args, "foo=bar, bar=baz");
-  args = NULL;
-
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_expr_ref(kvs)));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_null_new())));
-  _assert_format_kv(args, "foo=bar, bar=baz");
-  args = NULL;
-
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_expr_ref(kvs)));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_null_new())));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_null_new())));
-  _assert_format_kv(args, "foo=bar, bar=baz");
-  args = NULL;
-
-  filterx_expr_unref(kvs);
 }
 
 Test(filterx_func_format_kv, test_full)
@@ -166,8 +141,10 @@ Test(filterx_func_format_kv, test_full)
   GList *args = NULL;
 
   args = g_list_append(args, filterx_function_arg_new(NULL, kvs));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("@", -1))));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new(" | ", -1))));
+  args = g_list_append(args, filterx_function_arg_new("value_separator", filterx_literal_new(filterx_string_new("@",
+                                                      -1))));
+  args = g_list_append(args, filterx_function_arg_new("pair_separator", filterx_literal_new(filterx_string_new(" | ",
+                                                      -1))));
   _assert_format_kv(args, "foo@bar | bar@baz");
 }
 

--- a/modules/kvformat/tests/test_filterx_func_format_kv.c
+++ b/modules/kvformat/tests/test_filterx_func_format_kv.c
@@ -33,20 +33,20 @@
 #include "scratch-buffers.h"
 
 static void
-_assert_format_kv_init_fail(GList *argument_expressions)
+_assert_format_kv_init_fail(GList *positional_args)
 {
   GError *err = NULL;
-  FilterXFunction *func = filterx_function_format_kv_new("test", argument_expressions, &err);
+  FilterXFunction *func = filterx_function_format_kv_new("test", filterx_function_args_new(positional_args), &err);
   cr_assert(!func);
   cr_assert(err);
   g_error_free(err);
 }
 
 static void
-_assert_format_kv(GList *argument_expressions, const gchar *expected_output)
+_assert_format_kv(GList *positional_args, const gchar *expected_output)
 {
   GError *err = NULL;
-  FilterXFunction *func = filterx_function_format_kv_new("test", argument_expressions, &err);
+  FilterXFunction *func = filterx_function_format_kv_new("test", filterx_function_args_new(positional_args), &err);
   cr_assert(!err);
 
   FilterXObject *obj = filterx_expr_eval(&func->super);

--- a/modules/kvformat/tests/test_filterx_func_format_kv.c
+++ b/modules/kvformat/tests/test_filterx_func_format_kv.c
@@ -33,20 +33,22 @@
 #include "scratch-buffers.h"
 
 static void
-_assert_format_kv_init_fail(GList *positional_args)
+_assert_format_kv_init_fail(GList *args)
 {
   GError *err = NULL;
-  FilterXFunction *func = filterx_function_format_kv_new("test", filterx_function_args_new(positional_args), &err);
+  GError *args_err = NULL;
+  FilterXFunction *func = filterx_function_format_kv_new("test", filterx_function_args_new(args, &args_err), &err);
   cr_assert(!func);
   cr_assert(err);
   g_error_free(err);
 }
 
 static void
-_assert_format_kv(GList *positional_args, const gchar *expected_output)
+_assert_format_kv(GList *args, const gchar *expected_output)
 {
   GError *err = NULL;
-  FilterXFunction *func = filterx_function_format_kv_new("test", filterx_function_args_new(positional_args), &err);
+  GError *args_err = NULL;
+  FilterXFunction *func = filterx_function_format_kv_new("test", filterx_function_args_new(args, &args_err), &err);
   cr_assert(!err);
 
   FilterXObject *obj = filterx_expr_eval(&func->super);
@@ -69,68 +71,68 @@ Test(filterx_func_format_kv, test_invalid_args)
   _assert_format_kv_init_fail(NULL);
 
   /* empty value_separator */
-  args = g_list_append(args, filterx_literal_new(filterx_test_dict_new()));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("", -1)));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("", -1))));
   _assert_format_kv_init_fail(args);
   args = NULL;
 
   /* too long value_separator */
-  args = g_list_append(args, filterx_literal_new(filterx_test_dict_new()));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("->", -1)));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("->", -1))));
   _assert_format_kv_init_fail(args);
   args = NULL;
 
   /* non-literal value_separator */
-  args = g_list_append(args, filterx_literal_new(filterx_test_dict_new()));
-  args = g_list_append(args, filterx_non_literal_new(filterx_string_new("=", -1)));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_non_literal_new(filterx_string_new("=", -1))));
   _assert_format_kv_init_fail(args);
   args = NULL;
 
   /* non-string value_separator */
-  args = g_list_append(args, filterx_literal_new(filterx_test_dict_new()));
-  args = g_list_append(args, filterx_literal_new(filterx_integer_new(42)));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_integer_new(42))));
   _assert_format_kv_init_fail(args);
   args = NULL;
 
   /* error value_separator */
-  args = g_list_append(args, filterx_literal_new(filterx_test_dict_new()));
-  args = g_list_append(args, filterx_error_expr_new());
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_error_expr_new()));
   _assert_format_kv_init_fail(args);
   args = NULL;
 
   /* empty pair_separator */
-  args = g_list_append(args, filterx_literal_new(filterx_test_dict_new()));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("=", -1)));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("", -1)));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("=", -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("", -1))));
   _assert_format_kv_init_fail(args);
   args = NULL;
 
   /* non-literal pair_separator */
-  args = g_list_append(args, filterx_literal_new(filterx_test_dict_new()));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("=", -1)));
-  args = g_list_append(args, filterx_non_literal_new(filterx_string_new("", -1)));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("=", -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_non_literal_new(filterx_string_new("", -1))));
   _assert_format_kv_init_fail(args);
   args = NULL;
 
   /* non-string pair_separator */
-  args = g_list_append(args, filterx_literal_new(filterx_test_dict_new()));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("=", -1)));
-  args = g_list_append(args, filterx_literal_new(filterx_integer_new(42)));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("=", -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_integer_new(42))));
   _assert_format_kv_init_fail(args);
   args = NULL;
 
   /* error pair_separator */
-  args = g_list_append(args, filterx_literal_new(filterx_test_dict_new()));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("=", -1)));
-  args = g_list_append(args, filterx_error_expr_new());
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("=", -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_error_expr_new()));
   _assert_format_kv_init_fail(args);
   args = NULL;
 
   /* too_many_args */
-  args = g_list_append(args, filterx_literal_new(filterx_test_dict_new()));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("=", -1)));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new(", ", -1)));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("foobar", -1)));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("=", -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new(", ", -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("foobar", -1))));
   _assert_format_kv_init_fail(args);
   args = NULL;
 }
@@ -140,18 +142,18 @@ Test(filterx_func_format_kv, test_optional_arguments)
   FilterXExpr *kvs = filterx_literal_new(filterx_json_object_new_from_repr("{\"foo\":\"bar\",\"bar\":\"baz\"}", -1));
   GList *args = NULL;
 
-  args = g_list_append(args, filterx_expr_ref(kvs));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_expr_ref(kvs)));
   _assert_format_kv(args, "foo=bar, bar=baz");
   args = NULL;
 
-  args = g_list_append(args, filterx_expr_ref(kvs));
-  args = g_list_append(args, filterx_literal_new(filterx_null_new()));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_expr_ref(kvs)));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_null_new())));
   _assert_format_kv(args, "foo=bar, bar=baz");
   args = NULL;
 
-  args = g_list_append(args, filterx_expr_ref(kvs));
-  args = g_list_append(args, filterx_literal_new(filterx_null_new()));
-  args = g_list_append(args, filterx_literal_new(filterx_null_new()));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_expr_ref(kvs)));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_null_new())));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_null_new())));
   _assert_format_kv(args, "foo=bar, bar=baz");
   args = NULL;
 
@@ -163,9 +165,9 @@ Test(filterx_func_format_kv, test_full)
   FilterXExpr *kvs = filterx_literal_new(filterx_json_object_new_from_repr("{\"foo\":\"bar\",\"bar\":\"baz\"}", -1));
   GList *args = NULL;
 
-  args = g_list_append(args, kvs);
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("@", -1)));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new(" | ", -1)));
+  args = g_list_append(args, filterx_function_arg_new(NULL, kvs));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("@", -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new(" | ", -1))));
   _assert_format_kv(args, "foo@bar | bar@baz");
 }
 
@@ -175,7 +177,7 @@ Test(filterx_func_format_kv, test_inner_dict_and_list_is_skipped)
                        filterx_json_object_new_from_repr("{\"foo\":\"bar\",\"x\":{},\"y\":[],\"bar\":\"baz\"}", -1));
   GList *args = NULL;
 
-  args = g_list_append(args, kvs);
+  args = g_list_append(args, filterx_function_arg_new(NULL, kvs));
   _assert_format_kv(args, "foo=bar, bar=baz");
 }
 
@@ -185,7 +187,7 @@ Test(filterx_func_format_kv, test_space_gets_double_quoted)
                        filterx_json_object_new_from_repr("{\"foo\":\"bar\",\"bar\": \"almafa korte\\\"fa\"}", -1));
   GList *args = NULL;
 
-  args = g_list_append(args, kvs);
+  args = g_list_append(args, filterx_function_arg_new(NULL, kvs));
   _assert_format_kv(args, "foo=bar, bar=\"almafa korte\\\"fa\"");
 }
 

--- a/modules/kvformat/tests/test_filterx_func_parse_kv.c
+++ b/modules/kvformat/tests/test_filterx_func_parse_kv.c
@@ -37,7 +37,7 @@
 Test(filterx_func_parse_kv, test_empty_args_error)
 {
   GError *err = NULL;
-  FilterXExpr *func = filterx_function_parse_kv_new("test", NULL, &err);
+  FilterXFunction *func = filterx_function_parse_kv_new("test", filterx_function_args_new(NULL), &err);
 
   cr_assert_null(func);
   cr_assert_not_null(err);
@@ -52,11 +52,11 @@ Test(filterx_func_parse_kv, test_skipped_opts_causes_default_behaviour)
   args = g_list_append(args, filterx_literal_new(filterx_string_new("foo=bar, bar=baz", -1)));
 
   GError *err = NULL;
-  FilterXExpr *func = filterx_function_parse_kv_new("test", args, &err);
+  FilterXFunction *func = filterx_function_parse_kv_new("test", filterx_function_args_new(args), &err);
 
   cr_assert_null(err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = filterx_expr_eval(&func->super);
 
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(json_object)));
@@ -69,7 +69,7 @@ Test(filterx_func_parse_kv, test_skipped_opts_causes_default_behaviour)
   cr_assert(ok);
 
   cr_assert_str_eq(repr->str, "{\"foo\":\"bar\",\"bar\":\"baz\"}");
-  filterx_expr_unref(func);
+  filterx_expr_unref(&func->super);
   filterx_object_unref(obj);
   g_error_free(err);
 }
@@ -81,11 +81,11 @@ Test(filterx_func_parse_kv, test_optional_value_separator_option_first_character
   args = g_list_append(args, filterx_literal_new(filterx_string_new("@#$", -1))); // value separator
 
   GError *err = NULL;
-  FilterXExpr *func = filterx_function_parse_kv_new("test", args, &err);
+  FilterXFunction *func = filterx_function_parse_kv_new("test", filterx_function_args_new(args), &err);
 
   cr_assert_null(err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = filterx_expr_eval(&func->super);
 
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(json_object)));
@@ -98,7 +98,7 @@ Test(filterx_func_parse_kv, test_optional_value_separator_option_first_character
   cr_assert(ok);
 
   cr_assert_str_eq(repr->str, "{\"foo\":\"bar\",\"bar\":\"baz\"}");
-  filterx_expr_unref(func);
+  filterx_expr_unref(&func->super);
   filterx_object_unref(obj);
   g_error_free(err);
 }
@@ -110,7 +110,7 @@ Test(filterx_func_parse_kv, test_optional_empty_value_separator_option)
   args = g_list_append(args, filterx_literal_new(filterx_string_new("", -1))); // value separator
 
   GError *err = NULL;
-  FilterXExpr *func = filterx_function_parse_kv_new("test", args, &err);
+  FilterXFunction *func = filterx_function_parse_kv_new("test", filterx_function_args_new(args), &err);
 
   cr_assert_null(func);
   cr_assert_not_null(err);
@@ -128,11 +128,11 @@ Test(filterx_func_parse_kv, test_optional_pair_separator_option)
   args = g_list_append(args, filterx_literal_new(filterx_string_new("-=|=-", -1))); // pair separator
 
   GError *err = NULL;
-  FilterXExpr *func = filterx_function_parse_kv_new("test", args, &err);
+  FilterXFunction *func = filterx_function_parse_kv_new("test", filterx_function_args_new(args), &err);
 
   cr_assert_null(err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = filterx_expr_eval(&func->super);
 
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(json_object)));
@@ -145,7 +145,7 @@ Test(filterx_func_parse_kv, test_optional_pair_separator_option)
   cr_assert(ok);
 
   cr_assert_str_eq(repr->str, "{\"foo\":\"bar\",\"bar\":\"baz\"}");
-  filterx_expr_unref(func);
+  filterx_expr_unref(&func->super);
   filterx_object_unref(obj);
   g_error_free(err);
 }
@@ -159,11 +159,11 @@ Test(filterx_func_parse_kv, test_optional_stray_words_key_option)
   args = g_list_append(args, filterx_literal_new(filterx_string_new("straywords", -1))); // stray words
 
   GError *err = NULL;
-  FilterXExpr *func = filterx_function_parse_kv_new("test", args, &err);
+  FilterXFunction *func = filterx_function_parse_kv_new("test", filterx_function_args_new(args), &err);
 
   cr_assert_null(err);
 
-  FilterXObject *obj = filterx_expr_eval(func);
+  FilterXObject *obj = filterx_expr_eval(&func->super);
 
   cr_assert_not_null(obj);
   cr_assert(filterx_object_is_type(obj, &FILTERX_TYPE_NAME(json_object)));
@@ -176,7 +176,7 @@ Test(filterx_func_parse_kv, test_optional_stray_words_key_option)
   cr_assert(ok);
 
   cr_assert_str_eq(repr->str, "{\"foo\":\"bar\",\"bar\":\"baz\",\"straywords\":\"lookslikenonKV\"}");
-  filterx_expr_unref(func);
+  filterx_expr_unref(&func->super);
   filterx_object_unref(obj);
   g_error_free(err);
 }

--- a/modules/kvformat/tests/test_filterx_func_parse_kv.c
+++ b/modules/kvformat/tests/test_filterx_func_parse_kv.c
@@ -37,9 +37,11 @@
 Test(filterx_func_parse_kv, test_empty_args_error)
 {
   GError *err = NULL;
-  FilterXFunction *func = filterx_function_parse_kv_new("test", filterx_function_args_new(NULL), &err);
+  GError *args_err = NULL;
+  FilterXFunction *func = filterx_function_parse_kv_new("test", filterx_function_args_new(NULL, &args_err), &err);
 
   cr_assert_null(func);
+  cr_assert_null(args_err);
   cr_assert_not_null(err);
   cr_assert(strstr(err->message, FILTERX_FUNC_PARSE_KV_USAGE) != NULL);
   g_error_free(err);
@@ -49,11 +51,14 @@ Test(filterx_func_parse_kv, test_empty_args_error)
 Test(filterx_func_parse_kv, test_skipped_opts_causes_default_behaviour)
 {
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("foo=bar, bar=baz", -1)));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("foo=bar, bar=baz",
+                                                      -1))));
 
   GError *err = NULL;
-  FilterXFunction *func = filterx_function_parse_kv_new("test", filterx_function_args_new(args), &err);
+  GError *args_err = NULL;
+  FilterXFunction *func = filterx_function_parse_kv_new("test", filterx_function_args_new(args, &args_err), &err);
 
+  cr_assert_null(args_err);
   cr_assert_null(err);
 
   FilterXObject *obj = filterx_expr_eval(&func->super);
@@ -77,12 +82,16 @@ Test(filterx_func_parse_kv, test_skipped_opts_causes_default_behaviour)
 Test(filterx_func_parse_kv, test_optional_value_separator_option_first_character)
 {
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("foo@bar, bar@baz", -1)));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("@#$", -1))); // value separator
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("foo@bar, bar@baz",
+                                                      -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("@#$",
+                                                      -1)))); // value separator
 
   GError *err = NULL;
-  FilterXFunction *func = filterx_function_parse_kv_new("test", filterx_function_args_new(args), &err);
+  GError *args_err = NULL;
+  FilterXFunction *func = filterx_function_parse_kv_new("test", filterx_function_args_new(args, &args_err), &err);
 
+  cr_assert_null(args_err);
   cr_assert_null(err);
 
   FilterXObject *obj = filterx_expr_eval(&func->super);
@@ -106,13 +115,17 @@ Test(filterx_func_parse_kv, test_optional_value_separator_option_first_character
 Test(filterx_func_parse_kv, test_optional_empty_value_separator_option)
 {
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("foo=bar, bar=baz", -1)));
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("", -1))); // value separator
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("foo=bar, bar=baz",
+                                                      -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("",
+                                                      -1)))); // value separator
 
   GError *err = NULL;
-  FilterXFunction *func = filterx_function_parse_kv_new("test", filterx_function_args_new(args), &err);
+  GError *args_err = NULL;
+  FilterXFunction *func = filterx_function_parse_kv_new("test", filterx_function_args_new(args, &args_err), &err);
 
   cr_assert_null(func);
+  cr_assert_null(args_err);
   cr_assert_not_null(err);
 
   cr_assert(strstr(err->message, FILTERX_FUNC_PARSE_KV_USAGE) != NULL);
@@ -123,13 +136,17 @@ Test(filterx_func_parse_kv, test_optional_empty_value_separator_option)
 Test(filterx_func_parse_kv, test_optional_pair_separator_option)
 {
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("foo=bar-=|=-bar=baz", -1)));
-  args = g_list_append(args, filterx_literal_new(filterx_null_new())); // value separator
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("-=|=-", -1))); // pair separator
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("foo=bar-=|=-bar=baz",
+                                                      -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_null_new()))); // value separator
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("-=|=-",
+                                                      -1)))); // pair separator
 
   GError *err = NULL;
-  FilterXFunction *func = filterx_function_parse_kv_new("test", filterx_function_args_new(args), &err);
+  GError *args_err = NULL;
+  FilterXFunction *func = filterx_function_parse_kv_new("test", filterx_function_args_new(args, &args_err), &err);
 
+  cr_assert_null(args_err);
   cr_assert_null(err);
 
   FilterXObject *obj = filterx_expr_eval(&func->super);
@@ -153,14 +170,18 @@ Test(filterx_func_parse_kv, test_optional_pair_separator_option)
 Test(filterx_func_parse_kv, test_optional_stray_words_key_option)
 {
   GList *args = NULL;
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("foo=bar, lookslikenonKV bar=baz", -1)));
-  args = g_list_append(args, filterx_literal_new(filterx_null_new())); // value separator
-  args = g_list_append(args, filterx_literal_new(filterx_null_new())); // pair separator
-  args = g_list_append(args, filterx_literal_new(filterx_string_new("straywords", -1))); // stray words
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_string_new("foo=bar, lookslikenonKV bar=baz", -1))));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_null_new()))); // value separator
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_null_new()))); // pair separator
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("straywords",
+                                                      -1)))); // stray words
 
   GError *err = NULL;
-  FilterXFunction *func = filterx_function_parse_kv_new("test", filterx_function_args_new(args), &err);
+  GError *args_err = NULL;
+  FilterXFunction *func = filterx_function_parse_kv_new("test", filterx_function_args_new(args, &args_err), &err);
 
+  cr_assert_null(args_err);
   cr_assert_null(err);
 
   FilterXObject *obj = filterx_expr_eval(&func->super);

--- a/modules/kvformat/tests/test_filterx_func_parse_kv.c
+++ b/modules/kvformat/tests/test_filterx_func_parse_kv.c
@@ -84,8 +84,8 @@ Test(filterx_func_parse_kv, test_optional_value_separator_option_first_character
   GList *args = NULL;
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("foo@bar, bar@baz",
                                                       -1))));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("@#$",
-                                                      -1)))); // value separator
+  args = g_list_append(args, filterx_function_arg_new("value_separator", filterx_literal_new(filterx_string_new("@#$",
+                                                      -1))));
 
   GError *err = NULL;
   GError *args_err = NULL;
@@ -117,8 +117,8 @@ Test(filterx_func_parse_kv, test_optional_empty_value_separator_option)
   GList *args = NULL;
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("foo=bar, bar=baz",
                                                       -1))));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("",
-                                                      -1)))); // value separator
+  args = g_list_append(args, filterx_function_arg_new("value_separator", filterx_literal_new(filterx_string_new("",
+                                                      -1))));
 
   GError *err = NULL;
   GError *args_err = NULL;
@@ -138,9 +138,8 @@ Test(filterx_func_parse_kv, test_optional_pair_separator_option)
   GList *args = NULL;
   args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("foo=bar-=|=-bar=baz",
                                                       -1))));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_null_new()))); // value separator
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("-=|=-",
-                                                      -1)))); // pair separator
+  args = g_list_append(args, filterx_function_arg_new("pair_separator", filterx_literal_new(filterx_string_new("-=|=-",
+                                                      -1))));
 
   GError *err = NULL;
   GError *args_err = NULL;
@@ -172,10 +171,9 @@ Test(filterx_func_parse_kv, test_optional_stray_words_key_option)
   GList *args = NULL;
   args = g_list_append(args, filterx_function_arg_new(NULL,
                                                       filterx_literal_new(filterx_string_new("foo=bar, lookslikenonKV bar=baz", -1))));
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_null_new()))); // value separator
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_null_new()))); // pair separator
-  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("straywords",
-                                                      -1)))); // stray words
+  args = g_list_append(args, filterx_function_arg_new("stray_words_key",
+                                                      filterx_literal_new(filterx_string_new("straywords",
+                                                          -1))));
 
   GError *err = NULL;
   GError *args_err = NULL;

--- a/tests/light/functional_tests/filterx/test_filterx.py
+++ b/tests/light/functional_tests/filterx/test_filterx.py
@@ -1188,36 +1188,10 @@ def test_parse_kv_default_option_set_is_skippable(config, syslog_ng):
     assert file_true.read_log() == '{"foo":"bar","bar":"baz"}\n'
 
 
-def test_parse_kv_default_options_are_nullable(config, syslog_ng):
-    (file_true, file_false) = create_config(
-        config, """
-    $MSG = parse_kv("foo=bar, thisisstray bar=baz", null, null);
-    """,
-    )
-    syslog_ng.start(config)
-
-    assert file_true.get_stats()["processed"] == 1
-    assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == '{"foo":"bar","bar":"baz"}\n'
-
-
-def test_parse_kv_opts_over_max_opt_are_skipped(config, syslog_ng):
-    (file_true, file_false) = create_config(
-        config, """
-    $MSG = parse_kv("foo=bar, bar=baz", null, null, null, null, null, null, null, null, null);
-    """,
-    )
-    syslog_ng.start(config)
-
-    assert file_true.get_stats()["processed"] == 1
-    assert "processed" not in file_false.get_stats()
-    assert file_true.read_log() == "{\"foo\":\"bar\",\"bar\":\"baz\"}\n"
-
-
 def test_parse_kv_value_separator(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, """
-    $MSG = parse_kv("foo@bar, bar@baz", "@");
+    $MSG = parse_kv("foo@bar, bar@baz", value_separator="@");
     """,
     )
     syslog_ng.start(config)
@@ -1230,7 +1204,7 @@ def test_parse_kv_value_separator(config, syslog_ng):
 def test_parse_kv_value_separator_use_first_character(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, """
-    $MSG = parse_kv("foo@bar, bar@baz", "@!$");
+    $MSG = parse_kv("foo@bar, bar@baz", value_separator="@!$");
     """,
     )
     syslog_ng.start(config)
@@ -1243,7 +1217,7 @@ def test_parse_kv_value_separator_use_first_character(config, syslog_ng):
 def test_parse_kv_pair_separator(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, """
-    $MSG = parse_kv("foo=bar#bar=baz", null, "#");
+    $MSG = parse_kv("foo=bar#bar=baz", pair_separator="#");
     """,
     )
     syslog_ng.start(config)
@@ -1256,7 +1230,7 @@ def test_parse_kv_pair_separator(config, syslog_ng):
 def test_parse_kv_stray_words_value_name(config, syslog_ng):
     (file_true, file_false) = create_config(
         config, """
-    $MSG = parse_kv("foo=bar, thisisstray bar=baz", null, null, "stray_words");
+    $MSG = parse_kv("foo=bar, thisisstray bar=baz", stray_words_key="stray_words");
     """,
     )
     syslog_ng.start(config)


### PR DESCRIPTION
Functional changes:
```
format_kv(kvs_dict, value_separator="=", pair_separator=", ")
parse_kv(msg, value_separator="=", pair_separator=", ", stray_words_key="stray_words")
```

Function arguments are really similar to our existing driver level options:
* An argument is either positional or named.
* Positional arguments are always set before named arguments.
* Positional arguments are always mandatory.
* Named arguments can be set in any order.
* Usually named arguments are optional.