### PR TITLE
filterx: `unset_empties()`

### DIFF
--- a/lib/filterx/CMakeLists.txt
+++ b/lib/filterx/CMakeLists.txt
@@ -38,6 +38,7 @@ set(FILTERX_HEADERS
     filterx/filterx-private.h
     filterx/func-istype.h
     filterx/func-len.h
+    filterx/func-unset-empties.h
     PARENT_SCOPE
     )
 
@@ -81,6 +82,7 @@ set(FILTERX_SOURCES
     filterx/expr-regexp.c
     filterx/func-istype.c
     filterx/func-len.c
+    filterx/func-unset-empties.c
     filterx/filterx-private.c
     PARENT_SCOPE
     )

--- a/lib/filterx/Makefile.am
+++ b/lib/filterx/Makefile.am
@@ -39,6 +39,7 @@ filterxinclude_HEADERS = 			\
 	lib/filterx/expr-regexp.h		\
 	lib/filterx/func-istype.h		\
 	lib/filterx/func-len.h		\
+	lib/filterx/func-unset-empties.h		\
 	lib/filterx/filterx-private.h
 
 
@@ -82,6 +83,7 @@ filterx_sources = 				\
 	lib/filterx/expr-regexp.c		\
 	lib/filterx/func-istype.c		\
 	lib/filterx/func-len.c		\
+	lib/filterx/func-unset-empties.c		\
 	lib/filterx/filterx-private.c	\
 	lib/filterx/filterx-grammar.y
 

--- a/lib/filterx/expr-function.c
+++ b/lib/filterx/expr-function.c
@@ -28,6 +28,7 @@
 #include "filterx/filterx-eval.h"
 #include "filterx/expr-literal.h"
 #include "filterx/object-string.h"
+#include "filterx/object-primitive.h"
 #include "filterx/object-null.h"
 #include "plugin.h"
 #include "cfg.h"
@@ -318,6 +319,40 @@ filterx_function_args_get_named_literal_string(FilterXFunctionArgs *self, const 
 
   filterx_expr_unref(expr);
   return str;
+}
+
+gboolean
+filterx_function_args_get_named_literal_boolean(FilterXFunctionArgs *self, const gchar *name, gboolean *exists,
+                                                gboolean *error)
+{
+  *error = FALSE;
+
+  FilterXExpr *expr = filterx_function_args_get_named_expr(self, name);
+  *exists = !!expr;
+  if (!expr)
+    return FALSE;
+
+  FilterXObject *obj = NULL;
+  gboolean value = FALSE;
+
+  if (!filterx_expr_is_literal(expr))
+    goto error;
+
+  obj = filterx_expr_eval(expr);
+  if (!obj)
+    goto error;
+
+  if (!filterx_boolean_unwrap(obj, &value))
+    goto error;
+
+  goto success;
+
+error:
+  *error = TRUE;
+success:
+  filterx_object_unref(obj);
+  filterx_expr_unref(expr);
+  return value;
 }
 
 void

--- a/lib/filterx/expr-function.h
+++ b/lib/filterx/expr-function.h
@@ -67,6 +67,8 @@ FilterXExpr *filterx_function_args_get_named_expr(FilterXFunctionArgs *self, con
 FilterXObject *filterx_function_args_get_named_object(FilterXFunctionArgs *self, const gchar *name, gboolean *exists);
 const gchar *filterx_function_args_get_named_literal_string(FilterXFunctionArgs *self, const gchar *name,
                                                             gsize *len, gboolean *exists);
+gboolean filterx_function_args_get_named_literal_boolean(FilterXFunctionArgs *self, const gchar *name,
+                                                         gboolean *exists, gboolean *error);
 void filterx_function_args_free(FilterXFunctionArgs *self);
 
 FilterXExpr *filterx_function_lookup(GlobalConfig *cfg, const gchar *function_name, GList *args, GError **error);

--- a/lib/filterx/filterx-globals.c
+++ b/lib/filterx/filterx-globals.c
@@ -32,6 +32,7 @@
 #include "filterx/object-dict-interface.h"
 #include "filterx/func-istype.h"
 #include "filterx/func-len.h"
+#include "filterx/func-unset-empties.h"
 
 static GHashTable *filterx_builtin_simple_functions = NULL;
 static GHashTable *filterx_builtin_function_ctors = NULL;
@@ -108,6 +109,7 @@ _ctors_init(void)
   filterx_builtin_function_ctors_init_private(&filterx_builtin_function_ctors);
   g_assert(filterx_builtin_function_ctor_register("strptime", filterx_function_strptime_new));
   g_assert(filterx_builtin_function_ctor_register("istype", filterx_function_istype_new));
+  g_assert(filterx_builtin_function_ctor_register("unset_empties", filterx_function_unset_empties_new));
 }
 
 static void

--- a/lib/filterx/filterx-grammar.ym
+++ b/lib/filterx/filterx-grammar.ym
@@ -338,6 +338,7 @@ arguments
 argument
 	: expr					{ $$ = filterx_function_arg_new(NULL, $1); }
 	| string KW_ASSIGN expr			{ $$ = filterx_function_arg_new($1, $3); free($1); }
+	| KW_NULL KW_ASSIGN expr		{ $$ = filterx_function_arg_new("null", $3); }
 	;
 
 literal: literal_object				{ $$ = filterx_literal_new(filterx_config_freeze_object(configuration, $1)); }

--- a/lib/filterx/func-unset-empties.c
+++ b/lib/filterx/func-unset-empties.c
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2024 Attila Szakacs
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "filterx/func-unset-empties.h"
+#include "filterx/object-string.h"
+#include "filterx/object-primitive.h"
+#include "filterx/object-null.h"
+#include "filterx/object-dict-interface.h"
+#include "filterx/object-list-interface.h"
+#include "filterx/filterx-eval.h"
+#include "filterx/filterx-globals.h"
+
+#define FILTERX_FUNC_UNSET_EMPTIES_USAGE "Usage: unset_empties(object, recursive=true, string=true, null=true, number=true, dict=true, list=true)"
+
+typedef struct FilterXFunctionUnsetEmpties_
+{
+  FilterXFunction super;
+  FilterXExpr *object_expr;
+  gboolean recursive;
+  gboolean drop_strings;
+  gboolean drop_nulls;
+  gboolean drop_numbers;
+  gboolean drop_dicts;
+  gboolean drop_lists;
+} FilterXFunctionUnsetEmpties;
+
+static gboolean _process_dict(FilterXFunctionUnsetEmpties *self, FilterXObject *obj);
+static gboolean _process_list(FilterXFunctionUnsetEmpties *self, FilterXObject *obj);
+
+static gboolean
+_should_unset(FilterXFunctionUnsetEmpties *self, FilterXObject *obj)
+{
+  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(string)))
+    {
+      if (!self->drop_strings)
+        return FALSE;
+
+      gsize len;
+      filterx_string_get_value(obj, &len);
+      return len == 0;
+    }
+
+  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(null)))
+    {
+      return self->drop_nulls;
+    }
+
+  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(integer)) ||
+      filterx_object_is_type(obj, &FILTERX_TYPE_NAME(double)))
+    {
+      if (!self->drop_numbers)
+        return FALSE;
+
+      GenericNumber gn = filterx_primitive_get_value(obj);
+      return gn_is_zero(&gn);
+    }
+
+  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(dict)))
+    {
+      if (!self->drop_dicts)
+        return FALSE;
+
+      guint64 len;
+      filterx_object_len(obj, &len);
+      return len == 0;
+    }
+
+  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(list)))
+    {
+      if (!self->drop_lists)
+        return FALSE;
+
+      guint64 len;
+      filterx_object_len(obj, &len);
+      return len == 0;
+    }
+
+  return FALSE;
+}
+
+/* Also unsets inner dicts' and lists' values is recursive is set. */
+static gboolean
+_add_key_to_unset_list_if_needed(FilterXObject *key, FilterXObject *value, gpointer user_data)
+{
+  FilterXFunctionUnsetEmpties *self = ((gpointer *) user_data)[0];
+  GList **keys_to_unset = ((gpointer *) user_data)[1];
+
+  if (self->recursive)
+    {
+      if (filterx_object_is_type(value, &FILTERX_TYPE_NAME(dict)) && !_process_dict(self, value))
+        return FALSE;
+      if (filterx_object_is_type(value, &FILTERX_TYPE_NAME(list)) && !_process_list(self, value))
+        return FALSE;
+    }
+
+  if (!_should_unset(self, value))
+    return TRUE;
+
+  *keys_to_unset = g_list_append(*keys_to_unset, filterx_object_ref(key));
+  return TRUE;
+}
+
+static gboolean
+_process_dict(FilterXFunctionUnsetEmpties *self, FilterXObject *obj)
+{
+  GList *keys_to_unset = NULL;
+  gpointer user_data[] = { self, &keys_to_unset };
+  gboolean success = filterx_dict_iter(obj, _add_key_to_unset_list_if_needed, user_data);
+
+  for (GList *elem = keys_to_unset; elem && success; elem = elem->next)
+    {
+      FilterXObject *key = (FilterXObject *) elem->data;
+      if (!filterx_object_unset_key(obj, key))
+        success = FALSE;
+    }
+
+  g_list_free_full(keys_to_unset, (GDestroyNotify) filterx_object_unref);
+  return success;
+}
+
+/* Takes reference of obj. */
+static FilterXObject *
+_eval_on_dict(FilterXFunctionUnsetEmpties *self, FilterXObject *obj)
+{
+  gboolean success = _process_dict(self, obj);
+  filterx_object_unref(obj);
+  return success ? filterx_boolean_new(TRUE) : NULL;
+}
+
+static gboolean
+_process_list(FilterXFunctionUnsetEmpties *self, FilterXObject *obj)
+{
+  guint64 len;
+  filterx_object_len(obj, &len);
+  if (len == 0)
+    return TRUE;
+
+  for (gint64 i = ((gint64) len) - 1; i >= 0; i--)
+    {
+      FilterXObject *elem = filterx_list_get_subscript(obj, i);
+
+      if (self->recursive)
+        {
+          if (filterx_object_is_type(elem, &FILTERX_TYPE_NAME(dict)) && !_process_dict(self, elem))
+            {
+              filterx_object_unref(elem);
+              return FALSE;
+            }
+          if (filterx_object_is_type(elem, &FILTERX_TYPE_NAME(list)) && !_process_list(self, elem))
+            {
+              filterx_object_unref(elem);
+              return FALSE;
+            }
+        }
+
+      if (_should_unset(self, elem))
+        {
+          if (!filterx_list_unset_index(obj, i))
+            {
+              filterx_object_unref(elem);
+              return FALSE;
+            }
+        }
+
+      filterx_object_unref(elem);
+    }
+
+  return TRUE;
+}
+
+/* Takes reference of obj. */
+static FilterXObject *
+_eval_on_list(FilterXFunctionUnsetEmpties *self, FilterXObject *obj)
+{
+  gboolean success = _process_list(self, obj);
+  filterx_object_unref(obj);
+  return success ? filterx_boolean_new(TRUE) : NULL;
+}
+
+static FilterXObject *
+_eval(FilterXExpr *s)
+{
+  FilterXFunctionUnsetEmpties *self = (FilterXFunctionUnsetEmpties *) s;
+
+  FilterXObject *obj = filterx_expr_eval(self->object_expr);
+  if (!obj)
+    {
+      filterx_eval_push_error("Failed to evaluate first argument. " FILTERX_FUNC_UNSET_EMPTIES_USAGE, s, NULL);
+      return NULL;
+    }
+
+  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(dict)))
+    return _eval_on_dict(self, obj);
+
+  if (filterx_object_is_type(obj, &FILTERX_TYPE_NAME(list)))
+    return _eval_on_list(self, obj);
+
+  filterx_eval_push_error("Object must be dict or list. " FILTERX_FUNC_UNSET_EMPTIES_USAGE, s, obj);
+  filterx_object_unref(obj);
+  return NULL;
+}
+
+static void
+_free(FilterXExpr *s)
+{
+  FilterXFunctionUnsetEmpties *self = (FilterXFunctionUnsetEmpties *) s;
+  filterx_expr_unref(self->object_expr);
+  filterx_function_free_method(&self->super);
+}
+
+static FilterXExpr *
+_extract_object_expr(FilterXFunctionArgs *args, GError **error)
+{
+  FilterXExpr *object_expr = filterx_function_args_get_expr(args, 0);
+  if (!object_expr)
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  "argument must be set: object. " FILTERX_FUNC_UNSET_EMPTIES_USAGE);
+      return NULL;
+    }
+
+  return object_expr;
+}
+
+static gboolean
+_extract_optional_literal_bool_arg(FilterXFunctionArgs *args, const gchar *arg_name, gboolean *output, GError **error)
+{
+  gboolean exists, eval_error;
+  gboolean value = filterx_function_args_get_named_literal_boolean(args, arg_name, &exists, &eval_error);
+  if (!exists)
+    return TRUE;
+
+  if (eval_error)
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  "%s argument must be boolean literal. " FILTERX_FUNC_UNSET_EMPTIES_USAGE, arg_name);
+      return FALSE;
+    }
+
+  *output = value;
+  return TRUE;
+}
+
+static gboolean
+_extract_optional_args(FilterXFunctionUnsetEmpties *self, FilterXFunctionArgs *args, GError **error)
+{
+  return _extract_optional_literal_bool_arg(args, "recursive", &self->recursive, error) &&
+         _extract_optional_literal_bool_arg(args, "string", &self->drop_strings, error) &&
+         _extract_optional_literal_bool_arg(args, "null", &self->drop_nulls, error) &&
+         _extract_optional_literal_bool_arg(args, "number", &self->drop_numbers, error) &&
+         _extract_optional_literal_bool_arg(args, "dict", &self->drop_dicts, error) &&
+         _extract_optional_literal_bool_arg(args, "list", &self->drop_lists, error);
+}
+
+static gboolean
+_extract_args(FilterXFunctionUnsetEmpties *self, FilterXFunctionArgs *args, GError **error)
+{
+  if (filterx_function_args_len(args) != 1)
+    {
+      g_set_error(error, FILTERX_FUNCTION_ERROR, FILTERX_FUNCTION_ERROR_CTOR_FAIL,
+                  "invalid number of arguments. " FILTERX_FUNC_UNSET_EMPTIES_USAGE);
+      return FALSE;
+    }
+
+  self->object_expr = _extract_object_expr(args, error);
+  if (!self->object_expr)
+    return FALSE;
+
+  if (!_extract_optional_args(self, args, error))
+    return FALSE;
+
+  return TRUE;
+}
+
+FilterXFunction *
+filterx_function_unset_empties_new(const gchar *function_name, FilterXFunctionArgs *args, GError **error)
+{
+  FilterXFunctionUnsetEmpties *self = g_new0(FilterXFunctionUnsetEmpties, 1);
+  filterx_function_init_instance(&self->super, function_name);
+  self->super.super.eval = _eval;
+  self->super.super.free_fn = _free;
+
+  self->recursive = TRUE;
+  self->drop_strings = self->drop_nulls = self->drop_numbers = self->drop_dicts = self->drop_lists = TRUE;
+
+  if (!_extract_args(self, args, error))
+    goto error;
+
+  filterx_function_args_free(args);
+  return &self->super;
+
+error:
+  filterx_function_args_free(args);
+  filterx_expr_unref(&self->super.super);
+  return NULL;
+}

--- a/lib/filterx/func-unset-empties.h
+++ b/lib/filterx/func-unset-empties.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Attila Szakacs
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef FILTERX_FUNC_UNSET_EMPTIES_H_INCLUDED
+#define FILTERX_FUNC_UNSET_EMPTIES_H_INCLUDED
+
+#include "filterx/expr-function.h"
+
+FilterXFunction *filterx_function_unset_empties_new(const gchar *function_name, FilterXFunctionArgs *args,
+                                                    GError **error);
+
+#endif

--- a/lib/filterx/object-json-array.c
+++ b/lib/filterx/object-json-array.c
@@ -117,7 +117,11 @@ _get_subscript(FilterXList *s, guint64 index)
 
   struct json_object *jso = json_object_array_get_idx(self->jso, index);
   if (!jso)
-    return NULL;
+    {
+      /* NULL is returned if the stored value is null. */
+      if (json_object_array_length(self->jso) > index + 1)
+        return NULL;
+    }
 
   return filterx_json_convert_json_to_object_cached(&s->super, &self->root_container, jso);
 }

--- a/lib/filterx/object-json-array.c
+++ b/lib/filterx/object-json-array.c
@@ -79,6 +79,17 @@ _marshal(FilterXObject *s, GString *repr, LogMessageValueType *t)
 }
 
 static gboolean
+_repr(FilterXObject *s, GString *repr)
+{
+  FilterXJsonArray *self = (FilterXJsonArray *) s;
+
+  const gchar *json_repr = json_object_to_json_string_ext(self->jso, JSON_C_TO_STRING_PLAIN);
+  g_string_append(repr, json_repr);
+
+  return TRUE;
+}
+
+static gboolean
 _map_to_json(FilterXObject *s, struct json_object **jso, FilterXObject **assoc_object)
 {
   FilterXJsonArray *self = (FilterXJsonArray *) s;
@@ -351,6 +362,7 @@ FILTERX_DEFINE_TYPE(json_array, FILTERX_TYPE_NAME(list),
                     .truthy = _truthy,
                     .free_fn = _free,
                     .marshal = _marshal,
+                    .repr = _repr,
                     .map_to_json = _map_to_json,
                     .clone = _clone,
                     .list_factory = filterx_json_array_new_empty,

--- a/lib/filterx/object-json-object.c
+++ b/lib/filterx/object-json-object.c
@@ -54,6 +54,17 @@ _marshal(FilterXObject *s, GString *repr, LogMessageValueType *t)
 }
 
 static gboolean
+_repr(FilterXObject *s, GString *repr)
+{
+  FilterXJsonObject *self = (FilterXJsonObject *) s;
+
+  const gchar *json_repr = json_object_to_json_string_ext(self->jso, JSON_C_TO_STRING_PLAIN);
+  g_string_append(repr, json_repr);
+
+  return TRUE;
+}
+
+static gboolean
 _map_to_json(FilterXObject *s, struct json_object **jso, FilterXObject **assoc_object)
 {
   FilterXJsonObject *self = (FilterXJsonObject *) s;
@@ -253,6 +264,7 @@ FILTERX_DEFINE_TYPE(json_object, FILTERX_TYPE_NAME(dict),
                     .truthy = _truthy,
                     .free_fn = _free,
                     .marshal = _marshal,
+                    .repr = _repr,
                     .map_to_json = _map_to_json,
                     .clone = _clone,
                     .list_factory = filterx_json_array_new_empty,

--- a/lib/filterx/object-json.c
+++ b/lib/filterx/object-json.c
@@ -76,6 +76,8 @@ _convert_json_to_object(FilterXObject *self, FilterXWeakRef *root_container, str
 {
   switch (json_object_get_type(jso))
     {
+    case json_type_null:
+      return filterx_null_new();
     case json_type_double:
       return filterx_double_new(json_object_get_double(jso));
     case json_type_boolean:
@@ -132,6 +134,10 @@ filterx_json_convert_json_to_object_cached(FilterXObject *self, FilterXWeakRef *
 void
 filterx_json_associate_cached_object(struct json_object *jso, FilterXObject *filterx_obj)
 {
+  /* null JSON value turns into NULL pointer. */
+  if (!jso)
+    return;
+
   filterx_eval_store_weak_ref(filterx_obj);
 
   /* we are not storing a reference in userdata to avoid circular

--- a/lib/filterx/object-json.c
+++ b/lib/filterx/object-json.c
@@ -115,7 +115,14 @@ filterx_json_convert_json_to_object_cached(FilterXObject *self, FilterXWeakRef *
        *
        * Changing the value of the double to the same value, ditches this,
        * but only if necessary.
+       *
+       * This only works starting with 0.14, before that json_object_set_double()
+       * does not drop the string user data, so we cannot check if it is our
+       * filterx object or the string, which means we cannot cache doubles.
        */
+
+      if (JSON_C_MAJOR_VERSION == 0 && JSON_C_MINOR_VERSION < 14)
+        return _convert_json_to_object(self, root_container, jso);
 
       json_object_set_double(jso, json_object_get_double(jso));
     }

--- a/lib/filterx/tests/CMakeLists.txt
+++ b/lib/filterx/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_unit_test(LIBTEST CRITERION TARGET test_object_integer DEPENDS json-plugin $
 add_unit_test(LIBTEST CRITERION TARGET test_object_double DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_type_registry DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_func_istype DEPENDS json-plugin ${JSONC_LIBRARY})
+add_unit_test(LIBTEST CRITERION TARGET test_func_unset_empties DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_expr_function DEPENDS json-plugin ${JSONC_LIBRARY})
 add_unit_test(LIBTEST CRITERION TARGET test_expr_regexp DEPENDS json-plugin ${JSONC_LIBRARY})
 

--- a/lib/filterx/tests/Makefile.am
+++ b/lib/filterx/tests/Makefile.am
@@ -18,6 +18,7 @@ lib_filterx_tests_TESTS		 =              \
 		lib/filterx/tests/test_builtin_functions \
 		lib/filterx/tests/test_type_registry \
 		lib/filterx/tests/test_func_istype \
+		lib/filterx/tests/test_func_unset_empties \
 		lib/filterx/tests/test_expr_regexp
 
 EXTRA_DIST += lib/filterx/tests/CMakeLists.txt
@@ -74,6 +75,9 @@ lib_filterx_tests_test_type_registry_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
 
 lib_filterx_tests_test_func_istype_CFLAGS  = $(TEST_CFLAGS)
 lib_filterx_tests_test_func_istype_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
+
+lib_filterx_tests_test_func_unset_empties_CFLAGS  = $(TEST_CFLAGS)
+lib_filterx_tests_test_func_unset_empties_LDADD   = $(TEST_LDADD) $(JSON_LIBS)
 
 lib_filterx_tests_test_expr_function_CFLAGS	= $(TEST_CFLAGS)
 lib_filterx_tests_test_expr_function_LDADD	= $(TEST_LDADD) $(JSON_LIBS)

--- a/lib/filterx/tests/test_func_unset_empties.c
+++ b/lib/filterx/tests/test_func_unset_empties.c
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2024 Attila Szakacs
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include "libtest/filterx-lib.h"
+
+#include "filterx/func-unset-empties.h"
+#include "filterx/object-string.h"
+#include "filterx/object-primitive.h"
+#include "filterx/object-json.h"
+#include "filterx/expr-literal.h"
+
+#include "apphook.h"
+#include "scratch-buffers.h"
+
+static void
+_assert_unset_empties_init_fail(GList *args)
+{
+  GError *err = NULL;
+  GError *args_err = NULL;
+  FilterXFunction *func = filterx_function_unset_empties_new("test", filterx_function_args_new(args, &args_err), &err);
+  cr_assert(!func);
+  cr_assert(err);
+  g_error_free(err);
+}
+
+static void
+_assert_unset_empties(GList *args, const gchar *expected_repr)
+{
+  FilterXExpr *modifiable_object_expr = filterx_expr_ref(((FilterXFunctionArg *) args->data)->value);
+
+  GError *err = NULL;
+  GError *args_err = NULL;
+  FilterXFunction *func = filterx_function_unset_empties_new("test", filterx_function_args_new(args, &args_err), &err);
+  cr_assert(!err);
+
+  FilterXObject *obj = filterx_expr_eval(&func->super);
+  cr_assert(obj);
+  gboolean success;
+  cr_assert(filterx_boolean_unwrap(obj, &success));
+  cr_assert(success);
+
+  FilterXObject *modifiable_object = filterx_expr_eval(modifiable_object_expr);
+  cr_assert(modifiable_object);
+
+  GString *repr = g_string_new(NULL);
+  cr_assert(filterx_object_repr(modifiable_object, repr));
+  cr_assert_str_eq(repr->str, expected_repr, "unset_empties() result is unexpected. Actual: %s Expected: %s", repr->str,
+                   expected_repr);
+
+  g_string_free(repr, TRUE);
+  filterx_object_unref(obj);
+  filterx_expr_unref(&func->super);
+  filterx_object_unref(modifiable_object);
+  filterx_expr_unref(modifiable_object_expr);
+}
+
+Test(filterx_func_unset_empties, invalid_args)
+{
+  const gchar *named_literal_bool_arg_names[] = {"recursive", "string", "number", "null", "dict", "list"};
+  GList *args = NULL;
+
+  /* no args */
+  _assert_unset_empties_init_fail(NULL);
+
+  /* non-literal named arg */
+  for (gint i = 0; i < G_N_ELEMENTS(named_literal_bool_arg_names); i++)
+    {
+      args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
+      args = g_list_append(args, filterx_function_arg_new(named_literal_bool_arg_names[i],
+                                                          filterx_non_literal_new(filterx_boolean_new(TRUE))));
+      _assert_unset_empties_init_fail(args);
+      args = NULL;
+    }
+
+  /* non-boolean named arg */
+  for (gint i = 0; i < G_N_ELEMENTS(named_literal_bool_arg_names); i++)
+    {
+      args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
+      args = g_list_append(args, filterx_function_arg_new(named_literal_bool_arg_names[i],
+                                                          filterx_literal_new(filterx_string_new("", -1))));
+      _assert_unset_empties_init_fail(args);
+      args = NULL;
+    }
+
+  /* too many args */
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_test_dict_new())));
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_string_new("", -1))));
+  _assert_unset_empties_init_fail(args);
+  args = NULL;
+}
+
+static void
+_test_type_modifier(const gchar *option_name, const gchar *value)
+{
+  GString *buffer = g_string_new(NULL);
+  GList *args = NULL;
+
+  /* dict */
+
+  /* default is always true */
+  g_string_printf(buffer, "{\"foo\":%s}", value);
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_json_new_from_repr(buffer->str,
+                                                      buffer->len))));
+  _assert_unset_empties(args, "{}");
+  args = NULL;
+
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_json_new_from_repr(buffer->str,
+                                                      buffer->len))));
+  args = g_list_append(args, filterx_function_arg_new(option_name, filterx_literal_new(filterx_boolean_new(FALSE))));
+  _assert_unset_empties(args, buffer->str);
+  args = NULL;
+
+  /* list */
+
+  /* default is always true */
+  g_string_printf(buffer, "[%s]", value);
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_json_new_from_repr(buffer->str,
+                                                      buffer->len))));
+  _assert_unset_empties(args, "[]");
+  args = NULL;
+
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_json_new_from_repr(buffer->str,
+                                                      buffer->len))));
+  args = g_list_append(args, filterx_function_arg_new(option_name, filterx_literal_new(filterx_boolean_new(FALSE))));
+  _assert_unset_empties(args, buffer->str);
+  args = NULL;
+
+  g_string_free(buffer, TRUE);
+}
+
+Test(filterx_func_unset_empties, type_modifiers)
+{
+  _test_type_modifier("string", "\"\"");
+  _test_type_modifier("number", "0");
+  _test_type_modifier("number", "0.0");
+  _test_type_modifier("null", "null");
+  _test_type_modifier("dict", "{}");
+  _test_type_modifier("list", "[]");
+}
+
+Test(filterx_func_unset_empties, recursive)
+{
+  GList *args = NULL;
+
+  /* dict */
+
+  /* default is true */
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_json_new_from_repr("[{\"foo\": 0}]", -1))));
+  _assert_unset_empties(args, "[]");
+  args = NULL;
+
+  args = g_list_append(args, filterx_function_arg_new(NULL,
+                                                      filterx_literal_new(filterx_json_new_from_repr("[{\"foo\": 0}]", -1))));
+  args = g_list_append(args, filterx_function_arg_new("recursive", filterx_literal_new(filterx_boolean_new(FALSE))));
+  _assert_unset_empties(args, "[{\"foo\":0}]");
+  args = NULL;
+
+  /* list */
+
+  /* default is true */
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_json_new_from_repr("[[0]]",
+                                                      -1))));
+  _assert_unset_empties(args, "[]");
+  args = NULL;
+
+  args = g_list_append(args, filterx_function_arg_new(NULL, filterx_literal_new(filterx_json_new_from_repr("[[0]]",
+                                                      -1))));
+  args = g_list_append(args, filterx_function_arg_new("recursive", filterx_literal_new(filterx_boolean_new(FALSE))));
+  _assert_unset_empties(args, "[[0]]");
+  args = NULL;
+}
+
+static void
+setup(void)
+{
+  app_startup();
+  init_libtest_filterx();
+}
+
+static void
+teardown(void)
+{
+  scratch_buffers_explicit_gc();
+  deinit_libtest_filterx();
+  app_shutdown();
+}
+
+TestSuite(filterx_func_unset_empties, .init = setup, .fini = teardown);


### PR DESCRIPTION
Usage: `unset_empties(object, recursive=true, string=true, null=true, number=true, dict=true, list=true)`

Example:
```
unset_empties(dict);
unset_empties(dict, recursive=true, string=true, number=true, null=true, dict=true, list=true);

unset_empties(list);
unset_empties(list, recursive=true, string=true, number=true, null=true, dict=true, list=true);
```

In recursive mode, it also unsets empty values deep in embedded lists and dicts, and unsets those dicts and lists as well, if they end up not having any values.