### PR TITLE
json: fix crash in case cache_json_file() can't load the file

### DIFF
--- a/modules/json/filterx-cache-json-file.c
+++ b/modules/json/filterx-cache-json-file.c
@@ -143,7 +143,8 @@ _free(FilterXExpr *s)
   FilterXFuntionCacheJsonFile *self = (FilterXFuntionCacheJsonFile *) s;
 
   g_free(self->filepath);
-  filterx_object_unfreeze_and_free(self->cached_json);
+  if (self->cached_json)
+    filterx_object_unfreeze_and_free(self->cached_json);
   filterx_function_free_method(&self->super);
 }
 


### PR DESCRIPTION
This fixes a potential NULL deref in the error path.
