### PR TITLE
helm: multiple fixes

### DIFF
--- a/contrib/syslog-ng-helm-chart/templates/compress-job.yaml
+++ b/contrib/syslog-ng-helm-chart/templates/compress-job.yaml
@@ -18,7 +18,7 @@ data:
        fi
       done
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "syslog-ng.fullname" . }}-compressor

--- a/contrib/syslog-ng-helm-chart/templates/deployment.yaml
+++ b/contrib/syslog-ng-helm-chart/templates/deployment.yaml
@@ -33,10 +33,16 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-          - name: tcp-port
+          - name: tcp-port-601
             containerPort: 601
             protocol: TCP
-          - name: udp-port
+          - name: tcp-port-514
+            containerPort: 514
+            protocol: TCP
+          - name: tcp-port-6514
+            containerPort: 6514
+            protocol: TCP
+          - name: udp-port-514
             containerPort: 514
             protocol: UDP
           volumeMounts:

--- a/contrib/syslog-ng-helm-chart/templates/deployment.yaml
+++ b/contrib/syslog-ng-helm-chart/templates/deployment.yaml
@@ -46,17 +46,21 @@ spec:
             containerPort: 514
             protocol: UDP
           volumeMounts:
+        {{- if .Values.config }}
           - mountPath: /etc/syslog-ng/syslog-ng.conf
             name: config
             subPath: syslog-ng.conf
+        {{- end }}
         {{- if .Values.storage.enable }}
           - mountPath: /var/log
             name: logs
         {{- end }}
       volumes:
+      {{- if .Values.config }}
       - name: config
         configMap:
           name: {{ include "syslog-ng.fullname" . }}
+      {{- end }}
       {{- if .Values.storage.enable }}
       - name: logs
         persistentVolumeClaim:

--- a/contrib/syslog-ng-helm-chart/templates/deployment.yaml
+++ b/contrib/syslog-ng-helm-chart/templates/deployment.yaml
@@ -34,10 +34,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
           - name: tcp-port
-            containerPort: 601
+            containerPort: 514
             protocol: TCP
           - name: udp-port
-            containerPort: 514
+            containerPort: 601
             protocol: UDP
           volumeMounts:
           - mountPath: /etc/syslog-ng/syslog-ng.conf

--- a/contrib/syslog-ng-helm-chart/templates/deployment.yaml
+++ b/contrib/syslog-ng-helm-chart/templates/deployment.yaml
@@ -34,10 +34,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
           - name: tcp-port
-            containerPort: 514
+            containerPort: 601
             protocol: TCP
           - name: udp-port
-            containerPort: 601
+            containerPort: 514
             protocol: UDP
           volumeMounts:
           - mountPath: /etc/syslog-ng/syslog-ng.conf

--- a/contrib/syslog-ng-helm-chart/templates/service.yaml
+++ b/contrib/syslog-ng-helm-chart/templates/service.yaml
@@ -16,12 +16,12 @@ spec:
   {{- end }}
   ports:
     - name: udp-port
-      port: 514
-      targetPort: 514
-      protocol: UDP
-    - name: tcp-port
       port: 601
       targetPort: 601
+      protocol: UDP
+    - name: tcp-port
+      port: 514
+      targetPort: 514
       protocol: TCP 
   selector:
     {{- include "syslog-ng.selectorLabels" . | nindent 4 }}

--- a/contrib/syslog-ng-helm-chart/templates/service.yaml
+++ b/contrib/syslog-ng-helm-chart/templates/service.yaml
@@ -16,12 +16,12 @@ spec:
   {{- end }}
   ports:
     - name: udp-port
-      port: 601
-      targetPort: 601
-      protocol: UDP
-    - name: tcp-port
       port: 514
       targetPort: 514
+      protocol: UDP
+    - name: tcp-port
+      port: 601
+      targetPort: 601
       protocol: TCP 
   selector:
     {{- include "syslog-ng.selectorLabels" . | nindent 4 }}

--- a/contrib/syslog-ng-helm-chart/templates/service.yaml
+++ b/contrib/syslog-ng-helm-chart/templates/service.yaml
@@ -15,13 +15,21 @@ spec:
   type: {{ .Values.service.type }}
   {{- end }}
   ports:
-    - name: udp-port
+    - name: tcp-port-514
+      port: 514
+      targetPort: 514
+      protocol: TCP
+    - name: tcp-port-601
+      port: 601
+      targetPort: 601
+      protocol: TCP
+    - name: tcp-port-6514
+      port: 6514
+      targetPort: 6514
+      protocol: TCP
+    - name: udp-port-514
       port: 514
       targetPort: 514
       protocol: UDP
-    - name: tcp-port
-      port: 601
-      targetPort: 601
-      protocol: TCP 
   selector:
     {{- include "syslog-ng.selectorLabels" . | nindent 4 }}

--- a/contrib/syslog-ng-helm-chart/values.yaml
+++ b/contrib/syslog-ng-helm-chart/values.yaml
@@ -8,28 +8,52 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "4.7.1"
 
-# By default, the network() driver binds to 0.0.0.0, meaning that it listens 
-# on every available IPV4 interface on the TCP/601 port.
+# By default, https://github.com/syslog-ng/syslog-ng/blob/master/docker/syslog-ng.conf will be used that is part of the image
+# You can ovverride this by providing your own config, for example:
+# config: |
+#   #############################################################################
+#   # Default syslog-ng.conf file which collects all local logs into a
+#   # single file called /var/log/messages tailored to container usage.
+#   #
+#   # The changes from the stock, default syslog-ng.conf file is that we've
+#   # dropped the system() source that is not needed and that we enabled network
+#   # connections using default-network-drivers(). Customize as needed and
+#   # override using the -v option to docker, such as:
+#   #
+#   #  docker run ...  -v "$PWD/syslog-ng.conf":/etc/syslog-ng/syslog-ng.conf
+#   #
 
-config: |
-  @version: 4.7
-  @include "scl.conf"
-  options {
-    # enable or disable directory creation for destination files
-    create_dirs(yes);
+#   @version: 4.7
+#   @include "scl.conf"
 
-    # keep hostnames from source host
-    keep_hostname(yes);
+#   source s_local {
+#     internal();
+#   };
 
-    # use ISO8601 timestamps
-    ts_format(iso);
-  };
-  log {
-  	source {
-  		network();
-  	};
-  	destination { file("/var/log/${YEAR}-${MONTH}-syslog"); };
-  };
+#   source s_network {
+#     default-network-drivers(
+#       # NOTE: TLS support
+#       #
+#       # the default-network-drivers() source driver opens the TLS
+#       # enabled ports as well, however without an actual key/cert
+#       # pair they will not operate and syslog-ng would display a
+#       # warning at startup.
+#       #
+#       #tls(key-file("/path/to/ssl-private-key") cert-file("/path/to/ssl-cert"))
+#     );
+#   };
+
+#   destination d_local {
+#     file("/var/log/messages");
+#     file("/var/log/messages-kv.log" template("$ISODATE $HOST $(format-welf --scope all-nv-pairs)\n") frac-digits(3));
+#   };
+
+#   log {
+#     source(s_local);
+#     source(s_network);
+#     destination(d_local);
+#   };
+config: ""
 
 storage:
   enable: True

--- a/contrib/syslog-ng-helm-chart/values.yaml
+++ b/contrib/syslog-ng-helm-chart/values.yaml
@@ -6,13 +6,13 @@ image:
   repository: balabit/syslog-ng
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "3.27.1"
+  tag: "4.7.1"
 
 # By default, the network() driver binds to 0.0.0.0, meaning that it listens 
 # on every available IPV4 interface on the TCP/601 port.
 
 config: |
-  @version: 3.27
+  @version: 4.7
   @include "scl.conf"
   options {
     # enable or disable directory creation for destination files


### PR DESCRIPTION
Multiple fixes in the `contrib/syslog-ng-helm-chart` helm chart
- updated the `apiVersion: batch/v1beta1` to `apiVersion: batch/v1` of the CronJob that was deprecated in 1.21 and removed in 1.25 k8s versions
- upgraded syslog-ng image tag and config @version from `3.27.1` to `4.7.1` in values.yaml
- fixed the tcp and udp ports that were mixed up in `service.yaml` and `deployment.yaml`