### PR TITLE
diskq: open the dirlock file in read-write mode

### DIFF
--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -216,7 +216,7 @@ _grab_dirlock(const gchar *dir, gint *fd)
 
   g_mutex_lock(&filename_lock);
 
-  *fd = open(dirlock_file_path, O_RDONLY | O_CREAT, 0600);
+  *fd = open(dirlock_file_path, O_RDWR | O_CREAT, 0600);
   if (*fd < 0)
     {
       msg_error("Failed to open disk-buffer dirlock file",


### PR DESCRIPTION
In case of NFS, flock() is emulated via fcntl() locks that only works in case we have write access as well.

Reported-by: Arpad Kunszt
Signed-off-by: Balazs Scheidler <balazs.scheidler@axoflow.com>

Backport: [#124](https://github.com/axoflow/axosyslog/pull/124)