### PR TITLE
S3 server side encryption

### DIFF
--- a/modules/python-modules/syslogng/modules/s3/s3_object.py
+++ b/modules/python-modules/syslogng/modules/s3/s3_object.py
@@ -165,8 +165,6 @@ class S3ObjectPersist:
                 "compress",
                 "compresslevel",
                 "chunk-size",
-                "server-side-encryption",
-                "kms-key",
                 "storage-class",
                 "finished",
                 "upload-id",

--- a/modules/python-modules/syslogng/modules/s3/s3_object.py
+++ b/modules/python-modules/syslogng/modules/s3/s3_object.py
@@ -156,6 +156,16 @@ class S3ObjectPersist:
                     raise PersistLoadError from e
 
         if path:
+            # fields added in later releases can be missing from the persist JSON
+            # set a sane default value which can be overriden later if the user set
+            # the appropriate configuration directives
+            for upgrade_field in {
+                "canned-acl",
+                "kms-key",
+                "server-side-encryption",
+            }:
+                cache[upgrade_field] = cache.get(upgrade_field, "")
+
             for field in {
                 "persist-name",
                 "bucket",
@@ -170,12 +180,16 @@ class S3ObjectPersist:
                 "upload-id",
                 "uploaded-parts",
                 "pending-parts",
+                "canned-acl",
+                "kms-key",
+                "server-side-encryption",
             }:
                 try:
                     cache[field]
                 except KeyError as e:
                     raise PersistLoadError from e
 
+        # fields
         self.__persist_name: str = cache.get("persist-name", persist_name)
         self.__bucket: str = cache.get("bucket", bucket)
         self.__target_key: str = cache.get("target-key", target_key)
@@ -184,14 +198,15 @@ class S3ObjectPersist:
         self.__compress: bool = cache.get("compress", compress)
         self.__compresslevel: bool = cache.get("compresslevel", compresslevel)
         self.__chunk_size: bool = cache.get("chunk-size", chunk_size)
-        self.__server_side_encryption: str = cache.get("server-side-encryption", server_side_encryption)
-        self.__kms_key: str = cache.get("kms-key", kms_key)
         self.__storage_class: str = cache.get("storage-class", storage_class)
-        self.__canned_acl: str = cache.get("canned-acl", canned_acl)
         self.__finished: bool = cache.get("finished", False)
         self.__upload_id: str = cache.get("upload-id", "")
         self.__uploaded_parts: List[Dict[str, Any]] = cache.get("uploaded-parts", [])
         self.__pending_parts: Dict[str, Any] = cache.get("pending-parts", dict())
+        # upgrade fields
+        self.__canned_acl: str = cache.get("canned-acl", canned_acl)
+        self.__kms_key: str = cache.get("kms-key", kms_key)
+        self.__server_side_encryption: str = cache.get("server-side-encryption", server_side_encryption)
 
         self.__flush()
 

--- a/modules/python-modules/syslogng/modules/s3/s3_object.py
+++ b/modules/python-modules/syslogng/modules/s3/s3_object.py
@@ -117,6 +117,8 @@ class S3ObjectPersist:
         compress: Optional[bool] = None,
         compresslevel: Optional[int] = None,
         chunk_size: Optional[int] = None,
+        server_side_encryption: Optional[str] = None,
+        kms_key: Optional[str] = None,
         storage_class: Optional[str] = None,
         canned_acl: Optional[str] = None,
     ):
@@ -133,6 +135,8 @@ class S3ObjectPersist:
                 and compresslevel is not None
                 and chunk_size is not None
                 and storage_class is not None
+                and server_side_encryption is not None
+                and kms_key is not None
                 and canned_acl is not None
             )
         else:
@@ -161,6 +165,8 @@ class S3ObjectPersist:
                 "compress",
                 "compresslevel",
                 "chunk-size",
+                "server-side-encryption",
+                "kms-key",
                 "storage-class",
                 "finished",
                 "upload-id",
@@ -180,6 +186,8 @@ class S3ObjectPersist:
         self.__compress: bool = cache.get("compress", compress)
         self.__compresslevel: bool = cache.get("compresslevel", compresslevel)
         self.__chunk_size: bool = cache.get("chunk-size", chunk_size)
+        self.__server_side_encryption: str = cache.get("server-side-encryption", server_side_encryption)
+        self.__kms_key: str = cache.get("kms-key", kms_key)
         self.__storage_class: str = cache.get("storage-class", storage_class)
         self.__canned_acl: str = cache.get("canned-acl", canned_acl)
         self.__finished: bool = cache.get("finished", False)
@@ -202,6 +210,8 @@ class S3ObjectPersist:
             "index": self.__index,
             "compress": self.__compress,
             "compresslevel": self.__compresslevel,
+            "server-side-encryption": self.__server_side_encryption,
+            "kms-key": self.__kms_key,
             "storage-class": self.__storage_class,
             "canned-acl": self.__canned_acl,
             "chunk-size": self.__chunk_size,
@@ -263,6 +273,14 @@ class S3ObjectPersist:
     @property
     def chunk_size(self) -> bool:
         return self.__chunk_size
+
+    @property
+    def server_side_encryption(self) -> str:
+        return self.__server_side_encryption
+
+    @property
+    def kms_key(self) -> str:
+        return self.__kms_key
 
     @property
     def storage_class(self) -> str:
@@ -345,6 +363,8 @@ class S3Object:
         compress: Optional[bool] = None,
         chunk_size: Optional[int] = None,
         compresslevel: Optional[int] = None,
+        server_side_encryption: Optional[str] = None,
+        kms_key: Optional[str] = None,
         storage_class: Optional[str] = None,
         canned_acl: Optional[str] = None,
         persist: Optional[S3ObjectPersist] = None,
@@ -377,6 +397,8 @@ class S3Object:
                 and compress is not None
                 and chunk_size is not None
                 and compresslevel is not None
+                and server_side_encryption is not None
+                and kms_key is not None
                 and storage_class is not None
                 and canned_acl is not None
             )
@@ -389,6 +411,8 @@ class S3Object:
                 compress=compress,
                 compresslevel=compresslevel,
                 chunk_size=chunk_size,
+                server_side_encryption=server_side_encryption,
+                kms_key=kms_key,
                 storage_class=storage_class,
                 canned_acl=canned_acl,
             )
@@ -431,6 +455,8 @@ class S3Object:
         timestamp: str,
         compress: bool,
         compresslevel: int,
+        server_side_encryption: str,
+        kms_key: str,
         storage_class: str,
         canned_acl: str,
         persist_name: str,
@@ -451,6 +477,8 @@ class S3Object:
             target_index=0,
             compress=compress,
             compresslevel=compresslevel,
+            server_side_encryption=server_side_encryption,
+            kms_key=kms_key,
             storage_class=storage_class,
             canned_acl=canned_acl,
             chunk_size=chunk_size,
@@ -480,6 +508,8 @@ class S3Object:
             target_index=self.index + 1,
             compress=self.__persist.compress,
             compresslevel=self.__persist.compresslevel,
+            server_side_encryption=self.__persist.server_side_encryption,
+            kms_key=self.__persist.kms_key,
             storage_class=self.__persist.storage_class,
             canned_acl=self.__persist.canned_acl,
             chunk_size=self.__persist.chunk_size,
@@ -546,6 +576,13 @@ class S3Object:
         if self.__persist.upload_id != "":
             return True
 
+        sse_arguments = {}
+        if self.__persist.server_side_encryption != "":
+            sse_arguments["ServerSideEncryption"] = self.__persist.server_side_encryption
+
+        if self.__persist.kms_key != "":
+            sse_arguments["SSEKMSKeyId"] = self.__persist.kms_key
+
         try:
             if self.__persist.canned_acl != "":
                 response = self.__client.create_multipart_upload(
@@ -553,12 +590,14 @@ class S3Object:
                     Key=self.key,
                     StorageClass=self.__persist.storage_class,
                     ACL=self.__persist.canned_acl,
+                    **sse_arguments,
                 )
             else:
                 response = self.__client.create_multipart_upload(
                     Bucket=self.bucket,
                     Key=self.key,
                     StorageClass=self.__persist.storage_class,
+                    **sse_arguments,
                 )
         except (ClientError, EndpointConnectionError) as e:
             self.__logger.error(f"Failed to create multipart upload: {self.bucket}/{self.key} => {e}")

--- a/modules/python-modules/syslogng/modules/s3/scl/s3.conf
+++ b/modules/python-modules/syslogng/modules/s3/scl/s3.conf
@@ -37,6 +37,8 @@ block destination s3(
     max_pending_uploads(32)
     flush_grace_period(60)
     region("")
+    server_side_encryption("")
+    kms_key("")
     storage_class("STANDARD")
     canned_acl("")
     ...
@@ -61,6 +63,8 @@ block destination s3(
             "max_pending_uploads" => `max_pending_uploads`
             "flush_grace_period" => `flush_grace_period`
             "region" => "`region`"
+            "server_side_encryption" => "`server_side_encryption`"
+            "kms_key" => "`kms_key`"
             "storage_class" => "`storage_class`"
             "canned_acl" => "`canned_acl`"
         )

--- a/news/feature-4993.md
+++ b/news/feature-4993.md
@@ -1,0 +1,31 @@
+`s3()`: Introduced server side encryption related options
+
+`server-side-encryption()` and `kms-key()` can be used to configure encryption.
+
+Currently only `server-side-encryption("aws:kms")` is supported.
+The `kms-key()` should be:
+  * an ID of a key
+  * an alias of a key, but in that case you have to add the alias/prefix
+  * an ARN of a key
+
+To be able to use the aws:kms encryption the AWS Role or User has to have the following
+permissions on the given key:
+  * `kms:Decrypt`
+  * `kms:Encrypt`
+  * `kms:GenerateDataKey`
+
+Check [this](https://repost.aws/knowledge-center/s3-large-file-encryption-kms-key) page on why the `kms:Decrypt` is mandatory.
+
+Example config:
+```
+destination d_s3 {
+  s3(
+    bucket("log-archive-bucket")
+    object-key("logs/syslog")
+    server-side-encryption("aws:kms")
+    kms-key("alias/log-archive")
+  );
+};
+```
+
+See the [S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html) documentation for more details.


### PR DESCRIPTION
This PR enables to use the server side encryption on the s3() destination. It is a common pattern that data stored on the S3 bucket is encrypted at the rest.

S3 supports multiple server side encryption possibilities. This is only for the `aws:kms` method. In theory `aws:kms:dsse` should also work but as it uses the same arguments but I didn't test it so I disabled that intentionally.

Check the [s3api](https://docs.aws.amazon.com/cli/latest/reference/s3api/create-multipart-upload.html) documentation for the details.

This means that the server-side-encryption() option accepts only `aws:kms` or an empty string, which is the default.

The kms-key() should be:

    * an ID of a key

    * an alias of a key, but in that case you have to add the `alias/` prefix

    * an ARN of a key


For example:

```
destination d_s3 {
        s3(
                bucket( "log-archive-bucket" )
                object-key( "logs/syslog" )
                server-side-encryption( "aws:kms" )
                kms-key( "alias/log-archive" )
        );
};
```

To be able to use the `aws:kms` encryption the AWS Role or User has to have the following permissions on the given key:

    * kms:Decrypt

    * kms:Encrypt

    * kms:GenerateDataKey


Check [this](https://repost.aws/knowledge-center/s3-large-file-encryption-kms-key) page on why the kms:Decrypt is mandatory.

Setting server-side-encryption() to `aws:kms` without setting kms-key() will terminate the syslog-ng process.

Setting kms-key() without setting server-side-encryption() emits a warning and ignores the kms-key(). The server side encryption will be disabled in this case.

It also worth mentioning that kms-key() cannot be changed after the create_multipart_upload executed. I am not sure what will happen if someone modifies the key and then just reloads the syslog-ng configuration. A normal restart would work as syslog-ng finishes the multipart upload during the shutdown.

Signed-off-by: Arpad Kunszt <akunszt@hiya.com>

Backport: [#127](https://github.com/axoflow/axosyslog/pull/127)