### PR TITLE
fix: otel kvlist get_subscript

### DIFF
--- a/modules/grpc/otel/filterx/object-otel-kvlist.cpp
+++ b/modules/grpc/otel/filterx/object-otel-kvlist.cpp
@@ -154,10 +154,7 @@ KVList::get_subscript(FilterXObject *key)
   ProtobufField *converter = otel_converter_by_type(FieldDescriptor::TYPE_MESSAGE);
   KeyValue *kv = get_mutable_kv_for_key(key_c_str);
   if (!kv)
-    {
-      kv = repeated_kv->Add();
-      kv->set_key(key_c_str);
-    }
+    return NULL;
 
   return converter->Get(kv, "value");
 }


### PR DESCRIPTION
otel: filterx kv-list get_subscript now returns hard NULL on missing key

Backport: [#150](https://github.com/axoflow/axosyslog/pull/150)