### PR TITLE
multiline-options: Allow multi_line_timeout  set to a none integer value

### DIFF
--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -179,8 +179,8 @@ source_affile_options
         ;
 
 source_affile_option
-	: KW_FOLLOW_FREQ '(' nonnegative_float ')'		{ file_reader_options_set_follow_freq(last_file_reader_options, (long) ($3 * 1000)); }
-	| KW_PAD_SIZE '(' nonnegative_integer ')'	{ last_log_proto_options->pad_size = $3; }
+	: KW_FOLLOW_FREQ '(' nonnegative_float ')' { file_reader_options_set_follow_freq(last_file_reader_options, (gint) ($3 * 1000)); }
+	| KW_PAD_SIZE '(' nonnegative_integer ')' { last_log_proto_options->pad_size = $3; }
 	| multi_line_option
 	| multi_line_timeout
 	| file_perm_option
@@ -240,9 +240,9 @@ source_afpipe_option
 	;
 
 multi_line_timeout
-	: KW_MULTI_LINE_TIMEOUT '(' nonnegative_integer ')'
+	: KW_MULTI_LINE_TIMEOUT '(' nonnegative_float ')'
 	  {
-	    	file_reader_options_set_multi_line_timeout(last_file_reader_options, ($3 * 1000));
+		file_reader_options_set_multi_line_timeout(last_file_reader_options, (gint) ($3 * 1000));
 	  }
 	;
 


### PR DESCRIPTION
The actual implementation. and validations restrict only the value to be higher than the `follow-freq` (ideally multiplication of it). As the `follow-freq` can be much smaller than one second it makes sense to allow this value to be a non-integer value as well.

Signed-off-by: Hofi <hofione@gmail.com>
