### PR TITLE
Fixed Fedora Rawhide not Building in DBLD

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -36,8 +36,10 @@ jobs:
       distros: '[
         "almalinux-8",
         "almalinux-9",
+        "centos-stream9",
         "debian-bookworm",
         "debian-testing",
         "fedora-latest",
+        "fedora-rawhide",
         "ubuntu-noble"
       ]'

--- a/dbld/builddeps
+++ b/dbld/builddeps
@@ -31,14 +31,14 @@ function install_dbld_dependencies()
 {
     case "${OS_DISTRIBUTION}" in
         centos|almalinux)
-            $YUM_INSTALL wget yum-utils
+            $YUM_INSTALL yum-utils
             ;;
         debian|ubuntu)
             apt-get update
-            $APT_INSTALL wget gnupg2
+            $APT_INSTALL curl gnupg2
             ;;
         fedora)
-            $DNF_INSTALL -y wget dnf-plugins-core
+            $DNF_INSTALL -y dnf-plugins-core
             ;;
     esac
 }
@@ -92,7 +92,7 @@ function install_pip2 {
 function download_target() {
     target=$1
     output=$2
-    wget --no-check-certificate $target --output-document=$output
+    curl --location --insecure "$target" --output "$output"
 }
 
 function filter_packages_by_platform {
@@ -214,9 +214,9 @@ function install_perf {
 function install_bison_from_source {
     BISON_VERSION=3.7.6
     cd /tmp
-    wget https://ftp.gnu.org/gnu/bison/bison-${BISON_VERSION}.tar.gz
-    tar xvfz bison-${BISON_VERSION}.tar.gz
-    cd bison-${BISON_VERSION}
+    download_target https://ftp.gnu.org/gnu/bison/bison-${BISON_VERSION}.tar.gz /tmp/bison-${BISON_VERSION}.tar.gz
+    tar xvfz /tmp/bison-${BISON_VERSION}.tar.gz
+    cd /tmp/bison-${BISON_VERSION}
     ./configure --prefix=/usr/local --disable-nls
     make && make install
 }

--- a/dbld/images/centos-stream9.dockerfile
+++ b/dbld/images/centos-stream9.dockerfile
@@ -20,6 +20,8 @@ RUN /dbld/builddeps install_rpm_build_deps
 RUN /dbld/builddeps install_criterion
 RUN /dbld/builddeps install_gradle
 
+RUN dnf upgrade -y
+
 VOLUME /source
 VOLUME /build
 

--- a/dbld/images/debian-testing.dockerfile
+++ b/dbld/images/debian-testing.dockerfile
@@ -19,6 +19,8 @@ RUN /dbld/builddeps install_dbld_dependencies
 RUN /dbld/builddeps install_apt_packages
 RUN /dbld/builddeps install_debian_build_deps
 
+RUN apt upgrade -y
+
 VOLUME /source
 VOLUME /build
 

--- a/dbld/images/fedora-rawhide.dockerfile
+++ b/dbld/images/fedora-rawhide.dockerfile
@@ -20,6 +20,8 @@ RUN /dbld/builddeps install_rpm_build_deps
 RUN /dbld/builddeps install_criterion
 RUN /dbld/builddeps install_gradle
 
+RUN dnf upgrade -y
+
 VOLUME /source
 VOLUME /build
 


### PR DESCRIPTION
<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->
This build failure was caused by wget linking to a different version library than what it was built with. This was fixed by transitioning duilddeps to use curl.
This PR also adds a package update to the testing images to ensure they are up-to-date and provide better early warning capabilities for breaking changes in their respective OS family.

<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
