### PR TITLE
ci: re-enable debian-testing package update test

### DIFF
--- a/.github/workflows/test-apt-packages.yml
+++ b/.github/workflows/test-apt-packages.yml
@@ -27,11 +27,6 @@ jobs:
         upgrade-from:
           - "debian-official"
           - "syslog-ng-last"
-        exclude:
-          # The official syslog-ng got removed from debian:testing because of pcre:
-          # https://tracker.debian.org/news/1445295/syslog-ng-removed-from-testing/
-          - distro: "debian:testing"
-            upgrade-from: "debian-official"
       fail-fast: false
     runs-on: ubuntu-latest
     container: ${{ matrix.distro }}


### PR DESCRIPTION
Backport: [#207](https://github.com/axoflow/axosyslog/pull/207)