### PR TITLE
 lib,modules: fix gcc warnings about discarded const qualifiers

### DIFF
--- a/lib/scanner/csv-scanner/csv-scanner.c
+++ b/lib/scanner/csv-scanner/csv-scanner.c
@@ -163,7 +163,7 @@ _skip_whitespace(const gchar **src)
 static void
 _parse_opening_quote_character(CSVScanner *self)
 {
-  gchar *quote = _strchr_optimized_for_single_char_haystack(self->options->quotes_start, *self->src);
+  const gchar *quote = _strchr_optimized_for_single_char_haystack(self->options->quotes_start, *self->src);
 
   if (quote != NULL)
     {

--- a/lib/str-utils.h
+++ b/lib/str-utils.h
@@ -98,11 +98,11 @@ gchar *normalize_flag(const gchar *buffer);
  *
  * NOTE: don't use this unless strchr() really shows up in your profile.
  */
-static inline char *
+static inline const char *
 _strchr_optimized_for_single_char_haystack(const char *str, int c)
 {
   if (str[0] == c)
-    return (char *) str;
+    return str;
   else if (str[0] == '\0')
     return NULL;
   if (str[1] == '\0')
@@ -110,7 +110,7 @@ _strchr_optimized_for_single_char_haystack(const char *str, int c)
       if (c != '\0')
         return NULL;
       else
-        return (char *) &str[1];
+        return &str[1];
     }
   return strchr(str + 1, c);
 }

--- a/lib/tests/test_str-utils.c
+++ b/lib/tests/test_str-utils.c
@@ -78,7 +78,7 @@ ParameterizedTestParameters(str_utils, test_str_utils_find_char)
 
 ParameterizedTest(StrChrTestData *test_data, str_utils, test_str_utils_find_char)
 {
-  char *result = strchr_under_test(test_data->str, test_data->c);
+  const char *result = strchr_under_test(test_data->str, test_data->c);
 
   cr_assert_not_null(result, "expected a non-NULL return");
   cr_assert(result - test_data->str <= strlen(test_data->str),

--- a/modules/afsnmp/afsnmpdest.c
+++ b/modules/afsnmp/afsnmpdest.c
@@ -138,7 +138,7 @@ snmpdest_dd_set_port(LogDriver *d, gint port)
 static gint
 snmp_dd_compare_object_ids(gconstpointer a, gconstpointer b)
 {
-  return strcmp((gchar *) a, (gchar *) b);
+  return strcmp((const gchar *) a, (const gchar *) b);
 }
 
 gboolean
@@ -155,7 +155,7 @@ snmpdest_dd_set_snmp_obj(LogDriver *d, GlobalConfig *cfg, const gchar *objectid,
       return FALSE;
     }
 
-  gchar *s_objectid = "objectid";
+  const gchar *s_objectid = "objectid";
 
   /* check the multiple 'objectid' types - only one type='objectid' is allowed */
   if (!strcmp(type, s_objectid) && self->snmp_objs)
@@ -453,7 +453,7 @@ snmpdest_worker_insert(LogThreadedDestDriver *s, LogMessage *msg)
 static const gchar *
 snmpdest_dd_format_persist_name(const LogPipe *s)
 {
-  SNMPDestDriver *self = (SNMPDestDriver *) s;
+  const SNMPDestDriver *self = (const SNMPDestDriver *) s;
   static gchar persist_name[1024];
 
   g_snprintf(persist_name, sizeof(persist_name), "snmpdest(%s,%u)", self->host, self->port);


### PR DESCRIPTION
Signed-off-by: László Várady <laszlo.varady@anno.io>

Backport: [#211](https://github.com/axoflow/axosyslog/pull/211)