### PR TITLE
cfg: Allow usage of `current` in config @version by default if it is not presented

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -693,9 +693,10 @@ cfg_read_config(GlobalConfig *self, const gchar *fname, gchar *preprocess_into)
 
       if (self->user_version == 0)
         {
-          msg_error("ERROR: configuration files without a version number have become unsupported in " VERSION_3_13
-                    ", please specify a version number using @version as the first line in the configuration file");
-          return FALSE;
+          msg_warning("WARNING: no version information provided in the configuration file. Please specify `current` "
+                      "to use the latest version and silence this warning, or specify a specific version number using "
+                      "@version as the first line in the configuration file.");
+          cfg_set_current_version(self);
         }
 
       if (res)

--- a/news/other-5030.md
+++ b/news/other-5030.md
@@ -1,0 +1,5 @@
+`cfg`: allow usage of `current` in config @version by default if it is not presented
+
+This change allows syslog-ng to start even if the `@version` information is not present in the configuration file and treats the version as the latest in that case.
+
+**NOTE:** syslog-ng will still raise a warning if `@version` is not present. Please use `@version: current` to confirm the intention of always using the latest version and silence the warning.


### PR DESCRIPTION
This change allows syslog-ng to start even if the `@version` information is not present in the configuration file and treats the version as the latest in that case.

**NOTE:** syslog-ng will still raise a warning if `@version` is not present. Please use `@version: current` to confirm the intention of always using the latest version and silence the warning.

Signed-off-by: Hofi <hofione@gmail.com>

Modified backport: [#212](https://github.com/axoflow/axosyslog/pull/212)
