### PR TITLE
Fix release targz build issues

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -162,6 +162,11 @@ local-check:
 				TESTS="${current_tests} ${subdir_tests}"
 endif
 
+# We use VERSION.txt, as VERSION file can cause C++ build errors on case-insensitive file-systems.
+# Some step(s?) still can produce or leave behind a VERSION file, clean it up before packing the final dist tar.gz file.
+dist-hook:
+	rm -f VERSION
+
 check: check_target_guard
 
 check_target_guard:

--- a/cmake/Makefile.am
+++ b/cmake/Makefile.am
@@ -13,6 +13,7 @@ EXTRA_DIST +=	\
 	cmake/Modules/FindFLEX.cmake	\
 	cmake/Modules/FindGettext.cmake	\
 	cmake/Modules/FindGLIB.cmake	\
+	cmake/Modules/FindGperf.cmake	\
 	cmake/Modules/FindGradle.cmake	\
 	cmake/Modules/FindgRPC.cmake	\
 	cmake/Modules/FindHiredis.cmake	\
@@ -36,4 +37,5 @@ EXTRA_DIST +=	\
 	cmake/Modules/ProtobufGenerateCpp.cmake	\
 	cmake/module_switch.cmake		\
 	cmake/openssl_functions.cmake \
-	cmake/print_config_summary.cmake
+	cmake/print_config_summary.cmake \
+	cmake/python_build_venv.cmake

--- a/modules/afmongodb/Makefile.am
+++ b/modules/afmongodb/Makefile.am
@@ -41,7 +41,8 @@ BUILT_SOURCES					+=	\
 
 EXTRA_DIST					+=	\
 	modules/afmongodb/afmongodb-grammar.ym \
-	modules/afmongodb/CMakeLists.txt
+	modules/afmongodb/CMakeLists.txt \
+	modules/afmongodb/tests/CMakeLists.txt
 
 
 .PHONY: modules/afmongodb/ mod-afmongodb mod-mongodb


### PR DESCRIPTION
This fix addresses multiple CMake build issues from the release tar.gz file.

Thanks to @Schamschula and @czanik for reporting the issues.

NOTE: The release tar.gz file still cannot be built on case-insensitive file systems with `ivykis=internal` that is an [ivykis issue](https://github.com/buytenh/ivykis/issues/36) that hopefully will be fixed shortly, so I did not add a workaround for that at the end.

Signed-off-by: Hofi <hofione@gmail.com>

Fixes #4779