### PR TITLE
CI: enable grpc in macOS CI builds

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,7 +58,6 @@ jobs:
             --with-python=3
             --with-systemd-journal=no
             --disable-smtp
-            --disable-grpc
             --disable-java
             --disable-java-modules
             --disable-mqtt

--- a/configure.ac
+++ b/configure.ac
@@ -2301,6 +2301,7 @@ AM_CONDITIONAL([HAVE_FMEMOPEN], [test x$ac_cv_func_fmemopen = xyes])
 AM_CONDITIONAL([HAVE_JAVAH], [test -n "$JAVAH_BIN"])
 AM_CONDITIONAL(ENABLE_IPV6, [test $enable_ipv6 = yes])
 
+AM_CONDITIONAL(OS_TYPE_MACOS, [test $ostype = "Darwin"])
 
 AC_SUBST(PYTHON_VENV)
 AC_SUBST(PYTHON_VENV_DIR)

--- a/contrib/Brewfile
+++ b/contrib/Brewfile
@@ -26,4 +26,6 @@ brew "python@3", link: true, force: true
 brew "rabbitmq-c"
 brew "riemann-client"
 
+brew "grpc"
+
 brew "criterion"

--- a/modules/grpc/otel/tests/Makefile.am
+++ b/modules/grpc/otel/tests/Makefile.am
@@ -1,5 +1,6 @@
 if ENABLE_GRPC
 
+if ! OS_TYPE_MACOS
 modules_grpc_otel_tests_TESTS = \
   modules/grpc/otel/tests/test_otel_protobuf_parser \
   modules/grpc/otel/tests/test_otel_protobuf_formatter \
@@ -7,6 +8,7 @@ modules_grpc_otel_tests_TESTS = \
   modules/grpc/otel/tests/test_otel_filterx
 
 check_PROGRAMS += ${modules_grpc_otel_tests_TESTS}
+endif
 
 modules_grpc_otel_tests_test_otel_protobuf_parser_SOURCES = \
   modules/grpc/otel/tests/test-otel-protobuf-parser.cpp


### PR DESCRIPTION
Turned on GRPC modules for macOS builds, but because of various CMake issues only for autotools builds currently.

Signed-off-by: Hofi <hofione@gmail.com>