### PR TITLE
cfg: Fix overflow of config port number definitions

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -87,6 +87,7 @@ set (LIB_HEADERS
     cfg-block.h
     cfg-block-generator.h
     cfg-grammar-internal.h
+    cfg-helpers.h
     cfg-parser.h
     cfg-path.h
     cfg-source.h
@@ -186,6 +187,7 @@ set(LIB_SOURCES
     cfg-lexer.c
     cfg-lexer-subst.c
     cfg-grammar-internal.c
+    cfg-helpers.c
     cfg-parser.c
     cfg-path.c
     cfg-source.c

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -100,6 +100,7 @@ pkginclude_HEADERS			+= \
 	lib/cfg.h			\
 	lib/cfg-grammar.h		\
 	lib/cfg-grammar-internal.h	\
+	lib/cfg-helpers.h		\
 	lib/cfg-lexer.h			\
 	lib/cfg-lexer-subst.h		\
 	lib/cfg-args.h			\
@@ -202,6 +203,7 @@ lib_libsyslog_ng_la_SOURCES		= \
 	lib/cfg-block-generator.c	\
 	lib/cfg-lexer.c			\
 	lib/cfg-lexer-subst.c		\
+	lib/cfg-helpers.c		\
 	lib/cfg-parser.c		\
 	lib/cfg-path.c			\
 	lib/cfg-source.c		\

--- a/lib/cfg-helpers.c
+++ b/lib/cfg-helpers.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2024 OneIdentity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "cfg-helpers.h"
+
+gboolean
+cfg_check_port(const gchar *port)
+{
+  /* only digits (->numbers) are allowed */
+  int len = strlen(port);
+  if (len < 1 || len > 5)
+    return FALSE;
+  for (int i = 0; i < len; ++i)
+    if (port[i] < '0' || port[i] > '9')
+      return FALSE;
+  int port_num = atoi(port);
+  return port_num > 0 && port_num <= G_MAXUINT16;
+}

--- a/lib/cfg-helpers.h
+++ b/lib/cfg-helpers.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017 Balabit
+ * Copyright (c) 2024 OneIdentity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef CFG_HELPERS_H_INCLUDED
+#define CFG_HELPERS_H_INCLUDED 1
+
+#include "syslog-ng.h"
+
+gboolean cfg_check_port(const gchar *port);
+
+#endif

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_unit_test(CRITERION TARGET test_cfg_lexer_subst)
 add_unit_test(CRITERION TARGET test_cfg_tree)
+add_unit_test(CRITERION TARGET test_cfg_helpers)
 add_unit_test(CRITERION TARGET test_parse_number)
 add_unit_test(CRITERION TARGET test_reloc)
 add_unit_test(CRITERION TARGET test_hostname)

--- a/lib/tests/Makefile.am
+++ b/lib/tests/Makefile.am
@@ -2,6 +2,7 @@ lib_tests_TESTS		= \
 	lib/tests/test_cfg_lexer_subst	\
 	lib/tests/test_lexer_block	\
 	lib/tests/test_cfg_tree		\
+	lib/tests/test_cfg_helpers	\
 	lib/tests/test_parse_number	\
 	lib/tests/test_generic_number	\
 	lib/tests/test_reloc		\
@@ -63,6 +64,11 @@ lib_tests_test_lexer_block_LDADD	=	\
 lib_tests_test_cfg_tree_CFLAGS		=	\
 	$(TEST_CFLAGS)
 lib_tests_test_cfg_tree_LDADD		=	\
+	$(TEST_LDADD)
+
+lib_tests_test_cfg_helpers_CFLAGS		=	\
+	$(TEST_CFLAGS)
+lib_tests_test_cfg_helpers_LDADD		=	\
 	$(TEST_LDADD)
 
 

--- a/lib/tests/test_cfg_helpers.c
+++ b/lib/tests/test_cfg_helpers.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018 Balabit
+ * Copyright (c) 2024 OneIdentity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include <criterion/parameterized.h>
+
+#include "cfg-helpers.h"
+
+
+Test(test_cfg_helpers, test_port)
+{
+  cr_assert(cfg_check_port("1"));
+  cr_assert(cfg_check_port("65535"));
+
+  cr_assert_not(cfg_check_port("0"));
+  cr_assert_not(cfg_check_port("-1"));
+  cr_assert_not(cfg_check_port("65536"));
+  cr_assert_not(cfg_check_port("1234567890"));
+}

--- a/modules/afamqp/afamqp-grammar.ym
+++ b/modules/afamqp/afamqp-grammar.ym
@@ -31,6 +31,7 @@
 %code {
 
 #include "cfg-grammar-internal.h"
+#include "cfg-helpers.h"
 
 }
 
@@ -80,7 +81,7 @@ afamqp_options
 
 afamqp_option
 	: KW_HOST '(' string ')'                   { afamqp_dd_set_host(last_driver, $3); free($3); }
-	| KW_PORT '(' positive_integer ')'         { afamqp_dd_set_port(last_driver, $3); }
+	| KW_PORT '(' string_or_number ')'         { CHECK_ERROR(cfg_check_port($3), @3, "Illegal port number: %s", $3); afamqp_dd_set_port(last_driver, atoi($3)); free($3); }
 	| KW_VHOST '(' string ')'                  { afamqp_dd_set_vhost(last_driver, $3); free($3); }
 	| KW_EXCHANGE '(' string ')'               { afamqp_dd_set_exchange(last_driver, $3); free($3); }
 	| KW_EXCHANGE_DECLARE '(' yesno ')'        { afamqp_dd_set_exchange_declare(last_driver, $3); }

--- a/modules/afsmtp/afsmtp-grammar.ym
+++ b/modules/afsmtp/afsmtp-grammar.ym
@@ -31,6 +31,7 @@
 
 #include "cfg-parser.h"
 #include "cfg-grammar-internal.h"
+#include "cfg-helpers.h"
 #include "plugin.h"
 
 extern LogDriver *last_driver;
@@ -77,7 +78,7 @@ afsmtp_option
             afsmtp_dd_set_host(last_driver, $3);
             free($3);
           }
-        | KW_PORT '(' positive_integer ')' { afsmtp_dd_set_port(last_driver, $3); }
+        | KW_PORT '(' string_or_number ')' { CHECK_ERROR(cfg_check_port($3), @3, "Illegal port number: %s", $3); afsmtp_dd_set_port(last_driver, atoi($3)); free($3); }
         | KW_SUBJECT '(' template_content ')'
           {
             afsmtp_dd_set_subject(last_driver, $3);

--- a/modules/afsnmp/afsnmp-grammar.ym
+++ b/modules/afsnmp/afsnmp-grammar.ym
@@ -31,6 +31,7 @@
 #include <strings.h>
 #include "cfg-parser.h"
 #include "cfg-grammar-internal.h"
+#include "cfg-helpers.h"
 #include "syslog-names.h"
 
 #include "messages.h"
@@ -100,7 +101,7 @@ dest_snmpdest_option
           snmpdest_dd_set_version(last_driver, $3); free($3);
           }
         | KW_HOST '(' string ')' { snmpdest_dd_set_host(last_driver, $3); free($3); }
-        | KW_PORT '(' positive_integer ')' { snmpdest_dd_set_port(last_driver, $3); }
+        | KW_PORT '(' string_or_number ')' { CHECK_ERROR(cfg_check_port($3), @3, "Illegal port number: %s", $3); snmpdest_dd_set_port(last_driver, atoi($3)); free($3); }
         | KW_SNMP_OBJ '(' string string string ')' {
           CHECK_ERROR(snmpdest_dd_set_snmp_obj(last_driver, configuration, $3, $4, $5), @1, "SNMP: error set snmp object");
           free($3); free($4); free($5);

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -39,6 +39,7 @@
 #include "syslog-names.h"
 #include "plugin.h"
 #include "cfg-grammar-internal.h"
+#include "cfg-helpers.h"
 #include "socket-options-inet.h"
 #include "socket-options-unix.h"
 #include "transport-mapper-inet.h"
@@ -352,8 +353,8 @@ source_afinet_udp_option
 source_afinet_option
 	: KW_LOCALIP '(' string ')'		{ afinet_sd_set_localip(last_driver, $3); free($3); }
 	| KW_IP '(' string ')'			{ afinet_sd_set_localip(last_driver, $3); free($3); }
-	| KW_LOCALPORT '(' string_or_number ')'	{ afinet_sd_set_localport(last_driver, $3); free($3); }
-	| KW_PORT '(' string_or_number ')'	{ afinet_sd_set_localport(last_driver, $3); free($3); }
+	| KW_LOCALPORT '(' string_or_number ')' { CHECK_ERROR(cfg_check_port($3), @3, "Illegal port number: %s", $3); afinet_sd_set_localport(last_driver, $3); free($3); }
+	| KW_PORT '(' string_or_number ')' { CHECK_ERROR(cfg_check_port($3), @3, "Illegal port number: %s", $3); afinet_sd_set_localport(last_driver, $3); free($3); }
 	| source_reader_option
 	| source_driver_option
 	| inet_socket_option
@@ -595,9 +596,9 @@ dest_afinet_udp_options
 
 dest_afinet_option
 	: KW_LOCALIP '(' string ')'		{ afinet_dd_set_localip(last_driver, $3); free($3); }
-	| KW_LOCALPORT '(' string_or_number ')'	{ afinet_dd_set_localport(last_driver, $3); free($3); }
-	| KW_PORT '(' string_or_number ')'	{ afinet_dd_set_destport(last_driver, $3); free($3); }
-	| KW_DESTPORT '(' string_or_number ')'	{ afinet_dd_set_destport(last_driver, $3); free($3); }
+	| KW_LOCALPORT '(' string_or_number ')' { CHECK_ERROR(cfg_check_port($3), @3, "Illegal port number: %s", $3); afinet_dd_set_localport(last_driver, $3); free($3); }
+	| KW_PORT '(' string_or_number ')' { CHECK_ERROR(cfg_check_port($3), @3, "Illegal port number: %s", $3); afinet_dd_set_destport(last_driver, $3); free($3); }
+	| KW_DESTPORT '(' string_or_number ')' { CHECK_ERROR(cfg_check_port($3), @3, "Illegal port number: %s", $3); afinet_dd_set_destport(last_driver, $3); free($3); }
 	| KW_FAILOVER_SERVERS { afinet_dd_enable_failover(last_driver); } '(' string_list ')'	{ afinet_dd_add_failovers(last_driver, $4); }
 	| KW_FAILOVER { afinet_dd_enable_failover(last_driver); } '(' dest_failover_options ')'	{ $$ = $4; }
 	| inet_socket_option

--- a/modules/afsql/afsql-grammar.ym
+++ b/modules/afsql/afsql-grammar.ym
@@ -31,6 +31,7 @@
 
 #include "afsql.h"
 #include "cfg-grammar-internal.h"
+#include "cfg-helpers.h"
 #include "cfg-parser.h"
 #include "messages.h"
 #include "plugin.h"
@@ -100,12 +101,7 @@ dest_afsql_options
 dest_afsql_option
         : KW_TYPE '(' string ')'		{ afsql_dd_set_type(last_driver, $3); free($3); }
         | KW_HOST '(' string ')'		{ afsql_dd_set_host(last_driver, $3); free($3); }
-        | KW_PORT '(' string_or_number ')'
-          {
-            CHECK_ERROR(afsql_dd_check_port($3), @3, "Illegal sql port number: %s", $3);
-            afsql_dd_set_port(last_driver, $3);
-            free($3);
-          }
+        | KW_PORT '(' string_or_number ')' { CHECK_ERROR(cfg_check_port($3), @3, "Illegal port number: %s", $3); afsql_dd_set_port(last_driver, $3); free($3); }
         | KW_USERNAME '(' string ')'		{ afsql_dd_set_user(last_driver, $3); free($3); }
         | KW_DBD_OPTION '(' string LL_NUMBER ')' { afsql_dd_add_dbd_option_numeric(last_driver, $3, $4); free($3); }
         | KW_DBD_OPTION '(' string string ')'    { afsql_dd_add_dbd_option(last_driver, $3, $4); free($3); free($4); }

--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -101,17 +101,6 @@ afsql_dd_set_host(LogDriver *s, const gchar *host)
   self->host = g_strdup(host);
 }
 
-gboolean
-afsql_dd_check_port(const gchar *port)
-{
-  /* only digits (->numbers) are allowed */
-  int len = strlen(port);
-  for (int i = 0; i < len; ++i)
-    if (port[i] < '0' || port[i] > '9')
-      return FALSE;
-  return TRUE;
-}
-
 void
 afsql_dd_set_port(LogDriver *s, const gchar *port)
 {

--- a/modules/afsql/afsql.h
+++ b/modules/afsql/afsql.h
@@ -101,7 +101,6 @@ typedef struct _AFSqlDestDriver
 
 void afsql_dd_set_type(LogDriver *s, const gchar *type);
 void afsql_dd_set_host(LogDriver *s, const gchar *host);
-gboolean afsql_dd_check_port(const gchar *port);
 void afsql_dd_set_port(LogDriver *s, const gchar *port);
 void afsql_dd_set_user(LogDriver *s, const gchar *user);
 void afsql_dd_set_password(LogDriver *s, const gchar *password);

--- a/modules/afstomp/afstomp-grammar.ym
+++ b/modules/afstomp/afstomp-grammar.ym
@@ -32,6 +32,7 @@
 
 #include "cfg-parser.h"
 #include "cfg-grammar-internal.h"
+#include "cfg-helpers.h"
 #include "plugin.h"
 #include "value-pairs/value-pairs.h"
 
@@ -71,7 +72,7 @@ afstomp_options
 
 afstomp_option
         : KW_HOST '(' string ')'		{ afstomp_dd_set_host(last_driver, $3); free($3); }
-        | KW_PORT '(' positive_integer ')'		{ afstomp_dd_set_port(last_driver, $3); }
+        | KW_PORT '(' string_or_number ')' { CHECK_ERROR(cfg_check_port($3), @3, "Illegal port number: %s", $3); afstomp_dd_set_port(last_driver, atoi($3)); free($3); }
         | KW_STOMP_DESTINATION '(' string ')'	{ afstomp_dd_set_destination(last_driver, $3); free($3); }
         | KW_BODY '(' template_name_or_content ')'	{ afstomp_dd_set_body(last_driver, $3); }
         | KW_PERSISTENT '(' yesno ')'		{ afstomp_dd_set_persistent(last_driver, $3); }

--- a/modules/grpc/otel/otel-grammar.ym
+++ b/modules/grpc/otel/otel-grammar.ym
@@ -29,6 +29,7 @@
 %code {
 
 #include "cfg-grammar-internal.h"
+#include "cfg-helpers.h"
 #include "plugin.h"
 #include "syslog-names.h"
 #include "otel-source.h"
@@ -112,7 +113,7 @@ source_otel_options
   ;
 
 source_otel_option
-  : KW_PORT '(' positive_integer ')' { otel_sd_set_port(last_driver, $3); }
+  : KW_PORT '(' string_or_number ')' { CHECK_ERROR(cfg_check_port($3), @3, "Illegal port number: %s", $3); otel_sd_set_port(last_driver, atoll($3)); free($3); }
   | KW_LOG_FETCH_LIMIT '(' nonnegative_integer ')' { otel_sd_set_fetch_limit(last_driver, $3); }
   | KW_CONCURRENT_REQUESTS '(' positive_integer ')' { CHECK_ERROR($3 >= 2, @1, "concurrent-requests() must be greater than 1"); otel_sd_set_concurrent_requests(last_driver, $3); }
   | KW_CHANNEL_ARGS '(' source_otel_channel_args ')'

--- a/modules/redis/redis-grammar.ym
+++ b/modules/redis/redis-grammar.ym
@@ -30,6 +30,7 @@
 %code {
 
 #include "cfg-grammar-internal.h"
+#include "cfg-helpers.h"
 #include "plugin.h"
 }
 
@@ -67,9 +68,11 @@ redis_option
             redis_dd_set_host(last_driver, $3);
             free($3);
           }
-        | KW_PORT '(' positive_integer ')'
+        | KW_PORT '(' string_or_number ')'
           {
-            redis_dd_set_port(last_driver, $3);
+            CHECK_ERROR(cfg_check_port($3), @3, "Illegal port number: %s", $3);
+            redis_dd_set_port(last_driver, atoi($3));
+            free($3);
           }
         | KW_AUTH '(' string ')'
           {

--- a/modules/riemann/riemann-grammar.ym
+++ b/modules/riemann/riemann-grammar.ym
@@ -31,6 +31,7 @@
 %code {
 
 #include "cfg-grammar-internal.h"
+#include "cfg-helpers.h"
 #include "cfg-parser.h"
 #include "plugin.h"
 #include "riemann/event.h"
@@ -82,9 +83,11 @@ riemann_option
             riemann_dd_set_server(last_driver, $3);
             free($3);
           }
-        | KW_PORT '(' positive_integer ')'
+        | KW_PORT '(' string_or_number ')'
           {
-            riemann_dd_set_port(last_driver, $3);
+            CHECK_ERROR(cfg_check_port($3), @3, "Illegal port number: %s", $3);
+            riemann_dd_set_port(last_driver, atoi($3));
+            free($3);
           }
         | KW_HOST '(' template_content ')'
           {


### PR DESCRIPTION
There was no port number validity check in the config file, numbers larger than 65535 or smaller than 0 were accepted and could cause incorrect port number usage without any warning or error.

Signed-off-by: Hofi <hofione@gmail.com>