### PR TITLE
dist: removed workaround of VERSION file cleanup and added the real fix

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -162,11 +162,6 @@ local-check:
 				TESTS="${current_tests} ${subdir_tests}"
 endif
 
-# We use VERSION.txt, as VERSION file can cause C++ build errors on case-insensitive file-systems.
-# Some step(s?) still can produce or leave behind a VERSION file, clean it up before packing the final dist tar.gz file.
-dist-hook:
-	rm -f VERSION
-
 check: check_target_guard
 
 check_target_guard:

--- a/dbld/pkg-tarball
+++ b/dbld/pkg-tarball
@@ -14,7 +14,7 @@ rm -rf $SYSLOGNG_DIR
 tar xfz $SYSLOGNG_TARBALL
 cd $SYSLOGNG_DIR
 
-echo ${VERSION} > VERSION
+echo ${VERSION} > VERSION.txt
 
 /dbld/generate-debian-directory $MODE
 /dbld/generate-rpm-specfile $MODE


### PR DESCRIPTION
The real fix of the VERSION file cleanup.

Thanks for @MrAnno for [finding this](https://github.com/axoflow/axosyslog/pull/228)