### PR TITLE
Add no-piggyback-errors flag to syslog-parser() and syslog related source drivers.

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1263,6 +1263,19 @@ log_msg_format_sdata(const LogMessage *self, GString *result,  guint32 seq_num)
   log_msg_append_format_sdata(self, result, seq_num);
 }
 
+void
+log_msg_clear_sdata(LogMessage *self)
+{
+  for (gint i = 0; i < self->num_sdata; i++)
+    log_msg_unset_value(self, self->sdata[i]);
+  if (!log_msg_chk_flag(self, LF_STATE_OWN_SDATA))
+    {
+      self->sdata = NULL;
+      self->alloc_sdata = 0;
+    }
+  self->num_sdata = 0;
+}
+
 gboolean
 log_msg_append_tags_callback(const LogMessage *self, LogTagId tag_id, const gchar *name, gpointer user_data)
 {
@@ -1388,12 +1401,7 @@ log_msg_clear(LogMessage *self)
     }
 
   log_msg_clear_matches(self);
-  if (!log_msg_chk_flag(self, LF_STATE_OWN_SDATA))
-    {
-      self->sdata = NULL;
-      self->alloc_sdata = 0;
-    }
-  self->num_sdata = 0;
+  log_msg_clear_sdata(self);
 
   if (log_msg_chk_flag(self, LF_STATE_OWN_SADDR))
     g_sockaddr_unref(self->saddr);

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -2019,6 +2019,14 @@ log_msg_tags_init(void)
   log_tags_register_predefined_tag("syslog.unexpected_framing", LM_T_SYSLOG_UNEXPECTED_FRAMING);
   log_tags_register_predefined_tag("syslog.rfc3164_missing_header", LM_T_SYSLOG_RFC3164_MISSING_HEADER);
   log_tags_register_predefined_tag("syslog.rfc5424_unquoted_sdata_value", LM_T_SYSLOG_RFC5424_UNQUOTED_SDATA_VALUE);
+
+  log_tags_register_predefined_tag("syslog.rfc5424_missing_hostname", LM_T_SYSLOG_RFC5424_MISSING_HOSTNAME);
+  log_tags_register_predefined_tag("syslog.rfc5424_missing_app_name", LM_T_SYSLOG_RFC5424_MISSING_APP_NAME);
+  log_tags_register_predefined_tag("syslog.rfc5424_missing_procid", LM_T_SYSLOG_RFC5424_MISSING_PROCID);
+  log_tags_register_predefined_tag("syslog.rfc5424_missing_msgid", LM_T_SYSLOG_RFC5424_MISSING_MSGID);
+  log_tags_register_predefined_tag("syslog.rfc5424_missing_sdata", LM_T_SYSLOG_RFC5424_MISSING_SDATA);
+  log_tags_register_predefined_tag("syslog.rfc5424_invalid_sdata", LM_T_SYSLOG_RFC5424_INVALID_SDATA);
+  log_tags_register_predefined_tag("syslog.rfc5424_missing_message", LM_T_SYSLOG_RFC5424_MISSING_MESSAGE);
 }
 
 void

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -1366,6 +1366,8 @@ log_msg_init(LogMessage *self)
 void
 log_msg_clear(LogMessage *self)
 {
+  g_assert(!log_msg_is_write_protected(self));
+
   if(log_msg_chk_flag(self, LF_STATE_OWN_PAYLOAD))
     nv_table_unref(self->payload);
   self->payload = nv_table_new(LM_V_MAX, 16, 256);

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -483,6 +483,7 @@ void log_msg_rename_value(LogMessage *self, NVHandle from, NVHandle to);
 
 void log_msg_append_format_sdata(const LogMessage *self, GString *result, guint32 seq_num);
 void log_msg_format_sdata(const LogMessage *self, GString *result, guint32 seq_num);
+void log_msg_clear_sdata(LogMessage *self);
 
 void log_msg_set_tag_by_id_onoff(LogMessage *self, LogTagId id, gboolean on);
 void log_msg_set_tag_by_id(LogMessage *self, LogTagId id);

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -120,6 +120,22 @@ enum
   LM_T_SYSLOG_RFC3164_MISSING_HEADER,
   /* incorrectly quoted RFC5424 SDATA */
   LM_T_SYSLOG_RFC5424_UNQUOTED_SDATA_VALUE,
+  /* hostname field missing */
+  LM_T_SYSLOG_RFC5424_MISSING_HOSTNAME,
+  /* program field missing */
+  LM_T_SYSLOG_RFC5424_MISSING_APP_NAME,
+  /* pid field missing */
+  LM_T_SYSLOG_RFC5424_MISSING_PROCID,
+  /* msgid field missing */
+  LM_T_SYSLOG_RFC5424_MISSING_MSGID,
+  /* sdata field missing */
+  LM_T_SYSLOG_RFC5424_MISSING_SDATA,
+  /* invalid SDATA */
+  LM_T_SYSLOG_RFC5424_INVALID_SDATA,
+  /* sdata field missing */
+  LM_T_SYSLOG_RFC5424_MISSING_MESSAGE,
+  /* message field missing */
+  LM_T_SYSLOG_MISSING_MESSAGE,
   LM_T_PREDEFINED_MAX,
 };
 

--- a/lib/logmsg/tests/test_log_message.c
+++ b/lib/logmsg/tests/test_log_message.c
@@ -77,6 +77,9 @@ assert_log_msg_clear_clears_all_properties(LogMessage *message, NVHandle nv_hand
                                            NVHandle sd_handle, const gchar *tag_name)
 {
   message->flags |= LF_LOCAL + LF_UTF8 + LF_INTERNAL + LF_MARK;
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+
+  log_msg_make_writable(&message, &path_options);
   log_msg_clear(message);
 
   cr_assert_str_empty(log_msg_get_value(message, nv_handle, NULL),

--- a/lib/logmsg/tests/test_log_message.c
+++ b/lib/logmsg/tests/test_log_message.c
@@ -189,6 +189,19 @@ Test(log_message, test_log_message_can_be_cleared)
   log_message_test_params_free(params);
 }
 
+Test(log_message, test_log_message_clear_sdata_unsets_all_sdata)
+{
+  LogMessageTestParams *params = log_message_test_params_new();
+
+  log_msg_clear_sdata(params->message);
+
+  cr_assert(params->message->num_sdata == 0);
+  cr_assert_str_empty(log_msg_get_value(params->message, params->sd_handle, NULL),
+                      "Message still contains sdata value after log_msg_clear_sdata");
+
+  log_message_test_params_free(params);
+}
+
 Test(log_message, test_log_msg_clear_handles_cloned_noninline_tags_properly)
 {
   LogMessage *msg = _construct_log_message();

--- a/lib/msg-format.h
+++ b/lib/msg-format.h
@@ -59,6 +59,7 @@ enum
   LP_GUESS_TIMEZONE = 0x1000,
   LP_NO_HEADER = 0x2000,
   LP_NO_RFC3164_FALLBACK = 0x4000,
+  LP_PIGGYBACK_ERRORS = 0x8000,
 };
 
 typedef struct _MsgFormatHandler MsgFormatHandler;

--- a/lib/msg-format.h
+++ b/lib/msg-format.h
@@ -76,6 +76,7 @@ typedef struct _MsgFormatOptions
   gchar *sdata_prefix;
   gsize sdata_prefix_len;
   gint sdata_param_value_max;
+  gboolean use_fqdn;
 } MsgFormatOptions;
 
 struct _MsgFormatHandler

--- a/lib/tests/test_msgparse.c
+++ b/lib/tests/test_msgparse.c
@@ -244,7 +244,7 @@ Test(msgparse, test_bad_sd_data_unescaped)
   {
     {
       "<132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a i=\"\"ok\"] An application event log entry...",
-      LP_SYSLOG_PROTOCOL, NULL,
+      LP_SYSLOG_PROTOCOL | LP_PIGGYBACK_ERRORS, NULL,
       43,             // pri
       0, 0, 0,    // timestamp (sec/usec/zone)
       NULL,        // host
@@ -694,7 +694,8 @@ Test(msgparse, test_expected_sd_pairs_1)
       expected_sd_pairs_test_1
     },
     {
-      "<7>1 2006-10-29T01:59:59.156Z mymachine.example.com evntslog - ID47 [ exampleSDID@0 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@0 class=\"high\"] \xEF\xBB\xBF" "An application event log entry...",  LP_SYSLOG_PROTOCOL, NULL,
+      "<7>1 2006-10-29T01:59:59.156Z mymachine.example.com evntslog - ID47 [ exampleSDID@0 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"][examplePriority@0 class=\"high\"] \xEF\xBB\xBF" "An application event log entry...",
+      LP_PIGGYBACK_ERRORS | LP_SYSLOG_PROTOCOL, NULL,
       43,             // pri
       0, 0, 0,    // timestamp (sec/usec/zone)
       NULL,        // host
@@ -882,7 +883,8 @@ Test(msgparse, test_expected_sd_pairs_long)
 
     // parse longer than 255 sd id
     {
-      "<132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa i=\"long\"] An application event log entry...",  LP_SYSLOG_PROTOCOL, NULL,
+      "<132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa i=\"long\"] An application event log entry...",
+      LP_PIGGYBACK_ERRORS | LP_SYSLOG_PROTOCOL, NULL,
       43,                         // pri
       0, 0, 0,    // timestamp (sec/usec/zone)
       NULL,         // host
@@ -926,7 +928,8 @@ Test(msgparse, test_unescaped_too_long_message_parts)
   {
     // too long hostname
     {
-      "<132>1 2006-10-29T01:59:59.156+01:00 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa evntslog - - [a i=\"ok\"] An application event log entry...",  LP_SYSLOG_PROTOCOL, NULL,
+      "<132>1 2006-10-29T01:59:59.156+01:00 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa evntslog - - [a i=\"ok\"] An application event log entry...",
+      LP_PIGGYBACK_ERRORS | LP_SYSLOG_PROTOCOL, NULL,
       43,        // pri
       0, 0, 0,    // timestamp (sec/usec/zone)
       NULL, //host
@@ -982,7 +985,8 @@ Test(msgparse, test_unescaped_too_long_message_parts)
 
     // unescaped ]
     {
-      "<132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a i=\"]ok\"] An application event log entry...",  LP_SYSLOG_PROTOCOL, NULL,
+      "<132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a i=\"]ok\"] An application event log entry...",
+      LP_PIGGYBACK_ERRORS | LP_SYSLOG_PROTOCOL, NULL,
       43,             // pri
       0, 0, 0,    // timestamp (sec/usec/zone)
       NULL,        // host
@@ -997,7 +1001,8 @@ Test(msgparse, test_unescaped_too_long_message_parts)
 
     // bad sd data unescaped "
     {
-      "<132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a i=\"\"ok\"] An application event log entry...",  LP_SYSLOG_PROTOCOL, NULL,
+      "<132>1 2006-10-29T01:59:59.156+01:00 mymachine evntslog - - [a i=\"\"ok\"] An application event log entry...",
+      LP_PIGGYBACK_ERRORS | LP_SYSLOG_PROTOCOL, NULL,
       43,      // pri
       0, 0, 0, // timestamp (sec/usec/zone)
       NULL,    // host
@@ -1221,7 +1226,7 @@ Test(msgparse, test_no_rfc3164_fallback_flag)
   {
     {
       .msg = "<189>some message",
-      .parse_flags = LP_SYSLOG_PROTOCOL | LP_NO_RFC3164_FALLBACK,
+      .parse_flags = LP_SYSLOG_PROTOCOL | LP_NO_RFC3164_FALLBACK | LP_PIGGYBACK_ERRORS,
       .expected_pri = 43,
       .expected_program = "syslog-ng",
       .expected_host = NULL,

--- a/news/feature-5063.md
+++ b/news/feature-5063.md
@@ -1,0 +1,13 @@
+`syslog-parser`: Added the `no-piggyback-errors` and the `piggyback-errors` flags to control whether the message retains the original message or not. By default the old behaviour/`no-piggyback-errors` flag is active, modifing the original message on error.
+
+- `no-piggyback-errors`: On failure the original message, will be left as it was before parsing, the value of `$MSGFORMAT` will be set to `syslog-error`, and a tag will be placed on the message roccesponding to the parser's failure.
+- `piggyback-errors`: On failure the old behaviour is used (clearing the entire message then syslog-ng will generate a new message in place of the old one describing the parser's error).
+
+The following new tags can be added by the `syslog-parser` to the message when the parsing failed:
+  - `syslog.rfc5424_missing_hostname`
+  - `syslog.rfc5424_missing_app_name`
+  - `syslog.rfc5424_missing_procid`
+  - `syslog.rfc5424_missing_msgid`
+  - `syslog.rfc5424_missing_sdata`
+  - `syslog.rfc5424_invalid_sdata`
+  - `syslog.rfc5424_missing_message`


### PR DESCRIPTION
Backport of [#245](https://github.com/axoflow/axosyslog/pull/245) by @bazsi
