### PR TITLE
Revert "github-actions: temp remove debian-testing official test"

### DIFF
--- a/.github/workflows/test-apt-packages.yml
+++ b/.github/workflows/test-apt-packages.yml
@@ -27,11 +27,6 @@ jobs:
         upgrade-from:
           - "debian-official"
           - "syslog-ng-last"
-        exclude:
-          # The official syslog-ng got removed from debian:testing because of libesmtp:
-          # https://tracker.debian.org/news/1550704/syslog-ng-removed-from-testing/
-          - distro: "debian:testing"
-            upgrade-from: "debian-official"
       fail-fast: false
     runs-on: ubuntu-latest
     container: ${{ matrix.distro }}


### PR DESCRIPTION
Reverts syslog-ng/syslog-ng#5060 as syslog-ng is back on debian-testing