### PR TITLE
tls: Add support for ssl peer fingerprint

### DIFF
--- a/lib/transport/tls-session.c
+++ b/lib/transport/tls-session.c
@@ -523,7 +523,7 @@ void
 tls_session_info_callback(const SSL *ssl, int where, int ret)
 {
   TLSSession *self = (TLSSession *)SSL_get_app_data(ssl);
-  if( !self->peer_info.found && where == (SSL_ST_ACCEPT|SSL_CB_LOOP) )
+  if (!self->peer_info.found && where == (SSL_ST_ACCEPT|SSL_CB_LOOP))
     {
       X509 *cert = SSL_get_peer_certificate(ssl);
 
@@ -532,9 +532,9 @@ tls_session_info_callback(const SSL *ssl, int where, int ret)
           self->peer_info.found = 1; /* mark this found so we don't keep checking on every callback */
           X509_NAME *name = X509_get_subject_name(cert);
 
-          X509_NAME_get_text_by_NID( name, NID_commonName, self->peer_info.cn, X509_MAX_CN_LEN );
-          X509_NAME_get_text_by_NID( name, NID_organizationName, self->peer_info.o, X509_MAX_O_LEN );
-          X509_NAME_get_text_by_NID( name, NID_organizationalUnitName, self->peer_info.ou, X509_MAX_OU_LEN );
+          X509_NAME_get_text_by_NID(name, NID_commonName, self->peer_info.cn, X509_MAX_CN_LEN);
+          X509_NAME_get_text_by_NID(name, NID_organizationName, self->peer_info.o, X509_MAX_O_LEN);
+          X509_NAME_get_text_by_NID(name, NID_organizationalUnitName, self->peer_info.ou, X509_MAX_OU_LEN);
 
           X509_free(cert);
         }

--- a/lib/transport/tls-session.c
+++ b/lib/transport/tls-session.c
@@ -132,6 +132,7 @@ tls_session_verify_fingerprint(X509_STORE_CTX *ctx)
           if (strcmp((const gchar *)(current_fingerprint->data), hash->str) == 0)
             {
               match = TRUE;
+              g_strlcpy(self->peer_info.fingerprint, hash->str, sizeof(self->peer_info.fingerprint));
               break;
             }
         }

--- a/lib/transport/tls-session.h
+++ b/lib/transport/tls-session.h
@@ -28,6 +28,7 @@
 #define X509_MAX_CN_LEN 64
 #define X509_MAX_O_LEN 64
 #define X509_MAX_OU_LEN 32
+#define X509_MAX_FP_LEN 256
 
 typedef struct _TLSContext TLSContext;
 typedef struct _TLSSession
@@ -41,6 +42,7 @@ typedef struct _TLSSession
     gchar o[X509_MAX_O_LEN];
     gchar ou[X509_MAX_OU_LEN];
     gchar cn[X509_MAX_CN_LEN];
+    gchar fingerprint[X509_MAX_FP_LEN];
   } peer_info;
 } TLSSession;
 

--- a/lib/transport/transport-tls.c
+++ b/lib/transport/transport-tls.c
@@ -112,6 +112,8 @@ log_transport_tls_read_method(LogTransport *s, gpointer buf, gsize buflen, LogTr
           log_transport_aux_data_add_nv_pair(aux, ".tls.x509_o", self->tls_session->peer_info.o);
           log_transport_aux_data_add_nv_pair(aux, ".tls.x509_ou", self->tls_session->peer_info.ou);
         }
+      if (self->tls_session->peer_info.fingerprint[0])
+        log_transport_aux_data_add_nv_pair(aux, ".tls.x509_fp", self->tls_session->peer_info.fingerprint);
 
       /* NOTE: we only support TLS on top of TCP for now.  We could reuse the
        * proto auto detection code from transport-socket to make this more

--- a/news/feature-136.md
+++ b/news/feature-136.md
@@ -1,0 +1,3 @@
+`tls()`: expose the key fingerprint of the peer in ${.tls.x509_fp} if
+trusted-keys() is used to retain the actual peer identity in received
+messages.


### PR DESCRIPTION
`tls()`: expose the key fingerprint of the peer in ${.tls.x509_fp} if trusted-keys() is used to retain the actual peer identity in received messages.

Backport of [#136](https://github.com/axoflow/axosyslog/pull/136/commits) by @bazsi 