### PR TITLE
http: bind output_http_requests_total counter lifecycle to worker's 

### DIFF
--- a/lib/metrics/CMakeLists.txt
+++ b/lib/metrics/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(METRICS_HEADERS
     metrics/metrics.h
+    metrics/metrics-cache.h
     metrics/metrics-tls-cache.h
     metrics/metrics-template.h
     metrics/label-template.h
@@ -7,6 +8,7 @@ set(METRICS_HEADERS
 
 set(METRICS_SOURCES
     metrics/metrics.c
+    metrics/metrics-cache.c
     metrics/metrics-tls-cache.c
     metrics/metrics-template.c
     metrics/label-template.c

--- a/lib/metrics/Makefile.am
+++ b/lib/metrics/Makefile.am
@@ -4,12 +4,14 @@ EXTRA_DIST += lib/metrics/CMakeLists.txt
 
 metricsinclude_HEADERS = \
 	lib/metrics/metrics.h	\
+	lib/metrics/metrics-cache.h	\
 	lib/metrics/metrics-tls-cache.h	\
 	lib/metrics/metrics-template.h	\
 	lib/metrics/label-template.h
 
 metrics_sources = \
 	lib/metrics/metrics.c	\
+	lib/metrics/metrics-cache.c	\
 	lib/metrics/metrics-tls-cache.c	\
 	lib/metrics/metrics-template.c	\
 	lib/metrics/label-template.c

--- a/lib/metrics/metrics-cache.c
+++ b/lib/metrics/metrics-cache.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2023-2024 Attila Szakacs <attila.szakacs@axoflow.com>
+ * Copyright (c) 2024 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ * Copyright (c) 2024 Axoflow
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "metrics-cache.h"
+#include "stats/stats-cluster-single.h"
+
+struct _MetricsCache
+{
+  GHashTable *clusters;
+  GArray *label_buffers;
+};
+
+static StatsCluster *
+_register_single_cluster_locked(StatsClusterKey *key, gint stats_level)
+{
+  StatsCluster *cluster;
+
+  stats_lock();
+  {
+    StatsCounterItem *counter;
+    cluster = stats_register_dynamic_counter(stats_level, key, SC_TYPE_SINGLE_VALUE, &counter);
+  }
+  stats_unlock();
+
+  return cluster;
+}
+
+static void
+_unregister_single_cluster_locked(StatsCluster *cluster)
+{
+  stats_lock();
+  {
+    StatsCounterItem *counter = stats_cluster_single_get_counter(cluster);
+    stats_unregister_dynamic_counter(cluster, SC_TYPE_SINGLE_VALUE, &counter);
+  }
+  stats_unlock();
+}
+
+MetricsCache *
+metrics_cache_new(void)
+{
+  MetricsCache *self = g_new0(MetricsCache, 1);
+
+  self->clusters = g_hash_table_new_full((GHashFunc) stats_cluster_key_hash,
+                                         (GEqualFunc) stats_cluster_key_equal,
+                                         NULL,
+                                         (GDestroyNotify) _unregister_single_cluster_locked);
+  self->label_buffers = g_array_new(FALSE, FALSE, sizeof(StatsClusterLabel));
+
+  return self;
+}
+
+void
+metrics_cache_free(MetricsCache *self)
+{
+  g_hash_table_destroy(self->clusters);
+  g_array_free(self->label_buffers, TRUE);
+  g_free(self);
+}
+
+StatsCounterItem *
+metrics_cache_get_counter(MetricsCache *self, StatsClusterKey *key, gint level)
+{
+  StatsCluster *cluster = g_hash_table_lookup(self->clusters, key);
+  if (!cluster)
+    {
+      cluster = _register_single_cluster_locked(key, level);
+      if (cluster)
+        g_hash_table_insert(self->clusters, &cluster->key, cluster);
+    }
+
+  return stats_cluster_single_get_counter(cluster);
+}
+
+void
+metrics_cache_reset_labels(MetricsCache *self)
+{
+  self->label_buffers = g_array_set_size(self->label_buffers, 0);
+}
+
+StatsClusterLabel *
+metrics_cache_alloc_label(MetricsCache *self)
+{
+  self->label_buffers = g_array_set_size(self->label_buffers, self->label_buffers->len + 1);
+  return &g_array_index(self->label_buffers, StatsClusterLabel, self->label_buffers->len - 1);
+}
+
+StatsClusterLabel *
+metrics_cache_get_labels(MetricsCache *self)
+{
+  return (StatsClusterLabel *) self->label_buffers->data;
+}
+
+guint
+metrics_cache_get_labels_len(MetricsCache *self)
+{
+  return self->label_buffers->len;
+}

--- a/lib/metrics/metrics-cache.h
+++ b/lib/metrics/metrics-cache.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023-2024 Attila Szakacs <attila.szakacs@axoflow.com>
+ * Copyright (c) 2024 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ * Copyright (c) 2024 Axoflow
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef METRICS_CACHE_H_INCLUDED
+#define METRICS_CACHE_H_INCLUDED
+
+#include "stats/stats-registry.h"
+
+/*
+ * There is a recurring inconvenience with dynamic counters.
+ *
+ * Registering, changing and unregistering a counter makes it orphaned,
+ * as no one is keeping it alive. Non-dynamic counters do not have this
+ * issue, as they are always stored on their call-site, binding their
+ * lifecycle to the call-site.
+ *
+ * This class intends to solve this problem by providing a cache,
+ * which keeps alive its counters until the cache is freed. On the
+ * call-site you only need to keep the cache alive, to keep the
+ * counters alive.
+ *
+ * It also grants a label cache for performance optimization needs.
+ *
+ * Note: The cache is NOT thread safe, make sure to eliminate
+ * concurrency on the call site. If you need a cache that is bound
+ * to the current thread, see metrics/metrics-tls-cache.h.
+ */
+
+typedef struct _MetricsCache MetricsCache;
+
+MetricsCache *metrics_cache_new(void);
+void metrics_cache_free(MetricsCache *self);
+
+StatsCounterItem *metrics_cache_get_counter(MetricsCache *self, StatsClusterKey *key, gint level);
+void metrics_cache_reset_labels(MetricsCache *self);
+StatsClusterLabel *metrics_cache_alloc_label(MetricsCache *self);
+StatsClusterLabel *metrics_cache_get_labels(MetricsCache *self);
+guint metrics_cache_get_labels_len(MetricsCache *self);
+
+#endif

--- a/lib/metrics/metrics-tls-cache.h
+++ b/lib/metrics/metrics-tls-cache.h
@@ -27,13 +27,9 @@
 #define METRICS_TLS_CACHE_H_INCLUDED
 
 #include "stats/stats-registry.h"
+#include "metrics-cache.h"
 
-StatsCounterItem *metrics_tls_cache_get_counter(StatsClusterKey *key, gint level);
-
-void metrics_tls_cache_reset_labels(void);
-StatsClusterLabel *metrics_tls_cache_alloc_label(void);
-StatsClusterLabel *metrics_tls_cache_get_labels(void);
-guint metrics_tls_cache_get_labels_len(void);
+MetricsCache *metrics_tls_cache(void);
 
 void metrics_tls_cache_global_init(void);
 void metrics_tls_cache_global_deinit(void);

--- a/modules/http/http-worker.h
+++ b/modules/http/http-worker.h
@@ -29,6 +29,7 @@
 #include "http-loadbalancer.h"
 #include "http-curl-header-list.h"
 #include "compression.h"
+#include "metrics/metrics-cache.h"
 
 typedef struct _HTTPDestinationWorker
 {
@@ -44,7 +45,7 @@ typedef struct _HTTPDestinationWorker
 
   struct
   {
-    StatsClusterLabel *requests_labels;
+    MetricsCache *cache;
     gchar requests_response_code_str_buffer[4];
   } metrics;
 } HTTPDestinationWorker;

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -89,6 +89,7 @@ lib/cfg-source\.[ch]
 lib/metrics-pipe\.[ch]
 lib/metrics/label-template\.(c|h)$
 lib/metrics/metrics-template\.(c|h)$
+lib/metrics/metrics-cache\.(c|h)$
 lib/metrics/metrics-tls-cache\.(c|h)$
 lib/metrics/metrics\.(c|h)$
 lib/rewrite/rewrite-set-facility\.h


### PR DESCRIPTION
Depends on #5071

We do not show the orphaned metrics in the prometheus stats output. Registering, incrementing then unregistering the counter makes it orphaned.

This can be solved with binding the lifecycle of the counters to the worker.

No news file entry is needed, the counters disappeared after 4.7 was released.

Backport of [#180](https://github.com/axoflow/axosyslog/pull/180) by @alltilla 