### PR TITLE
diskq/diskq-global-metrics: use metrics cache to keep counters alive

### DIFF
--- a/lib/metrics/metrics-cache.c
+++ b/lib/metrics/metrics-cache.c
@@ -94,6 +94,12 @@ metrics_cache_get_counter(MetricsCache *self, StatsClusterKey *key, gint level)
   return stats_cluster_single_get_counter(cluster);
 }
 
+gboolean
+metrics_cache_remove_counter(MetricsCache *self, StatsClusterKey *key)
+{
+  return g_hash_table_remove(self->clusters, key);
+}
+
 void
 metrics_cache_reset_labels(MetricsCache *self)
 {

--- a/lib/metrics/metrics-cache.h
+++ b/lib/metrics/metrics-cache.h
@@ -54,6 +54,7 @@ MetricsCache *metrics_cache_new(void);
 void metrics_cache_free(MetricsCache *self);
 
 StatsCounterItem *metrics_cache_get_counter(MetricsCache *self, StatsClusterKey *key, gint level);
+gboolean metrics_cache_remove_counter(MetricsCache *self, StatsClusterKey *key);
 void metrics_cache_reset_labels(MetricsCache *self);
 StatsClusterLabel *metrics_cache_alloc_label(MetricsCache *self);
 StatsClusterLabel *metrics_cache_get_labels(MetricsCache *self);


### PR DESCRIPTION
Depends on #5072

We do not show the orphaned metrics in the prometheus stats output. Registering, incrementing then unregistering
the counter makes it orphaned.

This can be solved with binding the lifecycle of the counters to the diskq_global_metrics instance.

No news file entry is needed, the counters disappeared after 4.7 was released.

Backport of [#182](https://github.com/axoflow/axosyslog/pull/182) by @alltilla 