### PR TITLE
CI: replace deprecated template usage in trivy scan

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -79,8 +79,7 @@ jobs:
         with:
           image-ref: ${{ steps.tags.outputs.TAGS }}
 
-          format: 'template'
-          template: '@/contrib/sarif.tpl'
+          format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
 


### PR DESCRIPTION
https://github.com/aquasecurity/trivy/discussions/1571

Signed-off-by: Hofi <hofione@gmail.com>