### PR TITLE
Segmentation fault in format json with a space before the = 5065

### DIFF
--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -458,3 +458,19 @@ Test(format_json, test_format_json_with_key_delimiter)
   assert_template_format("$(format-json --key-delimiter ~ top~foo=1 top~bar=2 top~baz=3 top~sub~key1=val1 top~sub~key2=val2)",
                          "{\"top\":{\"sub\":{\"key2\":\"val2\",\"key1\":\"val1\"},\"foo\":\"1\",\"baz\":\"3\",\"bar\":\"2\"}}");
 }
+
+Test(format_json, test_format_json_key_value_with_spaces)
+{
+  assert_template_format("$(format-json foo =alma)",
+                         "{\"foo\":\"alma\"}");
+  assert_template_format("$(format-json foo= alma)",
+                         "{\"foo\":\"alma\"}");
+  assert_template_format("$(format-json foo = alma)",
+                         "{\"foo\":\"alma\"}");
+  assert_template_format("$(format-json foo=\" alma \")",
+                         "{\"foo\":\" alma \"}");
+  assert_template_format("$(format-json foo= \" alma \")",
+                         "{\"foo\":\" alma \"}");
+  assert_template_format("$(format-json foo1= alma foo2 =korte foo3 = szilva foo4 = \" meggy \")",
+                         "{\"foo4\":\" meggy \",\"foo3\":\"szilva\",\"foo2\":\"korte\",\"foo1\":\"alma\"}");
+}

--- a/news/other-5080.md
+++ b/news/other-5080.md
@@ -1,0 +1,16 @@
+`format-json`: spaces around `=` in `$(format-json)` template function could cause a
+[crash](https://github.com/syslog-ng/syslog-ng/issues/5065).
+The fix of the issue also introduced an enhancement, from now on spaces are allowed
+around the `=` operator, so the following `$(format-json)` template function calls
+are all valid:
+```
+$(format-json foo =alma)
+$(format-json foo= alma)
+$(format-json foo = alma)
+$(format-json foo=\" alma \")
+$(format-json foo= \" alma \")
+$(format-json foo1= alma foo2 =korte foo3 = szilva foo4 = \" meggy \" foo5=\"\")
+```
+Please note the usage of the escaped strings like `\" meggy \"`, and the (escaped and) quoted form
+that used for an empty value `\"\"`, the latter is a breaking change as earlier an expression like
+`key= ` led to a json key-value pair with an empty value `{"key":""}` that will not work anymore.


### PR DESCRIPTION
Spaces around `=` in `$(format-json)` template function could cause a [crash](https://github.com/syslog-ng/syslog-ng/issues/5065).
The fix of the issue also introduced an enhancement, from now on spaces are allowed around the `=` operator, so the following `$(format-json)` template function calls are all valid:
```
$(format-json foo =alma)
$(format-json foo= alma)
$(format-json foo = alma)
$(format-json foo=\" alma \")
$(format-json foo= \" alma \")
$(format-json foo1= alma foo2 =korte foo3 = szilva foo4 = \" meggy \" foo5=\"\")
```
Please note the usage of the escaped strings like `\" meggy \"`, and the (escaped and) quoted form that used for an empty value `\"\"`, the latter is a breaking change as earlier an expression like `key= ` led to a json key-value pair with an empty value `{"key":""}` that will not work anymore.

Fixes: #5065

Signed-off-by: Hofi <hofione@gmail.com>