### PR TITLE
Syslog ng service crashes in g hash table lookup function after syslog ng ctl reload 5018

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -288,8 +288,6 @@ cfg_is_shutting_down(GlobalConfig *cfg)
 gboolean
 cfg_init(GlobalConfig *cfg)
 {
-  gint regerr;
-
   msg_apply_config_log_level(cfg->log_level);
   if (cfg->file_template_name && !(cfg->file_template = cfg_tree_lookup_template(&cfg->tree, cfg->file_template_name)))
     msg_error("Error resolving file template",
@@ -300,6 +298,7 @@ cfg_init(GlobalConfig *cfg)
 
   if (cfg->bad_hostname_re)
     {
+      gint regerr;
       if ((regerr = regcomp(&cfg->bad_hostname, cfg->bad_hostname_re, REG_NOSUB | REG_EXTENDED)) != 0)
         {
           gchar buf[256];

--- a/lib/driver.c
+++ b/lib/driver.c
@@ -41,6 +41,7 @@ log_driver_plugin_free_method(LogDriverPlugin *self)
 void
 log_driver_plugin_init_instance(LogDriverPlugin *self, const gchar *name)
 {
+  self->signal_connector = NULL;
   self->name = name;
   self->free_fn = log_driver_plugin_free_method;
 }

--- a/lib/driver.h
+++ b/lib/driver.h
@@ -29,6 +29,7 @@
 #include "logpipe.h"
 #include "logqueue.h"
 #include "cfg.h"
+#include "signal-slot-connector/signal-slot-connector.h"
 
 /*
  * Drivers overview
@@ -70,6 +71,7 @@ typedef struct _LogDriverPlugin LogDriverPlugin;
 
 struct _LogDriverPlugin
 {
+  SignalSlotConnector *signal_connector;
   const gchar *name;
   /* this function is called when the plugin is attached to a LogDriver
    * instance.  It should do whatever it is necessary to extend the

--- a/lib/logpipe.c
+++ b/lib/logpipe.c
@@ -119,7 +119,7 @@ _free(LogPipe *self)
   g_free((gpointer)self->persist_name);
   g_free(self->plugin_name);
   g_list_free_full(self->info, g_free);
-  signal_slot_connector_free(self->signal_slot_connector);
+  signal_slot_connector_unref(self->signal_slot_connector);
   g_free(self);
 }
 

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -290,7 +290,7 @@ main_loop_reload_config_apply(gpointer user_data)
 
   /* The threads have stopped, deinit methods were called, but
    * self->current_configuration still points to the old config.  We either
-   * go to the new config is cfg_init() is successful (just below) or revert
+   * go to the new config if cfg_init() is successful (just below) or revert
    * to the old one if it's not.
    * */
 

--- a/lib/signal-slot-connector/signal-slot-connector.h
+++ b/lib/signal-slot-connector/signal-slot-connector.h
@@ -53,7 +53,8 @@ void signal_slot_disconnect(SignalSlotConnector *self, Signal signal, Slot slot,
 void signal_slot_emit(SignalSlotConnector *self, Signal signal, gpointer user_data);
 
 SignalSlotConnector *signal_slot_connector_new(void);
-void signal_slot_connector_free(SignalSlotConnector *self);
+SignalSlotConnector *signal_slot_connector_ref(SignalSlotConnector *self);
+void signal_slot_connector_unref(SignalSlotConnector *self);
 
 #endif
 

--- a/lib/signal-slot-connector/tests/test_signal_slots.c
+++ b/lib/signal-slot-connector/tests/test_signal_slots.c
@@ -97,7 +97,7 @@ Test(basic_signal_slots, when_the_signal_is_emitted_then_the_connected_slot_is_e
   cr_expect_eq(slot_obj1.ctr, 1);
   cr_expect_eq(slot_obj2.ctr, 1);
 
-  signal_slot_connector_free(ssc);
+  signal_slot_connector_unref(ssc);
 }
 
 Test(basic_signal_slots, abort_when_trying_to_connect_multiple_times_the_same_connection, .signal = SIGABRT)
@@ -128,7 +128,7 @@ Test(basic_signal_slots, abort_when_trying_to_disconnect_multiple_times_the_same
 
   cr_expect_eq(test_data.slot_ctr, 1);
 
-  signal_slot_connector_free(ssc);
+  signal_slot_connector_unref(ssc);
 }
 
 Test(basic_signal_slots,
@@ -160,7 +160,7 @@ Test(basic_signal_slots,
   cr_expect_eq(test_data.slot_ctr, 1);
   cr_expect_eq(slot_obj.ctr, 1);
 
-  signal_slot_connector_free(ssc);
+  signal_slot_connector_unref(ssc);
 }
 
 Test(basic_signal_slots, when_disconnect_the_connected_slot_from_a_signal_then_the_signal_is_unregistered)
@@ -178,7 +178,7 @@ Test(basic_signal_slots, when_disconnect_the_connected_slot_from_a_signal_then_t
   cr_expect_eq(test_data.slot_ctr, 0);
   cr_expect_eq(slot_obj.ctr, 0);
 
-  signal_slot_connector_free(ssc);
+  signal_slot_connector_unref(ssc);
 }
 
 Test(basic_signal_slots,
@@ -266,7 +266,7 @@ Test(multiple_signals_slots,
 
   _disconnect_all_test_slots_from_a_signal(ssc, signals[0]);
 
-  signal_slot_connector_free(ssc);
+  signal_slot_connector_unref(ssc);
 }
 
 Test(multiple_signals_slots,
@@ -300,7 +300,7 @@ Test(multiple_signals_slots,
   cr_expect_eq(slot_objects[1].ctr, 1);
   cr_expect_eq(slot_objects[2].ctr, 2);
 
-  signal_slot_connector_free(ssc);
+  signal_slot_connector_unref(ssc);
 }
 
 void

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -166,7 +166,7 @@ afinet_dd_tls_verify_data_new(TLSContext *ctx, const gchar *hostname, SignalSlot
 
   self->tls_context = tls_context_ref(ctx);
   self->hostname = g_strdup(hostname);
-  self->signal_connector = signal_connector;
+  self->signal_connector = signal_slot_connector_ref(signal_connector);
   return self;
 }
 
@@ -180,6 +180,7 @@ afinet_dd_tls_verify_data_free(gpointer s)
   if (self)
     {
       tls_context_unref(self->tls_context);
+      signal_slot_connector_unref(self->signal_connector);
       g_free(self->hostname);
       g_free(self);
     }
@@ -219,10 +220,10 @@ void
 afinet_dd_setup_tls_verifier(AFInetDestDriver *self)
 {
   TransportMapperInet *transport_mapper_inet = (TransportMapperInet *) self->super.transport_mapper;
-
-  AFInetDestDriverTLSVerifyData *verify_data;
-  verify_data = afinet_dd_tls_verify_data_new(transport_mapper_inet->tls_context, _afinet_dd_get_hostname(self),
-                                              self->super.super.super.super.signal_slot_connector);
+  SignalSlotConnector *slot_connector = self->super.super.super.super.signal_slot_connector;
+  AFInetDestDriverTLSVerifyData *verify_data = afinet_dd_tls_verify_data_new(transport_mapper_inet->tls_context,
+                                               _afinet_dd_get_hostname(self),
+                                               slot_connector);
   TLSVerifier *verifier = tls_verifier_new(afinet_dd_verify_callback, verify_data, afinet_dd_tls_verify_data_free);
 
   transport_mapper_inet_set_tls_verifier(transport_mapper_inet, verifier);

--- a/modules/examples/inner-destinations/http-test-slots/http-test-slots.c
+++ b/modules/examples/inner-destinations/http-test-slots/http-test-slots.c
@@ -48,12 +48,13 @@ _slot_append_test_headers(HttpTestSlotsPlugin *self, HttpHeaderRequestSignalData
 static gboolean
 _attach(LogDriverPlugin *s, LogDriver *driver)
 {
-  SignalSlotConnector *ssc = driver->super.signal_slot_connector;
+  g_assert(s->signal_connector == NULL);
+  s->signal_connector = signal_slot_connector_ref(driver->super.signal_slot_connector);
 
   msg_debug("HttpTestSlotsPlugin::attach()",
-            evt_tag_printf("SignalSlotConnector", "%p", ssc));
+            evt_tag_printf("SignalSlotConnector", "%p", s->signal_connector));
 
-  CONNECT(ssc, signal_http_header_request, _slot_append_test_headers, s);
+  CONNECT(s->signal_connector, signal_http_header_request, _slot_append_test_headers, s);
 
   return TRUE;
 }
@@ -61,12 +62,13 @@ _attach(LogDriverPlugin *s, LogDriver *driver)
 static void
 _detach(LogDriverPlugin *s, LogDriver *driver)
 {
-  SignalSlotConnector *ssc = driver->super.signal_slot_connector;
-
   msg_debug("HttpTestSlotsPlugin::detach()",
-            evt_tag_printf("SignalSlotConnector", "%p", ssc));
+            evt_tag_printf("SignalSlotConnector", "%p", s->signal_connector));
 
-  DISCONNECT(ssc, signal_http_header_request, _slot_append_test_headers, s);
+  DISCONNECT(s->signal_connector, signal_http_header_request, _slot_append_test_headers, s);
+
+  signal_slot_connector_unref(s->signal_connector);
+  s->signal_connector = NULL;
 }
 
 static void

--- a/modules/examples/inner-destinations/tls-test-validation/tls-test-validation.c
+++ b/modules/examples/inner-destinations/tls-test-validation/tls-test-validation.c
@@ -52,12 +52,13 @@ _slot_append_test_identity(TlsTestValidationPlugin *self, AFSocketTLSCertificate
 static gboolean
 _attach(LogDriverPlugin *s, LogDriver *driver)
 {
-  SignalSlotConnector *ssc = driver->super.signal_slot_connector;
+  g_assert(s->signal_connector == NULL);
+  s->signal_connector = signal_slot_connector_ref(driver->super.signal_slot_connector);
 
   msg_debug("TlsTestValidationPlugin::attach()",
-            evt_tag_printf("SignalSlotConnector", "%p", ssc));
+            evt_tag_printf("SignalSlotConnector", "%p", s->signal_connector));
 
-  CONNECT(ssc, signal_afsocket_tls_certificate_validation, _slot_append_test_identity, s);
+  CONNECT(s->signal_connector, signal_afsocket_tls_certificate_validation, _slot_append_test_identity, s);
 
   return TRUE;
 }
@@ -65,12 +66,13 @@ _attach(LogDriverPlugin *s, LogDriver *driver)
 static void
 _detach(LogDriverPlugin *s, LogDriver *driver)
 {
-  SignalSlotConnector *ssc = driver->super.signal_slot_connector;
-
   msg_debug("TlsTestValidationPlugin::detach()",
-            evt_tag_printf("SignalSlotConnector", "%p", ssc));
+            evt_tag_printf("SignalSlotConnector", "%p", s->signal_connector));
 
-  DISCONNECT(ssc, signal_afsocket_tls_certificate_validation, _slot_append_test_identity, s);
+  DISCONNECT(s->signal_connector, signal_afsocket_tls_certificate_validation, _slot_append_test_identity, s);
+
+  signal_slot_connector_unref(s->signal_connector);
+  s->signal_connector = NULL;
 }
 
 static void


### PR DESCRIPTION
Fixes: #5018

Signed-off-by: Hofi <hofione@gmail.com>