### PR TITLE
Add missing inttypes.h and define __STDC_FORMAT_MACROS if undefined

### DIFF
--- a/lib/compat/inttypes.h
+++ b/lib/compat/inttypes.h
@@ -1,0 +1,10 @@
+#ifndef COMPAT_INTTYPES_H_INCLUDED
+#define COMPAT_INTTYPES_H_INCLUDED
+
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
+#include <inttypes.h>
+
+#endif

--- a/modules/geoip2/maxminddb-helper.c
+++ b/modules/geoip2/maxminddb-helper.c
@@ -22,6 +22,7 @@
 
 #include "maxminddb-helper.h"
 #include "scratch-buffers.h"
+#include "compat/inttypes.h"
 #include <logmsg/logmsg.h>
 #include <messages.h>
 

--- a/modules/grpc/otel/otel-protobuf-formatter.cpp
+++ b/modules/grpc/otel/otel-protobuf-formatter.cpp
@@ -28,6 +28,7 @@
 #include "value-pairs/value-pairs.h"
 #include "scanner/list-scanner/list-scanner.h"
 #include "compat/cpp-end.h"
+#include "compat/inttypes.h"
 
 #include <syslog.h>
 

--- a/modules/grpc/otel/otel-protobuf-parser.cpp
+++ b/modules/grpc/otel/otel-protobuf-parser.cpp
@@ -31,8 +31,7 @@
 #include "str-repr/encode.h"
 #include "scratch-buffers.h"
 #include "compat/cpp-end.h"
-
-#include <inttypes.h>
+#include "compat/inttypes.h"
 
 using namespace syslogng::grpc::otel;
 using namespace google::protobuf;


### PR DESCRIPTION
Some platforms need `inttypes.h` and `__STDC_FORMAT_MACROS` defined prior to including it in order for macros like `PRIu64` to work. Fix that.