### PR TITLE
Add missing inttypes.h and define __STDC_FORMAT_MACROS if undefined

### DIFF
--- a/lib/compat/CMakeLists.txt
+++ b/lib/compat/CMakeLists.txt
@@ -18,6 +18,7 @@ set(COMPAT_HEADERS
     compat/cpp-end.h
     compat/curl.h
     compat/json.h
+    compat/inttypes.h
     PARENT_SCOPE)
 
 set(COMPAT_SOURCES

--- a/lib/compat/Makefile.am
+++ b/lib/compat/Makefile.am
@@ -22,7 +22,8 @@ compatinclude_HEADERS		= 	\
 	lib/compat/un.h			\
 	lib/compat/cpp-start.h	\
 	lib/compat/cpp-end.h	\
-	lib/compat/curl.h
+	lib/compat/curl.h	\
+	lib/compat/inttypes.h
 
 compat_sources			= 	\
 	lib/compat/getutent.c		\

--- a/lib/compat/inttypes.h
+++ b/lib/compat/inttypes.h
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2002-2014 Balabit
+ * Copyright (c) 2024 Sergey Fedorov
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
 #ifndef COMPAT_INTTYPES_H_INCLUDED
 #define COMPAT_INTTYPES_H_INCLUDED
 

--- a/lib/compat/inttypes.h
+++ b/lib/compat/inttypes.h
@@ -1,0 +1,10 @@
+#ifndef COMPAT_INTTYPES_H_INCLUDED
+#define COMPAT_INTTYPES_H_INCLUDED
+
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
+#include <inttypes.h>
+
+#endif

--- a/modules/geoip2/maxminddb-helper.c
+++ b/modules/geoip2/maxminddb-helper.c
@@ -22,6 +22,7 @@
 
 #include "maxminddb-helper.h"
 #include "scratch-buffers.h"
+#include "compat/inttypes.h"
 #include <logmsg/logmsg.h>
 #include <messages.h>
 

--- a/modules/grpc/otel/otel-protobuf-formatter.cpp
+++ b/modules/grpc/otel/otel-protobuf-formatter.cpp
@@ -28,6 +28,7 @@
 #include "value-pairs/value-pairs.h"
 #include "scanner/list-scanner/list-scanner.h"
 #include "compat/cpp-end.h"
+#include "compat/inttypes.h"
 
 #include <syslog.h>
 

--- a/modules/grpc/otel/otel-protobuf-parser.cpp
+++ b/modules/grpc/otel/otel-protobuf-parser.cpp
@@ -31,8 +31,7 @@
 #include "str-repr/encode.h"
 #include "scratch-buffers.h"
 #include "compat/cpp-end.h"
-
-#include <inttypes.h>
+#include "compat/inttypes.h"
 
 using namespace syslogng::grpc::otel;
 using namespace google::protobuf;

--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -84,6 +84,7 @@ Files: lib/cache.*
        lib/compat/socket.h
        lib/compat/string.h
        lib/compat/strtok_r.c
+       lib/compat/inttypes.h
        lib/control/control-server.*
        lib/control/control-server-unix.c
        lib/hostname.h


### PR DESCRIPTION
Some platforms need inttypes.h and __STDC_FORMAT_MACROS defined prior to including it in order for macros like PRIu64 to work. Fix that.

Signed-off-by: Sergey Fedorov <barracuda@macos-powerpc.org>
Signed-off-by: Hofi <hofione@gmail.com>