### PR TITLE
wildcard-source(): stop directory monitors at wildcard-source shutdown as soon as possible

### DIFF
--- a/modules/affile/wildcard-source.c
+++ b/modules/affile/wildcard-source.c
@@ -366,6 +366,7 @@ _deinit(LogPipe *s)
 
   g_pattern_spec_free(self->compiled_pattern);
   g_hash_table_foreach(self->file_readers, _deinit_reader, NULL);
+  g_hash_table_remove_all(self->directory_monitors);
   return TRUE;
 }
 


### PR DESCRIPTION
Related also #5086

Backport of [293](https://github.com/axoflow/axosyslog/pull/293) by @MrAnno 