### PR TITLE
python venv: disable `too-many-positional-arguments` as well for pylint

### DIFF
--- a/modules/python-modules/Makefile.am
+++ b/modules/python-modules/Makefile.am
@@ -127,7 +127,7 @@ pymodules-unit: python-venv
 pymodules-checks: pymodules-unit pymodules-pycodestyle pymodules-pylint
 
 pymodules-pycodestyle: python-venv
-	$(PYTHON_VENV) -m pycodestyle --ignore=E501,E121,E123,E126,E226,E24,E704,W503,W504 $(PYMODULES_SRCDIR)/$(PYMODULES_ROOT_MODULE)
+	$(PYTHON_VENV) -m pycodestyle --ignore=E501,E121,E123,E126,E226,E24,E704,W503,W504,R0917 $(PYMODULES_SRCDIR)/$(PYMODULES_ROOT_MODULE)
 
 pymodules-pylint: python-venv
 	$(PYTHON_VENV) -m pylint -r n --rcfile=$(PYMODULES_SRCDIR)/pylintrc $(PYMODULES_SRCDIR)/$(PYMODULES_ROOT_MODULE)

--- a/modules/python-modules/syslogng/debuggercli/tests/test_langcompleter.py
+++ b/modules/python-modules/syslogng/debuggercli/tests/test_langcompleter.py
@@ -57,7 +57,7 @@ class TestLangCompleter(CompleterTestCase):
         'PARTIAL_TOKEN': ChoiceCompleter(("tokenP-a", "tokenP-b"), prefix='@', suffix='')
     }
 
-    # pylint: disable=arguments-differ,too-many-arguments
+    # pylint: disable=arguments-differ,too-many-arguments,too-many-positional-arguments
     def _construct_completer(self, expected_token=None, expected_tokens=None,
                              replaced_token=None, replaced_token_pos=-1,
                              completers=None, prefix="<!--"):


### PR DESCRIPTION
Signed-off-by: Hofi <hofione@gmail.com>