### PR TITLE
Various memory leak fixes

### DIFF
--- a/lib/logsource.c
+++ b/lib/logsource.c
@@ -752,6 +752,8 @@ _set_metric_options(LogSource *self, const gchar *stats_id, StatsClusterKeyBuild
                                                self->stats_id, instance_name);
     stats_cluster_key_builder_set_legacy_alias_name(self->metrics.stats_kb, "processed");
     stats_cluster_key_builder_add_label(self->metrics.stats_kb, stats_cluster_label("id", self->stats_id));
+    if (self->metrics.recvd_messages_key)
+      stats_cluster_key_free(self->metrics.recvd_messages_key);
     self->metrics.recvd_messages_key = stats_cluster_key_builder_build_single(self->metrics.stats_kb);
   }
   stats_cluster_key_builder_pop(self->metrics.stats_kb);
@@ -760,6 +762,8 @@ _set_metric_options(LogSource *self, const gchar *stats_id, StatsClusterKeyBuild
   {
     stats_cluster_key_builder_set_name(self->metrics.stats_kb, "input_event_bytes_total");;
     stats_cluster_key_builder_add_label(self->metrics.stats_kb, stats_cluster_label("id", self->stats_id));
+    if (self->metrics.recvd_bytes_key)
+      stats_cluster_key_free(self->metrics.recvd_bytes_key);
     self->metrics.recvd_bytes_key = stats_cluster_key_builder_build_single(self->metrics.stats_kb);
   }
   stats_cluster_key_builder_pop(self->metrics.stats_kb);

--- a/lib/logthrdest/logthrdestdrv.c
+++ b/lib/logthrdest/logthrdestdrv.c
@@ -1324,6 +1324,15 @@ _unregister_driver_stats(LogThreadedDestDriver *self)
         stats_cluster_key_free(self->metrics.processed_sc_key);
         self->metrics.processed_sc_key = NULL;
       }
+
+    if (self->metrics.output_event_retries_sc_key)
+      {
+        stats_unregister_counter(self->metrics.output_event_retries_sc_key, SC_TYPE_SINGLE_VALUE,
+                                 &self->metrics.output_event_retries);
+
+        stats_cluster_key_free(self->metrics.output_event_retries_sc_key);
+        self->metrics.output_event_retries_sc_key = NULL;
+      }
   }
   stats_unlock();
 }

--- a/lib/metrics/dyn-metrics-template.c
+++ b/lib/metrics/dyn-metrics-template.c
@@ -164,6 +164,7 @@ dyn_metrics_template_clone(DynMetricsTemplate *self, GlobalConfig *cfg)
       LabelTemplate *label_template = (LabelTemplate *) elem->data;
       cloned->label_templates = g_list_append(cloned->label_templates, label_template_clone(label_template));
     }
+  value_pairs_unref(cloned->vp);
   cloned->vp = value_pairs_ref(self->vp);
   return cloned;
 }

--- a/lib/pragma-grammar.ym
+++ b/lib/pragma-grammar.ym
@@ -190,6 +190,7 @@ requires_stmt
                               evt_tag_str("details", $3 ? : "none"),
                               cfg_lexer_format_location_tag(lexer,&@1));
                     free($2);
+                    free($3);
                     PRAGMA_ERROR();
                   }
                 else
@@ -201,6 +202,7 @@ requires_stmt
                   }
               }
             free($2);
+            free($3);
           }
 	;
 

--- a/modules/metrics-probe/metrics-probe.c
+++ b/modules/metrics-probe/metrics-probe.c
@@ -157,6 +157,7 @@ _clone(LogPipe *s)
   MetricsProbe *cloned = (MetricsProbe *) metrics_probe_new(s->cfg);
 
   log_parser_clone_settings(&self->super, &cloned->super);
+  dyn_metrics_template_free(cloned->metrics_template);
   cloned->metrics_template = dyn_metrics_template_clone(self->metrics_template, s->cfg);
 
   metrics_probe_set_increment_template(&cloned->super, self->increment_template);


### PR DESCRIPTION
Fixes the following memory leaks:


==95913== 230 (104 direct, 126 indirect) bytes in 1 blocks are definitely lost in loss record 1,519 of 1,829
==95913==    at 0x48489F3: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==95913==    by 0x4A87BD9: g_malloc0 (gmem.c:133)
==95913==    by 0x49645EA: stats_cluster_key_builder_build_single (stats-cluster-key-builder.c:386)
==95913==    by 0x48C8ACE: _set_metric_options (logsource.c:738)
==95913==    by 0x48C8B62: log_source_set_options (logsource.c:756)
==95913==    by 0x48C43FD: log_reader_set_options (logreader.c:79)
==95913==    by 0x9C8E319: afsocket_sc_init (afsocket-source.c:186)
==95913==    by 0x9C8DC87: log_pipe_init (logpipe.h:387)
==95913==    by 0x9C8ED3A: afsocket_sd_process_connection (afsocket-source.c:480)
==95913==    by 0x9C907D2: _sd_open_dgram (afsocket-source.c:1137)
==95913==    by 0x9C908FC: afsocket_sd_open_listener (afsocket-source.c:1166)
==95913==    by 0x9C9108F: afsocket_sd_init_method (afsocket-source.c:1328)


==95913== 258 (104 direct, 154 indirect) bytes in 1 blocks are definitely lost in loss record 1,530 of 1,829
==95913==    at 0x48489F3: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==95913==    by 0x4A87BD9: g_malloc0 (gmem.c:133)
==95913==    by 0x49645EA: stats_cluster_key_builder_build_single (stats-cluster-key-builder.c:386)
==95913==    by 0x48C8A1F: _set_metric_options (logsource.c:730)
==95913==    by 0x48C8B62: log_source_set_options (logsource.c:756)
==95913==    by 0x48C43FD: log_reader_set_options (logreader.c:79)
==95913==    by 0x9C8E319: afsocket_sc_init (afsocket-source.c:186)
==95913==    by 0x9C8DC87: log_pipe_init (logpipe.h:387)
==95913==    by 0x9C8ED3A: afsocket_sd_process_connection (afsocket-source.c:480)
==95913==    by 0x9C907D2: _sd_open_dgram (afsocket-source.c:1137)
==95913==    by 0x9C908FC: afsocket_sd_open_listener (afsocket-source.c:1166)
==95913==    by 0x9C9108F: afsocket_sd_init_method (afsocket-source.c:1328)


==95913== 460 (208 direct, 252 indirect) bytes in 2 blocks are definitely lost in loss record 1,548 of 1,829
==95913==    at 0x48489F3: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==95913==    by 0x4A87BD9: g_malloc0 (gmem.c:133)
==95913==    by 0x49645EA: stats_cluster_key_builder_build_single (stats-cluster-key-builder.c:386)
==95913==    by 0x48C8ACE: _set_metric_options (logsource.c:738)
==95913==    by 0x48C8B62: log_source_set_options (logsource.c:756)
==95913==    by 0x48C43FD: log_reader_set_options (logreader.c:79)
==95913==    by 0x9C8E319: afsocket_sc_init (afsocket-source.c:186)
==95913==    by 0x9C8DC87: log_pipe_init (logpipe.h:387)
==95913==    by 0x9C90363: afsocket_sd_restore_kept_alive_connections (afsocket-source.c:1021)
==95913==    by 0x9C91083: afsocket_sd_init_method (afsocket-source.c:1326)
==95913==    by 0x9C945CB: afinet_sd_init (afinet-source.c:104)
==95913==    by 0x48B0F0A: log_pipe_init (logpipe.h:387)


==95913== 516 (208 direct, 308 indirect) bytes in 2 blocks are definitely lost in loss record 1,552 of 1,829
==95913==    at 0x48489F3: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==95913==    by 0x4A87BD9: g_malloc0 (gmem.c:133)
==95913==    by 0x49645EA: stats_cluster_key_builder_build_single (stats-cluster-key-builder.c:386)
==95913==    by 0x48C8A1F: _set_metric_options (logsource.c:730)
==95913==    by 0x48C8B62: log_source_set_options (logsource.c:756)
==95913==    by 0x48C43FD: log_reader_set_options (logreader.c:79)
==95913==    by 0x9C8E319: afsocket_sc_init (afsocket-source.c:186)
==95913==    by 0x9C8DC87: log_pipe_init (logpipe.h:387)
==95913==    by 0x9C90363: afsocket_sd_restore_kept_alive_connections (afsocket-source.c:1021)
==95913==    by 0x9C91083: afsocket_sd_init_method (afsocket-source.c:1326)
==95913==    by 0x9C945CB: afinet_sd_init (afinet-source.c:104)
==95913==    by 0x48B0F0A: log_pipe_init (logpipe.h:387)


==95913== 610 (208 direct, 402 indirect) bytes in 2 blocks are definitely lost in loss record 1,573 of 1,829
==95913==    at 0x48489F3: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==95913==    by 0x4A87BD9: g_malloc0 (gmem.c:133)
==95913==    by 0x49645EA: stats_cluster_key_builder_build_single (stats-cluster-key-builder.c:386)
==95913==    by 0x498AE8B: _register_driver_stats (logthrdestdrv.c:1270)
==95913==    by 0x498B48B: log_threaded_dest_driver_init_method (logthrdestdrv.c:1411)
==95913==    by 0xB988F3E: http_dd_init (http.c:442)
==95913==    by 0x48B0F0A: log_pipe_init (logpipe.h:387)
==95913==    by 0x48B3B97: cfg_tree_start (cfg-tree.c:1586)
==95913==    by 0x48A80FC: cfg_init (cfg.c:308)
==95913==    by 0x48D005D: main_loop_initialize_state (mainloop.c:203)
==95913==    by 0x48D1258: main_loop_read_and_init_config (mainloop.c:700)
==95913==    by 0x10AA39: main (main.c:319)


==95913== 1,364 bytes in 8 blocks are definitely lost in loss record 1,729 of 1,829
==95913==    at 0x4843808: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==95913==    by 0x4C14589: strdup (strdup.c:42)
==95913==    by 0x48F09CB: _cfg_lexer_lex (cfg-lex.l:383)
==95913==    by 0x48AC8C0: _invoke__cfg_lexer_lex (cfg-lexer.c:971)
==95913==    by 0x48ACAD1: cfg_lexer_lex_next_token (cfg-lexer.c:1015)
==95913==    by 0x48AD0AE: cfg_lexer_lex (cfg-lexer.c:1202)
==95913==    by 0x48DCA1E: pragma_lex (pragma-parser.c:91)
==95913==    by 0x490A86C: pragma_parse (pragma-grammar.c:3486)
==95913==    by 0x48AF069: cfg_parser_parse (cfg-parser.c:299)
==95913==    by 0x48ACEE0: cfg_lexer_parse_pragma (cfg-lexer.c:1119)
==95913==    by 0x48ACFD2: cfg_lexer_preprocess (cfg-lexer.c:1163)
==95913==    by 0x48AD24D: cfg_lexer_lex (cfg-lexer.c:1242)


==95913== 1,600 (576 direct, 1,024 indirect) bytes in 8 blocks are definitely lost in loss record 1,749 of 1,829
==95913==    at 0x48489F3: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==95913==    by 0x4A87BD9: g_malloc0 (gmem.c:133)
==95913==    by 0x495B65C: value_pairs_new (value-pairs.c:992)
==95913==    by 0x4967319: dyn_metrics_template_new (dyn-metrics-template.c:142)
==95913==    by 0x4967397: dyn_metrics_template_clone (dyn-metrics-template.c:158)
==95913==    by 0x9CEAE06: _clone (metrics-probe.c:160)
==95913==    by 0x48B1078: log_pipe_clone (logpipe.h:498)
==95913==    by 0x48B2542: cfg_tree_compile_single (cfg-tree.c:777)
==95913==    by 0x48B34D9: cfg_tree_compile_node (cfg-tree.c:1370)
==95913==    by 0x48B2B9C: cfg_tree_compile_sequence (cfg-tree.c:1019)
==95913==    by 0x48B3531: cfg_tree_compile_node (cfg-tree.c:1376)
==95913==    by 0x48B2937: cfg_tree_compile_reference (cfg-tree.c:905)


==95913== 1,830 (624 direct, 1,206 indirect) bytes in 6 blocks are definitely lost in loss record 1,751 of 1,829
==95913==    at 0x48489F3: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==95913==    by 0x4A87BD9: g_malloc0 (gmem.c:133)
==95913==    by 0x49645EA: stats_cluster_key_builder_build_single (stats-cluster-key-builder.c:386)
==95913==    by 0x498AE8B: _register_driver_stats (logthrdestdrv.c:1270)
==95913==    by 0x498B48B: log_threaded_dest_driver_init_method (logthrdestdrv.c:1411)
==95913==    by 0xB988F3E: http_dd_init (http.c:442)
==95913==    by 0x48B0F0A: log_pipe_init (logpipe.h:387)
==95913==    by 0x48B3B97: cfg_tree_start (cfg-tree.c:1586)
==95913==    by 0x48A80FC: cfg_init (cfg.c:308)
==95913==    by 0x48D02C1: main_loop_reload_config_apply (mainloop.c:287)
==95913==    by 0x48D2622: _consume_action (mainloop-worker.c:258)
==95913==    by 0x48D265A: _invoke_sync_call_actions (mainloop-worker.c:268)


==95913== 1,856 (256 direct, 1,600 indirect) bytes in 8 blocks are definitely lost in loss record 1,753 of 1,829
==95913==    at 0x48489F3: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==95913==    by 0x4A87BD9: g_malloc0 (gmem.c:133)
==95913==    by 0x4967309: dyn_metrics_template_new (dyn-metrics-template.c:140)
==95913==    by 0x9CEAF2F: metrics_probe_new (metrics-probe.c:191)
==95913==    by 0x9CEADD1: _clone (metrics-probe.c:157)
==95913==    by 0x48B1078: log_pipe_clone (logpipe.h:498)
==95913==    by 0x48B2542: cfg_tree_compile_single (cfg-tree.c:777)
==95913==    by 0x48B34D9: cfg_tree_compile_node (cfg-tree.c:1370)
==95913==    by 0x48B2B9C: cfg_tree_compile_sequence (cfg-tree.c:1019)
==95913==    by 0x48B3531: cfg_tree_compile_node (cfg-tree.c:1376)
==95913==    by 0x48B2937: cfg_tree_compile_reference (cfg-tree.c:905)
==95913==    by 0x48B3505: cfg_tree_compile_node (cfg-tree.c:1373)

Note: reloading was necessary to trigger some of these.


Slightly modified backport of [#300](https://github.com/axoflow/axosyslog/pull/300) by @alltilla 