### PR TITLE
logqueue-fifo: remove legacy flow-control+log-fifo-size() coupling

### DIFF
--- a/lib/driver.c
+++ b/lib/driver.c
@@ -266,17 +266,6 @@ _create_memory_queue(LogDestDriver *self, const gchar *persist_name, gint stats_
 
   gint log_fifo_size = self->log_fifo_size < 0 ? cfg->log_fifo_size : self->log_fifo_size;
 
-  if (cfg_is_config_version_older(cfg, VERSION_VALUE_3_22))
-    {
-      msg_warning_once("WARNING: log-fifo-size() works differently starting with " VERSION_3_22 " to avoid dropping "
-                       "flow-controlled messages when log-fifo-size() is misconfigured. From now on, log-fifo-size() "
-                       "only affects messages that are not flow-controlled. (Flow-controlled log paths have the "
-                       "flags(flow-control) option set.) To enable the new behaviour, update the @version string in "
-                       "your configuration and consider lowering the value of log-fifo-size().");
-
-      return log_queue_fifo_legacy_new(log_fifo_size, persist_name, stats_level, driver_sck_builder, queue_sck_builder);
-    }
-
   return log_queue_fifo_new(log_fifo_size, persist_name, stats_level, driver_sck_builder, queue_sck_builder);
 }
 

--- a/lib/logqueue-fifo.h
+++ b/lib/logqueue-fifo.h
@@ -30,9 +30,6 @@
 LogQueue *log_queue_fifo_new(gint log_fifo_size, const gchar *persist_name, gint stats_level,
                              StatsClusterKeyBuilder *driver_sck_builder,
                              StatsClusterKeyBuilder *queue_sck_builder);
-LogQueue *log_queue_fifo_legacy_new(gint log_fifo_size, const gchar *persist_name, gint stats_level,
-                                    StatsClusterKeyBuilder *driver_sck_builder,
-                                    StatsClusterKeyBuilder *queue_sck_builder);
 
 QueueType log_queue_fifo_get_type(void);
 


### PR DESCRIPTION
I was investigating a log source hang, and it occurred to me in this context that it's time to part ways with the legacy force-suspend functionality.

In the average configurations we have seen, the possible memory usage would have been doubled or tripled. We needed to avoid that scenario with this compatibility warning.

Backport of [#295](https://github.com/axoflow/axosyslog/pull/295) by @MrAnno