### PR TITLE
Light fixes

### DIFF
--- a/tests/light/functional_tests/conftest.py
+++ b/tests/light/functional_tests/conftest.py
@@ -85,7 +85,7 @@ def setup(request):
     global base_number_of_open_fds
     number_of_open_fds = len(psutil.Process().open_files())
     assert base_number_of_open_fds + 1 == number_of_open_fds, "Previous testcase has unclosed opened fds"
-    assert len(psutil.Process().connections(kind="inet")) == 0, "Previous testcase has unclosed opened sockets"
+    assert len(psutil.Process().net_connections(kind="inet")) == 0, "Previous testcase has unclosed opened sockets"
     testcase_parameters = request.getfixturevalue("testcase_parameters")
 
     copy_file(testcase_parameters.get_testcase_file(), Path.cwd())

--- a/tests/light/src/syslog_ng/syslog_ng_cli.py
+++ b/tests/light/src/syslog_ng/syslog_ng_cli.py
@@ -80,7 +80,6 @@ class SyslogNgCli(object):
     def __wait_for_control_socket_alive(self):
         def is_alive(s):
             if not s.is_process_running():
-                self.__process = None
                 self.__error_handling("syslog-ng is not running")
             return s.__syslog_ng_ctl.is_control_socket_alive()
         return wait_until_true(is_alive, self)
@@ -167,6 +166,10 @@ class SyslogNgCli(object):
                 core_file.replace(Path(core_file))
             if core_file_found:
                 raise Exception("syslog-ng core file was found and processed")
+            if self.__process.returncode in [-6, -9, -11]:
+                ret_code = self.__process.returncode
+                self.__process = None
+                raise Exception("syslog-ng process crashed with signal {}".format(ret_code))
 
     def set_start_parameters(self, stderr, debug, trace, verbose, startup_debug, no_caps, config_path, persist_path, pid_path, control_socket_path):
         self.__stderr = stderr


### PR DESCRIPTION
These minor fixes helps to run light more comfortable.

    fix 1: add fix for a deprecated API call (psutil.Process().connections())
    fix 2: handle syslog-ng crash when no core file has been detected

Backport of [#302](https://github.com/axoflow/axosyslog/pull/302) by @mitzkia 