### PR TITLE
logreader: fix spurious wakeups by updating the suspended flag on I/O poll

### DIFF
--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -335,6 +335,7 @@ log_reader_update_watches(LogReader *self)
   switch (prepare_action)
     {
     case LPPA_POLL_IO:
+      self->suspended = FALSE;
       poll_events_update_watches(self->poll_events, cond);
       break;
     case LPPA_FORCE_SCHEDULE_FETCH:


### PR DESCRIPTION
Backport of [@299](https://github.com/axoflow/axosyslog/pull/299) by @MrAnno 