### PR TITLE
dbld: re-enable smtp on debian-testing

### DIFF
--- a/dbld/build.manifest
+++ b/dbld/build.manifest
@@ -30,7 +30,7 @@
 # libcriterion-dev is available starting with bullseye
 debian-bullseye		python3,nojava,notzdatalegacy
 debian-bookworm		python3,nojava,notzdatalegacy
-debian-testing		python3,nojava,nosmtp
+debian-testing		python3,nojava
 debian-sid		python3,nojava
 
 # on ubuntu, we start using Python3 at focal onwards.


### PR DESCRIPTION
Reverts syslog-ng/syslog-ng#5054

libesmtp is back on debian-testing