### PR TITLE
light test: add EXTRA_ARGS processing on light tests

### DIFF
--- a/tests/light/CMakeLists.txt
+++ b/tests/light/CMakeLists.txt
@@ -3,7 +3,7 @@ add_custom_target(light-self-check
    DEPENDS BuildPyVirtualEnv)
 
 add_custom_target(light-check
-   COMMAND ${PYTHON_VENV_EXECUTABLE} -m pytest ${PROJECT_SOURCE_DIR}/tests/light/functional_tests --installdir=${CMAKE_INSTALL_PREFIX} --showlocals --verbosity=3
+   COMMAND ${PYTHON_VENV_EXECUTABLE} -m pytest ${PROJECT_SOURCE_DIR}/tests/light/functional_tests --installdir=${CMAKE_INSTALL_PREFIX} --showlocals --verbosity=3 $$EXTRA_ARGS
    DEPENDS BuildPyVirtualEnv)
 
 add_custom_target(light-linters


### PR DESCRIPTION
The make light-check command appends the EXTRA_ARGS environment variable to the command line arguments. Its primary purpose is to filter light tests during execution, but by not enforcing the -k argument, its use becomes more versatile.

example: `make light-check EXTRA_ARGS="-k test_unset_empties"`

Backport of [#308](https://github.com/axoflow/axosyslog/pull/308) by @bshifter 