### PR TITLE
cfg: fix config-version incosistencies

### DIFF
--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -26,6 +26,7 @@
 #include "cfg-lexer-subst.h"
 #include "cfg-block-generator.h"
 #include "cfg-grammar.h"
+#include "cfg.h"
 #include "block-ref-parser.h"
 #include "pragma-parser.h"
 #include "messages.h"
@@ -1106,6 +1107,15 @@ cfg_lexer_preprocess(CfgLexer *self, gint tok, CFG_STYPE *yylval, CFG_LTYPE *yyl
         return CLPR_ERROR;
 
       return CLPR_LEX_AGAIN;
+    }
+  else if (cfg_lexer_get_context_type(self) != LL_CONTEXT_PRAGMA && !self->first_non_pragma_seen)
+    {
+      /* Config version must be set before the first non-pragma element to avoid
+       * version-specific inconsistencies (e.g. template functions). */
+      if (cfg_get_user_version(self->cfg) == 0)
+        cfg_set_current_version(self->cfg);
+
+      self->first_non_pragma_seen = TRUE;
     }
 
   return CLPR_OK;

--- a/lib/cfg-lexer.h
+++ b/lib/cfg-lexer.h
@@ -181,7 +181,7 @@ struct _CfgLexer
   GString *token_pretext;
   GString *token_text;
   GlobalConfig *cfg;
-  guint ignore_pragma:1;
+  guint first_non_pragma_seen:1, ignore_pragma:1;
 };
 
 /* pattern buffer */

--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -363,9 +363,12 @@ cfg_set_version(GlobalConfig *self, gint version)
 {
   if (self->user_version != 0)
     {
-      msg_warning("WARNING: you have multiple @version directives in your configuration, only the first one is considered",
+      msg_warning("WARNING: The @version directive must be placed at the top of the main configuration file "
+                  "(preferably as the very first line), preceding any @include directives and other configuration "
+                  "elements, otherwise, the current version will be used. If you specify multiple @version directives "
+                  "in your configuration, only the first one will be considered",
                   cfg_format_config_version_tag(self),
-                  cfg_format_version_tag("new-version", version));
+                  cfg_format_version_tag("ignored-version", version));
       return TRUE;
     }
   cfg_set_version_without_validation(self, version);

--- a/news/bugfix-5145.md
+++ b/news/bugfix-5145.md
@@ -1,0 +1,2 @@
+Config `@version`: fixed compat-mode inconsistencies when `@version` was not specified at the top of the configuration
+file or was not specified at all


### PR DESCRIPTION
Template functions, for example, are constructed right when syslog-ng parses the configuration, so the @version directive must be placed at the top of the config file to make it consistent.

This patch fixes the implicit "current version" mechanism (when no @version is specified) by moving it back to the lexer, and warns the user about misplaced or redefined @version directives.

Reproducer: Place a template("$(format-json asd=asd)" anywhere in the configuration without an explicit @version declaration or place the @version declaration after the config block containing the mentioned template. A compatibility warning will be produced and syslog-ng will operate in half-"compat mode".

Backport of [#312](https://github.com/axoflow/axosyslog/pull/312) by @MrAnno 