### PR TITLE
package-indexer: use afd_endpoints instead of endpoints in CDN purge call

### DIFF
--- a/packaging/package-indexer/cdn/azure_cdn.py
+++ b/packaging/package-indexer/cdn/azure_cdn.py
@@ -95,19 +95,19 @@ class AzureCDN(CDN):
             tenant_id=cfg["tenant-id"],
             client_id=cfg["client-id"],
             client_secret=cfg["client-secret"],
-            domains=cfg["domains"]
+            domains=cfg["domains"],
         )
 
     def refresh_cache(self, path: Path) -> None:
         path_str = str(Path("/", path))
 
-        self._log_info("Refreshing CDN cache.", path=path_str, domains=self.__domains)
+        self._log_info("Refreshing CDN cache.", path=path_str, domains=str(self.__domains))
 
         poller: LROPoller = self.__cdn.afd_endpoints.begin_purge_content(
             resource_group_name=self.__resource_group_name,
             profile_name=self.__profile_name,
             endpoint_name=self.__endpoint_name,
-            contents={'contentPaths': [path_str], "domains": self.__domains},
+            contents={"contentPaths": [path_str], "domains": self.__domains},
         )
         poller.wait()
 
@@ -115,4 +115,4 @@ class AzureCDN(CDN):
         if not status == "Succeeded":
             raise Exception("Failed to refresh CDN cache. status: {}".format(status))
 
-        self._log_info("Successfully refreshed CDN cache.", path=path_str, domains=self.__domains)
+        self._log_info("Successfully refreshed CDN cache.", path=path_str, domains=str(self.__domains))

--- a/packaging/package-indexer/index-packages.py
+++ b/packaging/package-indexer/index-packages.py
@@ -73,6 +73,11 @@ def add_optional_arguments(parser: ArgumentParser) -> None:
         type=str,
         help="Also log more verbosely into this file.",
     )
+    parser.add_argument(
+        "--flush-cache-only",
+        action="store_true",
+        help="Only flush the caches of the Azure CDN. Used for testing that part.",
+    )
 
 
 def parse_args() -> dict:
@@ -157,8 +162,12 @@ def main() -> None:
     cfg = load_config(args)
 
     indexers = construct_indexers(cfg, args)
-    for indexer in indexers:
-        indexer.index()
+    if args["flush_cache_only"]:
+        for indexer in indexers:
+            indexer.flush_cdn_cache()
+    else:
+        for indexer in indexers:
+            indexer.index()
 
 
 if __name__ == "__main__":

--- a/packaging/package-indexer/indexer/indexer.py
+++ b/packaging/package-indexer/indexer/indexer.py
@@ -86,6 +86,9 @@ class Indexer(ABC):
         self.__sync_to_remote()
         self.__refresh_cdn_cache()
 
+    def flush_cdn_cache(self) -> None:
+        self.__refresh_cdn_cache()
+
     @staticmethod
     def __create_logger() -> logging.Logger:
         logger = logging.getLogger("Indexer")


### PR DESCRIPTION
That's the new object to handle AFD endpoints instead of the old CDN endpoint we upgraded from.

