### PR TITLE
s3: workaround on-reload memleak when no role is set

### DIFF
--- a/modules/python-modules/syslogng/modules/s3/s3_destination.py
+++ b/modules/python-modules/syslogng/modules/s3/s3_destination.py
@@ -249,13 +249,13 @@ class S3Destination(LogDestination):
         if self.is_opened():
             return True
 
-        self.session = Session(
-            aws_access_key_id=self.access_key if self.access_key != "" else None,
-            aws_secret_access_key=self.secret_key if self.secret_key != "" else None,
-            region_name=self.region,
-        )
-
         if self.role != "":
+            self.session = Session(
+                aws_access_key_id=self.access_key if self.access_key != "" else None,
+                aws_secret_access_key=self.secret_key if self.secret_key != "" else None,
+                region_name=self.region,
+            )
+
             # NOTE: The Session.set_credentials always creates a new Credentials object from the given keys.
             # NOTE: The DeferredRefreshableCredentials class is a child of RefreshableCredentials which is a
             # NOTE: child of the Credentials class.
@@ -271,10 +271,18 @@ class S3Destination(LogDestination):
             whoami = sts.get_caller_identity().get("Arn")
             self.logger.info(f"Using {whoami} to access the bucket")
 
-        self.client = self.session.client(
-            service_name="s3",
-            endpoint_url=self.url if self.url != "" else None,
-        )
+            self.client = self.session.client(
+                service_name="s3",
+                endpoint_url=self.url if self.url != "" else None,
+            )
+        else:
+            self.client = client(
+                service_name="s3",
+                endpoint_url=self.url if self.url != "" else None,
+                aws_access_key_id=self.access_key if self.access_key != "" else None,
+                aws_secret_access_key=self.secret_key if self.secret_key != "" else None,
+                region_name=self.region,
+            )
 
         is_opened = False
         try:

--- a/modules/python-modules/syslogng/modules/s3/s3_destination.py
+++ b/modules/python-modules/syslogng/modules/s3/s3_destination.py
@@ -249,6 +249,9 @@ class S3Destination(LogDestination):
         if self.is_opened():
             return True
 
+        # NOTE: Creating a client via a Session object does some unusual caching, which increases memory usage
+        # NOTE: each reload.  Because of this, we only create Session object if the role is set, and in that case
+        # NOTE: the memory usage is expected to behave unusually.  Sometime we should investigate this further.
         if self.role != "":
             self.session = Session(
                 aws_access_key_id=self.access_key if self.access_key != "" else None,

--- a/news/bugfix-5149.md
+++ b/news/bugfix-5149.md
@@ -1,0 +1,6 @@
+`s3()`: Eliminated indefinite memory usage increase for each reload.
+
+The increased memory usage is caused by the `botocore` library, which
+caches the session information. We only need the Session object, if
+`role()` is set. The increased memory usage still happens with that set,
+currently we only fixed the unset case.


### PR DESCRIPTION
[syslog-ng](https://github.com/axoflow/axosyslog/issues/317) leaks an amount of memory every time it's reloaded if an s3 destination is configured. As a quick workaround we partially revert the patch introducing the use of boto3.Session when no role() is set.

Backport of [318](https://github.com/axoflow/axosyslog/pull/318) by @orymate