### PR TITLE
afsocket-dest: fixed the stats_cluster_untrack_counter assertation

### DIFF
--- a/modules/afsocket/afsocket-dest.h
+++ b/modules/afsocket/afsocket-dest.h
@@ -58,6 +58,7 @@ struct _AFSocketDestDriver
   {
     StatsCounterItem *output_unreachable;
   } metrics;
+  const gchar *original_dest_name;
 
   LogWriter *(*construct_writer)(AFSocketDestDriver *self);
   gboolean (*setup_addresses)(AFSocketDestDriver *s);


### PR DESCRIPTION
caused by an unregister attempt of a key that might have no matching registered element pair as the address label in the registered key might have changed if not a fixed port is used.

Signed-off-by: Hofi <hofione@gmail.com>