### PR TITLE
Fixed crash on startup caused by missing cfg options in certain scl drivers

### DIFF
--- a/lib/cfg-block-generator.c
+++ b/lib/cfg-block-generator.c
@@ -39,12 +39,15 @@ _report_generator_args(gpointer key, gpointer value, gpointer user_data)
 {
   GString *result = (GString *) user_data;
   g_string_append_printf(result, "## %s=", (gchar *) key);
-  for (const gchar *c = (const gchar *) value; *c; c++)
+  if (value != NULL)
     {
-      if (*c == '\n' && *(c + 1))
-        g_string_append(result, "\n## ");
-      else
-        g_string_append_c(result, *c);
+      for (const gchar *c = (const gchar *) value; *c; c++)
+        {
+          if (*c == '\n' && *(c + 1))
+            g_string_append(result, "\n## ");
+          else
+            g_string_append_c(result, *c);
+        }
     }
 
   g_string_append_c(result, '\n');

--- a/news/bugfix-5163.md
+++ b/news/bugfix-5163.md
@@ -1,0 +1,1 @@
+cfg: Fixed syslog-ng crashing on startup when using certain scl drivers without some options defined.


### PR DESCRIPTION
<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->
Certain SCL drivers have options without default values. This could (and in certain cases does) result in `_report_generator_args` trying to iterate  on a nullpointer, and crashing syslog-ng in the process.

<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
