### PR TITLE
ci: fix macOS dep conflict

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew update --preinstall
-          brew bundle --file=contrib/Brewfile
+          brew bundle --force --file=contrib/Brewfile
 
           OS_NAME=$([[ ${{ matrix.version }} -eq 13 ]] && echo "Ventura" || echo "Sonoma")
           MACPORTS_PKG_NAME=MacPorts-2.10.1-${{ matrix.version }}-${OS_NAME}.pkg

--- a/contrib/Brewfile
+++ b/contrib/Brewfile
@@ -12,7 +12,7 @@ brew "json-c"
 brew "libtool"
 brew "openssl@3"
 brew "pcre2"
-brew "pkg-config"
+brew "pkgconf"
 
 brew "curl"
 brew "gradle"


### PR DESCRIPTION
pkgconf is a newer, actively maintained implementation of pkg-config.

BackPort of [#387](https://github.com/axoflow/axosyslog/pull/387) by @MrAnno 