### PR TITLE
ci: fix cfg-grammar's PR ID query

### DIFF
--- a/.github/workflows/comment-cfg-grammar-changes.yml
+++ b/.github/workflows/comment-cfg-grammar-changes.yml
@@ -49,7 +49,13 @@ jobs:
           # There is also no json field in the `gh run view` command, which could give us the PR ID, so we can only query it based on the fork and branch.
           # See https://github.com/orgs/community/discussions/25220
 
-          PR_ID=$(gh pr view -R "${{ github.repository }}" "${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}" --json "number" --jq ".number")
+          if [[ "${{ github.event.workflow_run.head_repository.url }}" == "${{ github.event.workflow_run.repository.url }}" ]]; then
+            PR_ID=$(gh pr view -R "${{ github.repository }}" "${{ github.event.workflow_run.head_branch }}" --json "number" --jq ".number")
+          else
+            # PR is from a fork
+            PR_ID=$(gh pr view -R "${{ github.repository }}" "${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}" --json "number" --jq ".number")
+          fi
+
           echo "pr-id=${PR_ID}" >> $GITHUB_OUTPUT
 
       - name: Update or remove PR comment


### PR DESCRIPTION
The owner is only needed if it's coming from a fork

BackPort of [#322](https://github.com/axoflow/axosyslog/pull/322) by @OverOrion 