### PR TITLE
Otlp fix addr

### DIFF
--- a/lib/gsockaddr.c
+++ b/lib/gsockaddr.c
@@ -512,6 +512,17 @@ g_sockaddr_inet_or_inet6_new(const gchar *name, guint16 port)
   return addr;
 }
 
+gboolean
+g_sockaddr_inet_or_inet6_check(GSockAddr *a)
+{
+#if SYSLOG_NG_ENABLE_IPV6
+  if (G_UNLIKELY(g_sockaddr_inet6_check(a)))
+    return TRUE;
+#endif
+
+  return g_sockaddr_inet_check(a);
+}
+
 /* AF_UNIX socket address */
 
 /*+

--- a/lib/gsockaddr.h
+++ b/lib/gsockaddr.h
@@ -162,6 +162,7 @@ gboolean g_sockaddr_inet6_is_v4_mapped(GSockAddr *s);
 #endif
 
 GSockAddr *g_sockaddr_inet_or_inet6_new(const gchar *name, guint16 port);
+gboolean g_sockaddr_inet_or_inet6_check(GSockAddr *a);
 
 GSockAddr *g_sockaddr_unix_new(const gchar *name);
 GSockAddr *g_sockaddr_unix_new2(struct sockaddr_un *s_un, int sunlen);

--- a/modules/grpc/otel/otel-protobuf-formatter.cpp
+++ b/modules/grpc/otel/otel-protobuf-formatter.cpp
@@ -585,14 +585,14 @@ ProtobufFormatter::set_syslog_ng_addresses(LogMessage *msg, LogRecord &log_recor
 {
   /* source address */
 
-  if (msg->saddr)
+  if (msg->saddr && g_sockaddr_inet_or_inet6_check(msg->saddr))
     {
       KeyValue *sa = log_record.add_attributes();
       sa->set_key("sa");
       set_syslog_ng_address_attrs(msg->saddr, sa->mutable_value()->mutable_kvlist_value(), false);
     }
 
-  if (msg->daddr)
+  if (msg->daddr && g_sockaddr_inet_or_inet6_check(msg->daddr))
     {
       /* dest address */
       KeyValue *da = log_record.add_attributes();


### PR DESCRIPTION
Messages originated from unix-stream or unix-dgram sockets made otlp crash.

Since it is unnecessary to forward local unix-based addresses, the fix is to skip non-inet addresses (instead of extending the implementation of g_sockaddr_get_address()).

Backport of [#328](https://github.com/axoflow/axosyslog/pull/328) by @MrAnno 

Depend on https://github.com/syslog-ng/syslog-ng/pull/5174