### PR TITLE
ci: fix trivy action

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout syslog-ng source
         uses: actions/checkout@v4
 
-      
+
       - name: Set up Docker
         # Build and load multi-platform images
         # https://docs.docker.com/build/ci/github-actions/multi-platform/#build-and-load-multi-platform-images
@@ -111,6 +111,10 @@ jobs:
           format: 'table'
           dependency-tree: true
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+        env:
+          # Use the most reliable and quicker AWS ECR location for trivy DBs
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:1
 
       - name: Upload Trivy scan sarif file results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3

--- a/scripts/syslog-ng-update-virtualenv.in
+++ b/scripts/syslog-ng-update-virtualenv.in
@@ -84,6 +84,6 @@ ${SYSTEM_PYTHON} -m venv ${python_venvdir}
 echo "Running python -m pip install..."
 ${VENV_PYTHON} -m pip install --upgrade pip
 ${VENV_PYTHON} -m pip install --upgrade pip setuptools
-${VENV_PYTHON} -m pip install --upgrade -r "${REQUIREMENTS_FILE}"
+${VENV_PYTHON} -m pip install --no-compile --upgrade -r "${REQUIREMENTS_FILE}"
 cp "${REQUIREMENTS_FILE}" "${python_venvdir}"
 echo "Finished."


### PR DESCRIPTION
1.
By default it also checks for secrets in compiled Python binary files (/var/lib/syslog-ng-venv/lib/python3.12/site-packages/google/auth/crypt/__pycache__/_python_rsa.cpython-312.pyc)

See pip docs for more details
https://pip.pypa.io/en/stable/cli/pip_install/

Signed-off-by: Szilard Parrag <szilard.parrag@axoflow.com>

2.
Use the most reliable and quicker [AWS ECR location for trivy DBs](https://github.com/aquasecurity/trivy-java-db/issues/35)

Backport of:
[331](https://github.com/axoflow/axosyslog/pull/331) by @OverOrion 
[366](https://github.com/axoflow/axosyslog/pull/366/files) by @MrAnno