### PR TITLE
dbld/rules: fix login and root-login targets

### DIFF
--- a/dbld/rules
+++ b/dbld/rules
@@ -275,12 +275,12 @@ exec-%: setup
 	$(DOCKER) exec ${DOCKER_INTERACTIVE}  $$container $(EXEC_COMMAND)
 
 login: login-$(DEFAULT_IMAGE)
-login-%: EXEC_COMMAND=sudo -u $(shell whoami) /dbld/shell
+login-%: EXEC_COMMAND=sudo -E -u $(shell whoami) /dbld/shell $(if $(SHELL_COMMAND),"$(SHELL_COMMAND)",bash)
 login-%: exec-%
 	@true
 
 root-login: root-login-$(DEFAULT_IMAGE)
-root-login-%: EXEC_COMMAND=bash
+root-login-%: EXEC_COMMAND=/dbld/shell $(if $(SHELL_COMMAND),"$(SHELL_COMMAND)",bash)
 root-login-%: exec-%
 	@true
 


### PR DESCRIPTION
No command was passed to /dbld/shell in these cases, causing these shells to exit.

Backport of [#335](https://github.com/axoflow/axosyslog/pull/335/commits) by @bazsi 