### PR TITLE
Fix space in capabilities documentation

### DIFF
--- a/doc/man/syslog-ng.8.xml
+++ b/doc/man/syslog-ng.8.xml
@@ -66,10 +66,10 @@
             <para>Run  process with the specified POSIX capability flags.</para>
             <itemizedlist>
               <listitem>
-                <para>If the <parameter>--no-caps</parameter> option is not set, and the host supports CAP_SYSLOG,  uses the following capabilities: "cap_net_bind_service, cap_net_broadcast, cap_net_raw, cap_dac_read_search, cap_dac_override, cap_chown, cap_fowner=p cap_syslog=ep"</para>
+                <para>If the <parameter>--no-caps</parameter> option is not set, and the host supports CAP_SYSLOG, uses the following capabilities: "cap_net_bind_service,cap_net_broadcast,cap_net_raw,cap_dac_read_search,cap_dac_override,cap_chown,cap_fowner=p cap_syslog=ep"</para>
               </listitem>
               <listitem>
-                <para>If the <parameter>--no-caps</parameter> option is not set, and the host does not support CAP_SYSLOG,  uses the following capabilities: "cap_net_bind_service, cap_net_broadcast, cap_net_raw,cap_dac_read_search, cap_dac_override, cap_chown, cap_fowner=p cap_sys_admin=ep"</para>
+                <para>If the <parameter>--no-caps</parameter> option is not set, and the host does not support CAP_SYSLOG, uses the following capabilities: "cap_net_bind_service,cap_net_broadcast,cap_net_raw,cap_dac_read_search,cap_dac_override,cap_chown,cap_fowner=p cap_sys_admin=ep"</para>
               </listitem>
             </itemizedlist>
             <para>For example:</para>


### PR DESCRIPTION
According to cap_from_text(3):

> A textual representation of capability sets consists of one or more whitespace-separated clauses.
> [...]
> Each clause consists of a list of comma-separated capability names [...], followed by an action-list.  An action-list consists of a sequence of operator flag pairs.  Legal operators are: '=', '+', and '-'.  Legal flags are: 'e', 'i', and 'p'.

The spaces before the coma is therefore unexpected, and will cause startup error, e.g.:

```
syslog-ng: Error parsing capabilities: cap_net_bind_service, cap_net_broadcast, cap_net_raw, cap_dac_read_search, cap_dac_override, cap_chown, cap_fowner=p cap_syslog=ep
```

Remove them so that the example can be copied-pasted from the man page to the cli.
