### PR TITLE
slog: New implementation of pseudo-random function

### DIFF
--- a/doc/man/secure-logging.7.xml
+++ b/doc/man/secure-logging.7.xml
@@ -48,7 +48,7 @@
       <para>The main objective of the secure logging module is to provide tamper evident logging, i.e. to adequately protect log records of an information system and to provide a sensor indicating
 attack attempts. The secure logging module achieves this by authentically encrypting each
 log record with an individual cryptographic key used only once and protecting the integrity of
-the whole log archive by a cryptographic authentication code. Each attempt to tamper
+the whole log archive with a hash-based message authentication code (HMAC). Each attempt to tamper
 with either an individual log record or the log archive itself will be immediately detected
 during log archive verification. Therefore, an attacker can no longer tamper with log
       records without being detected.</para>
@@ -104,11 +104,11 @@ AgAAAAAAAAA=:5UVybnKL1EAbgC4CLfd8HpgurjREf4LEN61/yWHSD2hbXjRD4QmQdtbwguT1chzdItK
     </refsection>
     <refsection version="5.0">
       <title>Key generation</title>
-      <para> In order to bootstrap the system, an initial key k0 must be created and installed on the log host before secure logging environment is started for the first time.</para>
+      <para> In order to bootstrap the system, an initial host key k0 must be created and installed on the log host before secure logging environment is started for the first time.</para>
       <para>
         The newly created host key k0 has its counter set to 0 indicating that it represents the initial host key k0. This host key k0 must be kept secret and not be disclosed to third parties. It will be required to successfully decrypt
         and verify log archives processed by the secure logging environment. As each log entry will be encrypted with its
-        own key, a new host key will be created after successful processing of a log entry and will replace the previous key. Therefore, the initial host key needs to be stored in a safe place before starting the secure logging environment, as it will be deleted from the log host after processing of the first log entry. The following steps must be done before starting the secure logging environment. Steps 1 and 2 are performed with the <command>slogkey</command> utility. See <link linkend="slogkey.1"><command>slogkey</command>(1)</link> for details on how to generate a master key and to derive a host key from it. Step 3 and 4 depend on the actual deployment in a target environment.</para>
+        own key, a new host key will be created after the successful processing of a single log entry and will replace the previous key. Therefore, the initial host key needs to be stored in a safe place before starting the secure logging environment, as it will be deleted from the log host after processing of the first log entry. The following steps must be done before starting the secure logging environment. Steps 1 and 2 are performed with the <command>slogkey</command> utility. See <link linkend="slogkey.1"><command>slogkey</command>(1)</link> for details on how to generate a master key and to derive a host key from it. Step 3 and 4 depend on the actual deployment in a target environment.</para>
       <orderedlist numeration="arabic">
 	<listitem> <para>Create a master key</para>
         </listitem>
@@ -134,7 +134,7 @@ AgAAAAAAAAA=:5UVybnKL1EAbgC4CLfd8HpgurjREf4LEN61/yWHSD2hbXjRD4QmQdtbwguT1chzdItK
            <command>slog</command>
           </term>
           <listitem>
-            <para>The name of the secure logging template function. This name can be also be found by calling <command>syslog-ng</command> with the <command>--module-registry</command> arguments and checking the <command>template-func</command> property of the secure logging module in the corresponding output.</para>
+            <para>The name of the secure logging template function. This name can be also be found by calling <command>syslog-ng</command> with the <command>--module-registry</command> argument and checking the <command>template-func</command> property of the secure logging module in the corresponding output.</para>
          </listitem>
         </varlistentry>
         <varlistentry>
@@ -142,7 +142,7 @@ AgAAAAAAAAA=:5UVybnKL1EAbgC4CLfd8HpgurjREf4LEN61/yWHSD2hbXjRD4QmQdtbwguT1chzdItK
            <command>--key-file</command> or <command>-k</command>
           </term>
           <listitem>
-            <para>The host key. &lt;host key file&gt; is the full path of the file storing the host key on the log host. If this arguments is not supplied or does not point to a valid regular key file, <command>syslog-ng</command> will not start and a display a corresponding error message.</para>
+            <para>The host key. &lt;host key file&gt; is the full path of the file storing the host key on the log host. If this argument is not supplied or does not point to a valid regular key file, <command>syslog-ng</command> will not start and a display a corresponding error message.</para>
          </listitem>
         </varlistentry>
         <varlistentry>
@@ -231,8 +231,7 @@ log {
     </refsection>      
     <refsection version="5.0">
       <title>Log Verification</title>
-      <para>In order to analyze the log file created in a secure logging environment, the log files must be decrypted and their integrity
-      be verified. Verification requires both the initial host key k0 and the corresponding MAC file and is performed with the <command>slogverify</command> utility. It is not normally performed on the log host where the secure logging environment is producing log data. In a typical deployment, log files would be retrieved from the log host and transferred to a central log collector where verification it performed. As verification requires the use of the initial host key k0, it should only be performed in a trusted environment. </para>
+      <para>In order to analyze the log file created in a secure logging environment, the log files must be decrypted and their integrity must be verified. Verification requires both the initial host key k0 and the corresponding MAC file and is performed with the <command>slogverify</command> utility. It is not normally performed on the log host where the secure logging environment is producing log data. In a typical deployment, log files would be retrieved from the log host and transferred to a central log collector where verification it performed. As verification requires the use of the initial host key k0, it should only be performed in a trusted environment. </para>
       <refsection version="5.0">
       <title>Normal mode</title>
       <para>In normal mode, a complete log archive is verified at once. In a typical environment, this would mean retrieving a log file together with is MAC file from a log host and retrieving the corresponding initial key k0 form a safe location and supplying them to the <command>slogverify </command> utility. A typical call sequence for verification in normal mode would look like this</para>
@@ -283,7 +282,7 @@ log {
       <refsection version="5.0">
       <title>Iterative mode</title>
       <para>
-      Verification in normal mode may not be suitable for some application scenarios. Many log hosts use log rotation in order to preserve storage space. In log rotation, a threshold for the maximum amount of storage space and the number of generations is defined for different type of log files. When either storage space is exhausted or the number of generations is reached, the oldest log file will be overwritten by new incoming log data. This procedure is not possible in secure logging environment, as overwriting, i.e. deleting a log file would break the cryptographic chain that is established between the log entries. This comes as no surprise, as one of the main objectives of secure logging is to protect against deletion of log entries by a potential attacker.</para>
+      Verification in normal mode may not be suitable for some application scenarios. Many log hosts use log rotation in order to preserve storage space. In log rotation, a threshold for the maximum amount of storage space and the number of generations is defined for different type of log files. When either storage space is exhausted or the number of generations is reached, the oldest log file will be overwritten by newly incoming log data. This procedure is not suitable for use in secure logging environment, as overwriting, i.e. deleting a log file would break the cryptographic chain that is established between the log entries. This comes as no surprise, as one of the main objectives of secure logging is to protect against deletion of log entries by a potential attacker.</para>
       <para>In order allow for a procedure similar to log rotation, the secure logging environment features an iterative mode. In iterative mode, log files can be split into different files and each of these files can be verified separately. Care must be taken when performing verification in iterative mode, as each of the different log files needs to be accompanied by a copy of the host key and the MAC files present on the system at the time of retrieval. A typical usage scenario for the iterative mode would look like this:
       <orderedlist>
 	<listitem> <para>Define a storage threshold for the secure logging file destination. In this example we assume 500MB.</para>
@@ -304,7 +303,7 @@ log {
         </listitem>
           </orderedlist>
       </para>
-      <para>Steps 2-6 have to repeated each time the log file reaches a size of 50 MB. Assuming that the log file parts will be named after the iteration, e.g. log.1, log.2, log.3, etc. and a similar convention is applied to the host keys and MAC files, a typical call sequence for the validation of a log file part in iterative mode after three iterations will look like this:
+      <para>Steps 2-6 have to repeated each time the log file reaches a size of 500 MB. Assuming that the log file parts will be named after the iteration, e.g. log.1, log.2, log.3, etc. and a similar convention is applied to the host keys and MAC files, a typical call sequence for the validation of a log file part in iterative mode after three iterations will look like this:
       </para>
       <para><command>slogverify --iterative --prev-key-file host.key.2 --prev-mac-file mac.dat.2 --mac-file mac.dat /var/log/messages.slog.3 /var/log/verified/messages.3</command></para>
       <para>with</para>
@@ -353,7 +352,7 @@ log {
         </varlistentry>
       </variablelist>
     </para>
-      <para>In a real deployment, the above steps would typically be automated using a scripting engine.
+      <para>In a real deployment, the above steps would typically be automated, e.g. with a scripting engine.
       </para>
       <para> See <link linkend="slogverify.1"><command>slogverify</command>(1)</link> for details on verification in iterative mode.</para>
       </refsection>
@@ -388,9 +387,9 @@ log {
         <link linkend="slogverify.1"><command>slogverify</command>(1)</link>
       </para>
       <note version="5.0">
-        <para>For the detailed documentation of see <link xmlns:ns1="http://www.w3.org/1999/xlink" ns1:href="https://www.balabit.com/documents/syslog-ng-ose-latest-guides/en/syslog-ng-ose-guide-admin/html/index.html"><command>The syslog-ng Administrator Guide</command></link></para>
+        <para>For the detailed documentation of see <link xmlns:ns1="http://www.w3.org/1999/xlink" ns1:href="https://syslog-ng.github.io/admin-guide/README"><command>The syslog-ng Administrator Guide</command></link></para>
         <para>If you experience any problems or need help with syslog-ng, visit the <link xmlns:ns1="http://www.w3.org/1999/xlink" ns1:href="https://lists.balabit.hu/mailman/listinfo/syslog-ng"><command>syslog-ng mailing list</command></link>.</para>
-        <para>For news and notifications about of syslog-ng, visit the <link xmlns:ns1="http://www.w3.org/1999/xlink" ns1:href="https://syslog-ng.org/blogs/"><command>syslog-ng blogs</command></link>.</para>
+        <para>For news and notifications about of syslog-ng, visit the <link xmlns:ns1="http://www.w3.org/1999/xlink" ns1:href="https://www.syslog-ng.com/community/b/blog/"><command>syslog-ng blogs</command></link>.</para>
         <para>For specific information requests related to secure logging send a mail to the Airbus Secure Logging Team &lt;secure-logging@airbus.com&gt;.</para>
       </note>
     </refsection>

--- a/modules/secure-logging/slog.c
+++ b/modules/secure-logging/slog.c
@@ -59,13 +59,13 @@ static unsigned char GAMMA[AES_BLOCKSIZE] = { [0 ... (AES_BLOCKSIZE-1) ] =  EPAD
 void cond_msg_error(GError *myError, char *errorMsg)
 {
 
-  if (myError==NULL)
+    if (myError==NULL)
     {
-      msg_error(errorMsg);
+        msg_error(errorMsg);
     }
-  else
+    else
     {
-      msg_error(errorMsg, evt_tag_str("error", myError->message));
+        msg_error(errorMsg, evt_tag_str("error", myError->message));
     }
 
 }
@@ -81,18 +81,18 @@ void cond_msg_error(GError *myError, char *errorMsg)
  */
 void deriveSubKeys(unsigned char *mainKey, unsigned char *encKey, unsigned char *MACKey)
 {
-  deriveEncSubKey(mainKey, encKey);
-  deriveMACSubKey(mainKey, MACKey);
+    deriveEncSubKey(mainKey, encKey);
+    deriveMACSubKey(mainKey, MACKey);
 }
 
 void deriveEncSubKey(unsigned char *mainKey, unsigned char *encKey)
 {
-  PRF(mainKey, KEYPATTERN, sizeof(KEYPATTERN), encKey, KEY_LENGTH);
+    PRF(mainKey, KEYPATTERN, sizeof(KEYPATTERN), encKey, KEY_LENGTH);
 }
 
 void deriveMACSubKey(unsigned char *mainKey, unsigned char *MACKey)
 {
-  PRF(mainKey, MACPATTERN, sizeof(MACPATTERN), MACKey, KEY_LENGTH);
+    PRF(mainKey, MACPATTERN, sizeof(MACPATTERN), MACKey, KEY_LENGTH);
 }
 
 
@@ -118,81 +118,81 @@ int sLogEncrypt(unsigned char *plaintext, int plaintext_len,
                 unsigned char *key, unsigned char *iv,
                 unsigned char *ciphertext, unsigned char *tag)
 {
-  /*
-   * This function is largely borrowed from
-   *
-   * https://wiki.openssl.org/index.php/EVP_Authenticated_Encryption_and_Decryption#Authenticated_Encryption_using_GCM_mode
-   *
-   */
-  EVP_CIPHER_CTX *ctx;
+    /*
+     * This function is largely borrowed from
+     *
+     * https://wiki.openssl.org/index.php/EVP_Authenticated_Encryption_and_Decryption#Authenticated_Encryption_using_GCM_mode
+     *
+     */
+    EVP_CIPHER_CTX *ctx;
 
-  int len;
-  int ciphertext_len;
+    int len;
+    int ciphertext_len;
 
-  /* Create and initialise the context */
-  if(!(ctx = EVP_CIPHER_CTX_new()))
+    /* Create and initialise the context */
+    if(!(ctx = EVP_CIPHER_CTX_new()))
     {
-      msg_error("[SLOG] ERROR: Unable to initialize OpenSSL context");
-      return 0;
+        msg_error("[SLOG] ERROR: Unable to initialize OpenSSL context");
+        return 0;
     }
 
-  /* Initialise the encryption operation. */
-  if(1 != EVP_EncryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL))
+    /* Initialise the encryption operation. */
+    if(1 != EVP_EncryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL))
     {
-      msg_error("[SLOG] ERROR: Unable to initialize OpenSSL context");
-      return 0;
+        msg_error("[SLOG] ERROR: Unable to initialize OpenSSL context");
+        return 0;
     }
 
-  if (IV_LENGTH!=12)
+    if (IV_LENGTH!=12)
     {
-      /* Set IV length if default 12 bytes (96 bits) is not appropriate */
-      if(1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, IV_LENGTH, NULL))
+        /* Set IV length if default 12 bytes (96 bits) is not appropriate */
+        if(1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, IV_LENGTH, NULL))
         {
-          msg_error("[SLOG] ERROR: Unable to set IV length");
-          return 0;
+            msg_error("[SLOG] ERROR: Unable to set IV length");
+            return 0;
         }
     }
 
-  /* Initialise key and IV */
-  if(1 != EVP_EncryptInit_ex(ctx, NULL, NULL, key, iv))
+    /* Initialise key and IV */
+    if(1 != EVP_EncryptInit_ex(ctx, NULL, NULL, key, iv))
     {
-      msg_error("[SLOG] ERROR: Unable to initialize encryption key and IV");
-      return 0;
+        msg_error("[SLOG] ERROR: Unable to initialize encryption key and IV");
+        return 0;
     }
 
-  /* Provide the message to be encrypted, and obtain the encrypted output.
-   * EVP_EncryptUpdate can be called multiple times if necessary
-   */
-  if(1 != EVP_EncryptUpdate(ctx, ciphertext, &len, plaintext, plaintext_len))
+    /* Provide the message to be encrypted, and obtain the encrypted output.
+     * EVP_EncryptUpdate can be called multiple times if necessary
+     */
+    if(1 != EVP_EncryptUpdate(ctx, ciphertext, &len, plaintext, plaintext_len))
     {
-      msg_error("[SLOG] ERROR: Unable to encrypt data");
-      return 0;
+        msg_error("[SLOG] ERROR: Unable to encrypt data");
+        return 0;
     }
 
-  ciphertext_len = len;
+    ciphertext_len = len;
 
-  /* Finalise the encryption. Normally ciphertext bytes may be written at
-   * this stage, but this does not occur in GCM mode
-   */
-  if(1 != EVP_EncryptFinal_ex(ctx, ciphertext + len, &len))
+    /* Finalise the encryption. Normally ciphertext bytes may be written at
+     * this stage, but this does not occur in GCM mode
+     */
+    if(1 != EVP_EncryptFinal_ex(ctx, ciphertext + len, &len))
     {
-      msg_error("[SLOG] ERROR: Unable to complete encryption of data");
-      return 0;
+        msg_error("[SLOG] ERROR: Unable to complete encryption of data");
+        return 0;
     }
 
-  ciphertext_len += len;
+    ciphertext_len += len;
 
-  /* Get the tag */
-  if(1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, AES_BLOCKSIZE, tag))
+    /* Get the tag */
+    if(1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, AES_BLOCKSIZE, tag))
     {
-      msg_error("[SLOG] ERROR: Unable to acquire encryption tag");
-      return 0;
+        msg_error("[SLOG] ERROR: Unable to acquire encryption tag");
+        return 0;
     }
 
-  /* Clean up */
-  EVP_CIPHER_CTX_free(ctx);
+    /* Clean up */
+    EVP_CIPHER_CTX_free(ctx);
 
-  return ciphertext_len;
+    return ciphertext_len;
 }
 
 /*
@@ -215,77 +215,77 @@ int sLogDecrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *ta
                 unsigned char *iv,
                 unsigned char *plaintext)
 {
-  EVP_CIPHER_CTX *ctx;
-  int len;
-  int plaintext_len;
-  int ret;
+    EVP_CIPHER_CTX *ctx;
+    int len;
+    int plaintext_len;
+    int ret;
 
-  /* Create and initialise the context */
-  if(!(ctx = EVP_CIPHER_CTX_new()))
+    /* Create and initialise the context */
+    if(!(ctx = EVP_CIPHER_CTX_new()))
     {
-      msg_error("[SLOG] ERROR: Unable to initialize OpenSSL context");
-      return 0;
+        msg_error("[SLOG] ERROR: Unable to initialize OpenSSL context");
+        return 0;
     }
 
-  /* Initialise the decryption operation. */
-  if(!EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL))
+    /* Initialise the decryption operation. */
+    if(!EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL))
     {
-      msg_error("[SLOG] ERROR: Unable initiate decryption operation");
-      return 0;
+        msg_error("[SLOG] ERROR: Unable initiate decryption operation");
+        return 0;
     }
 
-  if(IV_LENGTH!=12)
+    if(IV_LENGTH!=12)
     {
-      /* Set IV length. Not necessary if this is 12 bytes (96 bits) */
-      if(!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, IV_LENGTH, NULL))
+        /* Set IV length. Not necessary if this is 12 bytes (96 bits) */
+        if(!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, IV_LENGTH, NULL))
         {
-          msg_error("[SLOG] ERROR: Unable set IV length");
-          return 0;
+            msg_error("[SLOG] ERROR: Unable set IV length");
+            return 0;
         }
     }
 
-  /* Initialise key and IV */
-  if(!EVP_DecryptInit_ex(ctx, NULL, NULL, key, iv))
+    /* Initialise key and IV */
+    if(!EVP_DecryptInit_ex(ctx, NULL, NULL, key, iv))
     {
-      msg_error("[SLOG] ERROR: Unable to initialize key and IV");
-      return 0;
+        msg_error("[SLOG] ERROR: Unable to initialize key and IV");
+        return 0;
     }
 
-  /* Provide the message to be decrypted, and obtain the plaintext output.
-   * EVP_DecryptUpdate can be called multiple times if necessary
-   */
-  if(!EVP_DecryptUpdate(ctx, plaintext, &len, ciphertext, ciphertext_len))
+    /* Provide the message to be decrypted, and obtain the plaintext output.
+     * EVP_DecryptUpdate can be called multiple times if necessary
+     */
+    if(!EVP_DecryptUpdate(ctx, plaintext, &len, ciphertext, ciphertext_len))
     {
-      msg_error("Unable to decrypt");
-      return 0;
+        msg_error("Unable to decrypt");
+        return 0;
     }
 
-  plaintext_len = len;
+    plaintext_len = len;
 
-  /* Set expected tag value. Works in OpenSSL 1.0.1d and later */
-  if(!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, AES_BLOCKSIZE, tag))
+    /* Set expected tag value. Works in OpenSSL 1.0.1d and later */
+    if(!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, AES_BLOCKSIZE, tag))
     {
-      msg_error("[SLOG] ERROR: Unable set tag value");
-      return 0;
+        msg_error("[SLOG] ERROR: Unable set tag value");
+        return 0;
     }
 
-  /* Finalise the decryption. A positive return value indicates success,
-   * anything else is a failure - the plaintext is not trustworthy.
-   */
-  ret = EVP_DecryptFinal_ex(ctx, plaintext + len, &len);
+    /* Finalise the decryption. A positive return value indicates success,
+     * anything else is a failure - the plaintext is not trustworthy.
+     */
+    ret = EVP_DecryptFinal_ex(ctx, plaintext + len, &len);
 
-  /* Clean up */
-  EVP_CIPHER_CTX_free(ctx);
-  if(ret > 0)
+    /* Clean up */
+    EVP_CIPHER_CTX_free(ctx);
+    if(ret > 0)
     {
-      /* Success */
-      plaintext_len += len;
-      return plaintext_len;
+        /* Success */
+        plaintext_len += len;
+        return plaintext_len;
     }
-  else
+    else
     {
-      /* Verify failed */
-      return -1;
+        /* Verify failed */
+        return -1;
     }
 }
 
@@ -306,80 +306,96 @@ int sLogDecrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *ta
 void sLogEntry(guint64 numberOfLogEntries, GString *text, unsigned char *mainKey, unsigned char *inputBigMac,
                GString *output, unsigned char *outputBigMac, gsize outputBigMac_capacity)
 {
+    int slen = (int) text->len;
 
-  unsigned char encKey[KEY_LENGTH];
-  unsigned char MACKey[KEY_LENGTH];
-  deriveSubKeys(mainKey, encKey, MACKey);
+    // This buffer holds everything: AggregatedMAC, IV, Tag, and CText
+    // Binary data cannot be larger than its base64 encoding
+    unsigned char* bigBuf = g_new0(unsigned char, AES_BLOCKSIZE+IV_LENGTH+AES_BLOCKSIZE+slen);
 
-  // Compute current log entry number
-  gchar *counterString = convertToBase64((unsigned char *)&numberOfLogEntries, sizeof(numberOfLogEntries));
+    if (bigBuf == NULL)
+    {
+        const char* error_msg ="[SLOG] ERROR: Unable to allocate memory buffer";
+        msg_error(error_msg);
 
-  int slen = (int) text->len;
+        g_string_printf(output, "%s", error_msg);
 
-  // This buffer holds everything: AggregatedMAC, IV, Tag, and CText
-  // Binary data cannot be larger than its base64 encoding
-  unsigned char bigBuf[AES_BLOCKSIZE+IV_LENGTH+AES_BLOCKSIZE+slen];
+        return;
+    }
 
-  // This is where are ciphertext related data starts
-  unsigned char *ctBuf = &bigBuf[AES_BLOCKSIZE];
-  unsigned char *iv = ctBuf;
-  unsigned char *tag = &bigBuf[AES_BLOCKSIZE+IV_LENGTH];
-  unsigned char *ciphertext = &bigBuf[AES_BLOCKSIZE+IV_LENGTH+AES_BLOCKSIZE];
+    unsigned char encKey[KEY_LENGTH];
+    unsigned char MACKey[KEY_LENGTH];
+    deriveSubKeys(mainKey, encKey, MACKey);
 
-  // Generate random nonce
-  if (RAND_bytes(iv, IV_LENGTH)==1)
+    // Compute current log entry number
+    gchar *counterString = convertToBase64((unsigned char *)&numberOfLogEntries, sizeof(numberOfLogEntries));
+
+    // This is where are ciphertext related data starts
+    unsigned char *ctBuf = &bigBuf[AES_BLOCKSIZE];
+    unsigned char *iv = ctBuf;
+    unsigned char *tag = &bigBuf[AES_BLOCKSIZE+IV_LENGTH];
+    unsigned char *ciphertext = &bigBuf[AES_BLOCKSIZE+IV_LENGTH+AES_BLOCKSIZE];
+
+    // Generate random nonce
+    if (RAND_bytes(iv, IV_LENGTH)==1)
     {
 
-      // Encrypt log data
-      int ct_length = sLogEncrypt((guchar *)text->str, slen, encKey, iv, ciphertext, tag);
-      if(ct_length <= 0)
+        // Encrypt log data
+        int ct_length = sLogEncrypt((guchar *)text->str, slen, encKey, iv, ciphertext, tag);
+        if(ct_length <= 0)
         {
-          msg_error("[SLOG] ERROR: Unable to correctly encrypt log message");
+            msg_error("[SLOG] ERROR: Unable to correctly encrypt log message");
 
-          g_string_printf(output, "%*.*s:%s: %s", COUNTER_LENGTH, COUNTER_LENGTH, counterString,
-                          "[SLOG] ERROR: Unable to correctly encrypt the following log message:", text->str);
-          g_free(counterString);
+            g_string_printf(output, "%*.*s:%s: %s", COUNTER_LENGTH, COUNTER_LENGTH, counterString,
+                            "[SLOG] ERROR: Unable to correctly encrypt the following log message:", text->str);
 
-          return;
+            // Free resources
+            g_free(counterString);
+            g_free(bigBuf);
+
+            return;
         }
 
-      // Write current log entry number
-      g_string_printf (output, "%*.*s:", COUNTER_LENGTH, COUNTER_LENGTH, counterString);
-      g_free(counterString);
+        // Write current log entry number
+        g_string_printf (output, "%*.*s:", COUNTER_LENGTH, COUNTER_LENGTH, counterString);
+        g_free(counterString);
 
 
-      // Write IV, tag, and ciphertext at once
-      gchar *encodedCtBuf = convertToBase64(ctBuf, IV_LENGTH+AES_BLOCKSIZE+ct_length);
-      g_string_append(output, encodedCtBuf);
-      g_free(encodedCtBuf);
+        // Write IV, tag, and ciphertext at once
+        gchar *encodedCtBuf = convertToBase64(ctBuf, IV_LENGTH+AES_BLOCKSIZE+ct_length);
+        g_string_append(output, encodedCtBuf);
+        g_free(encodedCtBuf);
 
-      // Compute aggregated MAC
-      // Not the first aggregated MAC
-      if (numberOfLogEntries>0)
+        // Compute aggregated MAC
+        // Not the first aggregated MAC
+        if (numberOfLogEntries>0)
         {
-          memcpy(bigBuf, inputBigMac, AES_BLOCKSIZE);
+            memcpy(bigBuf, inputBigMac, AES_BLOCKSIZE);
 
-          gsize outlen;
-          cmac(MACKey, bigBuf, AES_BLOCKSIZE+IV_LENGTH+AES_BLOCKSIZE+ct_length, outputBigMac, &outlen, outputBigMac_capacity);
+            gsize outlen;
+            cmac(MACKey, bigBuf, AES_BLOCKSIZE+IV_LENGTH+AES_BLOCKSIZE+ct_length, outputBigMac, &outlen, outputBigMac_capacity);
         }
-      else   // First aggregated MAC
+        else   // First aggregated MAC
         {
-          gsize outlen = 0;
+            gsize outlen = 0;
 
-          cmac(MACKey, &bigBuf[AES_BLOCKSIZE], IV_LENGTH+AES_BLOCKSIZE+ct_length, outputBigMac, &outlen, outputBigMac_capacity);
+            cmac(MACKey, bigBuf+AES_BLOCKSIZE, IV_LENGTH+AES_BLOCKSIZE+ct_length, outputBigMac, &outlen, outputBigMac_capacity);
         }
     }
-  else
+    else
     {
-      // We did not get enough random bytes
-      msg_error("[SLOG] ERROR: Could not obtain enough random bytes");
+        // We did not get enough random bytes
+        msg_error("[SLOG] ERROR: Could not obtain enough random bytes");
 
-      g_string_printf(output, "%*.*s:%s: %s", COUNTER_LENGTH, COUNTER_LENGTH, counterString,
-                      "[SLOG] ERROR: Could not obtain enough random bytes for the following log message:", text->str);
-      g_free(counterString);
+        g_string_printf(output, "%*.*s:%s: %s", COUNTER_LENGTH, COUNTER_LENGTH, counterString,
+                        "[SLOG] ERROR: Could not obtain enough random bytes for the following log message:", text->str);
+        g_free(counterString);
 
-      return;
+        // MAC cannot contain meaningful data -> Initialize contents
+        memset(outputBigMac, 0, outputBigMac_capacity);
     }
+
+    // Free buffer
+    g_free(bigBuf);
 }
 
 /*
@@ -394,20 +410,20 @@ void sLogEntry(guint64 numberOfLogEntries, GString *text, unsigned char *mainKey
  */
 void deriveKey(unsigned char *dst, guint64 index, guint64 currentKey)
 {
-  for (guint64 i = currentKey; i<index; i++)
+    for (guint64 i = currentKey; i<index; i++)
     {
-      evolveKey(dst);
+        evolveKey(dst);
     }
 }
 
 guchar *convertToBin(char *input, gsize *outLen)
 {
-  return g_base64_decode ((const gchar *) input, outLen);
+    return g_base64_decode ((const gchar *) input, outLen);
 }
 
 gchar *convertToBase64(unsigned char *input, gsize len)
 {
-  return  g_base64_encode ((const guchar *) input, len);
+    return  g_base64_encode ((const guchar *) input, len);
 }
 
 /*
@@ -428,32 +444,31 @@ gchar *convertToBase64(unsigned char *input, gsize len)
 void cmac(unsigned char *key, const void *input, gsize length, unsigned char *out, gsize *outlen, gsize out_capacity)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-  EVP_MAC *mac = EVP_MAC_fetch(NULL, "CMAC", NULL);
-  OSSL_PARAM params[] =
-  {
-    OSSL_PARAM_utf8_string("cipher", "aes-256-cbc", 0),
-    OSSL_PARAM_END,
-  };
+    EVP_MAC *mac = EVP_MAC_fetch(NULL, "CMAC", NULL);
+    OSSL_PARAM params[] =
+    {
+        OSSL_PARAM_utf8_string("cipher", "aes-256-cbc", 0),
+        OSSL_PARAM_END,
+    };
 
-  EVP_MAC_CTX *ctx = EVP_MAC_CTX_new(mac);
+    EVP_MAC_CTX *ctx = EVP_MAC_CTX_new(mac);
 
-  EVP_MAC_init(ctx, key, KEY_LENGTH, params);
-  EVP_MAC_update(ctx, input, length);
-  size_t out_len;
-  EVP_MAC_final(ctx, out, &out_len, out_capacity);
+    EVP_MAC_init(ctx, key, KEY_LENGTH, params);
+    EVP_MAC_update(ctx, input, length);
+    EVP_MAC_final(ctx, out, outlen, out_capacity);
 
-  EVP_MAC_CTX_free(ctx);
-  EVP_MAC_free(mac);
+    EVP_MAC_CTX_free(ctx);
+    EVP_MAC_free(mac);
 #else
-  CMAC_CTX *ctx = CMAC_CTX_new();
+    CMAC_CTX *ctx = CMAC_CTX_new();
 
-  CMAC_Init(ctx, key, KEY_LENGTH, EVP_aes_256_cbc(), NULL);
-  CMAC_Update(ctx, input, length);
+    CMAC_Init(ctx, key, KEY_LENGTH, EVP_aes_256_cbc(), NULL);
+    CMAC_Update(ctx, input, length);
 
-  size_t out_len;
-  CMAC_Final(ctx, out, &out_len);
-  *outlen = out_len;
-  CMAC_CTX_free(ctx);
+    size_t out_len;
+    CMAC_Final(ctx, out, &out_len);
+    *outlen = out_len;
+    CMAC_CTX_free(ctx);
 #endif
 }
 
@@ -468,13 +483,16 @@ void cmac(unsigned char *key, const void *input, gsize length, unsigned char *ou
 void evolveKey(unsigned char *key)
 {
 
-  unsigned char buf[KEY_LENGTH];
-  PRF(key, GAMMA, sizeof(GAMMA), buf, KEY_LENGTH);
-  memcpy(key, buf, KEY_LENGTH);
+    unsigned char buf[KEY_LENGTH];
+    PRF(key, GAMMA, sizeof(GAMMA), buf, KEY_LENGTH);
+    memcpy(key, buf, KEY_LENGTH);
 }
 
 /*
- * AES-CMAC based pseudo-random function (with variable input length and output length)
+ * AES-CMAC based pseudo-random function (with variable input and output lengths)
+ *
+ * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Cr2.pdf
+ * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-108r1-upd1.pdf
  *
  * 1. Parameter: Pointer to key (input)
  * 2. Parameter: Pointer to input (input)
@@ -482,37 +500,77 @@ void evolveKey(unsigned char *key)
  * 4. Parameter: Pointer to output (output)
  * 5. Parameter: Required output length (input)
  *
- * Note: For security, outputLength must be less than 255 * AES_BLOCKSIZE.
- *
  */
 void PRF(unsigned char *key, unsigned char *originalInput, guint64 inputLength, unsigned char *output,
          guint64 outputLength)
 {
+    // Define data type sizes
+    gsize gs = sizeof(gsize);
+    gsize gsout = sizeof(outputLength);
 
-  unsigned char input[inputLength];
-  memcpy(input, originalInput, inputLength);
+    // First, extraction
+    guchar ktmp[KEY_LENGTH]; // Temporary key
 
-  // Make sure that temporary buffer can hold at least outputLength bytes, rounded up to a multiple of AES_BLOCKSIZE
-  unsigned char buf[outputLength+AES_BLOCKSIZE];
-  gsize buf_capacity = G_N_ELEMENTS(buf);
-  // Prepare plaintext
-  for (int i=0; i<outputLength/AES_BLOCKSIZE; i++)
-    {
-      gsize outlen;
-      cmac(key, input, AES_BLOCKSIZE, buf + (i*AES_BLOCKSIZE), &outlen, buf_capacity - (i*AES_BLOCKSIZE));
-      input[inputLength-1]++;
-    }
+    // Initialize to all zero, in case CMAC_LENGTH < KEY_LENGTH
+    bzero(ktmp, KEY_LENGTH);
+    gsize outlen = -1;
 
-  if (outputLength % AES_BLOCKSIZE!=0)
-    {
-      int index = outputLength/AES_BLOCKSIZE;
-      gsize outlen;
-      cmac(key, input, AES_BLOCKSIZE, buf + (index*AES_BLOCKSIZE), &outlen, buf_capacity - (index*AES_BLOCKSIZE));
-    }
+    // Assume that KEY_LENGTH >= CMAC_LENGTH
+    cmac(key, originalInput, inputLength, ktmp, &outlen, CMAC_LENGTH);
 
-  memcpy(output, buf, outputLength);
+    // Then, expansion
+    gsize n = outputLength / CMAC_LENGTH;
+
+    gchar label[] = "key-expansion";
+    gchar context[] = "none";
+    gsize label_len = strlen(label);
+    gsize context_len = strlen(context);
+
+    // Total space needed for i || Label || 00 || Context || outputLength;
+    gsize total_input_length = gs + label_len + 1 + context_len + gsout;
+    guchar input[total_input_length];
+
+    for (gsize i = 0 ; i < n ; i++)
+      {
+        // input = i || Label || 00 || Context || outputLength;
+
+        // Write input chunk and label
+        memcpy(input, &i, gs);
+        memcpy(input + gs, label, label_len);
+
+        // Write the 0x00 byte
+        *(input + gs + label_len) = 0;
+
+        // Write the context and output
+        memcpy(input + gs + label_len + 1, context, context_len);
+        memcpy(input + gs + label_len + 1 + context_len, &outputLength, gsout);
+
+        // Finally apply the CMAC
+        cmac(ktmp, input, total_input_length, output + (i*CMAC_LENGTH), &outlen, CMAC_LENGTH);
+      }
+
+    // Finalize the output
+    if (outputLength % CMAC_LENGTH != 0)
+      {
+        guchar buf[CMAC_LENGTH];
+
+        // Write last input chunk and label
+        memcpy(input, &n, gs);
+        memcpy(input + gs, label, label_len);
+
+        // Write the 0x00 byte
+        *(input + gs + label_len) = 0;
+
+        // Write the context and output
+        memcpy(input + gs + label_len + 1, context, context_len);
+        memcpy(input + gs + label_len + 1 + context_len, &outputLength, gsout);
+        // Apply the final CMAC
+        cmac(ktmp, input, total_input_length, buf, &outlen, CMAC_LENGTH);
+
+        // Copy result to output buffer
+        memcpy(output + n * CMAC_LENGTH, buf, outputLength % CMAC_LENGTH);
+      }
 }
-
 
 /*
  * Generate a master key
@@ -526,58 +584,71 @@ void PRF(unsigned char *key, unsigned char *originalInput, guint64 inputLength, 
  */
 int generateMasterKey(guchar *masterkey)
 {
-  return RAND_bytes(masterkey, KEY_LENGTH);
+    return RAND_bytes(masterkey, KEY_LENGTH);
 }
 
 /*
  * Generate a host key based on a previously created master key
  *
- * 1. Parameter: master key
- * 2. Parameter: Host MAC address
- * 3. Parameter: Host S/N
+ * 1. Parameter: master key (input)
+ * 2. Parameter: Host MAC address (input)
+ * 3. Parameter: Host S/N (input)
+ * 4. Parameter: Host key (output)
  *
- * The specific unique host key k_0 is k_0 = H(master key|| MAC address || S/N)
- * and requires 48 bytes of storage. Additional 8 bytes need to be allocated to store
- * the serial number of the host key. The caller has to allocate this memory.
+ * The specific unique host key k_0 is k_0 = PRF_{master_key}(MAC address ||
+ * S/N) and requires 32 bytes of storage. The caller has to allocate this
+ * memory.
  *
  * Return:
  * 1 on success
  * 0 on error
  */
+#define newDeriveHostKey
 int deriveHostKey(guchar *masterkey, gchar *macAddr, gchar *serial, guchar *hostkey)
 {
-  EVP_MD_CTX *ctx;
 
-  if((ctx = EVP_MD_CTX_create()) == NULL)
-    return 0;
+#ifdef newDeriveHostKey
+    gchar concatString[strlen(macAddr) + strlen(serial) + 1];
+    strncpy(concatString, macAddr, strlen(macAddr));
+    strncat(concatString, serial, strlen(serial));
 
-  if(1 != EVP_DigestInit_ex(ctx, EVP_sha256(), NULL))
-    return 0;
+    PRF(masterkey, (guchar*) concatString, strlen(concatString), hostkey, KEY_LENGTH);
 
-  if(1 != EVP_DigestUpdate(ctx, masterkey, KEY_LENGTH))
-    return 0;
+    return 1;
+#else
+    EVP_MD_CTX *ctx;
 
-  if(1 != EVP_DigestUpdate(ctx, macAddr, strlen(macAddr)))
-    return 0;
+    if((ctx = EVP_MD_CTX_create()) == NULL)
+        return 0;
 
-  if(1 != EVP_DigestUpdate(ctx, serial, strlen(serial)))
-    return 0;
+    if(1 != EVP_DigestInit_ex(ctx, EVP_sha256(), NULL))
+        return 0;
 
-  if(KEY_LENGTH != SHA256_DIGEST_LENGTH)
+    if(1 != EVP_DigestUpdate(ctx, masterkey, KEY_LENGTH))
+        return 0;
+
+    if(1 != EVP_DigestUpdate(ctx, macAddr, strlen(macAddr)))
+        return 0;
+
+    if(1 != EVP_DigestUpdate(ctx, serial, strlen(serial)))
+        return 0;
+
+    if(KEY_LENGTH != SHA256_DIGEST_LENGTH)
     {
-      msg_error("[SLOG] ERROR: Error in updating digest");
-      g_assert_not_reached();
-      return 0;
+        msg_error("[SLOG] ERROR: Error in updating digest");
+        g_assert_not_reached();
+        return 0;
     }
 
-  guint digest_len = KEY_LENGTH;
+    guint digest_len = KEY_LENGTH;
 
-  if(1 != EVP_DigestFinal_ex(ctx, hostkey, &digest_len))
-    return 0;
+    if(1 != EVP_DigestFinal_ex(ctx, hostkey, &digest_len))
+        return 0;
 
-  EVP_MD_CTX_destroy(ctx);
+    EVP_MD_CTX_destroy(ctx);
 
-  return 1;
+    return 1;
+#endif
 }
 
 /*
@@ -589,93 +660,93 @@ int deriveHostKey(guchar *masterkey, gchar *macAddr, gchar *serial, guchar *host
  */
 int writeBigMAC(gchar *filename, char *outputBuffer)
 {
-  GError *error = NULL;
+    GError *error = NULL;
 
-  GIOChannel *macfile = g_io_channel_new_file(filename, "w+", &error);
-  if(!macfile)
+    GIOChannel *macfile = g_io_channel_new_file(filename, "w+", &error);
+    if(!macfile)
     {
-      msg_error("[SLOG] ERROR: Unable open MAC file",
-                evt_tag_str("base_dir", filename));
-      cond_msg_error(error, "Additional Information");
+        msg_error("[SLOG] ERROR: Unable open MAC file",
+                  evt_tag_str("base_dir", filename));
+        cond_msg_error(error, "Additional Information");
 
-      g_clear_error(&error);
+        g_clear_error(&error);
 
-      return 0;
+        return 0;
     }
 
-  GIOStatus status = g_io_channel_set_encoding(macfile, NULL, &error);
-  if(status != G_IO_STATUS_NORMAL)
+    GIOStatus status = g_io_channel_set_encoding(macfile, NULL, &error);
+    if(status != G_IO_STATUS_NORMAL)
     {
-      msg_error("[SLOG] ERROR: Unable to set encoding for MAC data",
-                evt_tag_str("File", filename));
-      cond_msg_error(error, "Additional information");
+        msg_error("[SLOG] ERROR: Unable to set encoding for MAC data",
+                  evt_tag_str("File", filename));
+        cond_msg_error(error, "Additional information");
 
-      g_clear_error(&error);
+        g_clear_error(&error);
 
-      g_io_channel_shutdown(macfile, TRUE, &error);
-      g_io_channel_unref(macfile);
+        g_io_channel_shutdown(macfile, TRUE, &error);
+        g_io_channel_unref(macfile);
 
-      g_clear_error(&error);
+        g_clear_error(&error);
 
-      return 0;
+        return 0;
     }
 
-  gsize outlen = 0;
-  status = g_io_channel_write_chars(macfile, outputBuffer, CMAC_LENGTH, &outlen, &error);
-  if(status != G_IO_STATUS_NORMAL)
+    gsize outlen = 0;
+    status = g_io_channel_write_chars(macfile, outputBuffer, CMAC_LENGTH, &outlen, &error);
+    if(status != G_IO_STATUS_NORMAL)
     {
-      msg_error("[SLOG] ERROR: Unable to write big MAC data",
-                evt_tag_str("File", filename));
-      cond_msg_error(error, "Additional information");
+        msg_error("[SLOG] ERROR: Unable to write big MAC data",
+                  evt_tag_str("File", filename));
+        cond_msg_error(error, "Additional information");
 
-      g_clear_error(&error);
+        g_clear_error(&error);
 
-      g_io_channel_shutdown(macfile, TRUE, &error);
-      g_io_channel_unref(macfile);
+        g_io_channel_shutdown(macfile, TRUE, &error);
+        g_io_channel_unref(macfile);
 
-      g_clear_error(&error);
+        g_clear_error(&error);
 
-      return 0;
+        return 0;
     }
 
-  // Compute aggregated MAC
-  gchar outputmacdata[CMAC_LENGTH];
-  gsize outputmacdata_capacity = G_N_ELEMENTS(outputmacdata);
-  unsigned char keyBuffer[KEY_LENGTH];
-  bzero(keyBuffer, KEY_LENGTH);
-  unsigned char zeroBuffer[CMAC_LENGTH];
-  bzero(zeroBuffer, CMAC_LENGTH);
-  memcpy(keyBuffer, outputBuffer, MIN(CMAC_LENGTH, KEY_LENGTH));
-  cmac(keyBuffer, zeroBuffer, CMAC_LENGTH, (guchar *)outputmacdata, &outlen, outputmacdata_capacity);
+    // Compute aggregated MAC
+    gchar outputmacdata[CMAC_LENGTH];
+    gsize outputmacdata_capacity = G_N_ELEMENTS(outputmacdata);
+    unsigned char keyBuffer[KEY_LENGTH];
+    bzero(keyBuffer, KEY_LENGTH);
+    unsigned char zeroBuffer[CMAC_LENGTH];
+    bzero(zeroBuffer, CMAC_LENGTH);
+    memcpy(keyBuffer, outputBuffer, MIN(CMAC_LENGTH, KEY_LENGTH));
+    cmac(keyBuffer, zeroBuffer, CMAC_LENGTH, (guchar *)outputmacdata, &outlen, outputmacdata_capacity);
 
-  status = g_io_channel_write_chars(macfile, outputmacdata, CMAC_LENGTH, &outlen, &error);
+    status = g_io_channel_write_chars(macfile, outputmacdata, CMAC_LENGTH, &outlen, &error);
 
-  if(status != G_IO_STATUS_NORMAL)
+    if(status != G_IO_STATUS_NORMAL)
     {
-      msg_error("[SLOG] ERROR: Unable to write aggregated MAC",
-                evt_tag_str("File", filename));
-      cond_msg_error(error, "Additional information");
+        msg_error("[SLOG] ERROR: Unable to write aggregated MAC",
+                  evt_tag_str("File", filename));
+        cond_msg_error(error, "Additional information");
 
-      g_clear_error(&error);
+        g_clear_error(&error);
 
-      g_io_channel_shutdown(macfile, TRUE, &error);
-      g_io_channel_unref(macfile);
+        g_io_channel_shutdown(macfile, TRUE, &error);
+        g_io_channel_unref(macfile);
 
-      g_clear_error(&error);
+        g_clear_error(&error);
 
-      return 0;
+        return 0;
     }
-  status = g_io_channel_shutdown(macfile, TRUE, &error);
-  g_io_channel_unref(macfile);
+    status = g_io_channel_shutdown(macfile, TRUE, &error);
+    g_io_channel_unref(macfile);
 
-  if(status != G_IO_STATUS_NORMAL)
+    if(status != G_IO_STATUS_NORMAL)
     {
-      cond_msg_error(error, "[SLOG] ERROR: Cannot close aggregated MAC");
+        cond_msg_error(error, "[SLOG] ERROR: Cannot close aggregated MAC");
 
-      g_clear_error(&error);
+        g_clear_error(&error);
     }
 
-  return 1;
+    return 1;
 }
 
 /*
@@ -687,92 +758,92 @@ int writeBigMAC(gchar *filename, char *outputBuffer)
  */
 int readBigMAC(gchar *filename, char *outputBuffer)
 {
-  GError *myError = NULL;
+    GError *myError = NULL;
 
-  GIOChannel *macfile = g_io_channel_new_file(filename, "r", &myError);
+    GIOChannel *macfile = g_io_channel_new_file(filename, "r", &myError);
 
-  if(!macfile)
+    if(!macfile)
     {
-      // MAC file does not exist -> New MAC file will be created
-      g_clear_error(&myError);
+        // MAC file does not exist -> New MAC file will be created
+        g_clear_error(&myError);
 
-      return 0;
+        return 0;
     }
 
-  GIOStatus status = g_io_channel_set_encoding(macfile, NULL, &myError);
-  if (status != G_IO_STATUS_NORMAL)
+    GIOStatus status = g_io_channel_set_encoding(macfile, NULL, &myError);
+    if (status != G_IO_STATUS_NORMAL)
     {
-      cond_msg_error(myError, "[SLOG] ERROR: Cannot set encoding of MAC file");
-      g_clear_error(&myError);
+        cond_msg_error(myError, "[SLOG] ERROR: Cannot set encoding of MAC file");
+        g_clear_error(&myError);
 
-      g_io_channel_shutdown(macfile, TRUE, &myError);
-      g_io_channel_unref(macfile);
+        g_io_channel_shutdown(macfile, TRUE, &myError);
+        g_io_channel_unref(macfile);
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      return 0;
+        return 0;
     }
 
-  gchar macdata[2*CMAC_LENGTH];
-  gsize mac_bytes_read = 0;
+    gchar macdata[2*CMAC_LENGTH];
+    gsize mac_bytes_read = 0;
 
-  status = g_io_channel_read_chars(macfile, macdata, 2*CMAC_LENGTH, &mac_bytes_read, &myError);
-  if(status != G_IO_STATUS_NORMAL)
+    status = g_io_channel_read_chars(macfile, macdata, 2*CMAC_LENGTH, &mac_bytes_read, &myError);
+    if(status != G_IO_STATUS_NORMAL)
     {
-      cond_msg_error(myError, "[SLOG] ERROR: Cannot read MAC file");
+        cond_msg_error(myError, "[SLOG] ERROR: Cannot read MAC file");
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      g_io_channel_shutdown(macfile, TRUE, &myError);
-      g_io_channel_unref(macfile);
+        g_io_channel_shutdown(macfile, TRUE, &myError);
+        g_io_channel_unref(macfile);
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      return 0;
+        return 0;
     }
 
-  status = g_io_channel_shutdown(macfile, TRUE, &myError);
-  g_io_channel_unref(macfile);
+    status = g_io_channel_shutdown(macfile, TRUE, &myError);
+    g_io_channel_unref(macfile);
 
-  if(status != G_IO_STATUS_NORMAL)
+    if(status != G_IO_STATUS_NORMAL)
     {
-      msg_error("[SLOG] ERROR: Cannot close MAC file");
+        msg_error("[SLOG] ERROR: Cannot close MAC file");
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      return 0;
+        return 0;
     }
 
-  if (mac_bytes_read!=2*CMAC_LENGTH)
+    if (mac_bytes_read!=2*CMAC_LENGTH)
     {
-      msg_error("[SLOG] ERROR: $(slog) parsing failed, invalid size of MAC file");
-      return 0;
+        msg_error("[SLOG] ERROR: $(slog) parsing failed, invalid size of MAC file");
+        return 0;
     }
 
-  gsize outlen = 0;
-  unsigned char keyBuffer[KEY_LENGTH];
-  bzero(keyBuffer, KEY_LENGTH);
-  unsigned char zeroBuffer[CMAC_LENGTH];
-  bzero(zeroBuffer, CMAC_LENGTH);
-  memcpy(keyBuffer, macdata, MIN(CMAC_LENGTH, KEY_LENGTH));
+    gsize outlen = 0;
+    unsigned char keyBuffer[KEY_LENGTH];
+    bzero(keyBuffer, KEY_LENGTH);
+    unsigned char zeroBuffer[CMAC_LENGTH];
+    bzero(zeroBuffer, CMAC_LENGTH);
+    memcpy(keyBuffer, macdata, MIN(CMAC_LENGTH, KEY_LENGTH));
 
-  unsigned char testOutput[CMAC_LENGTH];
-  gsize testOutput_capacity = G_N_ELEMENTS(testOutput);
-  cmac(keyBuffer, zeroBuffer, CMAC_LENGTH, testOutput, &outlen, testOutput_capacity);
+    unsigned char testOutput[CMAC_LENGTH];
+    gsize testOutput_capacity = G_N_ELEMENTS(testOutput);
+    cmac(keyBuffer, zeroBuffer, CMAC_LENGTH, testOutput, &outlen, testOutput_capacity);
 
-  if (0 != memcmp(testOutput, &macdata[CMAC_LENGTH], CMAC_LENGTH))
+    if (0 != memcmp(testOutput, &macdata[CMAC_LENGTH], CMAC_LENGTH))
     {
-      msg_warning("[SLOG] ERROR: MAC computation invalid");
-      return 0;
+        msg_warning("[SLOG] ERROR: MAC computation invalid");
+        return 0;
     }
-  else
+    else
     {
-      msg_info("[SLOG] INFO: MAC successfully loaded");
+        msg_info("[SLOG] INFO: MAC successfully loaded");
     }
 
-  memcpy(outputBuffer, macdata, CMAC_LENGTH);
+    memcpy(outputBuffer, macdata, CMAC_LENGTH);
 
-  return 1;
+    return 1;
 }
 
 /*
@@ -785,116 +856,116 @@ int readBigMAC(gchar *filename, char *outputBuffer)
 int readKey(char *destKey, guint64 *destCounter, gchar *keypath)
 {
 
-  GError *myError = NULL;
+    GError *myError = NULL;
 
-  GIOChannel *keyfile = g_io_channel_new_file(keypath, "r", &myError);
+    GIOChannel *keyfile = g_io_channel_new_file(keypath, "r", &myError);
 
-  if (!keyfile)
+    if (!keyfile)
     {
-      cond_msg_error(myError, "[SLOG] ERROR: Key file not found");
-      g_clear_error(&myError);
+        cond_msg_error(myError, "[SLOG] ERROR: Key file not found");
+        g_clear_error(&myError);
 
-      return 0;
+        return 0;
     }
 
-  GIOStatus status = g_io_channel_set_encoding(keyfile, NULL, &myError);
+    GIOStatus status = g_io_channel_set_encoding(keyfile, NULL, &myError);
 
-  if(status != G_IO_STATUS_NORMAL)
+    if(status != G_IO_STATUS_NORMAL)
     {
-      cond_msg_error(myError, "[SLOG] ERROR: Unable to set encoding for key file");
-      g_clear_error(&myError);
+        cond_msg_error(myError, "[SLOG] ERROR: Unable to set encoding for key file");
+        g_clear_error(&myError);
 
-      g_io_channel_shutdown(keyfile, TRUE, &myError);
-      g_io_channel_unref(keyfile);
+        g_io_channel_shutdown(keyfile, TRUE, &myError);
+        g_io_channel_unref(keyfile);
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
 
-      return 0;
+        return 0;
     }
 
-  // Key file contains
-  // 1. the number of log entries already logged (and therewith the index of the key); this is at the end of the key file
-  // 2. the actual 32 byte key, this is at the beginning of the key file
-  // 3. a 16 byte CMAC of the two previous data, this is stored after the key
+    // Key file contains
+    // 1. the number of log entries already logged (and therewith the index of the key); this is at the end of the key file
+    // 2. the actual 32 byte key, this is at the beginning of the key file
+    // 3. a 16 byte CMAC of the two previous data, this is stored after the key
 
-  gchar keydata[KEY_LENGTH + CMAC_LENGTH];
-  gsize key_bytes_read = 0;
+    gchar keydata[KEY_LENGTH + CMAC_LENGTH];
+    gsize key_bytes_read = 0;
 
-  status = g_io_channel_read_chars(keyfile, keydata, KEY_LENGTH + CMAC_LENGTH, &key_bytes_read, &myError);
+    status = g_io_channel_read_chars(keyfile, keydata, KEY_LENGTH + CMAC_LENGTH, &key_bytes_read, &myError);
 
-  if (status != G_IO_STATUS_NORMAL)
+    if (status != G_IO_STATUS_NORMAL)
     {
-      cond_msg_error(myError, "[SLOG] ERROR: Cannot read from key file");
+        cond_msg_error(myError, "[SLOG] ERROR: Cannot read from key file");
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      g_io_channel_shutdown(keyfile, TRUE, &myError);
-      g_io_channel_unref(keyfile);
+        g_io_channel_shutdown(keyfile, TRUE, &myError);
+        g_io_channel_unref(keyfile);
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      return 0;
+        return 0;
 
     }
 
-  if (key_bytes_read!=KEY_LENGTH+CMAC_LENGTH)
+    if (key_bytes_read!=KEY_LENGTH+CMAC_LENGTH)
     {
-      msg_error("[SLOG] ERROR: Invalid key file. Missing CMAC");
+        msg_error("[SLOG] ERROR: Invalid key file. Missing CMAC");
 
-      status = g_io_channel_shutdown(keyfile, TRUE, &myError);
-      g_io_channel_unref(keyfile);
+        status = g_io_channel_shutdown(keyfile, TRUE, &myError);
+        g_io_channel_unref(keyfile);
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      return 0;
+        return 0;
     }
 
-  guint64 littleEndianCounter;
+    guint64 littleEndianCounter;
 
-  status = g_io_channel_read_chars(keyfile, (gchar *) &littleEndianCounter, sizeof(littleEndianCounter), &key_bytes_read,
-                                   &myError);
-  if (status != G_IO_STATUS_NORMAL)
+    status = g_io_channel_read_chars(keyfile, (gchar *) &littleEndianCounter, sizeof(littleEndianCounter), &key_bytes_read,
+                                     &myError);
+    if (status != G_IO_STATUS_NORMAL)
     {
-      cond_msg_error(myError, "[SLOG] ERROR: Cannot read counter from key file");
+        cond_msg_error(myError, "[SLOG] ERROR: Cannot read counter from key file");
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      g_io_channel_shutdown(keyfile, TRUE, &myError);
-      g_io_channel_unref(keyfile);
+        g_io_channel_shutdown(keyfile, TRUE, &myError);
+        g_io_channel_unref(keyfile);
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      return 0;
+        return 0;
     }
 
-  status = g_io_channel_shutdown(keyfile, TRUE, &myError);
-  g_io_channel_unref(keyfile);
+    status = g_io_channel_shutdown(keyfile, TRUE, &myError);
+    g_io_channel_unref(keyfile);
 
-  g_clear_error(&myError);
+    g_clear_error(&myError);
 
-  if (key_bytes_read!=sizeof(littleEndianCounter))
+    if (key_bytes_read!=sizeof(littleEndianCounter))
     {
-      msg_error("[SLOG] ERROR: $(slog) parsing failed, key file invalid while reading counter");
-      return 0;
+        msg_error("[SLOG] ERROR: $(slog) parsing failed, key file invalid while reading counter");
+        return 0;
     }
 
-  gsize outlen=0;
-  unsigned char testOutput[CMAC_LENGTH];
-  gsize testOutputCapacity = G_N_ELEMENTS(testOutput);
+    gsize outlen=0;
+    unsigned char testOutput[CMAC_LENGTH];
+    gsize testOutputCapacity = G_N_ELEMENTS(testOutput);
 
-  cmac((guchar *)keydata, &(littleEndianCounter), sizeof(littleEndianCounter), testOutput, &outlen, testOutputCapacity);
+    cmac((guchar *)keydata, &(littleEndianCounter), sizeof(littleEndianCounter), testOutput, &outlen, testOutputCapacity);
 
-  if (0!=memcmp(testOutput, &keydata[KEY_LENGTH], CMAC_LENGTH))
+    if (0!=memcmp(testOutput, &keydata[KEY_LENGTH], CMAC_LENGTH))
     {
-      msg_warning("[SLOG] ERROR: Host key corrupted. CMAC in key file not matching");
-      return 0;
+        msg_warning("[SLOG] ERROR: Host key corrupted. CMAC in key file not matching");
+        return 0;
     }
 
-  memcpy(destKey, keydata, KEY_LENGTH);
-  *destCounter = GUINT64_FROM_LE(littleEndianCounter);
+    memcpy(destKey, keydata, KEY_LENGTH);
+    *destCounter = GUINT64_FROM_LE(littleEndianCounter);
 
-  return 1;
+    return 1;
 }
 
 /*
@@ -906,102 +977,102 @@ int readKey(char *destKey, guint64 *destCounter, gchar *keypath)
  */
 int writeKey(char *key, guint64 counter, gchar *keypath)
 {
-  GError *error = NULL;
-  GIOChannel *keyfile = g_io_channel_new_file(keypath, "w+", &error);
+    GError *error = NULL;
+    GIOChannel *keyfile = g_io_channel_new_file(keypath, "w+", &error);
 
-  if(!keyfile)
+    if(!keyfile)
     {
-      cond_msg_error(error, "[SLOG] ERROR: Cannot open key file");
+        cond_msg_error(error, "[SLOG] ERROR: Cannot open key file");
 
-      g_clear_error(&error);
+        g_clear_error(&error);
 
-      return 0;
+        return 0;
     }
 
-  GIOStatus status = g_io_channel_set_encoding(keyfile, NULL, &error);
-  if(status != G_IO_STATUS_NORMAL)
+    GIOStatus status = g_io_channel_set_encoding(keyfile, NULL, &error);
+    if(status != G_IO_STATUS_NORMAL)
     {
-      cond_msg_error(error, "[SLOG] ERROR: Unable to set encoding for key file");
+        cond_msg_error(error, "[SLOG] ERROR: Unable to set encoding for key file");
 
-      g_clear_error(&error);
+        g_clear_error(&error);
 
-      g_io_channel_shutdown(keyfile, TRUE, &error);
-      g_io_channel_unref(keyfile);
+        g_io_channel_shutdown(keyfile, TRUE, &error);
+        g_io_channel_unref(keyfile);
 
-      g_clear_error(&error);
+        g_clear_error(&error);
 
-      return 0;
+        return 0;
     }
 
-  gsize outlen = 0;
-  // Write key
-  status = g_io_channel_write_chars(keyfile, key, KEY_LENGTH, &outlen, &error);
-  if(status != G_IO_STATUS_NORMAL)
+    gsize outlen = 0;
+    // Write key
+    status = g_io_channel_write_chars(keyfile, key, KEY_LENGTH, &outlen, &error);
+    if(status != G_IO_STATUS_NORMAL)
     {
-      cond_msg_error(error, "[SLOG] ERROR: Unable to write updated key");
+        cond_msg_error(error, "[SLOG] ERROR: Unable to write updated key");
 
-      g_clear_error(&error);
+        g_clear_error(&error);
 
-      g_io_channel_shutdown(keyfile, TRUE, &error);
-      g_io_channel_unref(keyfile);
+        g_io_channel_shutdown(keyfile, TRUE, &error);
+        g_io_channel_unref(keyfile);
 
-      g_clear_error(&error);
+        g_clear_error(&error);
 
-      return 0;
+        return 0;
     }
 
-  guint64 littleEndianCounter = GINT64_TO_LE(counter);
-  gchar outputmacdata[CMAC_LENGTH];
-  gsize outputmacdata_capacity = G_N_ELEMENTS(outputmacdata);
-  cmac((guchar *)key, &littleEndianCounter, sizeof(littleEndianCounter), (guchar *)outputmacdata, &outlen,
-       outputmacdata_capacity);
+    guint64 littleEndianCounter = GINT64_TO_LE(counter);
+    gchar outputmacdata[CMAC_LENGTH];
+    gsize outputmacdata_capacity = G_N_ELEMENTS(outputmacdata);
+    cmac((guchar *)key, &littleEndianCounter, sizeof(littleEndianCounter), (guchar *)outputmacdata, &outlen,
+         outputmacdata_capacity);
 
-  // Write CMAC
-  status = g_io_channel_write_chars(keyfile, outputmacdata, CMAC_LENGTH, &outlen, &error);
-  if(status != G_IO_STATUS_NORMAL)
+    // Write CMAC
+    status = g_io_channel_write_chars(keyfile, outputmacdata, CMAC_LENGTH, &outlen, &error);
+    if(status != G_IO_STATUS_NORMAL)
     {
-      cond_msg_error(error, "[SLOG] ERROR: Unable to write key CMAC");
+        cond_msg_error(error, "[SLOG] ERROR: Unable to write key CMAC");
 
-      g_clear_error(&error);
+        g_clear_error(&error);
 
-      g_io_channel_shutdown(keyfile, TRUE, &error);
-      g_io_channel_unref(keyfile);
+        g_io_channel_shutdown(keyfile, TRUE, &error);
+        g_io_channel_unref(keyfile);
 
-      g_clear_error(&error);
+        g_clear_error(&error);
 
-      return 0;
+        return 0;
     }
 
-  // Write counter
-  status = g_io_channel_write_chars(keyfile, (gchar *) &littleEndianCounter, sizeof(littleEndianCounter), &outlen,
-                                    &error);
-  if(status != G_IO_STATUS_NORMAL)
+    // Write counter
+    status = g_io_channel_write_chars(keyfile, (gchar *) &littleEndianCounter, sizeof(littleEndianCounter), &outlen,
+                                      &error);
+    if(status != G_IO_STATUS_NORMAL)
     {
-      cond_msg_error(error, "[SLOG] ERROR: Unable to write key counter");
+        cond_msg_error(error, "[SLOG] ERROR: Unable to write key counter");
 
-      g_clear_error(&error);
+        g_clear_error(&error);
 
-      g_io_channel_shutdown(keyfile, TRUE, &error);
-      g_io_channel_unref(keyfile);
+        g_io_channel_shutdown(keyfile, TRUE, &error);
+        g_io_channel_unref(keyfile);
 
-      g_clear_error(&error);
+        g_clear_error(&error);
 
-      return 0;
+        return 0;
     }
 
-  status = g_io_channel_shutdown(keyfile, TRUE, &error);
-  g_io_channel_unref(keyfile);
+    status = g_io_channel_shutdown(keyfile, TRUE, &error);
+    g_io_channel_unref(keyfile);
 
-  if (status != G_IO_STATUS_NORMAL)
+    if (status != G_IO_STATUS_NORMAL)
     {
-      cond_msg_error(error, "[SLOG] ERROR: Cannot close key file");
+        cond_msg_error(error, "[SLOG] ERROR: Cannot close key file");
 
-      g_clear_error(&error);
+        g_clear_error(&error);
 
-      return 0;
+        return 0;
     }
 
-  return 1;
+    return 1;
 
 }
 
@@ -1010,167 +1081,167 @@ int iterateBuffer(guint64 entriesInBuffer, GString **input, guint64 *nextLogEntr
                   gsize cmac_tag_capacity, GHashTable *tab)
 {
 
-  int ret = 1;
-  for (guint64 i=0; i<entriesInBuffer; i++)
+    int ret = 1;
+    for (guint64 i=0; i<entriesInBuffer; i++)
     {
 
-      output[i] = g_string_new(NULL);
+        output[i] = g_string_new(NULL);
 
-      guint64 len = input[i]->len;
-      if (len > (COUNTER_LENGTH + 1))
+        guint64 len = input[i]->len;
+        if (len > (COUNTER_LENGTH + 1))
         {
-          // Interpret the first COUNTER_LENGTH+1 characters
-          char ctrbuf[COUNTER_LENGTH+1];
-          memcpy(ctrbuf, input[i]->str, COUNTER_LENGTH);
-          ctrbuf[COUNTER_LENGTH] = 0;
+            // Interpret the first COUNTER_LENGTH+1 characters
+            char ctrbuf[COUNTER_LENGTH+1];
+            memcpy(ctrbuf, input[i]->str, COUNTER_LENGTH);
+            ctrbuf[COUNTER_LENGTH] = 0;
 
-          gsize outLen;
-          guchar *tmp = convertToBin(ctrbuf, &outLen);
+            gsize outLen;
+            guchar *tmp = convertToBin(ctrbuf, &outLen);
 
-          guint64 logEntryOnDisk;
-          if (outLen!=sizeof(guint64))
+            guint64 logEntryOnDisk;
+            if (outLen!=sizeof(guint64))
             {
-              msg_error("[SLOG] ERROR: Cannot derive integer value from counter field", evt_tag_long("Log entry number",
-                        *nextLogEntry));
-              logEntryOnDisk = *nextLogEntry;
-              g_free(tmp);
+                msg_error("[SLOG] ERROR: Cannot derive integer value from counter field", evt_tag_long("Log entry number",
+                          *nextLogEntry));
+                logEntryOnDisk = *nextLogEntry;
+                g_free(tmp);
             }
-          else
+            else
             {
-              memcpy(&logEntryOnDisk, tmp, sizeof(logEntryOnDisk));
-              g_free(tmp);
-            }
-
-          len = len - (COUNTER_LENGTH+1);
-
-          if (logEntryOnDisk != *nextLogEntry)
-            {
-              if (tab != NULL)
-                {
-                  char key[CTR_LEN_SIMPLE+1];
-                  snprintf(key, CTR_LEN_SIMPLE+1, "%"G_GUINT64_FORMAT, logEntryOnDisk);
-                  if(g_hash_table_contains(tab, key) == TRUE)
-                    {
-                      msg_error("[SLOG] ERROR: Duplicate entry detected", evt_tag_long("entry", logEntryOnDisk));
-                      ret = 0;
-                    }
-                }
-              if (logEntryOnDisk<(*nextLogEntry))
-                {
-                  if (logEntryOnDisk<keyNumber)
-                    {
-                      msg_error("[SLOG] ERROR: Log claims to be past entry from past archive. We cannot rewind back to this key without key0. This is going to fail.",
-                                evt_tag_long("entry", logEntryOnDisk));
-                      ret = 0;
-                    }
-                  else
-                    {
-                      msg_error("[SLOG] ERROR: Log claims to be past entry. We rewind from first known key, this might take some time",
-                                evt_tag_long("entry", logEntryOnDisk));
-                      // Rewind key to k0
-                      memcpy(mainKey, keyZero, KEY_LENGTH);
-                      deriveKey(mainKey, logEntryOnDisk, keyNumber);
-                      *nextLogEntry = logEntryOnDisk;
-                      ret = 0;
-                    }
-                }
-              if (logEntryOnDisk-(*nextLogEntry)>1000000)
-                {
-                  msg_info("[SLOG] INFO: Deriving key for distant future. This might take some time.",
-                           evt_tag_long("next log entry should be", *nextLogEntry), evt_tag_long("key to derive to", logEntryOnDisk),
-                           evt_tag_long("number of log entries", *numberOfLogEntries));
-                }
-              deriveKey(mainKey, logEntryOnDisk, *nextLogEntry);
-              *nextLogEntry = logEntryOnDisk;
+                memcpy(&logEntryOnDisk, tmp, sizeof(logEntryOnDisk));
+                g_free(tmp);
             }
 
-          GString *line = input[i];
+            len = len - (COUNTER_LENGTH+1);
 
-          char *ct = &(line->str)[COUNTER_LENGTH+1];
-          gsize outputLength;
-
-          // binBuf = IV + TAG + CT
-          guchar *binBuf = convertToBin(ct, &outputLength);
-          int pt_length = 0;
-
-          // Check whether something weird has happened during conversion
-          if (outputLength>IV_LENGTH+AES_BLOCKSIZE)
+            if (logEntryOnDisk != *nextLogEntry)
             {
-              unsigned char pt[outputLength - IV_LENGTH - AES_BLOCKSIZE];
-
-              unsigned char encKey[KEY_LENGTH];
-              deriveEncSubKey(mainKey, encKey);
-
-              pt_length = sLogDecrypt(&binBuf[IV_LENGTH+AES_BLOCKSIZE], outputLength - IV_LENGTH - AES_BLOCKSIZE, &binBuf[IV_LENGTH],
-                                      encKey, binBuf, pt);
-
-              if (pt_length>0)
+                if (tab != NULL)
                 {
-                  // Include colon, whitespace, and \0
-                  g_string_append_printf(output[i], "%0*"G_GINT64_MODIFIER"x: %.*s", CTR_LEN_SIMPLE, logEntryOnDisk, pt_length, pt);
-
-                  if (tab != NULL)
+                    char key[CTR_LEN_SIMPLE+1];
+                    snprintf(key, CTR_LEN_SIMPLE+1, "%"G_GUINT64_FORMAT, logEntryOnDisk);
+                    if(g_hash_table_contains(tab, key) == TRUE)
                     {
-                      char *key = g_new0(char, CTR_LEN_SIMPLE+1);
-                      snprintf(key, CTR_LEN_SIMPLE+1, "%"G_GUINT64_FORMAT, logEntryOnDisk);
+                        msg_error("[SLOG] ERROR: Duplicate entry detected", evt_tag_long("entry", logEntryOnDisk));
+                        ret = 0;
+                    }
+                }
+                if (logEntryOnDisk<(*nextLogEntry))
+                {
+                    if (logEntryOnDisk<keyNumber)
+                    {
+                        msg_error("[SLOG] ERROR: Log claims to be past entry from past archive. We cannot rewind back to this key without key0. This is going to fail.",
+                                  evt_tag_long("entry", logEntryOnDisk));
+                        ret = 0;
+                    }
+                    else
+                    {
+                        msg_error("[SLOG] ERROR: Log claims to be past entry. We rewind from first known key, this might take some time",
+                                  evt_tag_long("entry", logEntryOnDisk));
+                        // Rewind key to k0
+                        memcpy(mainKey, keyZero, KEY_LENGTH);
+                        deriveKey(mainKey, logEntryOnDisk, keyNumber);
+                        *nextLogEntry = logEntryOnDisk;
+                        ret = 0;
+                    }
+                }
+                if (logEntryOnDisk-(*nextLogEntry)>1000000)
+                {
+                    msg_info("[SLOG] INFO: Deriving key for distant future. This might take some time.",
+                             evt_tag_long("next log entry should be", *nextLogEntry), evt_tag_long("key to derive to", logEntryOnDisk),
+                             evt_tag_long("number of log entries", *numberOfLogEntries));
+                }
+                deriveKey(mainKey, logEntryOnDisk, *nextLogEntry);
+                *nextLogEntry = logEntryOnDisk;
+            }
 
-                      if (g_hash_table_insert(tab, key, (gpointer)logEntryOnDisk) == FALSE)
+            GString *line = input[i];
+
+            char *ct = &(line->str)[COUNTER_LENGTH+1];
+            gsize outputLength;
+
+            // binBuf = IV + TAG + CT
+            guchar *binBuf = convertToBin(ct, &outputLength);
+            int pt_length = 0;
+
+            // Check whether something weird has happened during conversion
+            if (outputLength>IV_LENGTH+AES_BLOCKSIZE)
+            {
+                unsigned char pt[outputLength - IV_LENGTH - AES_BLOCKSIZE];
+
+                unsigned char encKey[KEY_LENGTH];
+                deriveEncSubKey(mainKey, encKey);
+
+                pt_length = sLogDecrypt(&binBuf[IV_LENGTH+AES_BLOCKSIZE], outputLength - IV_LENGTH - AES_BLOCKSIZE, &binBuf[IV_LENGTH],
+                                        encKey, binBuf, pt);
+
+                if (pt_length>0)
+                {
+                    // Include colon, whitespace, and \0
+                    g_string_append_printf(output[i], "%0*"G_GINT64_MODIFIER"x: %.*s", CTR_LEN_SIMPLE, logEntryOnDisk, pt_length, pt);
+
+                    if (tab != NULL)
+                    {
+                        char *key = g_new0(char, CTR_LEN_SIMPLE+1);
+                        snprintf(key, CTR_LEN_SIMPLE+1, "%"G_GUINT64_FORMAT, logEntryOnDisk);
+
+                        if (g_hash_table_insert(tab, key, (gpointer)logEntryOnDisk) == FALSE)
                         {
-                          msg_warning("[SLOG] WARNING: Unable to process hash table while entering decrypted log entry", evt_tag_long("entry",
-                                      logEntryOnDisk));
-                          ret = 0;
+                            msg_warning("[SLOG] WARNING: Unable to process hash table while entering decrypted log entry", evt_tag_long("entry",
+                                        logEntryOnDisk));
+                            ret = 0;
                         }
                     }
 
-                  // Update BigHMAC
-                  if ((*numberOfLogEntries) == 0UL)   // First aggregated MAC
+                    // Update BigHMAC
+                    if ((*numberOfLogEntries) == 0UL)   // First aggregated MAC
                     {
-                      gsize outlen = 0;
+                        gsize outlen = 0;
 
-                      unsigned char MACKey[KEY_LENGTH];
-                      deriveMACSubKey(mainKey, MACKey);
+                        unsigned char MACKey[KEY_LENGTH];
+                        deriveMACSubKey(mainKey, MACKey);
 
-                      cmac(MACKey, binBuf, IV_LENGTH+AES_BLOCKSIZE+pt_length, cmac_tag, &outlen, cmac_tag_capacity);
+                        cmac(MACKey, binBuf, IV_LENGTH+AES_BLOCKSIZE+pt_length, cmac_tag, &outlen, cmac_tag_capacity);
                     }
-                  else
+                    else
                     {
-                      // numberOfEntries > 0
-                      gsize outlen;
-                      unsigned char bigBuf[AES_BLOCKSIZE+IV_LENGTH+AES_BLOCKSIZE+pt_length];
-                      memcpy(bigBuf, cmac_tag, AES_BLOCKSIZE);
-                      memcpy(&bigBuf[AES_BLOCKSIZE], binBuf, IV_LENGTH+AES_BLOCKSIZE+pt_length);
+                        // numberOfEntries > 0
+                        gsize outlen;
+                        unsigned char bigBuf[AES_BLOCKSIZE+IV_LENGTH+AES_BLOCKSIZE+pt_length];
+                        memcpy(bigBuf, cmac_tag, AES_BLOCKSIZE);
+                        memcpy(&bigBuf[AES_BLOCKSIZE], binBuf, IV_LENGTH+AES_BLOCKSIZE+pt_length);
 
-                      unsigned char MACKey[KEY_LENGTH];
-                      deriveMACSubKey(mainKey, MACKey);
+                        unsigned char MACKey[KEY_LENGTH];
+                        deriveMACSubKey(mainKey, MACKey);
 
-                      cmac(MACKey, bigBuf, AES_BLOCKSIZE+IV_LENGTH+AES_BLOCKSIZE+pt_length, cmac_tag, &outlen, cmac_tag_capacity);
+                        cmac(MACKey, bigBuf, AES_BLOCKSIZE+IV_LENGTH+AES_BLOCKSIZE+pt_length, cmac_tag, &outlen, cmac_tag_capacity);
                     }
                 }
             }
 
-          if (pt_length<=0)
+            if (pt_length<=0)
             {
-              msg_warning("[SLOG] WARNING: Decryption not successful",
-                          evt_tag_long("entry", logEntryOnDisk));
-              ret = 0;
+                msg_warning("[SLOG] WARNING: Decryption not successful",
+                            evt_tag_long("entry", logEntryOnDisk));
+                ret = 0;
             }
 
-          g_free(binBuf);
+            g_free(binBuf);
 
-          evolveKey(mainKey);
-          (*numberOfLogEntries)++;
-          (*nextLogEntry)++;
+            evolveKey(mainKey);
+            (*numberOfLogEntries)++;
+            (*nextLogEntry)++;
 
         }
-      else
+        else
         {
-          msg_error("[SLOG] ERROR: Cannot read log entry", evt_tag_long("", *nextLogEntry));
-          ret = 0;
+            msg_error("[SLOG] ERROR: Cannot read log entry", evt_tag_long("", *nextLogEntry));
+            ret = 0;
         }
 
     } // for
 
-  return ret;
+    return ret;
 }
 
 // Perform the final verification step
@@ -1178,97 +1249,103 @@ int finalizeVerify(guint64 startingEntry, guint64 entriesInFile, unsigned char *
                    GHashTable *tab)
 {
 
-  int ret = 1;
+    int ret = 1;
 
-  // Check which entries are missing
-  guint64 notRecovered = 0;
-  for (guint64 i = startingEntry; i < startingEntry + entriesInFile; i++)
+    // Check which entries are missing
+    guint64 notRecovered = 0;
+    for (guint64 i = startingEntry; i < startingEntry + entriesInFile; i++)
     {
-      if (tab != NULL)
+        if (tab != NULL)
         {
-          // Hashtable key
-          char key[CTR_LEN_SIMPLE+1];
-          snprintf(key, CTR_LEN_SIMPLE+1, "%"G_GUINT64_FORMAT, i);
+            // Hashtable key
+            char key[CTR_LEN_SIMPLE+1];
+            snprintf(key, CTR_LEN_SIMPLE+1, "%"G_GUINT64_FORMAT, i);
 
-          if(g_hash_table_contains(tab, key) == FALSE)
+            if(g_hash_table_contains(tab, key) == FALSE)
             {
-              notRecovered++;
-              msg_warning("[SLOG] WARNING: Unable to recover", evt_tag_long("entry", i));
-              ret = 0;
+                notRecovered++;
+                msg_warning("[SLOG] WARNING: Unable to recover", evt_tag_long("entry", i));
+                ret = 0;
             }
         }
     }
 
-  if ((notRecovered == 0) && (tab != NULL))
+    if ((notRecovered == 0) && (tab != NULL))
     {
-      msg_info("[SLOG] INFO: All entries recovered successfully");
+        msg_info("[SLOG] INFO: All entries recovered successfully");
     }
 
-  int equal = memcmp(bigMac, cmac_tag, CMAC_LENGTH);
+    int equal = memcmp(bigMac, cmac_tag, CMAC_LENGTH);
 
-  if (equal != 0)
+    if (equal != 0)
     {
-      msg_warning("[SLOG] WARNING: Aggregated MAC mismatch. Log might be incomplete");
-      ret = 0;
+        msg_warning("[SLOG] WARNING: Aggregated MAC mismatch. Log might be incomplete");
+        ret = 0;
     }
-  else
+    else
     {
-      msg_info("[SLOG] Aggregated MAC matches. Log contains all expected log messages.");
+        msg_info("[SLOG] Aggregated MAC matches. Log contains all expected log messages.");
     }
 
-  g_hash_table_unref(tab);
+    g_hash_table_unref(tab);
 
-  return ret;
+    return ret;
 }
 
 // Initialize log verification
 int initVerify(guint64 entriesInFile, unsigned char *mainKey, guint64 *nextLogEntry, guint64 *startingEntry,
                GString **input, GHashTable **tab)
 {
-  // Create hash table
-  *tab = g_hash_table_new(g_str_hash, g_str_equal);
-  if (*tab == NULL)
+    if (input[0] == NULL)
     {
-      msg_error("[SLOG] ERROR: Cannot create hash table");
-      return 0;
+        msg_error("[SLOG] ERROR: Input == NULL in initVerify");
+        return 0;
     }
 
-  if (input[0]->len>(COUNTER_LENGTH+1))
+    // Create hash table
+    *tab = g_hash_table_new(g_str_hash, g_str_equal);
+    if (*tab == NULL)
     {
-      gsize outLen;
-      char buf[COUNTER_LENGTH+1];
-      memcpy(buf, input[0]->str, COUNTER_LENGTH);
-      buf[COUNTER_LENGTH] = 0;
-      guchar *tempInt = convertToBin(buf, &outLen);
-      if (outLen!=sizeof(guint64))
-        {
-          msg_warning("[SLOG] WARNING: Cannot derive integer value from first input line counter");
-          (*startingEntry) = 0UL;
-          g_free(tempInt);
-          return 0;
-        }
-      else
-        {
-          memcpy(startingEntry, tempInt, sizeof(guint64));
-          g_free(tempInt);
-        }
-
-      if((*startingEntry) > 0)
-        {
-          msg_warning("[SLOG] WARNING: Log does not start with index 0",
-                      evt_tag_long("index", (*startingEntry)));
-          (*nextLogEntry) = (*startingEntry);
-          deriveKey(mainKey, (*nextLogEntry), 0);
-          return 0;
-        }
-    }
-  else
-    {
-      msg_warning("[SLOG] WARNING: Problems reading log entry at first line.");
-      return 0;
+        msg_error("[SLOG] ERROR: Cannot create hash table");
+        return 0;
     }
 
-  return 1;
+    if (input[0]->len>(COUNTER_LENGTH+1))
+    {
+        gsize outLen;
+        char buf[COUNTER_LENGTH+1];
+        memcpy(buf, input[0]->str, COUNTER_LENGTH);
+        buf[COUNTER_LENGTH] = 0;
+        guchar *tempInt = convertToBin(buf, &outLen);
+        if (outLen!=sizeof(guint64))
+        {
+            msg_warning("[SLOG] WARNING: Cannot derive integer value from first input line counter");
+            (*startingEntry) = 0UL;
+            g_free(tempInt);
+            return 0;
+        }
+        else
+        {
+            memcpy(startingEntry, tempInt, sizeof(guint64));
+            g_free(tempInt);
+        }
+
+        if((*startingEntry) > 0)
+        {
+            msg_warning("[SLOG] WARNING: Log does not start with index 0",
+                        evt_tag_long("index", (*startingEntry)));
+            (*nextLogEntry) = (*startingEntry);
+            deriveKey(mainKey, (*nextLogEntry), 0);
+            return 0;
+        }
+    }
+    else
+    {
+        msg_warning("[SLOG] WARNING: Problems reading log entry at first line.");
+        return 0;
+    }
+
+    return 1;
 }
 
 
@@ -1283,302 +1360,309 @@ int iterativeFileVerify(unsigned char *previousMAC, unsigned char *mainKey, char
                         char *outputFileName, guint64 entriesInFile, int chunkLength, guint64 keyNumber)
 {
 
-  if(entriesInFile==0)
+    if(entriesInFile==0)
     {
-      msg_error("[SLOG] ERROR: Nothing to verify");
-      return 0;
+        msg_error("[SLOG] ERROR: Nothing to verify");
+        return 0;
     }
 
-  unsigned char keyZero[KEY_LENGTH];
-  memcpy(keyZero, mainKey, KEY_LENGTH);
-  int startedWithZero = 0;
+    unsigned char keyZero[KEY_LENGTH];
+    memcpy(keyZero, mainKey, KEY_LENGTH);
+    int startedWithZero = 0;
 
-  if (keyNumber!=0)
+    if (keyNumber!=0)
     {
-      msg_info("[SLOG] INFO: Verification using a key different from k0", evt_tag_long("key number", keyNumber));
+        msg_info("[SLOG] INFO: Verification using a key different from k0", evt_tag_long("key number", keyNumber));
     }
-  else
+    else
     {
-      msg_info("[SLOG] INFO: Verification starting with k0. Is this really what you want?");
-      startedWithZero = 1;
+        msg_info("[SLOG] INFO: Verification starting with k0. Is this really what you want?");
+        startedWithZero = 1;
     }
-  int ret = 1;
+    int ret = 1;
 
-  GError *myError = NULL;
-  GIOChannel *input = g_io_channel_new_file(inputFileName, "r", &myError);
-  if (!input)
+    GError *myError = NULL;
+    GIOChannel *input = g_io_channel_new_file(inputFileName, "r", &myError);
+    if (!input)
     {
-      cond_msg_error (myError, "[SLOG] ERROR: Cannot open input file");
+        cond_msg_error (myError, "[SLOG] ERROR: Cannot open input file");
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      return 0;
-    }
-
-  GIOStatus status = g_io_channel_set_encoding(input, NULL, &myError);
-  if(status != G_IO_STATUS_NORMAL)
-    {
-      cond_msg_error (myError, "[SLOG] ERROR: set encoding for input file");
-
-      g_clear_error(&myError);
-
-      g_io_channel_shutdown(input, TRUE, &myError);
-      g_io_channel_unref(input);
-
-      g_clear_error(&myError);
-
-      return 0;
+        return 0;
     }
 
-  GIOChannel *output = g_io_channel_new_file(outputFileName, "w+", &myError);
-
-  if (!output)
+    GIOStatus status = g_io_channel_set_encoding(input, NULL, &myError);
+    if(status != G_IO_STATUS_NORMAL)
     {
-      cond_msg_error(myError, "[SLOG] ERROR: Cannot open output file");
+        cond_msg_error (myError, "[SLOG] ERROR: set encoding for input file");
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      g_io_channel_shutdown(input, TRUE, &myError);
-      g_io_channel_unref(input);
+        g_io_channel_shutdown(input, TRUE, &myError);
+        g_io_channel_unref(input);
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      return 0;
-    }
-  status = g_io_channel_set_encoding(output, NULL, &myError);
-  if (status != G_IO_STATUS_NORMAL)
-    {
-      cond_msg_error(myError, "[SLOG] ERROR: Cannot set output file encoding");
-      g_clear_error(&myError);
-
-      g_io_channel_shutdown(input, TRUE, &myError);
-      g_io_channel_unref(input);
-
-      g_clear_error(&myError);
-
-      g_io_channel_shutdown(output, TRUE, &myError);
-      g_io_channel_unref(output);
-
-      g_clear_error(&myError);
-
-      return  0;
+        return 0;
     }
 
+    GIOChannel *output = g_io_channel_new_file(outputFileName, "w+", &myError);
 
-  GString **inputBuffer = g_new0(GString *, chunkLength);
-  GString **outputBuffer = g_new0(GString *, chunkLength);
-
-  if ((outputBuffer==NULL)||(inputBuffer == NULL))
+    if (!output)
     {
-      msg_error("[SLOG] ERROR: [iterativeFileVerify] cannot allocate memory");
+        cond_msg_error(myError, "[SLOG] ERROR: Cannot open output file");
 
-      g_io_channel_shutdown(input, TRUE, &myError);
-      g_io_channel_unref(input);
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      g_io_channel_shutdown(output, TRUE, &myError);
-      g_io_channel_unref(output);
-      g_clear_error(&myError);
+        g_io_channel_shutdown(input, TRUE, &myError);
+        g_io_channel_unref(input);
 
-      g_free(inputBuffer);
-      g_free(outputBuffer);
+        g_clear_error(&myError);
 
-      return 0;
+        return 0;
+    }
+    status = g_io_channel_set_encoding(output, NULL, &myError);
+    if (status != G_IO_STATUS_NORMAL)
+    {
+        cond_msg_error(myError, "[SLOG] ERROR: Cannot set output file encoding");
+        g_clear_error(&myError);
+
+        g_io_channel_shutdown(input, TRUE, &myError);
+        g_io_channel_unref(input);
+
+        g_clear_error(&myError);
+
+        g_io_channel_shutdown(output, TRUE, &myError);
+        g_io_channel_unref(output);
+
+        g_clear_error(&myError);
+
+        return  0;
     }
 
-  unsigned char cmac_tag[CMAC_LENGTH];
-  gsize cmac_tag_capacity = G_N_ELEMENTS(cmac_tag);
-  memcpy(cmac_tag, previousMAC, CMAC_LENGTH);
 
-  guint64 nextLogEntry = keyNumber;
-  guint64 startingEntry = keyNumber;
-  guint64 numberOfLogEntries = keyNumber;
+    GString **inputBuffer = g_new0(GString *, chunkLength);
+    GString **outputBuffer = g_new0(GString *, chunkLength);
 
-  // This is only to avoid updating BigMAC during the first iteration
-  if (keyNumber == 0)
+    if ((outputBuffer==NULL)||(inputBuffer == NULL))
     {
-      numberOfLogEntries = 1;
-    }
+        msg_error("[SLOG] ERROR: [iterativeFileVerify] cannot allocate memory");
 
-  if (chunkLength>entriesInFile)
-    {
-      chunkLength = entriesInFile;
-    }
+        g_io_channel_shutdown(input, TRUE, &myError);
+        g_io_channel_unref(input);
+        g_clear_error(&myError);
 
-  // Create the hash table
-  GHashTable *tab = g_hash_table_new(g_str_hash, g_str_equal);
-  if (tab == NULL)
-    {
-      msg_error("[SLOG] ERROR: Cannot create hash table");
-      return 0;
-    }
+        g_io_channel_shutdown(output, TRUE, &myError);
+        g_io_channel_unref(output);
+        g_clear_error(&myError);
 
-  // Process file in chunks
-  for (int j = 0; j < (entriesInFile / chunkLength); j++)
-    {
-      for (guint64 i = 0; i < chunkLength; i++)
+        if(inputBuffer != NULL)
         {
-          inputBuffer[i] = g_string_new(NULL);
-          status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
-          if (status != G_IO_STATUS_NORMAL)
+            g_free(inputBuffer);
+        }
+
+        if (outputBuffer != NULL)
+        {
+            g_free(outputBuffer);
+        }
+
+        return 0;
+    }
+
+    unsigned char cmac_tag[CMAC_LENGTH];
+    gsize cmac_tag_capacity = G_N_ELEMENTS(cmac_tag);
+    memcpy(cmac_tag, previousMAC, CMAC_LENGTH);
+
+    guint64 nextLogEntry = keyNumber;
+    guint64 startingEntry = keyNumber;
+    guint64 numberOfLogEntries = keyNumber;
+
+    // This is only to avoid updating BigMAC during the first iteration
+    if (keyNumber == 0)
+    {
+        numberOfLogEntries = 1;
+    }
+
+    if (chunkLength>entriesInFile)
+    {
+        chunkLength = entriesInFile;
+    }
+
+    // Create the hash table
+    GHashTable *tab = g_hash_table_new(g_str_hash, g_str_equal);
+    if (tab == NULL)
+    {
+        msg_error("[SLOG] ERROR: Cannot create hash table");
+        return 0;
+    }
+
+    // Process file in chunks
+    for (int j = 0; j < (entriesInFile / chunkLength); j++)
+    {
+        for (guint64 i = 0; i < chunkLength; i++)
+        {
+            inputBuffer[i] = g_string_new(NULL);
+            status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
+            if (status != G_IO_STATUS_NORMAL)
             {
-              cond_msg_error(myError, "[SLOG] ERROR: reading from input file");
+                cond_msg_error(myError, "[SLOG] ERROR: reading from input file");
 
-              g_clear_error(&myError);
+                g_clear_error(&myError);
 
-              g_io_channel_shutdown(input, TRUE, &myError);
-              g_io_channel_unref(input);
+                g_io_channel_shutdown(input, TRUE, &myError);
+                g_io_channel_unref(input);
 
-              g_clear_error(&myError);
+                g_clear_error(&myError);
 
-              g_io_channel_shutdown(output, TRUE, &myError);
-              g_io_channel_unref(output);
+                g_io_channel_shutdown(output, TRUE, &myError);
+                g_io_channel_unref(output);
 
-              g_clear_error(&myError);
+                g_clear_error(&myError);
 
-              g_free(inputBuffer);
-              g_free(outputBuffer);
+                g_free(inputBuffer);
+                g_free(outputBuffer);
 
-              return  0;
+                return  0;
             }
 
-          // Cut last character to remove the trailing new line...
-          g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
+            // Cut last character to remove the trailing new line...
+            g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
         }
-      ret = ret * iterateBuffer(chunkLength, inputBuffer, &nextLogEntry, mainKey, keyZero, keyNumber, outputBuffer,
-                                &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
+        ret = ret * iterateBuffer(chunkLength, inputBuffer, &nextLogEntry, mainKey, keyZero, keyNumber, outputBuffer,
+                                  &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
 
-      // ...and write to file
-      for (guint64 i = 0; i < chunkLength; i++)
+        // ...and write to file
+        for (guint64 i = 0; i < chunkLength; i++)
         {
-          if (outputBuffer[i]->len!=0)
+            if (outputBuffer[i]->len!=0)
             {
-              gsize size;
-              //Add newline
-              g_string_append(outputBuffer[i], "\n");
-              status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
+                gsize size;
+                //Add newline
+                g_string_append(outputBuffer[i], "\n");
+                status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
 
-              if (status != G_IO_STATUS_NORMAL)
+                if (status != G_IO_STATUS_NORMAL)
                 {
-                  cond_msg_error(myError, "[SLOG] ERROR: writing to output file");
+                    cond_msg_error(myError, "[SLOG] ERROR: writing to output file");
 
-                  g_clear_error(&myError);
+                    g_clear_error(&myError);
 
-                  g_io_channel_shutdown(input, TRUE, &myError);
-                  g_io_channel_unref(input);
+                    g_io_channel_shutdown(input, TRUE, &myError);
+                    g_io_channel_unref(input);
 
-                  g_clear_error(&myError);
+                    g_clear_error(&myError);
 
-                  g_io_channel_shutdown(output, TRUE, &myError);
-                  g_io_channel_unref(output);
+                    g_io_channel_shutdown(output, TRUE, &myError);
+                    g_io_channel_unref(output);
 
-                  g_clear_error(&myError);
+                    g_clear_error(&myError);
 
-                  g_free(inputBuffer);
-                  g_free(outputBuffer);
+                    g_free(inputBuffer);
+                    g_free(outputBuffer);
 
-                  return  0;
+                    return  0;
                 }
             }
-          g_string_free(outputBuffer[i], TRUE);
-          g_string_free(inputBuffer[i], TRUE);
+            g_string_free(outputBuffer[i], TRUE);
+            g_string_free(inputBuffer[i], TRUE);
         }
     }
 
-  if ((entriesInFile % chunkLength) > 0)
+    if ((entriesInFile % chunkLength) > 0)
     {
-      for (guint64 i = 0; i < (entriesInFile % chunkLength); i++)
+        for (guint64 i = 0; i < (entriesInFile % chunkLength); i++)
         {
-          inputBuffer[i] = g_string_new(NULL);
-          status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
-          if (status != G_IO_STATUS_NORMAL)
+            inputBuffer[i] = g_string_new(NULL);
+            status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
+            if (status != G_IO_STATUS_NORMAL)
             {
-              cond_msg_error(myError, "[SLOG] ERROR: reading from input file");
+                cond_msg_error(myError, "[SLOG] ERROR: reading from input file");
 
-              g_clear_error(&myError);
+                g_clear_error(&myError);
 
-              g_io_channel_shutdown(input, TRUE, &myError);
-              g_io_channel_unref(input);
+                g_io_channel_shutdown(input, TRUE, &myError);
+                g_io_channel_unref(input);
 
-              g_clear_error(&myError);
+                g_clear_error(&myError);
 
-              g_io_channel_shutdown(output, TRUE, &myError);
-              g_io_channel_unref(output);
+                g_io_channel_shutdown(output, TRUE, &myError);
+                g_io_channel_unref(output);
 
-              g_clear_error(&myError);
+                g_clear_error(&myError);
 
-              g_free(inputBuffer);
-              g_free(outputBuffer);
+                g_free(inputBuffer);
+                g_free(outputBuffer);
 
 
-              return  0;
+                return  0;
             }
 
-          // Cut last character to remove the trailing new line
-          g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
+            // Cut last character to remove the trailing new line
+            g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
         }
-      ret = ret * iterateBuffer((entriesInFile % chunkLength), inputBuffer, &nextLogEntry, mainKey, keyZero, keyNumber,
-                                outputBuffer, &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
+        ret = ret * iterateBuffer((entriesInFile % chunkLength), inputBuffer, &nextLogEntry, mainKey, keyZero, keyNumber,
+                                  outputBuffer, &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
 
-      for (guint64 i = 0; i < (entriesInFile % chunkLength); i++)
+        for (guint64 i = 0; i < (entriesInFile % chunkLength); i++)
         {
-          if (outputBuffer[i]->len!=0)
+            if (outputBuffer[i]->len!=0)
             {
 
-              gsize size;
+                gsize size;
 
-              //Add newline
-              g_string_append(outputBuffer[i], "\n");
-              status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
-              if (status != G_IO_STATUS_NORMAL)
+                //Add newline
+                g_string_append(outputBuffer[i], "\n");
+                status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
+                if (status != G_IO_STATUS_NORMAL)
                 {
-                  cond_msg_error(myError, "[SLOG] ERROR: writing to output file");
+                    cond_msg_error(myError, "[SLOG] ERROR: writing to output file");
 
-                  g_clear_error(&myError);
+                    g_clear_error(&myError);
 
-                  g_io_channel_shutdown(input, TRUE, &myError);
-                  g_io_channel_unref(input);
+                    g_io_channel_shutdown(input, TRUE, &myError);
+                    g_io_channel_unref(input);
 
-                  g_clear_error(&myError);
+                    g_clear_error(&myError);
 
-                  g_io_channel_shutdown(output, TRUE, &myError);
-                  g_io_channel_unref(output);
+                    g_io_channel_shutdown(output, TRUE, &myError);
+                    g_io_channel_unref(output);
 
-                  g_clear_error(&myError);
+                    g_clear_error(&myError);
 
-                  g_free(inputBuffer);
-                  g_free(outputBuffer);
+                    g_free(inputBuffer);
+                    g_free(outputBuffer);
 
-                  return  0;
+                    return  0;
                 }
 
             }
-          g_string_free(outputBuffer[i], TRUE);
-          g_string_free(inputBuffer[i], TRUE);
+            g_string_free(outputBuffer[i], TRUE);
+            g_string_free(inputBuffer[i], TRUE);
         }
     }
 
-  if (startedWithZero==1)
+    if (startedWithZero==1)
     {
-      msg_info("[SLOG] INFO: We started with key key0. There might be a lot of warnings about missing log entries.");
+        msg_info("[SLOG] INFO: We started with key key0. There might be a lot of warnings about missing log entries.");
     }
 
-  ret = ret * finalizeVerify(startingEntry, entriesInFile, bigMAC, cmac_tag, tab);
+    ret = ret * finalizeVerify(startingEntry, entriesInFile, bigMAC, cmac_tag, tab);
 
-  g_free(inputBuffer);
-  g_free(outputBuffer);
+    g_free(inputBuffer);
+    g_free(outputBuffer);
 
-  g_io_channel_shutdown(input, TRUE, &myError);
-  g_io_channel_unref(input);
+    g_io_channel_shutdown(input, TRUE, &myError);
+    g_io_channel_unref(input);
 
-  g_clear_error(&myError);
+    g_clear_error(&myError);
 
-  g_io_channel_shutdown(output, TRUE, &myError);
-  g_io_channel_unref(output);
+    g_io_channel_shutdown(output, TRUE, &myError);
+    g_io_channel_unref(output);
 
-  g_clear_error(&myError);
+    g_clear_error(&myError);
 
-  return ret;
+    return ret;
 
 }
 
@@ -1593,353 +1677,373 @@ int fileVerify(unsigned char *mainKey, char *inputFileName, char *outputFileName
                guint64 entriesInFile, int chunkLength)
 {
 
-  unsigned char keyZero[KEY_LENGTH];
-  memcpy(keyZero, mainKey, KEY_LENGTH);
+    unsigned char keyZero[KEY_LENGTH];
+    memcpy(keyZero, mainKey, KEY_LENGTH);
 
-  GHashTable *tab = NULL;
+    GHashTable *tab = NULL;
 
-  int ret = 1;
+    int ret = 1;
 
-  if(entriesInFile==0)
+    if(entriesInFile==0)
     {
-      msg_error("[SLOG] ERROR: Nothing to verify");
-      return 0;
+        msg_error("[SLOG] ERROR: Nothing to verify");
+        return 0;
     }
 
-  GError *myError = NULL;
-  GIOChannel *input = g_io_channel_new_file(inputFileName, "r", &myError);
-  if (!input)
+    GError *myError = NULL;
+    GIOChannel *input = g_io_channel_new_file(inputFileName, "r", &myError);
+    if (!input)
     {
-      cond_msg_error (myError, "[SLOG] ERROR: Cannot open input file");
+        cond_msg_error (myError, "[SLOG] ERROR: Cannot open input file");
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      return 0;
+        return 0;
     }
 
-  GIOStatus status =  g_io_channel_set_encoding(input, NULL, &myError);
-  if (status != G_IO_STATUS_NORMAL)
+    GIOStatus status =  g_io_channel_set_encoding(input, NULL, &myError);
+    if (status != G_IO_STATUS_NORMAL)
     {
-      cond_msg_error (myError, "[SLOG] ERROR: Cannot set input file encoding");
+        cond_msg_error (myError, "[SLOG] ERROR: Cannot set input file encoding");
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      g_io_channel_shutdown(input, TRUE, &myError);
-      g_io_channel_unref(input);
+        g_io_channel_shutdown(input, TRUE, &myError);
+        g_io_channel_unref(input);
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      return 0;
+        return 0;
     }
 
-  GIOChannel *output = g_io_channel_new_file(outputFileName, "w+", &myError);
+    GIOChannel *output = g_io_channel_new_file(outputFileName, "w+", &myError);
 
-  if (!output)
+    if (!output)
     {
-      cond_msg_error (myError, "[SLOG] ERROR: Cannot open output file");
+        cond_msg_error (myError, "[SLOG] ERROR: Cannot open output file");
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      g_io_channel_shutdown(input, TRUE, &myError);
-      g_io_channel_unref(input);
+        g_io_channel_shutdown(input, TRUE, &myError);
+        g_io_channel_unref(input);
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
 
-      return 0;
+        return 0;
     }
 
-  status = g_io_channel_set_encoding(output, NULL, &myError);
+    status = g_io_channel_set_encoding(output, NULL, &myError);
 
-  if (status != G_IO_STATUS_NORMAL)
+    if (status != G_IO_STATUS_NORMAL)
     {
-      cond_msg_error (myError, "[SLOG] ERROR: Cannot set output file encoding");
+        cond_msg_error (myError, "[SLOG] ERROR: Cannot set output file encoding");
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      g_io_channel_shutdown(input, TRUE, &myError);
-      g_io_channel_unref(input);
+        g_io_channel_shutdown(input, TRUE, &myError);
+        g_io_channel_unref(input);
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      g_io_channel_shutdown(output, TRUE, &myError);
-      g_io_channel_unref(output);
+        g_io_channel_shutdown(output, TRUE, &myError);
+        g_io_channel_unref(output);
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      return 0;
+        return 0;
     }
 
-  GString **inputBuffer = g_new0(GString *, chunkLength);
-  GString **outputBuffer = g_new0(GString *, chunkLength);
+    GString **inputBuffer = g_new0(GString *, chunkLength);
+    GString **outputBuffer = g_new0(GString *, chunkLength);
 
-  if ((outputBuffer==NULL)||(inputBuffer == NULL))
+    if ((outputBuffer==NULL)||(inputBuffer == NULL))
     {
-      msg_error("[SLOG] ERROR: [fileVerify] cannot allocate memory");
+        msg_error("[SLOG] ERROR: [fileVerify] cannot allocate memory");
 
-      g_io_channel_shutdown(input, TRUE, &myError);
-      g_io_channel_unref(input);
+        g_io_channel_shutdown(input, TRUE, &myError);
+        g_io_channel_unref(input);
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      g_io_channel_shutdown(output, TRUE, &myError);
-      g_io_channel_unref(output);
+        g_io_channel_shutdown(output, TRUE, &myError);
+        g_io_channel_unref(output);
 
-      g_clear_error(&myError);
+        g_clear_error(&myError);
 
-      return 0;
-    }
-
-  guint64 nextLogEntry = 0UL;
-  guint64 startingEntry = 0UL;
-  unsigned char cmac_tag[CMAC_LENGTH];
-  gsize cmac_tag_capacity = G_N_ELEMENTS(cmac_tag);
-  guint64 numberOfLogEntries = 0UL;
-
-  if (chunkLength>entriesInFile)
-    {
-      chunkLength = entriesInFile;
-    }
-
-  for (guint64 i = 0; i < chunkLength; i++)
-    {
-      inputBuffer[i] = g_string_new(NULL);
-      status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
-      if (status != G_IO_STATUS_NORMAL)
+        if (inputBuffer != NULL)
         {
-          cond_msg_error (myError, "[SLOG] ERROR: Cannot read from input file");
-
-          g_clear_error(&myError);
-
-          g_io_channel_shutdown(input, TRUE, &myError);
-          g_io_channel_unref(input);
-
-          g_clear_error(&myError);
-
-          g_io_channel_shutdown(output, TRUE, &myError);
-          g_io_channel_unref(output);
-
-          g_clear_error(&myError);
-
-          g_free(inputBuffer);
-          g_free(outputBuffer);
-
-          return 0;
+            g_free(inputBuffer);
         }
 
-      // Cut last character to remove the trailing new line
-      g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
+        if (outputBuffer != NULL)
+        {
+            g_free(outputBuffer);
+        }
+
+        return 0;
     }
 
-  ret = ret * initVerify(entriesInFile, mainKey, &nextLogEntry, &startingEntry, inputBuffer, &tab);
-  ret = ret * iterateBuffer(chunkLength, inputBuffer, &nextLogEntry, mainKey, keyZero, 0, outputBuffer,
-                            &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
+    guint64 nextLogEntry = 0UL;
+    guint64 startingEntry = 0UL;
+    unsigned char cmac_tag[CMAC_LENGTH];
+    gsize cmac_tag_capacity = G_N_ELEMENTS(cmac_tag);
+    guint64 numberOfLogEntries = 0UL;
 
-  // Write to file
-  for (guint64 i = 0; i < chunkLength; i++)
+    if (chunkLength>entriesInFile)
     {
-      if (outputBuffer[i]->len!=0)
+        chunkLength = entriesInFile;
+    }
+
+    for (guint64 i = 0; i < chunkLength; i++)
+    {
+        inputBuffer[i] = g_string_new(NULL);
+
+        status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
+        if (status != G_IO_STATUS_NORMAL)
         {
-          gsize size;
-          //Add newline
-          g_string_append(outputBuffer[i], "\n");
-          status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
-          if (status != G_IO_STATUS_NORMAL)
+            cond_msg_error (myError, "[SLOG] ERROR: Cannot read from input file");
+
+            g_clear_error(&myError);
+
+            g_io_channel_shutdown(input, TRUE, &myError);
+            g_io_channel_unref(input);
+
+            g_clear_error(&myError);
+
+            g_io_channel_shutdown(output, TRUE, &myError);
+            g_io_channel_unref(output);
+
+            g_clear_error(&myError);
+
+            g_free(inputBuffer);
+            g_free(outputBuffer);
+
+            return 0;
+        }
+
+        // Cut last character to remove the trailing new line
+        g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
+    }
+
+    ret = ret * initVerify(entriesInFile, mainKey, &nextLogEntry, &startingEntry, inputBuffer, &tab);
+    ret = ret * iterateBuffer(chunkLength, inputBuffer, &nextLogEntry, mainKey, keyZero, 0, outputBuffer,
+                              &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
+
+    // Write to file
+    for (guint64 i = 0; i < chunkLength; i++)
+    {
+        if (outputBuffer[i] == NULL)
+        {
+            msg_error ("[SLOG] ERROR: Invalid output buffer (== NULL)");
+            g_free(inputBuffer);
+            g_free(outputBuffer);
+
+            return 0;
+        }
+
+        if (outputBuffer[i]->len!=0)
+        {
+            gsize size;
+            //Add newline
+            g_string_append(outputBuffer[i], "\n");
+            status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
+            if (status != G_IO_STATUS_NORMAL)
             {
-              cond_msg_error (myError, "[SLOG] ERROR: writing to output file");
-              g_clear_error(&myError);
+                cond_msg_error (myError, "[SLOG] ERROR: writing to output file");
+                g_clear_error(&myError);
 
-              g_io_channel_shutdown(input, TRUE, &myError);
-              g_io_channel_unref(input);
+                g_io_channel_shutdown(input, TRUE, &myError);
+                g_io_channel_unref(input);
 
-              g_clear_error(&myError);
+                g_clear_error(&myError);
 
-              g_io_channel_shutdown(output, TRUE, &myError);
-              g_io_channel_unref(output);
+                g_io_channel_shutdown(output, TRUE, &myError);
+                g_io_channel_unref(output);
 
-              g_clear_error(&myError);
+                g_clear_error(&myError);
 
-              g_free(inputBuffer);
-              g_free(outputBuffer);
+                g_free(inputBuffer);
+                g_free(outputBuffer);
 
-              return 0;
+                return 0;
             }
         }
 
-      g_string_free(outputBuffer[i], TRUE);
-      g_string_free(inputBuffer[i], TRUE);
+        g_string_free(outputBuffer[i], TRUE);
+        g_string_free(inputBuffer[i], TRUE);
 
     }
 
-  // Process file in chunks
-  for (int j = 0; j<(entriesInFile/chunkLength)-1; j++)
+    // Process file in chunks
+    for (int j = 0; j<(entriesInFile/chunkLength)-1; j++)
     {
-      for (guint64 i = 0; i < chunkLength; i++)
+        for (guint64 i = 0; i < chunkLength; i++)
         {
-          inputBuffer[i] = g_string_new(NULL);
-          status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
-          if (status != G_IO_STATUS_NORMAL)
+            inputBuffer[i] = g_string_new(NULL);
+            status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
+            if (status != G_IO_STATUS_NORMAL)
             {
-              cond_msg_error (myError, "[SLOG] ERROR: Cannot read from input file");
-              g_clear_error(&myError);
+                cond_msg_error (myError, "[SLOG] ERROR: Cannot read from input file");
+                g_clear_error(&myError);
 
-              g_io_channel_shutdown(input, TRUE, &myError);
-              g_io_channel_unref(input);
+                g_io_channel_shutdown(input, TRUE, &myError);
+                g_io_channel_unref(input);
 
-              g_clear_error(&myError);
+                g_clear_error(&myError);
 
-              g_io_channel_shutdown(output, TRUE, &myError);
-              g_io_channel_unref(output);
+                g_io_channel_shutdown(output, TRUE, &myError);
+                g_io_channel_unref(output);
 
-              g_clear_error(&myError);
+                g_clear_error(&myError);
 
-              g_free(inputBuffer);
-              g_free(outputBuffer);
+                g_free(inputBuffer);
+                g_free(outputBuffer);
 
-              return 0;
+                return 0;
             }
-          // Cut last character to remove the trailing new line...
-          g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
+            // Cut last character to remove the trailing new line...
+            g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
         }
-      ret = ret * iterateBuffer(chunkLength, inputBuffer, &nextLogEntry, mainKey, keyZero, 0, outputBuffer,
-                                &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
+        ret = ret * iterateBuffer(chunkLength, inputBuffer, &nextLogEntry, mainKey, keyZero, 0, outputBuffer,
+                                  &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
 
-      // ...and write to file
-      for (guint64 i = 0; i < chunkLength; i++)
+        // ...and write to file
+        for (guint64 i = 0; i < chunkLength; i++)
         {
-          if (outputBuffer[i]->len!=0)
+            if (outputBuffer[i]->len!=0)
             {
-              gsize size;
-              //Add newline
-              g_string_append(outputBuffer[i], "\n");
-              status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
-              if (status != G_IO_STATUS_NORMAL)
+                gsize size;
+                //Add newline
+                g_string_append(outputBuffer[i], "\n");
+                status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
+                if (status != G_IO_STATUS_NORMAL)
                 {
-                  cond_msg_error (myError, "[SLOG] ERROR: writing to output file");
+                    cond_msg_error (myError, "[SLOG] ERROR: writing to output file");
 
-                  g_clear_error(&myError);
+                    g_clear_error(&myError);
 
-                  g_io_channel_shutdown(input, TRUE, &myError);
-                  g_io_channel_unref(input);
+                    g_io_channel_shutdown(input, TRUE, &myError);
+                    g_io_channel_unref(input);
 
-                  g_clear_error(&myError);
+                    g_clear_error(&myError);
 
-                  g_io_channel_shutdown(output, TRUE, &myError);
-                  g_io_channel_unref(output);
+                    g_io_channel_shutdown(output, TRUE, &myError);
+                    g_io_channel_unref(output);
 
-                  g_clear_error(&myError);
+                    g_clear_error(&myError);
 
-                  g_free(inputBuffer);
-                  g_free(outputBuffer);
+                    g_free(inputBuffer);
+                    g_free(outputBuffer);
 
-                  return 0;
+                    return 0;
                 }
 
             }
-          g_string_free(outputBuffer[i], TRUE);
-          g_string_free(inputBuffer[i], TRUE);
+            g_string_free(outputBuffer[i], TRUE);
+            g_string_free(inputBuffer[i], TRUE);
         }
     }
 
-  if ((entriesInFile % chunkLength) > 0)
+    if ((entriesInFile % chunkLength) > 0)
     {
-      for (guint64 i = 0; i < (entriesInFile % chunkLength); i++)
+        for (guint64 i = 0; i < (entriesInFile % chunkLength); i++)
         {
-          inputBuffer[i] = g_string_new(NULL);
-          status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
-          if (status != G_IO_STATUS_NORMAL)
+            inputBuffer[i] = g_string_new(NULL);
+            status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
+            if (status != G_IO_STATUS_NORMAL)
             {
-              cond_msg_error (myError, "[SLOG] ERROR: Cannot read from input file");
-              g_clear_error(&myError);
+                cond_msg_error (myError, "[SLOG] ERROR: Cannot read from input file");
+                g_clear_error(&myError);
 
-              g_io_channel_shutdown(input, TRUE, &myError);
-              g_io_channel_unref(input);
+                g_io_channel_shutdown(input, TRUE, &myError);
+                g_io_channel_unref(input);
 
-              g_clear_error(&myError);
+                g_clear_error(&myError);
 
-              g_io_channel_shutdown(output, TRUE, &myError);
-              g_io_channel_unref(output);
+                g_io_channel_shutdown(output, TRUE, &myError);
+                g_io_channel_unref(output);
 
-              g_clear_error(&myError);
+                g_clear_error(&myError);
 
-              g_free(inputBuffer);
-              g_free(outputBuffer);
+                g_free(inputBuffer);
+                g_free(outputBuffer);
 
-              return 0;
+                return 0;
             }
-          // Cut last character to remove the trailing new line
-          g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
+            // Cut last character to remove the trailing new line
+            g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
         }
-      ret = ret * iterateBuffer((entriesInFile % chunkLength), inputBuffer, &nextLogEntry, mainKey, keyZero, 0, outputBuffer,
-                                &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
+        ret = ret * iterateBuffer((entriesInFile % chunkLength), inputBuffer, &nextLogEntry, mainKey, keyZero, 0, outputBuffer,
+                                  &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
 
-      for (guint64 i = 0; i < (entriesInFile % chunkLength); i++)
+        for (guint64 i = 0; i < (entriesInFile % chunkLength); i++)
         {
-          if (outputBuffer[i]->len!=0)
+            if (outputBuffer[i]->len!=0)
             {
 
-              gsize size;
-              //Add newline
-              g_string_append(outputBuffer[i], "\n");
-              status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
-              if (status != G_IO_STATUS_NORMAL)
+                gsize size;
+                //Add newline
+                g_string_append(outputBuffer[i], "\n");
+                status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
+                if (status != G_IO_STATUS_NORMAL)
                 {
-                  cond_msg_error (myError, "[SLOG] ERROR: Cannot write to output file");
-                  g_clear_error(&myError);
+                    cond_msg_error (myError, "[SLOG] ERROR: Cannot write to output file");
+                    g_clear_error(&myError);
 
-                  g_io_channel_shutdown(input, TRUE, &myError);
-                  g_io_channel_unref(input);
+                    g_io_channel_shutdown(input, TRUE, &myError);
+                    g_io_channel_unref(input);
 
-                  g_clear_error(&myError);
+                    g_clear_error(&myError);
 
-                  g_io_channel_shutdown(output, TRUE, &myError);
-                  g_io_channel_unref(output);
+                    g_io_channel_shutdown(output, TRUE, &myError);
+                    g_io_channel_unref(output);
 
-                  g_clear_error(&myError);
+                    g_clear_error(&myError);
 
-                  g_free(inputBuffer);
-                  g_free(outputBuffer);
+                    g_free(inputBuffer);
+                    g_free(outputBuffer);
 
-                  return 0;
+                    return 0;
                 }
             }
-          g_string_free(outputBuffer[i], TRUE);
-          g_string_free(inputBuffer[i], TRUE);
+            g_string_free(outputBuffer[i], TRUE);
+            g_string_free(inputBuffer[i], TRUE);
         }
 
     }
 
-  ret = ret * finalizeVerify(startingEntry, entriesInFile, bigMac, cmac_tag, tab);
+    ret = ret * finalizeVerify(startingEntry, entriesInFile, bigMac, cmac_tag, tab);
 
-  g_free(inputBuffer);
-  g_free(outputBuffer);
+    g_free(inputBuffer);
+    g_free(outputBuffer);
 
-  g_io_channel_shutdown(input, TRUE, &myError);
-  g_io_channel_unref(input);
+    g_io_channel_shutdown(input, TRUE, &myError);
+    g_io_channel_unref(input);
 
-  g_clear_error(&myError);
+    g_clear_error(&myError);
 
-  g_io_channel_shutdown(output, TRUE, &myError);
-  g_io_channel_unref(output);
+    g_io_channel_shutdown(output, TRUE, &myError);
+    g_io_channel_unref(output);
 
-  g_clear_error(&myError);
+    g_clear_error(&myError);
 
-  return ret;
+    return ret;
 }
 
 // Print usage message and clean up
 int slog_usage(GOptionContext *ctx, GOptionGroup *grp, GString *errormsg)
 {
-  if(errormsg != NULL)
+    if(errormsg != NULL)
     {
-      g_print ("\nERROR: %s\n\n", errormsg->str);
-      g_string_free(errormsg, TRUE);
+        g_print ("\nERROR: %s\n\n", errormsg->str);
+        g_string_free(errormsg, TRUE);
     }
 
-  g_print("%s", g_option_context_get_help(ctx, TRUE, NULL));
-  g_option_context_free(ctx);
+    g_print("%s", g_option_context_get_help(ctx, TRUE, NULL));
+    g_option_context_free(ctx);
 
-  return 1;
+    return 1;
 }
 
 /*
@@ -1951,43 +2055,43 @@ int slog_usage(GOptionContext *ctx, GOptionGroup *grp, GString *errormsg)
  */
 gboolean validFileNameArg(const gchar *option_name, const gchar *value, gpointer data, GError **error)
 {
-  gboolean isValid = FALSE;
-  GString *currentOption = g_string_new(option_name);
-  GString *currentValue = g_string_new(value);
-  GString *longOption = g_string_new(LONG_OPT_INDICATOR);
-  GString *shortOption = g_string_new(SHORT_OPT_INDICATOR);
+    gboolean isValid = FALSE;
+    GString *currentOption = g_string_new(option_name);
+    GString *currentValue = g_string_new(value);
+    GString *longOption = g_string_new(LONG_OPT_INDICATOR);
+    GString *shortOption = g_string_new(SHORT_OPT_INDICATOR);
 
-  SLogOptions *opts = (SLogOptions *)data;
+    SLogOptions *opts = (SLogOptions *)data;
 
-  for(SLogOptions *option = opts; option != NULL && option->longname != NULL; option++)
+    for(SLogOptions *option = opts; option != NULL && option->longname != NULL; option++)
     {
-      g_string_append(longOption, option->longname);
-      g_string_append_c(shortOption, option->shortname);
+        g_string_append(longOption, option->longname);
+        g_string_append_c(shortOption, option->shortname);
 
-      if(g_string_equal(currentOption, longOption) || g_string_equal(currentOption, shortOption))
+        if(g_string_equal(currentOption, longOption) || g_string_equal(currentOption, shortOption))
         {
-          if(g_file_test(value, G_FILE_TEST_IS_REGULAR))
+            if(g_file_test(value, G_FILE_TEST_IS_REGULAR))
             {
-              option->arg = currentValue->str;
-              isValid = TRUE;
-              break;
+                option->arg = currentValue->str;
+                isValid = TRUE;
+                break;
             }
         }
 
-      // Reset for next option argument to check
-      g_string_assign(longOption, LONG_OPT_INDICATOR);
-      g_string_assign(shortOption, SHORT_OPT_INDICATOR);
+        // Reset for next option argument to check
+        g_string_assign(longOption, LONG_OPT_INDICATOR);
+        g_string_assign(shortOption, SHORT_OPT_INDICATOR);
     }
 
-  if (!isValid)
+    if (!isValid)
     {
-      *error = g_error_new(G_FILE_ERROR, G_OPTION_ERROR_FAILED, "Invalid path or non existing regular file: %s", value);
+        *error = g_error_new(G_FILE_ERROR, G_OPTION_ERROR_FAILED, "Invalid path or non existing regular file: %s", value);
     }
 
-  g_string_free(currentOption, TRUE);
-  g_string_free(currentValue, FALSE);
-  g_string_free(longOption, TRUE);
-  g_string_free(shortOption, TRUE);
+    g_string_free(currentOption, TRUE);
+    g_string_free(currentValue, FALSE);
+    g_string_free(longOption, TRUE);
+    g_string_free(shortOption, TRUE);
 
-  return isValid;
+    return isValid;
 }

--- a/modules/secure-logging/slog.c
+++ b/modules/secure-logging/slog.c
@@ -59,13 +59,13 @@ static unsigned char GAMMA[AES_BLOCKSIZE] = { [0 ... (AES_BLOCKSIZE-1) ] =  EPAD
 void cond_msg_error(GError *myError, char *errorMsg)
 {
 
-    if (myError==NULL)
+  if (myError==NULL)
     {
-        msg_error(errorMsg);
+      msg_error(errorMsg);
     }
-    else
+  else
     {
-        msg_error(errorMsg, evt_tag_str("error", myError->message));
+      msg_error(errorMsg, evt_tag_str("error", myError->message));
     }
 
 }
@@ -81,18 +81,18 @@ void cond_msg_error(GError *myError, char *errorMsg)
  */
 void deriveSubKeys(unsigned char *mainKey, unsigned char *encKey, unsigned char *MACKey)
 {
-    deriveEncSubKey(mainKey, encKey);
-    deriveMACSubKey(mainKey, MACKey);
+  deriveEncSubKey(mainKey, encKey);
+  deriveMACSubKey(mainKey, MACKey);
 }
 
 void deriveEncSubKey(unsigned char *mainKey, unsigned char *encKey)
 {
-    PRF(mainKey, KEYPATTERN, sizeof(KEYPATTERN), encKey, KEY_LENGTH);
+  PRF(mainKey, KEYPATTERN, sizeof(KEYPATTERN), encKey, KEY_LENGTH);
 }
 
 void deriveMACSubKey(unsigned char *mainKey, unsigned char *MACKey)
 {
-    PRF(mainKey, MACPATTERN, sizeof(MACPATTERN), MACKey, KEY_LENGTH);
+  PRF(mainKey, MACPATTERN, sizeof(MACPATTERN), MACKey, KEY_LENGTH);
 }
 
 
@@ -118,81 +118,81 @@ int sLogEncrypt(unsigned char *plaintext, int plaintext_len,
                 unsigned char *key, unsigned char *iv,
                 unsigned char *ciphertext, unsigned char *tag)
 {
-    /*
-     * This function is largely borrowed from
-     *
-     * https://wiki.openssl.org/index.php/EVP_Authenticated_Encryption_and_Decryption#Authenticated_Encryption_using_GCM_mode
-     *
-     */
-    EVP_CIPHER_CTX *ctx;
+  /*
+   * This function is largely borrowed from
+   *
+   * https://wiki.openssl.org/index.php/EVP_Authenticated_Encryption_and_Decryption#Authenticated_Encryption_using_GCM_mode
+   *
+   */
+  EVP_CIPHER_CTX *ctx;
 
-    int len;
-    int ciphertext_len;
+  int len;
+  int ciphertext_len;
 
-    /* Create and initialise the context */
-    if(!(ctx = EVP_CIPHER_CTX_new()))
+  /* Create and initialise the context */
+  if(!(ctx = EVP_CIPHER_CTX_new()))
     {
-        msg_error("[SLOG] ERROR: Unable to initialize OpenSSL context");
-        return 0;
+      msg_error("[SLOG] ERROR: Unable to initialize OpenSSL context");
+      return 0;
     }
 
-    /* Initialise the encryption operation. */
-    if(1 != EVP_EncryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL))
+  /* Initialise the encryption operation. */
+  if(1 != EVP_EncryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL))
     {
-        msg_error("[SLOG] ERROR: Unable to initialize OpenSSL context");
-        return 0;
+      msg_error("[SLOG] ERROR: Unable to initialize OpenSSL context");
+      return 0;
     }
 
-    if (IV_LENGTH!=12)
+  if (IV_LENGTH!=12)
     {
-        /* Set IV length if default 12 bytes (96 bits) is not appropriate */
-        if(1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, IV_LENGTH, NULL))
+      /* Set IV length if default 12 bytes (96 bits) is not appropriate */
+      if(1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, IV_LENGTH, NULL))
         {
-            msg_error("[SLOG] ERROR: Unable to set IV length");
-            return 0;
+          msg_error("[SLOG] ERROR: Unable to set IV length");
+          return 0;
         }
     }
 
-    /* Initialise key and IV */
-    if(1 != EVP_EncryptInit_ex(ctx, NULL, NULL, key, iv))
+  /* Initialise key and IV */
+  if(1 != EVP_EncryptInit_ex(ctx, NULL, NULL, key, iv))
     {
-        msg_error("[SLOG] ERROR: Unable to initialize encryption key and IV");
-        return 0;
+      msg_error("[SLOG] ERROR: Unable to initialize encryption key and IV");
+      return 0;
     }
 
-    /* Provide the message to be encrypted, and obtain the encrypted output.
-     * EVP_EncryptUpdate can be called multiple times if necessary
-     */
-    if(1 != EVP_EncryptUpdate(ctx, ciphertext, &len, plaintext, plaintext_len))
+  /* Provide the message to be encrypted, and obtain the encrypted output.
+   * EVP_EncryptUpdate can be called multiple times if necessary
+   */
+  if(1 != EVP_EncryptUpdate(ctx, ciphertext, &len, plaintext, plaintext_len))
     {
-        msg_error("[SLOG] ERROR: Unable to encrypt data");
-        return 0;
+      msg_error("[SLOG] ERROR: Unable to encrypt data");
+      return 0;
     }
 
-    ciphertext_len = len;
+  ciphertext_len = len;
 
-    /* Finalise the encryption. Normally ciphertext bytes may be written at
-     * this stage, but this does not occur in GCM mode
-     */
-    if(1 != EVP_EncryptFinal_ex(ctx, ciphertext + len, &len))
+  /* Finalise the encryption. Normally ciphertext bytes may be written at
+   * this stage, but this does not occur in GCM mode
+   */
+  if(1 != EVP_EncryptFinal_ex(ctx, ciphertext + len, &len))
     {
-        msg_error("[SLOG] ERROR: Unable to complete encryption of data");
-        return 0;
+      msg_error("[SLOG] ERROR: Unable to complete encryption of data");
+      return 0;
     }
 
-    ciphertext_len += len;
+  ciphertext_len += len;
 
-    /* Get the tag */
-    if(1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, AES_BLOCKSIZE, tag))
+  /* Get the tag */
+  if(1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, AES_BLOCKSIZE, tag))
     {
-        msg_error("[SLOG] ERROR: Unable to acquire encryption tag");
-        return 0;
+      msg_error("[SLOG] ERROR: Unable to acquire encryption tag");
+      return 0;
     }
 
-    /* Clean up */
-    EVP_CIPHER_CTX_free(ctx);
+  /* Clean up */
+  EVP_CIPHER_CTX_free(ctx);
 
-    return ciphertext_len;
+  return ciphertext_len;
 }
 
 /*
@@ -215,77 +215,77 @@ int sLogDecrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *ta
                 unsigned char *iv,
                 unsigned char *plaintext)
 {
-    EVP_CIPHER_CTX *ctx;
-    int len;
-    int plaintext_len;
-    int ret;
+  EVP_CIPHER_CTX *ctx;
+  int len;
+  int plaintext_len;
+  int ret;
 
-    /* Create and initialise the context */
-    if(!(ctx = EVP_CIPHER_CTX_new()))
+  /* Create and initialise the context */
+  if(!(ctx = EVP_CIPHER_CTX_new()))
     {
-        msg_error("[SLOG] ERROR: Unable to initialize OpenSSL context");
-        return 0;
+      msg_error("[SLOG] ERROR: Unable to initialize OpenSSL context");
+      return 0;
     }
 
-    /* Initialise the decryption operation. */
-    if(!EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL))
+  /* Initialise the decryption operation. */
+  if(!EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL))
     {
-        msg_error("[SLOG] ERROR: Unable initiate decryption operation");
-        return 0;
+      msg_error("[SLOG] ERROR: Unable initiate decryption operation");
+      return 0;
     }
 
-    if(IV_LENGTH!=12)
+  if(IV_LENGTH!=12)
     {
-        /* Set IV length. Not necessary if this is 12 bytes (96 bits) */
-        if(!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, IV_LENGTH, NULL))
+      /* Set IV length. Not necessary if this is 12 bytes (96 bits) */
+      if(!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, IV_LENGTH, NULL))
         {
-            msg_error("[SLOG] ERROR: Unable set IV length");
-            return 0;
+          msg_error("[SLOG] ERROR: Unable set IV length");
+          return 0;
         }
     }
 
-    /* Initialise key and IV */
-    if(!EVP_DecryptInit_ex(ctx, NULL, NULL, key, iv))
+  /* Initialise key and IV */
+  if(!EVP_DecryptInit_ex(ctx, NULL, NULL, key, iv))
     {
-        msg_error("[SLOG] ERROR: Unable to initialize key and IV");
-        return 0;
+      msg_error("[SLOG] ERROR: Unable to initialize key and IV");
+      return 0;
     }
 
-    /* Provide the message to be decrypted, and obtain the plaintext output.
-     * EVP_DecryptUpdate can be called multiple times if necessary
-     */
-    if(!EVP_DecryptUpdate(ctx, plaintext, &len, ciphertext, ciphertext_len))
+  /* Provide the message to be decrypted, and obtain the plaintext output.
+   * EVP_DecryptUpdate can be called multiple times if necessary
+   */
+  if(!EVP_DecryptUpdate(ctx, plaintext, &len, ciphertext, ciphertext_len))
     {
-        msg_error("Unable to decrypt");
-        return 0;
+      msg_error("Unable to decrypt");
+      return 0;
     }
 
-    plaintext_len = len;
+  plaintext_len = len;
 
-    /* Set expected tag value. Works in OpenSSL 1.0.1d and later */
-    if(!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, AES_BLOCKSIZE, tag))
+  /* Set expected tag value. Works in OpenSSL 1.0.1d and later */
+  if(!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, AES_BLOCKSIZE, tag))
     {
-        msg_error("[SLOG] ERROR: Unable set tag value");
-        return 0;
+      msg_error("[SLOG] ERROR: Unable set tag value");
+      return 0;
     }
 
-    /* Finalise the decryption. A positive return value indicates success,
-     * anything else is a failure - the plaintext is not trustworthy.
-     */
-    ret = EVP_DecryptFinal_ex(ctx, plaintext + len, &len);
+  /* Finalise the decryption. A positive return value indicates success,
+   * anything else is a failure - the plaintext is not trustworthy.
+   */
+  ret = EVP_DecryptFinal_ex(ctx, plaintext + len, &len);
 
-    /* Clean up */
-    EVP_CIPHER_CTX_free(ctx);
-    if(ret > 0)
+  /* Clean up */
+  EVP_CIPHER_CTX_free(ctx);
+  if(ret > 0)
     {
-        /* Success */
-        plaintext_len += len;
-        return plaintext_len;
+      /* Success */
+      plaintext_len += len;
+      return plaintext_len;
     }
-    else
+  else
     {
-        /* Verify failed */
-        return -1;
+      /* Verify failed */
+      return -1;
     }
 }
 
@@ -306,96 +306,96 @@ int sLogDecrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *ta
 void sLogEntry(guint64 numberOfLogEntries, GString *text, unsigned char *mainKey, unsigned char *inputBigMac,
                GString *output, unsigned char *outputBigMac, gsize outputBigMac_capacity)
 {
-    int slen = (int) text->len;
+  int slen = (int) text->len;
 
-    // This buffer holds everything: AggregatedMAC, IV, Tag, and CText
-    // Binary data cannot be larger than its base64 encoding
-    unsigned char* bigBuf = g_new0(unsigned char, AES_BLOCKSIZE+IV_LENGTH+AES_BLOCKSIZE+slen);
+  // This buffer holds everything: AggregatedMAC, IV, Tag, and CText
+  // Binary data cannot be larger than its base64 encoding
+  unsigned char *bigBuf = g_new0(unsigned char, AES_BLOCKSIZE+IV_LENGTH+AES_BLOCKSIZE+slen);
 
-    if (bigBuf == NULL)
+  if (bigBuf == NULL)
     {
-        const char* error_msg ="[SLOG] ERROR: Unable to allocate memory buffer";
-        msg_error(error_msg);
+      const char *error_msg ="[SLOG] ERROR: Unable to allocate memory buffer";
+      msg_error(error_msg);
 
-        g_string_printf(output, "%s", error_msg);
+      g_string_printf(output, "%s", error_msg);
 
-        return;
+      return;
     }
 
-    unsigned char encKey[KEY_LENGTH];
-    unsigned char MACKey[KEY_LENGTH];
-    deriveSubKeys(mainKey, encKey, MACKey);
+  unsigned char encKey[KEY_LENGTH];
+  unsigned char MACKey[KEY_LENGTH];
+  deriveSubKeys(mainKey, encKey, MACKey);
 
-    // Compute current log entry number
-    gchar *counterString = convertToBase64((unsigned char *)&numberOfLogEntries, sizeof(numberOfLogEntries));
+  // Compute current log entry number
+  gchar *counterString = convertToBase64((unsigned char *)&numberOfLogEntries, sizeof(numberOfLogEntries));
 
-    // This is where are ciphertext related data starts
-    unsigned char *ctBuf = &bigBuf[AES_BLOCKSIZE];
-    unsigned char *iv = ctBuf;
-    unsigned char *tag = &bigBuf[AES_BLOCKSIZE+IV_LENGTH];
-    unsigned char *ciphertext = &bigBuf[AES_BLOCKSIZE+IV_LENGTH+AES_BLOCKSIZE];
+  // This is where are ciphertext related data starts
+  unsigned char *ctBuf = &bigBuf[AES_BLOCKSIZE];
+  unsigned char *iv = ctBuf;
+  unsigned char *tag = &bigBuf[AES_BLOCKSIZE+IV_LENGTH];
+  unsigned char *ciphertext = &bigBuf[AES_BLOCKSIZE+IV_LENGTH+AES_BLOCKSIZE];
 
-    // Generate random nonce
-    if (RAND_bytes(iv, IV_LENGTH)==1)
+  // Generate random nonce
+  if (RAND_bytes(iv, IV_LENGTH)==1)
     {
 
-        // Encrypt log data
-        int ct_length = sLogEncrypt((guchar *)text->str, slen, encKey, iv, ciphertext, tag);
-        if(ct_length <= 0)
+      // Encrypt log data
+      int ct_length = sLogEncrypt((guchar *)text->str, slen, encKey, iv, ciphertext, tag);
+      if(ct_length <= 0)
         {
-            msg_error("[SLOG] ERROR: Unable to correctly encrypt log message");
+          msg_error("[SLOG] ERROR: Unable to correctly encrypt log message");
 
-            g_string_printf(output, "%*.*s:%s: %s", COUNTER_LENGTH, COUNTER_LENGTH, counterString,
-                            "[SLOG] ERROR: Unable to correctly encrypt the following log message:", text->str);
+          g_string_printf(output, "%*.*s:%s: %s", COUNTER_LENGTH, COUNTER_LENGTH, counterString,
+                          "[SLOG] ERROR: Unable to correctly encrypt the following log message:", text->str);
 
-            // Free resources
-            g_free(counterString);
-            g_free(bigBuf);
+          // Free resources
+          g_free(counterString);
+          g_free(bigBuf);
 
-            return;
+          return;
         }
 
-        // Write current log entry number
-        g_string_printf (output, "%*.*s:", COUNTER_LENGTH, COUNTER_LENGTH, counterString);
-        g_free(counterString);
+      // Write current log entry number
+      g_string_printf (output, "%*.*s:", COUNTER_LENGTH, COUNTER_LENGTH, counterString);
+      g_free(counterString);
 
 
-        // Write IV, tag, and ciphertext at once
-        gchar *encodedCtBuf = convertToBase64(ctBuf, IV_LENGTH+AES_BLOCKSIZE+ct_length);
-        g_string_append(output, encodedCtBuf);
-        g_free(encodedCtBuf);
+      // Write IV, tag, and ciphertext at once
+      gchar *encodedCtBuf = convertToBase64(ctBuf, IV_LENGTH+AES_BLOCKSIZE+ct_length);
+      g_string_append(output, encodedCtBuf);
+      g_free(encodedCtBuf);
 
-        // Compute aggregated MAC
-        // Not the first aggregated MAC
-        if (numberOfLogEntries>0)
+      // Compute aggregated MAC
+      // Not the first aggregated MAC
+      if (numberOfLogEntries>0)
         {
-            memcpy(bigBuf, inputBigMac, AES_BLOCKSIZE);
+          memcpy(bigBuf, inputBigMac, AES_BLOCKSIZE);
 
-            gsize outlen;
-            cmac(MACKey, bigBuf, AES_BLOCKSIZE+IV_LENGTH+AES_BLOCKSIZE+ct_length, outputBigMac, &outlen, outputBigMac_capacity);
+          gsize outlen;
+          cmac(MACKey, bigBuf, AES_BLOCKSIZE+IV_LENGTH+AES_BLOCKSIZE+ct_length, outputBigMac, &outlen, outputBigMac_capacity);
         }
-        else   // First aggregated MAC
+      else   // First aggregated MAC
         {
-            gsize outlen = 0;
+          gsize outlen = 0;
 
-            cmac(MACKey, bigBuf+AES_BLOCKSIZE, IV_LENGTH+AES_BLOCKSIZE+ct_length, outputBigMac, &outlen, outputBigMac_capacity);
+          cmac(MACKey, bigBuf+AES_BLOCKSIZE, IV_LENGTH+AES_BLOCKSIZE+ct_length, outputBigMac, &outlen, outputBigMac_capacity);
         }
     }
-    else
+  else
     {
-        // We did not get enough random bytes
-        msg_error("[SLOG] ERROR: Could not obtain enough random bytes");
+      // We did not get enough random bytes
+      msg_error("[SLOG] ERROR: Could not obtain enough random bytes");
 
-        g_string_printf(output, "%*.*s:%s: %s", COUNTER_LENGTH, COUNTER_LENGTH, counterString,
-                        "[SLOG] ERROR: Could not obtain enough random bytes for the following log message:", text->str);
-        g_free(counterString);
+      g_string_printf(output, "%*.*s:%s: %s", COUNTER_LENGTH, COUNTER_LENGTH, counterString,
+                      "[SLOG] ERROR: Could not obtain enough random bytes for the following log message:", text->str);
+      g_free(counterString);
 
-        // MAC cannot contain meaningful data -> Initialize contents
-        memset(outputBigMac, 0, outputBigMac_capacity);
+      // MAC cannot contain meaningful data -> Initialize contents
+      memset(outputBigMac, 0, outputBigMac_capacity);
     }
 
-    // Free buffer
-    g_free(bigBuf);
+  // Free buffer
+  g_free(bigBuf);
 }
 
 /*
@@ -410,20 +410,20 @@ void sLogEntry(guint64 numberOfLogEntries, GString *text, unsigned char *mainKey
  */
 void deriveKey(unsigned char *dst, guint64 index, guint64 currentKey)
 {
-    for (guint64 i = currentKey; i<index; i++)
+  for (guint64 i = currentKey; i<index; i++)
     {
-        evolveKey(dst);
+      evolveKey(dst);
     }
 }
 
 guchar *convertToBin(char *input, gsize *outLen)
 {
-    return g_base64_decode ((const gchar *) input, outLen);
+  return g_base64_decode ((const gchar *) input, outLen);
 }
 
 gchar *convertToBase64(unsigned char *input, gsize len)
 {
-    return  g_base64_encode ((const guchar *) input, len);
+  return  g_base64_encode ((const guchar *) input, len);
 }
 
 /*
@@ -444,31 +444,31 @@ gchar *convertToBase64(unsigned char *input, gsize len)
 void cmac(unsigned char *key, const void *input, gsize length, unsigned char *out, gsize *outlen, gsize out_capacity)
 {
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-    EVP_MAC *mac = EVP_MAC_fetch(NULL, "CMAC", NULL);
-    OSSL_PARAM params[] =
-    {
-        OSSL_PARAM_utf8_string("cipher", "aes-256-cbc", 0),
-        OSSL_PARAM_END,
-    };
+  EVP_MAC *mac = EVP_MAC_fetch(NULL, "CMAC", NULL);
+  OSSL_PARAM params[] =
+  {
+    OSSL_PARAM_utf8_string("cipher", "aes-256-cbc", 0),
+    OSSL_PARAM_END,
+  };
 
-    EVP_MAC_CTX *ctx = EVP_MAC_CTX_new(mac);
+  EVP_MAC_CTX *ctx = EVP_MAC_CTX_new(mac);
 
-    EVP_MAC_init(ctx, key, KEY_LENGTH, params);
-    EVP_MAC_update(ctx, input, length);
-    EVP_MAC_final(ctx, out, outlen, out_capacity);
+  EVP_MAC_init(ctx, key, KEY_LENGTH, params);
+  EVP_MAC_update(ctx, input, length);
+  EVP_MAC_final(ctx, out, outlen, out_capacity);
 
-    EVP_MAC_CTX_free(ctx);
-    EVP_MAC_free(mac);
+  EVP_MAC_CTX_free(ctx);
+  EVP_MAC_free(mac);
 #else
-    CMAC_CTX *ctx = CMAC_CTX_new();
+  CMAC_CTX *ctx = CMAC_CTX_new();
 
-    CMAC_Init(ctx, key, KEY_LENGTH, EVP_aes_256_cbc(), NULL);
-    CMAC_Update(ctx, input, length);
+  CMAC_Init(ctx, key, KEY_LENGTH, EVP_aes_256_cbc(), NULL);
+  CMAC_Update(ctx, input, length);
 
-    size_t out_len;
-    CMAC_Final(ctx, out, &out_len);
-    *outlen = out_len;
-    CMAC_CTX_free(ctx);
+  size_t out_len;
+  CMAC_Final(ctx, out, &out_len);
+  *outlen = out_len;
+  CMAC_CTX_free(ctx);
 #endif
 }
 
@@ -483,9 +483,9 @@ void cmac(unsigned char *key, const void *input, gsize length, unsigned char *ou
 void evolveKey(unsigned char *key)
 {
 
-    unsigned char buf[KEY_LENGTH];
-    PRF(key, GAMMA, sizeof(GAMMA), buf, KEY_LENGTH);
-    memcpy(key, buf, KEY_LENGTH);
+  unsigned char buf[KEY_LENGTH];
+  PRF(key, GAMMA, sizeof(GAMMA), buf, KEY_LENGTH);
+  memcpy(key, buf, KEY_LENGTH);
 }
 
 /*
@@ -504,72 +504,72 @@ void evolveKey(unsigned char *key)
 void PRF(unsigned char *key, unsigned char *originalInput, guint64 inputLength, unsigned char *output,
          guint64 outputLength)
 {
-    // Define data type sizes
-    gsize gs = sizeof(gsize);
-    gsize gsout = sizeof(outputLength);
+  // Define data type sizes
+  gsize gs = sizeof(gsize);
+  gsize gsout = sizeof(outputLength);
 
-    // First, extraction
-    guchar ktmp[KEY_LENGTH]; // Temporary key
+  // First, extraction
+  guchar ktmp[KEY_LENGTH]; // Temporary key
 
-    // Initialize to all zero, in case CMAC_LENGTH < KEY_LENGTH
-    bzero(ktmp, KEY_LENGTH);
-    gsize outlen = -1;
+  // Initialize to all zero, in case CMAC_LENGTH < KEY_LENGTH
+  bzero(ktmp, KEY_LENGTH);
+  gsize outlen = -1;
 
-    // Assume that KEY_LENGTH >= CMAC_LENGTH
-    cmac(key, originalInput, inputLength, ktmp, &outlen, CMAC_LENGTH);
+  // Assume that KEY_LENGTH >= CMAC_LENGTH
+  cmac(key, originalInput, inputLength, ktmp, &outlen, CMAC_LENGTH);
 
-    // Then, expansion
-    gsize n = outputLength / CMAC_LENGTH;
+  // Then, expansion
+  gsize n = outputLength / CMAC_LENGTH;
 
-    gchar label[] = "key-expansion";
-    gchar context[] = "none";
-    gsize label_len = strlen(label);
-    gsize context_len = strlen(context);
+  gchar label[] = "key-expansion";
+  gchar context[] = "none";
+  gsize label_len = strlen(label);
+  gsize context_len = strlen(context);
 
-    // Total space needed for i || Label || 00 || Context || outputLength;
-    gsize total_input_length = gs + label_len + 1 + context_len + gsout;
-    guchar input[total_input_length];
+  // Total space needed for i || Label || 00 || Context || outputLength;
+  gsize total_input_length = gs + label_len + 1 + context_len + gsout;
+  guchar input[total_input_length];
 
-    for (gsize i = 0 ; i < n ; i++)
-      {
-        // input = i || Label || 00 || Context || outputLength;
+  for (gsize i = 0 ; i < n ; i++)
+    {
+      // input = i || Label || 00 || Context || outputLength;
 
-        // Write input chunk and label
-        memcpy(input, &i, gs);
-        memcpy(input + gs, label, label_len);
+      // Write input chunk and label
+      memcpy(input, &i, gs);
+      memcpy(input + gs, label, label_len);
 
-        // Write the 0x00 byte
-        *(input + gs + label_len) = 0;
+      // Write the 0x00 byte
+      *(input + gs + label_len) = 0;
 
-        // Write the context and output
-        memcpy(input + gs + label_len + 1, context, context_len);
-        memcpy(input + gs + label_len + 1 + context_len, &outputLength, gsout);
+      // Write the context and output
+      memcpy(input + gs + label_len + 1, context, context_len);
+      memcpy(input + gs + label_len + 1 + context_len, &outputLength, gsout);
 
-        // Finally apply the CMAC
-        cmac(ktmp, input, total_input_length, output + (i*CMAC_LENGTH), &outlen, CMAC_LENGTH);
-      }
+      // Finally apply the CMAC
+      cmac(ktmp, input, total_input_length, output + (i*CMAC_LENGTH), &outlen, CMAC_LENGTH);
+    }
 
-    // Finalize the output
-    if (outputLength % CMAC_LENGTH != 0)
-      {
-        guchar buf[CMAC_LENGTH];
+  // Finalize the output
+  if (outputLength % CMAC_LENGTH != 0)
+    {
+      guchar buf[CMAC_LENGTH];
 
-        // Write last input chunk and label
-        memcpy(input, &n, gs);
-        memcpy(input + gs, label, label_len);
+      // Write last input chunk and label
+      memcpy(input, &n, gs);
+      memcpy(input + gs, label, label_len);
 
-        // Write the 0x00 byte
-        *(input + gs + label_len) = 0;
+      // Write the 0x00 byte
+      *(input + gs + label_len) = 0;
 
-        // Write the context and output
-        memcpy(input + gs + label_len + 1, context, context_len);
-        memcpy(input + gs + label_len + 1 + context_len, &outputLength, gsout);
-        // Apply the final CMAC
-        cmac(ktmp, input, total_input_length, buf, &outlen, CMAC_LENGTH);
+      // Write the context and output
+      memcpy(input + gs + label_len + 1, context, context_len);
+      memcpy(input + gs + label_len + 1 + context_len, &outputLength, gsout);
+      // Apply the final CMAC
+      cmac(ktmp, input, total_input_length, buf, &outlen, CMAC_LENGTH);
 
-        // Copy result to output buffer
-        memcpy(output + n * CMAC_LENGTH, buf, outputLength % CMAC_LENGTH);
-      }
+      // Copy result to output buffer
+      memcpy(output + n * CMAC_LENGTH, buf, outputLength % CMAC_LENGTH);
+    }
 }
 
 /*
@@ -584,7 +584,7 @@ void PRF(unsigned char *key, unsigned char *originalInput, guint64 inputLength, 
  */
 int generateMasterKey(guchar *masterkey)
 {
-    return RAND_bytes(masterkey, KEY_LENGTH);
+  return RAND_bytes(masterkey, KEY_LENGTH);
 }
 
 /*
@@ -608,46 +608,46 @@ int deriveHostKey(guchar *masterkey, gchar *macAddr, gchar *serial, guchar *host
 {
 
 #ifdef newDeriveHostKey
-    gchar concatString[strlen(macAddr) + strlen(serial) + 1];
-    strncpy(concatString, macAddr, strlen(macAddr));
-    strncat(concatString, serial, strlen(serial));
+  gchar concatString[strlen(macAddr) + strlen(serial) + 1];
+  strncpy(concatString, macAddr, strlen(macAddr));
+  strncat(concatString, serial, strlen(serial));
 
-    PRF(masterkey, (guchar*) concatString, strlen(concatString), hostkey, KEY_LENGTH);
+  PRF(masterkey, (guchar *) concatString, strlen(concatString), hostkey, KEY_LENGTH);
 
-    return 1;
+  return 1;
 #else
-    EVP_MD_CTX *ctx;
+  EVP_MD_CTX *ctx;
 
-    if((ctx = EVP_MD_CTX_create()) == NULL)
-        return 0;
+  if((ctx = EVP_MD_CTX_create()) == NULL)
+    return 0;
 
-    if(1 != EVP_DigestInit_ex(ctx, EVP_sha256(), NULL))
-        return 0;
+  if(1 != EVP_DigestInit_ex(ctx, EVP_sha256(), NULL))
+    return 0;
 
-    if(1 != EVP_DigestUpdate(ctx, masterkey, KEY_LENGTH))
-        return 0;
+  if(1 != EVP_DigestUpdate(ctx, masterkey, KEY_LENGTH))
+    return 0;
 
-    if(1 != EVP_DigestUpdate(ctx, macAddr, strlen(macAddr)))
-        return 0;
+  if(1 != EVP_DigestUpdate(ctx, macAddr, strlen(macAddr)))
+    return 0;
 
-    if(1 != EVP_DigestUpdate(ctx, serial, strlen(serial)))
-        return 0;
+  if(1 != EVP_DigestUpdate(ctx, serial, strlen(serial)))
+    return 0;
 
-    if(KEY_LENGTH != SHA256_DIGEST_LENGTH)
+  if(KEY_LENGTH != SHA256_DIGEST_LENGTH)
     {
-        msg_error("[SLOG] ERROR: Error in updating digest");
-        g_assert_not_reached();
-        return 0;
+      msg_error("[SLOG] ERROR: Error in updating digest");
+      g_assert_not_reached();
+      return 0;
     }
 
-    guint digest_len = KEY_LENGTH;
+  guint digest_len = KEY_LENGTH;
 
-    if(1 != EVP_DigestFinal_ex(ctx, hostkey, &digest_len))
-        return 0;
+  if(1 != EVP_DigestFinal_ex(ctx, hostkey, &digest_len))
+    return 0;
 
-    EVP_MD_CTX_destroy(ctx);
+  EVP_MD_CTX_destroy(ctx);
 
-    return 1;
+  return 1;
 #endif
 }
 
@@ -660,93 +660,93 @@ int deriveHostKey(guchar *masterkey, gchar *macAddr, gchar *serial, guchar *host
  */
 int writeBigMAC(gchar *filename, char *outputBuffer)
 {
-    GError *error = NULL;
+  GError *error = NULL;
 
-    GIOChannel *macfile = g_io_channel_new_file(filename, "w+", &error);
-    if(!macfile)
+  GIOChannel *macfile = g_io_channel_new_file(filename, "w+", &error);
+  if(!macfile)
     {
-        msg_error("[SLOG] ERROR: Unable open MAC file",
-                  evt_tag_str("base_dir", filename));
-        cond_msg_error(error, "Additional Information");
+      msg_error("[SLOG] ERROR: Unable open MAC file",
+                evt_tag_str("base_dir", filename));
+      cond_msg_error(error, "Additional Information");
 
-        g_clear_error(&error);
+      g_clear_error(&error);
 
-        return 0;
+      return 0;
     }
 
-    GIOStatus status = g_io_channel_set_encoding(macfile, NULL, &error);
-    if(status != G_IO_STATUS_NORMAL)
+  GIOStatus status = g_io_channel_set_encoding(macfile, NULL, &error);
+  if(status != G_IO_STATUS_NORMAL)
     {
-        msg_error("[SLOG] ERROR: Unable to set encoding for MAC data",
-                  evt_tag_str("File", filename));
-        cond_msg_error(error, "Additional information");
+      msg_error("[SLOG] ERROR: Unable to set encoding for MAC data",
+                evt_tag_str("File", filename));
+      cond_msg_error(error, "Additional information");
 
-        g_clear_error(&error);
+      g_clear_error(&error);
 
-        g_io_channel_shutdown(macfile, TRUE, &error);
-        g_io_channel_unref(macfile);
+      g_io_channel_shutdown(macfile, TRUE, &error);
+      g_io_channel_unref(macfile);
 
-        g_clear_error(&error);
+      g_clear_error(&error);
 
-        return 0;
+      return 0;
     }
 
-    gsize outlen = 0;
-    status = g_io_channel_write_chars(macfile, outputBuffer, CMAC_LENGTH, &outlen, &error);
-    if(status != G_IO_STATUS_NORMAL)
+  gsize outlen = 0;
+  status = g_io_channel_write_chars(macfile, outputBuffer, CMAC_LENGTH, &outlen, &error);
+  if(status != G_IO_STATUS_NORMAL)
     {
-        msg_error("[SLOG] ERROR: Unable to write big MAC data",
-                  evt_tag_str("File", filename));
-        cond_msg_error(error, "Additional information");
+      msg_error("[SLOG] ERROR: Unable to write big MAC data",
+                evt_tag_str("File", filename));
+      cond_msg_error(error, "Additional information");
 
-        g_clear_error(&error);
+      g_clear_error(&error);
 
-        g_io_channel_shutdown(macfile, TRUE, &error);
-        g_io_channel_unref(macfile);
+      g_io_channel_shutdown(macfile, TRUE, &error);
+      g_io_channel_unref(macfile);
 
-        g_clear_error(&error);
+      g_clear_error(&error);
 
-        return 0;
+      return 0;
     }
 
-    // Compute aggregated MAC
-    gchar outputmacdata[CMAC_LENGTH];
-    gsize outputmacdata_capacity = G_N_ELEMENTS(outputmacdata);
-    unsigned char keyBuffer[KEY_LENGTH];
-    bzero(keyBuffer, KEY_LENGTH);
-    unsigned char zeroBuffer[CMAC_LENGTH];
-    bzero(zeroBuffer, CMAC_LENGTH);
-    memcpy(keyBuffer, outputBuffer, MIN(CMAC_LENGTH, KEY_LENGTH));
-    cmac(keyBuffer, zeroBuffer, CMAC_LENGTH, (guchar *)outputmacdata, &outlen, outputmacdata_capacity);
+  // Compute aggregated MAC
+  gchar outputmacdata[CMAC_LENGTH];
+  gsize outputmacdata_capacity = G_N_ELEMENTS(outputmacdata);
+  unsigned char keyBuffer[KEY_LENGTH];
+  bzero(keyBuffer, KEY_LENGTH);
+  unsigned char zeroBuffer[CMAC_LENGTH];
+  bzero(zeroBuffer, CMAC_LENGTH);
+  memcpy(keyBuffer, outputBuffer, MIN(CMAC_LENGTH, KEY_LENGTH));
+  cmac(keyBuffer, zeroBuffer, CMAC_LENGTH, (guchar *)outputmacdata, &outlen, outputmacdata_capacity);
 
-    status = g_io_channel_write_chars(macfile, outputmacdata, CMAC_LENGTH, &outlen, &error);
+  status = g_io_channel_write_chars(macfile, outputmacdata, CMAC_LENGTH, &outlen, &error);
 
-    if(status != G_IO_STATUS_NORMAL)
+  if(status != G_IO_STATUS_NORMAL)
     {
-        msg_error("[SLOG] ERROR: Unable to write aggregated MAC",
-                  evt_tag_str("File", filename));
-        cond_msg_error(error, "Additional information");
+      msg_error("[SLOG] ERROR: Unable to write aggregated MAC",
+                evt_tag_str("File", filename));
+      cond_msg_error(error, "Additional information");
 
-        g_clear_error(&error);
+      g_clear_error(&error);
 
-        g_io_channel_shutdown(macfile, TRUE, &error);
-        g_io_channel_unref(macfile);
+      g_io_channel_shutdown(macfile, TRUE, &error);
+      g_io_channel_unref(macfile);
 
-        g_clear_error(&error);
+      g_clear_error(&error);
 
-        return 0;
+      return 0;
     }
-    status = g_io_channel_shutdown(macfile, TRUE, &error);
-    g_io_channel_unref(macfile);
+  status = g_io_channel_shutdown(macfile, TRUE, &error);
+  g_io_channel_unref(macfile);
 
-    if(status != G_IO_STATUS_NORMAL)
+  if(status != G_IO_STATUS_NORMAL)
     {
-        cond_msg_error(error, "[SLOG] ERROR: Cannot close aggregated MAC");
+      cond_msg_error(error, "[SLOG] ERROR: Cannot close aggregated MAC");
 
-        g_clear_error(&error);
+      g_clear_error(&error);
     }
 
-    return 1;
+  return 1;
 }
 
 /*
@@ -758,92 +758,92 @@ int writeBigMAC(gchar *filename, char *outputBuffer)
  */
 int readBigMAC(gchar *filename, char *outputBuffer)
 {
-    GError *myError = NULL;
+  GError *myError = NULL;
 
-    GIOChannel *macfile = g_io_channel_new_file(filename, "r", &myError);
+  GIOChannel *macfile = g_io_channel_new_file(filename, "r", &myError);
 
-    if(!macfile)
+  if(!macfile)
     {
-        // MAC file does not exist -> New MAC file will be created
-        g_clear_error(&myError);
+      // MAC file does not exist -> New MAC file will be created
+      g_clear_error(&myError);
 
-        return 0;
+      return 0;
     }
 
-    GIOStatus status = g_io_channel_set_encoding(macfile, NULL, &myError);
-    if (status != G_IO_STATUS_NORMAL)
+  GIOStatus status = g_io_channel_set_encoding(macfile, NULL, &myError);
+  if (status != G_IO_STATUS_NORMAL)
     {
-        cond_msg_error(myError, "[SLOG] ERROR: Cannot set encoding of MAC file");
-        g_clear_error(&myError);
+      cond_msg_error(myError, "[SLOG] ERROR: Cannot set encoding of MAC file");
+      g_clear_error(&myError);
 
-        g_io_channel_shutdown(macfile, TRUE, &myError);
-        g_io_channel_unref(macfile);
+      g_io_channel_shutdown(macfile, TRUE, &myError);
+      g_io_channel_unref(macfile);
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        return 0;
+      return 0;
     }
 
-    gchar macdata[2*CMAC_LENGTH];
-    gsize mac_bytes_read = 0;
+  gchar macdata[2*CMAC_LENGTH];
+  gsize mac_bytes_read = 0;
 
-    status = g_io_channel_read_chars(macfile, macdata, 2*CMAC_LENGTH, &mac_bytes_read, &myError);
-    if(status != G_IO_STATUS_NORMAL)
+  status = g_io_channel_read_chars(macfile, macdata, 2*CMAC_LENGTH, &mac_bytes_read, &myError);
+  if(status != G_IO_STATUS_NORMAL)
     {
-        cond_msg_error(myError, "[SLOG] ERROR: Cannot read MAC file");
+      cond_msg_error(myError, "[SLOG] ERROR: Cannot read MAC file");
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        g_io_channel_shutdown(macfile, TRUE, &myError);
-        g_io_channel_unref(macfile);
+      g_io_channel_shutdown(macfile, TRUE, &myError);
+      g_io_channel_unref(macfile);
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        return 0;
+      return 0;
     }
 
-    status = g_io_channel_shutdown(macfile, TRUE, &myError);
-    g_io_channel_unref(macfile);
+  status = g_io_channel_shutdown(macfile, TRUE, &myError);
+  g_io_channel_unref(macfile);
 
-    if(status != G_IO_STATUS_NORMAL)
+  if(status != G_IO_STATUS_NORMAL)
     {
-        msg_error("[SLOG] ERROR: Cannot close MAC file");
+      msg_error("[SLOG] ERROR: Cannot close MAC file");
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        return 0;
+      return 0;
     }
 
-    if (mac_bytes_read!=2*CMAC_LENGTH)
+  if (mac_bytes_read!=2*CMAC_LENGTH)
     {
-        msg_error("[SLOG] ERROR: $(slog) parsing failed, invalid size of MAC file");
-        return 0;
+      msg_error("[SLOG] ERROR: $(slog) parsing failed, invalid size of MAC file");
+      return 0;
     }
 
-    gsize outlen = 0;
-    unsigned char keyBuffer[KEY_LENGTH];
-    bzero(keyBuffer, KEY_LENGTH);
-    unsigned char zeroBuffer[CMAC_LENGTH];
-    bzero(zeroBuffer, CMAC_LENGTH);
-    memcpy(keyBuffer, macdata, MIN(CMAC_LENGTH, KEY_LENGTH));
+  gsize outlen = 0;
+  unsigned char keyBuffer[KEY_LENGTH];
+  bzero(keyBuffer, KEY_LENGTH);
+  unsigned char zeroBuffer[CMAC_LENGTH];
+  bzero(zeroBuffer, CMAC_LENGTH);
+  memcpy(keyBuffer, macdata, MIN(CMAC_LENGTH, KEY_LENGTH));
 
-    unsigned char testOutput[CMAC_LENGTH];
-    gsize testOutput_capacity = G_N_ELEMENTS(testOutput);
-    cmac(keyBuffer, zeroBuffer, CMAC_LENGTH, testOutput, &outlen, testOutput_capacity);
+  unsigned char testOutput[CMAC_LENGTH];
+  gsize testOutput_capacity = G_N_ELEMENTS(testOutput);
+  cmac(keyBuffer, zeroBuffer, CMAC_LENGTH, testOutput, &outlen, testOutput_capacity);
 
-    if (0 != memcmp(testOutput, &macdata[CMAC_LENGTH], CMAC_LENGTH))
+  if (0 != memcmp(testOutput, &macdata[CMAC_LENGTH], CMAC_LENGTH))
     {
-        msg_warning("[SLOG] ERROR: MAC computation invalid");
-        return 0;
+      msg_warning("[SLOG] ERROR: MAC computation invalid");
+      return 0;
     }
-    else
+  else
     {
-        msg_info("[SLOG] INFO: MAC successfully loaded");
+      msg_info("[SLOG] INFO: MAC successfully loaded");
     }
 
-    memcpy(outputBuffer, macdata, CMAC_LENGTH);
+  memcpy(outputBuffer, macdata, CMAC_LENGTH);
 
-    return 1;
+  return 1;
 }
 
 /*
@@ -856,116 +856,116 @@ int readBigMAC(gchar *filename, char *outputBuffer)
 int readKey(char *destKey, guint64 *destCounter, gchar *keypath)
 {
 
-    GError *myError = NULL;
+  GError *myError = NULL;
 
-    GIOChannel *keyfile = g_io_channel_new_file(keypath, "r", &myError);
+  GIOChannel *keyfile = g_io_channel_new_file(keypath, "r", &myError);
 
-    if (!keyfile)
+  if (!keyfile)
     {
-        cond_msg_error(myError, "[SLOG] ERROR: Key file not found");
-        g_clear_error(&myError);
+      cond_msg_error(myError, "[SLOG] ERROR: Key file not found");
+      g_clear_error(&myError);
 
-        return 0;
+      return 0;
     }
 
-    GIOStatus status = g_io_channel_set_encoding(keyfile, NULL, &myError);
+  GIOStatus status = g_io_channel_set_encoding(keyfile, NULL, &myError);
 
-    if(status != G_IO_STATUS_NORMAL)
+  if(status != G_IO_STATUS_NORMAL)
     {
-        cond_msg_error(myError, "[SLOG] ERROR: Unable to set encoding for key file");
-        g_clear_error(&myError);
+      cond_msg_error(myError, "[SLOG] ERROR: Unable to set encoding for key file");
+      g_clear_error(&myError);
 
-        g_io_channel_shutdown(keyfile, TRUE, &myError);
-        g_io_channel_unref(keyfile);
+      g_io_channel_shutdown(keyfile, TRUE, &myError);
+      g_io_channel_unref(keyfile);
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
 
-        return 0;
+      return 0;
     }
 
-    // Key file contains
-    // 1. the number of log entries already logged (and therewith the index of the key); this is at the end of the key file
-    // 2. the actual 32 byte key, this is at the beginning of the key file
-    // 3. a 16 byte CMAC of the two previous data, this is stored after the key
+  // Key file contains
+  // 1. the number of log entries already logged (and therewith the index of the key); this is at the end of the key file
+  // 2. the actual 32 byte key, this is at the beginning of the key file
+  // 3. a 16 byte CMAC of the two previous data, this is stored after the key
 
-    gchar keydata[KEY_LENGTH + CMAC_LENGTH];
-    gsize key_bytes_read = 0;
+  gchar keydata[KEY_LENGTH + CMAC_LENGTH];
+  gsize key_bytes_read = 0;
 
-    status = g_io_channel_read_chars(keyfile, keydata, KEY_LENGTH + CMAC_LENGTH, &key_bytes_read, &myError);
+  status = g_io_channel_read_chars(keyfile, keydata, KEY_LENGTH + CMAC_LENGTH, &key_bytes_read, &myError);
 
-    if (status != G_IO_STATUS_NORMAL)
+  if (status != G_IO_STATUS_NORMAL)
     {
-        cond_msg_error(myError, "[SLOG] ERROR: Cannot read from key file");
+      cond_msg_error(myError, "[SLOG] ERROR: Cannot read from key file");
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        g_io_channel_shutdown(keyfile, TRUE, &myError);
-        g_io_channel_unref(keyfile);
+      g_io_channel_shutdown(keyfile, TRUE, &myError);
+      g_io_channel_unref(keyfile);
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        return 0;
+      return 0;
 
     }
 
-    if (key_bytes_read!=KEY_LENGTH+CMAC_LENGTH)
+  if (key_bytes_read!=KEY_LENGTH+CMAC_LENGTH)
     {
-        msg_error("[SLOG] ERROR: Invalid key file. Missing CMAC");
+      msg_error("[SLOG] ERROR: Invalid key file. Missing CMAC");
 
-        status = g_io_channel_shutdown(keyfile, TRUE, &myError);
-        g_io_channel_unref(keyfile);
+      status = g_io_channel_shutdown(keyfile, TRUE, &myError);
+      g_io_channel_unref(keyfile);
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        return 0;
+      return 0;
     }
 
-    guint64 littleEndianCounter;
+  guint64 littleEndianCounter;
 
-    status = g_io_channel_read_chars(keyfile, (gchar *) &littleEndianCounter, sizeof(littleEndianCounter), &key_bytes_read,
-                                     &myError);
-    if (status != G_IO_STATUS_NORMAL)
+  status = g_io_channel_read_chars(keyfile, (gchar *) &littleEndianCounter, sizeof(littleEndianCounter), &key_bytes_read,
+                                   &myError);
+  if (status != G_IO_STATUS_NORMAL)
     {
-        cond_msg_error(myError, "[SLOG] ERROR: Cannot read counter from key file");
+      cond_msg_error(myError, "[SLOG] ERROR: Cannot read counter from key file");
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        g_io_channel_shutdown(keyfile, TRUE, &myError);
-        g_io_channel_unref(keyfile);
+      g_io_channel_shutdown(keyfile, TRUE, &myError);
+      g_io_channel_unref(keyfile);
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        return 0;
+      return 0;
     }
 
-    status = g_io_channel_shutdown(keyfile, TRUE, &myError);
-    g_io_channel_unref(keyfile);
+  status = g_io_channel_shutdown(keyfile, TRUE, &myError);
+  g_io_channel_unref(keyfile);
 
-    g_clear_error(&myError);
+  g_clear_error(&myError);
 
-    if (key_bytes_read!=sizeof(littleEndianCounter))
+  if (key_bytes_read!=sizeof(littleEndianCounter))
     {
-        msg_error("[SLOG] ERROR: $(slog) parsing failed, key file invalid while reading counter");
-        return 0;
+      msg_error("[SLOG] ERROR: $(slog) parsing failed, key file invalid while reading counter");
+      return 0;
     }
 
-    gsize outlen=0;
-    unsigned char testOutput[CMAC_LENGTH];
-    gsize testOutputCapacity = G_N_ELEMENTS(testOutput);
+  gsize outlen=0;
+  unsigned char testOutput[CMAC_LENGTH];
+  gsize testOutputCapacity = G_N_ELEMENTS(testOutput);
 
-    cmac((guchar *)keydata, &(littleEndianCounter), sizeof(littleEndianCounter), testOutput, &outlen, testOutputCapacity);
+  cmac((guchar *)keydata, &(littleEndianCounter), sizeof(littleEndianCounter), testOutput, &outlen, testOutputCapacity);
 
-    if (0!=memcmp(testOutput, &keydata[KEY_LENGTH], CMAC_LENGTH))
+  if (0!=memcmp(testOutput, &keydata[KEY_LENGTH], CMAC_LENGTH))
     {
-        msg_warning("[SLOG] ERROR: Host key corrupted. CMAC in key file not matching");
-        return 0;
+      msg_warning("[SLOG] ERROR: Host key corrupted. CMAC in key file not matching");
+      return 0;
     }
 
-    memcpy(destKey, keydata, KEY_LENGTH);
-    *destCounter = GUINT64_FROM_LE(littleEndianCounter);
+  memcpy(destKey, keydata, KEY_LENGTH);
+  *destCounter = GUINT64_FROM_LE(littleEndianCounter);
 
-    return 1;
+  return 1;
 }
 
 /*
@@ -977,102 +977,102 @@ int readKey(char *destKey, guint64 *destCounter, gchar *keypath)
  */
 int writeKey(char *key, guint64 counter, gchar *keypath)
 {
-    GError *error = NULL;
-    GIOChannel *keyfile = g_io_channel_new_file(keypath, "w+", &error);
+  GError *error = NULL;
+  GIOChannel *keyfile = g_io_channel_new_file(keypath, "w+", &error);
 
-    if(!keyfile)
+  if(!keyfile)
     {
-        cond_msg_error(error, "[SLOG] ERROR: Cannot open key file");
+      cond_msg_error(error, "[SLOG] ERROR: Cannot open key file");
 
-        g_clear_error(&error);
+      g_clear_error(&error);
 
-        return 0;
+      return 0;
     }
 
-    GIOStatus status = g_io_channel_set_encoding(keyfile, NULL, &error);
-    if(status != G_IO_STATUS_NORMAL)
+  GIOStatus status = g_io_channel_set_encoding(keyfile, NULL, &error);
+  if(status != G_IO_STATUS_NORMAL)
     {
-        cond_msg_error(error, "[SLOG] ERROR: Unable to set encoding for key file");
+      cond_msg_error(error, "[SLOG] ERROR: Unable to set encoding for key file");
 
-        g_clear_error(&error);
+      g_clear_error(&error);
 
-        g_io_channel_shutdown(keyfile, TRUE, &error);
-        g_io_channel_unref(keyfile);
+      g_io_channel_shutdown(keyfile, TRUE, &error);
+      g_io_channel_unref(keyfile);
 
-        g_clear_error(&error);
+      g_clear_error(&error);
 
-        return 0;
+      return 0;
     }
 
-    gsize outlen = 0;
-    // Write key
-    status = g_io_channel_write_chars(keyfile, key, KEY_LENGTH, &outlen, &error);
-    if(status != G_IO_STATUS_NORMAL)
+  gsize outlen = 0;
+  // Write key
+  status = g_io_channel_write_chars(keyfile, key, KEY_LENGTH, &outlen, &error);
+  if(status != G_IO_STATUS_NORMAL)
     {
-        cond_msg_error(error, "[SLOG] ERROR: Unable to write updated key");
+      cond_msg_error(error, "[SLOG] ERROR: Unable to write updated key");
 
-        g_clear_error(&error);
+      g_clear_error(&error);
 
-        g_io_channel_shutdown(keyfile, TRUE, &error);
-        g_io_channel_unref(keyfile);
+      g_io_channel_shutdown(keyfile, TRUE, &error);
+      g_io_channel_unref(keyfile);
 
-        g_clear_error(&error);
+      g_clear_error(&error);
 
-        return 0;
+      return 0;
     }
 
-    guint64 littleEndianCounter = GINT64_TO_LE(counter);
-    gchar outputmacdata[CMAC_LENGTH];
-    gsize outputmacdata_capacity = G_N_ELEMENTS(outputmacdata);
-    cmac((guchar *)key, &littleEndianCounter, sizeof(littleEndianCounter), (guchar *)outputmacdata, &outlen,
-         outputmacdata_capacity);
+  guint64 littleEndianCounter = GINT64_TO_LE(counter);
+  gchar outputmacdata[CMAC_LENGTH];
+  gsize outputmacdata_capacity = G_N_ELEMENTS(outputmacdata);
+  cmac((guchar *)key, &littleEndianCounter, sizeof(littleEndianCounter), (guchar *)outputmacdata, &outlen,
+       outputmacdata_capacity);
 
-    // Write CMAC
-    status = g_io_channel_write_chars(keyfile, outputmacdata, CMAC_LENGTH, &outlen, &error);
-    if(status != G_IO_STATUS_NORMAL)
+  // Write CMAC
+  status = g_io_channel_write_chars(keyfile, outputmacdata, CMAC_LENGTH, &outlen, &error);
+  if(status != G_IO_STATUS_NORMAL)
     {
-        cond_msg_error(error, "[SLOG] ERROR: Unable to write key CMAC");
+      cond_msg_error(error, "[SLOG] ERROR: Unable to write key CMAC");
 
-        g_clear_error(&error);
+      g_clear_error(&error);
 
-        g_io_channel_shutdown(keyfile, TRUE, &error);
-        g_io_channel_unref(keyfile);
+      g_io_channel_shutdown(keyfile, TRUE, &error);
+      g_io_channel_unref(keyfile);
 
-        g_clear_error(&error);
+      g_clear_error(&error);
 
-        return 0;
+      return 0;
     }
 
-    // Write counter
-    status = g_io_channel_write_chars(keyfile, (gchar *) &littleEndianCounter, sizeof(littleEndianCounter), &outlen,
-                                      &error);
-    if(status != G_IO_STATUS_NORMAL)
+  // Write counter
+  status = g_io_channel_write_chars(keyfile, (gchar *) &littleEndianCounter, sizeof(littleEndianCounter), &outlen,
+                                    &error);
+  if(status != G_IO_STATUS_NORMAL)
     {
-        cond_msg_error(error, "[SLOG] ERROR: Unable to write key counter");
+      cond_msg_error(error, "[SLOG] ERROR: Unable to write key counter");
 
-        g_clear_error(&error);
+      g_clear_error(&error);
 
-        g_io_channel_shutdown(keyfile, TRUE, &error);
-        g_io_channel_unref(keyfile);
+      g_io_channel_shutdown(keyfile, TRUE, &error);
+      g_io_channel_unref(keyfile);
 
-        g_clear_error(&error);
+      g_clear_error(&error);
 
-        return 0;
+      return 0;
     }
 
-    status = g_io_channel_shutdown(keyfile, TRUE, &error);
-    g_io_channel_unref(keyfile);
+  status = g_io_channel_shutdown(keyfile, TRUE, &error);
+  g_io_channel_unref(keyfile);
 
-    if (status != G_IO_STATUS_NORMAL)
+  if (status != G_IO_STATUS_NORMAL)
     {
-        cond_msg_error(error, "[SLOG] ERROR: Cannot close key file");
+      cond_msg_error(error, "[SLOG] ERROR: Cannot close key file");
 
-        g_clear_error(&error);
+      g_clear_error(&error);
 
-        return 0;
+      return 0;
     }
 
-    return 1;
+  return 1;
 
 }
 
@@ -1081,167 +1081,167 @@ int iterateBuffer(guint64 entriesInBuffer, GString **input, guint64 *nextLogEntr
                   gsize cmac_tag_capacity, GHashTable *tab)
 {
 
-    int ret = 1;
-    for (guint64 i=0; i<entriesInBuffer; i++)
+  int ret = 1;
+  for (guint64 i=0; i<entriesInBuffer; i++)
     {
 
-        output[i] = g_string_new(NULL);
+      output[i] = g_string_new(NULL);
 
-        guint64 len = input[i]->len;
-        if (len > (COUNTER_LENGTH + 1))
+      guint64 len = input[i]->len;
+      if (len > (COUNTER_LENGTH + 1))
         {
-            // Interpret the first COUNTER_LENGTH+1 characters
-            char ctrbuf[COUNTER_LENGTH+1];
-            memcpy(ctrbuf, input[i]->str, COUNTER_LENGTH);
-            ctrbuf[COUNTER_LENGTH] = 0;
+          // Interpret the first COUNTER_LENGTH+1 characters
+          char ctrbuf[COUNTER_LENGTH+1];
+          memcpy(ctrbuf, input[i]->str, COUNTER_LENGTH);
+          ctrbuf[COUNTER_LENGTH] = 0;
 
-            gsize outLen;
-            guchar *tmp = convertToBin(ctrbuf, &outLen);
+          gsize outLen;
+          guchar *tmp = convertToBin(ctrbuf, &outLen);
 
-            guint64 logEntryOnDisk;
-            if (outLen!=sizeof(guint64))
+          guint64 logEntryOnDisk;
+          if (outLen!=sizeof(guint64))
             {
-                msg_error("[SLOG] ERROR: Cannot derive integer value from counter field", evt_tag_long("Log entry number",
-                          *nextLogEntry));
-                logEntryOnDisk = *nextLogEntry;
-                g_free(tmp);
+              msg_error("[SLOG] ERROR: Cannot derive integer value from counter field", evt_tag_long("Log entry number",
+                        *nextLogEntry));
+              logEntryOnDisk = *nextLogEntry;
+              g_free(tmp);
             }
-            else
+          else
             {
-                memcpy(&logEntryOnDisk, tmp, sizeof(logEntryOnDisk));
-                g_free(tmp);
-            }
-
-            len = len - (COUNTER_LENGTH+1);
-
-            if (logEntryOnDisk != *nextLogEntry)
-            {
-                if (tab != NULL)
-                {
-                    char key[CTR_LEN_SIMPLE+1];
-                    snprintf(key, CTR_LEN_SIMPLE+1, "%"G_GUINT64_FORMAT, logEntryOnDisk);
-                    if(g_hash_table_contains(tab, key) == TRUE)
-                    {
-                        msg_error("[SLOG] ERROR: Duplicate entry detected", evt_tag_long("entry", logEntryOnDisk));
-                        ret = 0;
-                    }
-                }
-                if (logEntryOnDisk<(*nextLogEntry))
-                {
-                    if (logEntryOnDisk<keyNumber)
-                    {
-                        msg_error("[SLOG] ERROR: Log claims to be past entry from past archive. We cannot rewind back to this key without key0. This is going to fail.",
-                                  evt_tag_long("entry", logEntryOnDisk));
-                        ret = 0;
-                    }
-                    else
-                    {
-                        msg_error("[SLOG] ERROR: Log claims to be past entry. We rewind from first known key, this might take some time",
-                                  evt_tag_long("entry", logEntryOnDisk));
-                        // Rewind key to k0
-                        memcpy(mainKey, keyZero, KEY_LENGTH);
-                        deriveKey(mainKey, logEntryOnDisk, keyNumber);
-                        *nextLogEntry = logEntryOnDisk;
-                        ret = 0;
-                    }
-                }
-                if (logEntryOnDisk-(*nextLogEntry)>1000000)
-                {
-                    msg_info("[SLOG] INFO: Deriving key for distant future. This might take some time.",
-                             evt_tag_long("next log entry should be", *nextLogEntry), evt_tag_long("key to derive to", logEntryOnDisk),
-                             evt_tag_long("number of log entries", *numberOfLogEntries));
-                }
-                deriveKey(mainKey, logEntryOnDisk, *nextLogEntry);
-                *nextLogEntry = logEntryOnDisk;
+              memcpy(&logEntryOnDisk, tmp, sizeof(logEntryOnDisk));
+              g_free(tmp);
             }
 
-            GString *line = input[i];
+          len = len - (COUNTER_LENGTH+1);
 
-            char *ct = &(line->str)[COUNTER_LENGTH+1];
-            gsize outputLength;
-
-            // binBuf = IV + TAG + CT
-            guchar *binBuf = convertToBin(ct, &outputLength);
-            int pt_length = 0;
-
-            // Check whether something weird has happened during conversion
-            if (outputLength>IV_LENGTH+AES_BLOCKSIZE)
+          if (logEntryOnDisk != *nextLogEntry)
             {
-                unsigned char pt[outputLength - IV_LENGTH - AES_BLOCKSIZE];
-
-                unsigned char encKey[KEY_LENGTH];
-                deriveEncSubKey(mainKey, encKey);
-
-                pt_length = sLogDecrypt(&binBuf[IV_LENGTH+AES_BLOCKSIZE], outputLength - IV_LENGTH - AES_BLOCKSIZE, &binBuf[IV_LENGTH],
-                                        encKey, binBuf, pt);
-
-                if (pt_length>0)
+              if (tab != NULL)
                 {
-                    // Include colon, whitespace, and \0
-                    g_string_append_printf(output[i], "%0*"G_GINT64_MODIFIER"x: %.*s", CTR_LEN_SIMPLE, logEntryOnDisk, pt_length, pt);
-
-                    if (tab != NULL)
+                  char key[CTR_LEN_SIMPLE+1];
+                  snprintf(key, CTR_LEN_SIMPLE+1, "%"G_GUINT64_FORMAT, logEntryOnDisk);
+                  if(g_hash_table_contains(tab, key) == TRUE)
                     {
-                        char *key = g_new0(char, CTR_LEN_SIMPLE+1);
-                        snprintf(key, CTR_LEN_SIMPLE+1, "%"G_GUINT64_FORMAT, logEntryOnDisk);
+                      msg_error("[SLOG] ERROR: Duplicate entry detected", evt_tag_long("entry", logEntryOnDisk));
+                      ret = 0;
+                    }
+                }
+              if (logEntryOnDisk<(*nextLogEntry))
+                {
+                  if (logEntryOnDisk<keyNumber)
+                    {
+                      msg_error("[SLOG] ERROR: Log claims to be past entry from past archive. We cannot rewind back to this key without key0. This is going to fail.",
+                                evt_tag_long("entry", logEntryOnDisk));
+                      ret = 0;
+                    }
+                  else
+                    {
+                      msg_error("[SLOG] ERROR: Log claims to be past entry. We rewind from first known key, this might take some time",
+                                evt_tag_long("entry", logEntryOnDisk));
+                      // Rewind key to k0
+                      memcpy(mainKey, keyZero, KEY_LENGTH);
+                      deriveKey(mainKey, logEntryOnDisk, keyNumber);
+                      *nextLogEntry = logEntryOnDisk;
+                      ret = 0;
+                    }
+                }
+              if (logEntryOnDisk-(*nextLogEntry)>1000000)
+                {
+                  msg_info("[SLOG] INFO: Deriving key for distant future. This might take some time.",
+                           evt_tag_long("next log entry should be", *nextLogEntry), evt_tag_long("key to derive to", logEntryOnDisk),
+                           evt_tag_long("number of log entries", *numberOfLogEntries));
+                }
+              deriveKey(mainKey, logEntryOnDisk, *nextLogEntry);
+              *nextLogEntry = logEntryOnDisk;
+            }
 
-                        if (g_hash_table_insert(tab, key, (gpointer)logEntryOnDisk) == FALSE)
+          GString *line = input[i];
+
+          char *ct = &(line->str)[COUNTER_LENGTH+1];
+          gsize outputLength;
+
+          // binBuf = IV + TAG + CT
+          guchar *binBuf = convertToBin(ct, &outputLength);
+          int pt_length = 0;
+
+          // Check whether something weird has happened during conversion
+          if (outputLength>IV_LENGTH+AES_BLOCKSIZE)
+            {
+              unsigned char pt[outputLength - IV_LENGTH - AES_BLOCKSIZE];
+
+              unsigned char encKey[KEY_LENGTH];
+              deriveEncSubKey(mainKey, encKey);
+
+              pt_length = sLogDecrypt(&binBuf[IV_LENGTH+AES_BLOCKSIZE], outputLength - IV_LENGTH - AES_BLOCKSIZE, &binBuf[IV_LENGTH],
+                                      encKey, binBuf, pt);
+
+              if (pt_length>0)
+                {
+                  // Include colon, whitespace, and \0
+                  g_string_append_printf(output[i], "%0*"G_GINT64_MODIFIER"x: %.*s", CTR_LEN_SIMPLE, logEntryOnDisk, pt_length, pt);
+
+                  if (tab != NULL)
+                    {
+                      char *key = g_new0(char, CTR_LEN_SIMPLE+1);
+                      snprintf(key, CTR_LEN_SIMPLE+1, "%"G_GUINT64_FORMAT, logEntryOnDisk);
+
+                      if (g_hash_table_insert(tab, key, (gpointer)logEntryOnDisk) == FALSE)
                         {
-                            msg_warning("[SLOG] WARNING: Unable to process hash table while entering decrypted log entry", evt_tag_long("entry",
-                                        logEntryOnDisk));
-                            ret = 0;
+                          msg_warning("[SLOG] WARNING: Unable to process hash table while entering decrypted log entry", evt_tag_long("entry",
+                                      logEntryOnDisk));
+                          ret = 0;
                         }
                     }
 
-                    // Update BigHMAC
-                    if ((*numberOfLogEntries) == 0UL)   // First aggregated MAC
+                  // Update BigHMAC
+                  if ((*numberOfLogEntries) == 0UL)   // First aggregated MAC
                     {
-                        gsize outlen = 0;
+                      gsize outlen = 0;
 
-                        unsigned char MACKey[KEY_LENGTH];
-                        deriveMACSubKey(mainKey, MACKey);
+                      unsigned char MACKey[KEY_LENGTH];
+                      deriveMACSubKey(mainKey, MACKey);
 
-                        cmac(MACKey, binBuf, IV_LENGTH+AES_BLOCKSIZE+pt_length, cmac_tag, &outlen, cmac_tag_capacity);
+                      cmac(MACKey, binBuf, IV_LENGTH+AES_BLOCKSIZE+pt_length, cmac_tag, &outlen, cmac_tag_capacity);
                     }
-                    else
+                  else
                     {
-                        // numberOfEntries > 0
-                        gsize outlen;
-                        unsigned char bigBuf[AES_BLOCKSIZE+IV_LENGTH+AES_BLOCKSIZE+pt_length];
-                        memcpy(bigBuf, cmac_tag, AES_BLOCKSIZE);
-                        memcpy(&bigBuf[AES_BLOCKSIZE], binBuf, IV_LENGTH+AES_BLOCKSIZE+pt_length);
+                      // numberOfEntries > 0
+                      gsize outlen;
+                      unsigned char bigBuf[AES_BLOCKSIZE+IV_LENGTH+AES_BLOCKSIZE+pt_length];
+                      memcpy(bigBuf, cmac_tag, AES_BLOCKSIZE);
+                      memcpy(&bigBuf[AES_BLOCKSIZE], binBuf, IV_LENGTH+AES_BLOCKSIZE+pt_length);
 
-                        unsigned char MACKey[KEY_LENGTH];
-                        deriveMACSubKey(mainKey, MACKey);
+                      unsigned char MACKey[KEY_LENGTH];
+                      deriveMACSubKey(mainKey, MACKey);
 
-                        cmac(MACKey, bigBuf, AES_BLOCKSIZE+IV_LENGTH+AES_BLOCKSIZE+pt_length, cmac_tag, &outlen, cmac_tag_capacity);
+                      cmac(MACKey, bigBuf, AES_BLOCKSIZE+IV_LENGTH+AES_BLOCKSIZE+pt_length, cmac_tag, &outlen, cmac_tag_capacity);
                     }
                 }
             }
 
-            if (pt_length<=0)
+          if (pt_length<=0)
             {
-                msg_warning("[SLOG] WARNING: Decryption not successful",
-                            evt_tag_long("entry", logEntryOnDisk));
-                ret = 0;
+              msg_warning("[SLOG] WARNING: Decryption not successful",
+                          evt_tag_long("entry", logEntryOnDisk));
+              ret = 0;
             }
 
-            g_free(binBuf);
+          g_free(binBuf);
 
-            evolveKey(mainKey);
-            (*numberOfLogEntries)++;
-            (*nextLogEntry)++;
+          evolveKey(mainKey);
+          (*numberOfLogEntries)++;
+          (*nextLogEntry)++;
 
         }
-        else
+      else
         {
-            msg_error("[SLOG] ERROR: Cannot read log entry", evt_tag_long("", *nextLogEntry));
-            ret = 0;
+          msg_error("[SLOG] ERROR: Cannot read log entry", evt_tag_long("", *nextLogEntry));
+          ret = 0;
         }
 
     } // for
 
-    return ret;
+  return ret;
 }
 
 // Perform the final verification step
@@ -1249,103 +1249,103 @@ int finalizeVerify(guint64 startingEntry, guint64 entriesInFile, unsigned char *
                    GHashTable *tab)
 {
 
-    int ret = 1;
+  int ret = 1;
 
-    // Check which entries are missing
-    guint64 notRecovered = 0;
-    for (guint64 i = startingEntry; i < startingEntry + entriesInFile; i++)
+  // Check which entries are missing
+  guint64 notRecovered = 0;
+  for (guint64 i = startingEntry; i < startingEntry + entriesInFile; i++)
     {
-        if (tab != NULL)
+      if (tab != NULL)
         {
-            // Hashtable key
-            char key[CTR_LEN_SIMPLE+1];
-            snprintf(key, CTR_LEN_SIMPLE+1, "%"G_GUINT64_FORMAT, i);
+          // Hashtable key
+          char key[CTR_LEN_SIMPLE+1];
+          snprintf(key, CTR_LEN_SIMPLE+1, "%"G_GUINT64_FORMAT, i);
 
-            if(g_hash_table_contains(tab, key) == FALSE)
+          if(g_hash_table_contains(tab, key) == FALSE)
             {
-                notRecovered++;
-                msg_warning("[SLOG] WARNING: Unable to recover", evt_tag_long("entry", i));
-                ret = 0;
+              notRecovered++;
+              msg_warning("[SLOG] WARNING: Unable to recover", evt_tag_long("entry", i));
+              ret = 0;
             }
         }
     }
 
-    if ((notRecovered == 0) && (tab != NULL))
+  if ((notRecovered == 0) && (tab != NULL))
     {
-        msg_info("[SLOG] INFO: All entries recovered successfully");
+      msg_info("[SLOG] INFO: All entries recovered successfully");
     }
 
-    int equal = memcmp(bigMac, cmac_tag, CMAC_LENGTH);
+  int equal = memcmp(bigMac, cmac_tag, CMAC_LENGTH);
 
-    if (equal != 0)
+  if (equal != 0)
     {
-        msg_warning("[SLOG] WARNING: Aggregated MAC mismatch. Log might be incomplete");
-        ret = 0;
+      msg_warning("[SLOG] WARNING: Aggregated MAC mismatch. Log might be incomplete");
+      ret = 0;
     }
-    else
+  else
     {
-        msg_info("[SLOG] Aggregated MAC matches. Log contains all expected log messages.");
+      msg_info("[SLOG] Aggregated MAC matches. Log contains all expected log messages.");
     }
 
-    g_hash_table_unref(tab);
+  g_hash_table_unref(tab);
 
-    return ret;
+  return ret;
 }
 
 // Initialize log verification
 int initVerify(guint64 entriesInFile, unsigned char *mainKey, guint64 *nextLogEntry, guint64 *startingEntry,
                GString **input, GHashTable **tab)
 {
-    if (input[0] == NULL)
+  if (input[0] == NULL)
     {
-        msg_error("[SLOG] ERROR: Input == NULL in initVerify");
-        return 0;
+      msg_error("[SLOG] ERROR: Input == NULL in initVerify");
+      return 0;
     }
 
-    // Create hash table
-    *tab = g_hash_table_new(g_str_hash, g_str_equal);
-    if (*tab == NULL)
+  // Create hash table
+  *tab = g_hash_table_new(g_str_hash, g_str_equal);
+  if (*tab == NULL)
     {
-        msg_error("[SLOG] ERROR: Cannot create hash table");
-        return 0;
+      msg_error("[SLOG] ERROR: Cannot create hash table");
+      return 0;
     }
 
-    if (input[0]->len>(COUNTER_LENGTH+1))
+  if (input[0]->len>(COUNTER_LENGTH+1))
     {
-        gsize outLen;
-        char buf[COUNTER_LENGTH+1];
-        memcpy(buf, input[0]->str, COUNTER_LENGTH);
-        buf[COUNTER_LENGTH] = 0;
-        guchar *tempInt = convertToBin(buf, &outLen);
-        if (outLen!=sizeof(guint64))
+      gsize outLen;
+      char buf[COUNTER_LENGTH+1];
+      memcpy(buf, input[0]->str, COUNTER_LENGTH);
+      buf[COUNTER_LENGTH] = 0;
+      guchar *tempInt = convertToBin(buf, &outLen);
+      if (outLen!=sizeof(guint64))
         {
-            msg_warning("[SLOG] WARNING: Cannot derive integer value from first input line counter");
-            (*startingEntry) = 0UL;
-            g_free(tempInt);
-            return 0;
+          msg_warning("[SLOG] WARNING: Cannot derive integer value from first input line counter");
+          (*startingEntry) = 0UL;
+          g_free(tempInt);
+          return 0;
         }
-        else
+      else
         {
-            memcpy(startingEntry, tempInt, sizeof(guint64));
-            g_free(tempInt);
+          memcpy(startingEntry, tempInt, sizeof(guint64));
+          g_free(tempInt);
         }
 
-        if((*startingEntry) > 0)
+      if((*startingEntry) > 0)
         {
-            msg_warning("[SLOG] WARNING: Log does not start with index 0",
-                        evt_tag_long("index", (*startingEntry)));
-            (*nextLogEntry) = (*startingEntry);
-            deriveKey(mainKey, (*nextLogEntry), 0);
-            return 0;
+          msg_warning("[SLOG] WARNING: Log does not start with index 0",
+                      evt_tag_long("index", (*startingEntry)));
+          (*nextLogEntry) = (*startingEntry);
+          deriveKey(mainKey, (*nextLogEntry), 0);
+          return 0;
         }
     }
-    else
+  else
     {
-        msg_warning("[SLOG] WARNING: Problems reading log entry at first line.");
-        return 0;
+      msg_warning("[SLOG] WARNING: Problems reading log entry at first line.");
+      return 0;
     }
 
-    return 1;
+  return 1;
 }
 
 
@@ -1360,309 +1360,309 @@ int iterativeFileVerify(unsigned char *previousMAC, unsigned char *mainKey, char
                         char *outputFileName, guint64 entriesInFile, int chunkLength, guint64 keyNumber)
 {
 
-    if(entriesInFile==0)
+  if(entriesInFile==0)
     {
-        msg_error("[SLOG] ERROR: Nothing to verify");
-        return 0;
+      msg_error("[SLOG] ERROR: Nothing to verify");
+      return 0;
     }
 
-    unsigned char keyZero[KEY_LENGTH];
-    memcpy(keyZero, mainKey, KEY_LENGTH);
-    int startedWithZero = 0;
+  unsigned char keyZero[KEY_LENGTH];
+  memcpy(keyZero, mainKey, KEY_LENGTH);
+  int startedWithZero = 0;
 
-    if (keyNumber!=0)
+  if (keyNumber!=0)
     {
-        msg_info("[SLOG] INFO: Verification using a key different from k0", evt_tag_long("key number", keyNumber));
+      msg_info("[SLOG] INFO: Verification using a key different from k0", evt_tag_long("key number", keyNumber));
     }
-    else
+  else
     {
-        msg_info("[SLOG] INFO: Verification starting with k0. Is this really what you want?");
-        startedWithZero = 1;
+      msg_info("[SLOG] INFO: Verification starting with k0. Is this really what you want?");
+      startedWithZero = 1;
     }
-    int ret = 1;
+  int ret = 1;
 
-    GError *myError = NULL;
-    GIOChannel *input = g_io_channel_new_file(inputFileName, "r", &myError);
-    if (!input)
+  GError *myError = NULL;
+  GIOChannel *input = g_io_channel_new_file(inputFileName, "r", &myError);
+  if (!input)
     {
-        cond_msg_error (myError, "[SLOG] ERROR: Cannot open input file");
+      cond_msg_error (myError, "[SLOG] ERROR: Cannot open input file");
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        return 0;
-    }
-
-    GIOStatus status = g_io_channel_set_encoding(input, NULL, &myError);
-    if(status != G_IO_STATUS_NORMAL)
-    {
-        cond_msg_error (myError, "[SLOG] ERROR: set encoding for input file");
-
-        g_clear_error(&myError);
-
-        g_io_channel_shutdown(input, TRUE, &myError);
-        g_io_channel_unref(input);
-
-        g_clear_error(&myError);
-
-        return 0;
+      return 0;
     }
 
-    GIOChannel *output = g_io_channel_new_file(outputFileName, "w+", &myError);
-
-    if (!output)
+  GIOStatus status = g_io_channel_set_encoding(input, NULL, &myError);
+  if(status != G_IO_STATUS_NORMAL)
     {
-        cond_msg_error(myError, "[SLOG] ERROR: Cannot open output file");
+      cond_msg_error (myError, "[SLOG] ERROR: set encoding for input file");
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        g_io_channel_shutdown(input, TRUE, &myError);
-        g_io_channel_unref(input);
+      g_io_channel_shutdown(input, TRUE, &myError);
+      g_io_channel_unref(input);
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        return 0;
-    }
-    status = g_io_channel_set_encoding(output, NULL, &myError);
-    if (status != G_IO_STATUS_NORMAL)
-    {
-        cond_msg_error(myError, "[SLOG] ERROR: Cannot set output file encoding");
-        g_clear_error(&myError);
-
-        g_io_channel_shutdown(input, TRUE, &myError);
-        g_io_channel_unref(input);
-
-        g_clear_error(&myError);
-
-        g_io_channel_shutdown(output, TRUE, &myError);
-        g_io_channel_unref(output);
-
-        g_clear_error(&myError);
-
-        return  0;
+      return 0;
     }
 
+  GIOChannel *output = g_io_channel_new_file(outputFileName, "w+", &myError);
 
-    GString **inputBuffer = g_new0(GString *, chunkLength);
-    GString **outputBuffer = g_new0(GString *, chunkLength);
-
-    if ((outputBuffer==NULL)||(inputBuffer == NULL))
+  if (!output)
     {
-        msg_error("[SLOG] ERROR: [iterativeFileVerify] cannot allocate memory");
+      cond_msg_error(myError, "[SLOG] ERROR: Cannot open output file");
 
-        g_io_channel_shutdown(input, TRUE, &myError);
-        g_io_channel_unref(input);
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        g_io_channel_shutdown(output, TRUE, &myError);
-        g_io_channel_unref(output);
-        g_clear_error(&myError);
+      g_io_channel_shutdown(input, TRUE, &myError);
+      g_io_channel_unref(input);
 
-        if(inputBuffer != NULL)
+      g_clear_error(&myError);
+
+      return 0;
+    }
+  status = g_io_channel_set_encoding(output, NULL, &myError);
+  if (status != G_IO_STATUS_NORMAL)
+    {
+      cond_msg_error(myError, "[SLOG] ERROR: Cannot set output file encoding");
+      g_clear_error(&myError);
+
+      g_io_channel_shutdown(input, TRUE, &myError);
+      g_io_channel_unref(input);
+
+      g_clear_error(&myError);
+
+      g_io_channel_shutdown(output, TRUE, &myError);
+      g_io_channel_unref(output);
+
+      g_clear_error(&myError);
+
+      return  0;
+    }
+
+
+  GString **inputBuffer = g_new0(GString *, chunkLength);
+  GString **outputBuffer = g_new0(GString *, chunkLength);
+
+  if ((outputBuffer==NULL)||(inputBuffer == NULL))
+    {
+      msg_error("[SLOG] ERROR: [iterativeFileVerify] cannot allocate memory");
+
+      g_io_channel_shutdown(input, TRUE, &myError);
+      g_io_channel_unref(input);
+      g_clear_error(&myError);
+
+      g_io_channel_shutdown(output, TRUE, &myError);
+      g_io_channel_unref(output);
+      g_clear_error(&myError);
+
+      if(inputBuffer != NULL)
         {
-            g_free(inputBuffer);
+          g_free(inputBuffer);
         }
 
-        if (outputBuffer != NULL)
+      if (outputBuffer != NULL)
         {
-            g_free(outputBuffer);
+          g_free(outputBuffer);
         }
 
-        return 0;
+      return 0;
     }
 
-    unsigned char cmac_tag[CMAC_LENGTH];
-    gsize cmac_tag_capacity = G_N_ELEMENTS(cmac_tag);
-    memcpy(cmac_tag, previousMAC, CMAC_LENGTH);
+  unsigned char cmac_tag[CMAC_LENGTH];
+  gsize cmac_tag_capacity = G_N_ELEMENTS(cmac_tag);
+  memcpy(cmac_tag, previousMAC, CMAC_LENGTH);
 
-    guint64 nextLogEntry = keyNumber;
-    guint64 startingEntry = keyNumber;
-    guint64 numberOfLogEntries = keyNumber;
+  guint64 nextLogEntry = keyNumber;
+  guint64 startingEntry = keyNumber;
+  guint64 numberOfLogEntries = keyNumber;
 
-    // This is only to avoid updating BigMAC during the first iteration
-    if (keyNumber == 0)
+  // This is only to avoid updating BigMAC during the first iteration
+  if (keyNumber == 0)
     {
-        numberOfLogEntries = 1;
+      numberOfLogEntries = 1;
     }
 
-    if (chunkLength>entriesInFile)
+  if (chunkLength>entriesInFile)
     {
-        chunkLength = entriesInFile;
+      chunkLength = entriesInFile;
     }
 
-    // Create the hash table
-    GHashTable *tab = g_hash_table_new(g_str_hash, g_str_equal);
-    if (tab == NULL)
+  // Create the hash table
+  GHashTable *tab = g_hash_table_new(g_str_hash, g_str_equal);
+  if (tab == NULL)
     {
-        msg_error("[SLOG] ERROR: Cannot create hash table");
-        return 0;
+      msg_error("[SLOG] ERROR: Cannot create hash table");
+      return 0;
     }
 
-    // Process file in chunks
-    for (int j = 0; j < (entriesInFile / chunkLength); j++)
+  // Process file in chunks
+  for (int j = 0; j < (entriesInFile / chunkLength); j++)
     {
-        for (guint64 i = 0; i < chunkLength; i++)
+      for (guint64 i = 0; i < chunkLength; i++)
         {
-            inputBuffer[i] = g_string_new(NULL);
-            status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
-            if (status != G_IO_STATUS_NORMAL)
+          inputBuffer[i] = g_string_new(NULL);
+          status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
+          if (status != G_IO_STATUS_NORMAL)
             {
-                cond_msg_error(myError, "[SLOG] ERROR: reading from input file");
+              cond_msg_error(myError, "[SLOG] ERROR: reading from input file");
 
-                g_clear_error(&myError);
+              g_clear_error(&myError);
 
-                g_io_channel_shutdown(input, TRUE, &myError);
-                g_io_channel_unref(input);
+              g_io_channel_shutdown(input, TRUE, &myError);
+              g_io_channel_unref(input);
 
-                g_clear_error(&myError);
+              g_clear_error(&myError);
 
-                g_io_channel_shutdown(output, TRUE, &myError);
-                g_io_channel_unref(output);
+              g_io_channel_shutdown(output, TRUE, &myError);
+              g_io_channel_unref(output);
 
-                g_clear_error(&myError);
+              g_clear_error(&myError);
 
-                g_free(inputBuffer);
-                g_free(outputBuffer);
+              g_free(inputBuffer);
+              g_free(outputBuffer);
 
-                return  0;
+              return  0;
             }
 
-            // Cut last character to remove the trailing new line...
-            g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
+          // Cut last character to remove the trailing new line...
+          g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
         }
-        ret = ret * iterateBuffer(chunkLength, inputBuffer, &nextLogEntry, mainKey, keyZero, keyNumber, outputBuffer,
-                                  &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
+      ret = ret * iterateBuffer(chunkLength, inputBuffer, &nextLogEntry, mainKey, keyZero, keyNumber, outputBuffer,
+                                &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
 
-        // ...and write to file
-        for (guint64 i = 0; i < chunkLength; i++)
+      // ...and write to file
+      for (guint64 i = 0; i < chunkLength; i++)
         {
-            if (outputBuffer[i]->len!=0)
+          if (outputBuffer[i]->len!=0)
             {
-                gsize size;
-                //Add newline
-                g_string_append(outputBuffer[i], "\n");
-                status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
+              gsize size;
+              //Add newline
+              g_string_append(outputBuffer[i], "\n");
+              status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
 
-                if (status != G_IO_STATUS_NORMAL)
+              if (status != G_IO_STATUS_NORMAL)
                 {
-                    cond_msg_error(myError, "[SLOG] ERROR: writing to output file");
+                  cond_msg_error(myError, "[SLOG] ERROR: writing to output file");
 
-                    g_clear_error(&myError);
+                  g_clear_error(&myError);
 
-                    g_io_channel_shutdown(input, TRUE, &myError);
-                    g_io_channel_unref(input);
+                  g_io_channel_shutdown(input, TRUE, &myError);
+                  g_io_channel_unref(input);
 
-                    g_clear_error(&myError);
+                  g_clear_error(&myError);
 
-                    g_io_channel_shutdown(output, TRUE, &myError);
-                    g_io_channel_unref(output);
+                  g_io_channel_shutdown(output, TRUE, &myError);
+                  g_io_channel_unref(output);
 
-                    g_clear_error(&myError);
+                  g_clear_error(&myError);
 
-                    g_free(inputBuffer);
-                    g_free(outputBuffer);
+                  g_free(inputBuffer);
+                  g_free(outputBuffer);
 
-                    return  0;
+                  return  0;
                 }
             }
-            g_string_free(outputBuffer[i], TRUE);
-            g_string_free(inputBuffer[i], TRUE);
+          g_string_free(outputBuffer[i], TRUE);
+          g_string_free(inputBuffer[i], TRUE);
         }
     }
 
-    if ((entriesInFile % chunkLength) > 0)
+  if ((entriesInFile % chunkLength) > 0)
     {
-        for (guint64 i = 0; i < (entriesInFile % chunkLength); i++)
+      for (guint64 i = 0; i < (entriesInFile % chunkLength); i++)
         {
-            inputBuffer[i] = g_string_new(NULL);
-            status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
-            if (status != G_IO_STATUS_NORMAL)
+          inputBuffer[i] = g_string_new(NULL);
+          status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
+          if (status != G_IO_STATUS_NORMAL)
             {
-                cond_msg_error(myError, "[SLOG] ERROR: reading from input file");
+              cond_msg_error(myError, "[SLOG] ERROR: reading from input file");
 
-                g_clear_error(&myError);
+              g_clear_error(&myError);
 
-                g_io_channel_shutdown(input, TRUE, &myError);
-                g_io_channel_unref(input);
+              g_io_channel_shutdown(input, TRUE, &myError);
+              g_io_channel_unref(input);
 
-                g_clear_error(&myError);
+              g_clear_error(&myError);
 
-                g_io_channel_shutdown(output, TRUE, &myError);
-                g_io_channel_unref(output);
+              g_io_channel_shutdown(output, TRUE, &myError);
+              g_io_channel_unref(output);
 
-                g_clear_error(&myError);
+              g_clear_error(&myError);
 
-                g_free(inputBuffer);
-                g_free(outputBuffer);
+              g_free(inputBuffer);
+              g_free(outputBuffer);
 
 
-                return  0;
+              return  0;
             }
 
-            // Cut last character to remove the trailing new line
-            g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
+          // Cut last character to remove the trailing new line
+          g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
         }
-        ret = ret * iterateBuffer((entriesInFile % chunkLength), inputBuffer, &nextLogEntry, mainKey, keyZero, keyNumber,
-                                  outputBuffer, &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
+      ret = ret * iterateBuffer((entriesInFile % chunkLength), inputBuffer, &nextLogEntry, mainKey, keyZero, keyNumber,
+                                outputBuffer, &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
 
-        for (guint64 i = 0; i < (entriesInFile % chunkLength); i++)
+      for (guint64 i = 0; i < (entriesInFile % chunkLength); i++)
         {
-            if (outputBuffer[i]->len!=0)
+          if (outputBuffer[i]->len!=0)
             {
 
-                gsize size;
+              gsize size;
 
-                //Add newline
-                g_string_append(outputBuffer[i], "\n");
-                status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
-                if (status != G_IO_STATUS_NORMAL)
+              //Add newline
+              g_string_append(outputBuffer[i], "\n");
+              status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
+              if (status != G_IO_STATUS_NORMAL)
                 {
-                    cond_msg_error(myError, "[SLOG] ERROR: writing to output file");
+                  cond_msg_error(myError, "[SLOG] ERROR: writing to output file");
 
-                    g_clear_error(&myError);
+                  g_clear_error(&myError);
 
-                    g_io_channel_shutdown(input, TRUE, &myError);
-                    g_io_channel_unref(input);
+                  g_io_channel_shutdown(input, TRUE, &myError);
+                  g_io_channel_unref(input);
 
-                    g_clear_error(&myError);
+                  g_clear_error(&myError);
 
-                    g_io_channel_shutdown(output, TRUE, &myError);
-                    g_io_channel_unref(output);
+                  g_io_channel_shutdown(output, TRUE, &myError);
+                  g_io_channel_unref(output);
 
-                    g_clear_error(&myError);
+                  g_clear_error(&myError);
 
-                    g_free(inputBuffer);
-                    g_free(outputBuffer);
+                  g_free(inputBuffer);
+                  g_free(outputBuffer);
 
-                    return  0;
+                  return  0;
                 }
 
             }
-            g_string_free(outputBuffer[i], TRUE);
-            g_string_free(inputBuffer[i], TRUE);
+          g_string_free(outputBuffer[i], TRUE);
+          g_string_free(inputBuffer[i], TRUE);
         }
     }
 
-    if (startedWithZero==1)
+  if (startedWithZero==1)
     {
-        msg_info("[SLOG] INFO: We started with key key0. There might be a lot of warnings about missing log entries.");
+      msg_info("[SLOG] INFO: We started with key key0. There might be a lot of warnings about missing log entries.");
     }
 
-    ret = ret * finalizeVerify(startingEntry, entriesInFile, bigMAC, cmac_tag, tab);
+  ret = ret * finalizeVerify(startingEntry, entriesInFile, bigMAC, cmac_tag, tab);
 
-    g_free(inputBuffer);
-    g_free(outputBuffer);
+  g_free(inputBuffer);
+  g_free(outputBuffer);
 
-    g_io_channel_shutdown(input, TRUE, &myError);
-    g_io_channel_unref(input);
+  g_io_channel_shutdown(input, TRUE, &myError);
+  g_io_channel_unref(input);
 
-    g_clear_error(&myError);
+  g_clear_error(&myError);
 
-    g_io_channel_shutdown(output, TRUE, &myError);
-    g_io_channel_unref(output);
+  g_io_channel_shutdown(output, TRUE, &myError);
+  g_io_channel_unref(output);
 
-    g_clear_error(&myError);
+  g_clear_error(&myError);
 
-    return ret;
+  return ret;
 
 }
 
@@ -1677,373 +1677,373 @@ int fileVerify(unsigned char *mainKey, char *inputFileName, char *outputFileName
                guint64 entriesInFile, int chunkLength)
 {
 
-    unsigned char keyZero[KEY_LENGTH];
-    memcpy(keyZero, mainKey, KEY_LENGTH);
+  unsigned char keyZero[KEY_LENGTH];
+  memcpy(keyZero, mainKey, KEY_LENGTH);
 
-    GHashTable *tab = NULL;
+  GHashTable *tab = NULL;
 
-    int ret = 1;
+  int ret = 1;
 
-    if(entriesInFile==0)
+  if(entriesInFile==0)
     {
-        msg_error("[SLOG] ERROR: Nothing to verify");
-        return 0;
+      msg_error("[SLOG] ERROR: Nothing to verify");
+      return 0;
     }
 
-    GError *myError = NULL;
-    GIOChannel *input = g_io_channel_new_file(inputFileName, "r", &myError);
-    if (!input)
+  GError *myError = NULL;
+  GIOChannel *input = g_io_channel_new_file(inputFileName, "r", &myError);
+  if (!input)
     {
-        cond_msg_error (myError, "[SLOG] ERROR: Cannot open input file");
+      cond_msg_error (myError, "[SLOG] ERROR: Cannot open input file");
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        return 0;
+      return 0;
     }
 
-    GIOStatus status =  g_io_channel_set_encoding(input, NULL, &myError);
-    if (status != G_IO_STATUS_NORMAL)
+  GIOStatus status =  g_io_channel_set_encoding(input, NULL, &myError);
+  if (status != G_IO_STATUS_NORMAL)
     {
-        cond_msg_error (myError, "[SLOG] ERROR: Cannot set input file encoding");
+      cond_msg_error (myError, "[SLOG] ERROR: Cannot set input file encoding");
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        g_io_channel_shutdown(input, TRUE, &myError);
-        g_io_channel_unref(input);
+      g_io_channel_shutdown(input, TRUE, &myError);
+      g_io_channel_unref(input);
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        return 0;
+      return 0;
     }
 
-    GIOChannel *output = g_io_channel_new_file(outputFileName, "w+", &myError);
+  GIOChannel *output = g_io_channel_new_file(outputFileName, "w+", &myError);
 
-    if (!output)
+  if (!output)
     {
-        cond_msg_error (myError, "[SLOG] ERROR: Cannot open output file");
+      cond_msg_error (myError, "[SLOG] ERROR: Cannot open output file");
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        g_io_channel_shutdown(input, TRUE, &myError);
-        g_io_channel_unref(input);
+      g_io_channel_shutdown(input, TRUE, &myError);
+      g_io_channel_unref(input);
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
 
-        return 0;
+      return 0;
     }
 
-    status = g_io_channel_set_encoding(output, NULL, &myError);
+  status = g_io_channel_set_encoding(output, NULL, &myError);
 
-    if (status != G_IO_STATUS_NORMAL)
+  if (status != G_IO_STATUS_NORMAL)
     {
-        cond_msg_error (myError, "[SLOG] ERROR: Cannot set output file encoding");
+      cond_msg_error (myError, "[SLOG] ERROR: Cannot set output file encoding");
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        g_io_channel_shutdown(input, TRUE, &myError);
-        g_io_channel_unref(input);
+      g_io_channel_shutdown(input, TRUE, &myError);
+      g_io_channel_unref(input);
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        g_io_channel_shutdown(output, TRUE, &myError);
-        g_io_channel_unref(output);
+      g_io_channel_shutdown(output, TRUE, &myError);
+      g_io_channel_unref(output);
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        return 0;
+      return 0;
     }
 
-    GString **inputBuffer = g_new0(GString *, chunkLength);
-    GString **outputBuffer = g_new0(GString *, chunkLength);
+  GString **inputBuffer = g_new0(GString *, chunkLength);
+  GString **outputBuffer = g_new0(GString *, chunkLength);
 
-    if ((outputBuffer==NULL)||(inputBuffer == NULL))
+  if ((outputBuffer==NULL)||(inputBuffer == NULL))
     {
-        msg_error("[SLOG] ERROR: [fileVerify] cannot allocate memory");
+      msg_error("[SLOG] ERROR: [fileVerify] cannot allocate memory");
 
-        g_io_channel_shutdown(input, TRUE, &myError);
-        g_io_channel_unref(input);
+      g_io_channel_shutdown(input, TRUE, &myError);
+      g_io_channel_unref(input);
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        g_io_channel_shutdown(output, TRUE, &myError);
-        g_io_channel_unref(output);
+      g_io_channel_shutdown(output, TRUE, &myError);
+      g_io_channel_unref(output);
 
-        g_clear_error(&myError);
+      g_clear_error(&myError);
 
-        if (inputBuffer != NULL)
+      if (inputBuffer != NULL)
         {
-            g_free(inputBuffer);
+          g_free(inputBuffer);
         }
 
-        if (outputBuffer != NULL)
+      if (outputBuffer != NULL)
         {
-            g_free(outputBuffer);
+          g_free(outputBuffer);
         }
 
-        return 0;
+      return 0;
     }
 
-    guint64 nextLogEntry = 0UL;
-    guint64 startingEntry = 0UL;
-    unsigned char cmac_tag[CMAC_LENGTH];
-    gsize cmac_tag_capacity = G_N_ELEMENTS(cmac_tag);
-    guint64 numberOfLogEntries = 0UL;
+  guint64 nextLogEntry = 0UL;
+  guint64 startingEntry = 0UL;
+  unsigned char cmac_tag[CMAC_LENGTH];
+  gsize cmac_tag_capacity = G_N_ELEMENTS(cmac_tag);
+  guint64 numberOfLogEntries = 0UL;
 
-    if (chunkLength>entriesInFile)
+  if (chunkLength>entriesInFile)
     {
-        chunkLength = entriesInFile;
+      chunkLength = entriesInFile;
     }
 
-    for (guint64 i = 0; i < chunkLength; i++)
+  for (guint64 i = 0; i < chunkLength; i++)
     {
-        inputBuffer[i] = g_string_new(NULL);
+      inputBuffer[i] = g_string_new(NULL);
 
-        status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
-        if (status != G_IO_STATUS_NORMAL)
+      status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
+      if (status != G_IO_STATUS_NORMAL)
         {
-            cond_msg_error (myError, "[SLOG] ERROR: Cannot read from input file");
+          cond_msg_error (myError, "[SLOG] ERROR: Cannot read from input file");
 
-            g_clear_error(&myError);
+          g_clear_error(&myError);
 
-            g_io_channel_shutdown(input, TRUE, &myError);
-            g_io_channel_unref(input);
+          g_io_channel_shutdown(input, TRUE, &myError);
+          g_io_channel_unref(input);
 
-            g_clear_error(&myError);
+          g_clear_error(&myError);
 
-            g_io_channel_shutdown(output, TRUE, &myError);
-            g_io_channel_unref(output);
+          g_io_channel_shutdown(output, TRUE, &myError);
+          g_io_channel_unref(output);
 
-            g_clear_error(&myError);
+          g_clear_error(&myError);
 
-            g_free(inputBuffer);
-            g_free(outputBuffer);
+          g_free(inputBuffer);
+          g_free(outputBuffer);
 
-            return 0;
+          return 0;
         }
 
-        // Cut last character to remove the trailing new line
-        g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
+      // Cut last character to remove the trailing new line
+      g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
     }
 
-    ret = ret * initVerify(entriesInFile, mainKey, &nextLogEntry, &startingEntry, inputBuffer, &tab);
-    ret = ret * iterateBuffer(chunkLength, inputBuffer, &nextLogEntry, mainKey, keyZero, 0, outputBuffer,
-                              &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
+  ret = ret * initVerify(entriesInFile, mainKey, &nextLogEntry, &startingEntry, inputBuffer, &tab);
+  ret = ret * iterateBuffer(chunkLength, inputBuffer, &nextLogEntry, mainKey, keyZero, 0, outputBuffer,
+                            &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
 
-    // Write to file
-    for (guint64 i = 0; i < chunkLength; i++)
+  // Write to file
+  for (guint64 i = 0; i < chunkLength; i++)
     {
-        if (outputBuffer[i] == NULL)
+      if (outputBuffer[i] == NULL)
         {
-            msg_error ("[SLOG] ERROR: Invalid output buffer (== NULL)");
-            g_free(inputBuffer);
-            g_free(outputBuffer);
+          msg_error ("[SLOG] ERROR: Invalid output buffer (== NULL)");
+          g_free(inputBuffer);
+          g_free(outputBuffer);
 
-            return 0;
+          return 0;
         }
 
-        if (outputBuffer[i]->len!=0)
+      if (outputBuffer[i]->len!=0)
         {
-            gsize size;
-            //Add newline
-            g_string_append(outputBuffer[i], "\n");
-            status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
-            if (status != G_IO_STATUS_NORMAL)
+          gsize size;
+          //Add newline
+          g_string_append(outputBuffer[i], "\n");
+          status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
+          if (status != G_IO_STATUS_NORMAL)
             {
-                cond_msg_error (myError, "[SLOG] ERROR: writing to output file");
-                g_clear_error(&myError);
+              cond_msg_error (myError, "[SLOG] ERROR: writing to output file");
+              g_clear_error(&myError);
 
-                g_io_channel_shutdown(input, TRUE, &myError);
-                g_io_channel_unref(input);
+              g_io_channel_shutdown(input, TRUE, &myError);
+              g_io_channel_unref(input);
 
-                g_clear_error(&myError);
+              g_clear_error(&myError);
 
-                g_io_channel_shutdown(output, TRUE, &myError);
-                g_io_channel_unref(output);
+              g_io_channel_shutdown(output, TRUE, &myError);
+              g_io_channel_unref(output);
 
-                g_clear_error(&myError);
+              g_clear_error(&myError);
 
-                g_free(inputBuffer);
-                g_free(outputBuffer);
+              g_free(inputBuffer);
+              g_free(outputBuffer);
 
-                return 0;
+              return 0;
             }
         }
 
-        g_string_free(outputBuffer[i], TRUE);
-        g_string_free(inputBuffer[i], TRUE);
+      g_string_free(outputBuffer[i], TRUE);
+      g_string_free(inputBuffer[i], TRUE);
 
     }
 
-    // Process file in chunks
-    for (int j = 0; j<(entriesInFile/chunkLength)-1; j++)
+  // Process file in chunks
+  for (int j = 0; j<(entriesInFile/chunkLength)-1; j++)
     {
-        for (guint64 i = 0; i < chunkLength; i++)
+      for (guint64 i = 0; i < chunkLength; i++)
         {
-            inputBuffer[i] = g_string_new(NULL);
-            status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
-            if (status != G_IO_STATUS_NORMAL)
+          inputBuffer[i] = g_string_new(NULL);
+          status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
+          if (status != G_IO_STATUS_NORMAL)
             {
-                cond_msg_error (myError, "[SLOG] ERROR: Cannot read from input file");
-                g_clear_error(&myError);
+              cond_msg_error (myError, "[SLOG] ERROR: Cannot read from input file");
+              g_clear_error(&myError);
 
-                g_io_channel_shutdown(input, TRUE, &myError);
-                g_io_channel_unref(input);
+              g_io_channel_shutdown(input, TRUE, &myError);
+              g_io_channel_unref(input);
 
-                g_clear_error(&myError);
+              g_clear_error(&myError);
 
-                g_io_channel_shutdown(output, TRUE, &myError);
-                g_io_channel_unref(output);
+              g_io_channel_shutdown(output, TRUE, &myError);
+              g_io_channel_unref(output);
 
-                g_clear_error(&myError);
+              g_clear_error(&myError);
 
-                g_free(inputBuffer);
-                g_free(outputBuffer);
+              g_free(inputBuffer);
+              g_free(outputBuffer);
 
-                return 0;
+              return 0;
             }
-            // Cut last character to remove the trailing new line...
-            g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
+          // Cut last character to remove the trailing new line...
+          g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
         }
-        ret = ret * iterateBuffer(chunkLength, inputBuffer, &nextLogEntry, mainKey, keyZero, 0, outputBuffer,
-                                  &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
+      ret = ret * iterateBuffer(chunkLength, inputBuffer, &nextLogEntry, mainKey, keyZero, 0, outputBuffer,
+                                &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
 
-        // ...and write to file
-        for (guint64 i = 0; i < chunkLength; i++)
+      // ...and write to file
+      for (guint64 i = 0; i < chunkLength; i++)
         {
-            if (outputBuffer[i]->len!=0)
+          if (outputBuffer[i]->len!=0)
             {
-                gsize size;
-                //Add newline
-                g_string_append(outputBuffer[i], "\n");
-                status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
-                if (status != G_IO_STATUS_NORMAL)
+              gsize size;
+              //Add newline
+              g_string_append(outputBuffer[i], "\n");
+              status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
+              if (status != G_IO_STATUS_NORMAL)
                 {
-                    cond_msg_error (myError, "[SLOG] ERROR: writing to output file");
+                  cond_msg_error (myError, "[SLOG] ERROR: writing to output file");
 
-                    g_clear_error(&myError);
+                  g_clear_error(&myError);
 
-                    g_io_channel_shutdown(input, TRUE, &myError);
-                    g_io_channel_unref(input);
+                  g_io_channel_shutdown(input, TRUE, &myError);
+                  g_io_channel_unref(input);
 
-                    g_clear_error(&myError);
+                  g_clear_error(&myError);
 
-                    g_io_channel_shutdown(output, TRUE, &myError);
-                    g_io_channel_unref(output);
+                  g_io_channel_shutdown(output, TRUE, &myError);
+                  g_io_channel_unref(output);
 
-                    g_clear_error(&myError);
+                  g_clear_error(&myError);
 
-                    g_free(inputBuffer);
-                    g_free(outputBuffer);
+                  g_free(inputBuffer);
+                  g_free(outputBuffer);
 
-                    return 0;
+                  return 0;
                 }
 
             }
-            g_string_free(outputBuffer[i], TRUE);
-            g_string_free(inputBuffer[i], TRUE);
+          g_string_free(outputBuffer[i], TRUE);
+          g_string_free(inputBuffer[i], TRUE);
         }
     }
 
-    if ((entriesInFile % chunkLength) > 0)
+  if ((entriesInFile % chunkLength) > 0)
     {
-        for (guint64 i = 0; i < (entriesInFile % chunkLength); i++)
+      for (guint64 i = 0; i < (entriesInFile % chunkLength); i++)
         {
-            inputBuffer[i] = g_string_new(NULL);
-            status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
-            if (status != G_IO_STATUS_NORMAL)
+          inputBuffer[i] = g_string_new(NULL);
+          status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
+          if (status != G_IO_STATUS_NORMAL)
             {
-                cond_msg_error (myError, "[SLOG] ERROR: Cannot read from input file");
-                g_clear_error(&myError);
+              cond_msg_error (myError, "[SLOG] ERROR: Cannot read from input file");
+              g_clear_error(&myError);
 
-                g_io_channel_shutdown(input, TRUE, &myError);
-                g_io_channel_unref(input);
+              g_io_channel_shutdown(input, TRUE, &myError);
+              g_io_channel_unref(input);
 
-                g_clear_error(&myError);
+              g_clear_error(&myError);
 
-                g_io_channel_shutdown(output, TRUE, &myError);
-                g_io_channel_unref(output);
+              g_io_channel_shutdown(output, TRUE, &myError);
+              g_io_channel_unref(output);
 
-                g_clear_error(&myError);
+              g_clear_error(&myError);
 
-                g_free(inputBuffer);
-                g_free(outputBuffer);
+              g_free(inputBuffer);
+              g_free(outputBuffer);
 
-                return 0;
+              return 0;
             }
-            // Cut last character to remove the trailing new line
-            g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
+          // Cut last character to remove the trailing new line
+          g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
         }
-        ret = ret * iterateBuffer((entriesInFile % chunkLength), inputBuffer, &nextLogEntry, mainKey, keyZero, 0, outputBuffer,
-                                  &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
+      ret = ret * iterateBuffer((entriesInFile % chunkLength), inputBuffer, &nextLogEntry, mainKey, keyZero, 0, outputBuffer,
+                                &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
 
-        for (guint64 i = 0; i < (entriesInFile % chunkLength); i++)
+      for (guint64 i = 0; i < (entriesInFile % chunkLength); i++)
         {
-            if (outputBuffer[i]->len!=0)
+          if (outputBuffer[i]->len!=0)
             {
 
-                gsize size;
-                //Add newline
-                g_string_append(outputBuffer[i], "\n");
-                status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
-                if (status != G_IO_STATUS_NORMAL)
+              gsize size;
+              //Add newline
+              g_string_append(outputBuffer[i], "\n");
+              status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
+              if (status != G_IO_STATUS_NORMAL)
                 {
-                    cond_msg_error (myError, "[SLOG] ERROR: Cannot write to output file");
-                    g_clear_error(&myError);
+                  cond_msg_error (myError, "[SLOG] ERROR: Cannot write to output file");
+                  g_clear_error(&myError);
 
-                    g_io_channel_shutdown(input, TRUE, &myError);
-                    g_io_channel_unref(input);
+                  g_io_channel_shutdown(input, TRUE, &myError);
+                  g_io_channel_unref(input);
 
-                    g_clear_error(&myError);
+                  g_clear_error(&myError);
 
-                    g_io_channel_shutdown(output, TRUE, &myError);
-                    g_io_channel_unref(output);
+                  g_io_channel_shutdown(output, TRUE, &myError);
+                  g_io_channel_unref(output);
 
-                    g_clear_error(&myError);
+                  g_clear_error(&myError);
 
-                    g_free(inputBuffer);
-                    g_free(outputBuffer);
+                  g_free(inputBuffer);
+                  g_free(outputBuffer);
 
-                    return 0;
+                  return 0;
                 }
             }
-            g_string_free(outputBuffer[i], TRUE);
-            g_string_free(inputBuffer[i], TRUE);
+          g_string_free(outputBuffer[i], TRUE);
+          g_string_free(inputBuffer[i], TRUE);
         }
 
     }
 
-    ret = ret * finalizeVerify(startingEntry, entriesInFile, bigMac, cmac_tag, tab);
+  ret = ret * finalizeVerify(startingEntry, entriesInFile, bigMac, cmac_tag, tab);
 
-    g_free(inputBuffer);
-    g_free(outputBuffer);
+  g_free(inputBuffer);
+  g_free(outputBuffer);
 
-    g_io_channel_shutdown(input, TRUE, &myError);
-    g_io_channel_unref(input);
+  g_io_channel_shutdown(input, TRUE, &myError);
+  g_io_channel_unref(input);
 
-    g_clear_error(&myError);
+  g_clear_error(&myError);
 
-    g_io_channel_shutdown(output, TRUE, &myError);
-    g_io_channel_unref(output);
+  g_io_channel_shutdown(output, TRUE, &myError);
+  g_io_channel_unref(output);
 
-    g_clear_error(&myError);
+  g_clear_error(&myError);
 
-    return ret;
+  return ret;
 }
 
 // Print usage message and clean up
 int slog_usage(GOptionContext *ctx, GOptionGroup *grp, GString *errormsg)
 {
-    if(errormsg != NULL)
+  if(errormsg != NULL)
     {
-        g_print ("\nERROR: %s\n\n", errormsg->str);
-        g_string_free(errormsg, TRUE);
+      g_print ("\nERROR: %s\n\n", errormsg->str);
+      g_string_free(errormsg, TRUE);
     }
 
-    g_print("%s", g_option_context_get_help(ctx, TRUE, NULL));
-    g_option_context_free(ctx);
+  g_print("%s", g_option_context_get_help(ctx, TRUE, NULL));
+  g_option_context_free(ctx);
 
-    return 1;
+  return 1;
 }
 
 /*
@@ -2055,43 +2055,43 @@ int slog_usage(GOptionContext *ctx, GOptionGroup *grp, GString *errormsg)
  */
 gboolean validFileNameArg(const gchar *option_name, const gchar *value, gpointer data, GError **error)
 {
-    gboolean isValid = FALSE;
-    GString *currentOption = g_string_new(option_name);
-    GString *currentValue = g_string_new(value);
-    GString *longOption = g_string_new(LONG_OPT_INDICATOR);
-    GString *shortOption = g_string_new(SHORT_OPT_INDICATOR);
+  gboolean isValid = FALSE;
+  GString *currentOption = g_string_new(option_name);
+  GString *currentValue = g_string_new(value);
+  GString *longOption = g_string_new(LONG_OPT_INDICATOR);
+  GString *shortOption = g_string_new(SHORT_OPT_INDICATOR);
 
-    SLogOptions *opts = (SLogOptions *)data;
+  SLogOptions *opts = (SLogOptions *)data;
 
-    for(SLogOptions *option = opts; option != NULL && option->longname != NULL; option++)
+  for(SLogOptions *option = opts; option != NULL && option->longname != NULL; option++)
     {
-        g_string_append(longOption, option->longname);
-        g_string_append_c(shortOption, option->shortname);
+      g_string_append(longOption, option->longname);
+      g_string_append_c(shortOption, option->shortname);
 
-        if(g_string_equal(currentOption, longOption) || g_string_equal(currentOption, shortOption))
+      if(g_string_equal(currentOption, longOption) || g_string_equal(currentOption, shortOption))
         {
-            if(g_file_test(value, G_FILE_TEST_IS_REGULAR))
+          if(g_file_test(value, G_FILE_TEST_IS_REGULAR))
             {
-                option->arg = currentValue->str;
-                isValid = TRUE;
-                break;
+              option->arg = currentValue->str;
+              isValid = TRUE;
+              break;
             }
         }
 
-        // Reset for next option argument to check
-        g_string_assign(longOption, LONG_OPT_INDICATOR);
-        g_string_assign(shortOption, SHORT_OPT_INDICATOR);
+      // Reset for next option argument to check
+      g_string_assign(longOption, LONG_OPT_INDICATOR);
+      g_string_assign(shortOption, SHORT_OPT_INDICATOR);
     }
 
-    if (!isValid)
+  if (!isValid)
     {
-        *error = g_error_new(G_FILE_ERROR, G_OPTION_ERROR_FAILED, "Invalid path or non existing regular file: %s", value);
+      *error = g_error_new(G_FILE_ERROR, G_OPTION_ERROR_FAILED, "Invalid path or non existing regular file: %s", value);
     }
 
-    g_string_free(currentOption, TRUE);
-    g_string_free(currentValue, FALSE);
-    g_string_free(longOption, TRUE);
-    g_string_free(shortOption, TRUE);
+  g_string_free(currentOption, TRUE);
+  g_string_free(currentValue, FALSE);
+  g_string_free(longOption, TRUE);
+  g_string_free(shortOption, TRUE);
 
-    return isValid;
+  return isValid;
 }

--- a/news/bugfix-5205.md
+++ b/news/bugfix-5205.md
@@ -1,0 +1,22 @@
+slog: New implementation of the pseudo-random function
+
+The previous implementation allowed an attacker to distinguish between
+the pseudo-random function (PRF) and a real random function by supplying
+specially crafted inputs to it. This leads to a predictable way of how the
+PRF is generating output which should not by allowed by a good PRF.
+The new implementation provides a variable input length and
+constant output length PRF based on AES CMAC for key derivation using
+the current key K<sub>i</sub>, i.e. a key expansion of K<sub>i</sub> using 
+multiple iterations is performed. Subsequently, with K<sub>i</sub> as the 
+key used in the PRF, the input is defined as
+```
+(i || label || 0x00 || context || L)
+```
+with `i` as the number of the current iteration, `L` as the total length of
+the requested output, `label` and `context` for parametrization of the PRF
+output based on the intended purpose. See NIST reports SP-800-56cr2 and
+SP.800-108r1 for more information on key derivation schemes with a PRF.
+
+In the previous implementation, the input length was fixed
+at 16 bytes regardless of the actual length of the input data.
+This is also fixed in the new implementation.


### PR DESCRIPTION
<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
This PR solves issue #5205 by providing a new implementation of the pseudo-random function used for key derivation by the secure logging module.

The previous implementation allowed an attacker to distinguish between the pseudo-random function (PRF) and a real random function by supplying specially crafted inputs to it. This leads to a predictable way of how the PRF is generating output which should not by allowed by a good PRF. The new implementation provides a variable input length and constant output length PRF based on AES CMAC for key derivation using the current key K<sub>i</sub>, i.e. a key expansion of K<sub>i</sub> using multiple iterations is performed. Subsequently, with K<sub>i</sub> as the key used in the PRF, the input is defined as
```
(i || label || 0x00 || context || L)
```
with `i` as the number of the current iteration, `L` as the total length of the requested output, `label` and `context` for parametrization of the PRF output based on the intended purpose. See NIST reports [SP.800-56cr2](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Cr2.pdf) and [SP.800-108r1 -upd1](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-108r1-upd1.pdf) for more information on key derivation schemes with a PRF.

In the previous implementation, the input length was fixed at 16 bytes regardless of the actual length of the input data. This is also fixed in the new implementation.