### PR TITLE
dbld: install sudo pacakge into RHEL based docker images

### DIFF
--- a/dbld/builddeps
+++ b/dbld/builddeps
@@ -46,14 +46,14 @@ function install_dbld_dependencies()
 {
     case "${OS_DISTRIBUTION}" in
         centos|almalinux)
-            $YUM_INSTALL yum-utils
+            $YUM_INSTALL yum-utils sudo
             ;;
         debian|ubuntu)
             apt-get update
             $APT_INSTALL curl gnupg2
             ;;
         fedora)
-            $DNF_INSTALL -y dnf-plugins-core
+            $DNF_INSTALL -y dnf-plugins-core sudo
             ;;
     esac
 }


### PR DESCRIPTION
Base images of any RHEL/Fedora derived distros don't come with sudo in the base image, which will break the build later.

Signed-off-by: Tamas Pal <folti@balabit.com>