### PR TITLE
github: housekeeping use docker/login-action@v3 instead of @v1

### DIFF
--- a/.github/workflows/dbld-images.yml
+++ b/.github/workflows/dbld-images.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Log in to the Container registry
         if: env.UPLOAD_IMAGES_INTERNAL == 'true'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4.1.7
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.dockerhub-username }}
           password: ${{ secrets.dockerhub-password }}


### PR DESCRIPTION
@v1 is long obslete, and could break anytime.

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
