### PR TITLE
github: use ubuntu-22.04 runners for docker based builds.

### DIFF
--- a/.github/workflows/create-packages.yml
+++ b/.github/workflows/create-packages.yml
@@ -34,7 +34,8 @@ jobs:
   create-packages:
     name: ${{ matrix.distro }}
 
-    runs-on: ubuntu-latest
+    # FIXME: temporary because sudo doesn't work in RedHat and descendants on an ubuntu-24.04 hosts
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.github/workflows/dbld-images.yml
+++ b/.github/workflows/dbld-images.yml
@@ -25,7 +25,8 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    # FIXME: temporary because sudo doesn't work in RedHat and descendants on an ubuntu-24.04 hosts
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         image:


### PR DESCRIPTION
Due to currently sudo doesn't work if the runner is an ubuntu-24.04 and the container is a RedHat or derivative

