### PR TITLE
dbld: remove eol ubuntubuilds from the nightly as well

### DIFF
--- a/.github/workflows/test-apt-packages.yml
+++ b/.github/workflows/test-apt-packages.yml
@@ -22,8 +22,6 @@ jobs:
           - "ubuntu:focal"
           - "ubuntu:jammy"
           - "ubuntu:noble"
-          - "ubuntu:lunar"
-          - "ubuntu:mantic"
         upgrade-from:
           - "debian-official"
           - "syslog-ng-last"


### PR DESCRIPTION
Signed-off-by: Hofi <hofione@gmail.com>