### PR TITLE
CI: (temporally?!) removed the usage of the silently disappearing --preinstall option from the brew update command

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -45,7 +45,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew update --preinstall
+          # TODO: Seems the latest HomeBrew version silently removed the --preinstall option, started a discussion on the topic to confirm
+          # https://github.com/orgs/Homebrew/discussions/5896
+          brew update # --preinstall
           brew bundle --force --file=contrib/Brewfile
 
           OS_NAME=$([[ ${{ matrix.version }} -eq 13 ]] && echo "Ventura" || echo "Sonoma")


### PR DESCRIPTION
Signed-off-by: Hofi <hofione@gmail.com>