### PR TITLE
docker: add option to pass custom arguments to syslog-ng from docker run command line

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -26,6 +26,7 @@ ARCH=$(uname -m)
 
 unset LD_PRELOAD
 export LD_PRELOAD="/usr/lib/${ARCH}-linux-gnu/libjemalloc.so.2"
-set
+echo; set; echo
 
-/usr/sbin/syslog-ng -F
+echo "Starting syslog-ng with params: $@"
+/usr/sbin/syslog-ng -F $@


### PR DESCRIPTION
Signed-off-by: Hofi <hofione@gmail.com>