### PR TITLE
cfg: fix memory leaks when parsing config file

### DIFF
--- a/lib/scanner/xml-scanner/xml-scanner.c
+++ b/lib/scanner/xml-scanner/xml-scanner.c
@@ -24,7 +24,7 @@
 #include "xml-scanner.h"
 #include "scratch-buffers.h"
 #include "compat/glib.h"
-
+#include "string-list.h"
 
 /*
   For some patterns, GPatternSpec stores the pattern as reversed
@@ -86,8 +86,8 @@ xml_scanner_options_compile_exclude_tags_to_patterns(XMLScannerOptions *self)
 void
 xml_scanner_options_set_and_compile_exclude_tags(XMLScannerOptions *self, GList *exclude_tags)
 {
-  g_list_free_full(self->exclude_tags, g_free);
-  self->exclude_tags = g_list_copy_deep(exclude_tags, ((GCopyFunc)g_strdup), NULL);
+  string_list_free(self->exclude_tags);
+  self->exclude_tags = string_list_clone(exclude_tags);
   xml_scanner_options_compile_exclude_tags_to_patterns(self);
 }
 

--- a/lib/transport/tls-context.c
+++ b/lib/transport/tls-context.c
@@ -25,6 +25,7 @@
 #include "messages.h"
 #include "compat/openssl_support.h"
 #include "secret-storage/secret-storage.h"
+#include "string-list.h"
 
 #include <sys/socket.h>
 #include <arpa/inet.h>
@@ -901,7 +902,7 @@ gboolean
 tls_context_set_conf_cmds(TLSContext *self, GList *cmds, GError **error)
 {
 #if SYSLOG_NG_HAVE_DECL_SSL_CONF_CTX_NEW
-  g_list_foreach(self->conf_cmds_list, (GFunc) g_free, NULL);
+  string_list_free(self->conf_cmds_list);
   self->conf_cmds_list = cmds;
   return TRUE;
 #else
@@ -967,9 +968,9 @@ _tls_context_free(TLSContext *self)
 {
   g_free(self->location);
   SSL_CTX_free(self->ssl_ctx);
-  g_list_foreach(self->conf_cmds_list, (GFunc) g_free, NULL);
-  g_list_foreach(self->trusted_fingerprint_list, (GFunc) g_free, NULL);
-  g_list_foreach(self->trusted_dn_list, (GFunc) g_free, NULL);
+  string_list_free(self->conf_cmds_list);
+  string_list_free(self->trusted_fingerprint_list);
+  string_list_free(self->trusted_dn_list);
   g_free(self->key_file);
   g_free(self->pkcs12_file);
   g_free(self->cert_file);

--- a/lib/transport/tls-session.c
+++ b/lib/transport/tls-session.c
@@ -23,6 +23,7 @@
 #include "transport/tls-session.h"
 #include "transport/tls-context.h"
 #include "str-utils.h"
+#include "string-list.h"
 
 #include <glib/gstdio.h>
 #include <openssl/x509_vfy.h>
@@ -501,7 +502,7 @@ tls_session_set_trusted_fingerprints(TLSContext *self, GList *fingerprints)
 {
   g_assert(fingerprints);
 
-  g_list_foreach(self->trusted_fingerprint_list, (GFunc) g_free, NULL);
+  string_list_free(self->trusted_fingerprint_list);
   self->trusted_fingerprint_list = fingerprints;
 }
 
@@ -510,7 +511,7 @@ tls_session_set_trusted_dn(TLSContext *self, GList *dn)
 {
   g_assert(dn);
 
-  g_list_foreach(self->trusted_dn_list, (GFunc) g_free, NULL);
+  string_list_free(self->trusted_dn_list);
   self->trusted_dn_list = dn;
 }
 

--- a/modules/affile/collection-comparator.c
+++ b/modules/affile/collection-comparator.c
@@ -178,6 +178,7 @@ collection_comparator_stop(CollectionComparator *self)
   g_list_foreach(self->deleted_entries, _deleted_entries_callback, self);
   g_list_free_full(self->deleted_entries, free_collection_comparator_entry);
   g_list_foreach(self->added_entries, _added_entries_callback, self);
+  /* the items in self->added_entries are not owned here */
   g_list_free(self->added_entries);
   self->running = FALSE;
 }

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -800,25 +800,25 @@ tls_options
 	;
 
 tls_option
-        : KW_IFDEF {
-}
+  : KW_IFDEF
+    {
+    }
 
 	| KW_PEER_VERIFY '(' yesno ')'
 	  {
 	    gint verify_mode = $3 ? (TVM_REQUIRED | TVM_TRUSTED) : (TVM_OPTIONAL | TVM_UNTRUSTED);
 	    tls_context_set_verify_mode(last_tls_context, verify_mode);
-          }
+    }
 	| KW_PEER_VERIFY '(' string ')'
 	  {
-	    CHECK_ERROR(tls_context_set_verify_mode_by_name(last_tls_context, $3), @3,
-	                "unknown peer-verify() argument");
-            free($3);
-          }
+	    CHECK_ERROR(tls_context_set_verify_mode_by_name(last_tls_context, $3), @3, "unknown peer-verify() argument");
+      free($3);
+    }
 	| KW_KEY_FILE '(' path_secret ')'
 	  {
 	    tls_context_set_key_file(last_tls_context, $3);
-            free($3);
-          }
+      free($3);
+    }
 	| KW_KEYLOG_FILE '(' string ')'
 	  {
 	    GError *error = NULL;
@@ -828,88 +828,87 @@ tls_option
 	| KW_CERT_FILE '(' path_check ')'
 	  {
 	    tls_context_set_cert_file(last_tls_context, $3);
-            free($3);
-          }
-        | KW_DHPARAM_FILE '(' path_check ')'
-          {
-            tls_context_set_dhparam_file(last_tls_context, $3);
-            free($3);
-          }
-        | KW_PKCS12_FILE '(' path_check ')'
-          {
-            tls_context_set_pkcs12_file(last_tls_context, $3);
-            free($3);
-          }
-	| KW_CA_DIR '(' string ')'
+      free($3);
+    }
+  | KW_DHPARAM_FILE '(' path_check ')'
+    {
+      tls_context_set_dhparam_file(last_tls_context, $3);
+      free($3);
+    }
+  | KW_PKCS12_FILE '(' path_check ')'
+    {
+      tls_context_set_pkcs12_file(last_tls_context, $3);
+      free($3);
+    }
+  | KW_CA_DIR '(' string ')'
 	  {
 	    tls_context_set_ca_dir(last_tls_context, $3);
-            free($3);
-          }
+      free($3);
+    }
 	| KW_CRL_DIR '(' string ')'
 	  {
 	    tls_context_set_crl_dir(last_tls_context, $3);
-            free($3);
-          }
-        | KW_CA_FILE '(' path_check ')'
-          {
-            tls_context_set_ca_file(last_tls_context, $3);
-            free($3);
-          }
-        | KW_TRUSTED_KEYS '(' string_list ')'
-          {
-            tls_session_set_trusted_fingerprints(last_tls_context, $3);
-          }
-        | KW_TRUSTED_DN '(' string_list ')'
-          {
-            tls_session_set_trusted_dn(last_tls_context, $3);
-          }
-        | KW_CIPHER_SUITE '(' tls_cipher_suites ')'
-        | KW_CIPHER_SUITE '(' string ')'
-          {
-            /* compat for specifying TLS 1.2-or-older ciphers */
-            tls_context_set_cipher_suite(last_tls_context, $3);
-            free($3);
-          }
-        | KW_SIGALGS '(' string ')'
-          {
-            GError *error = NULL;
-            CHECK_ERROR_GERROR(tls_context_set_sigalgs(last_tls_context, $3, &error), @3, error, "Error setting sigalgs()");
-            free($3);
-          }
-        | KW_CLIENT_SIGALGS '(' string ')'
-          {
-            GError *error = NULL;
-            CHECK_ERROR_GERROR(tls_context_set_client_sigalgs(last_tls_context, $3, &error), @3, error, "Error setting client-sigalgs()");
-            free($3);
-          }
-        | KW_ECDH_CURVE_LIST '(' string ')'
-          {
-            tls_context_set_ecdh_curve_list(last_tls_context, $3);
-            free($3);
-          }
+      free($3);
+    }
+  | KW_CA_FILE '(' path_check ')'
+    {
+      tls_context_set_ca_file(last_tls_context, $3);
+      free($3);
+    }
+  | KW_TRUSTED_KEYS '(' string_list ')'
+    {
+      tls_session_set_trusted_fingerprints(last_tls_context, $3);
+    }
+  | KW_TRUSTED_DN '(' string_list ')'
+    {
+      tls_session_set_trusted_dn(last_tls_context, $3);
+    }
+  | KW_CIPHER_SUITE '(' tls_cipher_suites ')'
+  | KW_CIPHER_SUITE '(' string ')'
+    {
+      /* compat for specifying TLS 1.2-or-older ciphers */
+      tls_context_set_cipher_suite(last_tls_context, $3);
+      free($3);
+    }
+  | KW_SIGALGS '(' string ')'
+    {
+      GError *error = NULL;
+      CHECK_ERROR_GERROR(tls_context_set_sigalgs(last_tls_context, $3, &error), @3, error, "Error setting sigalgs()");
+      free($3);
+    }
+  | KW_CLIENT_SIGALGS '(' string ')'
+    {
+      GError *error = NULL;
+      CHECK_ERROR_GERROR(tls_context_set_client_sigalgs(last_tls_context, $3, &error), @3, error, "Error setting client-sigalgs()");
+      free($3);
+    }
+  | KW_ECDH_CURVE_LIST '(' string ')'
+    {
+      tls_context_set_ecdh_curve_list(last_tls_context, $3);
+      free($3);
+    }
 	| KW_SSL_OPTIONS '(' string_list ')'
 	  {
-            CHECK_ERROR(tls_context_set_ssl_options_by_name(last_tls_context, $3), @3,
-                        "unknown ssl-options() argument");
+      CHECK_ERROR(tls_context_set_ssl_options_by_name(last_tls_context, $3), @3, "unknown ssl-options() argument");
 	  }
 	| KW_SSL_VERSION '(' string ')'
 	  {
-            CHECK_ERROR(tls_context_set_ssl_version_by_name(last_tls_context, $3), @3,
-                        "unknown ssl-version() argument");
-	    free($3);
-          }
-        | KW_ALLOW_COMPRESS '(' yesno ')'
-          {
-            transport_mapper_inet_set_allow_compress(last_transport_mapper, $3);
-          }
+      CHECK_ERROR(tls_context_set_ssl_version_by_name(last_tls_context, $3), @3, "unknown ssl-version() argument");
+      free($3);
+    }
+  | KW_ALLOW_COMPRESS '(' yesno ')'
+    {
+      transport_mapper_inet_set_allow_compress(last_transport_mapper, $3);
+    }
 	| KW_CONF_CMDS '(' tls_conf_cmds ')'
 	  {
 	    GError *error = NULL;
 	    CHECK_ERROR_GERROR(tls_context_set_conf_cmds(last_tls_context, $3, &error), @3, error, "Error setting conf-cmds()");
 	  }
-        | KW_ENDIF {
-}
-        ;
+  | KW_ENDIF
+    {
+    }
+  ;
 
 tls_conf_cmds
 	: tls_conf_cmd_list_build

--- a/modules/afsocket/afsocket-grammar.ym
+++ b/modules/afsocket/afsocket-grammar.ym
@@ -44,6 +44,7 @@
 #include "socket-options-unix.h"
 #include "transport-mapper-inet.h"
 #include "service-management.h"
+#include "string-list.h"
 
 #include "systemd-syslog-source.h"
 #include "afsocket-systemd-override.h"
@@ -890,6 +891,7 @@ tls_option
 	| KW_SSL_OPTIONS '(' string_list ')'
 	  {
       CHECK_ERROR(tls_context_set_ssl_options_by_name(last_tls_context, $3), @3, "unknown ssl-options() argument");
+      string_list_free($3);
 	  }
 	| KW_SSL_VERSION '(' string ')'
 	  {

--- a/modules/http/http-grammar.ym
+++ b/modules/http/http-grammar.ym
@@ -35,6 +35,7 @@
 #include "response-handler.h"
 #include "autodetect-ca-location.h"
 #include "plugin.h"
+#include "string-list.h"
 
 #include <string.h>
 
@@ -148,7 +149,7 @@ http_option
       {
         GError *error = NULL;
         CHECK_ERROR_GERROR(http_dd_set_urls(last_driver, $3, &error), @3, error, "Error setting url");
-        g_list_free_full($3, free);
+        string_list_free($3);
       }
     | KW_USER       '(' string ')'            { http_dd_set_user(last_driver, $3); free($3); }
     | KW_PASSWORD   '(' string ')'            { http_dd_set_password(last_driver, $3); free($3); }

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -24,6 +24,7 @@
 #include "http.h"
 #include "http-worker.h"
 #include "compression.h"
+#include "string-list.h"
 
 /* HTTPDestinationDriver */
 void
@@ -104,8 +105,8 @@ http_dd_set_headers(LogDriver *d, GList *headers)
 {
   HTTPDestinationDriver *self = (HTTPDestinationDriver *) d;
 
-  g_list_free_full(self->headers, g_free);
-  self->headers = g_list_copy_deep(headers, ((GCopyFunc)g_strdup), NULL);
+  string_list_free(self->headers);
+  self->headers = string_list_clone(headers);
 }
 
 void

--- a/modules/xml/xml-grammar.ym
+++ b/modules/xml/xml-grammar.ym
@@ -33,6 +33,7 @@
 #include "syslog-names.h"
 #include "messages.h"
 #include "plugin.h"
+#include "string-list.h"
 
 #include <string.h>
 
@@ -109,7 +110,7 @@ xml_opt
         | KW_EXCLUDE_TAGS '(' string_list ')'
           {
             xml_scanner_options_set_and_compile_exclude_tags(last_xml_scanner_options, $3);
-            g_list_free_full($3, free);
+            string_list_free($3);
           }
         | KW_STRIP_WHITESPACES '(' yesno ')'
           { xml_scanner_options_set_strip_whitespaces(last_xml_scanner_options, $3); }


### PR DESCRIPTION
The first run of reviewing the config grammars and parsing.

Main issues we still have to address:

- further search for leaks like this, this run focused on string_list values only
- use common allocation/deallocation solutions for all types
- use common ownership agreements as currently
  - sometimes the callee, sometimes the caller makes the cleanup of the arguments passed towards from the grammar, we should make this common as well
  - when the caller takes over the ownership of the passed-toward argument it must be done consistently, now it is sometimes cloned/copied (like the string), but sometimes simply just assigned (like the string_list), I guess the copy/clone version is preferred to avoid possible allocator issues

Fixes: https://github.com/syslog-ng/syslog-ng/issues/5194

Signed-off-by: Hofi <hofione@gmail.com>