### PR TITLE
Syslog ng ctl attach command

### DIFF
--- a/lib/console.c
+++ b/lib/console.c
@@ -93,18 +93,19 @@ console_is_attached(void)
 }
 
 /* re-acquire a console after startup using an array of fds */
-void
+gboolean
 console_acquire_from_fds(gint fds[3])
 {
   const gchar *takeover_message_on_old_console = "[Console taken over, no further output here]\n";
-  g_assert(!console_is_attached());
-
-  if (using_initial_console)
-    {
-      (void) write(1, takeover_message_on_old_console, strlen(takeover_message_on_old_console));
-    }
+  gboolean result = FALSE;
 
   g_mutex_lock(&console_lock);
+  if (console_present)
+    {
+      if (!using_initial_console)
+        goto exit;
+      (void) write(1, takeover_message_on_old_console, strlen(takeover_message_on_old_console));
+    }
 
   dup2(fds[0], STDIN_FILENO);
   dup2(fds[1], STDOUT_FILENO);
@@ -112,7 +113,10 @@ console_acquire_from_fds(gint fds[3])
 
   console_present = TRUE;
   using_initial_console = FALSE;
+  result = TRUE;
+exit:
   g_mutex_unlock(&console_lock);
+  return result;
 }
 
 /**

--- a/lib/console.c
+++ b/lib/console.c
@@ -78,20 +78,6 @@ console_is_present(void)
   return result;
 }
 
-gboolean
-console_is_attached(void)
-{
-  gboolean result;
-  /* the lock only serves a memory barrier but is not a real synchronization */
-  g_mutex_lock(&console_lock);
-  if (using_initial_console)
-    result = FALSE;
-  else
-    result = console_present;
-  g_mutex_unlock(&console_lock);
-  return result;
-}
-
 /* re-acquire a console after startup using an array of fds */
 gboolean
 console_acquire_from_fds(gint fds[3])

--- a/lib/console.h
+++ b/lib/console.h
@@ -31,8 +31,7 @@ void console_printf(const gchar *fmt, ...) __attribute__ ((format (printf, 1, 2)
 
 gboolean console_is_present(void);
 gboolean console_is_attached(void);
-void console_acquire_from_fds(gint fds[3]);
-void console_acquire_from_stdio(void);
+gboolean console_acquire_from_fds(gint fds[3]);
 void console_release(void);
 
 void console_global_init(const gchar *console_prefix);

--- a/lib/console.h
+++ b/lib/console.h
@@ -30,7 +30,6 @@
 void console_printf(const gchar *fmt, ...) __attribute__ ((format (printf, 1, 2)));
 
 gboolean console_is_present(void);
-gboolean console_is_attached(void);
 gboolean console_acquire_from_fds(gint fds[3]);
 void console_release(void);
 

--- a/lib/control/control-command-thread.c
+++ b/lib/control/control-command-thread.c
@@ -27,6 +27,7 @@
 #include "messages.h"
 #include "secret-storage/secret-storage.h"
 #include "scratch-buffers.h"
+#include "apphook.h"
 #include <iv_event.h>
 
 struct _ControlCommandThread
@@ -70,7 +71,7 @@ _thread(gpointer user_data)
   ControlCommandThread *self = (ControlCommandThread *) user_data;
 
   iv_init();
-  scratch_buffers_allocator_init();
+  app_thread_start();
 
   msg_debug("Control command thread has started",
             evt_tag_str("control_command", self->command->str));
@@ -88,8 +89,8 @@ _thread(gpointer user_data)
             evt_tag_str("control_command", self->command->str));
 
   scratch_buffers_explicit_gc();
-  scratch_buffers_allocator_deinit();
   control_command_thread_unref(self);
+  app_thread_stop();
   iv_deinit();
 }
 

--- a/lib/control/control-command-thread.c
+++ b/lib/control/control-command-thread.c
@@ -44,6 +44,12 @@ struct _ControlCommandThread
   struct iv_event thread_finished;
 };
 
+gboolean
+control_command_thread_relates_to_connection(ControlCommandThread *self, ControlConnection *cc)
+{
+  return self->connection == cc;
+}
+
 static void
 _on_thread_finished(gpointer user_data)
 {

--- a/lib/control/control-command-thread.h
+++ b/lib/control/control-command-thread.h
@@ -27,6 +27,8 @@
 
 #include "control.h"
 
+gboolean control_command_thread_relates_to_connection(ControlCommandThread *self, ControlConnection *cc);
+
 void control_command_thread_run(ControlCommandThread *self);
 void control_command_thread_cancel(ControlCommandThread *self);
 const gchar *control_command_thread_get_command(ControlCommandThread *self);

--- a/lib/control/control-connection.c
+++ b/lib/control/control-connection.c
@@ -223,7 +223,7 @@ control_connection_io_input(void *s)
     }
   else if (rc == 0)
     {
-      msg_debug("EOF on control channel, closing connection");
+      msg_trace("EOF on control channel, closing connection");
       goto destroy_connection;
     }
   else

--- a/lib/control/control-connection.c
+++ b/lib/control/control-connection.c
@@ -36,6 +36,14 @@ _g_string_destroy(gpointer user_data)
   g_string_free(str, TRUE);
 }
 
+gboolean
+control_connection_get_attached_fds(ControlConnection *self, gint *fds, gsize *num_fds)
+{
+  if (self->get_attached_fds)
+    return self->get_attached_fds(self, fds, num_fds);
+  return FALSE;
+}
+
 static void
 _control_connection_free(ControlConnection *self)
 {

--- a/lib/control/control-connection.h
+++ b/lib/control/control-connection.h
@@ -41,6 +41,7 @@ struct _ControlConnection
   GString *output_buffer;
   gsize pos;
   ControlServer *server;
+  gboolean (*get_attached_fds)(ControlConnection *self, gint *fds, gsize *num_fds);
   gboolean (*run_command)(ControlConnection *self, ControlCommand *command_desc, GString *command_string);
   int (*read)(ControlConnection *self, gpointer buffer, gsize size);
   int (*write)(ControlConnection *self, gpointer buffer, gsize size);
@@ -56,6 +57,7 @@ struct _ControlConnection
 
 };
 
+gboolean control_connection_get_attached_fds(ControlConnection *self, gint *fds, gsize *num_fds);
 gboolean control_connection_run_command(ControlConnection *self, GString *command_string);
 void control_connection_send_reply(ControlConnection *self, GString *reply);
 void control_connection_send_batched_reply(ControlConnection *self, GString *reply);

--- a/lib/control/control-server.c
+++ b/lib/control/control-server.c
@@ -67,9 +67,7 @@ control_server_cancel_workers(ControlServer *self, ControlConnection *cc)
 {
   if (self->worker_threads)
     {
-      msg_debug("Cancelling control server worker threads");
       g_list_foreach(self->worker_threads, _cancel_worker, cc);
-      msg_debug("Control server worker threads have been cancelled");
     }
 }
 

--- a/lib/control/control-server.h
+++ b/lib/control/control-server.h
@@ -38,7 +38,7 @@ struct _ControlServer
   void (*free_fn)(ControlServer *self);
 };
 
-void control_server_cancel_workers(ControlServer *self);
+void control_server_cancel_all_workers(ControlServer *self);
 void control_server_connection_closed(ControlServer *self, ControlConnection *cc);
 void control_server_worker_started(ControlServer *self, ControlCommandThread *worker);
 void control_server_worker_finished(ControlServer *self, ControlCommandThread *worker);

--- a/lib/mainloop.c
+++ b/lib/mainloop.c
@@ -475,7 +475,7 @@ main_loop_exit_initiate(gpointer user_data)
   if (main_loop_is_terminating(self))
     return;
 
-  control_server_cancel_workers(self->control_server);
+  control_server_cancel_all_workers(self->control_server);
 
   app_pre_shutdown();
 

--- a/lib/scratch-buffers.c
+++ b/lib/scratch-buffers.c
@@ -245,10 +245,17 @@ _thread_maintenance_update_time(void)
 void
 scratch_buffers_lazy_update_stats(void)
 {
-  if (_thread_maintenance_period_elapsed())
+  if (iv_inited())
+    {
+      if (_thread_maintenance_period_elapsed())
+        {
+          scratch_buffers_update_stats();
+          _thread_maintenance_update_time();
+        }
+    }
+  else
     {
       scratch_buffers_update_stats();
-      _thread_maintenance_update_time();
     }
 }
 

--- a/syslog-ng-ctl/CMakeLists.txt
+++ b/syslog-ng-ctl/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(SYSLOG_NG_CTL_SOURCES
     syslog-ng-ctl.c
     control-client.h
+    commands/attach.h
+    commands/attach.c
     commands/commands.h
     commands/commands.c
     commands/credentials.h

--- a/syslog-ng-ctl/Makefile.am
+++ b/syslog-ng-ctl/Makefile.am
@@ -6,6 +6,8 @@ syslog_ng_ctl_syslog_ng_ctl_SOURCES		= 	\
 	syslog-ng-ctl/syslog-ng-ctl.c			\
 	syslog-ng-ctl/commands/commands.h		\
 	syslog-ng-ctl/commands/commands.c		\
+	syslog-ng-ctl/commands/attach.h			\
+	syslog-ng-ctl/commands/attach.c			\
 	syslog-ng-ctl/commands/config.h			\
 	syslog-ng-ctl/commands/config.c			\
 	syslog-ng-ctl/commands/credentials.h		\

--- a/syslog-ng-ctl/commands/attach.c
+++ b/syslog-ng-ctl/commands/attach.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2024 Balazs Scheidler <balazs.scheidler@axoflow.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "ctl-stats.h"
+#include "syslog-ng.h"
+
+static gint attach_options_seconds;
+static gchar *attach_options_log_level = NULL;
+static gchar **attach_commands = NULL;
+
+static gboolean
+_store_log_level(const gchar *option_name,
+                 const gchar *value,
+                 gpointer data,
+                 GError **error)
+{
+  if (!attach_options_log_level)
+    {
+      attach_options_log_level = g_strdup(value);
+      return TRUE;
+    }
+  g_set_error(error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED, "You can't specify multiple log-levels at a time.");
+  return FALSE;
+}
+
+GOptionEntry attach_options[] =
+{
+  { "seconds", 0, 0, G_OPTION_ARG_INT, &attach_options_seconds, "amount of time to attach for", NULL },
+  { "log-level", 0, 0, G_OPTION_ARG_CALLBACK, _store_log_level, "change syslog-ng log level", "<default|verbose|debug|trace>" },
+  { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, &attach_commands, "attach mode: logs, stdio", NULL },
+  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
+};
+
+gint
+slng_attach(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
+{
+  GString *command = g_string_new("ATTACH");
+  const gchar *attach_mode;
+
+  if (attach_commands)
+    {
+      if (attach_commands[1])
+        {
+          fprintf(stderr, "Too many arguments");
+          return 1;
+        }
+      attach_mode = attach_commands[0];
+    }
+  else
+    attach_mode = "stdio";
+
+  if (g_str_equal(attach_mode, "stdio"))
+    g_string_append(command, " STDIO");
+  else if (g_str_equal(attach_mode, "logs"))
+    g_string_append(command, " LOGS");
+  else
+    {
+      fprintf(stderr, "Unknown attach mode\n");
+      return 1;
+    }
+
+  g_string_append_printf(command, " %d", attach_options_seconds ? : -1);
+  if (attach_options_log_level)
+    g_string_append_printf(command, " %s", attach_options_log_level);
+  gint result = attach_command(command->str);
+  g_string_free(command, TRUE);
+  return result;
+}

--- a/syslog-ng-ctl/commands/attach.h
+++ b/syslog-ng-ctl/commands/attach.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2002-2013 Balabit
- * Copyright (c) 1998-2013 Balázs Scheidler
+ * Copyright (c) 2024 Balazs Scheidler <balazs.scheidler@axoflow.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -22,18 +21,12 @@
  *
  */
 
-#ifndef CONTROL_CLIENT_H
-#define CONTROL_CLIENT_H 1
+#ifndef SYSLOG_NG_CTL_ATTACH_H_INCLUDED
+#define SYSLOG_NG_CTL_ATTACH_H_INCLUDED 1
 
-#include "syslog-ng.h"
-#include "commands/commands.h"
+#include "commands.h"
 
-typedef struct _ControlClient ControlClient;
-
-ControlClient *control_client_new(const gchar *path);
-gboolean control_client_connect(ControlClient *self);
-gint control_client_send_command(ControlClient *self, const gchar *cmd, gboolean attach);
-gint control_client_read_reply(ControlClient *self, CommandResponseHandlerFunc cb, gpointer user_data);
-void control_client_free(ControlClient *self);
+extern GOptionEntry attach_options[];
+gint slng_attach(int argc, char *argv[], const gchar *mode, GOptionContext *ctx);
 
 #endif

--- a/syslog-ng-ctl/commands/commands.c
+++ b/syslog-ng-ctl/commands/commands.c
@@ -57,14 +57,14 @@ process_response_status(GString *response)
 }
 
 static gboolean
-slng_send_cmd(const gchar *cmd)
+slng_send_cmd(const gchar *cmd, gboolean attach)
 {
   if (!control_client_connect(control_client))
     {
       return FALSE;
     }
 
-  if (control_client_send_command(control_client, cmd) < 0)
+  if (control_client_send_command(control_client, cmd, attach) < 0)
     {
       return FALSE;
     }
@@ -75,7 +75,16 @@ slng_send_cmd(const gchar *cmd)
 gint
 slng_run_command(const gchar *command, CommandResponseHandlerFunc cb, gpointer user_data)
 {
-  if (!slng_send_cmd(command))
+  if (!slng_send_cmd(command, FALSE))
+    return 1;
+
+  return control_client_read_reply(control_client, cb, user_data);
+}
+
+gint
+slng_attach_command(const gchar *command, CommandResponseHandlerFunc cb, gpointer user_data)
+{
+  if (!slng_send_cmd(command, TRUE))
     return 1;
 
   return control_client_read_reply(control_client, cb, user_data);
@@ -87,17 +96,29 @@ _is_response_empty(GString *response)
   return (response == NULL || g_str_equal(response->str, ""));
 }
 
+static gboolean
+_is_response_alive(GString *response)
+{
+  return strncmp(response->str, "ALIVE", 5) == 0;
+}
+
 static gint
 _print_reply_to_stdout(GString *reply, gpointer user_data)
 {
   gboolean first_response = *((gboolean *)user_data);
   gint retval = 0;
+
+  if (_is_response_alive(reply))
+    return 0;
+
   if (first_response)
     {
       if (_is_response_empty(reply))
         retval = 1;
-      else retval = process_response_status(reply);
+      else
+        retval = process_response_status(reply);
     }
+
 
   printf("%s", reply->str);
   return retval;
@@ -110,6 +131,20 @@ dispatch_command(const gchar *cmd)
   gint retval = 0;
   gchar *dispatchable_command = g_strdup_printf("%s\n", cmd);
   retval = slng_run_command(dispatchable_command, _print_reply_to_stdout, &first_response);
+
+  secret_storage_wipe(dispatchable_command, strlen(dispatchable_command));
+  g_free(dispatchable_command);
+
+  return retval;
+}
+
+gint
+attach_command(const gchar *cmd)
+{
+  gboolean first_response = TRUE;
+  gint retval = 0;
+  gchar *dispatchable_command = g_strdup_printf("%s\n", cmd);
+  retval = slng_attach_command(dispatchable_command, _print_reply_to_stdout, &first_response);
 
   secret_storage_wipe(dispatchable_command, strlen(dispatchable_command));
   g_free(dispatchable_command);

--- a/syslog-ng-ctl/commands/commands.h
+++ b/syslog-ng-ctl/commands/commands.h
@@ -43,7 +43,7 @@ typedef struct _CommandDescriptor
 typedef gint (*CommandResponseHandlerFunc)(GString *response, gpointer user_data);
 
 gint dispatch_command(const gchar *cmd);
-gint slng_run_command(const gchar *command, CommandResponseHandlerFunc cb, gpointer user_data);
+gint attach_command(const gchar *cmd);
 gint process_response_status(GString *response);
 gboolean is_syslog_ng_running(void);
 

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -37,6 +37,7 @@
 #include "commands/query.h"
 #include "commands/license.h"
 #include "commands/healthcheck.h"
+#include "commands/attach.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -111,6 +112,7 @@ slng_export_config_graph(int argc, char *argv[], const gchar *mode, GOptionConte
 
 static CommandDescriptor modes[] =
 {
+  { "attach", attach_options, "Attach to a running syslog-ng instance", slng_attach, NULL },
   { "stats", stats_options, "Get syslog-ng statistics. Possible commands: csv, prometheus; default: csv", slng_stats, NULL },
   { "verbose", verbose_options, "Enable/query verbose messages", slng_verbose, NULL },
   { "debug", verbose_options, "Enable/query debug messages", slng_verbose, NULL },

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -118,6 +118,7 @@ lib/generic-number\.[ch]
 lib/tests/test_generic_number\.c
 lib/severity-aliases\.table
 syslog-ng-ctl/commands/log-level.[ch]
+syslog-ng-ctl/commands/attach.[ch]
 modules/afsocket/afsocket-signals.h
 syslog-ng-ctl/commands/healthcheck.[ch]
 modules/python-modules/syslogng/confgen\.py


### PR DESCRIPTION
This PR allows syslog-ng-ctl to connect back to syslog-ng's original stdin/out/err fds and re-acqiure the output on those fds.

There are three subcommands:

```
# this just takes the stdio fds for 10 seconds and displays syslog-ng output in that time period
$ syslog-ng-ctl attach stdio --seconds 10
```

The other allows you to steal the log messages:

```
$ syslog-ng-ctl attach logs --seconds 10 --level trace
```

The other allows you to start the debugger on the new console:

```
$ syslog-ng-ctl attach debugger
```

There can only be one such attached process at any time.


Backport of [326](https://github.com/axoflow/axosyslog/pull/326) by @bazsi

Depends on: https://github.com/syslog-ng/syslog-ng/pull/5237