### PR TITLE
Console io backup restore

### DIFF
--- a/lib/console.c
+++ b/lib/console.c
@@ -104,7 +104,7 @@ _get_fn_names(gint fns)
 
 /* re-acquire a console after startup using an array of fds */
 gboolean
-console_acquire_from_fds(gint fds[3], gint fds_to_steel)
+console_acquire_from_fds(gint fds[3], gint fds_to_steal)
 {
   gboolean result = FALSE;
 
@@ -112,14 +112,14 @@ console_acquire_from_fds(gint fds[3], gint fds_to_steel)
   if (!using_initial_console)
     goto exit;
 
-  GString *stolen_fn_names = _get_fn_names(fds_to_steel);
+  GString *stolen_fn_names = _get_fn_names(fds_to_steal);
   gchar *takeover_message_on_old_console = g_strdup_printf("[Console(%s) taken over, no further output here]\n",
                                                            stolen_fn_names->str);
   (void) write(STDOUT_FILENO, takeover_message_on_old_console, strlen(takeover_message_on_old_console));
   g_free(takeover_message_on_old_console);
   g_string_free(stolen_fn_names, TRUE);
 
-  stolen_fds = fds_to_steel;
+  stolen_fds = fds_to_steal;
 
   if (stolen_fds & (1 << STDIN_FILENO))
     initial_console_fds[0] = dup(STDIN_FILENO);

--- a/lib/console.h
+++ b/lib/console.h
@@ -30,7 +30,7 @@
 void console_printf(const gchar *fmt, ...) __attribute__ ((format (printf, 1, 2)));
 
 gboolean console_is_initial(void);
-gboolean console_acquire_from_fds(gint fds[3], gint fds_to_steel);
+gboolean console_acquire_from_fds(gint fds[3], gint fds_to_steal);
 void console_release(void);
 
 void console_global_init(const gchar *console_prefix);

--- a/lib/console.h
+++ b/lib/console.h
@@ -30,7 +30,7 @@
 void console_printf(const gchar *fmt, ...) __attribute__ ((format (printf, 1, 2)));
 
 gboolean console_is_initial(void);
-gboolean console_acquire_from_fds(gint fds[3]);
+gboolean console_acquire_from_fds(gint fds[3], gint fds_to_steel);
 void console_release(void);
 
 void console_global_init(const gchar *console_prefix);

--- a/lib/console.h
+++ b/lib/console.h
@@ -29,7 +29,7 @@
 
 void console_printf(const gchar *fmt, ...) __attribute__ ((format (printf, 1, 2)));
 
-gboolean console_is_present(void);
+gboolean console_is_initial(void);
 gboolean console_acquire_from_fds(gint fds[3]);
 void console_release(void);
 

--- a/lib/mainloop-control.c
+++ b/lib/mainloop-control.c
@@ -35,6 +35,7 @@
 #include "debugger/debugger-main.h"
 
 #include <string.h>
+#include <unistd.h>
 
 static gboolean
 _control_process_log_level(const gchar *level, GString *result)
@@ -119,26 +120,22 @@ _wait_until_peer_disappears(ControlConnection *cc, gint max_seconds, gboolean *c
   console_release();
 }
 
-static void
-control_connection_attach(ControlConnection *cc, GString *command, gpointer user_data, gboolean *cancelled)
+typedef struct _AttachCommandArgs
 {
-  MainLoop *main_loop = (MainLoop *) user_data;
-  gchar **cmds = g_strsplit(command->str, " ", 4);
+  gboolean start_debugger;
+  gint fds_to_steel;
+  gint n_seconds;
+  gboolean log_stderr;
+  gint log_level;
+} AttachCommandArgs;
 
-  GString *result = g_string_sized_new(128);
-  gint n_seconds = -1;
-  gboolean start_debugger = FALSE;
-  struct
-  {
-    gboolean log_stderr;
-    gint log_level;
-  } old_values, new_values;
+static gboolean
+_parse_attach_command_args(GString *command, AttachCommandArgs *args, GString *result)
+{
+  gboolean success = FALSE;
+  gchar **cmds = g_strsplit(command->str, " ", 5);
 
-  old_values.log_stderr = log_stderr;
-  old_values.log_level = msg_get_log_level();
-  new_values = old_values;
-
-  if (!cmds[1])
+  if (cmds[1] == NULL)
     {
       g_string_assign(result, "FAIL Invalid arguments received");
       goto exit;
@@ -146,22 +143,24 @@ control_connection_attach(ControlConnection *cc, GString *command, gpointer user
 
   if (g_str_equal(cmds[1], "STDIO"))
     {
-      ;
+      if (cmds[3])
+        args->fds_to_steel = atoi(cmds[3]);
     }
   else if (g_str_equal(cmds[1], "LOGS"))
     {
-      new_values.log_stderr = TRUE;
-      if (cmds[3])
-        new_values.log_level = msg_map_string_to_log_level(cmds[3]);
-      if (new_values.log_level < 0)
-        {
-          g_string_assign(result, "FAIL Invalid log level");
-          goto exit;
-        }
+      args->log_stderr = TRUE;
+      /* NOTE: as log_stderr uses stderr (what a surprise)
+       *          - we need to steal only the stderr
+       *          - caller of the `attach logs` will get the stderr output as well, so
+       *            they should redirect stderr to stdout if they want to capture it for
+       *            further processing e.g.
+       *                syslog-ng-ctl attach logs |& grep -i error
+       */
+      args->fds_to_steel = (1 << STDERR_FILENO);
     }
   else if (g_str_equal(cmds[1], "DEBUGGER"))
     {
-      start_debugger = TRUE;
+      args->start_debugger = TRUE;
     }
   else
     {
@@ -170,49 +169,85 @@ control_connection_attach(ControlConnection *cc, GString *command, gpointer user
     }
 
   if (cmds[2])
-    n_seconds = atoi(cmds[2]);
+    args->n_seconds = atoi(cmds[2]);
+
+  if (cmds[4])
+    args->log_level = msg_map_string_to_log_level(cmds[4]);
+  if (args->log_level < 0)
+    {
+      g_string_assign(result, "FAIL Invalid log level");
+      goto exit;
+    }
+  success = TRUE;
+
+exit:
+  g_strfreev(cmds);
+  return success;
+}
+
+static void
+control_connection_attach(ControlConnection *cc, GString *command, gpointer user_data, gboolean *cancelled)
+{
+  MainLoop *main_loop = (MainLoop *) user_data;
+  GString *result = g_string_sized_new(128);
+  struct
+  {
+    gboolean log_stderr;
+    gint log_level;
+  } old_values =
+  {
+    log_stderr,
+    msg_get_log_level()
+  };
+  AttachCommandArgs cmd_args =
+  {
+    .start_debugger = FALSE,
+    .fds_to_steel = (1 << STDOUT_FILENO) | (1 << STDERR_FILENO),
+    .n_seconds = -1,
+    .log_stderr = old_values.log_stderr,
+    .log_level = old_values.log_level
+  };
+
+  if (FALSE == _parse_attach_command_args(command, &cmd_args, result))
+    goto exit;
 
   gint fds[3];
   gsize num_fds = G_N_ELEMENTS(fds);
-  if (!control_connection_get_attached_fds(cc, fds, &num_fds) || num_fds != 3)
+  if (FALSE == control_connection_get_attached_fds(cc, fds, &num_fds) || num_fds != 3)
     {
       g_string_assign(result,
                       "FAIL The underlying transport for syslog-ng-ctl does not support fd passing or incorrect number of fds received");
       goto exit;
     }
 
-  if (!console_acquire_from_fds(fds))
+  if (FALSE == console_acquire_from_fds(fds, cmd_args.fds_to_steel))
     {
-      g_string_assign(result,
-                      "FAIL Error acquiring console");
+      g_string_assign(result, "FAIL Error acquiring console");
       goto exit;
     }
 
-  log_stderr = new_values.log_stderr;
-  msg_set_log_level(new_values.log_level);
+  log_stderr = cmd_args.log_stderr;
+  msg_set_log_level(cmd_args.log_level);
 
-  if (start_debugger && !debugger_is_running())
+  if (cmd_args.start_debugger && FALSE == debugger_is_running())
     {
       //cfg_load_module(self->current_configuration, "mod-python");
       debugger_start(main_loop, main_loop_get_current_config(main_loop));
     }
 
-  _wait_until_peer_disappears(cc, n_seconds, cancelled);
+  _wait_until_peer_disappears(cc, cmd_args.n_seconds, cancelled);
 
-  if (start_debugger && debugger_is_running())
-    {
-      debugger_stop();
-    }
+  if (cmd_args.start_debugger && debugger_is_running())
+    debugger_stop();
 
   log_stderr = old_values.log_stderr;
   msg_set_log_level(old_values.log_level);
 
-  g_string_assign(result, "OK [console output ends here]");
-exit:
+  g_string_assign(result, "OK [Console output ends here]");
 
+exit:
   control_connection_send_batched_reply(cc, result);
   control_connection_send_close_batch(cc);
-  g_strfreev(cmds);
 }
 
 static void

--- a/lib/mainloop-control.c
+++ b/lib/mainloop-control.c
@@ -123,7 +123,7 @@ _wait_until_peer_disappears(ControlConnection *cc, gint max_seconds, gboolean *c
 typedef struct _AttachCommandArgs
 {
   gboolean start_debugger;
-  gint fds_to_steel;
+  gint fds_to_steal;
   gint n_seconds;
   gboolean log_stderr;
   gint log_level;
@@ -144,7 +144,7 @@ _parse_attach_command_args(GString *command, AttachCommandArgs *args, GString *r
   if (g_str_equal(cmds[1], "STDIO"))
     {
       if (cmds[3])
-        args->fds_to_steel = atoi(cmds[3]);
+        args->fds_to_steal = atoi(cmds[3]);
     }
   else if (g_str_equal(cmds[1], "LOGS"))
     {
@@ -156,7 +156,7 @@ _parse_attach_command_args(GString *command, AttachCommandArgs *args, GString *r
        *            further processing e.g.
        *                syslog-ng-ctl attach logs |& grep -i error
        */
-      args->fds_to_steel = (1 << STDERR_FILENO);
+      args->fds_to_steal = (1 << STDERR_FILENO);
     }
   else if (g_str_equal(cmds[1], "DEBUGGER"))
     {
@@ -202,7 +202,7 @@ control_connection_attach(ControlConnection *cc, GString *command, gpointer user
   AttachCommandArgs cmd_args =
   {
     .start_debugger = FALSE,
-    .fds_to_steel = (1 << STDOUT_FILENO) | (1 << STDERR_FILENO),
+    .fds_to_steal = (1 << STDOUT_FILENO) | (1 << STDERR_FILENO),
     .n_seconds = -1,
     .log_stderr = old_values.log_stderr,
     .log_level = old_values.log_level
@@ -220,7 +220,7 @@ control_connection_attach(ControlConnection *cc, GString *command, gpointer user
       goto exit;
     }
 
-  if (FALSE == console_acquire_from_fds(fds, cmd_args.fds_to_steel))
+  if (FALSE == console_acquire_from_fds(fds, cmd_args.fds_to_steal))
     {
       g_string_assign(result, "FAIL Error acquiring console");
       goto exit;

--- a/syslog-ng-ctl/commands/attach.c
+++ b/syslog-ng-ctl/commands/attach.c
@@ -24,8 +24,11 @@
 #include "ctl-stats.h"
 #include "syslog-ng.h"
 
-static gint attach_options_seconds;
+#include <unistd.h>
+
+static gint attach_options_seconds = -1;
 static gchar *attach_options_log_level = NULL;
+static gint attach_options_fds_to_steel = 0;
 static gchar **attach_commands = NULL;
 
 static gboolean
@@ -43,10 +46,39 @@ _store_log_level(const gchar *option_name,
   return FALSE;
 }
 
+static gboolean
+_parse_fd_names(const gchar *option_name,
+                const gchar *value,
+                gpointer data,
+                GError **error)
+{
+  gboolean result = TRUE;
+  gchar **fds = g_strsplit(value, ",", 3);
+
+  attach_options_fds_to_steel = 0;
+  for (gchar **fd = fds; *fd; fd++)
+    {
+      if (g_str_equal(*fd, "stdin"))
+        attach_options_fds_to_steel |= (1 << STDIN_FILENO);
+      else if (g_str_equal(*fd, "stdout"))
+        attach_options_fds_to_steel |= (1 << STDOUT_FILENO);
+      else if (g_str_equal(*fd, "stderr"))
+        attach_options_fds_to_steel |= (1 << STDERR_FILENO);
+      else
+        {
+          g_set_error(error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED, "Unknown %s option value: %s", option_name, *fd);
+          result = FALSE;
+        }
+    }
+  g_strfreev(fds);
+  return result;
+}
+
 GOptionEntry attach_options[] =
 {
-  { "seconds", 0, 0, G_OPTION_ARG_INT, &attach_options_seconds, "amount of time to attach for", NULL },
-  { "log-level", 0, 0, G_OPTION_ARG_CALLBACK, _store_log_level, "change syslog-ng log level", "<default|verbose|debug|trace>" },
+  { "seconds", 's', 0, G_OPTION_ARG_INT, &attach_options_seconds, "amount of time to attach for", NULL },
+  { "log-level", 'l', 0, G_OPTION_ARG_CALLBACK, _store_log_level, "change syslog-ng log level", "<default|verbose|debug|trace>" },
+  { "fds-to-steel", 'f', 0, G_OPTION_ARG_CALLBACK, _parse_fd_names, "which stdio file handlers to attach to, default is <stdout,stderr>, valid only with the `stdio` attach mode", "<stdin|stdout|stderr> in a comma separated list"  },
   { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, &attach_commands, "attach mode: logs, debugger, stdio", NULL },
   { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
 };
@@ -61,7 +93,7 @@ slng_attach(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
     {
       if (attach_commands[1])
         {
-          fprintf(stderr, "Too many arguments");
+          fprintf(stderr, "Error parsing command line arguments: Too many arguments");
           return 1;
         }
       attach_mode = attach_commands[0];
@@ -77,13 +109,22 @@ slng_attach(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
     g_string_append(command, " DEBUGGER");
   else
     {
-      fprintf(stderr, "Unknown attach mode\n");
+      fprintf(stderr, "Error parsing command line arguments: Unknown attach mode\n");
+      return 1;
+    }
+  if (FALSE == g_str_equal(attach_mode, "stdio") && attach_options_fds_to_steel > 0)
+    {
+      fprintf(stderr, "Error parsing command line arguments: %s is valid only with %s attach mode\n",
+              "fds-to-steel", "stdio");
       return 1;
     }
 
-  g_string_append_printf(command, " %d", attach_options_seconds ? : -1);
+  g_string_append_printf(command, " %d", attach_options_seconds > 0 ? attach_options_seconds : -1);
+  g_string_append_printf(command, " %d",
+                         attach_options_fds_to_steel > 0 ? attach_options_fds_to_steel : (1 << STDOUT_FILENO) | (1 << STDERR_FILENO));
   if (attach_options_log_level)
     g_string_append_printf(command, " %s", attach_options_log_level);
+
   gint result = attach_command(command->str);
   g_string_free(command, TRUE);
   return result;

--- a/syslog-ng-ctl/commands/attach.c
+++ b/syslog-ng-ctl/commands/attach.c
@@ -21,7 +21,7 @@
  *
  */
 
-#include "ctl-stats.h"
+#include "commands.h"
 #include "syslog-ng.h"
 
 #include <unistd.h>
@@ -29,7 +29,6 @@
 static gint attach_options_seconds = -1;
 static gchar *attach_options_log_level = NULL;
 static gint attach_options_fds_to_steel = 0;
-static gchar **attach_commands = NULL;
 
 static gboolean
 _store_log_level(const gchar *option_name,
@@ -74,32 +73,11 @@ _parse_fd_names(const gchar *option_name,
   return result;
 }
 
-GOptionEntry attach_options[] =
-{
-  { "seconds", 's', 0, G_OPTION_ARG_INT, &attach_options_seconds, "amount of time to attach for", NULL },
-  { "log-level", 'l', 0, G_OPTION_ARG_CALLBACK, _store_log_level, "change syslog-ng log level", "<default|verbose|debug|trace>" },
-  { "fds-to-steel", 'f', 0, G_OPTION_ARG_CALLBACK, _parse_fd_names, "which stdio file handlers to attach to, default is <stdout,stderr>, valid only with the `stdio` attach mode", "<stdin|stdout|stderr> in a comma separated list"  },
-  { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, &attach_commands, "attach mode: logs, debugger, stdio", NULL },
-  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
-};
-
 gint
 slng_attach(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
 {
   GString *command = g_string_new("ATTACH");
-  const gchar *attach_mode;
-
-  if (attach_commands)
-    {
-      if (attach_commands[1])
-        {
-          fprintf(stderr, "Error parsing command line arguments: Too many arguments");
-          return 1;
-        }
-      attach_mode = attach_commands[0];
-    }
-  else
-    attach_mode = "stdio";
+  const gchar *attach_mode = mode ? : "stdio";
 
   if (g_str_equal(attach_mode, "stdio"))
     g_string_append(command, " STDIO");
@@ -129,3 +107,29 @@ slng_attach(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
   g_string_free(command, TRUE);
   return result;
 }
+
+#define SECONDS_OPTION_ENTRY OPTIONS_ENTRY("seconds", 's', 0, G_OPTION_ARG_INT, &attach_options_seconds, "amount of time to attach for", NULL)
+#define LOG_LEVEL_OPTION_ENTRY OPTIONS_ENTRY("log-level", 'l', 0, G_OPTION_ARG_CALLBACK, _store_log_level, "change syslog-ng log level", "<default|verbose|debug|trace>")
+
+const GOptionEntry attach_stdio_options[] =
+{
+  SECONDS_OPTION_ENTRY,
+  LOG_LEVEL_OPTION_ENTRY,
+  { "fds-to-steel", 'f', 0, G_OPTION_ARG_CALLBACK, _parse_fd_names, "which stdio file handlers to attach to, default is <stdout,stderr>", "<stdin|stdout|stderr> in a comma separated list"  },
+  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
+};
+
+GOptionEntry attach_logs_and_debugger_options[] =
+{
+  SECONDS_OPTION_ENTRY,
+  LOG_LEVEL_OPTION_ENTRY,
+  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
+};
+
+CommandDescriptor attach_commands[] =
+{
+  { "stdio", attach_stdio_options, "Attach to syslog-ng console using the given file handlers", slng_attach },
+  { "logs", attach_logs_and_debugger_options, "Attach to syslog-ng internal logs, which are normally redirected via stderr; for further processing, use another redirection, e.g., `syslog-ng-ctl attach logs |& grep -i error.`", slng_attach },
+  { "debugger", attach_logs_and_debugger_options, "Start and attach to syslog-ng debugger", slng_attach },
+  { NULL, NULL, NULL, NULL }
+};

--- a/syslog-ng-ctl/commands/attach.c
+++ b/syslog-ng-ctl/commands/attach.c
@@ -28,7 +28,7 @@
 
 static gint attach_options_seconds = -1;
 static gchar *attach_options_log_level = NULL;
-static gint attach_options_fds_to_steel = 0;
+static gint attach_options_fds_to_steal = 0;
 
 static gboolean
 _store_log_level(const gchar *option_name,
@@ -54,15 +54,15 @@ _parse_fd_names(const gchar *option_name,
   gboolean result = TRUE;
   gchar **fds = g_strsplit(value, ",", 3);
 
-  attach_options_fds_to_steel = 0;
+  attach_options_fds_to_steal = 0;
   for (gchar **fd = fds; *fd; fd++)
     {
       if (g_str_equal(*fd, "stdin"))
-        attach_options_fds_to_steel |= (1 << STDIN_FILENO);
+        attach_options_fds_to_steal |= (1 << STDIN_FILENO);
       else if (g_str_equal(*fd, "stdout"))
-        attach_options_fds_to_steel |= (1 << STDOUT_FILENO);
+        attach_options_fds_to_steal |= (1 << STDOUT_FILENO);
       else if (g_str_equal(*fd, "stderr"))
-        attach_options_fds_to_steel |= (1 << STDERR_FILENO);
+        attach_options_fds_to_steal |= (1 << STDERR_FILENO);
       else
         {
           g_set_error(error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED, "Unknown %s option value: %s", option_name, *fd);
@@ -90,7 +90,7 @@ slng_attach(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
       fprintf(stderr, "Error parsing command line arguments: Unknown attach mode\n");
       return 1;
     }
-  if (FALSE == g_str_equal(attach_mode, "stdio") && attach_options_fds_to_steel > 0)
+  if (FALSE == g_str_equal(attach_mode, "stdio") && attach_options_fds_to_steal > 0)
     {
       fprintf(stderr, "Error parsing command line arguments: %s is valid only with %s attach mode\n",
               "fds-to-steel", "stdio");
@@ -99,7 +99,7 @@ slng_attach(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
 
   g_string_append_printf(command, " %d", attach_options_seconds > 0 ? attach_options_seconds : -1);
   g_string_append_printf(command, " %d",
-                         attach_options_fds_to_steel > 0 ? attach_options_fds_to_steel : (1 << STDOUT_FILENO) | (1 << STDERR_FILENO));
+                         attach_options_fds_to_steal > 0 ? attach_options_fds_to_steal : (1 << STDOUT_FILENO) | (1 << STDERR_FILENO));
   if (attach_options_log_level)
     g_string_append_printf(command, " %s", attach_options_log_level);
 

--- a/syslog-ng-ctl/commands/attach.h
+++ b/syslog-ng-ctl/commands/attach.h
@@ -26,7 +26,6 @@
 
 #include "commands.h"
 
-extern GOptionEntry attach_options[];
-gint slng_attach(int argc, char *argv[], const gchar *mode, GOptionContext *ctx);
+extern CommandDescriptor attach_commands[];
 
 #endif

--- a/syslog-ng-ctl/commands/commands.h
+++ b/syslog-ng-ctl/commands/commands.h
@@ -29,6 +29,10 @@
 
 #include <stdio.h>
 
+/* Though clang has no issues, but gcc is stricter about requiring initializer elements to be compile-time constants when initializing structures directly
+ * This helper macro is used to initialize GOptionEntry structures with the same values as the GOptionEntry initializers without having to repeat the initializer values */
+#define OPTIONS_ENTRY(long_name, short_name, flags, arg, arg_data, description, arg_description) { long_name, short_name, flags, arg, arg_data, description, arg_description }
+
 extern GOptionEntry no_options[];
 
 typedef struct _CommandDescriptor

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -143,12 +143,6 @@ print_usage(const gchar *bin_name, CommandDescriptor *descriptors)
     }
 }
 
-gboolean
-_is_help(gchar *cmd)
-{
-  return g_str_equal(cmd, "--help");
-}
-
 static CommandDescriptor *
 find_active_mode(CommandDescriptor descriptors[], gint *argc, char **argv, GString *cmdname_accumulator)
 {
@@ -196,12 +190,6 @@ main(int argc, char *argv[])
   setlocale(LC_ALL, "");
 
   control_name = get_installation_path_for(PATH_CONTROL_SOCKET);
-
-  if (argc > 1 && _is_help(argv[1]))
-    {
-      print_usage(argv[0], modes);
-      exit(0);
-    }
 
   GString *cmdname_accumulator = g_string_new(argv[0]);
   CommandDescriptor *active_mode = find_active_mode(modes, &argc, argv, cmdname_accumulator);

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -112,7 +112,8 @@ slng_export_config_graph(int argc, char *argv[], const gchar *mode, GOptionConte
 
 static CommandDescriptor modes[] =
 {
-  { "attach", attach_options, "Attach to a running syslog-ng instance", slng_attach, NULL },
+  { "attach", no_options, "Attach to a running syslog-ng instance", NULL, attach_commands },
+  // TODO: Add proper details of the sub-commands like attach and credentials have
   { "stats", stats_options, "Get syslog-ng statistics. Possible commands: csv, prometheus; default: csv", slng_stats, NULL },
   { "verbose", verbose_options, "Enable/query verbose messages", slng_verbose, NULL },
   { "debug", verbose_options, "Enable/query debug messages", slng_verbose, NULL },
@@ -121,6 +122,7 @@ static CommandDescriptor modes[] =
   { "stop", no_options, "Stop syslog-ng process", slng_stop, NULL },
   { "reload", no_options, "Reload syslog-ng", slng_reload, NULL },
   { "reopen", no_options, "Re-open of log destination files", slng_reopen, NULL },
+  // TODO: Add proper details of the sub-commands like attach and credentials have
   { "query", query_options, "Query syslog-ng statistics. Possible commands: list, get, get --sum", slng_query, NULL },
   { "show-license-info", license_options, "Show information about the license", slng_license, NULL },
   { "credentials", no_options, "Credentials manager", NULL, credentials_commands },


### PR DESCRIPTION
console: add support for restoring the original console io handlers after an attached control client has finished its work

Signed-off-by: Hofi hofione@gmail.com

Depends on: https://github.com/syslog-ng/syslog-ng/pull/5240