### PR TITLE
Prometheus stats query support

### DIFF
--- a/lib/stats/stats-csv.h
+++ b/lib/stats/stats-csv.h
@@ -25,8 +25,11 @@
 #define STATS_CSV_H_INCLUDED 1
 
 #include "syslog-ng.h"
+#include "stats-cluster.h"
 
 typedef void (*StatsCSVRecordFunc)(const char *record, gpointer user_data);
+
+GString *stats_csv_format_counter(StatsCluster *sc, gint type, StatsCounterItem *counter);
 
 void stats_generate_csv(StatsCSVRecordFunc process_record, gpointer user_data, gboolean *cancelled);
 

--- a/lib/stats/stats-query.c
+++ b/lib/stats/stats-query.c
@@ -127,9 +127,6 @@ _format_selected_counter(StatsCounterItem *counter, gpointer user_data, StatsFor
 gboolean
 _stats_query_get(const gchar *expr, StatsFormatCb format_cb, gpointer result, gboolean must_reset)
 {
-  if (!expr)
-    return FALSE;
-
   const gchar *key_str = _setup_filter_expression(expr);
   return _process_matching_counters(key_str, _format_selected_counter, NULL, format_cb, result, must_reset);
 }

--- a/lib/stats/stats-query.h
+++ b/lib/stats/stats-query.h
@@ -31,8 +31,9 @@ typedef gboolean (*StatsFormatCb)(gpointer user_data);
 
 gboolean stats_query_list(const gchar *expr, StatsFormatCb format_cb, gpointer result);
 gboolean stats_query_list_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, gpointer result);
-gboolean stats_query_get(const gchar *expr, StatsFormatCb format_cb, gpointer result);
-gboolean stats_query_get_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, gpointer result);
+gboolean stats_query_get(const gchar *expr, StatsFormatCb format_cb, const gchar *output_fmt, gpointer result);
+gboolean stats_query_get_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, const gchar *output_fmt,
+                                            gpointer result);
 gboolean stats_query_get_sum(const gchar *expr, StatsFormatCb format_cb, gpointer result);
 gboolean stats_query_get_sum_and_reset_counters(const gchar *expr, StatsFormatCb format_cb, gpointer result);
 

--- a/news/feature-5248.md
+++ b/news/feature-5248.md
@@ -1,0 +1,7 @@
+`syslog-ng-ctl`: Formatting the output of the `syslog-ng-ctl stats` and `syslog-ng-ctl query` commands is unified.
+
+Both commands got a new `--format` (`-m`) argument that can control the output format of the given stat or query. The following formats are supported:
+
+- `kv` - the legacy key-value-pairs e.g. `center.queued.processed=0` (only for the `query` command yet)
+- `csv` - comma separated values e.g. `center;;queued;a;processed;0`
+- `prometheus` - the prometheus scraper ready format e.g. `syslogng_center_processed{stat_instance="queued"} 0`

--- a/syslog-ng-ctl/commands/attach.c
+++ b/syslog-ng-ctl/commands/attach.c
@@ -73,6 +73,8 @@ _parse_fd_names(const gchar *option_name,
   return result;
 }
 
+/* NOTE: this attach command handler uses the normal, automatic GLib Commandline Option Parser
+ *       to parse the sub-command arguments with options, so need to validate the sub-command and the options manually. */
 gint
 slng_attach(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
 {
@@ -85,17 +87,6 @@ slng_attach(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
     g_string_append(command, " LOGS");
   else if (g_str_equal(attach_mode, "debugger"))
     g_string_append(command, " DEBUGGER");
-  else
-    {
-      fprintf(stderr, "Error parsing command line arguments: Unknown attach mode\n");
-      return 1;
-    }
-  if (FALSE == g_str_equal(attach_mode, "stdio") && attach_options_fds_to_steal > 0)
-    {
-      fprintf(stderr, "Error parsing command line arguments: %s is valid only with %s attach mode\n",
-              "fds-to-steel", "stdio");
-      return 1;
-    }
 
   g_string_append_printf(command, " %d", attach_options_seconds > 0 ? attach_options_seconds : -1);
   g_string_append_printf(command, " %d",

--- a/syslog-ng-ctl/commands/commands.h
+++ b/syslog-ng-ctl/commands/commands.h
@@ -28,6 +28,7 @@
 #include "secret-storage/secret-storage.h"
 
 #include <stdio.h>
+#include <errno.h>
 
 /* Though clang has no issues, but gcc is stricter about requiring initializer elements to be compile-time constants when initializing structures directly
  * This helper macro is used to initialize GOptionEntry structures with the same values as the GOptionEntry initializers without having to repeat the initializer values */

--- a/syslog-ng-ctl/commands/credentials.c
+++ b/syslog-ng-ctl/commands/credentials.c
@@ -95,6 +95,7 @@ slng_passwd_add(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
       gchar *usage = g_option_context_get_help(ctx, TRUE, NULL);
       fprintf(stderr, "Error: missing arguments!\n%s\n", usage);
       g_free(usage);
+      g_option_context_set_description(ctx, "credentials");
       return EINVAL;
     }
 

--- a/syslog-ng-ctl/commands/credentials.c
+++ b/syslog-ng-ctl/commands/credentials.c
@@ -95,7 +95,7 @@ slng_passwd_add(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
       gchar *usage = g_option_context_get_help(ctx, TRUE, NULL);
       fprintf(stderr, "Error: missing arguments!\n%s\n", usage);
       g_free(usage);
-      return 1;
+      return EINVAL;
     }
 
   if (!is_syslog_ng_running())

--- a/syslog-ng-ctl/commands/ctl-stats.c
+++ b/syslog-ng-ctl/commands/ctl-stats.c
@@ -27,19 +27,11 @@
 static gboolean stats_options_reset_is_set = FALSE;
 static gboolean stats_options_remove_orphans = FALSE;
 static gboolean stats_options_legacy_metrics = FALSE;
-static gchar **stats_commands = NULL;
-
-GOptionEntry stats_options[] =
-{
-  { "reset", 'r', 0, G_OPTION_ARG_NONE, &stats_options_reset_is_set, "reset counters", NULL },
-  { "remove-orphans", 'o', 0, G_OPTION_ARG_NONE, &stats_options_remove_orphans, "remove orphaned statistics", NULL},
-  { "with-legacy-metrics", 'l', 0, G_OPTION_ARG_NONE, &stats_options_legacy_metrics, "show legacy metrics", NULL},
-  { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, &stats_commands, NULL, NULL },
-  { NULL,    0,   0, G_OPTION_ARG_NONE, NULL,                        NULL,             NULL }
-};
+static gchar *stats_options_out_format = NULL;
+static gchar **stats_legacy_commands = NULL;
 
 static const gchar *
-_stats_command_builder(void)
+_stats_command_builder(GOptionContext *ctx)
 {
   if (stats_options_reset_is_set)
     return "RESET_STATS";
@@ -47,27 +39,80 @@ _stats_command_builder(void)
   if (stats_options_remove_orphans)
     return "REMOVE_ORPHANED_STATS";
 
-  const gchar *stats_command = stats_commands ? stats_commands[0] : NULL;
-  if (!stats_command || g_str_equal(stats_command, "csv"))
-    return "STATS CSV";
+  /* NOTE: Yes, this is a mess, but it's a legacy mess, so we have to keep it currently to be backward compatible.
+   *       Unfortunately, there's no optional command construct in the GLib Commandline Option Parser
+   *       so, we cannot use the automatic way to parse the sub-command arguments with options.
+   *       See slng_attach() for a better example, how easy it could be on the proper, automatic way.
+   */
+  const gchar *stats_command = stats_legacy_commands ? stats_legacy_commands[0] : NULL;
 
-  if (g_str_equal(stats_command, "prometheus"))
+  if (stats_command && stats_legacy_commands[1]) // more than one sub-command
     {
+      g_option_context_set_description(ctx, "stats");
+      fprintf(stderr, "Error parsing command line arguments: Invalid stats command\n");
+      return NULL;
+    }
+
+  gboolean command_is_csv = stats_command && g_str_equal(stats_command, "csv");
+  gboolean command_is_prometheus = stats_command && g_str_equal(stats_command, "prometheus");
+  gboolean option_is_csv = stats_options_out_format && g_str_equal(stats_options_out_format, "csv");
+  gboolean option_is_prometheus = stats_options_out_format && g_str_equal(stats_options_out_format, "prometheus");
+
+  if (stats_command && FALSE == command_is_csv && FALSE == command_is_prometheus)
+    {
+      g_option_context_set_description(ctx, "stats");
+      fprintf(stderr, "Error parsing command line arguments: Unknown stats format, %s\n", stats_command);
+      return NULL;
+    }
+
+  if (stats_options_out_format && FALSE == option_is_csv && FALSE == option_is_prometheus)
+    {
+      g_option_context_set_description(ctx, "stats");
+      fprintf(stderr, "Error parsing command line arguments: Unknown stats format, %s\n", stats_options_out_format);
+      return NULL;
+    }
+
+  if ((stats_command == NULL && stats_options_out_format == NULL) ||
+      command_is_csv || option_is_csv)
+    {
+      if (option_is_prometheus || command_is_prometheus)
+        goto on_collision;
+      return "STATS CSV";
+    }
+  else if (command_is_prometheus || option_is_prometheus)
+    {
+      if (option_is_csv || command_is_csv)
+        goto on_collision;
       if (stats_options_legacy_metrics)
         return "STATS PROMETHEUS WITH_LEGACY";
       else
         return "STATS PROMETHEUS";
     }
 
+on_collision:
+  g_option_context_set_description(ctx, "stats");
+  fprintf(stderr,
+          "Error parsing command line arguments: Colliding stats format recieved: %s <-> %s\nUsing the `stats csv|stats prometheus` format is deprecated, please use the new `--%s csv|--%s prometheus` options instead\n\n",
+          stats_options_out_format, stats_command, stats_options[3].long_name, stats_options[3].long_name);
   return NULL;
 }
 
 gint
 slng_stats(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
 {
-  const gchar *command = _stats_command_builder();
+  const gchar *command = _stats_command_builder(ctx);
   if (command == NULL)
     return EINVAL;
 
   return dispatch_command(command);
 }
+
+GOptionEntry stats_options[] =
+{
+  { "reset", 'r', 0, G_OPTION_ARG_NONE, &stats_options_reset_is_set, "reset counters", NULL },
+  { "remove-orphans", 'o', 0, G_OPTION_ARG_NONE, &stats_options_remove_orphans, "remove orphaned statistics", NULL},
+  { "with-legacy-metrics", 'l', 0, G_OPTION_ARG_NONE, &stats_options_legacy_metrics, "show legacy metrics", NULL},
+  { "format", 'm', 0, G_OPTION_ARG_STRING, &stats_options_out_format, "output format, default is <csv>", "<csv|prometheus>" },
+  { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, &stats_legacy_commands, NULL, NULL },
+  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
+};

--- a/syslog-ng-ctl/commands/ctl-stats.c
+++ b/syslog-ng-ctl/commands/ctl-stats.c
@@ -66,8 +66,8 @@ gint
 slng_stats(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
 {
   const gchar *command = _stats_command_builder();
-  if (!command)
-    return 1;
+  if (command == NULL)
+    return EINVAL;
 
   return dispatch_command(command);
 }

--- a/syslog-ng-ctl/commands/query.c
+++ b/syslog-ng-ctl/commands/query.c
@@ -103,18 +103,6 @@ _shift_query_command_out_of_params(void)
     ++raw_query_params;
 }
 
-static gboolean
-_validate_get_params(gint query_cmd)
-{
-  if(query_cmd == QUERY_CMD_GET || query_cmd == QUERY_CMD_GET_SUM)
-    if (*raw_query_params == NULL)
-      {
-        fprintf(stderr, "error: need a path argument\n");
-        return TRUE;
-      }
-  return FALSE;
-}
-
 static gchar *
 _get_query_command_string(gint query_cmd)
 {
@@ -146,8 +134,6 @@ _get_dispatchable_query_command(void)
     return NULL;
 
   _shift_query_command_out_of_params();
-  if(_validate_get_params(query_cmd))
-    return NULL;
 
   return _get_query_command_string(query_cmd);
 }

--- a/syslog-ng-ctl/commands/query.c
+++ b/syslog-ng-ctl/commands/query.c
@@ -122,16 +122,22 @@ _get_query_command_string(gint query_cmd)
 }
 
 static gchar *
-_get_dispatchable_query_command(void)
+_get_dispatchable_query_command(GOptionContext *ctx)
 {
   gint query_cmd;
 
   if (_is_query_params_empty())
+    {
+      g_option_context_set_description(ctx, "stats");
     return NULL;
+    }
 
   query_cmd = _get_query_cmd(raw_query_params[QUERY_COMMAND]);
   if (query_cmd < 0)
+    {
+      g_option_context_set_description(ctx, "stats");
     return NULL;
+    }
 
   _shift_query_command_out_of_params();
 
@@ -143,7 +149,7 @@ slng_query(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
 {
   gint result;
 
-  gchar *cmd = _get_dispatchable_query_command();
+  gchar *cmd = _get_dispatchable_query_command(ctx);
   if (cmd == NULL)
     return EINVAL;
 

--- a/syslog-ng-ctl/commands/query.c
+++ b/syslog-ng-ctl/commands/query.c
@@ -145,7 +145,7 @@ slng_query(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
 
   gchar *cmd = _get_dispatchable_query_command();
   if (cmd == NULL)
-    return 1;
+    return EINVAL;
 
   result = dispatch_command(cmd);
 

--- a/syslog-ng-ctl/commands/query.c
+++ b/syslog-ng-ctl/commands/query.c
@@ -23,18 +23,10 @@
 
 #include "query.h"
 
-static const gint QUERY_COMMAND = 0;
 static gboolean query_is_get_sum = FALSE;
 static gboolean query_reset = FALSE;
+static gchar *query_options_out_format = "kv";
 static gchar **raw_query_params = NULL;
-
-GOptionEntry query_options[] =
-{
-  { "sum", 0, 0, G_OPTION_ARG_NONE, &query_is_get_sum, "aggregate sum", NULL },
-  { "reset", 0, 0, G_OPTION_ARG_NONE, &query_reset, "reset counters after query", NULL },
-  { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, &raw_query_params, NULL, NULL },
-  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
-};
 
 enum
 {
@@ -78,8 +70,8 @@ _get_query_get_cmd(void)
 
 }
 
-static gint
-_get_query_cmd(gchar *cmd)
+static inline gint
+_get_query_cmd(const gchar *cmd)
 {
   if (g_str_equal(cmd, "list"))
     return _get_query_list_cmd();
@@ -90,56 +82,53 @@ _get_query_cmd(gchar *cmd)
   return -1;
 }
 
+static inline gboolean
+_check_out_format(void)
+{
+  return g_str_equal(query_options_out_format, "kv") ||  g_str_equal(query_options_out_format, "csv")
+         ||  g_str_equal(query_options_out_format, "prometheus");
+}
+
 static gboolean
 _is_query_params_empty(void)
 {
   return raw_query_params == NULL;
 }
 
-static void
-_shift_query_command_out_of_params(void)
-{
-  if (raw_query_params[QUERY_COMMAND] != NULL)
-    ++raw_query_params;
-}
-
 static gchar *
 _get_query_command_string(gint query_cmd)
 {
-  gchar *query_params_to_pass, *command_to_dispatch;
-  query_params_to_pass = g_strjoinv(" ", raw_query_params);
+  gchar *command_to_dispatch;
+  gchar *query_params_to_pass = _is_query_params_empty() ? NULL : g_strjoinv(" ", raw_query_params);
+
   if (query_params_to_pass)
-    {
-      command_to_dispatch = g_strdup_printf("QUERY %s %s", QUERY_COMMANDS[query_cmd], query_params_to_pass);
-    }
+    command_to_dispatch = g_strdup_printf("QUERY %s %s %s", QUERY_COMMANDS[query_cmd], query_options_out_format,
+                                          query_params_to_pass);
   else
-    {
-      command_to_dispatch = g_strdup_printf("QUERY %s", QUERY_COMMANDS[query_cmd]);
-    }
-  g_free(query_params_to_pass);
+    command_to_dispatch = g_strdup_printf("QUERY %s %s", QUERY_COMMANDS[query_cmd], query_options_out_format);
+
+  if (_is_query_params_empty())
+    g_free(query_params_to_pass);
 
   return command_to_dispatch;
 }
 
 static gchar *
-_get_dispatchable_query_command(GOptionContext *ctx)
+_get_dispatchable_query_command(const gchar *mode, GOptionContext *ctx)
 {
-  gint query_cmd;
-
-  if (_is_query_params_empty())
+  if (FALSE == _check_out_format())
     {
-      g_option_context_set_description(ctx, "stats");
-    return NULL;
+      fprintf(stderr, "Error parsing command line arguments: Unknown stats format, %s\n", query_options_out_format);
+      g_option_context_set_description(ctx, "query");
+      return NULL;
     }
 
-  query_cmd = _get_query_cmd(raw_query_params[QUERY_COMMAND]);
+  gint query_cmd = _get_query_cmd(mode);
   if (query_cmd < 0)
     {
-      g_option_context_set_description(ctx, "stats");
-    return NULL;
+      g_option_context_set_description(ctx, "query");
+      return NULL;
     }
-
-  _shift_query_command_out_of_params();
 
   return _get_query_command_string(query_cmd);
 }
@@ -149,7 +138,7 @@ slng_query(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
 {
   gint result;
 
-  gchar *cmd = _get_dispatchable_query_command(ctx);
+  gchar *cmd = _get_dispatchable_query_command(mode, ctx);
   if (cmd == NULL)
     return EINVAL;
 
@@ -159,3 +148,26 @@ slng_query(int argc, char *argv[], const gchar *mode, GOptionContext *ctx)
 
   return result;
 }
+
+GOptionEntry query_list_options[] =
+{
+  { "reset", 0, 0, G_OPTION_ARG_NONE, &query_reset, "reset counters after query", NULL },
+  { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, &raw_query_params, "pattern", NULL },
+  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
+};
+
+GOptionEntry query_get_options[] =
+{
+  { "sum", 0, 0, G_OPTION_ARG_NONE, &query_is_get_sum, "aggregate sum", NULL },
+  { "reset", 0, 0, G_OPTION_ARG_NONE, &query_reset, "reset counters after query", NULL },
+  { "format", 'm', 0, G_OPTION_ARG_STRING, &query_options_out_format, "output format, default is <kv>", "<kv|csv|prometheus>" },
+  { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, &raw_query_params, "pattern", NULL },
+  { NULL, 0, 0, G_OPTION_ARG_NONE, NULL, NULL, NULL }
+};
+
+CommandDescriptor query_commands[] =
+{
+  { "list", query_list_options, "List available counters with names matching a pattern", slng_query },
+  { "get", query_get_options, "Query the values of counters with names matching a pattern", slng_query },
+  { NULL, NULL, NULL, NULL }
+};

--- a/syslog-ng-ctl/commands/query.h
+++ b/syslog-ng-ctl/commands/query.h
@@ -26,7 +26,6 @@
 
 #include "commands.h"
 
-extern GOptionEntry query_options[];
-gint slng_query(int argc, char *argv[], const gchar *mode, GOptionContext *ctx);
+extern CommandDescriptor query_commands[];
 
 #endif

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -121,8 +121,7 @@ static CommandDescriptor modes[] =
   { "stop", no_options, "Stop syslog-ng process", slng_stop, NULL },
   { "reload", no_options, "Reload syslog-ng", slng_reload, NULL },
   { "reopen", no_options, "Re-open of log destination files", slng_reopen, NULL },
-  // TODO: Add proper details of the sub-commands like attach and credentials have
-  { "query", query_options, "Query syslog-ng statistics. Possible commands: list, get, get --sum", slng_query, NULL },
+  { "query", no_options, "Query syslog-ng statistics. Possible commands: list [pattern], get [pattern]", NULL, query_commands },
   { "show-license-info", license_options, "Show information about the license", slng_license, NULL },
   { "credentials", no_options, "Credentials manager", NULL, credentials_commands },
   { "config", config_options, "Print current config", slng_config, NULL },

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -218,7 +218,7 @@ main(int argc, char *argv[])
     {
       fprintf(stderr, "Unknown command\n\n");
       print_usage(bin_name->str, "", modes);
-      exit(1);
+      return EINVAL;
     }
 
   if (!g_option_context_parse(ctx, &argc, &argv, &error))
@@ -226,7 +226,7 @@ main(int argc, char *argv[])
       fprintf(stderr, "Error parsing command line arguments: %s\n", error ? error->message : "Invalid arguments");
       g_clear_error(&error);
       g_option_context_free(ctx);
-      return 1;
+      return EINVAL;
     }
 
   result = run(control_name, argc, argv, active_mode, ctx);

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -192,8 +192,6 @@ setup_help_context(const gchar *cmdname, CommandDescriptor *active_mode)
   g_option_context_set_summary(ctx, active_mode->description);
   g_option_context_add_main_entries(ctx, active_mode->options, NULL);
   g_option_context_add_main_entries(ctx, slng_options, NULL);
-  // Further detailed descriptions might go to the end of the list
-  //g_option_context_set_description(ctx, active_mode->detailed_description);
 
   return ctx;
 }
@@ -214,22 +212,26 @@ main(int argc, char *argv[])
   GOptionContext *ctx = setup_help_context(cmdname_accumulator->len > 0 ? cmdname_accumulator->str : NULL, active_mode);
   g_string_free(cmdname_accumulator, TRUE);
 
-  if (!ctx)
+  if (ctx == NULL)
     {
       fprintf(stderr, "Unknown command\n\n");
       print_usage(bin_name->str, "", modes);
       return EINVAL;
     }
 
-  if (!g_option_context_parse(ctx, &argc, &argv, &error))
+  if (FALSE == g_option_context_parse(ctx, &argc, &argv, &error))
     {
       fprintf(stderr, "Error parsing command line arguments: %s\n", error ? error->message : "Invalid arguments");
       g_clear_error(&error);
-      g_option_context_free(ctx);
-      return EINVAL;
+      print_usage(bin_name->str, g_option_context_get_description(ctx), modes);
+      result = EINVAL;
+    }
+  else
+    {
+  if ((result = run(control_name, argc, argv, active_mode, ctx)) == EINVAL)
+    print_usage(bin_name->str, g_option_context_get_description(ctx), modes);
     }
 
-  result = run(control_name, argc, argv, active_mode, ctx);
   g_option_context_free(ctx);
   return result;
 }

--- a/syslog-ng-ctl/syslog-ng-ctl.c
+++ b/syslog-ng-ctl/syslog-ng-ctl.c
@@ -112,9 +112,8 @@ slng_export_config_graph(int argc, char *argv[], const gchar *mode, GOptionConte
 
 static CommandDescriptor modes[] =
 {
-  { "attach", no_options, "Attach to a running syslog-ng instance", NULL, attach_commands },
-  // TODO: Add proper details of the sub-commands like attach and credentials have
-  { "stats", stats_options, "Get syslog-ng statistics. Possible commands: csv, prometheus; default: csv", slng_stats, NULL },
+  { "attach", no_options, "Attach to a running syslog-ng instance. Possible commands: stdio, logs, debugger", NULL, attach_commands },
+  { "stats", stats_options, "Get syslog-ng statistics", slng_stats, NULL }, // do not reference the legacy sub-commands anymore, use the new --format option instead
   { "verbose", verbose_options, "Enable/query verbose messages", slng_verbose, NULL },
   { "debug", verbose_options, "Enable/query debug messages", slng_verbose, NULL },
   { "trace", verbose_options, "Enable/query trace messages", slng_verbose, NULL },
@@ -228,8 +227,8 @@ main(int argc, char *argv[])
     }
   else
     {
-  if ((result = run(control_name, argc, argv, active_mode, ctx)) == EINVAL)
-    print_usage(bin_name->str, g_option_context_get_description(ctx), modes);
+      if ((result = run(control_name, argc, argv, active_mode, ctx)) == EINVAL)
+        print_usage(bin_name->str, g_option_context_get_description(ctx), modes);
     }
 
   g_option_context_free(ctx);


### PR DESCRIPTION
`syslog-ng-ctl`: Formatting the output of the `syslog-ng-ctl stats` and `syslog-ng-ctl query` commands is unified.

Both commands got a new `--format` (`-m`) argument that can control the output format of the given stat or query. The following formats are supported:

- `kv` - the legacy key-value-pairs e.g. `center.queued.processed=0` (only for the `query` command yet)
- `csv` - comma separated values e.g. `center;;queued;a;processed;0`
- `prometheus` - the prometheus scraper ready format e.g. `syslogng_center_processed{stat_instance="queued"} 0`

Signed-off-by: Hofi <hofione@gmail.com>