### PR TITLE
syslog-format: Fix integer overflow on set pri

### DIFF
--- a/modules/syslogformat/syslog-format.c
+++ b/modules/syslogformat/syslog-format.c
@@ -135,7 +135,10 @@ _syslog_format_parse_pri(LogMessage *msg, const guchar **data, gint *length, gui
         {
           if (isdigit(*src))
             {
-              pri = pri * 10 + ((*src) - '0');
+              if (__builtin_mul_overflow(pri, 10, &pri))
+                return FALSE;
+              if (__builtin_add_overflow(pri, ((*src) - '0'), &pri))
+                return FALSE;
             }
           else
             {

--- a/news/bugfix-5254.md
+++ b/news/bugfix-5254.md
@@ -1,0 +1,1 @@
+syslogformat: Fix integer overflow on set pri


### PR DESCRIPTION
**A bug found by fuzzing with AFL++**

Backtrace:
```
* thread #2, name = 'syslog-ng', stop reason = signal SIGILL: illegal instruction operand
  * frame #0: 0x00007ffff3f1b923 libsyslogformat.so`log_msg_parse_pri(self=<unavailable>, data=<unavailable>, length=<unavailable>, flags=<unavailable>, default_pri=<unavailable>) at syslog-format.c:55:23
    frame #1: 0x00007ffff3f14068 libsyslogformat.so`log_msg_parse_legacy(parse_options=<unavailable>, data=<unavailable>, length=<unavailable>, self=<unavailable>, position=<unavailable>) at syslog-format.c:757:8
    frame #2: 0x00007ffff3f0e584 libsyslogformat.so`syslog_format_handler(parse_options=<unavailable>, data=<unavailable>, length=23, self=<unavailable>) at syslog-format.c:1012:15
    frame #3: 0x00007ffff7b460fe libsyslog-ng-3.27.so.0`msg_format_parse(options=0x0000616000000af0, data=<unavailable>, length=<unavailable>, msg=<unavailable>) at msg-format.c:57:7
    frame #4: 0x00007ffff7deb578 libsyslog-ng-3.27.so.0`log_msg_new(msg=<unavailable>, length=<unavailable>, parse_options=0x0000616000000af0) at logmsg.c:1337:3
    frame #5: 0x00007ffff7ae0534 libsyslog-ng-3.27.so.0`log_reader_work_perform [inlined] log_reader_handle_line(self=0x0000617000000400, line="<44444444444444444444<4\xbe\xbe\xbe\xbe\xbe\xbe\xbe\xbe\xbe"..., length=<unavailable>, aux=0x00007ffff36fa210) at logreader.c:444:7
    frame #6: 0x00007ffff7ae0489 libsyslog-ng-3.27.so.0`log_reader_work_perform at logreader.c:519
    frame #7: 0x00007ffff7adfb72 libsyslog-ng-3.27.so.0`log_reader_work_perform(s=<unavailable>, cond=<unavailable>) at logreader.c:359
    frame #8: 0x00007ffff7b381d8 libsyslog-ng-3.27.so.0`_work(self=<unavailable>) at mainloop-io-worker.c:69:3
    frame #9: 0x00007ffff74017da libivykis.so.0`iv_work_thread_got_event + 266
    frame #10: 0x00007ffff73fd243 libivykis.so.0`__iv_event_run_pending_events + 211
    frame #11: 0x00007ffff74026ac libivykis.so.0`iv_main + 252
    frame #12: 0x00007ffff7402b43 libivykis.so.0`iv_work_thread + 115
    frame #13: 0x00007ffff7403595 libivykis.so.0`iv_thread_handler + 37
    frame #14: 0x00007ffff77e53f9 libpthread.so.0`start_thread + 233
    frame #15: 0x00007ffff75afb53 libc.so.6`__clone + 67
```

AddressSanitizer detects integer overflow in the string
`pro = pro * 10 + ((*src) - '0'); `
When entering a string like "<44444444444444444444<4\xbe\xbe\xbe\xbe\xbe\xbe\xbe\xbe\xbe"

There will be an int overflow if you input a message with any string where there is <2147483648 or more at the beginning.
Overflow of the whole can cause undefined behavior or be the cause of vulnerability.

I suggest checking the overflow of the whole with the built-in GCC tools.