### PR TITLE
otel: Implement protobuf 30.0 compatiblity

### DIFF
--- a/modules/grpc/otel/filterx/object-otel-array.cpp
+++ b/modules/grpc/otel/filterx/object-otel-array.cpp
@@ -355,8 +355,8 @@ OtelArrayField::FilterXObjectSetter(google::protobuf::Message *message, ProtoRef
         return _set_array_field_from_list(message, reflectors, object, assoc_object);
 
       msg_error("otel-array: Failed to convert field, type is unsupported",
-                evt_tag_str("field", reflectors.fieldDescriptor->name().c_str()),
-                evt_tag_str("expected_type", reflectors.fieldDescriptor->type_name()),
+                evt_tag_str("field", reflectors.fieldDescriptor->name().data()),
+                evt_tag_str("expected_type", reflectors.fieldDescriptor->type_name().data()),
                 evt_tag_str("type", object->type->name));
       return false;
     }

--- a/modules/grpc/otel/filterx/object-otel-kvlist.cpp
+++ b/modules/grpc/otel/filterx/object-otel-kvlist.cpp
@@ -483,8 +483,8 @@ OtelKVListField::FilterXObjectSetter(google::protobuf::Message *message, ProtoRe
         return _set_kvlist_field_from_dict(message, reflectors, object, assoc_object);
 
       msg_error("otel-kvlist: Failed to convert field, type is unsupported",
-                evt_tag_str("field", reflectors.fieldDescriptor->name().c_str()),
-                evt_tag_str("expected_type", reflectors.fieldDescriptor->type_name()),
+                evt_tag_str("field", reflectors.fieldDescriptor->name().data()),
+                evt_tag_str("expected_type", reflectors.fieldDescriptor->type_name().data()),
                 evt_tag_str("type", object->type->name));
       return false;
     }

--- a/modules/grpc/otel/filterx/otel-field.cpp
+++ b/modules/grpc/otel/filterx/otel-field.cpp
@@ -100,7 +100,7 @@ AnyField::FilterXObjectGetter(Message *message, ProtoReflectors reflectors)
     }
 
   msg_error("otel-field: Unexpected protobuf field type",
-            evt_tag_str("name", reflectors.fieldDescriptor->name().c_str()),
+            evt_tag_str("name", reflectors.fieldDescriptor->name().data()),
             evt_tag_int("type", reflectors.fieldType));
   return nullptr;
 }
@@ -258,7 +258,7 @@ public:
         return true;
       }
 
-    return protobuf_converter_by_type(reflectors.fieldDescriptor->type())->Set(message, reflectors.fieldDescriptor->name(),
+    return protobuf_converter_by_type(reflectors.fieldDescriptor->type())->Set(message, std::string(reflectors.fieldDescriptor->name()),
            object, assoc_object);
   }
 };
@@ -313,7 +313,7 @@ ProtobufField *syslogng::grpc::otel::otel_converter_by_type(FieldDescriptor::Typ
 
 ProtobufField *syslogng::grpc::otel::otel_converter_by_field_descriptor(const FieldDescriptor *fd)
 {
-  const std::string &fieldName = fd->name();
+  const std::string_view &fieldName = fd->name();
   if (fieldName.compare("time_unix_nano") == 0 ||
       fieldName.compare("observed_time_unix_nano") == 0)
     {

--- a/modules/grpc/otel/filterx/protobuf-field.cpp
+++ b/modules/grpc/otel/filterx/protobuf-field.cpp
@@ -43,8 +43,8 @@ void
 log_type_error(ProtoReflectors reflectors, const char *type)
 {
   msg_error("protobuf-field: Failed to convert field, type is unsupported",
-            evt_tag_str("field", reflectors.fieldDescriptor->name().c_str()),
-            evt_tag_str("expected_type", reflectors.fieldDescriptor->type_name()),
+            evt_tag_str("field", reflectors.fieldDescriptor->name().data()),
+            evt_tag_str("expected_type", reflectors.fieldDescriptor->type_name().data()),
             evt_tag_str("type", type));
 }
 
@@ -160,7 +160,7 @@ public:
     if (val > INT64_MAX)
       {
         msg_error("protobuf-field: exceeding FilterX number value range",
-                  evt_tag_str("field", reflectors.fieldDescriptor->name().c_str()),
+                  evt_tag_str("field", reflectors.fieldDescriptor->name().data()),
                   evt_tag_long("range_min", INT64_MIN),
                   evt_tag_long("range_max", INT64_MAX),
                   evt_tag_printf("current", "%" G_GUINT64_FORMAT, val));
@@ -219,7 +219,7 @@ public:
         if (!json_literal)
           {
             msg_error("protobuf-field: json marshal error",
-                      evt_tag_str("field", reflectors.fieldDescriptor->name().c_str()));
+                      evt_tag_str("field", reflectors.fieldDescriptor->name().data()));
             return false;
           }
         reflectors.reflection->SetString(message, reflectors.fieldDescriptor, json_literal);

--- a/modules/grpc/otel/filterx/protobuf-field.hpp
+++ b/modules/grpc/otel/filterx/protobuf-field.hpp
@@ -49,7 +49,7 @@ struct ProtoReflectors
     this->descriptor = message.GetDescriptor();
     if (!this->reflection || !this->descriptor)
       {
-        std::string error_msg = "unable to access reflector for protobuf message: " + message.GetTypeName();
+        std::string error_msg = "unable to access reflector for protobuf message: " + std::string(message.GetTypeName());
         throw std::invalid_argument(error_msg);
       }
     this->fieldDescriptor = this->descriptor->FindFieldByName(fieldName);


### PR DESCRIPTION
Protobuf 30.0 (and above) has exchanged a few of their interface from
`std::string` to `std::string_view`.

Link: https://protobuf.dev/support/migration/#v30
Signed-off-by: Christian Heusel <christian@heusel.eu>

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
