### PR TITLE
Check program name for rfc3164

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -228,6 +228,7 @@
 %token KW_CHECK_HOSTNAME              10093
 %token KW_BAD_HOSTNAME                10094
 %token KW_LOG_LEVEL                   10095
+%token KW_CHECK_PROGRAM               10097
 
 %token KW_KEEP_TIMESTAMP              10100
 
@@ -1053,6 +1054,7 @@ options_item
 	| KW_CHAIN_HOSTNAMES '(' yesno ')'	{ configuration->chain_hostnames = $3; }
 	| KW_KEEP_HOSTNAME '(' yesno ')'	{ configuration->keep_hostname = $3; }
 	| KW_CHECK_HOSTNAME '(' yesno ')'	{ configuration->check_hostname = $3; }
+	| KW_CHECK_PROGRAM '(' yesno ')' { configuration->check_program = $3; }
 	| KW_BAD_HOSTNAME '(' string ')'	{ cfg_bad_hostname_set(configuration, $3); free($3); }
 	| KW_TIME_REOPEN '(' positive_integer ')'		{ configuration->time_reopen = $3; }
 	| KW_TIME_REAP '(' nonnegative_integer ')'		{ configuration->time_reap = $3; }
@@ -1097,7 +1099,7 @@ stat_option
 	: KW_STATS_FREQ '(' nonnegative_integer ')'          { last_stats_options->log_freq = $3; }
 	| KW_STATS_LEVEL '(' nonnegative_integer ')'         { last_stats_options->level = $3; }
 	| KW_STATS_LIFETIME '(' positive_integer ')'      { last_stats_options->lifetime = $3; }
-  | KW_STATS_MAX_DYNAMIC '(' nonnegative_integer ')'   { last_stats_options->max_dynamic = $3; }
+	| KW_STATS_MAX_DYNAMIC '(' nonnegative_integer ')'   { last_stats_options->max_dynamic = $3; }
 	| KW_STATS '(' stats_group_options ')'
 	;
 
@@ -1436,6 +1438,7 @@ source_reader_option
         /* NOTE: plugins need to set "last_reader_options" in order to incorporate this rule in their grammar */
 
 	: KW_CHECK_HOSTNAME '(' yesno ')'	{ last_reader_options->check_hostname = $3; }
+	| KW_CHECK_PROGRAM '(' yesno ')' { last_reader_options->check_program = $3; }
 	| KW_FLAGS '(' source_reader_option_flags ')'
 	| KW_LOG_FETCH_LIMIT '(' positive_integer ')'	{ last_reader_options->fetch_limit = $3; }
         | KW_FORMAT '(' string ')'              { last_reader_options->parse_options.format = g_strdup($3); free($3); }
@@ -1447,6 +1450,7 @@ source_reader_option
 source_reader_option_flags
         : string source_reader_option_flags     { CHECK_ERROR(log_reader_options_process_flag(last_reader_options, $1), @1, "Unknown flag \"%s\"", $1); free($1); }
         | KW_CHECK_HOSTNAME source_reader_option_flags     { log_reader_options_process_flag(last_reader_options, "check-hostname"); }
+        | KW_CHECK_PROGRAM source_reader_option_flags     { log_reader_options_process_flag(last_reader_options, "check-program"); }
 	|
 	;
 

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -116,6 +116,7 @@ static CfgLexerKeyword main_keywords[] =
   { "normalize_hostnames", KW_NORMALIZE_HOSTNAMES },
   { "keep_hostname",      KW_KEEP_HOSTNAME },
   { "check_hostname",     KW_CHECK_HOSTNAME },
+  { "check_program",      KW_CHECK_PROGRAM },
   { "bad_hostname",       KW_BAD_HOSTNAME },
   { "custom_domain",      KW_CUSTOM_DOMAIN },
   { "keep_timestamp",     KW_KEEP_TIMESTAMP },

--- a/lib/cfg.h
+++ b/lib/cfg.h
@@ -83,6 +83,7 @@ struct _GlobalConfig
   gboolean chain_hostnames;
   gboolean keep_hostname;
   gboolean check_hostname;
+  gboolean check_program;
   gboolean bad_hostname_compiled;
   regex_t bad_hostname;
   gchar *bad_hostname_re;

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -2018,6 +2018,7 @@ log_msg_tags_init(void)
   log_tags_register_predefined_tag("syslog.invalid_hostname", LM_T_SYSLOG_INVALID_HOSTNAME);
   log_tags_register_predefined_tag("syslog.unexpected_framing", LM_T_SYSLOG_UNEXPECTED_FRAMING);
   log_tags_register_predefined_tag("syslog.rfc3164_missing_header", LM_T_SYSLOG_RFC3164_MISSING_HEADER);
+  log_tags_register_predefined_tag("syslog.rfc3164_invalid_program", LM_T_SYSLOG_RFC_3164_INVALID_PROGRAM);
 
   log_tags_register_predefined_tag("syslog.rfc5424_missing_hostname", LM_T_SYSLOG_RFC5424_MISSING_HOSTNAME);
   log_tags_register_predefined_tag("syslog.rfc5424_missing_app_name", LM_T_SYSLOG_RFC5424_MISSING_APP_NAME);

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -134,6 +134,9 @@ enum
   LM_T_SYSLOG_RFC5424_MISSING_MESSAGE,
   /* message field missing */
   LM_T_SYSLOG_MISSING_MESSAGE,
+  /* invalid program name */
+  LM_T_SYSLOG_RFC_3164_INVALID_PROGRAM,
+
   LM_T_PREDEFINED_MAX,
 };
 

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -875,6 +875,11 @@ log_reader_options_init(LogReaderOptions *options, GlobalConfig *cfg, const gcha
     options->parse_options.flags |= LP_ASSUME_UTF8;
   if (cfg->threaded)
     options->flags |= LR_THREADED;
+  if (options->check_program == -1)
+    options->check_program = cfg->check_program;
+  if (options->check_program)
+    options->parse_options.flags |= LP_CHECK_PROGRAM;
+
   options->initialized = TRUE;
 }
 

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -52,6 +52,7 @@ typedef struct _LogReaderOptions
   gint fetch_limit;
   const gchar *group_name;
   gboolean check_hostname;
+  gboolean check_program;
 } LogReaderOptions;
 
 typedef struct _LogReader LogReader;

--- a/lib/msg-format.c
+++ b/lib/msg-format.c
@@ -333,6 +333,7 @@ CfgFlagHandler msg_format_flag_handlers[] =
   { "no-rfc3164-fallback",        CFH_SET, offsetof(MsgFormatOptions, flags), LP_NO_RFC3164_FALLBACK },
   { "piggyback-errors",           CFH_SET, offsetof(MsgFormatOptions, flags), LP_PIGGYBACK_ERRORS },
   { "no-piggyback-errors",      CFH_CLEAR, offsetof(MsgFormatOptions, flags), LP_PIGGYBACK_ERRORS },
+  { "check-program",              CFH_SET, offsetof(MsgFormatOptions, flags), LP_CHECK_PROGRAM },
   { NULL },
 };
 

--- a/lib/msg-format.h
+++ b/lib/msg-format.h
@@ -60,6 +60,7 @@ enum
   LP_NO_HEADER = 0x2000,
   LP_NO_RFC3164_FALLBACK = 0x4000,
   LP_PIGGYBACK_ERRORS = 0x8000,
+  LP_CHECK_PROGRAM = 0x10000,
 };
 
 typedef struct _MsgFormatHandler MsgFormatHandler;

--- a/modules/syslogformat/syslog-parser-grammar.ym
+++ b/modules/syslogformat/syslog-parser-grammar.ym
@@ -96,6 +96,7 @@ parser_syslog_opt
 parser_syslog_opt_flags
         : string parser_syslog_opt_flags                { CHECK_ERROR(msg_format_options_process_flag(&((SyslogParser *) last_parser)->parse_options, $1), @1, "Unknown flag %s", $1); free($1); }
         | KW_CHECK_HOSTNAME parser_syslog_opt_flags     { msg_format_options_process_flag(&((SyslogParser *) last_parser)->parse_options, "check-hostname");  }
+        | KW_CHECK_PROGRAM parser_syslog_opt_flags       { msg_format_options_process_flag(&((SyslogParser *) last_parser)->parse_options, "check-program");  }
         |
 	;
 

--- a/news/feature-5264.md
+++ b/news/feature-5264.md
@@ -1,0 +1,14 @@
+`check-program`: Introduced as a flag for global or source options.
+
+By default, this flag is set to false. Enabling the check-program flag triggers `program` name validation for `RFC3164` messages. Valid `program` names must adhere to the following criteria:
+
+Contain only these characters: `[a-zA-Z0-9-_/().]`
+Include at least one alphabetical character.
+If a `program` name fails validation, it will be considered part of the log message.
+
+
+Example:
+
+```
+source { network(flags(check-hostname, check-program)); };
+```


### PR DESCRIPTION
The check-program flag was added to validate the program field in syslog format. It verifies that the program field contains only the allowed characters '[a-zA-Z0-9].-_/()' and requires at least one alphabetical character in the program name. If these conditions are not met, it treats the program field and the remaining fields as part of the log message. This approach avoids using regular expressions to improve performance.

examples:
```
log {
    source { tcp(port(2000) flags(check-hostname, check-program, dont-store-legacy-msghdr)); };
...
```

Backport of [380](https://github.com/axoflow/axosyslog/pull/380) by @bshifter