### PR TITLE
http: fix batch-lines() in case only batch-bytes() is set

### DIFF
--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -458,6 +458,8 @@ http_dd_init(LogPipe *s)
           return FALSE;
         }
     }
+  if (self->batch_bytes > 0 && self->super.batch_lines == 0)
+    self->super.batch_lines = G_MAXINT;
 
   log_template_options_init(&self->template_options, cfg);
 


### PR DESCRIPTION
In case only batch-bytes() is set, the logthrdestdrv core will flush the batch, as it
will deduce that no batching is needed. Fix that.

PS: we might need a similar fix in gRPC related drivers.

Backport of [403](https://github.com/axoflow/axosyslog/pull/403) by @bazsi