### PR TITLE
grpc: fix batch-lines() in case only batch-bytes() is set

### DIFF
--- a/modules/grpc/common/grpc-dest.cpp
+++ b/modules/grpc/common/grpc-dest.cpp
@@ -97,6 +97,9 @@ DestDriver::init()
 
   log_threaded_dest_driver_register_aggregated_stats(&this->super->super);
 
+  if (this->batch_bytes > 0 && this->super->super.batch_lines <= 0)
+    this->super->super.batch_lines = G_MAXINT;
+
   StatsClusterKeyBuilder *kb = stats_cluster_key_builder_new();
   format_stats_key(kb);
   metrics.init(kb, log_pipe_is_internal(&super->super.super.super.super) ? STATS_LEVEL3 : STATS_LEVEL1);


### PR DESCRIPTION
Continuation of https://github.com/syslog-ng/syslog-ng/pull/5265

Backport of [404](https://github.com/axoflow/axosyslog/pull/404) by @alltilla

Depends on https://github.com/syslog-ng/syslog-ng/pull/5287