### PR TITLE
grpc: add service accounts

### DIFF
--- a/modules/grpc/common/credentials/grpc-credentials-builder.h
+++ b/modules/grpc/common/credentials/grpc-credentials-builder.h
@@ -61,6 +61,7 @@ typedef enum
   GCAM_TLS,
   GCAM_ALTS,
   GCAM_ADC,
+  GCAM_SERVICE_ACCOUNT,
 } GrpcClientAuthMode;
 
 typedef struct GrpcClientCredentialsBuilderW_ GrpcClientCredentialsBuilderW; // Wrapper struct
@@ -71,6 +72,10 @@ gboolean grpc_client_credentials_builder_set_tls_key_path(GrpcClientCredentialsB
 gboolean grpc_client_credentials_builder_set_tls_cert_path(GrpcClientCredentialsBuilderW *s, const gchar *cert_path);
 void grpc_client_credentials_builder_add_alts_target_service_account(GrpcClientCredentialsBuilderW *s,
     const gchar *target_service_account);
+gboolean grpc_client_credentials_builder_service_account_set_key(GrpcClientCredentialsBuilderW *s,
+    const gchar *key_path);
+void grpc_client_credentials_builder_service_account_set_validity_duration(GrpcClientCredentialsBuilderW *s,
+    guint64 validity_duration);
 
 #include "compat/cpp-end.h"
 

--- a/modules/grpc/common/credentials/grpc-credentials-builder.hpp
+++ b/modules/grpc/common/credentials/grpc-credentials-builder.hpp
@@ -73,6 +73,10 @@ public:
   /* ALTS */
   void add_alts_target_service_account(const char *target_service_account);
 
+  /*SERVICE ACCOUNTS*/
+  bool set_service_account_key_path(const char *key_path);
+  void set_service_account_validity_duration(guint64 validity_duration);
+
 private:
   ClientAuthMode mode = GCAM_INSECURE;
 
@@ -81,6 +85,13 @@ private:
 
   /* ALTS */
   ::grpc::experimental::AltsCredentialsOptions alts_credentials_options;
+
+  /* SERVICE ACCOUNT */
+  struct
+  {
+    std::string key;
+    guint64 validity_duration = 3600L;
+  } service_account;
 };
 
 }

--- a/modules/grpc/common/grpc-grammar.ym
+++ b/modules/grpc/common/grpc-grammar.ym
@@ -52,6 +52,9 @@ GrpcClientCredentialsBuilderW *last_grpc_client_credentials_builder;
 %token KW_TARGET_SERVICE_ACCOUNTS
 %token KW_URL
 %token KW_ADC
+%token KW_SERVICE_ACCOUNT
+%token KW_TOKEN_VALIDITY_DURATION
+%token KW_KEY
 %token KW_COMPRESSION
 %token KW_BATCH_BYTES
 %token KW_CONCURRENT_REQUESTS
@@ -211,6 +214,7 @@ grpc_client_credentials_option
   | KW_TLS { grpc_client_credentials_builder_set_mode(last_grpc_client_credentials_builder, GCAM_TLS); } '(' grpc_client_credentials_builder_tls_options ')'
   | KW_ALTS { grpc_client_credentials_builder_set_mode(last_grpc_client_credentials_builder, GCAM_ALTS); } '(' grpc_client_credentials_builder_alts_options ')'
   | KW_ADC { grpc_client_credentials_builder_set_mode(last_grpc_client_credentials_builder, GCAM_ADC); } '(' ')'
+  | KW_SERVICE_ACCOUNT { grpc_client_credentials_builder_set_mode(last_grpc_client_credentials_builder, GCAM_SERVICE_ACCOUNT); } '(' grpc_client_credentials_builder_service_account_options ')'
   ;
 
 grpc_client_credentials_builder_tls_options
@@ -253,6 +257,16 @@ grpc_client_credentials_builder_alts_target_service_accounts
       }
     grpc_client_credentials_builder_alts_target_service_accounts
   |
+  ;
+
+grpc_client_credentials_builder_service_account_options
+  : grpc_client_credentials_builder_service_account_option grpc_client_credentials_builder_service_account_options
+  |
+  ;
+
+grpc_client_credentials_builder_service_account_option
+  : KW_KEY '(' path_secret ')' { grpc_client_credentials_builder_service_account_set_key(last_grpc_client_credentials_builder, $3); free($3); }
+  | KW_TOKEN_VALIDITY_DURATION '(' nonnegative_integer64 ')' { grpc_client_credentials_builder_service_account_set_validity_duration(last_grpc_client_credentials_builder, $3); }
   ;
 
 /* END_RULES */

--- a/modules/grpc/common/grpc-parser.h
+++ b/modules/grpc/common/grpc-parser.h
@@ -35,6 +35,9 @@
   { "url",                       KW_URL }, \
   { "target_service_accounts",   KW_TARGET_SERVICE_ACCOUNTS }, \
   { "adc",                       KW_ADC }, \
+  { "service_account",           KW_SERVICE_ACCOUNT }, \
+  { "key",                       KW_KEY }, \
+  { "token_validity_duration",   KW_TOKEN_VALIDITY_DURATION }, \
   { "compression",               KW_COMPRESSION }, \
   { "batch_bytes",               KW_BATCH_BYTES }, \
   { "channel_args",              KW_CHANNEL_ARGS }, \

--- a/news/feature-5270.md
+++ b/news/feature-5270.md
@@ -1,0 +1,16 @@
+bigquery(), google-pubsub-grpc(): Added service-account() authentication option.
+
+Example usage:
+```
+destination {
+    google-pubsub-grpc(
+        project("test")
+        topic("test")
+        auth(service-account(key ("path_to_service_account_key.json")))
+    );
+};
+```
+
+Note: In contrary to the `http()` destination's similar option,
+we do not need to manually set the audience here as it is
+automatically recognized by the underlying gRPC API.


### PR DESCRIPTION
It seems like gRPC sets the audience and scope options based on the gRPC service name, so they can't be set in the config.

Example usage:
```
destination {
    google-pubsub-grpc(
        project("test")
        topic("test")
        auth(service-account(key ("path_to_service_account_key.json")))
    );
};
```

Backport of [412](https://github.com/axoflow/axosyslog/pull/412) by @sodomelle

Depends on https://github.com/syslog-ng/syslog-ng/pull/5269