### PR TITLE
workflows: added action to prevent opening of PRs directly to master

### DIFF
--- a/.github/workflows/no-direct-master-pr.yml
+++ b/.github/workflows/no-direct-master-pr.yml
@@ -1,0 +1,18 @@
+name: Master Branch PR check
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch
+        run: |
+          if [[ ${GITHUB_HEAD_REF} != develop ]];
+          then
+            echo "Error: Pull request to 'master' must come from 'develop'"
+            exit 1
+          fi


### PR DESCRIPTION
Action taken from https://stackoverflow.com/questions/46495855/restrict-branch-x-to-be-merged-only-from-one-specific-branch-y-in-github

Only allows merging a PR to master from develop branch.

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
