### PR TITLE
Backport/log msg avoid excess memcpy

### DIFF
--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -254,9 +254,7 @@ struct _LogMessage
    * 8 bytes, and it's highly unlikely that we'd be using more than 4GB for
    * a LogMessage */
 
-  guint allocated_bytes;
-
-  guint32 recvd_rawmsg_size;
+  guint32 allocated_bytes;
 
   AckRecord *ack_record;
   LMAckFunc ack_func;
@@ -293,6 +291,7 @@ struct _LogMessage
          proto:6;
   guint8 num_matches;
   guint32 host_id;
+  guint32 recvd_rawmsg_size;
   guint64 rcptid;
   guint8 num_tags;
   guint8 alloc_sdata;

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -237,6 +237,11 @@ struct _LogMessage
   /* if you change any of the fields here, be sure to adjust
    * log_msg_clone_cow() as well to initialize fields properly */
 
+  /* some of the fields in this struct are shared in copy-on-write
+   * scenarios, tracking of those fields are done using the "flags" member,
+   * see the LF_STATE_OWN_* flags
+   */
+
   /* ack_and_ref_and_abort_and_suspended is a 32 bit integer that is accessed in an atomic way.
    * The upper half contains the ACK count (and the abort flag), the lower half
    * the REF count.  It is not a GAtomicCounter as due to ref/ack caching it has
@@ -244,39 +249,14 @@ struct _LogMessage
    * log_msg_ref/unref.
    */
 
-  /* FIXME: the structure has holes, but right now it's 1 byte short to make
-   * it smaller (it is possible to create a 7 byte contiguos block but 8
-   * byte alignment is needed. Let's check this with the inline-tags stuff */
-
   gint ack_and_ref_and_abort_and_suspended;
+  guint32 flags;
 
-  /* NOTE: in theory this should be a size_t (or gsize), however that takes
-   * 8 bytes, and it's highly unlikely that we'd be using more than 4GB for
-   * a LogMessage */
-
-  guint32 allocated_bytes;
-
-  AckRecord *ack_record;
-  LMAckFunc ack_func;
+  NVTable *payload;
   LogMessage *original;
-
-  /* message parts */
-
-  /* the contents of the members below is directly copied into another
-   * LogMessage with pointer values.  To change any of the fields please use
-   * log_msg_set_*() functions, which will handle borrowed data members
-   * correctly.
-   */
-  /* ==== start of directly copied part ==== */
-  UnixTime timestamps[LM_TS_MAX];
   gulong *tags;
   NVHandle *sdata;
 
-  GSockAddr *saddr;
-  GSockAddr *daddr;
-  NVTable *payload;
-
-  guint32 flags;
   guint16 pri;
   guint8 initial_parse:1,
          recursed:1,
@@ -289,19 +269,45 @@ struct _LogMessage
           * LogMessage.  */
 
          proto:6;
+  /* number of capture groups retrieved from a regexp match (e.g. $1, $2, ...) */
   guint8 num_matches;
-  guint32 host_id;
-  guint32 recvd_rawmsg_size;
-  guint64 rcptid;
+
+  /* number of bits in the "tags" array, if less than 64, all such bits are
+   * stored in the "tags" pointer, otherwise it points to an allocated bit
+   * array */
   guint8 num_tags;
+  /* number of items allocated in the "sdata" array */
   guint8 alloc_sdata;
+  /* number of items stored in the "sdata" array */
   guint8 num_sdata;
-  /* ==== end of directly copied part ==== */
 
+  /* number of nodes pre-allocated as a part of LogMessage at the tail end of the structure */
   guint8 num_nodes;
-  guint8 cur_node;
-  guint8 write_protected;
 
+  /* the next available node */
+  guint8 cur_node;
+  /* is this message currently read only, used to track when we need to copy-on-write */
+  guint8 write_protected;
+  /* identifier of the source host */
+  guint32 host_id;
+  /* unique message identifier (upon receipt) */
+  guint64 rcptid;
+
+  /* number of bytes in the received message */
+  guint32 recvd_rawmsg_size;
+
+  /* allocated bytes in LogMessage, is limited to 32 bits as it's highly
+   * unlikely that we would ever need more than 4GB for a single message
+   * including overhead */
+  guint32 allocated_bytes;
+
+  AckRecord *ack_record;
+  LMAckFunc ack_func;
+
+  GSockAddr *saddr;
+  GSockAddr *daddr;
+
+  UnixTime timestamps[LM_TS_MAX];
 
   /* preallocated LogQueueNodes used to insert this message into a LogQueue */
   LogMessageQueueNode nodes[0];


### PR DESCRIPTION
In my effort to create a generation counter for the LogMessage (to indicate change), I was looking for an empty slot in the struct. While doing so, I documented the members and redid the layout of the struct to ensure that the most often changed fields all fit into the first cacheline.

I also noticed, that in case of cloning, we first zero initialized the struct and then overwritten its content using memcpy, which I have removed in this PR.

Backport of [437](https://github.com/axoflow/axosyslog/pull/437) by @bazsi