### PR TITLE
logmsg: add generation counter

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -589,6 +589,7 @@ log_msg_set_value_with_type(LogMessage *self, NVHandle handle,
   if (value_len < 0)
     value_len = strlen(value);
 
+  self->generation++;
   if (_log_name_value_updates(self))
     {
       msg_trace("Setting value",
@@ -647,6 +648,7 @@ log_msg_unset_value(LogMessage *self, NVHandle handle)
 {
   g_assert(!log_msg_is_write_protected(self));
 
+  self->generation++;
   if (_log_name_value_updates(self))
     {
       msg_trace("Unsetting value",
@@ -708,6 +710,7 @@ log_msg_set_value_indirect_with_type(LogMessage *self, NVHandle handle,
   name_len = 0;
   name = log_msg_get_value_name(handle, &name_len);
 
+  self->generation++;
   if (_log_name_value_updates(self))
     {
       msg_trace("Setting indirect value",
@@ -947,6 +950,7 @@ log_msg_set_tag_by_id_onoff(LogMessage *self, LogTagId id, gboolean on)
 
   g_assert(!log_msg_is_write_protected(self));
 
+  self->generation++;
   msg_trace("Setting tag",
             evt_tag_str("name", log_tags_get_by_id(id)),
             evt_tag_int("value", on),
@@ -1354,6 +1358,7 @@ log_msg_clear(LogMessage *self)
 {
   g_assert(!log_msg_is_write_protected(self));
 
+  self->generation++;
   if(log_msg_chk_flag(self, LF_STATE_OWN_PAYLOAD))
     nv_table_unref(self->payload);
   self->payload = nv_table_new(LM_V_MAX, 16, 256);

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -260,6 +260,10 @@ struct _LogMessage
   gulong *tags;
   NVHandle *sdata;
 
+  /* this member is incremented for any write operation and it can also
+   * overflow, so only track it for changes and assume that 2^16 operations
+   * would suffice between two checks */
+  guint16 generation;
   guint16 pri;
   guint8 initial_parse:1,
          recursed:1,


### PR DESCRIPTION
This adds a counter to LogMessage to track changes made to the NVTable. Any set_value() would increment that counter.
Any other fields (timestamps, etc) are not yet tracked, but probably should...

Backport of [447](https://github.com/axoflow/axosyslog/pull/447) by @bazsi

Depends on https://github.com/syslog-ng/syslog-ng/pull/5274