### PR TITLE
cfg-source: avoid indexing over the end of the lines array

### DIFF
--- a/lib/cfg-source.c
+++ b/lib/cfg-source.c
@@ -234,7 +234,10 @@ _extract_source_from_buffer_location(GString *result, const gchar *buffer_conten
   if (num_lines <= yylloc->first_line)
     goto exit;
 
-  for (gint lineno = yylloc->first_line; lineno <= yylloc->last_line; lineno++)
+  if (yylloc->first_column < 1)
+    goto exit;
+
+  for (gint lineno = yylloc->first_line; lineno < num_lines && lineno <= yylloc->last_line; lineno++)
     {
       gchar *line = lines[lineno - 1];
       gint linelen = strlen(line);


### PR DESCRIPTION
Sometimes (especially with location tracking bugs) a grammar location may be outside of the dimensions of the source text. Make sure we never index outside of the dimensions of the "lines" array.

This is not an exploitable problem, as the index that can overflow cannot be controlled externally. It will cause a segfault if there's a location tracking issue or if the source location we are extracting the source text from is incorrect.

Backport of [427](https://github.com/axoflow/axosyslog/pull/427) by @bazsi