### PR TITLE
logmsg: move log_msg_is_handle_*() to be inline

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -172,33 +172,6 @@ TLS_BLOCK_END;
  * LogMessage
  **********************************************************************/
 
-gboolean
-log_msg_is_handle_macro(NVHandle handle)
-{
-  guint16 flags;
-
-  flags = nv_registry_get_handle_flags(logmsg_registry, handle);
-  return !!(flags & LM_VF_MACRO);
-}
-
-gboolean
-log_msg_is_handle_sdata(NVHandle handle)
-{
-  guint16 flags;
-
-  flags = nv_registry_get_handle_flags(logmsg_registry, handle);
-  return !!(flags & LM_VF_SDATA);
-}
-
-gboolean
-log_msg_is_handle_match(NVHandle handle)
-{
-  guint16 flags;
-
-  flags = nv_registry_get_handle_flags(logmsg_registry, handle);
-  return !!(flags & LM_VF_MATCH);
-}
-
 static inline gboolean
 log_msg_chk_flag(const LogMessage *self, gint32 flag)
 {

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -336,9 +336,32 @@ NVHandle log_msg_get_value_handle(const gchar *value_name);
 gboolean log_msg_is_value_name_valid(const gchar *value);
 const gchar *log_msg_get_handle_name(NVHandle handle, gssize *length);
 
-gboolean log_msg_is_handle_macro(NVHandle handle);
-gboolean log_msg_is_handle_sdata(NVHandle handle);
-gboolean log_msg_is_handle_match(NVHandle handle);
+static inline gboolean
+log_msg_is_handle_macro(NVHandle handle)
+{
+  guint16 flags;
+
+  flags = nv_registry_get_handle_flags(logmsg_registry, handle);
+  return !!(flags & LM_VF_MACRO);
+}
+
+static inline gboolean
+log_msg_is_handle_sdata(NVHandle handle)
+{
+  guint16 flags;
+
+  flags = nv_registry_get_handle_flags(logmsg_registry, handle);
+  return !!(flags & LM_VF_SDATA);
+}
+
+static inline gboolean
+log_msg_is_handle_match(NVHandle handle)
+{
+  guint16 flags;
+
+  flags = nv_registry_get_handle_flags(logmsg_registry, handle);
+  return !!(flags & LM_VF_MATCH);
+}
 
 static inline gboolean
 log_msg_is_handle_referencable_from_an_indirect_value(NVHandle handle)


### PR DESCRIPTION
Backport of [442](https://github.com/axoflow/axosyslog/pull/442) by @bazsi