### PR TITLE
systemd-journal: fix spurious warning about about incorrect size passed to strncpy()

### DIFF
--- a/modules/systemd-journal/journal-reader.c
+++ b/modules/systemd-journal/journal-reader.c
@@ -205,22 +205,27 @@ _format_value_name_with_prefix(gchar *buf, gsize buf_len,
                                JournalReaderOptions *options,
                                const gchar *key, gssize key_len)
 {
-  gsize cont = 0;
+  /* NOTE: key is usually not NUL terminated (except if we are mapping it
+   * from the journald native key to syslog-ng field name) */
 
+  gsize cont = 0;
   if (key_len < 0)
     key_len = strlen(key);
 
   if (options->prefix)
     cont = g_strlcpy(buf, options->prefix, buf_len);
-  gsize left = buf_len - cont;
+  gssize left = buf_len - cont;
   if (left >= key_len + 1)
     {
-      strncpy(buf + cont, key, key_len);
+      /* we have more than enough space in buf */
+      memcpy(buf + cont, key, key_len);
       buf[cont + key_len] = 0;
     }
-  else
+  else if (left > 0)
     {
-      g_strlcpy(buf + cont, key, buf_len - cont);
+      /* truncate key */
+      memcpy(buf + cont, key, left - 1);
+      buf[cont + left - 1] = 0;
     }
 }
 


### PR DESCRIPTION
```
.../modules/systemd-journal/journal-reader.c: In function '_get_value_from_message.constprop.isra': .../modules/systemd-journal/journal-reader.c:218:7: warning: '__builtin___strncpy_chk' output truncated before terminating nul copying as many bytes from a string as its length [-Wstringop-truncation]
  218 |       strncpy(buf + cont, key, key_len);
      |       ^
In function '_format_value_name_with_prefix',
    inlined from '_get_value_from_message.constprop.isra' at /source/modules/systemd-journal/journal-reader.c:243:3:
.../modules/systemd-journal/journal-reader.c:211:15: note: length computed here
  211 |     key_len = strlen(key);
      |               ^~~~~~~~~~~
```
This wasn't an actual issue as we were explicitly terminating the string with NUL in this case, so missing the NUL character was actually expected.

Backport of [454](https://github.com/axoflow/axosyslog/pull/454) by @bazsi