### PR TITLE
http: enable flush-on-worker-key-change for 1 worker

### DIFF
--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -443,15 +443,14 @@ http_dd_init(LogPipe *s)
   if (!log_threaded_dest_driver_init_method(s))
     return FALSE;
 
-  if ((self->super.batch_lines || self->batch_bytes) && http_load_balancer_is_url_templated(self->load_balancer) &&
-      self->super.num_workers > 1)
+  if ((self->super.batch_lines || self->batch_bytes) && http_load_balancer_is_url_templated(self->load_balancer))
     {
       log_threaded_dest_driver_set_flush_on_worker_key_change(&self->super.super.super, TRUE);
 
       if (!self->super.worker_partition_key)
         {
           msg_error("http: worker-partition-key() must be set if using templates in the url() option "
-                    "while batching is enabled and multiple workers are configured. "
+                    "while batching is enabled. "
                     "Make sure to set worker-partition-key() with a template that contains all the templates "
                     "used in the url() option",
                     log_pipe_location_tag(&self->super.super.super.super));

--- a/news/bugfix-5281.md
+++ b/news/bugfix-5281.md
@@ -1,0 +1,1 @@
+`http`: Fixed a batching related bug that happened with templated URLs and a single worker.


### PR DESCRIPTION
When the URL is templated and batching is enabled it does not matter how many workers we have, we
need to close the batch when the partition key changes.

The condition for the if statement was wrong for a long time, however since 819001c6 it not only resulted in a missing error log and missing init fail, but we ran with `flush-on-worker-key-change(no)`, messing up the batching.

Signed-off-by: Attila Szakacs attila.szakacs@axoflow.com

Backport of [464](https://github.com/axoflow/axosyslog/pull/464) by @alltilla
