### PR TITLE
logreader: add exit-on-eof flag()

### DIFF
--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -419,6 +419,11 @@ log_reader_work_finished(void *s, gpointer arg)
 
       self->notify_code = 0;
       log_pipe_notify(self->control, notify_code, self);
+
+      if (notify_code == NC_CLOSE && (self->options->flags & LR_EXIT_ON_EOF))
+        {
+          cfg_shutdown(log_pipe_get_config(s));
+        }
     }
 
   if ((self->super.super.flags & PIF_INITIALIZED) && self->proto)
@@ -896,6 +901,7 @@ CfgFlagHandler log_reader_flag_handlers[] =
   { "empty-lines",                CFH_SET, offsetof(LogReaderOptions, flags),               LR_EMPTY_LINES },
   { "threaded",                   CFH_SET, offsetof(LogReaderOptions, flags),               LR_THREADED },
   { "ignore-aux-data",            CFH_SET, offsetof(LogReaderOptions, flags),               LR_IGNORE_AUX_DATA },
+  { "exit-on-eof",                CFH_SET, offsetof(LogReaderOptions, flags),               LR_EXIT_ON_EOF },
   { NULL },
 };
 

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -39,6 +39,7 @@
 #define LR_EMPTY_LINES     0x0004
 #define LR_IGNORE_AUX_DATA 0x0008
 #define LR_THREADED        0x0040
+#define LR_EXIT_ON_EOF     0x0080
 
 /* options */
 

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -422,13 +422,6 @@ _reopen_on_notify(LogPipe *s, gboolean recover_state)
 }
 
 static void
-_on_file_close(FileReader *self)
-{
-  if (self->options->exit_on_eof)
-    cfg_shutdown(log_pipe_get_config(&self->super));
-}
-
-static void
 _on_file_moved(FileReader *self)
 {
   msg_verbose("Follow-mode file source moved, tracking of the new file is started",
@@ -473,7 +466,6 @@ file_reader_notify_method(LogPipe *s, gint notify_code, gpointer user_data)
   switch (notify_code)
     {
     case NC_CLOSE:
-      _on_file_close(self);
       break;
 
     case NC_FILE_MOVED:

--- a/modules/affile/file-reader.h
+++ b/modules/affile/file-reader.h
@@ -32,7 +32,6 @@ typedef struct _FileReaderOptions
   gint multi_line_timeout;
   gboolean restore_state;
   LogReaderOptions reader_options;
-  gboolean exit_on_eof;
 } FileReaderOptions;
 
 typedef struct _FileReader FileReader;

--- a/modules/affile/stdin.c
+++ b/modules/affile/stdin.c
@@ -76,7 +76,7 @@ stdin_sd_new(GlobalConfig *cfg)
   self->super.super.super.init = stdin_sd_init;
 
   self->file_reader_options.restore_state = FALSE;
-  self->file_reader_options.exit_on_eof = TRUE;
+  self->file_reader_options.reader_options.flags |= LR_EXIT_ON_EOF;
   self->file_reader_options.reader_options.super.stats_source = stats_register_type("stdin");
   self->file_opener = file_opener_for_stdin_new();
   affile_sd_set_transport_name(self, "local+stdin");


### PR DESCRIPTION
With the exit-on-eof flag, you can request syslog-ng to exit whenever the first EOF is hit on the specific source, similarly to how the stdin() source behaves.

Backport of [351](https://github.com/axoflow/axosyslog/pull/351) by @bazsi