### PR TITLE
S3 updates

### DIFF
--- a/modules/python-modules/syslogng/modules/s3/s3_destination.py
+++ b/modules/python-modules/syslogng/modules/s3/s3_destination.py
@@ -83,6 +83,7 @@ class S3Destination(LogDestination):
             self.kms_key = str(options["kms_key"])
             self.storage_class = str(options["storage_class"]).upper().replace("-", "_")
             self.canned_acl = str(options["canned_acl"]).lower().replace("_", "-")
+            self.content_type = str(options["content_type"])
         except KeyError:
             assert False, (
                 f"S3: {str(exc_info()[1])[1:-1]}() option is missing. "
@@ -201,6 +202,7 @@ class S3Destination(LogDestination):
             "compresslevel": self.compresslevel,
             "max_object_size": self.max_object_size,
             "canned_acl": self.canned_acl,
+            "content_type": self.content_type,
         }
 
         self.s3_object_ready_queue: S3ObjectQueue = S3ObjectQueue()

--- a/modules/python-modules/syslogng/modules/s3/s3_destination.py
+++ b/modules/python-modules/syslogng/modules/s3/s3_destination.py
@@ -31,6 +31,7 @@ try:
     from signal import signal, SIGINT, SIG_IGN
     from syslogng import LogDestination, LogMessage, LogTemplate, get_installation_path_for
 
+    from importlib.metadata import version
     from os import listdir, mkdir
     from pathlib import Path
     from sys import exc_info
@@ -40,6 +41,8 @@ try:
 
     from boto3 import client, Session
     from boto3.s3.transfer import TransferConfig
+    import botocore
+    from botocore.config import Config
     from botocore.credentials import create_assume_role_refresher, DeferredRefreshableCredentials
     from botocore.exceptions import ClientError, EndpointConnectionError
 
@@ -84,6 +87,7 @@ class S3Destination(LogDestination):
             self.storage_class = str(options["storage_class"]).upper().replace("-", "_")
             self.canned_acl = str(options["canned_acl"]).lower().replace("_", "-")
             self.content_type = str(options["content_type"])
+            self.use_checksum = str(options["use_checksum"])
         except KeyError:
             assert False, (
                 f"S3: {str(exc_info()[1])[1:-1]}() option is missing. "
@@ -163,6 +167,16 @@ class S3Destination(LogDestination):
             )
             self.canned_acl = ""
 
+        VALID_CHECKSUM_SETTINGS = {
+            "when_supported",
+            "when_required",
+        }
+        if self.use_checksum not in VALID_CHECKSUM_SETTINGS:
+            self.logger.warning(
+                f"Invalid use-checksum(). Valid values are: {', '.join(sorted(VALID_CHECKSUM_SETTINGS))} or empty. Using when_supported."
+            )
+            self.use_checksum = "when_supported"
+
     def init(self, options: Dict[str, Any]) -> bool:
         if not deps_installed:
             if deps_missing:
@@ -185,6 +199,15 @@ class S3Destination(LogDestination):
         self.s3_client_config: Dict[str, Any] = {
             "endpoint_url": self.url if self.url != "" else None,
         }
+        if version('botocore') > '1.36':
+            self.s3_client_config.update({
+                "config": Config(
+                    request_checksum_calculation=self.use_checksum,
+                    response_checksum_validation=self.use_checksum,
+                )
+            })
+        else:
+            self.logger.info("The option 'use-checksum()' requires at least botocore version 1.36. Current version is {}".format(version('botocore')))
         self.s3_sse_options: Dict[str, Any] = {
             "ServerSideEncryption": self.server_side_encryption if self.server_side_encryption != "" else None,
             "SSEKMSKeyId": self.kms_key if self.server_side_encryption != "" else None,

--- a/modules/python-modules/syslogng/modules/s3/s3_object_buffer.py
+++ b/modules/python-modules/syslogng/modules/s3/s3_object_buffer.py
@@ -68,7 +68,7 @@ class S3ObjectBuffer:
         self.__meta_path = meta_path
         self.__path = Path(str(meta_path).removesuffix("_meta.json"))
         with open(self.__meta_path, "r") as meta_file:
-            self.__meta = json.loads(meta_file.read())
+            self.__meta = self.__meta | json.loads(meta_file.read())
         self.buffer = CompressableFileBuffer(self.__path, self.__meta["compression"], self.__meta["compresslevel"])
         self.__buffer_source = "loaded"
 

--- a/modules/python-modules/syslogng/modules/s3/s3_object_buffer.py
+++ b/modules/python-modules/syslogng/modules/s3/s3_object_buffer.py
@@ -48,7 +48,8 @@ class S3ObjectBuffer:
             "compression": object_settings.get("compression", False),
             "compresslevel": object_settings.get("compresslevel", 0),
             "max_size": object_settings.get("max_object_size", None),
-            "acl": object_settings.get("canned_acl", None)
+            "acl": object_settings.get("canned_acl", None),
+            "content_type": object_settings.get("content_type", "application/octet-stream"),
         }
         self.__basename = f"{object_key}_{uuid4()}"
         self.__path = Path(working_dir, self.__basename)
@@ -149,6 +150,10 @@ class S3ObjectBuffer:
     @property
     def acl(self):
         return self.__meta["acl"]
+
+    @property
+    def content_type(self):
+        return self.__meta["content_type"]
 
 
 class S3ObjectQueue:

--- a/modules/python-modules/syslogng/modules/s3/s3_session_handler.py
+++ b/modules/python-modules/syslogng/modules/s3/s3_session_handler.py
@@ -122,7 +122,14 @@ class S3SessionHandler:
         if not self.__upload_enabled:
             return rc
         try:
-            self.__client.upload_file(Filename=s3_object.path, Bucket=self.__bucket, Key=s3_object.full_target_key, Config=self.__transfer_config, ExtraArgs={"StorageClass": s3_object.storage_class, "ACL": s3_object.acl, "ContentType": s3_object.content_type})
+            extra_args: Dict[str, str] = {}
+            if s3_object.storage_class is not None:
+                extra_args["StorageClass"] = s3_object.storage_class
+            if s3_object.acl is not None:
+                extra_args["ACL"] = s3_object.acl
+            if s3_object.content_type is not None:
+                extra_args["ContentType"] = s3_object.content_type
+            self.__client.upload_file(Filename=s3_object.path, Bucket=self.__bucket, Key=s3_object.full_target_key, Config=self.__transfer_config, ExtraArgs=extra_args)
             rc = True
             self.logger.debug(f"Object {s3_object.full_target_key} successfully uploaded.")
             s3_object.deprecate()

--- a/modules/python-modules/syslogng/modules/s3/s3_session_handler.py
+++ b/modules/python-modules/syslogng/modules/s3/s3_session_handler.py
@@ -122,7 +122,7 @@ class S3SessionHandler:
         if not self.__upload_enabled:
             return rc
         try:
-            self.__client.upload_file(Filename=s3_object.path, Bucket=self.__bucket, Key=s3_object.full_target_key, Config=self.__transfer_config, ExtraArgs={"StorageClass": s3_object.storage_class, "ACL": s3_object.acl})
+            self.__client.upload_file(Filename=s3_object.path, Bucket=self.__bucket, Key=s3_object.full_target_key, Config=self.__transfer_config, ExtraArgs={"StorageClass": s3_object.storage_class, "ACL": s3_object.acl, "ContentType": s3_object.content_type})
             rc = True
             self.logger.debug(f"Object {s3_object.full_target_key} successfully uploaded.")
             s3_object.deprecate()

--- a/modules/python-modules/syslogng/modules/s3/scl/s3.conf
+++ b/modules/python-modules/syslogng/modules/s3/scl/s3.conf
@@ -42,6 +42,7 @@ block destination s3(
     kms_key("")
     storage_class("STANDARD")
     canned_acl("")
+    content_type("application/octet-stream")
     ...
 )
 {
@@ -69,6 +70,7 @@ block destination s3(
             "kms_key" => "`kms_key`"
             "storage_class" => "`storage_class`"
             "canned_acl" => "`canned_acl`"
+            "content_type" => "`content_type`"
         )
         `__VARARGS__`
     );

--- a/modules/python-modules/syslogng/modules/s3/scl/s3.conf
+++ b/modules/python-modules/syslogng/modules/s3/scl/s3.conf
@@ -43,6 +43,7 @@ block destination s3(
     storage_class("STANDARD")
     canned_acl("")
     content_type("application/octet-stream")
+    use_checksum("when_supported")
     ...
 )
 {
@@ -71,6 +72,7 @@ block destination s3(
             "storage_class" => "`storage_class`"
             "canned_acl" => "`canned_acl`"
             "content_type" => "`content_type`"
+            "use_checksum" => "`use_checksum`"
         )
         `__VARARGS__`
     );

--- a/news/feature-5286.md
+++ b/news/feature-5286.md
@@ -1,0 +1,20 @@
+`s3`: Added two new options
+
+* `content-type()`: users now can change the content type of the objects uploaded by syslog-ng.
+* `use_checksum()`: This option allows the users to change the default checksum settings for 
+S3 compatible solutions that don't support checksums. Requires botocore 1.36 or above. Acceptable values are
+`when_supported` (default) and `when_required`.
+
+Example:
+```
+s3(
+	url("http://localhost:9000")
+	bucket("testbucket")
+	object_key("testobject")
+	access_key("<ACCESS_KEY_ID>")
+	secret_key("<SECRET_ACCESS_KEY>")
+	content_type("text/plain")
+	use_checksum("when_required")
+);
+```
+


### PR DESCRIPTION
<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->

This pull request introduces two new options for `s3`:
* `content-type()`: users now can change the displayed content type of their logs.
* `use_compression()`: in version 1.36 botocore developers changed the default integrity check settings (see https://github.com/boto/boto3/issues/4392). This option allows the users to change the default `when_supported` value to `when_required` for S3 compatible solutions that don't support checksums.

Usage:
```
s3(
	url("http://localhost:9000")
	bucket("testbucket")
	object_key("testobject")
	access_key("<ACCESS_KEY_ID>")
	secret_key("<SECRET_ACCESS_KEY>")
	content_type("text/plain")
	use_checksum("when_required")
);
```

Based on [408](https://github.com/axoflow/axosyslog/pull/408), [486](https://github.com/axoflow/axosyslog/pull/486) and [488](https://github.com/axoflow/axosyslog/pull/488) by @alltilla 

<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
