### PR TITLE
grpc/otel: add missing client context creation to syslog-ng-otlp()

### DIFF
--- a/modules/grpc/otel/syslog-ng-otlp-dest-worker.cpp
+++ b/modules/grpc/otel/syslog-ng-otlp-dest-worker.cpp
@@ -57,6 +57,12 @@ SyslogNgDestWorker::insert(LogMessage *msg)
   logs_current_batch_bytes += log_record_bytes;
   log_threaded_dest_driver_insert_msg_length_stats(super->super.owner, log_record_bytes);
 
+  if (!client_context.get())
+    {
+      client_context = std::make_unique<::grpc::ClientContext>();
+      prepare_context_dynamic(*client_context, msg);
+    }
+
   if (should_initiate_flush())
     return log_threaded_dest_worker_flush(&super->super, LTF_FLUSH_NORMAL);
 

--- a/news/bugfix-5267.md
+++ b/news/bugfix-5267.md
@@ -1,0 +1,1 @@
+`syslog-ng-otlp()` destination: Fixed a crash.


### PR DESCRIPTION
Missing from:

[340532c3ac0c3c5979bc5cf3090d39384c4f45fa](https://github.com/syslog-ng/syslog-ng/pull/5184/commits/340532c3ac0c3c5979bc5cf3090d39384c4f45fa)

Backport of [384](https://github.com/axoflow/axosyslog/pull/384) by @alltilla

Depends on https://github.com/syslog-ng/syslog-ng/pull/5266