### PR TITLE
cloud-auth: do no directly include picojson/picojson.h

### DIFF
--- a/modules/cloud-auth/azure-auth.hpp
+++ b/modules/cloud-auth/azure-auth.hpp
@@ -28,7 +28,7 @@
 #include "cloud-auth.hpp"
 
 #include <mutex>
-#include <picojson/picojson.h>
+#include <jwt-cpp/jwt.h>
 
 namespace syslogng {
 namespace cloud_auth {

--- a/modules/cloud-auth/google-auth.hpp
+++ b/modules/cloud-auth/google-auth.hpp
@@ -29,7 +29,6 @@
 #include <mutex>
 #include <string>
 #include <jwt-cpp/jwt.h>
-#include <picojson/picojson.h>
 
 #include "compat/curl.h"
 


### PR DESCRIPTION
There is a macro that modifies the number parsing behavior of picojson (PICOJSON_USE_INT64).

When jwt-cpp/jwt.h includes picojson.h it explicitly enables PICOJSON_USE_INT64. I did not check the code thoroughly, but it is possible that they explicitly build on some int64_t related functionality.

However if we directly include picojson.h without setting PICOJSON_USE_INT64, picojson will not have int64_t support. This resulted in a strange behavior of having int64_t type hinted value in a json object, but the type checker not recognizing it as a number.

Backport of [481](https://github.com/axoflow/axosyslog/pull/481) by @alltilla

Depends on https://github.com/syslog-ng/syslog-ng/pull/5275