### PR TITLE
rename the table_name parameter of the azure monitor destination

### DIFF
--- a/modules/cloud-auth/CMakeLists.txt
+++ b/modules/cloud-auth/CMakeLists.txt
@@ -29,6 +29,9 @@ set(CLOUD_AUTH_CPP_SOURCES
   google-auth.h
   google-auth.cpp
   google-auth.hpp
+  azure-auth.h
+  azure-auth.cpp
+  azure-auth.hpp
 )
 
 set(OTEL_SOURCES

--- a/modules/cloud-auth/Makefile.am
+++ b/modules/cloud-auth/Makefile.am
@@ -6,7 +6,9 @@ modules_cloud_auth_libcloud_auth_cpp_la_SOURCES = \
   modules/cloud-auth/cloud-auth.hpp \
   modules/cloud-auth/cloud-auth.cpp \
   modules/cloud-auth/google-auth.hpp \
-  modules/cloud-auth/google-auth.cpp
+  modules/cloud-auth/google-auth.cpp \
+  modules/cloud-auth/azure-auth.hpp \
+  modules/cloud-auth/azure-auth.cpp
 
 modules_cloud_auth_libcloud_auth_cpp_la_CXXFLAGS = \
   $(AM_CXXFLAGS) \
@@ -29,7 +31,8 @@ modules_cloud_auth_libcloud_auth_la_SOURCES = \
   modules/cloud-auth/cloud-auth-plugin.c \
   modules/cloud-auth/cloud-auth.h \
   modules/cloud-auth/cloud-auth.c \
-  modules/cloud-auth/google-auth.h
+  modules/cloud-auth/google-auth.h \
+  modules/cloud-auth/azure-auth.h
 
 modules_cloud_auth_libcloud_auth_la_CPPFLAGS = \
   $(AM_CPPFLAGS) \

--- a/modules/cloud-auth/azure-auth.cpp
+++ b/modules/cloud-auth/azure-auth.cpp
@@ -124,7 +124,7 @@ AzureMonitorAuthenticator::send_token_post_request(std::string &response_payload
   ret = curl_easy_perform(hnd);
   if (ret != CURLE_OK)
     {
-      msg_error("cloud_auth::google::UserManagedServiceAccountAuthenticator: "
+      msg_error("cloud_auth::azure::AzureMonitorAuthenticator: "
                 "error sending HTTP request to metadata server",
                 evt_tag_str("url", auth_url.c_str()),
                 evt_tag_str("error", curl_easy_strerror(ret)));
@@ -135,7 +135,7 @@ AzureMonitorAuthenticator::send_token_post_request(std::string &response_payload
   ret = curl_easy_getinfo(hnd, CURLINFO_RESPONSE_CODE, &http_result_code);
   if (ret != CURLE_OK)
     {
-      msg_error("cloud_auth::google::UserManagedServiceAccountAuthenticator: "
+      msg_error("cloud_auth::azure::AzureMonitorAuthenticator: "
                 "failed to get HTTP result code",
                 evt_tag_str("url", auth_url.c_str()),
                 evt_tag_str("error", curl_easy_strerror(ret)));
@@ -144,7 +144,7 @@ AzureMonitorAuthenticator::send_token_post_request(std::string &response_payload
 
   if (http_result_code != 200)
     {
-      msg_error("cloud_auth::google::UserManagedServiceAccountAuthenticator: "
+      msg_error("cloud_auth::azure::AzureMonitorAuthenticator: "
                 "non 200 HTTP result code received",
                 evt_tag_str("url", auth_url.c_str()),
                 evt_tag_int("http_result_code", http_result_code));

--- a/modules/cloud-auth/azure-auth.cpp
+++ b/modules/cloud-auth/azure-auth.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025 Axoflow
+ * Copyright (c) 2025 Tamas Kosztyu <tamas.kosztyu@axoflow.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "azure-auth.hpp"
+
+using namespace syslogng::cloud_auth::azure;
+
+void AzureMonitorAuthenticator::handle_http_header_request(HttpHeaderRequestSignalData *data)
+{
+  ;
+}
+
+AzureMonitorAuthenticator::AzureMonitorAuthenticator()
+{
+  ;
+}
+
+/* C Wrappers */
+
+typedef struct AzureAuthenticator
+{
+  CloudAuthenticator super;
+
+} _AzureAuthenticator;
+
+static gboolean
+_init(CloudAuthenticator *s)
+{
+  return TRUE;
+}
+
+static void
+_free(CloudAuthenticator *s)
+{
+  ;
+}
+
+static void
+_set_default_options(AzureAuthenticator *self)
+{
+  ;
+}
+
+CloudAuthenticator *
+azure_authenticator_new(void)
+{
+  AzureAuthenticator *self = g_new0(AzureAuthenticator, 1);
+
+  self->super.init = _init;
+  self->super.free_fn = _free;
+
+  _set_default_options(self);
+
+  return &self->super;
+}

--- a/modules/cloud-auth/azure-auth.cpp
+++ b/modules/cloud-auth/azure-auth.cpp
@@ -22,16 +22,185 @@
  */
 #include "azure-auth.hpp"
 
+#include "compat/cpp-start.h"
+#include "scratch-buffers.h"
+#include "compat/cpp-end.h"
+
+#include <fstream>
+
 using namespace syslogng::cloud_auth::azure;
+
+AzureMonitorAuthenticator::AzureMonitorAuthenticator(const char *tenant_id,
+                                                     const char *app_id,
+                                                     const char *app_secret,
+                                                     const char *scope)
+{
+  auth_url = "https://login.microsoftonline.com/";
+  auth_url.append(tenant_id);
+  auth_url.append("/oauth2/v2.0/token");
+
+  auth_body = "grant_type=client_credentials&client_id=";
+  auth_body.append(app_id);
+  auth_body.append("&client_secret=");
+  auth_body.append(app_secret);
+  auth_body.append("&scope=");
+  auth_body.append(scope);
+}
 
 void AzureMonitorAuthenticator::handle_http_header_request(HttpHeaderRequestSignalData *data)
 {
-  ;
+  std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
+
+  lock.lock();
+
+  if (now <= refresh_token_after && !cached_token.empty())
+    {
+      add_token_to_header(data);
+      lock.unlock();
+
+      data->result = HTTP_SLOT_SUCCESS;
+      return;
+    }
+
+  cached_token.clear();
+
+  std::string response_payload_buffer;
+  if (!send_token_post_request(response_payload_buffer))
+    {
+      lock.unlock();
+
+      data->result = HTTP_SLOT_CRITICAL_ERROR;
+      return;
+    }
+
+  long expiry;
+  if (!parse_token_and_expiry_from_response(response_payload_buffer, cached_token, &expiry))
+    {
+      lock.unlock();
+
+      data->result = HTTP_SLOT_CRITICAL_ERROR;
+      return;
+    }
+
+  refresh_token_after = now + std::chrono::seconds{expiry - 60};
+  add_token_to_header(data);
+
+  lock.unlock();
+
+  data->result = HTTP_SLOT_SUCCESS;
 }
 
-AzureMonitorAuthenticator::AzureMonitorAuthenticator()
+void
+AzureMonitorAuthenticator::add_token_to_header(HttpHeaderRequestSignalData *data)
 {
-  ;
+  /* Scratch Buffers are marked at this point in http-worker.c */
+  GString *auth_buffer = scratch_buffers_alloc();
+  g_string_append(auth_buffer, "Authorization: Bearer ");
+  g_string_append(auth_buffer, cached_token.c_str());
+
+  list_append(data->request_headers, auth_buffer->str);
+}
+
+bool
+AzureMonitorAuthenticator::send_token_post_request(std::string &response_payload_buffer)
+{
+  CURLcode ret;
+  CURL *hnd = curl_easy_init();
+
+  if (!hnd)
+    {
+      msg_error("cloud_auth::azure::AzureMonitorAuthenticator: "
+                "failed to init cURL handle",
+                evt_tag_str("url", auth_url.c_str()));
+      goto error;
+    }
+
+  curl_easy_setopt(hnd, CURLOPT_URL, auth_url.c_str());
+  curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "POST");
+  curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, auth_body.c_str());
+  curl_easy_setopt(hnd, CURLOPT_WRITEFUNCTION, curl_write_callback);
+  curl_easy_setopt(hnd, CURLOPT_WRITEDATA, (void *) &response_payload_buffer);
+
+  ret = curl_easy_perform(hnd);
+  if (ret != CURLE_OK)
+    {
+      msg_error("cloud_auth::google::UserManagedServiceAccountAuthenticator: "
+                "error sending HTTP request to metadata server",
+                evt_tag_str("url", auth_url.c_str()),
+                evt_tag_str("error", curl_easy_strerror(ret)));
+      goto error;
+    }
+
+  long http_result_code;
+  ret = curl_easy_getinfo(hnd, CURLINFO_RESPONSE_CODE, &http_result_code);
+  if (ret != CURLE_OK)
+    {
+      msg_error("cloud_auth::google::UserManagedServiceAccountAuthenticator: "
+                "failed to get HTTP result code",
+                evt_tag_str("url", auth_url.c_str()),
+                evt_tag_str("error", curl_easy_strerror(ret)));
+      goto error;
+    }
+
+  if (http_result_code != 200)
+    {
+      msg_error("cloud_auth::google::UserManagedServiceAccountAuthenticator: "
+                "non 200 HTTP result code received",
+                evt_tag_str("url", auth_url.c_str()),
+                evt_tag_int("http_result_code", http_result_code));
+      goto error;
+    }
+
+  curl_easy_cleanup(hnd);
+  return true;
+
+error:
+  if (hnd)
+    {
+      curl_easy_cleanup(hnd);
+    }
+  return false;
+}
+
+bool
+AzureMonitorAuthenticator::parse_token_and_expiry_from_response(const std::string &response_payload,
+    std::string &token, long *expiry)
+{
+  picojson::value json;
+  std::string json_parse_error = picojson::parse(json, response_payload);
+  if (!json_parse_error.empty())
+    {
+      msg_error("cloud_auth::azure::AzureMonitorAuthenticator: "
+                "failed to parse response JSON",
+                evt_tag_str("url", auth_url.c_str()),
+                evt_tag_str("response_json", response_payload.c_str()));
+      return false;
+    }
+
+  if (!json.is<picojson::object>() || !json.contains("access_token") || !json.contains("expires_in"))
+    {
+      msg_error("cloud_auth::azure::AzureMonitorAuthenticator: "
+                "unexpected response JSON",
+                evt_tag_str("url", auth_url.c_str()),
+                evt_tag_str("response_json", response_payload.c_str()));
+      return false;
+    }
+
+  token.assign(json.get("access_token").get<std::string>());
+  *expiry = lround(json.get("expires_in").get<double>()); /* getting a long from picojson is not always available */
+  return true;
+}
+
+size_t
+AzureMonitorAuthenticator::curl_write_callback(void *contents, size_t size, size_t nmemb, void *userp)
+{
+  const char *data = (const char *) contents;
+  std::string *response_payload_buffer = (std::string *) userp;
+
+  size_t real_size = size * nmemb;
+  response_payload_buffer->append(data, real_size);
+
+  return real_size;
 }
 
 /* C Wrappers */
@@ -40,24 +209,106 @@ typedef struct AzureAuthenticator
 {
   CloudAuthenticator super;
 
+  AzureAuthenticatorAuthMode auth_mode;
+
+  gchar *tenant_id;
+  gchar *app_id;
+  gchar *scope;
+  gchar *app_secret;
 } _AzureAuthenticator;
+
+void
+azure_authenticator_set_auth_mode(CloudAuthenticator *s, AzureAuthenticatorAuthMode auth_mode)
+{
+  AzureAuthenticator *self = (AzureAuthenticator *) s;
+
+  self->auth_mode = auth_mode;
+}
+
+void
+azure_authenticator_set_tenant_id(CloudAuthenticator *s, const gchar *tenant_id)
+{
+  AzureAuthenticator *self = (AzureAuthenticator *) s;
+
+  g_free(self->tenant_id);
+  self->tenant_id = g_strdup(tenant_id);
+}
+
+void
+azure_authenticator_set_app_id(CloudAuthenticator *s, const gchar *app_id)
+{
+  AzureAuthenticator *self = (AzureAuthenticator *) s;
+
+  g_free(self->app_id);
+  self->app_id = g_strdup(app_id);
+}
+
+void
+azure_authenticator_set_scope(CloudAuthenticator *s, const gchar *scope)
+{
+  AzureAuthenticator *self = (AzureAuthenticator *) s;
+
+  g_free(self->scope);
+  self->scope = g_strdup(scope);
+}
+
+void
+azure_authenticator_set_app_secret(CloudAuthenticator *s, const gchar *app_secret)
+{
+  AzureAuthenticator *self = (AzureAuthenticator *) s;
+
+  g_free(self->app_secret);
+  self->app_secret = g_strdup(app_secret);
+}
 
 static gboolean
 _init(CloudAuthenticator *s)
 {
+  AzureAuthenticator *self = (AzureAuthenticator *) s;
+
+  switch (self->auth_mode)
+    {
+    case AAAM_MONITOR:
+      try
+        {
+          self->super.cpp = new AzureMonitorAuthenticator(self->tenant_id,
+                                                          self->app_id,
+                                                          self->app_secret,
+                                                          self->scope);
+        }
+      catch (const std::runtime_error &e)
+        {
+          msg_error("cloud_auth::azure: Failed to initialize AzureMonitorAuthenticator",
+                    evt_tag_str("error", e.what()));
+          return FALSE;
+        }
+      break;
+    case AAAM_UNDEFINED:
+      msg_error("cloud_auth::azure: Failed to initialize AzureMonitorAuthenticator",
+                evt_tag_str("error", "Authentication mode must be set (e.g. monitor())"));
+      return FALSE;
+    default:
+      g_assert_not_reached();
+    }
+
   return TRUE;
 }
 
 static void
 _free(CloudAuthenticator *s)
 {
-  ;
+  AzureAuthenticator *self = (AzureAuthenticator *) s;
+
+  g_free(self->tenant_id);
+  g_free(self->app_id);
+  g_free(self->scope);
+  g_free(self->app_secret);
 }
 
 static void
 _set_default_options(AzureAuthenticator *self)
 {
-  ;
+  self->scope = g_strdup("https://monitor.azure.com//.default");
 }
 
 CloudAuthenticator *

--- a/modules/cloud-auth/azure-auth.h
+++ b/modules/cloud-auth/azure-auth.h
@@ -26,6 +26,25 @@
 
 #include "cloud-auth.h"
 
+#include "compat/cpp-start.h"
+
+#include "compat/curl.h"
+
+typedef enum _AzureAuthenticatorAuthMode
+{
+  AAAM_UNDEFINED,
+  AAAM_MONITOR,
+} AzureAuthenticatorAuthMode;
+
 CloudAuthenticator *azure_authenticator_new(void);
+
+void azure_authenticator_set_auth_mode(CloudAuthenticator *s, AzureAuthenticatorAuthMode auth_mode);
+
+void azure_authenticator_set_tenant_id(CloudAuthenticator *s, const gchar *tenant_id);
+void azure_authenticator_set_app_id(CloudAuthenticator *s, const gchar *app_id);
+void azure_authenticator_set_scope(CloudAuthenticator *s, const gchar *scope);
+void azure_authenticator_set_app_secret(CloudAuthenticator *s, const gchar *app_secret);
+
+#include "compat/cpp-end.h"
 
 #endif

--- a/modules/cloud-auth/azure-auth.h
+++ b/modules/cloud-auth/azure-auth.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 Axoflow
+ * Copyright (c) 2025 Tamas Kosztyu <tamas.kosztyu@axoflow.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef AZURE_AUTH_H
+#define AZURE_AUTH_H
+
+#include "cloud-auth.h"
+
+CloudAuthenticator *azure_authenticator_new(void);
+
+#endif

--- a/modules/cloud-auth/azure-auth.hpp
+++ b/modules/cloud-auth/azure-auth.hpp
@@ -27,6 +27,9 @@
 #include "azure-auth.h"
 #include "cloud-auth.hpp"
 
+#include <mutex>
+#include <picojson/picojson.h>
+
 namespace syslogng {
 namespace cloud_auth {
 namespace azure {
@@ -34,10 +37,25 @@ namespace azure {
 class AzureMonitorAuthenticator: public syslogng::cloud_auth::Authenticator
 {
 public:
-  AzureMonitorAuthenticator();
+  AzureMonitorAuthenticator(const char *tenant_id, const char *app_id,
+                            const char *app_secret, const char *scope);
   ~AzureMonitorAuthenticator() {};
 
   void handle_http_header_request(HttpHeaderRequestSignalData *data);
+
+private:
+  std::string auth_url;
+  std::string auth_body;
+
+  std::mutex lock;
+  std::string cached_token;
+  std::chrono::system_clock::time_point refresh_token_after;
+
+  void add_token_to_header(HttpHeaderRequestSignalData *data);
+  bool parse_token_and_expiry_from_response(const std::string &response_payload,
+                                            std::string &token, long *expiry);
+  static size_t curl_write_callback(void *contents, size_t size, size_t nmemb, void *userp);
+  bool send_token_post_request(std::string &response_payload_buffer);
 };
 
 }

--- a/modules/cloud-auth/azure-auth.hpp
+++ b/modules/cloud-auth/azure-auth.hpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025 Axoflow
+ * Copyright (c) 2025 Tamas Kosztyu <tamas.kosztyu@axoflow.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef AZURE_AUTH_HPP
+#define AZURE_AUTH_HPP
+
+#include "azure-auth.h"
+#include "cloud-auth.hpp"
+
+namespace syslogng {
+namespace cloud_auth {
+namespace azure {
+
+class AzureMonitorAuthenticator: public syslogng::cloud_auth::Authenticator
+{
+public:
+  AzureMonitorAuthenticator();
+  ~AzureMonitorAuthenticator() {};
+
+  void handle_http_header_request(HttpHeaderRequestSignalData *data);
+};
+
+}
+}
+}
+
+#endif

--- a/modules/cloud-auth/cloud-auth-grammar.ym
+++ b/modules/cloud-auth/cloud-auth-grammar.ym
@@ -29,6 +29,7 @@
 #include "plugin.h"
 #include "cloud-auth.h"
 #include "google-auth.h"
+#include "azure-auth.h"
 
 LogDriverPlugin *last_plugin;
 CloudAuthenticator *last_authenticator;
@@ -55,6 +56,12 @@ CloudAuthenticator *last_authenticator;
 %token KW_USER_MANAGED_SERVICE_ACCOUNT
 %token KW_NAME
 %token KW_METADATA_URL
+%token KW_AZURE
+%token KW_MONITOR
+%token KW_TENANT_ID
+%token KW_APP_ID
+%token KW_APP_SECRET
+%token KW_SCOPE
 
 %%
 
@@ -80,7 +87,14 @@ inner_destination_cloud_auth_option
     {
       cloud_auth_dest_plugin_set_authenticator(last_plugin, last_authenticator);
     }
-  |
+  | KW_AZURE
+    {
+      last_authenticator = azure_authenticator_new();
+    }
+    '(' azure_dest_auth_options ')'
+    {
+      cloud_auth_dest_plugin_set_authenticator(last_plugin, last_authenticator);
+    }
   ;
 
 google_dest_auth_options
@@ -120,6 +134,31 @@ google_dest_auth_user_managed_service_account_options
 google_dest_auth_user_managed_service_account_option
   : KW_NAME '(' string ')' { google_authenticator_set_user_managed_service_account_name(last_authenticator, $3); free($3); }
   | KW_METADATA_URL '(' string ')' { google_authenticator_set_user_managed_service_account_metadata_url(last_authenticator, $3); free($3); }
+  ;
+
+azure_dest_auth_options
+  : azure_dest_auth_option azure_dest_auth_options
+  |
+  ;
+
+azure_dest_auth_option
+  : KW_MONITOR
+    {
+      azure_authenticator_set_auth_mode(last_authenticator, AAAM_MONITOR);
+    }
+    '(' azure_dest_monitor_options ')'
+  ;
+
+azure_dest_monitor_options
+  : azure_dest_monitor_option azure_dest_monitor_options
+  |
+  ;
+
+azure_dest_monitor_option
+  : KW_TENANT_ID '(' string ')' {azure_authenticator_set_tenant_id(last_authenticator, $3); free($3);}
+  | KW_APP_ID '(' string ')' {azure_authenticator_set_app_id(last_authenticator, $3); free($3);}
+  | KW_APP_SECRET '(' string ')' {azure_authenticator_set_app_secret(last_authenticator, $3); free($3);}
+  | KW_SCOPE '(' string ')' {azure_authenticator_set_scope(last_authenticator, $3); free($3);}
   ;
 
 /* INCLUDE_RULES */

--- a/modules/cloud-auth/cloud-auth-parser.c
+++ b/modules/cloud-auth/cloud-auth-parser.c
@@ -36,8 +36,14 @@ static CfgLexerKeyword cloud_auth_keywords[] =
   { "audience",                 KW_AUDIENCE },
   { "token_validity_duration",  KW_TOKEN_VALIDITY_DURATION },
   { "user_managed_service_account",  KW_USER_MANAGED_SERVICE_ACCOUNT },
-  { "name",                          KW_NAME},
+  { "name",                          KW_NAME },
   { "metadata_url",                  KW_METADATA_URL },
+  { "azure",                         KW_AZURE },
+  { "monitor",                       KW_MONITOR },
+  { "tenant_id",                     KW_TENANT_ID },
+  { "app_id",                        KW_APP_ID },
+  { "app_secret",                    KW_APP_SECRET },
+  { "scope",                         KW_SCOPE },
   { NULL }
 };
 

--- a/news/other-5293.md
+++ b/news/other-5293.md
@@ -1,0 +1,4 @@
+`azure-monitor()`: unified destination
+
+The `azure-monitor-builtin()` and `azure-monitor-custom()` destinations are deprecated in favor of `azure-monitor()`.
+`azure-monitor()` requires the `stream-name()` option instead of the table name.

--- a/scl/CMakeLists.txt
+++ b/scl/CMakeLists.txt
@@ -50,6 +50,7 @@ set(SCL_DIRS
     telegram
     websense
     windowseventlog
+    azure
 )
 
 install(DIRECTORY ${SCL_DIRS} DESTINATION share/syslog-ng/include/scl)

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -49,7 +49,8 @@ SCL_SUBDIRS	= \
 	system		\
 	websense	\
 	telegram	\
-	windowseventlog
+	windowseventlog \
+	azure
 
 
 SCL_CONFIGS	= scl.conf syslog-ng.conf

--- a/scl/azure/azure-monitor.conf
+++ b/scl/azure/azure-monitor.conf
@@ -1,0 +1,95 @@
+#############################################################################
+# Copyright (c) 2025 Axoflow
+# Copyright (c) 2025 Tamas Kosztyu <tamas.kosztyu@axoflow.com>
+# Copyright (c) 2025 Attila Szakacs <attila.szakacs@axoflow.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+block destination _azure_monitor_internal(
+  dce_uri()
+  dcr_id()
+  table_name()
+  template()
+  auth()
+  ...
+) {
+  http(
+    method("POST")
+    url("`dce_uri`/dataCollectionRules/`dcr_id`/streams/`table_name`?api-version=2023-01-01")
+    headers("Content-Type: application/json")
+    persist_name("azure-monitor,`dce_uri`,`dcr_id`,`table_name`")
+    cloud-auth(
+      azure(
+        monitor(
+          `auth`
+        )
+      )
+    )
+    body_prefix("[")
+    body(`template`)
+    delimiter(",")
+    body_suffix("]")
+    `__VARARGS__`
+  );
+};
+
+block destination azure_monitor_builtin(
+  dce_uri()
+  dcr_id()
+  table_name()
+  template("$MESSAGE")
+  auth()
+  ...
+) {
+
+@requires http "The azure-monitor-builtin() driver depends on the AxoSyslog http module, please install the axosyslog-mod-http (Debian & derivatives) or the axosyslog-http (RHEL & co) package"
+@requires cloud_auth "The azure-monitor-builtin() driver depends on the AxoSyslog Cloud Auth module, please install the axosyslog-mod-cloud-auth (Debian & derivatives) or the axosyslog-cloud-auth (RHEL & co) package"
+
+  _azure_monitor_internal(
+    dce_uri(`dce_uri`)
+    dcr_id(`dcr_id`)
+    table_name(`table_name`)
+    template(`template`)
+    auth(`auth`)
+    `__VARARGS__`
+  );
+};
+
+block destination azure_monitor_custom(
+  table_name()
+  dcr_id()
+  dce_uri()
+  template("$MESSAGE")
+  auth()
+  ...
+) {
+
+@requires http "The azure-monitor-custom() driver depends on the AxoSyslog http module, please install the axosyslog-mod-http (Debian & derivatives) or the axosyslog-http (RHEL & co) package"
+@requires cloud_auth "The azure-monitor-custom() driver depends on the AxoSyslog Cloud Auth module, please install the axosyslog-mod-cloud-auth (Debian & derivatives) or the axosyslog-cloud-auth (RHEL & co) package"
+
+  _azure_monitor_internal(
+    dce_uri(`dce_uri`)
+    dcr_id(`dcr_id`)
+    table_name("Custom-`table_name`_CL")
+    template(`template`)
+    auth(`auth`)
+    `__VARARGS__`
+  );
+};

--- a/scl/azure/azure-monitor.conf
+++ b/scl/azure/azure-monitor.conf
@@ -22,19 +22,23 @@
 #
 #############################################################################
 
-block destination _azure_monitor_internal(
+block destination azure_monitor(
   dce_uri()
   dcr_id()
-  table_name()
-  template()
+  stream_name()
+  template("$MESSAGE")
   auth()
   ...
 ) {
+
+@requires http "The azure-monitor() driver depends on the AxoSyslog http module, please install the axosyslog-mod-http (Debian & derivatives) or the axosyslog-http (RHEL & co) package"
+@requires cloud_auth "The azure-monitor() driver depends on the AxoSyslog Cloud Auth module, please install the axosyslog-mod-cloud-auth (Debian & derivatives) or the axosyslog-cloud-auth (RHEL & co) package"
+
   http(
     method("POST")
-    url("`dce_uri`/dataCollectionRules/`dcr_id`/streams/`table_name`?api-version=2023-01-01")
+    url("`dce_uri`/dataCollectionRules/`dcr_id`/streams/`stream_name`?api-version=2023-01-01")
     headers("Content-Type: application/json")
-    persist_name("azure-monitor,`dce_uri`,`dcr_id`,`table_name`")
+    persist_name("azure-monitor,`dce_uri`,`dcr_id`,`stream_name`")
     cloud-auth(
       azure(
         monitor(
@@ -62,10 +66,10 @@ block destination azure_monitor_builtin(
 @requires http "The azure-monitor-builtin() driver depends on the AxoSyslog http module, please install the axosyslog-mod-http (Debian & derivatives) or the axosyslog-http (RHEL & co) package"
 @requires cloud_auth "The azure-monitor-builtin() driver depends on the AxoSyslog Cloud Auth module, please install the axosyslog-mod-cloud-auth (Debian & derivatives) or the axosyslog-cloud-auth (RHEL & co) package"
 
-  _azure_monitor_internal(
+  azure_monitor(
     dce_uri(`dce_uri`)
     dcr_id(`dcr_id`)
-    table_name(`table_name`)
+    stream_name(`table_name`)
     template(`template`)
     auth(`auth`)
     `__VARARGS__`
@@ -84,10 +88,10 @@ block destination azure_monitor_custom(
 @requires http "The azure-monitor-custom() driver depends on the AxoSyslog http module, please install the axosyslog-mod-http (Debian & derivatives) or the axosyslog-http (RHEL & co) package"
 @requires cloud_auth "The azure-monitor-custom() driver depends on the AxoSyslog Cloud Auth module, please install the axosyslog-mod-cloud-auth (Debian & derivatives) or the axosyslog-cloud-auth (RHEL & co) package"
 
-  _azure_monitor_internal(
+  azure_monitor(
     dce_uri(`dce_uri`)
     dcr_id(`dcr_id`)
-    table_name("Custom-`table_name`_CL")
+    stream_name(`table_name`)
     template(`template`)
     auth(`auth`)
     `__VARARGS__`

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -233,6 +233,7 @@ scl/python/python-modules\.conf$
 scl/darwinosl/plugin\.conf$
 scl/splunk/splunk\.conf$
 scl/google/google-pubsub\.conf$
+scl/azure/azure-monitor\.conf$
 scl/openobserve/.*\.conf$
 scl/pgsql/pgsql\.conf$
 scl/qbittorrent/qbittorrent\.conf$

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -212,6 +212,7 @@ modules/grpc/common
 modules/grpc/protos/apphook\.(cpp|h)$
 modules/cloud-auth/cloud-auth(|-grammar|-parser|-plugin)\.(c|h|cpp|hpp|ym)$
 modules/cloud-auth/google-auth\.(h|cpp|hpp)$
+modules/cloud-auth/azure-auth\.(h|cpp|hpp)$
 modules/examples/inner-destinations/tls-test-validation
 modules/examples/sources/random-choice-generator
 modules/python/python-options.(c|h)$


### PR DESCRIPTION
The table_name parameter of the azure-monitor destination is actually referring to the stream name in the DCR, and not the table the logs end up getting written to. The actual destination table name is referenced in the DCR.
For this reason the table_name parameter should be rename to stream_name.

Backport of [531](https://github.com/axoflow/axosyslog/pull/531) by @jszigetvari
