### PR TITLE
`network(),syslog()`: Fixed a potential crash for TLS destinations during reload

### DIFF
--- a/lib/driver.c
+++ b/lib/driver.c
@@ -135,6 +135,9 @@ log_driver_free(LogPipe *s)
     g_free(self->group);
   if (self->id)
     g_free(self->id);
+
+  signal_slot_connector_free(self->signal_slot_connector);
+
   log_pipe_free_method(s);
 }
 
@@ -149,6 +152,8 @@ log_driver_init_instance(LogDriver *self, GlobalConfig *cfg)
   self->super.init = log_driver_init_method;
   self->super.deinit = log_driver_deinit_method;
   self->super.post_deinit = log_driver_post_deinit_method;
+
+  self->signal_slot_connector = signal_slot_connector_new();
 }
 
 /* LogSrcDriver */

--- a/lib/driver.h
+++ b/lib/driver.h
@@ -113,6 +113,9 @@ struct _LogDriver
   gboolean optional;
   gchar *group;
   gchar *id;
+
+  SignalSlotConnector *signal_slot_connector;
+
   GList *plugins;
 
   StatsCounterItem *processed_group_messages;

--- a/lib/logpipe.c
+++ b/lib/logpipe.c
@@ -154,7 +154,6 @@ log_pipe_init_instance(LogPipe *self, GlobalConfig *cfg)
   self->pipe_next = NULL;
   self->persist_name = NULL;
   self->plugin_name = NULL;
-  self->signal_slot_connector = signal_slot_connector_new();
 
   self->queue = log_pipe_forward_msg;
   self->free_fn = log_pipe_free_method;
@@ -196,7 +195,6 @@ _free(LogPipe *self)
   g_free((gpointer)self->persist_name);
   g_free(self->plugin_name);
   g_list_free_full(self->info, g_free);
-  signal_slot_connector_unref(self->signal_slot_connector);
   g_free(self);
 }
 

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -31,7 +31,6 @@
 #include "cfg.h"
 #include "atomic.h"
 #include "messages.h"
-#include "signal-slot-connector/signal-slot-connector.h"
 
 /* notify code values */
 #define NC_CLOSE       1
@@ -312,7 +311,6 @@ struct _LogPipe
   StatsCounterItem *discarded_messages;
   const gchar *persist_name;
   gchar *plugin_name;
-  SignalSlotConnector *signal_slot_connector;
   LogPipeOptions options;
 
   gboolean (*pre_init)(LogPipe *self);

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -1741,6 +1741,12 @@ log_writer_steal_proto(LogWriter *self)
   return proto;
 }
 
+LogProtoClient *
+log_writer_get_proto(LogWriter *self)
+{
+  return self->proto;
+}
+
 
 /* run in the main thread in reaction to a log_writer_reopen to change
  * the destination LogProtoClient instance. It needs to be ran in the main

--- a/lib/logwriter.h
+++ b/lib/logwriter.h
@@ -86,6 +86,7 @@ gboolean log_writer_has_pending_writes(LogWriter *self);
 gboolean log_writer_opened(LogWriter *self);
 void log_writer_reopen(LogWriter *self, LogProtoClient *proto);
 LogProtoClient *log_writer_steal_proto(LogWriter *self);
+LogProtoClient *log_writer_get_proto(LogWriter *self);
 void log_writer_set_queue(LogWriter *self, LogQueue *queue);
 LogQueue *log_writer_get_queue(LogWriter *s);
 LogWriter *log_writer_new(guint32 flags, GlobalConfig *cfg);

--- a/lib/signal-slot-connector/signal-slot-connector.c
+++ b/lib/signal-slot-connector/signal-slot-connector.c
@@ -254,29 +254,10 @@ signal_slot_connector_new(void)
   return self;
 }
 
-static void
+void
 signal_slot_connector_free(SignalSlotConnector *self)
 {
   g_mutex_clear(&self->lock);
   g_hash_table_unref(self->connections);
   g_free(self);
-}
-
-SignalSlotConnector *
-signal_slot_connector_ref(SignalSlotConnector *self)
-{
-  g_assert(!self || g_atomic_counter_get(&self->ref_cnt) > 0);
-
-  if (self)
-    g_atomic_counter_inc(&self->ref_cnt);
-
-  return self;
-}
-
-void
-signal_slot_connector_unref(SignalSlotConnector *self)
-{
-  g_assert(!self || g_atomic_counter_get(&self->ref_cnt));
-  if (self && (g_atomic_counter_dec_and_test(&self->ref_cnt)))
-    signal_slot_connector_free(self);
 }

--- a/lib/signal-slot-connector/signal-slot-connector.h
+++ b/lib/signal-slot-connector/signal-slot-connector.h
@@ -53,8 +53,7 @@ void signal_slot_disconnect(SignalSlotConnector *self, Signal signal, Slot slot,
 void signal_slot_emit(SignalSlotConnector *self, Signal signal, gpointer user_data);
 
 SignalSlotConnector *signal_slot_connector_new(void);
-SignalSlotConnector *signal_slot_connector_ref(SignalSlotConnector *self);
-void signal_slot_connector_unref(SignalSlotConnector *self);
+void signal_slot_connector_free(SignalSlotConnector *self);
 
 #endif
 

--- a/lib/signal-slot-connector/tests/test_signal_slots.c
+++ b/lib/signal-slot-connector/tests/test_signal_slots.c
@@ -97,7 +97,7 @@ Test(basic_signal_slots, when_the_signal_is_emitted_then_the_connected_slot_is_e
   cr_expect_eq(slot_obj1.ctr, 1);
   cr_expect_eq(slot_obj2.ctr, 1);
 
-  signal_slot_connector_unref(ssc);
+  signal_slot_connector_free(ssc);
 }
 
 Test(basic_signal_slots, abort_when_trying_to_connect_multiple_times_the_same_connection, .signal = SIGABRT)
@@ -128,7 +128,7 @@ Test(basic_signal_slots, abort_when_trying_to_disconnect_multiple_times_the_same
 
   cr_expect_eq(test_data.slot_ctr, 1);
 
-  signal_slot_connector_unref(ssc);
+  signal_slot_connector_free(ssc);
 }
 
 Test(basic_signal_slots,
@@ -160,7 +160,7 @@ Test(basic_signal_slots,
   cr_expect_eq(test_data.slot_ctr, 1);
   cr_expect_eq(slot_obj.ctr, 1);
 
-  signal_slot_connector_unref(ssc);
+  signal_slot_connector_free(ssc);
 }
 
 Test(basic_signal_slots, when_disconnect_the_connected_slot_from_a_signal_then_the_signal_is_unregistered)
@@ -178,7 +178,7 @@ Test(basic_signal_slots, when_disconnect_the_connected_slot_from_a_signal_then_t
   cr_expect_eq(test_data.slot_ctr, 0);
   cr_expect_eq(slot_obj.ctr, 0);
 
-  signal_slot_connector_unref(ssc);
+  signal_slot_connector_free(ssc);
 }
 
 Test(basic_signal_slots,
@@ -266,7 +266,7 @@ Test(multiple_signals_slots,
 
   _disconnect_all_test_slots_from_a_signal(ssc, signals[0]);
 
-  signal_slot_connector_unref(ssc);
+  signal_slot_connector_free(ssc);
 }
 
 Test(multiple_signals_slots,
@@ -300,7 +300,7 @@ Test(multiple_signals_slots,
   cr_expect_eq(slot_objects[1].ctr, 1);
   cr_expect_eq(slot_objects[2].ctr, 2);
 
-  signal_slot_connector_unref(ssc);
+  signal_slot_connector_free(ssc);
 }
 
 void

--- a/lib/transport/transport-adapter.c
+++ b/lib/transport/transport-adapter.c
@@ -27,7 +27,7 @@ gssize
 log_transport_adapter_read_method(LogTransport *s, gpointer buf, gsize buflen, LogTransportAuxData *aux)
 {
   LogTransportAdapter *self = (LogTransportAdapter *) s;
-  LogTransport *transport = log_transport_stack_get_transport(s->stack, self->base_index);
+  LogTransport *transport = log_transport_stack_get_or_create_transport(s->stack, self->base_index);
 
   return log_transport_read(transport, buf, buflen, aux);
 }
@@ -36,7 +36,7 @@ gssize
 log_transport_adapter_write_method(LogTransport *s, const gpointer buf, gsize count)
 {
   LogTransportAdapter *self = (LogTransportAdapter *) s;
-  LogTransport *transport = log_transport_stack_get_transport(s->stack, self->base_index);
+  LogTransport *transport = log_transport_stack_get_or_create_transport(s->stack, self->base_index);
 
   return log_transport_write(transport, buf, count);
 }
@@ -45,7 +45,7 @@ gssize
 log_transport_adapter_writev_method(LogTransport *s, struct iovec *iov, gint iov_count)
 {
   LogTransportAdapter *self = (LogTransportAdapter *) s;
-  LogTransport *transport = log_transport_stack_get_transport(s->stack, self->base_index);
+  LogTransport *transport = log_transport_stack_get_or_create_transport(s->stack, self->base_index);
 
   return log_transport_writev(transport, iov, iov_count);
 }

--- a/lib/transport/transport-stack.c
+++ b/lib/transport/transport-stack.c
@@ -59,7 +59,7 @@ log_transport_stack_switch(LogTransportStack *self, gint index)
 {
   g_assert(index < LOG_TRANSPORT__MAX);
   LogTransport *active_transport = log_transport_stack_get_active(self);
-  LogTransport *requested_transport = log_transport_stack_get_transport(self, index);
+  LogTransport *requested_transport = log_transport_stack_get_or_create_transport(self, index);
 
   if (!requested_transport)
     return FALSE;

--- a/lib/transport/transport-stack.h
+++ b/lib/transport/transport-stack.h
@@ -108,7 +108,7 @@ struct _LogTransportStack
 };
 
 static inline LogTransport *
-log_transport_stack_get_transport(LogTransportStack *self, gint index)
+log_transport_stack_get_or_create_transport(LogTransportStack *self, gint index)
 {
   g_assert(index < LOG_TRANSPORT__MAX);
 
@@ -127,7 +127,16 @@ log_transport_stack_get_transport(LogTransportStack *self, gint index)
 static inline LogTransport *
 log_transport_stack_get_active(LogTransportStack *self)
 {
-  return log_transport_stack_get_transport(self, self->active_transport);
+  // TODO - Change it to log_transport_stack_get_transport after checking call sites
+  return log_transport_stack_get_or_create_transport(self, self->active_transport);
+}
+
+static inline LogTransport *
+log_transport_stack_get_transport(LogTransportStack *self, gint index)
+{
+  g_assert(index < LOG_TRANSPORT__MAX);
+
+  return self->transports[index];
 }
 
 void log_transport_stack_add_factory(LogTransportStack *self, LogTransportFactory *);

--- a/lib/transport/transport-tls.c
+++ b/lib/transport/transport-tls.c
@@ -32,6 +32,8 @@
 #include <openssl/err.h>
 #include <errno.h>
 
+const gchar *TLS_TRANSPORT_NAME = "tls";
+
 typedef struct _LogTransportTLS
 {
   LogTransportSocket super;
@@ -239,6 +241,15 @@ tls_error:
   return -1;
 }
 
+TLSSession *
+log_tansport_tls_get_session(LogTransport *s)
+{
+  g_assert(s->name == TLS_TRANSPORT_NAME);
+
+  LogTransportTLS *self = (LogTransportTLS *)s;
+  return self->tls_session;
+}
+
 
 static void log_transport_tls_free_method(LogTransport *s);
 
@@ -248,7 +259,7 @@ log_transport_tls_new(TLSSession *tls_session, gint fd)
   LogTransportTLS *self = g_new0(LogTransportTLS, 1);
 
   log_transport_stream_socket_init_instance(&self->super, fd);
-  self->super.super.name = "tls";
+  self->super.super.name = TLS_TRANSPORT_NAME;
   self->super.super.cond = 0;
   self->super.super.read = log_transport_tls_read_method;
   self->super.super.write = log_transport_tls_write_method;

--- a/lib/transport/transport-tls.h
+++ b/lib/transport/transport-tls.h
@@ -28,5 +28,6 @@
 #include "transport/tls-context.h"
 
 LogTransport *log_transport_tls_new(TLSSession *tls_session, gint fd);
+TLSSession *log_tansport_tls_get_session(LogTransport *s);
 
 #endif

--- a/modules/afsocket/afinet-dest.c
+++ b/modules/afsocket/afinet-dest.c
@@ -751,10 +751,10 @@ _kept_alive_connection_free(AFSocketDestKeptAliveConnection *s)
 }
 
 static AFInetDestKeptAliveConnection *
-_kept_alive_connection_new(LogProtoClientFactory *proto_factory, GSockAddr *dest_addr, LogWriter *writer)
+_kept_alive_connection_new(const gchar *transport, const gchar *proto, GSockAddr *dest_addr, LogWriter *writer)
 {
   AFInetDestKeptAliveConnection *self = g_new(AFInetDestKeptAliveConnection, 1);
-  afsocket_kept_alive_connection_init_instance(&self->super, proto_factory, dest_addr, writer);
+  afsocket_kept_alive_connection_init_instance(&self->super, transport, proto, dest_addr, writer);
 
   self->super.free_fn = _kept_alive_connection_free;
 
@@ -765,7 +765,10 @@ static void
 afinet_dd_save_connection(AFSocketDestDriver *s)
 {
   AFInetDestDriver *self = (AFInetDestDriver *) s;
-  AFInetDestKeptAliveConnection *item = _kept_alive_connection_new(self->super.proto_factory, self->super.dest_addr,
+
+  const gchar *transport = transport_mapper_get_transport(self->super.transport_mapper);
+  const gchar *proto = transport_mapper_get_logproto(self->super.transport_mapper);
+  AFInetDestKeptAliveConnection *item = _kept_alive_connection_new(transport, proto, self->super.dest_addr,
                                                                    self->super.writer);
 
   afsocket_dd_save_connection(&self->super, &item->super);

--- a/modules/afsocket/afinet-dest.h
+++ b/modules/afsocket/afinet-dest.h
@@ -57,7 +57,6 @@ typedef struct _AFInetDestDriver
   gchar *bind_ip;
   /* character as it can contain a service name from /etc/services */
   gchar *dest_port;
-  /* destination hostname is stored in super.hostname */
 } AFInetDestDriver;
 
 void afinet_dd_set_localport(LogDriver *self, gchar *service);

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -37,13 +37,6 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
-typedef struct _ReloadStoreItem
-{
-  LogProtoClientFactory *proto_factory;
-  GSockAddr *dest_addr;
-  LogWriter *writer;
-} ReloadStoreItem;
-
 static ReloadStoreItem *
 _reload_store_item_new(AFSocketDestDriver *afsocket_dd)
 {

--- a/modules/afsocket/afsocket-dest.h
+++ b/modules/afsocket/afsocket-dest.h
@@ -32,6 +32,13 @@
 
 #include <iv.h>
 
+typedef struct _ReloadStoreItem
+{
+  LogProtoClientFactory *proto_factory;
+  GSockAddr *dest_addr;
+  LogWriter *writer;
+} ReloadStoreItem;
+
 typedef struct _AFSocketDestDriver AFSocketDestDriver;
 
 struct _AFSocketDestDriver

--- a/modules/afsocket/afsocket-dest.h
+++ b/modules/afsocket/afsocket-dest.h
@@ -72,7 +72,9 @@ struct _AFSocketDestDriver
 
 struct _AFSocketDestKeptAliveConnection
 {
-  LogProtoClientFactory *proto_factory; // gchar *transport;
+  gchar *transport;
+  gchar *proto;
+
   GSockAddr *dest_addr;
   LogWriter *writer;
 
@@ -118,7 +120,7 @@ gboolean afsocket_dd_should_restore_connection_method(AFSocketDestDriver *self, 
 void afsocket_dd_restore_connection_method(AFSocketDestDriver *self, AFSocketDestKeptAliveConnection *item);
 
 void afsocket_kept_alive_connection_init_instance(AFSocketDestKeptAliveConnection *s,
-                                                  LogProtoClientFactory *proto_factory,
+                                                  const gchar *transport, const gchar *proto,
                                                   GSockAddr *dest_addr, LogWriter *writer);
 
 void afsocket_kept_alive_connection_free_method(AFSocketDestKeptAliveConnection *s);

--- a/modules/afsocket/afsocket-dest.h
+++ b/modules/afsocket/afsocket-dest.h
@@ -32,14 +32,8 @@
 
 #include <iv.h>
 
-typedef struct _ReloadStoreItem
-{
-  LogProtoClientFactory *proto_factory;
-  GSockAddr *dest_addr;
-  LogWriter *writer;
-} ReloadStoreItem;
-
 typedef struct _AFSocketDestDriver AFSocketDestDriver;
+typedef struct _AFSocketDestKeptAliveConnection AFSocketDestKeptAliveConnection;
 
 struct _AFSocketDestDriver
 {
@@ -70,7 +64,21 @@ struct _AFSocketDestDriver
   LogWriter *(*construct_writer)(AFSocketDestDriver *self);
   gboolean (*setup_addresses)(AFSocketDestDriver *s);
   const gchar *(*get_dest_name)(const AFSocketDestDriver *s);
+
+  void (*save_connection)(AFSocketDestDriver *s);
+  gboolean (*should_restore_connection)(AFSocketDestDriver *s, AFSocketDestKeptAliveConnection *c);
+  void (*restore_connection)(AFSocketDestDriver *s, AFSocketDestKeptAliveConnection *c);
 };
+
+struct _AFSocketDestKeptAliveConnection
+{
+  LogProtoClientFactory *proto_factory; // gchar *transport;
+  GSockAddr *dest_addr;
+  LogWriter *writer;
+
+  void (*free_fn)(AFSocketDestKeptAliveConnection *s);
+};
+
 
 static inline LogWriter *
 afsocket_dd_construct_writer(AFSocketDestDriver *self)
@@ -103,5 +111,23 @@ gboolean afsocket_dd_init(LogPipe *s);
 gboolean afsocket_dd_deinit(LogPipe *s);
 void afsocket_dd_free(LogPipe *s);
 void afsocket_dd_connected_with_fd(gpointer self, gint fd, GSockAddr *saddr);
+
+
+void afsocket_dd_save_connection(AFSocketDestDriver *self, AFSocketDestKeptAliveConnection *c);
+gboolean afsocket_dd_should_restore_connection_method(AFSocketDestDriver *self, AFSocketDestKeptAliveConnection *c);
+void afsocket_dd_restore_connection_method(AFSocketDestDriver *self, AFSocketDestKeptAliveConnection *item);
+
+void afsocket_kept_alive_connection_init_instance(AFSocketDestKeptAliveConnection *s,
+                                                  LogProtoClientFactory *proto_factory,
+                                                  GSockAddr *dest_addr, LogWriter *writer);
+
+void afsocket_kept_alive_connection_free_method(AFSocketDestKeptAliveConnection *s);
+
+static inline void
+afsocket_kept_alive_connection_free(AFSocketDestKeptAliveConnection *self)
+{
+  self->free_fn(self);
+  g_free(self);
+}
 
 #endif

--- a/modules/afsocket/afsocket-source.c
+++ b/modules/afsocket/afsocket-source.c
@@ -1071,7 +1071,7 @@ afsocket_sd_open_socket(AFSocketSourceDriver *self, gint *sock)
   AFSocketSetupSocketSignalData signal_data = {0};
 
   signal_data.sock = *sock;
-  EMIT(self->super.super.super.signal_slot_connector, signal_afsocket_setup_socket, &signal_data);
+  EMIT(self->super.super.signal_slot_connector, signal_afsocket_setup_socket, &signal_data);
   return !signal_data.failure;
 }
 

--- a/modules/afsocket/transport-mapper-inet.c
+++ b/modules/afsocket/transport-mapper-inet.c
@@ -364,14 +364,13 @@ static gboolean
 transport_mapper_network_apply_transport(TransportMapper *s, GlobalConfig *cfg)
 {
   TransportMapperInet *self = (TransportMapperInet *) s;
-  const gchar *transport;
 
   /* determine default port, apply transport setting to afsocket flags */
 
   if (!transport_mapper_apply_transport_method(s, cfg))
     return FALSE;
 
-  transport = self->super.transport;
+  const gchar *transport = self->super.transport;
   self->server_port = NETWORK_PORT;
   if (strcasecmp(transport, "udp") == 0)
     {

--- a/modules/afsocket/transport-mapper.h
+++ b/modules/afsocket/transport-mapper.h
@@ -73,6 +73,18 @@ void transport_mapper_free(TransportMapper *self);
 void transport_mapper_free_method(TransportMapper *self);
 
 static inline const gchar *
+transport_mapper_get_transport(TransportMapper *self)
+{
+  return self->transport;
+}
+
+static inline const gchar *
+transport_mapper_get_logproto(TransportMapper *self)
+{
+  return self->logproto;
+}
+
+static inline const gchar *
 transport_mapper_get_transport_name(TransportMapper *self, gsize *len)
 {
   if (self->transport_name)

--- a/modules/azure-auth-header/azure-auth-header.c
+++ b/modules/azure-auth-header/azure-auth-header.c
@@ -181,14 +181,12 @@ _attach(LogDriverPlugin *s, LogDriver *driver)
 {
   AzureAuthHeaderPlugin *self = (AzureAuthHeaderPlugin *)s;
 
-  g_assert(s->signal_connector == NULL);
-  s->signal_connector = signal_slot_connector_ref(driver->super.signal_slot_connector);
-
+  SignalSlotConnector *ssc = driver->signal_slot_connector;
   msg_debug("AzureAuthHeaderPlugin::attach()",
-            evt_tag_printf("SignalSlotConnector", "%p", s->signal_connector),
+            evt_tag_printf("SignalSlotConnector", "%p", ssc),
             evt_tag_printf("AzureAuthHeaderPlugin", "%p", s));
 
-  CONNECT(s->signal_connector, signal_http_header_request, _slot_append_headers, self);
+  CONNECT(ssc, signal_http_header_request, _slot_append_headers, self);
 
   return TRUE;
 }
@@ -198,10 +196,8 @@ _detach(LogDriverPlugin *s, LogDriver *driver)
 {
   AzureAuthHeaderPlugin *self = (AzureAuthHeaderPlugin *)s;
 
-  DISCONNECT(s->signal_connector, signal_http_header_request, _slot_append_headers, self);
-
-  signal_slot_connector_unref(s->signal_connector);
-  s->signal_connector = NULL;
+  SignalSlotConnector *ssc = driver->signal_slot_connector;
+  DISCONNECT(ssc, signal_http_header_request, _slot_append_headers, self);
 }
 
 static void
@@ -230,5 +226,3 @@ azure_auth_header_plugin_new(void)
 
   return self;
 }
-
-

--- a/modules/cloud-auth/cloud-auth.c
+++ b/modules/cloud-auth/cloud-auth.c
@@ -35,15 +35,11 @@ static gboolean
 _attach(LogDriverPlugin *s, LogDriver *d)
 {
   CloudAuthDestPlugin *self = (CloudAuthDestPlugin *) s;
-  LogDestDriver *driver = (LogDestDriver *) d;
 
   if (!cloud_authenticator_init(self->authenticator))
     return FALSE;
 
-  g_assert(s->signal_connector == NULL);
-  s->signal_connector = signal_slot_connector_ref(driver->super.super.signal_slot_connector);
-
-  CONNECT(s->signal_connector, signal_http_header_request, cloud_authenticator_handle_http_header_request,
+  CONNECT(d->signal_slot_connector, signal_http_header_request, cloud_authenticator_handle_http_header_request,
           self->authenticator);
 
   return TRUE;
@@ -56,11 +52,8 @@ _detach(LogDriverPlugin *s, LogDriver *d)
 
   cloud_authenticator_deinit(self->authenticator);
 
-  DISCONNECT(s->signal_connector, signal_http_header_request, cloud_authenticator_handle_http_header_request,
+  DISCONNECT(d->signal_slot_connector, signal_http_header_request, cloud_authenticator_handle_http_header_request,
              self->authenticator);
-
-  signal_slot_connector_unref(s->signal_connector);
-  s->signal_connector = NULL;
 }
 
 void

--- a/modules/ebpf/ebpf-reuseport.c
+++ b/modules/ebpf/ebpf-reuseport.c
@@ -76,10 +76,8 @@ _attach(LogDriverPlugin *s, LogDriver *driver)
     }
   self->random->bss->number_of_sockets = self->number_of_sockets;
 
-  g_assert(s->signal_connector == NULL);
-  s->signal_connector = signal_slot_connector_ref(driver->super.signal_slot_connector);
-
-  CONNECT(s->signal_connector, signal_afsocket_setup_socket, _slot_setup_socket, self);
+  SignalSlotConnector *ssc = driver->signal_slot_connector;
+  CONNECT(ssc, signal_afsocket_setup_socket, _slot_setup_socket, self);
 
   return TRUE;
 }
@@ -89,9 +87,8 @@ _detach(LogDriverPlugin *s, LogDriver *driver)
 {
   EBPFReusePort *self = (EBPFReusePort *)s;
 
-  DISCONNECT(s->signal_connector, signal_afsocket_setup_socket, _slot_setup_socket, self);
-  signal_slot_connector_unref(s->signal_connector);
-  s->signal_connector = NULL;
+  SignalSlotConnector *ssc = driver->signal_slot_connector;
+  DISCONNECT(ssc, signal_afsocket_setup_socket, _slot_setup_socket, self);
 }
 
 static void

--- a/modules/examples/inner-destinations/http-test-slots/http-test-slots.c
+++ b/modules/examples/inner-destinations/http-test-slots/http-test-slots.c
@@ -48,13 +48,12 @@ _slot_append_test_headers(HttpTestSlotsPlugin *self, HttpHeaderRequestSignalData
 static gboolean
 _attach(LogDriverPlugin *s, LogDriver *driver)
 {
-  g_assert(s->signal_connector == NULL);
-  s->signal_connector = signal_slot_connector_ref(driver->super.signal_slot_connector);
+  SignalSlotConnector *ssc = driver->signal_slot_connector;
 
   msg_debug("HttpTestSlotsPlugin::attach()",
-            evt_tag_printf("SignalSlotConnector", "%p", s->signal_connector));
+            evt_tag_printf("SignalSlotConnector", "%p", ssc));
 
-  CONNECT(s->signal_connector, signal_http_header_request, _slot_append_test_headers, s);
+  CONNECT(ssc, signal_http_header_request, _slot_append_test_headers, s);
 
   return TRUE;
 }
@@ -62,13 +61,12 @@ _attach(LogDriverPlugin *s, LogDriver *driver)
 static void
 _detach(LogDriverPlugin *s, LogDriver *driver)
 {
+  SignalSlotConnector *ssc = driver->signal_slot_connector;
+
   msg_debug("HttpTestSlotsPlugin::detach()",
-            evt_tag_printf("SignalSlotConnector", "%p", s->signal_connector));
+            evt_tag_printf("SignalSlotConnector", "%p", ssc));
 
-  DISCONNECT(s->signal_connector, signal_http_header_request, _slot_append_test_headers, s);
-
-  signal_slot_connector_unref(s->signal_connector);
-  s->signal_connector = NULL;
+  DISCONNECT(ssc, signal_http_header_request, _slot_append_test_headers, s);
 }
 
 static void

--- a/modules/examples/inner-destinations/tls-test-validation/tls-test-validation.c
+++ b/modules/examples/inner-destinations/tls-test-validation/tls-test-validation.c
@@ -52,13 +52,12 @@ _slot_append_test_identity(TlsTestValidationPlugin *self, AFSocketTLSCertificate
 static gboolean
 _attach(LogDriverPlugin *s, LogDriver *driver)
 {
-  g_assert(s->signal_connector == NULL);
-  s->signal_connector = signal_slot_connector_ref(driver->super.signal_slot_connector);
+  SignalSlotConnector *ssc = driver->signal_slot_connector;
 
   msg_debug("TlsTestValidationPlugin::attach()",
-            evt_tag_printf("SignalSlotConnector", "%p", s->signal_connector));
+            evt_tag_printf("SignalSlotConnector", "%p", ssc));
 
-  CONNECT(s->signal_connector, signal_afsocket_tls_certificate_validation, _slot_append_test_identity, s);
+  CONNECT(ssc, signal_afsocket_tls_certificate_validation, _slot_append_test_identity, s);
 
   return TRUE;
 }
@@ -66,13 +65,12 @@ _attach(LogDriverPlugin *s, LogDriver *driver)
 static void
 _detach(LogDriverPlugin *s, LogDriver *driver)
 {
+  SignalSlotConnector *ssc = driver->signal_slot_connector;
+
   msg_debug("TlsTestValidationPlugin::detach()",
-            evt_tag_printf("SignalSlotConnector", "%p", s->signal_connector));
+            evt_tag_printf("SignalSlotConnector", "%p", ssc));
 
-  DISCONNECT(s->signal_connector, signal_afsocket_tls_certificate_validation, _slot_append_test_identity, s);
-
-  signal_slot_connector_unref(s->signal_connector);
-  s->signal_connector = NULL;
+  DISCONNECT(ssc, signal_afsocket_tls_certificate_validation, _slot_append_test_identity, s);
 }
 
 static void

--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -354,7 +354,7 @@ _collect_rest_headers(HTTPDestinationWorker *self, GError **error)
 
   HTTPDestinationDriver *owner = (HTTPDestinationDriver *) self->super.owner;
 
-  EMIT(owner->super.super.super.super.signal_slot_connector, signal_http_header_request, &signal_data);
+  EMIT(owner->super.super.super.signal_slot_connector, signal_http_header_request, &signal_data);
 
   _set_error_from_slot_result(signal_http_header_request, signal_data.result, error);
 }
@@ -784,7 +784,7 @@ _flush_on_target(HTTPDestinationWorker *self, const gchar *url)
     .http_code = http_code
   };
 
-  EMIT(owner->super.super.super.super.signal_slot_connector, signal_http_response_received, &signal_data);
+  EMIT(owner->super.super.super.signal_slot_connector, signal_http_response_received, &signal_data);
 
   if (signal_data.result == HTTP_SLOT_RESOLVED)
     {

--- a/modules/http/tests/test_http-signal_slot.c
+++ b/modules/http/tests/test_http-signal_slot.c
@@ -104,7 +104,7 @@ _check(const gchar *expected_body, HttpHeaderRequestSignalData *data)
 
 Test(test_http_signal_slot, basic)
 {
-  SignalSlotConnector *ssc = driver->super.super.super.super.signal_slot_connector;
+  SignalSlotConnector *ssc = driver->super.super.super.signal_slot_connector;
 
   const gchar *test_msg = "test message";
   CONNECT(ssc, signal_http_header_request, _check, test_msg);
@@ -123,7 +123,7 @@ Test(test_http_signal_slot, single_with_prefix_suffix)
   http_dd_set_body_suffix((LogDriver *)driver, "]");
   http_dd_set_delimiter((LogDriver *)driver, ",");
 
-  SignalSlotConnector *ssc = driver->super.super.super.super.signal_slot_connector;
+  SignalSlotConnector *ssc = driver->super.super.super.signal_slot_connector;
 
   CONNECT(ssc, signal_http_header_request, _check, "[almafa]");
 
@@ -143,7 +143,7 @@ Test(test_http_signal_slot, batch_with_prefix_suffix)
   log_threaded_dest_driver_set_batch_lines((LogDriver *)driver, 2);
   log_threaded_dest_driver_set_batch_timeout((LogDriver *)driver, 1000);
 
-  SignalSlotConnector *ssc = driver->super.super.super.super.signal_slot_connector;
+  SignalSlotConnector *ssc = driver->super.super.super.signal_slot_connector;
 
   CONNECT(ssc, signal_http_header_request, _check, "[1,2]");
 

--- a/modules/python/python-http-header.c
+++ b/modules/python/python-http-header.c
@@ -382,11 +382,10 @@ _attach(LogDriverPlugin *s, LogDriver *driver)
       return FALSE;
     }
 
-  g_assert(s->signal_connector == NULL);
-  s->signal_connector = signal_slot_connector_ref(driver->super.signal_slot_connector);
+  SignalSlotConnector *ssc = driver->signal_slot_connector;
 
-  CONNECT(s->signal_connector, signal_http_header_request, _append_headers, self);
-  CONNECT(s->signal_connector, signal_http_response_received, _on_http_response_received, self);
+  CONNECT(ssc, signal_http_header_request, _append_headers, self);
+  CONNECT(ssc, signal_http_response_received, _on_http_response_received, self);
 
   return TRUE;
 }
@@ -395,12 +394,10 @@ static void
 _detach(LogDriverPlugin *s, LogDriver *driver)
 {
   PythonHttpHeaderPlugin *self = (PythonHttpHeaderPlugin *) s;
+  SignalSlotConnector *ssc = driver->signal_slot_connector;
 
-  DISCONNECT(s->signal_connector, signal_http_header_request, _append_headers, self);
-  DISCONNECT(s->signal_connector, signal_http_response_received, _on_http_response_received, self);
-
-  signal_slot_connector_unref(s->signal_connector);
-  s->signal_connector = NULL;
+  DISCONNECT(ssc, signal_http_header_request, _append_headers, self);
+  DISCONNECT(ssc, signal_http_response_received, _on_http_response_received, self);
 
   python_binding_deinit(&self->binding);
 }

--- a/news/bugfix-5303.md
+++ b/news/bugfix-5303.md
@@ -1,0 +1,4 @@
+`network(), syslog()`: Fixed a potential crash for TLS destinations during reload
+
+In case of a TLS connection, if the handshake didn't happen before reloading syslog-ng,
+it crashed on the first message sent to that destination.

--- a/news/feature-5302.md
+++ b/news/feature-5302.md
@@ -1,0 +1,4 @@
+`syslog()` source driver: add support for RFC6587 style auto-detection of
+octet-count based framing to avoid confusion that stems from the sender
+using a different protocol to the server.  This behaviour can be enabled
+by using `transport(auto)` option for the `syslog()` source.


### PR DESCRIPTION
Fixes #5018

It is possible to keep TLS connections alive during reload.
In that case the LogWriter instance is persisted in cfg persist.
This LogWriter's signal slot connector wasn't updated based on the new configuration, which could cause a crash.
The signal slot connector is updated, so the newly configured verifier is used, instead of the old one.

Note that the fix in #5087 has a security issue, as in that PR, the connector's lifetime is extended, but the verifier plugins are deregistered during reload, which silently disables all TLS verifiers without the user knowing.


Backport of [418](https://github.com/axoflow/axosyslog/pull/418) by @sodomelle

Depends on https://github.com/syslog-ng/syslog-ng/pull/5322