### PR TITLE
ivykis: Use our own ivykis fork (in the internal ivykis builds)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "lib/ivykis"]
 	path = lib/ivykis
-	url = https://github.com/buytenh/ivykis.git
+	url = https://github.com/balabit/ivykis.git
 	ignore = dirty
 [submodule "modules/grpc/otel/opentelemetry-proto"]
 	path = modules/grpc/protos/opentelemetry-proto


### PR DESCRIPTION
This version is a simple replacement of the original https://github.com/buytenh/ivykis with our https://github.com/balabit/ivykis
The sub-module head still points to the latest master.


Resolves: https://github.com/syslog-ng/syslog-ng/issues/5193
Resolves: buytenh/ivykis#38