### PR TITLE
dqtool: Fixed segmentation fault when loading 16 bit buffer

### DIFF
--- a/lib/serialize.h
+++ b/lib/serialize.h
@@ -128,7 +128,7 @@ serialize_read_uint16_array(SerializeArchive *archive, guint32 *values, gsize el
   gboolean ret = FALSE;
   guint16 *buffer = g_new(guint16, elements);
 
-  if (serialize_archive_read_bytes(archive, (gchar *) &buffer, elements * sizeof(guint16)))
+  if (serialize_archive_read_bytes(archive, (gchar *) buffer, elements * sizeof(guint16)))
     {
       for (gsize i = 0; i < elements; i++)
         values[i] = GUINT16_FROM_BE(buffer[i]);


### PR DESCRIPTION
<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
