### PR TITLE
Wildcard file inotify

### DIFF
--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -41,6 +41,7 @@
 #define NC_FILE_EOF    5
 #define NC_REOPEN_REQUIRED 6
 #define NC_FILE_DELETED 7
+#define NC_FILE_MODIFIED 8
 
 /* notify result mask values */
 #define NR_OK          0x0000

--- a/lib/poll-events.h
+++ b/lib/poll-events.h
@@ -70,7 +70,8 @@ poll_events_start_watches(PollEvents *self)
 static inline void
 poll_events_stop_watches(PollEvents *self)
 {
-  self->stop_watches(self);
+  if (self->stop_watches)
+    self->stop_watches(self);
 }
 
 static inline gboolean

--- a/lib/poll-fd-events.h
+++ b/lib/poll-fd-events.h
@@ -27,5 +27,6 @@
 #include "poll-events.h"
 
 PollEvents *poll_fd_events_new(gint fd);
+PollEvents *notified_fd_events_new(gint fd);
 
 #endif

--- a/modules/affile/directory-monitor-inotify.c
+++ b/modules/affile/directory-monitor-inotify.c
@@ -53,6 +53,10 @@ _get_event_type(struct inotify_event *event, gchar *filename)
     {
       return DIRECTORY_DELETED;
     }
+  else if ((event->mask & IN_MODIFY))
+    {
+      return FILE_MODIFIED;
+    }
   return UNKNOWN;
 }
 
@@ -80,7 +84,7 @@ _start_watches(DirectoryMonitor *s)
   IV_INOTIFY_WATCH_INIT(&self->watcher);
   self->watcher.inotify = &self->inotify;
   self->watcher.pathname = self->super.dir;
-  self->watcher.mask = IN_CREATE | IN_DELETE | IN_MOVE | IN_DELETE_SELF | IN_MOVE_SELF;
+  self->watcher.mask = IN_CREATE | IN_DELETE | IN_MOVE | IN_DELETE_SELF | IN_MOVE_SELF | IN_MODIFY;
   self->watcher.cookie = self;
   self->watcher.handler = _handle_event;
   msg_trace("Starting to watch directory changes", evt_tag_str("dir", self->super.dir));
@@ -115,6 +119,8 @@ directory_monitor_inotify_new(const gchar *dir, guint recheck_time)
       directory_monitor_free(&self->super);
       return NULL;
     }
+
+  self->super.can_notify_file_changes = TRUE;
 
   self->super.start_watches = _start_watches;
   self->super.stop_watches = _stop_watches;

--- a/modules/affile/directory-monitor.c
+++ b/modules/affile/directory-monitor.c
@@ -206,18 +206,16 @@ rearm_timer(struct iv_timer *rescan_timer, gint rearm_time)
 void
 directory_monitor_start(DirectoryMonitor *self)
 {
-  msg_debug("Starting directory monitor", evt_tag_str("dir", self->dir), evt_tag_str("dir_monitor_method", self->method));
-
   main_loop_assert_main_thread();
-
-  GDir *directory = NULL;
-  GError *error = NULL;
   if (self->watches_running)
-    {
-      return;
-    }
+    return;
+
   _set_real_path(self);
-  directory = g_dir_open(self->real_path, 0, &error);
+
+  msg_debug("Starting directory monitor", evt_tag_str("dir", self->real_path), evt_tag_str("dir_monitor_method",
+            self->method));
+  GError *error = NULL;
+  GDir *directory = g_dir_open(self->real_path, 0, &error);
   if (!directory)
     {
       msg_error("Can not open directory",

--- a/modules/affile/directory-monitor.c
+++ b/modules/affile/directory-monitor.c
@@ -266,11 +266,17 @@ directory_monitor_stop_and_destroy(DirectoryMonitor *self)
   directory_monitor_free(self);
 }
 
+gboolean directory_monitor_can_notify_file_changes(DirectoryMonitor *self)
+{
+  return self->can_notify_file_changes;
+}
+
 void
 directory_monitor_init_instance(DirectoryMonitor *self, const gchar *dir, guint recheck_time, const gchar *method)
 {
   self->method = method;
   self->dir = g_strdup(dir);
+  self->can_notify_file_changes = FALSE;
   self->recheck_time = recheck_time;
 
   IV_TIMER_INIT(&self->check_timer);

--- a/modules/affile/directory-monitor.c
+++ b/modules/affile/directory-monitor.c
@@ -210,6 +210,16 @@ directory_monitor_start(DirectoryMonitor *self)
   if (self->watches_running)
     return;
 
+  /* FIXME: This must be fixed.
+   *    - this must be composed once in the directory_monitor_init_instance
+   *    - composing and using the real_path only is messed up. We need a full path instead everywhere, but
+   *      even the build_filename function can produce relative paths currenty that could lead to reader
+   *      persist name issues (as the wildcard file readers created by the monitor will get
+   *      their path based on this value, and their persist name will be based on this value as well)
+   *      Consistent setting the value of it is important, otherwise the persist name can be be different
+   *      after a config reload.
+   *    - once it fixed, we can use it in the maintenance/storage of the directory monitors
+   */
   _set_real_path(self);
 
   msg_debug("Starting directory monitor", evt_tag_str("dir", self->real_path), evt_tag_str("dir_monitor_method",
@@ -274,6 +284,8 @@ directory_monitor_init_instance(DirectoryMonitor *self, const gchar *dir, guint 
 {
   self->method = method;
   self->dir = g_strdup(dir);
+  // See directory_monitor_start notes above why cannot do this here as it would be the normal way
+  //_set_real_path(self);
   self->can_notify_file_changes = FALSE;
   self->recheck_time = recheck_time;
 

--- a/modules/affile/directory-monitor.h
+++ b/modules/affile/directory-monitor.h
@@ -31,6 +31,7 @@ typedef enum
   DIRECTORY_CREATED,
   FILE_DELETED,
   DIRECTORY_DELETED,
+  FILE_MODIFIED,
   UNKNOWN
 } DirectoryMonitorEventType;
 
@@ -51,6 +52,7 @@ struct _DirectoryMonitor
   const gchar *method;
   gchar *dir;
   gchar *real_path;
+  gboolean can_notify_file_changes;
   DirectoryMonitorEventCallback callback;
   gpointer callback_data;
 
@@ -74,6 +76,8 @@ void directory_monitor_stop(DirectoryMonitor *self);
 
 void directory_monitor_stop_and_destroy(DirectoryMonitor *self);
 void directory_monitor_schedule_destroy(DirectoryMonitor *self);
+
+gboolean directory_monitor_can_notify_file_changes(DirectoryMonitor *self);
 
 gchar *build_filename(const gchar *basedir, const gchar *path);
 void rearm_timer(struct iv_timer *rescan_timer, gint rearm_time);

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -260,13 +260,12 @@ _construct_poll_events(FileReader *self, gint fd)
       else
         poll_events = poll_multiline_file_changes_new(fd, self->filename->str, self->options->follow_freq,
                                                       self->options->multi_line_timeout, self);
-      msg_trace("File follow-mode is syslog-ng poll");
+      msg_debug("File follow-mode is syslog-ng poll");
     }
   else if (fd >= 0 && _is_fd_pollable(fd))
     {
       poll_events = poll_fd_events_new(fd);
-      msg_trace("File follow-mode is ivykis poll");
-      msg_trace("Selected ivykis poll method", evt_tag_str("file_poll_method", iv_poll_method_name()));
+      msg_debug("File follow-mode is ivykis poll", evt_tag_str("poll_method", iv_poll_method_name()));
     }
   else
     {

--- a/modules/affile/file-reader.h
+++ b/modules/affile/file-reader.h
@@ -45,6 +45,7 @@ struct _FileReader
   LogReader *reader;
   const gchar *persist_name;
   const gchar *persist_name_prefix;
+  gboolean should_poll_for_events;
 
   void (*on_file_moved)(FileReader *);
 };

--- a/modules/affile/tests/test_wildcard_file_reader.c
+++ b/modules/affile/tests/test_wildcard_file_reader.c
@@ -121,7 +121,7 @@ _init(void)
   app_startup();
   configuration = cfg_new_snippet();
   test_event = test_deleted_file_state_event_new();
-  reader = (WildcardFileReader *)wildcard_file_reader_new(TEST_FILE_NAME, NULL, NULL, NULL, configuration);
+  reader = (WildcardFileReader *)wildcard_file_reader_new(TEST_FILE_NAME, NULL, NULL, NULL, configuration, TRUE);
   wildcard_file_reader_on_deleted_file_eof(reader, _eof, test_event);
   cr_assert_eq(log_pipe_init(&reader->super.super), TRUE);
 }

--- a/modules/affile/wildcard-file-reader.c
+++ b/modules/affile/wildcard-file-reader.c
@@ -159,7 +159,7 @@ wildcard_file_reader_is_deleted(WildcardFileReader *self)
 
 WildcardFileReader *
 wildcard_file_reader_new(const gchar *filename, FileReaderOptions *options, FileOpener *opener, LogSrcDriver *owner,
-                         GlobalConfig *cfg)
+                         GlobalConfig *cfg, gboolean should_poll_for_events)
 {
   WildcardFileReader *self = g_new0(WildcardFileReader, 1);
   file_reader_init_instance(&self->super, filename, options, opener, owner, cfg, "wildcard_file_sd");
@@ -170,5 +170,6 @@ wildcard_file_reader_new(const gchar *filename, FileReaderOptions *options, File
   IV_TASK_INIT(&self->file_state_event_handler);
   self->file_state_event_handler.cookie = self;
   self->file_state_event_handler.handler = _handle_file_state_event;
+  self->super.should_poll_for_events = should_poll_for_events;
   return self;
 }

--- a/modules/affile/wildcard-file-reader.h
+++ b/modules/affile/wildcard-file-reader.h
@@ -55,7 +55,7 @@ struct _WildcardFileReader
 WildcardFileReader *
 wildcard_file_reader_new(const gchar *filename, FileReaderOptions *options,
                          FileOpener *opener, LogSrcDriver *owner,
-                         GlobalConfig *cfg);
+                         GlobalConfig *cfg, gboolean should_poll_for_events);
 
 void wildcard_file_reader_on_deleted_file_eof(WildcardFileReader *self, FileStateEventCallback cb, gpointer user_data);
 gboolean wildcard_file_reader_is_deleted(WildcardFileReader *self);

--- a/modules/affile/wildcard-source.c
+++ b/modules/affile/wildcard-source.c
@@ -55,7 +55,7 @@ _check_required_options(WildcardSourceDriver *self)
 }
 
 static void
-_remove_file_reader(FileReader *reader, gpointer user_data)
+_remove_and_readd_file_reader(FileReader *reader, gpointer user_data)
 {
   WildcardSourceDriver *self = (WildcardSourceDriver *) user_data;
 
@@ -119,7 +119,7 @@ _create_file_reader(WildcardSourceDriver *self, const gchar *full_path)
                                     cfg);
   log_pipe_set_options(&reader->super.super, &self->super.super.super.options);
 
-  wildcard_file_reader_on_deleted_file_eof(reader, _remove_file_reader, self);
+  wildcard_file_reader_on_deleted_file_eof(reader, _remove_and_readd_file_reader, self);
 
   log_pipe_append(&reader->super.super, &self->super.super.super);
   if (!log_pipe_init(&reader->super.super))

--- a/modules/affile/wildcard-source.c
+++ b/modules/affile/wildcard-source.c
@@ -112,11 +112,24 @@ _create_file_reader(WildcardSourceDriver *self, const gchar *full_path)
       return;
     }
 
+  g_assert(g_hash_table_size(self->directory_monitors) > 0);
+  GHashTableIter iter;
+  gpointer key, value;
+  g_hash_table_iter_init(&iter, self->directory_monitors);
+  g_hash_table_iter_next(&iter, &key, &value);
+  DirectoryMonitor *monitor = value;
+  /* FIXME: This assumes that all directory monitors are the same kind in a given WildcardSourceDriver
+   *        This can be removed once we fixed the directory monitor path resolution chaos,
+   *        after that we can lookup the directory monitor by the directory full name correctly.
+   *        See directory_monitor_start for more details. */
+  gboolean file_reader_should_poll_for_events = (FALSE == monitor->can_notify_file_changes);
+
   reader = wildcard_file_reader_new(full_path,
                                     &self->file_reader_options,
                                     self->file_opener,
                                     &self->super,
-                                    cfg);
+                                    cfg,
+                                    file_reader_should_poll_for_events);
   log_pipe_set_options(&reader->super.super, &self->super.super.super.options);
 
   wildcard_file_reader_on_deleted_file_eof(reader, _remove_and_readd_file_reader, self);
@@ -223,6 +236,15 @@ _handler_directory_deleted(WildcardSourceDriver *self, const DirectoryMonitorEve
 }
 
 static void
+_handler_file_modified(WildcardSourceDriver *self, const DirectoryMonitorEvent *event)
+{
+  FileReader *reader = g_hash_table_lookup(self->file_readers, event->full_path);
+
+  if (reader)
+    log_pipe_notify(&reader->super, NC_FILE_MODIFIED, NULL);
+}
+
+static void
 _on_directory_monitor_changed(const DirectoryMonitorEvent *event, gpointer user_data)
 {
   main_loop_assert_main_thread();
@@ -244,6 +266,10 @@ _on_directory_monitor_changed(const DirectoryMonitorEvent *event, gpointer user_
   else if (event->event_type == DIRECTORY_DELETED)
     {
       _handler_directory_deleted(self, event);
+    }
+  else if (event->event_type == FILE_MODIFIED)
+    {
+      _handler_file_modified(self, event);
     }
 }
 
@@ -315,8 +341,11 @@ _add_directory_monitor(WildcardSourceDriver *self, const gchar *directory)
     }
 
   directory_monitor_set_callback(monitor, _on_directory_monitor_changed, self);
-  directory_monitor_start(monitor);
+  /* FIXME: We have to use the full path of the monitor here instead (and in the _handler_directory_deleted
+   *        event
+   *        See directory_monitor_start for more. */
   g_hash_table_insert(self->directory_monitors, g_strdup(directory), monitor);
+  directory_monitor_start(monitor);
   return monitor;
 }
 

--- a/news/feature-5307.md
+++ b/news/feature-5307.md
@@ -1,0 +1,3 @@
+`ivykis`: We have switched to [our own fork](https://github.com/balabit/ivykis) of ivykis as the source for builds when using syslog-ng’s internal ivykis option (`--with-ivykis=internal` in autotools or `-DIVYKIS_SOURCE=internal` in CMake).
+
+We recommend switching to this internal version, as it includes new features not available in the [original version](https://github.com/buytenh/ivykis) and likely never will be.

--- a/news/feature-5312.md
+++ b/news/feature-5312.md
@@ -1,0 +1,3 @@
+`ivykis`: Fixed and merged the in development phase `io_uring` based polling method solution to [our ivykis fork](https://github.com/balabit/ivykis).
+
+This is am experimental integration and not selected by default, you must activate it directly either using the `IV_EXCLUDE_POLL_METHOD` or `IV_SELECT_POLL_METHOD` as described [here](https://syslog-ng.github.io/admin-guide/060_Sources/020_File/001_File_following).

--- a/news/feature-5315.md
+++ b/news/feature-5315.md
@@ -1,0 +1,5 @@
+`wildcard-file`: Added inotify-based regular file change detection using the existing inotify-based directory monitor.
+
+This improves efficiency on OSes like Linux, where only polling was available before, significantly reducing CPU usage while enhancing change detection accuracy.
+
+To enable this feature, inotify kernel support is required, along with `monitor-method()` set to `inotify` or `auto`, and `follow-freq()` set to 0.


### PR DESCRIPTION
`wildcard-file`: Added inotify-based regular file change detection using the existing inotify-based directory monitor.

This improves efficiency on OSes like Linux, where only polling was available before, significantly reducing CPU usage while enhancing change detection accuracy.

To enable this feature, inotify kernel support is required, along with `monitor-method()` set to `inotify` or `auto`, and `follow-freq()` set to 0.


This PR will have a follow-up pair as we have to fix the full-path handling in the file-reader and the directory monitor which is really messy. FIXME notes will be removed in the [next round](https://github.com/syslog-ng/syslog-ng/pull/5317).

Resolves: https://github.com/syslog-ng/syslog-ng/issues/5019

Signed-off-by: Hofi <hofione@gmail.com>