### PR TITLE
Logproto remove handshake in progress

### DIFF
--- a/lib/logproto/logproto-buffered-server.h
+++ b/lib/logproto/logproto-buffered-server.h
@@ -118,6 +118,8 @@ LogProtoPrepareAction log_proto_buffered_server_prepare(LogProtoServer *s, GIOCo
                                                         gint *timeout G_GNUC_UNUSED);
 LogProtoBufferedServerState *log_proto_buffered_server_get_state(LogProtoBufferedServer *self);
 void log_proto_buffered_server_put_state(LogProtoBufferedServer *self);
+gboolean log_proto_buffered_server_restart_with_state(LogProtoServer *s,
+                                                      PersistState *persist_state, const gchar *persist_name);
 
 /* LogProtoBufferedServer */
 gboolean log_proto_buffered_server_validate_options_method(LogProtoServer *s);

--- a/lib/logproto/logproto-client.h
+++ b/lib/logproto/logproto-client.h
@@ -73,8 +73,7 @@ struct _LogProtoClient
   LogProtoStatus (*process_in)(LogProtoClient *s);
   LogProtoStatus (*flush)(LogProtoClient *s);
   gboolean (*validate_options)(LogProtoClient *s);
-  gboolean (*handshake_in_progess)(LogProtoClient *s);
-  LogProtoStatus (*handshake)(LogProtoClient *s);
+  LogProtoStatus (*handshake)(LogProtoClient *s, gboolean *handshake_finished);
   gboolean (*restart_with_state)(LogProtoClient *s, PersistState *state, const gchar *persist_name);
   void (*free_fn)(LogProtoClient *s);
   LogProtoClientFlowControlFuncs flow_control_funcs;
@@ -113,23 +112,14 @@ log_proto_client_validate_options(LogProtoClient *self)
   return self->validate_options(self);
 }
 
-static inline gboolean
-log_proto_client_handshake_in_progress(LogProtoClient *s)
-{
-  if (s->handshake_in_progess)
-    {
-      return s->handshake_in_progess(s);
-    }
-  return FALSE;
-}
-
 static inline LogProtoStatus
-log_proto_client_handshake(LogProtoClient *s)
+log_proto_client_handshake(LogProtoClient *s, gboolean *handshake_finished)
 {
   if (s->handshake)
     {
-      return s->handshake(s);
+      return s->handshake(s, handshake_finished);
     }
+  *handshake_finished = TRUE;
   return LPS_SUCCESS;
 }
 

--- a/lib/logproto/logproto-server.h
+++ b/lib/logproto/logproto-server.h
@@ -88,8 +88,7 @@ struct _LogProtoServer
   LogProtoStatus (*fetch)(LogProtoServer *s, const guchar **msg, gsize *msg_len, gboolean *may_read,
                           LogTransportAuxData *aux, Bookmark *bookmark);
   gboolean (*validate_options)(LogProtoServer *s);
-  gboolean (*handshake_in_progess)(LogProtoServer *s);
-  LogProtoStatus (*handshake)(LogProtoServer *s);
+  LogProtoStatus (*handshake)(LogProtoServer *s, gboolean *handshake_finished);
   void (*free_fn)(LogProtoServer *s);
 };
 
@@ -99,23 +98,14 @@ log_proto_server_validate_options(LogProtoServer *self)
   return self->validate_options(self);
 }
 
-static inline gboolean
-log_proto_server_handshake_in_progress(LogProtoServer *s)
-{
-  if (s->handshake_in_progess)
-    {
-      return s->handshake_in_progess(s);
-    }
-  return FALSE;
-}
-
 static inline LogProtoStatus
-log_proto_server_handshake(LogProtoServer *s)
+log_proto_server_handshake(LogProtoServer *s, gboolean *handshake_finished)
 {
   if (s->handshake)
     {
-      return s->handshake(s);
+      return s->handshake(s, handshake_finished);
     }
+  *handshake_finished = TRUE;
   return LPS_SUCCESS;
 }
 

--- a/lib/logproto/tests/test-proxy-proto.c
+++ b/lib/logproto/tests/test-proxy-proto.c
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2020 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include <criterion/criterion.h>
+#include <criterion/parameterized.h>
+#include "libtest/mock-transport.h"
+#include "libtest/proto_lib.h"
+
+#include "logproto/logproto-proxied-text-server.h"
+#include <errno.h>
+
+typedef struct
+{
+  const gchar *proxy_header;
+  gboolean valid;
+} ProtocolHeaderTestParams;
+
+ParameterizedTestParameters(log_proto, test_proxy_protocol_parse_header)
+{
+  static ProtocolHeaderTestParams test_params[] =
+  {
+    /* SUCCESS */
+    { "PROXY UNKNOWN\r\n",                                    TRUE },
+    { "PROXY UNKNOWN extra ignored parameters\r\n",           TRUE },
+    { "PROXY TCP4 1.1.1.1 2.2.2.2 3333 4444\r\n",             TRUE },
+    { "PROXY TCP6 ::1 ::2 3333 4444\r\n",                     TRUE },
+
+    /* INVALID PROTO */
+    { "PROXY UNKNOWN\n",                                      TRUE }, // WRONG TERMINATION
+    { "PROXY TCP4 1.1.1.1 2.2.2.2 3333 4444\n",               TRUE }, // WRONG TERMINATION
+    { "PROXY UNKNOWN\r",                                      FALSE }, // WRONG TERMINATION
+    { "PROXY TCP4 1.1.1.1 2.2.2.2 3333 4444\r",               FALSE }, // WRONG TERMINATION
+    { "PROXY\r\n",                                            FALSE },
+    { "PROXY TCP4\r\n",                                       FALSE },
+    { "PROXY TCP4 1.1.1.1\r\n",                               FALSE },
+    { "PROXY TCP4 1.1.1.1 2.2.2.2\r\n",                       FALSE },
+    { "PROXY TCP4 1.1.1.1 2.2.2.2 3333\r\n",                  FALSE },
+    { "PROXY TCP4 1.1.1.1 2.2.2.2 3333 4444 extra param\r\n", TRUE},
+
+    /* EXTRA WHITESPACE - PERMISSIVE */
+    { "PROXY TCP4  1.1.1.1 2.2.2.2 3333 4444\r\n",            TRUE },
+    { "PROXY TCP4 1.1.1.1  2.2.2.2 3333 4444\r\n",            TRUE },
+    { "PROXY TCP4 1.1.1.1 2.2.2.2  3333 4444\r\n",            TRUE },
+    { "PROXY TCP4 1.1.1.1 2.2.2.2 3333  4444\r\n",            TRUE },
+    { "PROXY TCP4 1.1.1.1 2.2.2.2 3333 4444 \r\n",            TRUE },
+
+    /* EXTRA WHITESPACE BEFORE PARAMETERS */
+    { "PROXY  TCP4 1.1.1.1 2.2.2.2 3333 4444\r\n",            FALSE },
+
+
+    /* INVALID ARGUMENTS - PERMISSIVE */
+    { "PROXY TCP6 1.1.1.1 2.2.2.2 3333 4444\r\n",             TRUE }, // WRONG IP PROTO
+    { "PROXY TCP4 ::1 ::2 3333 4444\r\n",                     TRUE }, // WRONG IP PROTO
+    { "PROXY TCP4 1.1.1 2.2.2.2 3333 4444\r\n",               TRUE }, // WRONG IP
+    { "PROXY TCP4 1.1.1.1.1 2.2.2.2 3333 4444\r\n",           TRUE }, // WRONG IP
+    { "PROXY TCP6 ::1::0 ::1 3333 4444\r\n",                  TRUE }, // WRONG IP
+    { "PROXY TCP4 1.1.1.1 2.2.2.2 33333 0\r\n",               TRUE }, // WRONG PORT
+    { "PROXY TCP4 1.1.1.1 2.2.2.2 33333 -1\r\n",              TRUE }, // WRONG PORT
+    { "PROXY TCP4 1.1.1.1 2.2.2.2 33333 65536\r\n",           TRUE }, // WRONG PORT
+
+    /* INVALID ARGUMENT(S)*/
+    { "PROXY TCP3 1.1.1.1 2.2.2.2 3333 4444\r\n",             FALSE}, // WRONG IP PROTO
+
+
+    {
+      "PROXY TCP4 padpadpadpadpadpadpadpadpadpadpadpadpad"
+      "padpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpad"
+      "padpadpadpadpadpadpadpadpadpadpadpadpadpadpadpadpad",  FALSE
+    } // TOO LONG
+  };
+
+  return cr_make_param_array(ProtocolHeaderTestParams, test_params, G_N_ELEMENTS(test_params));
+}
+
+ParameterizedTest(ProtocolHeaderTestParams *params, log_proto, test_proxy_protocol_parse_header)
+{
+  LogProtoServer *proto = log_proto_proxied_text_server_new(log_transport_mock_records_new(params->proxy_header,
+                                                            -1, LTM_EOF),
+                                                            get_inited_proto_server_options());
+
+  gboolean handshake_finished = FALSE;
+  gboolean valid = log_proto_server_handshake(proto, &handshake_finished) == LPS_SUCCESS;
+
+  if (valid)
+    cr_assert(handshake_finished == TRUE);
+
+  cr_assert_eq(valid, params->valid,
+               "This should be %s: %s", params->valid ? "valid" : "invalid", params->proxy_header);
+
+  log_proto_server_free(proto);
+}
+
+Test(log_proto, test_proxy_protocol_handshake_and_fetch_success)
+{
+  LogTransport *transport = log_transport_mock_records_new("PROXY TCP4 1.1.1.1 2.2.2.2 3333 4444\r\n", -1,
+                                                           "test message\n", -1,
+                                                           LTM_EOF);
+  LogProtoServer *proto = log_proto_proxied_text_server_new(transport, get_inited_proto_server_options());
+
+  gboolean handshake_finished = FALSE;
+  cr_assert_eq(log_proto_server_handshake(proto, &handshake_finished), LPS_SUCCESS);
+  cr_assert(handshake_finished == TRUE);
+  assert_proto_server_fetch(proto, "test message", -1);
+
+  log_proto_server_free(proto);
+}
+
+Test(log_proto, test_proxy_protocol_handshake_failed)
+{
+  LogTransport *transport = log_transport_mock_records_new("invalid header\r\n", -1,
+                                                           "test message\n", -1,
+                                                           LTM_EOF);
+  LogProtoServer *proto = log_proto_proxied_text_server_new(transport, get_inited_proto_server_options());
+
+  gboolean handshake_finished = FALSE;
+  cr_assert_eq(log_proto_server_handshake(proto, &handshake_finished), LPS_ERROR);
+  cr_assert(handshake_finished == FALSE);
+
+  log_proto_server_free(proto);
+}
+
+static void
+get_aux_data_from_next_message(LogProtoServer *proto, LogTransportAuxData *aux)
+{
+  LogProtoStatus status;
+
+  const guchar *msg = NULL;
+  gsize msg_len = 0;
+  Bookmark bookmark;
+  gboolean may_read = TRUE;
+
+  do
+    {
+      log_transport_aux_data_init(aux);
+      status = log_proto_server_fetch(proto, &msg, &msg_len, &may_read, aux, &bookmark);
+      if (status == LPS_AGAIN)
+        status = LPS_SUCCESS;
+    }
+  while (status == LPS_SUCCESS && msg == NULL && may_read);
+}
+
+static void
+concat_nv(const gchar *name, const gchar *value, gsize value_len, gpointer user_data)
+{
+  GString *aux_nv_concated = user_data;
+  g_string_append_printf(aux_nv_concated, "%s:%s ", name, value);
+}
+
+Test(log_proto, test_proxy_protocol_aux_data)
+{
+  const gchar *expected = "PROXIED_SRCIP:1.1.1.1 PROXIED_DSTIP:2.2.2.2 "
+                          "PROXIED_SRCPORT:3333 PROXIED_DSTPORT:4444 "
+                          "PROXIED_IP_VERSION:4 ";
+  LogTransport *transport = log_transport_mock_records_new("PROXY TCP4 1.1.1.1 2.2.2.2 3333 4444\r\n", -1,
+                                                           "test message\n", -1,
+                                                           LTM_EOF);
+  LogProtoServer *proto = log_proto_proxied_text_server_new(transport, get_inited_proto_server_options());
+
+  gboolean handshake_finished = FALSE;
+  cr_assert_eq(log_proto_server_handshake(proto, &handshake_finished), LPS_SUCCESS);
+  cr_assert(handshake_finished == TRUE);
+
+  LogTransportAuxData aux;
+  log_transport_aux_data_init(&aux);
+  get_aux_data_from_next_message(proto, &aux);
+
+  GString *aux_nv_concated = g_string_new(NULL);
+  log_transport_aux_data_foreach(&aux, concat_nv, aux_nv_concated);
+  cr_assert_str_eq(aux_nv_concated->str, expected);
+
+  g_string_free(aux_nv_concated, TRUE);
+  log_transport_aux_data_destroy(&aux);
+  log_proto_server_free(proto);
+}
+
+Test(log_proto, test_proxy_protocol_v2_parse_header)
+{
+  const gchar *expected = "PROXIED_SRCIP:1.1.1.1 PROXIED_DSTIP:2.2.2.2 "
+                          "PROXIED_SRCPORT:33333 PROXIED_DSTPORT:44444 "
+                          "PROXIED_IP_VERSION:4 ";
+  LogProtoServer *proto = log_proto_proxied_text_server_new(log_transport_mock_records_new(
+                                                              "\r\n\r\n\0\r\nQUIT\n!\21\0\f\1\1\1\1\2\2\2\2\2025\255\234", 28,
+                                                              "test_message\n", -1,
+                                                              LTM_EOF
+                                                            ),
+                                                            get_inited_proto_server_options());
+
+  gboolean handshake_finished = FALSE;
+  cr_assert_eq(log_proto_server_handshake(proto, &handshake_finished), LPS_SUCCESS, "Proxy protocol v2 parsing failed");
+  cr_assert(handshake_finished == TRUE);
+
+  LogTransportAuxData aux;
+  log_transport_aux_data_init(&aux);
+  get_aux_data_from_next_message(proto, &aux);
+
+  GString *aux_nv_concated = g_string_new(NULL);
+  log_transport_aux_data_foreach(&aux, concat_nv, aux_nv_concated);
+  cr_assert_str_eq(aux_nv_concated->str, expected);
+
+  g_string_free(aux_nv_concated, TRUE);
+  log_transport_aux_data_destroy(&aux);
+  log_proto_server_free(proto);
+}
+
+Test(log_proto, test_proxy_protocol_header_partial_read)
+{
+  LogTransportMock *transport = (LogTransportMock *) log_transport_mock_records_new(LTM_EOF);
+  const char *proxy_header_segments[] = {"P", "ROXY TCP4 ", "1.1.1.1 ", "2.2.2.2 3333 ", "4444\r\n"};
+  size_t length = G_N_ELEMENTS(proxy_header_segments);
+
+  for(size_t i = 0; i < length; i++)
+    {
+      log_transport_mock_inject_data(transport, proxy_header_segments[i], -1);
+      log_transport_mock_inject_data(transport, LTM_INJECT_ERROR(EAGAIN));
+    }
+
+  log_transport_mock_inject_data(transport, "test message\n", -1);
+
+  LogProtoServer *proto = log_proto_proxied_text_server_new((LogTransport *) transport,
+                                                            get_inited_proto_server_options());
+
+  gboolean handshake_finished = FALSE;
+  for(size_t i = 0; i < length; i++)
+    {
+      cr_assert_eq(log_proto_server_handshake(proto, &handshake_finished), LPS_AGAIN);
+      cr_assert(handshake_finished == FALSE);
+    }
+
+  cr_assert_eq(log_proto_server_handshake(proto, &handshake_finished), LPS_SUCCESS);
+  cr_assert(handshake_finished == TRUE);
+
+
+
+  const gchar *expected = "PROXIED_SRCIP:1.1.1.1 PROXIED_DSTIP:2.2.2.2 "
+                          "PROXIED_SRCPORT:3333 PROXIED_DSTPORT:4444 "
+                          "PROXIED_IP_VERSION:4 ";
+  LogTransportAuxData aux;
+  log_transport_aux_data_init(&aux);
+  get_aux_data_from_next_message(proto, &aux);
+
+  GString *aux_nv_concated = g_string_new(NULL);
+  log_transport_aux_data_foreach(&aux, concat_nv, aux_nv_concated);
+  cr_assert_str_eq(aux_nv_concated->str, expected);
+
+  g_string_free(aux_nv_concated, TRUE);
+  log_transport_aux_data_destroy(&aux);
+
+  log_proto_server_free(proto);
+
+}

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -456,7 +456,8 @@ _add_aux_nvpair(const gchar *name, const gchar *value, gsize value_len, gpointer
 static inline gint
 log_reader_process_handshake(LogReader *self)
 {
-  LogProtoStatus status = log_proto_server_handshake(self->proto);
+  gboolean handshake_finished = FALSE;
+  LogProtoStatus status = log_proto_server_handshake(self->proto, &handshake_finished);
 
   switch (status)
     {
@@ -464,6 +465,8 @@ log_reader_process_handshake(LogReader *self)
     case LPS_ERROR:
       return status == LPS_ERROR ? NC_READ_ERROR : NC_CLOSE;
     case LPS_SUCCESS:
+      if (handshake_finished)
+        self->handshake_in_progress = FALSE;
       break;
     case LPS_AGAIN:
       break;
@@ -531,7 +534,7 @@ log_reader_fetch_log(LogReader *self)
     aux = NULL;
 
   log_transport_aux_data_init(aux);
-  if (log_proto_server_handshake_in_progress(self->proto))
+  if (self->handshake_in_progress)
     {
       return log_reader_process_handshake(self);
     }
@@ -806,6 +809,7 @@ log_reader_new(GlobalConfig *cfg)
   self->super.schedule_dynamic_window_realloc = _schedule_dynamic_window_realloc;
   self->super.metrics.raw_bytes_enabled = TRUE;
   self->immediate_check = FALSE;
+  self->handshake_in_progress = TRUE;
   log_reader_init_watches(self);
   g_mutex_init(&self->pending_close_lock);
   g_cond_init(&self->pending_close_cond);

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -62,7 +62,7 @@ struct _LogReader
 {
   LogSource super;
   LogProtoServer *proto;
-  gboolean immediate_check;
+  gboolean immediate_check, handshake_in_progress;
   LogPipe *control;
   LogReaderOptions *options;
   PollEvents *poll_events;

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -62,7 +62,7 @@ struct _LogReader
 {
   LogSource super;
   LogProtoServer *proto;
-  gboolean immediate_check, handshake_in_progress;
+  gboolean handshake_in_progress;
   LogPipe *control;
   LogReaderOptions *options;
   PollEvents *poll_events;
@@ -98,7 +98,6 @@ void log_reader_set_follow_filename(LogReader *self, const gchar *follow_filenam
 void log_reader_set_name(LogReader *s, const gchar *name);
 void log_reader_set_peer_addr(LogReader *s, GSockAddr *peer_addr);
 void log_reader_set_local_addr(LogReader *s, GSockAddr *local_addr);
-void log_reader_set_immediate_check(LogReader *s);
 void log_reader_disable_bookmark_saving(LogReader *s);
 void log_reader_trigger_one_check(LogReader *s);
 gboolean log_reader_is_opened(LogReader *s);

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -188,9 +188,6 @@ _can_check_eof(FileReader *self, gint fd)
 static gboolean
 _reader_check_eof(FileReader *self, gint fd)
 {
-  if (fd < 0)
-    return FALSE;
-
   off_t pos = lseek(fd, 0, SEEK_CUR);
   if (pos == (off_t) -1)
     {

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -319,7 +319,7 @@ _deinit_sd_logreader(FileReader *self)
 }
 
 static void
-_setup_logreader(LogPipe *s, PollEvents *poll_events, LogProtoServer *proto, gboolean check_immediately)
+_setup_logreader(LogPipe *s, PollEvents *poll_events, LogProtoServer *proto)
 {
   FileReader *self = (FileReader *) s;
 
@@ -336,23 +336,10 @@ _setup_logreader(LogPipe *s, PollEvents *poll_events, LogProtoServer *proto, gbo
                          self->owner->super.id,
                          kb);
 
-  if (check_immediately)
-    log_reader_set_immediate_check(self->reader);
-
   /* NOTE: if the file could not be opened, we ignore the last
    * remembered file position, if the file is created in the future
    * we're going to read from the start. */
   log_pipe_append((LogPipe *) self->reader, s);
-}
-
-static gboolean
-_is_immediate_check_needed(gboolean file_opened, gboolean open_deferred)
-{
-  if (file_opened)
-    return TRUE;
-  else if (open_deferred)
-    return FALSE;
-  return FALSE;
 }
 
 static gboolean
@@ -378,7 +365,6 @@ _reader_open_file(LogPipe *s, gboolean recover_state)
     {
       LogProtoServer *proto;
       PollEvents *poll_events;
-      gboolean check_immediately;
 
       poll_events = _construct_poll_events(self, fd);
       if (!poll_events)
@@ -388,8 +374,9 @@ _reader_open_file(LogPipe *s, gboolean recover_state)
         }
       proto = _construct_proto(self, fd);
 
-      check_immediately = _is_immediate_check_needed(file_opened, open_deferred);
-      _setup_logreader(s, poll_events, proto, check_immediately);
+      _setup_logreader(s, poll_events, proto);
+      if (recover_state)
+        _recover_state(s, cfg, proto);
       if (!log_pipe_init((LogPipe *) self->reader))
         {
           msg_error("Error initializing log_reader, closing fd",
@@ -399,8 +386,6 @@ _reader_open_file(LogPipe *s, gboolean recover_state)
           close(fd);
           return FALSE;
         }
-      if (recover_state)
-        _recover_state(s, cfg, proto);
     }
   else
     {

--- a/modules/affile/poll-file-changes.c
+++ b/modules/affile/poll-file-changes.c
@@ -153,8 +153,8 @@ poll_file_changes_check_file(gpointer s)
         }
       else
         {
-          msg_verbose("Follow mode file still does not exist",
-                      evt_tag_str("filename", self->follow_filename));
+          msg_trace("Follow mode file still does not exist",
+                    evt_tag_str("filename", self->follow_filename));
         }
     }
 reschedule:
@@ -171,11 +171,11 @@ poll_file_changes_stop_watches(PollEvents *s)
 }
 
 static void
-poll_file_changes_rearm_timer(PollFileChanges *self)
+poll_file_changes_rearm_timer(PollFileChanges *self, glong delay)
 {
   iv_validate_now();
   self->follow_timer.expires = iv_now;
-  timespec_add_msec(&self->follow_timer.expires, self->follow_freq);
+  timespec_add_msec(&self->follow_timer.expires, delay);
   iv_timer_register(&self->follow_timer);
 }
 
@@ -188,8 +188,21 @@ poll_file_changes_update_watches(PollEvents *s, GIOCondition cond)
 
   poll_file_changes_stop_watches(s);
 
+  if (self->fd < 0)
+    {
+      /* file does not exist yet, go back checking after follow_freq */
+      poll_file_changes_rearm_timer(self, self->follow_freq);
+      return;
+    }
+
   if (poll_file_changes_check_watches(self))
-    poll_file_changes_rearm_timer(self);
+    poll_file_changes_rearm_timer(self, self->follow_freq);
+  else
+    {
+      msg_trace("File exists and contains data",
+                evt_tag_str("follow_filename", self->follow_filename));
+      poll_file_changes_rearm_timer(self, 0);
+    }
 }
 
 void


### PR DESCRIPTION
The branch itself simplifies the LogProto handshake API and adds a unit test for the LogProtoAutoServer class (rfc6587)

Backport of [155](https://github.com/axoflow/axosyslog/pull/155) and its fix [407](https://github.com/axoflow/axosyslog/pull/407/commits) by @bazsi

Depends on https://github.com/syslog-ng/syslog-ng/pull/5318