### PR TITLE
grpc: response-action()

### DIFF
--- a/modules/grpc/common/grpc-dest.cpp
+++ b/modules/grpc/common/grpc-dest.cpp
@@ -139,7 +139,7 @@ DestDriver::deinit()
 bool
 DestDriver::handle_response(const ::grpc::Status &status, LogThreadedResult *ltr)
 {
-  if (status.error_code() >= GRPC_DEST_RESPONSE_ACTIONS_ARRAY_LEN)
+  if ((size_t) status.error_code() >= GRPC_DEST_RESPONSE_ACTIONS_ARRAY_LEN)
     {
       msg_error("Invalid gRPC status code", evt_tag_int("status_code", status.error_code()));
       return false;

--- a/modules/grpc/common/grpc-dest.h
+++ b/modules/grpc/common/grpc-dest.h
@@ -32,6 +32,36 @@
 #include "driver.h"
 #include "credentials/grpc-credentials-builder.h"
 
+typedef enum
+{
+  GDRA_UNSET = 0,
+  GDRA_DISCONNECT,
+  GDRA_DROP,
+  GDRA_RETRY,
+  GDRA_SUCCESS,
+} GrpcDestResponseAction;
+
+typedef enum
+{
+  GDR_OK,
+  GDR_UNAVAILABLE,
+  GDR_CANCELLED,
+  GDR_DEADLINE_EXCEEDED,
+  GDR_ABORTED,
+  GDR_OUT_OF_RANGE,
+  GDR_DATA_LOSS,
+  GDR_UNKNOWN,
+  GDR_INVALID_ARGUMENT,
+  GDR_NOT_FOUND,
+  GDR_ALREADY_EXISTS,
+  GDR_PERMISSION_DENIED,
+  GDR_UNAUTHENTICATED,
+  GDR_FAILED_PRECONDITION,
+  GDR_UNIMPLEMENTED,
+  GDR_INTERNAL,
+  GDR_RESOURCE_EXHAUSTED,
+} GrpcDestResponse;
+
 typedef struct GrpcDestDriver_ GrpcDestDriver;
 
 void grpc_dd_set_url(LogDriver *s, const gchar *url);
@@ -45,6 +75,7 @@ void grpc_dd_add_string_channel_arg(LogDriver *s, const gchar *name, const gchar
 gboolean grpc_dd_add_header(LogDriver *s, const gchar *name, LogTemplate *value);
 gboolean grpc_dd_add_schema_field(LogDriver *d, const gchar *name, const gchar *type, LogTemplate *value);
 void grpc_dd_set_protobuf_schema(LogDriver *d, const gchar *proto_path, GList *values);
+void grpc_dd_set_response_action(LogDriver *d, GrpcDestResponse response, GrpcDestResponseAction action);
 
 LogTemplateOptions *grpc_dd_get_template_options(LogDriver *d);
 GrpcClientCredentialsBuilderW *grpc_dd_get_credentials_builder(LogDriver *s);

--- a/modules/grpc/common/grpc-dest.hpp
+++ b/modules/grpc/common/grpc-dest.hpp
@@ -40,6 +40,8 @@
 #include <list>
 #include <sstream>
 
+#define GRPC_DEST_RESPONSE_ACTIONS_ARRAY_LEN (64)
+
 namespace syslogng {
 namespace grpc {
 
@@ -54,6 +56,7 @@ public:
   virtual const char *format_stats_key(StatsClusterKeyBuilder *kb) = 0;
   virtual const char *generate_persist_name() = 0;
   virtual LogThreadedDestWorker *construct_worker(int worker_index) = 0;
+  virtual bool handle_response(const ::grpc::Status &status, LogThreadedResult *ltr);
 
   void set_url(const char *u)
   {
@@ -130,6 +133,11 @@ public:
     return true;
   }
 
+  void set_response_action(const ::grpc::StatusCode status_code, GrpcDestResponseAction action)
+  {
+    this->response_actions[status_code] = action;
+  }
+
   void extend_worker_partition_key(const std::string &extension)
   {
     if (this->worker_partition_key.rdbuf()->in_avail())
@@ -185,6 +193,8 @@ protected:
 
   std::list<NameValueTemplatePair> headers;
   bool dynamic_headers_enabled;
+
+  std::array<GrpcDestResponseAction, GRPC_DEST_RESPONSE_ACTIONS_ARRAY_LEN> response_actions;
 
   LogTemplateOptions template_options;
 

--- a/modules/grpc/common/grpc-grammar.ym
+++ b/modules/grpc/common/grpc-grammar.ym
@@ -67,7 +67,32 @@ GrpcClientCredentialsBuilderW *last_grpc_client_credentials_builder;
 %token KW_SCHEMA
 %token KW_PROTOBUF_SCHEMA
 
+%token KW_RESPONSE_ACTION
+%token KW_DISCONNECT
+%token KW_DROP
+%token KW_RETRY
+%token KW_SUCCESS
+%token KW_OK
+%token KW_UNAVAILABLE
+%token KW_CANCELLED
+%token KW_DEADLINE_EXCEEDED
+%token KW_ABORTED
+%token KW_OUT_OF_RANGE
+%token KW_DATA_LOSS
+%token KW_UNKNOWN
+%token KW_INVALID_ARGUMENT
+%token KW_NOT_FOUND
+%token KW_ALREADY_EXISTS
+%token KW_PERMISSION_DENIED
+%token KW_UNAUTHENTICATED
+%token KW_FAILED_PRECONDITION
+%token KW_UNIMPLEMENTED
+%token KW_INTERNAL
+%token KW_RESOURCE_EXHAUSTED
+
 %type <num> grpc_server_credentials_builder_tls_peer_verify
+%type <num> grpc_dest_response
+%type <num> grpc_dest_response_action
 
 /* END_DECLS */
 
@@ -103,6 +128,7 @@ grpc_dest_general_option
   | KW_KEEP_ALIVE '(' grpc_keepalive_options ')'
   | KW_CHANNEL_ARGS '(' grpc_dest_channel_args ')'
   | KW_HEADERS '(' grpc_dest_headers ')'
+  | KW_RESPONSE_ACTION '(' grpc_dest_response_action_items ')'
   | threaded_dest_driver_general_option
   | threaded_dest_driver_batch_option
   | threaded_dest_driver_workers_option
@@ -167,6 +193,42 @@ grpc_dest_header
         free($1);
         log_template_unref($3);
       }
+  ;
+
+grpc_dest_response_action_items
+  : grpc_dest_response_action_item grpc_dest_response_action_items
+  |
+  ;
+
+grpc_dest_response_action_item
+  : grpc_dest_response LL_ARROW grpc_dest_response_action { grpc_dd_set_response_action(last_driver, $1, $3); }
+  ;
+
+grpc_dest_response
+  : KW_OK { $$ = GDR_OK; }
+  | KW_UNAVAILABLE { $$ = GDR_UNAVAILABLE; }
+  | KW_CANCELLED { $$ = GDR_CANCELLED; }
+  | KW_DEADLINE_EXCEEDED { $$ = GDR_DEADLINE_EXCEEDED; }
+  | KW_ABORTED { $$ = GDR_ABORTED; }
+  | KW_OUT_OF_RANGE { $$ = GDR_OUT_OF_RANGE; }
+  | KW_DATA_LOSS { $$ = GDR_DATA_LOSS; }
+  | KW_UNKNOWN { $$ = GDR_UNKNOWN; }
+  | KW_INVALID_ARGUMENT { $$ = GDR_INVALID_ARGUMENT; }
+  | KW_NOT_FOUND { $$ = GDR_NOT_FOUND; }
+  | KW_ALREADY_EXISTS { $$ = GDR_ALREADY_EXISTS; }
+  | KW_PERMISSION_DENIED { $$ = GDR_PERMISSION_DENIED; }
+  | KW_UNAUTHENTICATED { $$ = GDR_UNAUTHENTICATED; }
+  | KW_FAILED_PRECONDITION { $$ = GDR_FAILED_PRECONDITION; }
+  | KW_UNIMPLEMENTED { $$ = GDR_UNIMPLEMENTED; }
+  | KW_INTERNAL { $$ = GDR_INTERNAL; }
+  | KW_RESOURCE_EXHAUSTED { $$ = GDR_RESOURCE_EXHAUSTED; }
+  ;
+
+grpc_dest_response_action
+  : KW_DISCONNECT { $$ = GDRA_DISCONNECT; }
+  | KW_DROP { $$ = GDRA_DROP; }
+  | KW_RETRY { $$ = GDRA_RETRY; }
+  | KW_SUCCESS { $$ = GDRA_SUCCESS; }
   ;
 
 grpc_server_credentials_builder_option

--- a/modules/grpc/common/grpc-parser.h
+++ b/modules/grpc/common/grpc-parser.h
@@ -54,6 +54,28 @@
   { "optional_trusted",          KW_OPTIONAL_TRUSTED }, \
   { "required_untrusted",        KW_REQUIRED_UNTRUSTED }, \
   { "required_trusted",          KW_REQUIRED_TRUSTED }, \
-  { "concurrent_requests",       KW_CONCURRENT_REQUESTS }
+  { "concurrent_requests",       KW_CONCURRENT_REQUESTS }, \
+  { "response_action",           KW_RESPONSE_ACTION }, \
+  { "disconnect",                KW_DISCONNECT }, \
+  { "drop",                      KW_DROP }, \
+  { "retry",                     KW_RETRY }, \
+  { "success",                   KW_SUCCESS }, \
+  { "ok",                        KW_OK }, \
+  { "unavailable",               KW_UNAVAILABLE }, \
+  { "cancelled",                 KW_CANCELLED }, \
+  { "deadline_exceeded",         KW_DEADLINE_EXCEEDED }, \
+  { "aborted",                   KW_ABORTED }, \
+  { "out_of_range",              KW_OUT_OF_RANGE }, \
+  { "data_loss",                 KW_DATA_LOSS }, \
+  { "unknown",                   KW_UNKNOWN }, \
+  { "invalid_argument",          KW_INVALID_ARGUMENT }, \
+  { "not_found",                 KW_NOT_FOUND }, \
+  { "already_exists",            KW_ALREADY_EXISTS }, \
+  { "permission_denied",         KW_PERMISSION_DENIED }, \
+  { "unauthenticated",           KW_UNAUTHENTICATED }, \
+  { "failed_precondition",       KW_FAILED_PRECONDITION }, \
+  { "unimplemented",             KW_UNIMPLEMENTED }, \
+  { "internal",                  KW_INTERNAL }, \
+  { "resource_exhausted",        KW_RESOURCE_EXHAUSTED }
 
 #endif

--- a/modules/grpc/otel/otel-dest-worker.cpp
+++ b/modules/grpc/otel/otel-dest-worker.cpp
@@ -418,7 +418,10 @@ DestWorker::flush_log_records()
   ::grpc::Status status = logs_service_stub->Export(client_context.get(), logs_service_request,
                                                     &logs_service_response);
   owner.metrics.insert_grpc_request_stats(status);
-  LogThreadedResult result = _map_grpc_status_to_log_threaded_result(status);
+
+  LogThreadedResult result;
+  if (!owner.handle_response(status, &result))
+    result = _map_grpc_status_to_log_threaded_result(status);
 
   if (result == LTR_SUCCESS)
     {
@@ -436,7 +439,10 @@ DestWorker::flush_metrics()
   ::grpc::Status status = metrics_service_stub->Export(client_context.get(), metrics_service_request,
                                                        &metrics_service_response);
   owner.metrics.insert_grpc_request_stats(status);
-  LogThreadedResult result = _map_grpc_status_to_log_threaded_result(status);
+
+  LogThreadedResult result;
+  if (!owner.handle_response(status, &result))
+    result = _map_grpc_status_to_log_threaded_result(status);
 
   if (result == LTR_SUCCESS)
     {
@@ -454,7 +460,10 @@ DestWorker::flush_spans()
   ::grpc::Status status = trace_service_stub->Export(client_context.get(), trace_service_request,
                                                      &trace_service_response);
   owner.metrics.insert_grpc_request_stats(status);
-  LogThreadedResult result = _map_grpc_status_to_log_threaded_result(status);
+
+  LogThreadedResult result;
+  if (!owner.handle_response(status, &result))
+    result = _map_grpc_status_to_log_threaded_result(status);
 
   if (result == LTR_SUCCESS)
     {

--- a/modules/grpc/pubsub/pubsub-dest-worker.cpp
+++ b/modules/grpc/pubsub/pubsub-dest-worker.cpp
@@ -210,7 +210,11 @@ DestWorker::flush(LogThreadedFlushMode mode)
   ::google::pubsub::v1::PublishResponse response;
 
   ::grpc::Status status = this->stub->Publish(this->client_context.get(), this->request, &response);
-  LogThreadedResult result = _map_grpc_status_to_log_threaded_result(status);
+
+  LogThreadedResult result;
+  if (!owner.handle_response(status, &result))
+    result = _map_grpc_status_to_log_threaded_result(status);
+
   if (result != LTR_SUCCESS)
     goto exit;
 

--- a/news/feature-561.md
+++ b/news/feature-561.md
@@ -1,0 +1,48 @@
+gRPC based destinations: Added `response-action()` option
+
+With this option, it is possible to fine tune how syslog-ng
+behaves in case of different gRPC results.
+
+Supported by the following destination drivers:
+  * `opentelemetry()`
+  * `loki()`
+  * `bigquery()`
+  * `clickhouse()`
+  * `google-pubsub-grpc()`
+
+Supported gRPC results:
+  * ok
+  * unavailable
+  * cancelled
+  * deadline-exceeded
+  * aborted
+  * out-of-range
+  * data-loss
+  * unknown
+  * invalid-argument
+  * not-found
+  * already-exists
+  * permission-denied
+  * unauthenticated
+  * failed-precondition
+  * unimplemented
+  * internal
+  * resource-exhausted
+
+Supported actions:
+  * disconnect
+  * drop
+  * retry
+  * success
+
+Usage:
+```
+google-pubsub-grpc(
+  project("my-project")
+  topic("my-topic")
+  response-action(
+    not-found => disconnect
+    unavailable => drop
+  )
+);
+```


### PR DESCRIPTION
With this option, it is possible to fine tune how AxoSyslog behaves in case of different gRPC results.

Supported by the following destination drivers:

- opentelemetry()
- loki()
- bigquery()
- clickhouse()
- google-pubsub-grpc()

Supported gRPC results:

- ok
- unavailable
- cancelled
- deadline-exceeded
- aborted
- out-of-range
- data-loss
- unknown
- invalid-argument
- not-found
- already-exists
- permission-denied
- unauthenticated
- failed-precondition
- unimplemented
- internal
- resource-exhausted

Supported actions:

- disconnect
- drop
- retry
- success

Usage:

```
google-pubsub-grpc(
  project("my-project")
  topic("my-topic")
  response-action(
    not-found => disconnect
    unavailable => drop
  )
);
```

Depends on  https://github.com/syslog-ng/syslog-ng/pull/5324

Backport of [561](https://github.com/axoflow/axosyslog/pull/561) by @alltilla