### PR TITLE
modules/affile/std{in|out}: register stdin/stdout with proper name instead of dash

### DIFF
--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -422,6 +422,7 @@ log_reader_work_finished(void *s, gpointer arg)
 
       if (notify_code == NC_CLOSE && (self->options->flags & LR_EXIT_ON_EOF))
         {
+          msg_trace("Exiting because exit-on-eof was set");
           cfg_shutdown(log_pipe_get_config(s));
         }
     }

--- a/modules/affile/stdin.c
+++ b/modules/affile/stdin.c
@@ -71,7 +71,7 @@ stdin_sd_init(LogPipe *s)
 LogDriver *
 stdin_sd_new(GlobalConfig *cfg)
 {
-  AFFileSourceDriver *self = affile_sd_new_instance("-", cfg);
+  AFFileSourceDriver *self = affile_sd_new_instance("/dev/stdin", cfg);
 
   self->super.super.super.init = stdin_sd_init;
 

--- a/modules/affile/stdout.c
+++ b/modules/affile/stdout.c
@@ -59,7 +59,7 @@ stdout_dd_new(GlobalConfig *cfg)
 {
   LogTemplate *filename_template = log_template_new(cfg, NULL);
 
-  log_template_compile_literal_string(filename_template, "-");
+  log_template_compile_literal_string(filename_template, "/dev/stdout");
   AFFileDestDriver *self = affile_dd_new_instance(filename_template, cfg);
 
   self->writer_options.stats_source = stats_register_type("stdout");


### PR DESCRIPTION
Backport of [557](https://github.com/axoflow/axosyslog/pull/557) by @OverOrion