### PR TITLE
Fix wildcard file regression

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -153,6 +153,7 @@ pkginclude_HEADERS			+= \
 	lib/ml-batched-timer.h		\
 	lib/msg-format.h		\
 	lib/msg-stats.h			\
+	lib/notified-fd-events.h		\
 	lib/on-error.h			\
 	lib/parse-number.h		\
 	lib/pathutils.h         \

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -41,6 +41,7 @@
 #define NC_REOPEN_REQUIRED  6
 #define NC_FILE_DELETED     7
 #define NC_FILE_MODIFIED    8
+#define NC_AGAIN            9
 
 /* notify result mask values */
 #define NR_OK          0x0000

--- a/lib/logpipe.h
+++ b/lib/logpipe.h
@@ -33,14 +33,14 @@
 #include "messages.h"
 
 /* notify code values */
-#define NC_CLOSE       1
-#define NC_READ_ERROR  2
-#define NC_WRITE_ERROR 3
-#define NC_FILE_MOVED  4
-#define NC_FILE_EOF    5
-#define NC_REOPEN_REQUIRED 6
-#define NC_FILE_DELETED 7
-#define NC_FILE_MODIFIED 8
+#define NC_CLOSE            1
+#define NC_READ_ERROR       2
+#define NC_WRITE_ERROR      3
+#define NC_FILE_MOVED       4
+#define NC_FILE_EOF         5
+#define NC_REOPEN_REQUIRED  6
+#define NC_FILE_DELETED     7
+#define NC_FILE_MODIFIED    8
 
 /* notify result mask values */
 #define NR_OK          0x0000

--- a/lib/logproto/logproto-text-server.c
+++ b/lib/logproto/logproto-text-server.c
@@ -30,13 +30,12 @@ LogProtoPrepareAction
 log_proto_text_server_poll_prepare_method(LogProtoServer *s, GIOCondition *cond, gint *timeout)
 {
   LogProtoTextServer *self = (LogProtoTextServer *) s;
-  gboolean avail;
 
   LogProtoPrepareAction action = log_proto_buffered_server_poll_prepare(s, cond, timeout);
   if (action != LPPA_POLL_IO)
     return action;
 
-  avail = (self->cached_eol_pos != 0);
+  gboolean avail = (self->cached_eol_pos != 0);
   return avail ? LPPA_FORCE_SCHEDULE_FETCH : LPPA_POLL_IO;
 }
 

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -30,7 +30,7 @@
 #include "str-format.h"
 
 static void log_reader_io_handle_in(gpointer s);
-static gboolean log_reader_fetch_log(LogReader *self);
+static gint log_reader_fetch_log(LogReader *self);
 static void log_reader_update_watches(LogReader *self);
 
 /*****************************************************************************

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -557,7 +557,15 @@ log_reader_fetch_log(LogReader *self)
   log_transport_aux_data_init(aux);
   if (self->handshake_in_progress)
     {
-      return log_reader_process_handshake(self);
+      gint result = log_reader_process_handshake(self);
+      /* TODO: usage of can_fetch_after_handshake might not needed at all here, just wanted to keep the original flow
+       *       to be surely backward compatible, my bet is that every successfull handshake can be followed by an
+       *       immediate fetch normally */
+      if (FALSE == self->can_fetch_after_handshake || result != 0 || self->handshake_in_progress)
+        {
+          log_transport_aux_data_destroy(aux);
+          return result;
+        }
     }
 
   /* NOTE: this loop is here to decrease the load on the main loop, we try

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -398,7 +398,7 @@ log_reader_work_finished(void *s, gpointer arg)
       g_mutex_unlock(&self->pending_close_lock);
     }
 
-  if (self->notify_code)
+  if (self->notify_code && self->notify_code != NC_AGAIN)
     {
       gint notify_code = self->notify_code;
 
@@ -424,6 +424,11 @@ log_reader_work_finished(void *s, gpointer arg)
         }
       log_proto_server_reset_error(self->proto);
       log_reader_update_watches(self);
+
+      if (self->notify_code == NC_AGAIN && poll_events_system_notified(self->poll_events))
+        {
+          log_reader_force_check_in_next_poll(self);
+        }
     }
 }
 
@@ -572,12 +577,19 @@ log_reader_fetch_log(LogReader *self)
    * to fetch a couple of messages in a single run (but only up to
    * fetch_limit).
    */
-  while (msg_count < self->options->fetch_limit && !main_loop_worker_job_quit())
+  gint result = 0;
+  while (!main_loop_worker_job_quit())
     {
       Bookmark *bookmark;
       const guchar *msg;
       gsize msg_len;
       LogProtoStatus status;
+
+      if (msg_count >= self->options->fetch_limit)
+        {
+          result = NC_AGAIN;
+          break;
+        }
 
       msg = NULL;
 
@@ -625,7 +637,7 @@ log_reader_fetch_log(LogReader *self)
     }
   log_transport_aux_data_destroy(aux);
 
-  return 0;
+  return result;
 }
 
 static void

--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -552,14 +552,11 @@ log_reader_handle_line(LogReader *self, const guchar *line, gint length, LogTran
 static gint
 log_reader_fetch_log(LogReader *self)
 {
-  gint msg_count = 0;
-  gboolean may_read = TRUE;
   LogTransportAuxData aux_storage, *aux = &aux_storage;
-
   if ((self->options->flags & LR_IGNORE_AUX_DATA))
     aux = NULL;
-
   log_transport_aux_data_init(aux);
+
   if (self->handshake_in_progress)
     {
       gint result = log_reader_process_handshake(self);
@@ -577,31 +574,28 @@ log_reader_fetch_log(LogReader *self)
    * to fetch a couple of messages in a single run (but only up to
    * fetch_limit).
    */
+  gint msg_count = 0;
+  gboolean may_read = TRUE;
   gint result = 0;
   while (!main_loop_worker_job_quit())
     {
-      Bookmark *bookmark;
-      const guchar *msg;
-      gsize msg_len;
-      LogProtoStatus status;
-
       if (msg_count >= self->options->fetch_limit)
         {
           result = NC_AGAIN;
           break;
         }
 
-      msg = NULL;
+      log_transport_aux_data_reinit(aux);
+      Bookmark *bookmark = ack_tracker_request_bookmark(self->super.ack_tracker);
+      const guchar *msg = NULL;
+      gsize msg_len;
 
       /* NOTE: may_read is used to implement multi-read checking. It
        * is initialized to TRUE to indicate that the protocol is
        * allowed to issue a read(). If multi-read is disallowed in the
        * protocol, it resets may_read to FALSE after the first read was issued.
        */
-
-      log_transport_aux_data_reinit(aux);
-      bookmark = ack_tracker_request_bookmark(self->super.ack_tracker);
-      status = log_proto_server_fetch(self->proto, &msg, &msg_len, &may_read, aux, bookmark);
+      LogProtoStatus status = log_proto_server_fetch(self->proto, &msg, &msg_len, &may_read, aux, bookmark);
       switch (status)
         {
         case LPS_EOF:

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -71,10 +71,6 @@ struct _LogReader
   StatsAggregator *max_message_size;
   StatsAggregator *average_messages_size;
   StatsAggregator *CPS;
-
-  /* NOTE: these used to be LogReaderWatch members, which were merged into
-   * LogReader with the multi-thread refactorization */
-
   struct iv_task restart_task;
   struct iv_event schedule_wakeup;
   MainLoopIOWorkerJob io_job;

--- a/lib/logreader.h
+++ b/lib/logreader.h
@@ -62,7 +62,6 @@ struct _LogReader
 {
   LogSource super;
   LogProtoServer *proto;
-  gboolean handshake_in_progress;
   LogPipe *control;
   LogReaderOptions *options;
   PollEvents *poll_events;
@@ -74,7 +73,11 @@ struct _LogReader
   struct iv_task restart_task;
   struct iv_event schedule_wakeup;
   MainLoopIOWorkerJob io_job;
-  guint watches_running:1, suspended:1, realloc_window_after_fetch:1;
+  guint watches_running:1,
+        suspended:1,
+        realloc_window_after_fetch:1,
+        handshake_in_progress:1,
+        can_fetch_after_handshake:1;
   gint notify_code;
 
   /* proto & poll_events pending to be applied. As long as the previous

--- a/lib/notified-fd-events.h
+++ b/lib/notified-fd-events.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2002-2013 Balabit
- * Copyright (c) 1998-2013 Balázs Scheidler
+ * Copyright (c) 2025 One Identity LLC.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -21,18 +20,29 @@
  * COPYING for details.
  *
  */
-#ifndef POLL_FD_EVENTS_H_INCLUDED
-#define POLL_FD_EVENTS_H_INCLUDED
+#ifndef NOTIFIED_FD_EVENTS_H_INCLUDED
+#define NOTIFIED_FD_EVENTS_H_INCLUDED
 
-#include "poll-events.h"
-#include <iv.h>
+#include "poll-fd-events.h"
 
-typedef struct _PollFdEvents
+static inline void
+notified_fd_events_update_watches(PollEvents *s, GIOCondition cond)
 {
-  PollEvents super;
-  struct iv_fd fd_watch;
-} PollFdEvents;
+  poll_events_check_watches(s);
+}
 
-PollEvents *poll_fd_events_new(gint fd);
+static inline PollEvents *
+notified_fd_events_new(gint fd)
+{
+  PollFdEvents *self = (PollFdEvents *) poll_fd_events_new(fd);
+
+  self->super.type = PET_NOTIFIED;
+  self->super.start_watches = NULL;
+  self->super.stop_watches = NULL;
+  self->super.suspend_watches = NULL;
+  self->super.update_watches = notified_fd_events_update_watches;
+
+  return &self->super;
+}
 
 #endif

--- a/lib/notified-fd-events.h
+++ b/lib/notified-fd-events.h
@@ -36,7 +36,7 @@ notified_fd_events_new(gint fd)
 {
   PollFdEvents *self = (PollFdEvents *) poll_fd_events_new(fd);
 
-  self->super.type = PET_NOTIFIED;
+  self->super.type = FM_INOTIFY;
   self->super.start_watches = NULL;
   self->super.stop_watches = NULL;
   self->super.suspend_watches = NULL;

--- a/lib/poll-events.h
+++ b/lib/poll-events.h
@@ -28,7 +28,7 @@
 
 typedef enum
 {
-  FM_AUTO,
+  FM_LEGACY,
   FM_POLL,
   FM_SYSTEM_POLL,
   FM_INOTIFY,

--- a/lib/poll-events.h
+++ b/lib/poll-events.h
@@ -26,17 +26,23 @@
 
 #include "syslog-ng.h"
 
-#define PET_SYLOG_NG  0x0001
-#define PET_SYSTEM    0x0002
-#define PET_NOTIFIED  0x0003
+typedef enum
+{
+  FM_AUTO,
+  FM_POLL,
+  FM_SYSTEM_POLL,
+  FM_INOTIFY,
+  FM_UNKNOWN
+} FollowMethod;
 
 typedef struct _PollEvents PollEvents;
 typedef void (*PollCallback)(gpointer user_data);
 typedef gboolean (*PollChecker)(PollEvents *self, gpointer user_data);
 
+/* TODO: Poll is just a legacy word here, rename to sg. more appropriate (e.g. FollowEvents) */
 struct _PollEvents
 {
-  gint32 type;
+  FollowMethod type;
   PollCallback callback;
   gpointer callback_data;
   gpointer checker_data;
@@ -61,13 +67,13 @@ poll_events_get_fd(PollEvents *self)
 static inline gboolean
 poll_events_system_polled(PollEvents *self)
 {
-  return self->type == PET_SYSTEM;
+  return self->type == FM_SYSTEM_POLL;
 }
 
 static inline gboolean
 poll_events_system_notified(PollEvents *self)
 {
-  return self->type == PET_NOTIFIED;
+  return self->type == FM_INOTIFY;
 }
 
 static inline void

--- a/lib/poll-events.h
+++ b/lib/poll-events.h
@@ -26,13 +26,17 @@
 
 #include "syslog-ng.h"
 
+#define PET_SYLOG_NG  0x0001
+#define PET_SYSTEM    0x0002
+#define PET_NOTIFIED  0x0003
+
 typedef struct _PollEvents PollEvents;
 typedef void (*PollCallback)(gpointer user_data);
 typedef gboolean (*PollChecker)(PollEvents *self, gpointer user_data);
 
 struct _PollEvents
 {
-  gboolean system_polled;
+  gint32 type;
   PollCallback callback;
   gpointer callback_data;
   gpointer checker_data;
@@ -57,7 +61,13 @@ poll_events_get_fd(PollEvents *self)
 static inline gboolean
 poll_events_system_polled(PollEvents *self)
 {
-  return self->system_polled;
+  return self->type == PET_SYSTEM;
+}
+
+static inline gboolean
+poll_events_system_notified(PollEvents *self)
+{
+  return self->type == PET_NOTIFIED;
 }
 
 static inline void

--- a/lib/poll-fd-events.c
+++ b/lib/poll-fd-events.c
@@ -23,14 +23,6 @@
  */
 #include "poll-fd-events.h"
 
-#include <iv.h>
-
-typedef struct _PollFdEvents
-{
-  PollEvents super;
-  struct iv_fd fd_watch;
-} PollFdEvents;
-
 #define IV_FD_CALLBACK(x) ((void (*)(void *)) (x))
 
 static inline gint
@@ -105,19 +97,6 @@ poll_fd_events_new(gint fd)
   IV_FD_INIT(&self->fd_watch);
   self->fd_watch.fd = fd;
   self->fd_watch.cookie = self;
-
-  return &self->super;
-}
-
-PollEvents *
-notified_fd_events_new(gint fd)
-{
-  PollFdEvents *self = (PollFdEvents *)poll_fd_events_new(fd);
-
-  self->super.type = PET_NOTIFIED;
-  self->super.start_watches = NULL;
-  self->super.stop_watches = NULL;
-  self->super.suspend_watches = NULL;
 
   return &self->super;
 }

--- a/lib/poll-fd-events.c
+++ b/lib/poll-fd-events.c
@@ -29,7 +29,6 @@ typedef struct _PollFdEvents
 {
   PollEvents super;
   struct iv_fd fd_watch;
-  gboolean notified;
 } PollFdEvents;
 
 #define IV_FD_CALLBACK(x) ((void (*)(void *)) (x))
@@ -76,7 +75,7 @@ poll_fd_events_update_watches(PollEvents *s, GIOCondition cond)
 
   poll_events_suspend_watches(s);
 
-  if (poll_events_check_watches(s) && FALSE == self->notified)
+  if (poll_events_check_watches(s) && FALSE == poll_events_system_notified(s))
     {
       if (cond & G_IO_IN)
         iv_fd_set_handler_in(&self->fd_watch, IV_FD_CALLBACK(poll_events_invoke_callback));
@@ -100,9 +99,8 @@ poll_fd_events_new(gint fd)
   self->super.stop_watches = poll_fd_events_stop_watches;
   self->super.update_watches = poll_fd_events_update_watches;
   self->super.suspend_watches = poll_fd_events_suspend_watches;
-  self->super.system_polled = TRUE;
+  self->super.type = PET_SYSTEM;
   self->super.get_fd = _get_fd;
-  self->notified = FALSE;
 
   IV_FD_INIT(&self->fd_watch);
   self->fd_watch.fd = fd;
@@ -116,7 +114,7 @@ notified_fd_events_new(gint fd)
 {
   PollFdEvents *self = (PollFdEvents *)poll_fd_events_new(fd);
 
-  self->notified = TRUE;
+  self->super.type = PET_NOTIFIED;
   self->super.start_watches = NULL;
   self->super.stop_watches = NULL;
   self->super.suspend_watches = NULL;

--- a/lib/poll-fd-events.c
+++ b/lib/poll-fd-events.c
@@ -91,7 +91,7 @@ poll_fd_events_new(gint fd)
   self->super.stop_watches = poll_fd_events_stop_watches;
   self->super.update_watches = poll_fd_events_update_watches;
   self->super.suspend_watches = poll_fd_events_suspend_watches;
-  self->super.type = PET_SYSTEM;
+  self->super.type = FM_SYSTEM_POLL;
   self->super.get_fd = _get_fd;
 
   IV_FD_INIT(&self->fd_watch);

--- a/modules/affile/CMakeLists.txt
+++ b/modules/affile/CMakeLists.txt
@@ -1,4 +1,4 @@
-set (AFFILE_SOURCES
+set(AFFILE_SOURCES
   "affile-dest.h"
   "affile-dest-internal-queue-filter.h"
   "affile-parser.h"
@@ -10,6 +10,7 @@ set (AFFILE_SOURCES
   "directory-monitor-poll.h"
   "file-opener.h"
   "file-reader.h"
+  "file-monitor-factory.h"
   "file-specializations.h"
   "logproto-file-reader.h"
   "logproto-file-writer.h"
@@ -31,6 +32,7 @@ set (AFFILE_SOURCES
   "directory-monitor-factory.c"
   "directory-monitor-content-comparator.c"
   "directory-monitor-poll.c"
+  "file-monitor-factory.c"
   "file-opener.c"
   "file-reader.c"
   "linux-kmsg.c"

--- a/modules/affile/Makefile.am
+++ b/modules/affile/Makefile.am
@@ -12,6 +12,8 @@ modules_affile_libaffile_la_SOURCES	=			\
 	modules/affile/transport-prockmsg.h			\
 	modules/affile/file-reader.c				\
 	modules/affile/file-reader.h				\
+	modules/affile/file-monitor-factory.h			\
+	modules/affile/file-monitor-factory.c			\
 	modules/affile/wildcard-file-reader.c		\
 	modules/affile/wildcard-file-reader.h		\
 	modules/affile/wildcard-source.h			\

--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -107,89 +107,89 @@ affile_grammar_set_wildcard_file_source_driver(WildcardSourceDriver *sd)
 %token KW_STDIN
 %token KW_STDOUT
 
-%type	<ptr> source_affile
-%type	<ptr> source_affile_params
-%type	<ptr> source_afpipe_params
-%type	<ptr> source_stdin_params
-%type   <ptr> dest_affile
-%type	<ptr> dest_affile_params
-%type   <ptr> dest_afpipe_params
-%type   <ptr> dest_stdout_params
+%type  <ptr> source_affile
+%type  <ptr> source_affile_params
+%type  <ptr> source_afpipe_params
+%type  <ptr> source_stdin_params
+%type  <ptr> dest_affile
+%type  <ptr> dest_affile_params
+%type  <ptr> dest_afpipe_params
+%type  <ptr> dest_stdout_params
 
 %%
 
 start
-        : LL_CONTEXT_SOURCE source_affile                        { YYACCEPT; }
-	| LL_CONTEXT_DESTINATION dest_affile			 { YYACCEPT; }
-        ;
+  : LL_CONTEXT_SOURCE source_affile { YYACCEPT; }
+  | LL_CONTEXT_DESTINATION dest_affile { YYACCEPT; }
+  ;
 
 source_affile
-	: KW_FILE '(' _inner_src_context_push source_affile_params _inner_src_context_pop ')'	{ $$ = $4; }
-	| KW_PIPE '(' _inner_src_context_push source_afpipe_params _inner_src_context_pop ')'	{ $$ = $4; }
-	| KW_STDIN '(' _inner_src_context_push source_stdin_params _inner_src_context_pop ')'	{ $$ = $4; }
-	| KW_WILDCARD_FILE
-	{
-	  WildcardSourceDriver *sd = (WildcardSourceDriver *) wildcard_sd_new(configuration);;
-	  *instance = &sd->super.super;
-	  affile_grammar_set_wildcard_file_source_driver(sd);
-	} '(' _inner_src_context_push source_wildcard_params _inner_src_context_pop ')' { $$ = last_driver; }
-	;
+  : KW_FILE '(' _inner_src_context_push source_affile_params _inner_src_context_pop ')'  { $$ = $4; }
+  | KW_PIPE '(' _inner_src_context_push source_afpipe_params _inner_src_context_pop ')'  { $$ = $4; }
+  | KW_STDIN '(' _inner_src_context_push source_stdin_params _inner_src_context_pop ')'  { $$ = $4; }
+  | KW_WILDCARD_FILE
+  {
+    WildcardSourceDriver *sd = (WildcardSourceDriver *) wildcard_sd_new(configuration);;
+    *instance = &sd->super.super;
+    affile_grammar_set_wildcard_file_source_driver(sd);
+  } '(' _inner_src_context_push source_wildcard_params _inner_src_context_pop ')' { $$ = last_driver; }
+  ;
 
 source_wildcard_params
-    : source_wildcard_options
-    ;
+  : source_wildcard_options
+  ;
 
 source_wildcard_options
-    : source_wildcard_option source_wildcard_options
-    |
-    ;
+  : source_wildcard_option source_wildcard_options
+  |
+  ;
 
 source_stdin_params
-	:
-	  {
-	    AFFileSourceDriver *sd = (AFFileSourceDriver *) stdin_sd_new(configuration);
-	    *instance = &sd->super.super;
-	    affile_grammar_set_file_source_driver(sd);
-	  }
-          source_affile_options                 { $$ = last_driver; }
-	;
+  :
+    {
+      AFFileSourceDriver *sd = (AFFileSourceDriver *) stdin_sd_new(configuration);
+      *instance = &sd->super.super;
+      affile_grammar_set_file_source_driver(sd);
+    }
+    source_affile_options { $$ = last_driver; }
+  ;
 
 source_affile_params
-	: string
-	  {
-	    if (!affile_is_legacy_wildcard_source($1))
-	      {
-	        AFFileSourceDriver *sd = (AFFileSourceDriver *) affile_sd_new($1, configuration);
-	        *instance = &sd->super.super;
-	        affile_grammar_set_file_source_driver(sd);
-	      }
-	    else
-	      {
-	        WildcardSourceDriver *sd = (WildcardSourceDriver *) wildcard_sd_legacy_new($1, configuration);
-	        last_legacy_wildcard_src_driver = sd;
-	        *instance = &sd->super.super;
-	        affile_grammar_set_wildcard_file_source_driver(sd);
-	      }
-	  }
-          source_affile_options                 { $$ = last_driver; last_legacy_wildcard_src_driver = NULL; free($1); }
-        ;
+  : string
+    {
+      if (!affile_is_legacy_wildcard_source($1))
+        {
+          AFFileSourceDriver *sd = (AFFileSourceDriver *) affile_sd_new($1, configuration);
+          *instance = &sd->super.super;
+          affile_grammar_set_file_source_driver(sd);
+        }
+      else
+        {
+          WildcardSourceDriver *sd = (WildcardSourceDriver *) wildcard_sd_legacy_new($1, configuration);
+          last_legacy_wildcard_src_driver = sd;
+          *instance = &sd->super.super;
+          affile_grammar_set_wildcard_file_source_driver(sd);
+        }
+    }
+    source_affile_options { $$ = last_driver; last_legacy_wildcard_src_driver = NULL; free($1); }
+  ;
 
 source_affile_options
-        : source_affile_option source_affile_options
-        | source_legacy_wildcard_option source_affile_options
-        |
-        ;
+  : source_affile_option source_affile_options
+  | source_legacy_wildcard_option source_affile_options
+  |
+  ;
 
 source_affile_option
-	: KW_FOLLOW_FREQ '(' nonnegative_float ')' { file_reader_options_set_follow_freq(last_file_reader_options, (gint) ($3 * 1000)); }
-	| KW_FOLLOW_METHOD '(' string ')' { CHECK_ERROR(file_reader_options_set_follow_method(last_file_reader_options, $3), @3, "Invalid follow-method"); free($3); }
-	| KW_PAD_SIZE '(' nonnegative_integer ')' { last_log_proto_options->pad_size = $3; }
-	| multi_line_option
-	| multi_line_timeout
-	| file_perm_option
-        | source_reader_option
-	| source_driver_option
-        ;
+  : KW_FOLLOW_FREQ '(' nonnegative_float ')' { file_reader_options_set_follow_freq(last_file_reader_options, (gint) ($3 * 1000)); }
+  | KW_FOLLOW_METHOD '(' string ')' { CHECK_ERROR(file_reader_options_set_follow_method(last_file_reader_options, $3), @3, "Invalid follow-method"); free($3); }
+  | KW_PAD_SIZE '(' nonnegative_integer ')' { last_log_proto_options->pad_size = $3; }
+  | multi_line_option
+  | multi_line_timeout
+  | file_perm_option
+  | source_reader_option
+  | source_driver_option
+  ;
 
 source_wildcard_option
   : KW_BASE_DIR '(' string ')' { wildcard_sd_set_base_dir(last_driver, $3); free($3); }
@@ -198,135 +198,136 @@ source_wildcard_option
       wildcard_sd_set_filename_pattern(last_driver, $3);
       free($3);
     }
-	| KW_RECURSIVE '(' yesno ')' { wildcard_sd_set_recursive(last_driver, $3); }
-	| KW_MAX_FILES '(' positive_integer ')' { wildcard_sd_set_max_files(last_driver, $3); }
-	| KW_MONITOR_METHOD '(' string ')' { CHECK_ERROR(wildcard_sd_set_monitor_method(last_driver, $3), @3, "Invalid monitor-method"); free($3); }
-	| KW_MONITOR_FREQ '(' nonnegative_float ')' { wildcard_sd_set_monitor_freq(last_driver, (gint) ($3 * 1000)); }
-	| source_affile_option
-	;
+  | KW_RECURSIVE '(' yesno ')' { wildcard_sd_set_recursive(last_driver, $3); }
+  | KW_MAX_FILES '(' positive_integer ')' { wildcard_sd_set_max_files(last_driver, $3); }
+  | KW_MONITOR_METHOD '(' string ')' { CHECK_ERROR(wildcard_sd_set_monitor_method(last_driver, $3), @3, "Invalid monitor-method"); free($3); }
+  | KW_MONITOR_FREQ '(' nonnegative_float ')' { wildcard_sd_set_monitor_freq(last_driver, (gint) ($3 * 1000)); }
+  | source_affile_option
+  ;
 
 source_legacy_wildcard_option
-	: KW_FORCE_DIRECTORY_POLLING '(' yesno ')'
-	  {
-	    CHECK_ERROR(last_legacy_wildcard_src_driver, @1, "Invalid option, force-directory-polling() can only be used in legacy wildcard file sources");
-	    wildcard_sd_set_monitor_method(&last_legacy_wildcard_src_driver->super.super, $3 ? "poll" : "auto");
-	  }
-	| KW_RECURSIVE '(' yesno ')'
-	  {
-	    CHECK_ERROR(last_legacy_wildcard_src_driver, @1, "Invalid option, recursive() can only be used in legacy wildcard file sources");
-	    wildcard_sd_set_recursive(&last_legacy_wildcard_src_driver->super.super, $3);
-	  }
-	;
+  : KW_FORCE_DIRECTORY_POLLING '(' yesno ')'
+    {
+      CHECK_ERROR(last_legacy_wildcard_src_driver, @1, "Invalid option, force-directory-polling() can only be used in legacy wildcard file sources");
+      wildcard_sd_set_monitor_method(&last_legacy_wildcard_src_driver->super.super, $3 ? "poll" : "auto");
+    }
+  | KW_RECURSIVE '(' yesno ')'
+    {
+      CHECK_ERROR(last_legacy_wildcard_src_driver, @1, "Invalid option, recursive() can only be used in legacy wildcard file sources");
+      wildcard_sd_set_recursive(&last_legacy_wildcard_src_driver->super.super, $3);
+    }
+  ;
 
 source_afpipe_params
-	: string
-	  {
-	    AFFileSourceDriver *sd = (AFFileSourceDriver *) pipe_sd_new($1, configuration);
-	    *instance = &sd->super.super;
-	    affile_grammar_set_file_source_driver(sd);
-	  }
-	  source_afpipe_options				{ $$ = last_driver; free($1); }
-	;
+  : string
+    {
+      AFFileSourceDriver *sd = (AFFileSourceDriver *) pipe_sd_new($1, configuration);
+      *instance = &sd->super.super;
+      affile_grammar_set_file_source_driver(sd);
+    }
+    source_afpipe_options { $$ = last_driver; free($1); }
+  ;
 
 source_afpipe_options
-        : source_afpipe_option source_afpipe_options
-        |
-        ;
+  : source_afpipe_option source_afpipe_options
+  |
+  ;
 
 source_afpipe_option
-	: KW_OPTIONAL '(' yesno ')'			{ last_driver->optional = $3; }
-	| KW_PAD_SIZE '(' nonnegative_integer ')'	{ last_log_proto_options->pad_size = $3; }
-	| KW_CREATE_DIRS '(' yesno ')'			{ pipe_sd_set_create_dirs(last_driver, $3); }
-	| multi_line_option
-	| file_perm_option
-	| source_reader_option
-	| source_driver_option
-	;
+  : KW_OPTIONAL '(' yesno ')' { last_driver->optional = $3; }
+  | KW_PAD_SIZE '(' nonnegative_integer ')'  { last_log_proto_options->pad_size = $3; }
+  | KW_CREATE_DIRS '(' yesno ')' { pipe_sd_set_create_dirs(last_driver, $3); }
+  | multi_line_option
+  | file_perm_option
+  | source_reader_option
+  | source_driver_option
+  ;
 
 multi_line_timeout
-	: KW_MULTI_LINE_TIMEOUT '(' nonnegative_float ')'
-	  {
-		file_reader_options_set_multi_line_timeout(last_file_reader_options, (gint) ($3 * 1000));
-	  }
-	;
+  : KW_MULTI_LINE_TIMEOUT '(' nonnegative_float ')'
+    {
+    file_reader_options_set_multi_line_timeout(last_file_reader_options, (gint) ($3 * 1000));
+    }
+  ;
 
 dest_affile
-	: KW_FILE '(' _inner_dest_context_push dest_affile_params _inner_dest_context_pop ')'	{ $$ = $4; }
-	| KW_PIPE '(' _inner_dest_context_push dest_afpipe_params _inner_dest_context_pop ')'   { $$ = $4; }
-	| KW_STDOUT '(' _inner_dest_context_push dest_stdout_params _inner_dest_context_pop ')'	{ $$ = $4; }
-	;
+  : KW_FILE '(' _inner_dest_context_push dest_affile_params _inner_dest_context_pop ')'  { $$ = $4; }
+  | KW_PIPE '(' _inner_dest_context_push dest_afpipe_params _inner_dest_context_pop ')' { $$ = $4; }
+  | KW_STDOUT '(' _inner_dest_context_push dest_stdout_params _inner_dest_context_pop ')'  { $$ = $4; }
+  ;
 
 dest_affile_params
-	: template_content
-	  {
-	    last_driver = *instance = affile_dd_new($1, configuration);
-	    last_writer_options = &((AFFileDestDriver *) last_driver)->writer_options;
-	    last_file_perm_options = &((AFFileDestDriver *) last_driver)->file_opener_options.file_perm_options;
-	  }
-	  dest_affile_options                           { $$ = last_driver; }
-	;
+  : template_content
+    {
+      last_driver = *instance = affile_dd_new($1, configuration);
+      last_writer_options = &((AFFileDestDriver *) last_driver)->writer_options;
+      last_file_perm_options = &((AFFileDestDriver *) last_driver)->file_opener_options.file_perm_options;
+    }
+    dest_affile_options { $$ = last_driver; }
+  ;
 
 dest_affile_options
-	: dest_affile_option dest_affile_options
-        |
-	;
+  : dest_affile_option dest_affile_options
+  |
+  ;
 
 dest_affile_option
-	: dest_writer_option
-	| dest_driver_option
-        | file_perm_option
-	| KW_OPTIONAL '(' yesno ')'		{ last_driver->optional = $3; }
-	| KW_OVERWRITE_IF_OLDER '(' nonnegative_integer ')'	{ affile_dd_set_overwrite_if_older(last_driver, $3); }
-	| KW_SYMLINK_AS '(' string ')'		{ affile_dd_set_symlink_as(last_driver, $3); }
-	| KW_FSYNC '(' yesno ')'		{ affile_dd_set_fsync(last_driver, $3); }
-        | dest_affile_common_option
-	;
+  : dest_writer_option
+  | dest_driver_option
+  | file_perm_option
+  | KW_OPTIONAL '(' yesno ')' { last_driver->optional = $3; }
+  | KW_OVERWRITE_IF_OLDER '(' nonnegative_integer ')'  { affile_dd_set_overwrite_if_older(last_driver, $3); }
+  | KW_SYMLINK_AS '(' string ')' { affile_dd_set_symlink_as(last_driver, $3); }
+  | KW_FSYNC '(' yesno ')' { affile_dd_set_fsync(last_driver, $3); }
+  | dest_affile_common_option
+  ;
 
 dest_afpipe_params
-	: template_content
-	  {
-	    last_driver = *instance = pipe_dd_new($1, configuration);
-	    last_writer_options = &((AFFileDestDriver *) last_driver)->writer_options;
-	    last_file_perm_options = &((AFFileDestDriver *) last_driver)->file_opener_options.file_perm_options;
-	  }
-	  dest_afpipe_options                   { $$ = last_driver; }
-	;
+  : template_content
+    {
+      last_driver = *instance = pipe_dd_new($1, configuration);
+      last_writer_options = &((AFFileDestDriver *) last_driver)->writer_options;
+      last_file_perm_options = &((AFFileDestDriver *) last_driver)->file_opener_options.file_perm_options;
+    }
+    dest_afpipe_options { $$ = last_driver; }
+  ;
 
 dest_afpipe_options
-	: dest_afpipe_option dest_afpipe_options
-	|
-	;
+  : dest_afpipe_option dest_afpipe_options
+  |
+  ;
 
 dest_afpipe_option
-	: dest_writer_option
-	| dest_driver_option
-	| file_perm_option
-        | dest_affile_common_option
-	;
+  : dest_writer_option
+  | dest_driver_option
+  | file_perm_option
+  | dest_affile_common_option
+  ;
 
 dest_affile_common_option
-	: KW_TIME_REAP '(' nonnegative_integer ')'		{ affile_dd_set_time_reap(last_driver, $3); }
-	| KW_CREATE_DIRS '(' yesno ')'		{ affile_dd_set_create_dirs(last_driver, $3); }
-        ;
+  : KW_TIME_REAP '(' nonnegative_integer ')' { affile_dd_set_time_reap(last_driver, $3); }
+  | KW_CREATE_DIRS '(' yesno ')' { affile_dd_set_create_dirs(last_driver, $3); }
+  ;
 
 dest_stdout_params
-	:
-          {
-            last_driver = *instance = stdout_dd_new(configuration);
-            last_writer_options = &((AFFileDestDriver *) last_driver)->writer_options;
-            last_file_perm_options = &((AFFileDestDriver *) last_driver)->file_opener_options.file_perm_options;
-          } dest_stdout_options
-	;
+  :
+    {
+      last_driver = *instance = stdout_dd_new(configuration);
+      last_writer_options = &((AFFileDestDriver *) last_driver)->writer_options;
+      last_file_perm_options = &((AFFileDestDriver *) last_driver)->file_opener_options.file_perm_options;
+    }
+    dest_stdout_options
+  ;
 
 dest_stdout_options
-        : dest_stdout_option dest_stdout_options
-        |
-        ;
+  : dest_stdout_option dest_stdout_options
+  |
+  ;
 
 dest_stdout_option
-	: dest_writer_option
-	| dest_driver_option
-        ;
+  : dest_writer_option
+  | dest_driver_option
+  ;
 
 /* INCLUDE_RULES */
 

--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -89,6 +89,7 @@ affile_grammar_set_wildcard_file_source_driver(WildcardSourceDriver *sd)
 
 %token KW_FSYNC
 %token KW_FOLLOW_FREQ
+%token KW_FOLLOW_METHOD
 %token KW_MONITOR_FREQ
 %token KW_OVERWRITE_IF_OLDER
 %token KW_SYMLINK_AS
@@ -181,6 +182,7 @@ source_affile_options
 
 source_affile_option
 	: KW_FOLLOW_FREQ '(' nonnegative_float ')' { file_reader_options_set_follow_freq(last_file_reader_options, (gint) ($3 * 1000)); }
+	| KW_FOLLOW_METHOD '(' string ')' { CHECK_ERROR(file_reader_options_set_follow_method(last_file_reader_options, $3), @3, "Invalid follow-method"); free($3); }
 	| KW_PAD_SIZE '(' nonnegative_integer ')' { last_log_proto_options->pad_size = $3; }
 	| multi_line_option
 	| multi_line_timeout

--- a/modules/affile/affile-parser.c
+++ b/modules/affile/affile-parser.c
@@ -50,6 +50,7 @@ static CfgLexerKeyword affile_keywords[] =
   { "overwrite_if_older", KW_OVERWRITE_IF_OLDER },
   { "symlink_as",         KW_SYMLINK_AS },
   { "follow_freq",        KW_FOLLOW_FREQ },
+  { "follow_method",      KW_FOLLOW_METHOD },
   { "monitor_freq",       KW_MONITOR_FREQ },
   { "multi_line_timeout", KW_MULTI_LINE_TIMEOUT },
   { "time_reap",          KW_TIME_REAP },

--- a/modules/affile/file-monitor-factory.c
+++ b/modules/affile/file-monitor-factory.c
@@ -32,9 +32,9 @@
 FollowMethod
 file_monitor_factory_follow_method_from_string(const gchar *method)
 {
-  if (strcmp(method, "auto") == 0)
+  if (strcmp(method, "legacy") == 0)
     {
-      return FM_AUTO;
+      return FM_LEGACY;
     }
   else if (strcmp(method, "poll") == 0)
     {

--- a/modules/affile/file-monitor-factory.c
+++ b/modules/affile/file-monitor-factory.c
@@ -54,7 +54,7 @@ file_monitor_factory_follow_method_from_string(const gchar *method)
 }
 
 PollEvents *
-create_file_monitor(FileReader *self, FollowMethod file_follow_mode, gint fd)
+create_file_monitor_events(FileReader *self, FollowMethod file_follow_mode, gint fd)
 {
   PollEvents *poll_events = NULL;
 
@@ -79,6 +79,7 @@ create_file_monitor(FileReader *self, FollowMethod file_follow_mode, gint fd)
       break;
 
     default:
+      g_assert_not_reached();
       break;
     }
   return poll_events;

--- a/modules/affile/file-monitor-factory.c
+++ b/modules/affile/file-monitor-factory.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025 One Identity
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "file-monitor-factory.h"
+#include "poll-fd-events.h"
+
+#include <string.h>
+#include <stdio.h>
+
+FollowMethod
+file_monitor_factory_follow_method_from_string(const gchar *method)
+{
+  if (strcmp(method, "auto") == 0)
+    {
+      return FM_AUTO;
+    }
+  else if (strcmp(method, "poll") == 0)
+    {
+      return FM_POLL;
+    }
+  else if (strcmp(method, "system") == 0)
+    {
+      return FM_SYSTEM_POLL;
+    }
+#if SYSLOG_NG_HAVE_INOTIFY
+  else if (strcmp(method, "inotify") == 0)
+    {
+      return FM_INOTIFY;
+    }
+#endif
+  return FM_UNKNOWN;
+}

--- a/modules/affile/file-monitor-factory.h
+++ b/modules/affile/file-monitor-factory.h
@@ -26,4 +26,6 @@
 
 FollowMethod file_monitor_factory_follow_method_from_string(const gchar *method_name);
 
+PollEvents *create_file_monitor(FileReader *self, FollowMethod poll_event_type, gint fd);
+
 #endif /* MODULES_AFFILE_FILE_MONITOR_FACTORY_H_ */

--- a/modules/affile/file-monitor-factory.h
+++ b/modules/affile/file-monitor-factory.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 One Identity
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#ifndef MODULES_AFFILE_FILE_MONITOR_FACTORY_H_
+#define MODULES_AFFILE_FILE_MONITOR_FACTORY_H_
+
+#include "file-reader.h"
+
+FollowMethod file_monitor_factory_follow_method_from_string(const gchar *method_name);
+
+#endif /* MODULES_AFFILE_FILE_MONITOR_FACTORY_H_ */

--- a/modules/affile/file-monitor-factory.h
+++ b/modules/affile/file-monitor-factory.h
@@ -26,6 +26,6 @@
 
 FollowMethod file_monitor_factory_follow_method_from_string(const gchar *method_name);
 
-PollEvents *create_file_monitor(FileReader *self, FollowMethod poll_event_type, gint fd);
+PollEvents *create_file_monitor_events(FileReader *self, FollowMethod poll_event_type, gint fd);
 
 #endif /* MODULES_AFFILE_FILE_MONITOR_FACTORY_H_ */

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -235,8 +235,8 @@ _reader_check_watches(PollEvents *poll_events, gpointer user_data)
   return check_again;
 }
 
-static gboolean
-_is_fd_pollable(gint fd)
+gboolean
+iv_can_poll_fd(gint fd)
 {
   struct iv_fd check_fd;
   gboolean pollable;
@@ -273,7 +273,7 @@ _construct_poll_events(FileReader *self, gint fd)
       msg_debug("File follow-mode is inotify from directory-monitor");
     }
 #endif
-  else if (fd >= 0 && _is_fd_pollable(fd))
+  else if (fd >= 0 && iv_can_poll_fd(fd))
     {
       poll_events = poll_fd_events_new(fd);
       msg_debug("File follow-mode is ivykis poll", evt_tag_str("poll_method", iv_poll_method_name()));

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -541,10 +541,10 @@ file_reader_cue_buffer_flush(FileReader *self)
 }
 
 void
-file_reader_init_instance (FileReader *self, const gchar *filename,
-                           FileReaderOptions *options, FileOpener *opener,
-                           LogSrcDriver *owner, GlobalConfig *cfg,
-                           const gchar *persist_name_prefix)
+file_reader_init_instance(FileReader *self, const gchar *filename,
+                          FileReaderOptions *options, FileOpener *opener,
+                          LogSrcDriver *owner, GlobalConfig *cfg,
+                          const gchar *persist_name_prefix)
 {
   log_pipe_init_instance (&self->super, cfg);
   self->super.init = file_reader_init_method;
@@ -568,7 +568,7 @@ file_reader_new(const gchar *filename, FileReaderOptions *options, FileOpener *o
 {
   FileReader *self = g_new0(FileReader, 1);
 
-  file_reader_init_instance (self, filename, options, opener, owner, cfg, "affile_sd");
+  file_reader_init_instance(self, filename, options, opener, owner, cfg, "affile_sd");
   return self;
 }
 

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -427,7 +427,7 @@ _reader_open_file(LogPipe *s, gboolean recover_state)
   FileReader *self = (FileReader *) s;
   GlobalConfig *cfg = log_pipe_get_config(s);
 
-  gint fd;
+  gint fd = -1;
   FileOpenerResult res = file_opener_open_fd(self->opener, self->filename->str, AFFILE_DIR_READ, &fd);
   gboolean file_opened = (res == FILE_OPENER_RESULT_SUCCESS);
   g_assert(file_opened || fd == -1);

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -30,6 +30,7 @@
 #include "transport/transport-pipe.h"
 #include "transport-prockmsg.h"
 #include "logproto/logproto-buffered-server.h"
+#include "notified-fd-events.h"
 #include "poll-fd-events.h"
 #include "poll-file-changes.h"
 #include "poll-multiline-file-changes.h"

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -431,7 +431,7 @@ _on_file_deleted(FileReader *self)
    * NOTE: Do not try to close the reader directly from here, as there might already be
    *       an io-operation in progress!
    */
-  if (poll_events_system_polled(self->reader->poll_events))
+  if (poll_events_system_polled(self->reader->poll_events) || poll_events_system_notified(self->reader->poll_events))
     log_reader_trigger_one_check(self->reader);
 }
 

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -266,11 +266,13 @@ _construct_poll_events(FileReader *self, gint fd)
                                                       self->options->multi_line_timeout, self);
       msg_debug("File follow-mode is syslog-ng poll");
     }
+#if SYSLOG_NG_HAVE_INOTIFY
   else if (fd >= 0 && FALSE == self->should_poll_for_events)
     {
       poll_events = notified_fd_events_new(fd);
       msg_debug("File follow-mode is inotify from directory-monitor");
     }
+#endif
   else if (fd >= 0 && _is_fd_pollable(fd))
     {
       poll_events = poll_fd_events_new(fd);

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -435,6 +435,12 @@ _on_file_deleted(FileReader *self)
     log_reader_trigger_one_check(self->reader);
 }
 
+static inline void
+_on_file_modified(FileReader *self)
+{
+  log_reader_trigger_one_check(self->reader);
+}
+
 static void
 _on_read_error(FileReader *self)
 {
@@ -468,7 +474,7 @@ file_reader_notify_method(LogPipe *s, gint notify_code, gpointer user_data)
 
     case NC_FILE_MODIFIED:
       /* This is a notification from the directory monitor, we can read the file for changes */
-      log_reader_trigger_one_check(self->reader);
+      _on_file_modified(self);
       break;
 
     default:

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -225,6 +225,12 @@ _reader_check_watches(PollEvents *poll_events, gpointer user_data)
                 evt_tag_int("fn", fd));
       check_again = _reader_on_eof(self);
     }
+  else
+    {
+      if (poll_events_system_notified(poll_events))
+        log_reader_trigger_one_check(self->reader);
+    }
+
   return check_again;
 }
 

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -324,6 +324,7 @@ _setup_logreader(LogPipe *s, PollEvents *poll_events, LogProtoServer *proto)
   FileReader *self = (FileReader *) s;
 
   self->reader = log_reader_new(log_pipe_get_config(s));
+  self->reader->can_fetch_after_handshake = TRUE;
   log_pipe_set_options(&self->reader->super.super, &self->super.options);
   log_reader_open(self->reader, proto, poll_events);
 

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -257,7 +257,7 @@ _get_file_follow_mode(FileReader *self, gint fd)
       msg_debug("File follow-mode is syslog-ng poll");
     }
 #if SYSLOG_NG_HAVE_INOTIFY
-  else if (fd >= 0 && FALSE == self->should_poll_for_events)
+  else if (fd >= 0 && self->monitor_can_notify_file_changes)
     {
       file_follow_mode = FM_INOTIFY;
       msg_debug("File follow-mode is inotify from directory-monitor");
@@ -575,7 +575,7 @@ file_reader_init_instance(FileReader *self, const gchar *filename,
   self->filename = g_string_new (filename);
   self->options = options;
   self->opener = opener;
-  self->should_poll_for_events = TRUE;
+  self->monitor_can_notify_file_changes = FALSE;
   self->owner = owner;
   self->super.expr_node = owner->super.super.expr_node;
 }

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -283,7 +283,7 @@ _get_file_follow_mode(FileReader *self, gint fd)
 static PollEvents *
 _construct_file_monitor(FileReader *self, FollowMethod file_follow_mode, gint fd)
 {
-  PollEvents *poll_events = create_file_monitor(self, file_follow_mode, fd);
+  PollEvents *poll_events = create_file_monitor_events(self, file_follow_mode, fd);
 
   if (poll_events && _can_check_eof(self, fd))
     poll_events_set_checker(poll_events, _reader_check_watches, self);

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -472,7 +472,6 @@ _reader_open_file(LogPipe *s, gboolean recover_state)
       return self->owner->super.optional;
     }
   return TRUE;
-
 }
 
 static void
@@ -674,7 +673,6 @@ file_reader_options_set_follow_method(FileReaderOptions *options, const gchar *f
     }
   options->follow_method = new_method;
   return TRUE;
-
 }
 
 void

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -625,6 +625,7 @@ file_reader_options_defaults(FileReaderOptions *options)
   log_proto_file_reader_options_defaults(file_reader_options_get_log_proto_options(options));
   options->reader_options.parse_options.flags |= LP_LOCAL;
   options->restore_state = FALSE;
+  options->follow_method = FM_LEGACY;
 }
 
 static gboolean

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -594,6 +594,22 @@ file_reader_options_set_follow_freq(FileReaderOptions *options, gint follow_freq
   options->follow_freq = follow_freq;
 }
 
+gboolean
+file_reader_options_set_follow_method(FileReaderOptions *options, const gchar *follow_method)
+{
+  FollowMethod new_method = file_monitor_factory_follow_method_from_string(follow_method);
+
+  if (new_method == FM_UNKNOWN)
+    {
+      msg_error("file-reader(): Invalid value for follow-method()",
+                evt_tag_str("follow-method", follow_method));
+      return FALSE;
+    }
+  options->follow_method = new_method;
+  return TRUE;
+
+}
+
 void
 file_reader_options_set_multi_line_timeout(FileReaderOptions *options, gint multi_line_timeout)
 {

--- a/modules/affile/file-reader.c
+++ b/modules/affile/file-reader.c
@@ -272,7 +272,7 @@ static gboolean is_system_poll_options(FileReaderOptions *options, gboolean can_
 }
 
 static FollowMethod
-_get_file_follow_mode(FileReader *self, gint fd)
+_get_effective_file_follow_mode(FileReader *self, gint fd)
 {
   FollowMethod file_follow_mode = FM_UNKNOWN;
 
@@ -432,7 +432,7 @@ _reader_open_file(LogPipe *s, gboolean recover_state)
   gboolean file_opened = (res == FILE_OPENER_RESULT_SUCCESS);
   g_assert(file_opened || fd == -1);
 
-  FollowMethod file_follow_mode = _get_file_follow_mode(self, fd);
+  FollowMethod file_follow_mode = _get_effective_file_follow_mode(self, fd);
   if (!_validate_file_follow_mode(self, file_follow_mode, fd))
     {
       close(fd);

--- a/modules/affile/file-reader.h
+++ b/modules/affile/file-reader.h
@@ -46,7 +46,7 @@ struct _FileReader
   LogReader *reader;
   const gchar *persist_name;
   const gchar *persist_name_prefix;
-  gboolean should_poll_for_events;
+  gboolean monitor_can_notify_file_changes;
 
   void (*on_file_moved)(FileReader *);
 };

--- a/modules/affile/file-reader.h
+++ b/modules/affile/file-reader.h
@@ -29,6 +29,7 @@
 typedef struct _FileReaderOptions
 {
   gint follow_freq;
+  FollowMethod follow_method;
   gint multi_line_timeout;
   gboolean restore_state;
   LogReaderOptions reader_options;
@@ -73,6 +74,7 @@ void file_reader_stop_follow_file(FileReader *self);
 void file_reader_cue_buffer_flush(FileReader *self);
 
 void file_reader_options_set_follow_freq(FileReaderOptions *options, gint follow_freq);
+gboolean file_reader_options_set_follow_method(FileReaderOptions *options, const gchar *follow_method);
 void file_reader_options_set_multi_line_timeout(FileReaderOptions *options, gint multi_line_timeout);
 
 void file_reader_options_defaults(FileReaderOptions *options);

--- a/modules/affile/file-reader.h
+++ b/modules/affile/file-reader.h
@@ -73,6 +73,8 @@ void file_reader_remove_persist_state(FileReader *self);
 void file_reader_stop_follow_file(FileReader *self);
 void file_reader_cue_buffer_flush(FileReader *self);
 
+gboolean iv_can_poll_fd(gint fd);
+
 void file_reader_options_set_follow_freq(FileReaderOptions *options, gint follow_freq);
 gboolean file_reader_options_set_follow_method(FileReaderOptions *options, const gchar *follow_method);
 void file_reader_options_set_multi_line_timeout(FileReaderOptions *options, gint multi_line_timeout);

--- a/modules/affile/poll-file-changes.c
+++ b/modules/affile/poll-file-changes.c
@@ -220,7 +220,7 @@ poll_file_changes_init_instance(PollFileChanges *self, gint fd, const gchar *fol
 {
   self->super.stop_watches = poll_file_changes_stop_watches;
   self->super.update_watches = poll_file_changes_update_watches;
-  self->super.system_polled = FALSE;
+  self->super.type = PET_SYLOG_NG;
   self->super.get_fd = _get_fd;
   self->super.free_fn = poll_file_changes_free;
 

--- a/modules/affile/poll-file-changes.c
+++ b/modules/affile/poll-file-changes.c
@@ -220,7 +220,7 @@ poll_file_changes_init_instance(PollFileChanges *self, gint fd, const gchar *fol
 {
   self->super.stop_watches = poll_file_changes_stop_watches;
   self->super.update_watches = poll_file_changes_update_watches;
-  self->super.type = PET_SYLOG_NG;
+  self->super.type = FM_POLL;
   self->super.get_fd = _get_fd;
   self->super.free_fn = poll_file_changes_free;
 

--- a/modules/affile/tests/test_wildcard_file_reader.c
+++ b/modules/affile/tests/test_wildcard_file_reader.c
@@ -121,7 +121,7 @@ _init(void)
   app_startup();
   configuration = cfg_new_snippet();
   test_event = test_deleted_file_state_event_new();
-  reader = (WildcardFileReader *)wildcard_file_reader_new(TEST_FILE_NAME, NULL, NULL, NULL, configuration, TRUE);
+  reader = (WildcardFileReader *)wildcard_file_reader_new(TEST_FILE_NAME, NULL, NULL, NULL, configuration, FALSE);
   wildcard_file_reader_on_deleted_file_eof(reader, _eof, test_event);
   cr_assert_eq(log_pipe_init(&reader->super.super), TRUE);
 }

--- a/modules/affile/wildcard-file-reader.c
+++ b/modules/affile/wildcard-file-reader.c
@@ -159,7 +159,7 @@ wildcard_file_reader_is_deleted(WildcardFileReader *self)
 
 WildcardFileReader *
 wildcard_file_reader_new(const gchar *filename, FileReaderOptions *options, FileOpener *opener, LogSrcDriver *owner,
-                         GlobalConfig *cfg, gboolean should_poll_for_events)
+                         GlobalConfig *cfg, gboolean monitor_can_notify_file_changes)
 {
   WildcardFileReader *self = g_new0(WildcardFileReader, 1);
   file_reader_init_instance(&self->super, filename, options, opener, owner, cfg, "wildcard_file_sd");
@@ -170,6 +170,6 @@ wildcard_file_reader_new(const gchar *filename, FileReaderOptions *options, File
   IV_TASK_INIT(&self->file_state_event_handler);
   self->file_state_event_handler.cookie = self;
   self->file_state_event_handler.handler = _handle_file_state_event;
-  self->super.should_poll_for_events = should_poll_for_events;
+  self->super.monitor_can_notify_file_changes = monitor_can_notify_file_changes;
   return self;
 }

--- a/modules/affile/wildcard-file-reader.h
+++ b/modules/affile/wildcard-file-reader.h
@@ -55,7 +55,7 @@ struct _WildcardFileReader
 WildcardFileReader *
 wildcard_file_reader_new(const gchar *filename, FileReaderOptions *options,
                          FileOpener *opener, LogSrcDriver *owner,
-                         GlobalConfig *cfg, gboolean should_poll_for_events);
+                         GlobalConfig *cfg, gboolean monitor_can_notify_file_changes);
 
 void wildcard_file_reader_on_deleted_file_eof(WildcardFileReader *self, FileStateEventCallback cb, gpointer user_data);
 gboolean wildcard_file_reader_is_deleted(WildcardFileReader *self);

--- a/modules/affile/wildcard-source.c
+++ b/modules/affile/wildcard-source.c
@@ -191,13 +191,13 @@ _handle_directory_created(WildcardSourceDriver *self, const DirectoryMonitorEven
 void
 _handle_file_deleted(WildcardSourceDriver *self, const DirectoryMonitorEvent *event)
 {
-  FileReader *reader = g_hash_table_lookup(self->file_readers, event->full_path);
+  WildcardFileReader *reader = g_hash_table_lookup(self->file_readers, event->full_path);
 
   if (reader)
     {
       msg_debug("wildcard-file(): Monitored file was deleted, reading it to the end",
                 evt_tag_str("filename", event->full_path));
-      log_pipe_notify(&reader->super, NC_FILE_DELETED, NULL);
+      log_pipe_notify(&reader->super.super, NC_FILE_DELETED, NULL);
     }
 
   if (pending_file_list_remove(self->waiting_list, event->full_path))
@@ -227,10 +227,10 @@ _handler_directory_deleted(WildcardSourceDriver *self, const DirectoryMonitorEve
 static void
 _handler_file_modified(WildcardSourceDriver *self, const DirectoryMonitorEvent *event)
 {
-  FileReader *reader = g_hash_table_lookup(self->file_readers, event->full_path);
+  WildcardFileReader *reader = g_hash_table_lookup(self->file_readers, event->full_path);
 
   if (reader)
-    log_pipe_notify(&reader->super, NC_FILE_MODIFIED, NULL);
+    log_pipe_notify(&reader->super.super, NC_FILE_MODIFIED, NULL);
 }
 
 static void

--- a/modules/affile/wildcard-source.c
+++ b/modules/affile/wildcard-source.c
@@ -134,6 +134,8 @@ _create_file_reader(WildcardSourceDriver *self, const gchar *full_path)
   else
     {
       g_hash_table_insert(self->file_readers, g_strdup(full_path), reader);
+      msg_debug("wildcard-file(): file created, start tailing",
+                evt_tag_str("filename", full_path));
     }
 }
 
@@ -147,8 +149,6 @@ _handle_file_created(WildcardSourceDriver *self, const DirectoryMonitorEvent *ev
       if (!reader)
         {
           _create_file_reader(self, event->full_path);
-          msg_debug("wildcard-file(): file created, start tailing",
-                    evt_tag_str("filename", event->full_path));
         }
       else
         {

--- a/modules/affile/wildcard-source.c
+++ b/modules/affile/wildcard-source.c
@@ -113,13 +113,12 @@ _create_file_reader(WildcardSourceDriver *self, const gchar *full_path)
   gchar *base_dir = g_path_get_dirname(full_path);
   DirectoryMonitor *monitor = g_hash_table_lookup(self->directory_monitors, base_dir);
   g_free(base_dir);
-  gboolean file_reader_should_poll_for_events = (FALSE == monitor->can_notify_file_changes);
   WildcardFileReader *reader = wildcard_file_reader_new(full_path,
                                                         &self->file_reader_options,
                                                         self->file_opener,
                                                         &self->super,
                                                         cfg,
-                                                        file_reader_should_poll_for_events);
+                                                        monitor->can_notify_file_changes);
   wildcard_file_reader_on_deleted_file_eof(reader, _remove_and_readd_file_reader, self);
 
   log_pipe_set_options(&reader->super.super, &self->super.super.super.options);

--- a/news/feature-5338.md
+++ b/news/feature-5338.md
@@ -1,0 +1,9 @@
+`file()`, `wildcard-file()`: Added `follow-method()` option.
+
+|Accepted values:| legacy \| inotify \| poll \| system |
+
+This option controls how syslog-ng will follow file changes.\
+The default `legacy` mode preserves the pre-4.9 version file follow-mode behavior of syslog-ng, which is based on the value of follow-freq().\
+The `poll` value forces syslog-ng to poll for file changes at the interval specified by the monitor-freq() option, even if a more efficient method (such as `inotify` or `kqueue`) is available.\
+If `inotify` is selected and supported by the platform, syslog-ng uses it to detect changes in source files. This is the most efficient and least resource-consuming option available on Linux for regular files.\
+The `system` value will use system poll methods (via ivykis) like `port-timer` `port` `dev_poll` `epoll-timerfd` `epoll` `kqueue` `ppoll` `poll` and `uring`. For more information about how to control the system polling methods used, see [How content changes are followed in file() and wildcard-file() sources](https://syslog-ng.github.io/admin-guide/060_Sources/020_File/001_File_following).


### PR DESCRIPTION
This PR 

- fixes issues of the new inotify-driven `file()` and `wildcard-file()` monitoring, even though inotify sends file change notifications correctly, but not fully processed changes (e.g. when there are more changes than a fetch cycle (fetch-limit) can handle) will not be notified again till there are no new changes that could lead to delayed or lost change processing
- adds `follow-method()` option to `file()` and `wildcard-file()` sources

Doc PR: https://github.com/syslog-ng/syslog-ng.github.io/pull/192

Signed-off-by: Hofi hofione@gmail.com