### PR TITLE
dev-requirements: remove logilab dep for old drone.io

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,6 @@ pycodestyle
 isort
 pylint
 astroid
-logilab-common<=0.63.0
 prometheus-client
 psutil
 pytest


### PR DESCRIPTION
Removes the no longer needed python 2 dep (logilib-common)
