### PR TITLE
github: draft-release action target master branch when creating a release

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -109,7 +109,8 @@ jobs:
             "${{ needs.create-release-tarball.outputs.TARBALL_NAME }}" \
             --draft \
             --title "${{ needs.create-release-tarball.outputs.RELEASE_NAME }}" \
-            --notes-file "NEWS.md"
+            --notes-file "NEWS.md" \
+            --target master
 
   comment-workflow-result:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Otherwise, it'd use the default branch, which now develop