### PR TITLE
python-modules/webhook: fix issue when stopping the server on rhel9

### DIFF
--- a/modules/python-modules/syslogng/modules/webhook/source.py
+++ b/modules/python-modules/syslogng/modules/webhook/source.py
@@ -1,5 +1,6 @@
 #############################################################################
 # Copyright (c) 2024 László Várady
+# Copyright (c) 2025 One Identity LLC.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 as published
@@ -133,7 +134,11 @@ class HTTPSource(LogSource):
 
         self.suspended = threading.Event()
         self.event_loop = asyncio.new_event_loop()
-        self.request_exit = asyncio.Event()
+        self.request_exit = None
+
+        async def init_request_exit():
+            self.request_exit = asyncio.Event()
+        self.event_loop.run_until_complete(init_request_exit())
 
         handlers = list(map(lambda p: (p, Handler, {"source": self}), self.paths))
         if len(handlers) == 0:

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -252,7 +252,8 @@ modules/ebpf/.*
 modules/python-modules/syslogng/modules/hypr/.*
 modules/python-modules/syslogng/modules/example/.*
 modules/python-modules/syslogng/modules/s3/.*
-modules/python-modules/syslogng/modules/webhook/.*
+modules/python-modules/syslogng/modules/webhook/scl/*
+modules/python-modules/syslogng/modules/webhook/__init__.py
 modules/python-modules/setup\.py
 scripts/build-python-venv\.sh
 modules/syslogformat/sdata-parser\.[ch]
@@ -323,6 +324,7 @@ modules/http/http\.[ch]
 modules/http/http-parser.c
 modules/http/http-grammar.ym
 modules/correlation/group-lines.c
+modules/python-modules/syslogng/modules/webhook/source.py
 docker/Dockerfile
 docker/entrypoint.sh
 Doxyfile


### PR DESCRIPTION
In python 3.9 the event must be created inside the event loop that will await on it or else the await will fail