### PR TITLE
webhook: add missing copyright header

### DIFF
--- a/modules/python-modules/syslogng/modules/webhook/source.py
+++ b/modules/python-modules/syslogng/modules/webhook/source.py
@@ -1,4 +1,5 @@
 #############################################################################
+# Copyright (c) 2024-2025 Axoflow
 # Copyright (c) 2024 László Várady
 # Copyright (c) 2025 One Identity LLC.
 #

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -252,7 +252,7 @@ modules/ebpf/.*
 modules/python-modules/syslogng/modules/hypr/.*
 modules/python-modules/syslogng/modules/example/.*
 modules/python-modules/syslogng/modules/s3/.*
-modules/python-modules/syslogng/modules/webhook/scl/*
+modules/python-modules/syslogng/modules/webhook/scl/.*
 modules/python-modules/syslogng/modules/webhook/__init__.py
 modules/python-modules/setup\.py
 scripts/build-python-venv\.sh


### PR DESCRIPTION
>webhook: add missing copyright header
>>The feature was developed by me during working hours, on behalf of
Axoflow.

Backport of [630](https://github.com/axoflow/axosyslog/pull/630) by @MrAnno 
