### PR TITLE
get-github-actions-status: verbose reporting of API errors.

### DIFF
--- a/contrib/get-github-actions-status.py
+++ b/contrib/get-github-actions-status.py
@@ -13,8 +13,9 @@ def get_workflow_runs(workflow, branch='develop'):
     try:
         with urllib.request.urlopen(request) as response:
             binary_response = response.read()
-    except urllib.error.HTTPError:
+    except urllib.error.HTTPError as err:
         print('"' + workflow + '" is not a valid workflow. See .github/workflows/')
+        print("Response was: %s: %s" % (err.code, err.reason))
         sys.exit(1)
 
     runs = json.loads(binary_response.decode())["workflow_runs"]


### PR DESCRIPTION
report the proper response in case a call to the GitHub API failed.