### PR TITLE
freebsd-audit-source: add the source scl

### DIFF
--- a/news/feature-5383.md
+++ b/news/feature-5383.md
@@ -1,0 +1,3 @@
+`freebsd-audit()`: added a simple source SCL to collect FreeBSD audit logs using the built-in praudit program
+
+https://www.syslog-ng.com/community/b/blog/posts/freebsd-audit-source-for-syslog-ng

--- a/scl/CMakeLists.txt
+++ b/scl/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SCL_DIRS
     discord
     elasticsearch
     ewmm
+    freebsd-audit
     fortigate
     google
     graphite

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -12,6 +12,7 @@ SCL_SUBDIRS	= \
 	elasticsearch	\
 	ewmm		\
 	fortigate	\
+	freebsd-audit	\
 	google	\
 	graphite	\
 	graylog2	\

--- a/scl/freebsd-audit/plugin.conf
+++ b/scl/freebsd-audit/plugin.conf
@@ -1,0 +1,31 @@
+#############################################################################
+# Copyright (c) 2025 One Identity LLC.
+# Copyright (c) 2025 Peter Czanik
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+@define def-praudit-params " -p -l -x"
+
+block source freebsd-audit(params("`def-praudit-params`")) {
+  program(
+    "tail -F /var/audit/current | praudit `params`"
+    flags(no-parse)
+  );
+};


### PR DESCRIPTION
`freebsd-audit()`: added a simple source SCL to collect FreeBSD audit logs using the built-in praudit program
 
https://www.syslog-ng.com/community/b/blog/posts/freebsd-audit-source-for-syslog-ng

Resolves https://github.com/syslog-ng/syslog-ng/issues/5373
Related https://github.com/syslog-ng/syslog-ng/discussions/5150
