### PR TITLE
lib/compat: fix warning in test_strtok_r

### DIFF
--- a/lib/compat/tests/test_strtok_r.c
+++ b/lib/compat/tests/test_strtok_r.c
@@ -64,7 +64,7 @@ assert_if_tokenizer_concatenated_result_not_match(STRTOK_R_FUN tokenizer,
                                                   const char *expected)
 {
   gchar *token;
-  gchar *saveptr;
+  gchar *saveptr = NULL;
   gchar *result = (char *)g_malloc(strlen(input)+1);
   gchar *raw_string;
   gchar *result_ref = NULL;


### PR DESCRIPTION
Backport of [634](https://github.com/axoflow/axosyslog/pull/634) by @bazsi