### PR TITLE
feat(scl/cisco): add support for Cisco Nexus NXOS 9.3 syslog format

### DIFF
--- a/scl/cisco/plugin.conf
+++ b/scl/cisco/plugin.conf
@@ -44,8 +44,12 @@
 #<187>138076: RP/0/RP0/CPU0:Dec 11 12:43:29.227 EST: snmpd[1002]: %SNMP-SNMP-3-AUTH_FAIL : Received snmp request on unknown community from 0.0.0.0
 #<187>3408: CLC 6/0: Dec 11 13:31:14.214 EST: %PKI-3-CERTIFICATE_INVALID_EXPIRED: Certificate chain validation has failed.  The certificate (SN: XXXXXXXX) has expired.    Validity period ended on 2025-01-23T00:00:00Z
 
+# NXOS 9.3 format
+#<187>: 2025 Jun 25 11:27:28 GMT: %AUTHPRIV-3-SYSTEM_MSG: pam_aaa:Authentication failed from 192.168.1.10 - dcos_sshd[23099]
+
 @define cisco-parser-timestamp-pattern '^[\*\.]?([A-Za-z]{3} [0-9 ]\d (\d{4} )?\d{2}:\d{2}:\d{2}(\.\d{3})?( (AM|PM))?)'
 @define cisco-parser-ISO-timestamp-pattern '^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})'
+@define cisco-parser-nxos-timestamp-pattern '^(\d{4} [A-Za-z]{3} [0-9 ]\d \d{2}:\d{2}:\d{2})'
 
 #
 # parses a cisco timestamp with explicit date-parser
@@ -54,7 +58,7 @@
 block parser cisco-timestamp-parser(template()) {
     channel {
         parser {
-            regexp-parser(patterns('`cisco-parser-timestamp-pattern`' '`cisco-parser-ISO-timestamp-pattern`') template(`template`));
+            regexp-parser(patterns('`cisco-parser-timestamp-pattern`' '`cisco-parser-ISO-timestamp-pattern`' '`cisco-parser-nxos-timestamp-pattern`') template(`template`));
         };
         parser {
             date-parser(format('%b %d %I:%M:%S %p.%f',
@@ -63,7 +67,8 @@ block parser cisco-timestamp-parser(template()) {
                                '%b %d %H:%M:%S',
                                '%b %d %Y %H:%M:%S.%f',
                                '%b %d %Y %H:%M:%S',
-                               '%Y-%m-%dT%H:%M:%S')
+                               '%Y-%m-%dT%H:%M:%S',
+                               '%Y %b %d %H:%M:%S')
                         template("$1"));
         };
     };
@@ -105,8 +110,8 @@ block parser cisco-parser(prefix(".cisco.") template("$MSG")) {
         rewrite {
             set('%$2', value("MSG"));
 
-            # drop "seqno: " if present
-            subst("^([0-9]+: )?", "", value('1'));
+            # drop "seqno: " if present, or just ": " (NXOS 9.3 format)
+            subst("^([0-9]+: |: )?", "", value('1'));
 
         };
 
@@ -123,12 +128,12 @@ block parser cisco-parser(prefix(".cisco.") template("$MSG")) {
                 };
             };
             parser { cisco-timestamp-parser(template("$1")); };
-	} elif {
-	    # RP is from ios-xr 7.x NCS5500 and asr9922
+        } elif {
+            # RP is from ios-xr 7.x NCS5500 and asr9922
             # CLC comes from CBR8 running ios-xe 16.x and 17.x
             parser { regexp-parser(
-			patterns("^(?'cpu_module'RP/[0-9]/[^:]+):(.*)",
-                                 "^(?'cpu_module'CLC [0-9]/[0-9]): +(.*)")
+                    patterns("^(?'cpu_module'RP/[0-9]/[^:]+):(.*)",
+                             "^(?'cpu_module'CLC [0-9]/[0-9]): +(.*)")
                         template('$1') prefix("`prefix`"));
             };
             parser { cisco-timestamp-parser(template("$2")); };
@@ -146,4 +151,4 @@ block parser cisco-parser(prefix(".cisco.") template("$MSG")) {
 application cisco[syslog-raw] {
 	filter { message(": %" type(string) flags(substring)); };
 	parser { cisco-parser(); };
-};
+}; 


### PR DESCRIPTION
- Add cisco-parser-nxos-timestamp-pattern for YYYY MMM DD HH:MM:SS timestamps
- Extend date-parser with %Y %b %d %H:%M:%S format
- Update sequence number handling to support both traditional "seqno: " and NXOS ": " prefixes
- Add documentation and example for NXOS 9.3 format

The NXOS 9.3 format differs from traditional IOS by using different
timestamp and ": " prefix instead of "seqno: " after the priority field.

Example: <187>: 2025 Jun 25 11:27:28 GMT: %AUTHPRIV-3-SYSTEM_MSG: message