### PR TITLE
Fix invalid access of freed log-writer cfg

### DIFF
--- a/news/bugfix-5444.md
+++ b/news/bugfix-5444.md
@@ -1,0 +1,1 @@
+afprog: Fix invalid access of freed log-writer cfg.


### PR DESCRIPTION
<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
## Description
Reloading syslog-ng after a config change caused syslog-ng to crash. During the `main_loop_reload_config_apply` the cfg is de-initialized and freed, however in `afprogram_dd_deinit` the log writer is stored `afprogram_dd_store_reload_store_item` before the cfg is freed. The log writer is then restored and the cfg it points to no longer exists. When `log_pipe_init` or `log_pipe_deinit` calls `cfg_tree_register_initialized_pipe` for the log_writer this results in an invalid read, causing a seg fault crashing syslog-ng. 

See here: https://github.com/syslog-ng/syslog-ng/issues/5444

## Implementation
To prevent the crash, when the log-writer is stored before the reload takes place the stored log-writer's pointer to the cfg is released. When the log-writer is restored, the cfg is set to the new cfg.

Alternative fixes were considered, such as always creating a new log-writer on reload. However, as the log-writer is being stored, it must be required that the log-writer be persistent after the reload.

## Testing
This fix was tested by following the reproduction method outlined in https://github.com/syslog-ng/syslog-ng/issues/5444. Observing that valgrind did not detect an invalid read after using `syslog-ng-ctl reload`. No syslog-ng crashes have been observed with this patch applied. 

Fixes: #5444