### PR TITLE
S3: Fix missing upload trigger

### DIFF
--- a/modules/python-modules/syslogng/modules/s3/s3_destination.py
+++ b/modules/python-modules/syslogng/modules/s3/s3_destination.py
@@ -371,6 +371,8 @@ class S3Destination(LogDestination):
                     with self.__indices_lock:
                         last_index = self.__indices.pop(s3_object.object_key)
                         self.__indices[s3_object.object_key] = last_index
+        if not self.s3_object_ready_queue.queue.empty():
+            self.__session_handler.trigger_upload()
 
         self.__start_flush_poll_timer()
 

--- a/news/bugfix-5447.md
+++ b/news/bugfix-5447.md
@@ -1,0 +1,1 @@
+s3: Fixed bug where in certain conditions finished object buffers would fail to upload.


### PR DESCRIPTION


<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->

S3 destination did not trigger uploading files if the number of ready buffers was higher than the maximum parallel uploads.

<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
