### PR TITLE
Disable app armor in package creations

### DIFF
--- a/.github/workflows/create-packages.yml
+++ b/.github/workflows/create-packages.yml
@@ -134,6 +134,10 @@ jobs:
             false
           fi
 
+      # temp workaround of no sudo allowed
+      - name: Disable AppArmor on the GitHub runner
+        uses: cisagov/action-disable-apparmor@437d94f26a2e4bf8c03acfb500a6afc688b497db # v1.0.0
+
       - name: Create package
         working-directory: syslog-ng
         run: |


### PR DESCRIPTION
temp, quick workaround of no more sudo in app armoure protected (now just in arm64, but I guess soon in all) rhel derivated images