### PR TITLE
Add cryptography python package to kira

### DIFF
--- a/dbld/pip_packages.manifest
+++ b/dbld/pip_packages.manifest
@@ -1,5 +1,6 @@
 # pip packages for kira tests
 distro                  [kira]                                                 [python2, python3]
+cryptography            [kira]                                                 [python2]
 hy                      [kira]                                                 [python3]
 hyrule                  [kira]                                                 [python3]
 requests                [kira]                                                 [python2, python3]


### PR DESCRIPTION
This fixes the current kira issue where cryptography is not installed