### PR TITLE
Detect and use either kqueue or inotify, but never both.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,7 +308,6 @@ find_package(OpenSSL REQUIRED)
 find_package(FLEX REQUIRED)
 find_package(Resolv REQUIRED)
 find_package(WRAP)
-find_package(Inotify)
 find_package(LIBCAP)
 find_package(LIBNET)
 
@@ -348,11 +347,15 @@ set (SYSLOG_NG_ENABLE_SYSTEMD ${ENABLE_SYSTEMD})
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
-if (Inotify_FOUND)
-  set(SYSLOG_NG_HAVE_INOTIFY 1)
-endif()
-
+# Use only one of them if both are present, like on FreeBSD, where the inotify wrapper started to be distributed.
+# Prioritize kqueue, as inotify is just a wrapper around it if both are present.
 check_function_exists(kqueue SYSLOG_NG_HAVE_KQUEUE)
+if(NOT SYSLOG_NG_HAVE_KQUEUE)
+  find_package(Inotify)
+  if(Inotify_FOUND)
+    set(SYSLOG_NG_HAVE_INOTIFY 1)
+  endif()
+endif()
 
 set (PYTHON_VERSION "AUTO" CACHE STRING "Version of the installed development library" )
 

--- a/configure.ac
+++ b/configure.ac
@@ -1191,7 +1191,6 @@ AC_CHECK_LIB(regex, regexec, REGEX_LIBS="-lregex")
 AC_CHECK_LIB(resolv, res_init, RESOLV_LIBS="-lresolv")
 
 CHECK_FUNCS_AND_DEFINE([
-    kqueue
     fmemopen
     getutent
     memrchr
@@ -1212,9 +1211,21 @@ CHECK_FUNCS_AND_DEFINE([
     strnlen
     getline
     strtok_r
-    inotify_init
     getrandom
 ])
+dnl Use only one of them if both are present, like on FreeBSD, where the inotify wrapper started to be distributed.
+dnl Prioritize kqueue, as inotify is just a wrapper around it if both are present.
+AC_CHECK_FUNCS([kqueue inotify_init])
+if test "x$ac_cv_func_kqueue" = xyes; then
+  have_kqueue=yes
+  have_inotify=no
+elif test "x$ac_cv_func_inotify_init" = xyes; then
+  have_kqueue=no
+  have_inotify=yes
+else
+  have_kqueue=no
+  have_inotify=no
+fi
 
 dnl You can always use the saved ones - CFLAGS_SAVE CPPFLAGS_SAVE LIBS_SAVE LDFLAGS_SAVE between SAFE_C_CHECK_BEGIN/SAFE_C_CHECK_END if needed
 SAFE_C_CHECK_BEGIN
@@ -2617,8 +2628,8 @@ AC_DEFINE_UNQUOTED(ENABLE_KAFKA, `enable_value $enable_kafka`, [Enable kafka sup
 AC_DEFINE_UNQUOTED(ENABLE_CPP, `enable_value $enable_cpp`, [Enable C++ support])
 AC_DEFINE_UNQUOTED(ENABLE_STACKDUMP, `enable_value $enable_stackdump`, [Enable stackdump using libunwind])
 AC_DEFINE_UNQUOTED(SYSTEMD_JOURNAL_MODE, `journald_mode`, [Systemd-journal support mode])
-AC_DEFINE_UNQUOTED(HAVE_INOTIFY, `enable_value $ac_cv_func_inotify_init`, [Have inotify])
-AC_DEFINE_UNQUOTED(HAVE_KQUEUE, `enable_value $ac_cv_func_kqueue`, [Have kqueue])
+AC_DEFINE_UNQUOTED([HAVE_KQUEUE], [`enable_value $have_kqueue`], [Have kqueue])
+AC_DEFINE_UNQUOTED([HAVE_INOTIFY], [`enable_value $have_inotify`], [Have inotify])
 AC_DEFINE_UNQUOTED(USE_CONST_IVYKIS_MOCK, `enable_value $IVYKIS_VERSION_UPDATED`, [ivykis version is greater than $IVYKIS_UPDATED_VERSION])
 
 dnl WARNING
@@ -2672,8 +2683,8 @@ AM_CONDITIONAL(ENABLE_TESTING, [test "$enable_tests" != "no"])
 AM_CONDITIONAL(ENABLE_EXAMPLE_MODULES, [test "$enable_example_modules" = "yes"])
 AM_CONDITIONAL(ENABLE_SANITIZER, [test "$with_sanitizer" != "no"])
 AM_CONDITIONAL(ENABLE_DEBUG, [test "$enable_debug" != "no"])
-AM_CONDITIONAL([HAVE_INOTIFY], [test x$ac_cv_func_inotify_init = xyes])
-AM_CONDITIONAL([HAVE_KQUEUE], [test x$ac_cv_func_kqueue = xyes])
+AM_CONDITIONAL([HAVE_KQUEUE], [test "x$have_kqueue" = xyes])
+AM_CONDITIONAL([HAVE_INOTIFY], [test "x$have_inotify" = xyes])
 AM_CONDITIONAL([HAVE_GETRANDOM], [test x$ac_cv_func_getrandom = xyes])
 AM_CONDITIONAL([HAVE_FMEMOPEN], [test x$ac_cv_func_fmemopen = xyes])
 AM_CONDITIONAL([HAVE_JAVAH], [test -n "$JAVAH_BIN"])

--- a/modules/affile/CMakeLists.txt
+++ b/modules/affile/CMakeLists.txt
@@ -52,15 +52,17 @@ set(AFFILE_SOURCES
   "logrotate.c"
 )
 
-if(SYSLOG_NG_HAVE_INOTIFY)
+# Use only one of them if both are present, like on FreeBSD, where the inotify wrapper started to be distributed.
+# Prioritize kqueue, as inotify is just a wrapper around it if both are present.
+if(SYSLOG_NG_HAVE_KQUEUE)
+list(APPEND AFFILE_SOURCES
+  "directory-monitor-kqueue.h"
+  "directory-monitor-kqueue.c"
+)
+elseif(SYSLOG_NG_HAVE_INOTIFY)
   list(APPEND AFFILE_SOURCES
     "directory-monitor-inotify.h"
     "directory-monitor-inotify.c"
-  )
-elseif(SYSLOG_NG_HAVE_KQUEUE)
-  list(APPEND AFFILE_SOURCES
-    "directory-monitor-kqueue.h"
-    "directory-monitor-kqueue.c"
   )
 endif ()
 

--- a/modules/affile/Makefile.am
+++ b/modules/affile/Makefile.am
@@ -53,25 +53,24 @@ modules_affile_libaffile_la_SOURCES	=			\
 	modules/affile/logrotate.h \
 	modules/affile/logrotate.c
 
-if HAVE_INOTIFY
-  modules_affile_libaffile_la_SOURCES +=      \
-  modules/affile/directory-monitor-inotify.h  \
-  modules/affile/directory-monitor-inotify.c
-else
-  EXTRA_DIST +=                               \
-  modules/affile/directory-monitor-inotify.h  \
-  modules/affile/directory-monitor-inotify.c
-endif
-
+# Use only one of them if both are present, like on FreeBSD, where the inotify wrapper started to be distributed.
+# Prioritize kqueue, as inotify is just a wrapper around it if both are present.
 if HAVE_KQUEUE
-  modules_affile_libaffile_la_SOURCES +=      \
-  modules/affile/directory-monitor-kqueue.h  \
-  modules/affile/directory-monitor-kqueue.c
+modules_affile_libaffile_la_SOURCES += \
+	modules/affile/directory-monitor-kqueue.h \
+	modules/affile/directory-monitor-kqueue.c
 else
-  EXTRA_DIST +=                               \
-  modules/affile/directory-monitor-kqueue.h  \
-  modules/affile/directory-monitor-kqueue.c
+if HAVE_INOTIFY
+modules_affile_libaffile_la_SOURCES += \
+	modules/affile/directory-monitor-inotify.h \
+	modules/affile/directory-monitor-inotify.c
 endif
+endif
+EXTRA_DIST += \
+	modules/affile/directory-monitor-inotify.h \
+	modules/affile/directory-monitor-inotify.c \
+	modules/affile/directory-monitor-kqueue.h \
+	modules/affile/directory-monitor-kqueue.c
 
 BUILT_SOURCES				+= 			\
 	modules/affile/affile-grammar.y				\


### PR DESCRIPTION
- prefer kqueue always as inotify is just a wrapper around it if both are presented
- like it is implemented in ivykis
- make sure the current logic in our directory and file monitors will not hurt if both are presented (do not change the current source logic)

