### PR TITLE
package-indexer: generate static index.html files

### DIFF
--- a/packaging/package-indexer/Dockerfile
+++ b/packaging/package-indexer/Dockerfile
@@ -6,7 +6,8 @@ RUN apt-get update && apt-get install -y \
   gnupg2 \
   createrepo-c \
   python3-pexpect \
-  rpm
+  rpm \
+  wget
 
 RUN pip install \
   azure-storage-blob \
@@ -14,3 +15,8 @@ RUN pip install \
   azure-identity \
   pyyaml \
   types-PyYAML
+
+# https://github.com/glowinthedark/index-html-generator
+RUN wget -O /usr/local/bin/genindex.py https://raw.githubusercontent.com/glowinthedark/index-html-generator/refs/heads/master/genindex.py || true
+# https://github.com/joshbrunty/Indexer
+RUN wget -O /usr/loca/bin/indexer.py https://raw.githubusercontent.com/joshbrunty/Indexer/refs/heads/main/indexer.py || true


### PR DESCRIPTION
Because the backend doesn't support dynamic index files, we have to generate static index.html's during the indexing process, to make the repositories browsable.

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
