### PR TITLE
further fixes for the static html support for the package indexer

### DIFF
--- a/packaging/package-indexer/remote_storage_synchronizer/azure_container_synchronizer.py
+++ b/packaging/package-indexer/remote_storage_synchronizer/azure_container_synchronizer.py
@@ -219,7 +219,7 @@ class AzureContainerSynchronizer(RemoteStorageSynchronizer):
                 "File differs locally and remotely.",
                 remote_path=str(Path(self.remote_dir.root_dir, relative_file_path)),
                 local_path=str(Path(self.local_dir.root_dir, relative_file_path)),
-                remote_md5sum=remote_md5.hex(),
+                remote_md5sum=remote_md5.hex() if remote_md5 else "N/A",
                 local_md5sum=local_md5.hex(),
             )
             return FileSyncState.DIFFERENT

--- a/packaging/package-indexer/remote_storage_synchronizer/azure_container_synchronizer.py
+++ b/packaging/package-indexer/remote_storage_synchronizer/azure_container_synchronizer.py
@@ -20,11 +20,12 @@
 #
 #############################################################################
 
+import mimetypes
 from hashlib import md5
 from pathlib import Path
 from typing import List, Optional
 
-from azure.storage.blob import BlobClient, ContainerClient
+from azure.storage.blob import BlobClient, ContainerClient, ContentSettings
 
 from .remote_storage_synchronizer import FileSyncState, RemoteStorageSynchronizer
 
@@ -103,15 +104,17 @@ class AzureContainerSynchronizer(RemoteStorageSynchronizer):
 
     def __upload_file(self, relative_file_path: str) -> None:
         local_path = Path(self.local_dir.root_dir, relative_file_path)
-
+        mimetype = mimetypes.guess_type(local_path.name)[0]
+        content_settings = ContentSettings(content_type = mimetype)
         self._log_info(
             "Uploading file.",
             local_path=str(local_path),
             remote_path=relative_file_path,
+            content_type=mimetype,
         )
 
         with local_path.open("rb") as local_file_data:
-            self.__client.upload_blob(relative_file_path, local_file_data, overwrite=True)
+            self.__client.upload_blob(relative_file_path, local_file_data, overwrite=True, content_settings=content_settings)
 
     def __delete_local_file(self, relative_file_path: str) -> None:
         local_file_path = Path(self.local_dir.root_dir, relative_file_path).resolve()


### PR DESCRIPTION
Collection of fixes found during testing:

Set proper content-type for uploaded files.

Container synchronizer handles properly, when the blob's checksum field is empty. 

Container synchronizer sets the proper mtime on the downloaded files, so the static html files contain the proper last modified information too.
