### PR TITLE
modules/python-modules/webhook: Remove signal handling that kills the…

### DIFF
--- a/modules/python-modules/syslogng/modules/webhook/source.py
+++ b/modules/python-modules/syslogng/modules/webhook/source.py
@@ -34,8 +34,6 @@ import signal
 import json
 from typing import Any
 
-signal.signal(signal.SIGINT, signal.SIG_IGN)
-signal.signal(signal.SIGTERM, signal.SIG_IGN)
 WEBHOOK_NV_PREFIX = "webhook."
 WEBHOOK_QUERY_NV_PREFIX = WEBHOOK_NV_PREFIX + "query."
 WEBHOOK_HEADERS_KEY = WEBHOOK_NV_PREFIX + "headers"


### PR DESCRIPTION
This patch removes the signal handling in the webhook code.
With this code the syslog-ng process can no longer handle the SIGTERM and SIGINT signals.

For example when the following config is used:

```
@version: current
@include "scl.conf"
source s_webhook_source {
    file("/tmp/src.txt");
};
destination d_file {
    file("/tmp/dst.txt");
};
log {
    source(s_webhook_source);
    destination(d_file);
    flags(flow-control);
};
```

and syslog-ng is ran by systemd and  `systemctl stop syslog-ng` is requested syslog-ng will ignore the SIGTERM signal all together which will cause systemd to kill the process due to the failed timeout of the shutdown, this patch fixes this