### PR TITLE
Readme: fix ident for MyDestination

### DIFF
--- a/modules/python-modules/README.md
+++ b/modules/python-modules/README.md
@@ -134,7 +134,7 @@ from syslogng import LogDestination
 
 class MyDestination(LogDestination):
     def send(self, msg):
-	return True
+	    return True
 
 ```
 


### PR DESCRIPTION
Python code for function `send` in class `MyDestination` should be nested in `modules/python-modules/README.md`.
