### PR TITLE
lib/cfg: replace low-level SHA256() with OpenSSL EVP interface

### DIFF
--- a/lib/cfg.c
+++ b/lib/cfg.c
@@ -52,6 +52,7 @@
 #include <stdlib.h>
 #include <iv_work.h>
 #include <openssl/sha.h>
+#include <openssl/evp.h>
 
 #define CONFIG_HASH_LENGTH SHA256_DIGEST_LENGTH
 #define CONFIG_HASH_STR_LENGTH (CONFIG_HASH_LENGTH * 2 + 1)
@@ -662,7 +663,13 @@ cfg_format_id(GlobalConfig *self, GString *id)
 static void
 cfg_hash_config(GlobalConfig *self)
 {
-  SHA256((const guchar *) self->preprocess_config->str, self->preprocess_config->len, self->config_hash);
+  EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
+  if (mdctx) {
+    EVP_DigestInit_ex(mdctx, EVP_sha256(), NULL);
+    EVP_DigestUpdate(mdctx, self->preprocess_config->str, self->preprocess_config->len);
+    EVP_DigestFinal_ex(mdctx, self->config_hash, NULL);
+    EVP_MD_CTX_free(mdctx);
+  }
 }
 
 gboolean


### PR DESCRIPTION
### Problem
The current implementation in lib/cfg.c uses the low-level OpenSSL function SHA256() to hash the preprocessed configuration string:
```c
SHA256((const guchar *) self->preprocess_config->str,
       self->preprocess_config->len,
       self->config_hash);
```
These low-level APIs are discouraged in modern OpenSSL and may cause compatibility issues in environments that restrict or deprecate direct use of legacy digest functions.

### Solution
This PR replaces the low-level SHA256() function with the OpenSSL EVP interface, using:
- EVP_MD_CTX_new()
- EVP_DigestInit_ex()
- EVP_DigestUpdate()
- EVP_DigestFinal_ex()
- EVP_MD_CTX_free()

The hashing logic (SHA-256) remains identical, but the EVP interface provides better abstraction, extensibility, and long-term support.

### Benefits
- Avoids deprecated or discouraged OpenSSL APIs.
- Improves compatibility with OpenSSL 3.x and future releases.
- Enhances maintainability and aligns with OpenSSL best practices.
- Keeps behavior identical to the original implementation.

### Code Changes
Updated lib/cfg.c to use the EVP interface for computing SHA-256 in cfg_hash_config().


Fixes: https://github.com/syslog-ng/syslog-ng/issues/5530