### PR TITLE
package-indexer: set mimetype to default

### DIFF
--- a/packaging/package-indexer/remote_storage_synchronizer/azure_container_synchronizer.py
+++ b/packaging/package-indexer/remote_storage_synchronizer/azure_container_synchronizer.py
@@ -110,7 +110,9 @@ class AzureContainerSynchronizer(RemoteStorageSynchronizer):
 
     def __upload_file(self, relative_file_path: str) -> None:
         local_path = Path(self.local_dir.root_dir, relative_file_path)
-        mimetype = str(mimetypes.guess_type(local_path.name)[0])
+        mimetype = mimetypes.guess_type(local_path.name)[0]
+        if mimetype is None:
+            mimetype = "application/octet-stream"
         content_settings = ContentSettings(content_type=mimetype)
         self._log_info(
             "Uploading file.",


### PR DESCRIPTION
 in case mimetypes can't determine the file's mime type, instead of Null

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
