### PR TITLE
WIP: initial Windows compatibility (ivykis, eventlog, compat, build fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ aclocal.m4-e
 modules/java-modules/.gradle
 stm32-tools
 modules/java-modules/reports/problems
+/.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,11 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 project(syslog-ng C)
 
+if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
+    # normalize once → POSIX form for file/grep/sed
+    set(WIN_BUILD)
+endif()
+
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules ${PROJECT_SOURCE_DIR}/cmake/)
 set(CMAKE_POSITION_INDEPENDENT_CODE 1)
 set(BISON_FLAGS "-Wno-other -Werror=conflicts-sr -Werror=conflicts-rr -Wcounterexamples")
@@ -298,6 +303,9 @@ find_package(FLEX REQUIRED)
 find_package(Resolv REQUIRED)
 find_package(WRAP)
 find_package(LIBCAP)
+if (WIN_BUILD)
+  find_package(LIBNET REQUIRED)
+endif()
 
 include(enable_systemd)
 

--- a/cmake/Modules/ExternalIVYKIS.cmake
+++ b/cmake/Modules/ExternalIVYKIS.cmake
@@ -61,7 +61,7 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/lib/ivykis/src/include/iv.h.in)
       rm -rf autom4te.cache
       libtoolize -cfi || true
       autoreconf -fiv
-      ./configure --prefix='${IVY_PREFIX}' CFLAGS='-fPIC ${CMAKE_C_FLAGS} ${INTERNAL_IVYKIS_DEBUG_FLAGS} --disable-shared --enable-static'
+      ./configure --prefix='${IVY_PREFIX}' --disable-shared --enable-static CFLAGS='-fPIC ${CMAKE_C_FLAGS} ${INTERNAL_IVYKIS_DEBUG_FLAGS}'
       ")
     file(WRITE "${IVY_BUILD_SH}"   "set -e\ncd '${IVY_SRC}'\nCFLAGS='-fPIC ${CMAKE_C_FLAGS} ${INTERNAL_IVYKIS_DEBUG_FLAGS}' make -j1 SUBDIRS=src\n")
     file(WRITE "${IVY_INSTALL_SH}" "set -e\ncd '${IVY_SRC}'\nmake SUBDIRS=src install\n")

--- a/cmake/Modules/GenerateYFromYm.cmake
+++ b/cmake/Modules/GenerateYFromYm.cmake
@@ -34,7 +34,7 @@ function(generate_y_from_ym FileWoExt)
         configure_file(${PROJECT_SOURCE_DIR}/${FileWoExt}.ym       ${PROJECT_BINARY_DIR}/${FileWoExt}.clean.ym NEWLINE_STYLE UNIX)
 
         add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/${FileWoExt}.y
-            COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_BINARY_DIR}/lib/merge-grammar.py
+            COMMAND ${PYTHON_LAUNCHER} ${PROJECT_BINARY_DIR}/lib/merge-grammar.py
                     ${PROJECT_BINARY_DIR}/${FileWoExt}.clean.ym > ${PROJECT_BINARY_DIR}/${FileWoExt}.y
             DEPENDS ${PROJECT_BINARY_DIR}/lib/merge-grammar.py
                     ${PROJECT_BINARY_DIR}/lib/cfg-grammar.y
@@ -53,7 +53,7 @@ function(generate_y_from_ym FileWoExt)
         configure_file(${PROJECT_SOURCE_DIR}/${FileWoExt}.ym       ${PROJECT_BINARY_DIR}/${FileWoExt}.clean.ym NEWLINE_STYLE UNIX)
 
         add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/${ARGV1}.y
-            COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_BINARY_DIR}/lib/merge-grammar.py
+            COMMAND ${PYTHON_LAUNCHER} ${PROJECT_BINARY_DIR}/lib/merge-grammar.py
                     ${PROJECT_BINARY_DIR}/${FileWoExt}.clean.ym > ${PROJECT_BINARY_DIR}/${ARGV1}.y
             DEPENDS ${PROJECT_BINARY_DIR}/lib/merge-grammar.py
                     ${PROJECT_BINARY_DIR}/lib/cfg-grammar.y
@@ -85,7 +85,7 @@ function(module_generate_y_from_ym FileWoExtSrc FileWoExtDst)
         configure_file(${FileWoExtSrc}.ym                         ${FileWoExtDst}.clean.ym                   NEWLINE_STYLE UNIX)
 
         add_custom_command(OUTPUT ${FileWoExtDst}.y
-            COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_BINARY_DIR}/lib/merge-grammar.py
+            COMMAND ${PYTHON_LAUNCHER} ${PROJECT_BINARY_DIR}/lib/merge-grammar.py
                     ${FileWoExtDst}.clean.ym > ${FileWoExtDst}.y
             DEPENDS ${PROJECT_BINARY_DIR}/lib/merge-grammar.py
                     ${PROJECT_BINARY_DIR}/lib/cfg-grammar.y

--- a/cmake/Modules/GenerateYFromYm.cmake
+++ b/cmake/Modules/GenerateYFromYm.cmake
@@ -25,15 +25,44 @@
 
 function(generate_y_from_ym FileWoExt)
     if (${ARGC} EQUAL 1)
+      if (WIN32)
+        # clean copies in build/lib
+        file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+        configure_file(${PROJECT_SOURCE_DIR}/lib/merge-grammar.py  ${PROJECT_BINARY_DIR}/lib/merge-grammar.py  NEWLINE_STYLE UNIX)
+        configure_file(${PROJECT_SOURCE_DIR}/lib/cfg-grammar.y     ${PROJECT_BINARY_DIR}/lib/cfg-grammar.y     NEWLINE_STYLE UNIX)
+        configure_file(${PROJECT_SOURCE_DIR}/${FileWoExt}.ym       ${PROJECT_BINARY_DIR}/${FileWoExt}.clean.ym NEWLINE_STYLE UNIX)
+
+        add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/${FileWoExt}.y
+            COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_BINARY_DIR}/lib/merge-grammar.py
+                    ${PROJECT_BINARY_DIR}/${FileWoExt}.clean.ym > ${PROJECT_BINARY_DIR}/${FileWoExt}.y
+            DEPENDS ${PROJECT_BINARY_DIR}/lib/merge-grammar.py
+                    ${PROJECT_BINARY_DIR}/lib/cfg-grammar.y
+                    ${PROJECT_BINARY_DIR}/${FileWoExt}.clean.ym)
+      else()
         add_custom_command (OUTPUT ${PROJECT_BINARY_DIR}/${FileWoExt}.y
             COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/lib/merge-grammar.py ${PROJECT_SOURCE_DIR}/${FileWoExt}.ym > ${PROJECT_BINARY_DIR}/${FileWoExt}.y
             DEPENDS ${PROJECT_SOURCE_DIR}/lib/cfg-grammar.y
                     ${PROJECT_SOURCE_DIR}/${FileWoExt}.ym)
+      endif()
     elseif(${ARGC} EQUAL 2)
+      if (WIN32)
+        file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+        configure_file(${PROJECT_SOURCE_DIR}/lib/merge-grammar.py  ${PROJECT_BINARY_DIR}/lib/merge-grammar.py  NEWLINE_STYLE UNIX)
+        configure_file(${PROJECT_SOURCE_DIR}/lib/cfg-grammar.y     ${PROJECT_BINARY_DIR}/lib/cfg-grammar.y     NEWLINE_STYLE UNIX)
+        configure_file(${PROJECT_SOURCE_DIR}/${FileWoExt}.ym       ${PROJECT_BINARY_DIR}/${FileWoExt}.clean.ym NEWLINE_STYLE UNIX)
+
+        add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/${ARGV1}.y
+            COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_BINARY_DIR}/lib/merge-grammar.py
+                    ${PROJECT_BINARY_DIR}/${FileWoExt}.clean.ym > ${PROJECT_BINARY_DIR}/${ARGV1}.y
+            DEPENDS ${PROJECT_BINARY_DIR}/lib/merge-grammar.py
+                    ${PROJECT_BINARY_DIR}/lib/cfg-grammar.y
+                    ${PROJECT_BINARY_DIR}/${FileWoExt}.clean.ym)
+      else()
         add_custom_command (OUTPUT ${PROJECT_BINARY_DIR}/${ARGV1}.y
             COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/lib/merge-grammar.py ${PROJECT_SOURCE_DIR}/${FileWoExt}.ym > ${PROJECT_BINARY_DIR}/${ARGV1}.y
             DEPENDS ${PROJECT_SOURCE_DIR}/lib/cfg-grammar.y
                     ${PROJECT_SOURCE_DIR}/${FileWoExt}.ym)
+      endif()
     else()
         message(SEND_ERROR "Wrong usage of generate_y_from_ym() function")
     endif()
@@ -48,10 +77,25 @@ function(module_generate_y_from_ym FileWoExtSrc FileWoExtDst)
         set(DEPS ${DEPS} ${ARGV2})
       endif()
 
-      add_custom_command (OUTPUT ${FileWoExtDst}.y
-        COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/lib/merge-grammar.py ${FileWoExtSrc}.ym > ${FileWoExtDst}.y
+      if (WIN32)
+        file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+        configure_file(${PROJECT_SOURCE_DIR}/lib/merge-grammar.py ${PROJECT_BINARY_DIR}/lib/merge-grammar.py NEWLINE_STYLE UNIX)
+        configure_file(${PROJECT_SOURCE_DIR}/lib/cfg-grammar.y    ${PROJECT_BINARY_DIR}/lib/cfg-grammar.y    NEWLINE_STYLE UNIX)
+        configure_file(${FileWoExtSrc}.ym                         ${FileWoExtDst}.clean.ym                   NEWLINE_STYLE UNIX)
+
+        add_custom_command(OUTPUT ${FileWoExtDst}.y
+            COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_BINARY_DIR}/lib/merge-grammar.py
+                    ${FileWoExtDst}.clean.ym > ${FileWoExtDst}.y
+            DEPENDS ${PROJECT_BINARY_DIR}/lib/merge-grammar.py
+                    ${PROJECT_BINARY_DIR}/lib/cfg-grammar.y
+                    ${FileWoExtDst}.clean.ym
+                    ${DEPS})
+      else()
+        add_custom_command (OUTPUT ${FileWoExtDst}.y
+            COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/lib/merge-grammar.py ${FileWoExtSrc}.ym > ${FileWoExtDst}.y
             DEPENDS ${DEPS}
             ${FileWoExtSrc}.ym)
+      endif()
     else()
         message(SEND_ERROR "Wrong usage of module_generate_y_from_ym() function")
     endif()

--- a/cmake/Modules/GenerateYFromYm.cmake
+++ b/cmake/Modules/GenerateYFromYm.cmake
@@ -1,5 +1,6 @@
 #############################################################################
 # Copyright (c) 2016 Balabit
+# Copyright (c) 2025 One Identity
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -398,7 +398,28 @@ set_target_properties(syslog-ng
     PROPERTIES VERSION ${SYSLOG_NG_VERSION}
     SOVERSION ${SYSLOG_NG_VERSION})
 
-gperf_generate(severity-aliases.table ${CMAKE_CURRENT_BINARY_DIR}/severity-aliases.h syslog-ng)
+
+# severity-aliases.h generation
+if (WIN32)
+  set(BASH "C:/msys64/usr/bin/bash.exe")
+  set(SEVERITY_IN    "${CMAKE_SOURCE_DIR}/lib/severity-aliases.table")
+  set(SEVERITY_CLEAN "${CMAKE_CURRENT_BINARY_DIR}/severity-aliases.clean.table")
+
+  add_custom_command(
+    OUTPUT  ${SEVERITY_CLEAN}
+    COMMAND ${BASH} -lc "sed 's/\\r$//' '${SEVERITY_IN}' > '${SEVERITY_CLEAN}'"
+    DEPENDS ${SEVERITY_IN}
+    VERBATIM)
+
+  # Reuse the existing macro, but feed it the cleaned file
+  gperf_generate(${SEVERITY_CLEAN}
+                 ${CMAKE_CURRENT_BINARY_DIR}/severity-aliases.h
+                 syslog-ng)
+else()
+  gperf_generate(severity-aliases.table
+                 ${CMAKE_CURRENT_BINARY_DIR}/severity-aliases.h
+                 syslog-ng)
+endif()
 
 if (${IVYKIS_INTERNAL})
    add_dependencies(syslog-ng IVYKIS)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -398,6 +398,10 @@ set_target_properties(syslog-ng
     PROPERTIES VERSION ${SYSLOG_NG_VERSION}
     SOVERSION ${SYSLOG_NG_VERSION})
 
+if (WIN32 AND DEFINED SYSLOG_NG_VERSION)
+  # Make the C macro available so mainloop.c can use it
+  target_compile_definitions(syslog-ng PRIVATE SYSLOG_NG_VERSION="${SYSLOG_NG_VERSION}")
+endif()
 
 # severity-aliases.h generation
 if (WIN32)

--- a/lib/alarms.c
+++ b/lib/alarms.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/alarms.c
+++ b/lib/alarms.c
@@ -27,10 +27,10 @@
 #include "messages.h"
 
 #ifndef _WIN32
-  #include <unistd.h>
-  #include <signal.h>
+#include <unistd.h>
+#include <signal.h>
 #else
-  #include <windows.h>
+#include <windows.h>
 #endif
 
 #include <string.h>
@@ -55,7 +55,8 @@ static HANDLE g_alarm_timer = NULL;
 static VOID CALLBACK
 _alarm_callback(PVOID ctx, BOOLEAN fired)
 {
-  (void)ctx; (void)fired;
+  (void)ctx;
+  (void)fired;
   sig_alarm_received = TRUE;
   alarm_pending = FALSE;
 }

--- a/lib/alarms.h
+++ b/lib/alarms.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/cfg-lexer.c
+++ b/lib/cfg-lexer.c
@@ -35,7 +35,7 @@
 #include "plugin-types.h"
 
 #include <string.h>
-#include <glob.h>
+#include "compat/glob.h"
 #include <sys/stat.h>
 
 /* include header for generated lexer */

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -33,7 +33,7 @@
 
 /* put near the top, after includes */
 #if defined(_WIN32) && defined(ERROR)
-  #undef ERROR
+#undef ERROR
 #endif
 
 extern int main_debug;

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -30,6 +30,11 @@
 #include <stdlib.h>
 #include "str-utils.h"
 
+/* put near the top, after includes */
+#if defined(_WIN32) && defined(ERROR)
+  #undef ERROR
+#endif
+
 extern int main_debug;
 
 /* defined in the parser */

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2017 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/compat/CMakeLists.txt
+++ b/lib/compat/CMakeLists.txt
@@ -26,6 +26,8 @@ set(COMPAT_HEADERS
     compat/ivykis_fd.h
     compat/ivykis_signal.h
     compat/realpath.h
+    compat/mmap.h
+    compat/pagesize.h
     PARENT_SCOPE)
 
 set(COMPAT_SOURCES
@@ -45,6 +47,7 @@ set(COMPAT_SOURCES
     compat/getent-generic.c
     compat/glob-win.c
     compat/ivykis_fd_windows.c
+    compat/mmap_win.c
     PARENT_SCOPE)
 
 add_test_subdirectory(tests)

--- a/lib/compat/CMakeLists.txt
+++ b/lib/compat/CMakeLists.txt
@@ -25,6 +25,7 @@ set(COMPAT_HEADERS
     compat/glob.h
     compat/ivykis_fd.h
     compat/ivykis_signal.h
+    compat/realpath.h
     PARENT_SCOPE)
 
 set(COMPAT_SOURCES

--- a/lib/compat/CMakeLists.txt
+++ b/lib/compat/CMakeLists.txt
@@ -22,6 +22,7 @@ set(COMPAT_HEADERS
     compat/uio.h
     compat/syslog.h
     compat/alarm.h
+    compat/glob.h
     PARENT_SCOPE)
 
 set(COMPAT_SOURCES
@@ -39,6 +40,7 @@ set(COMPAT_SOURCES
     compat/getent-sun.c
     compat/getent-openbsd.c
     compat/getent-generic.c
+    compat/glob-win.c
     PARENT_SCOPE)
 
 add_test_subdirectory(tests)

--- a/lib/compat/CMakeLists.txt
+++ b/lib/compat/CMakeLists.txt
@@ -19,6 +19,7 @@ set(COMPAT_HEADERS
     compat/curl.h
     compat/json.h
     compat/inttypes.h
+    compat/uio.h
     PARENT_SCOPE)
 
 set(COMPAT_SOURCES

--- a/lib/compat/CMakeLists.txt
+++ b/lib/compat/CMakeLists.txt
@@ -24,6 +24,7 @@ set(COMPAT_HEADERS
     compat/alarm.h
     compat/glob.h
     compat/ivykis_fd.h
+    compat/ivykis_signal.h
     PARENT_SCOPE)
 
 set(COMPAT_SOURCES

--- a/lib/compat/CMakeLists.txt
+++ b/lib/compat/CMakeLists.txt
@@ -20,6 +20,8 @@ set(COMPAT_HEADERS
     compat/json.h
     compat/inttypes.h
     compat/uio.h
+    compat/syslog.h
+    compat/alarm.h
     PARENT_SCOPE)
 
 set(COMPAT_SOURCES

--- a/lib/compat/CMakeLists.txt
+++ b/lib/compat/CMakeLists.txt
@@ -23,6 +23,7 @@ set(COMPAT_HEADERS
     compat/syslog.h
     compat/alarm.h
     compat/glob.h
+    compat/ivykis_fd.h
     PARENT_SCOPE)
 
 set(COMPAT_SOURCES
@@ -41,6 +42,7 @@ set(COMPAT_SOURCES
     compat/getent-openbsd.c
     compat/getent-generic.c
     compat/glob-win.c
+    compat/ivykis_fd_windows.c
     PARENT_SCOPE)
 
 add_test_subdirectory(tests)

--- a/lib/compat/Makefile.am
+++ b/lib/compat/Makefile.am
@@ -24,7 +24,8 @@ compatinclude_HEADERS		= 	\
 	lib/compat/cpp-end.h	\
 	lib/compat/curl.h	\
 	lib/compat/inttypes.h	\
-	lib/compat/gprocess-compat.h
+	lib/compat/gprocess-compat.h	\
+	lib/compat/uio.h
 
 compat_sources			= 	\
 	lib/compat/getutent.c		\

--- a/lib/compat/Makefile.am
+++ b/lib/compat/Makefile.am
@@ -25,7 +25,9 @@ compatinclude_HEADERS		= 	\
 	lib/compat/curl.h	\
 	lib/compat/inttypes.h	\
 	lib/compat/gprocess-compat.h	\
-	lib/compat/uio.h
+	lib/compat/uio.h	\
+	lib/compat/syslog.h	\
+	lib/compat/alarm.h
 
 compat_sources			= 	\
 	lib/compat/getutent.c		\

--- a/lib/compat/Makefile.am
+++ b/lib/compat/Makefile.am
@@ -31,7 +31,9 @@ compatinclude_HEADERS		= 	\
 	lib/compat/glob.h	\
 	lib/compat/ivykis_fd.h	\
 	lib/compat/ivykis_signal.h	\
-	lib/compat/realpath.h
+	lib/compat/realpath.h	\
+	lib/compat/mmap.h	\
+	lib/compat/pagesize.h
 
 
 compat_sources			= 	\
@@ -50,6 +52,7 @@ compat_sources			= 	\
 	lib/compat/getent-openbsd.c	\
 	lib/compat/getent-generic.c	\
 	lib/compat/glob-win.c	\
-    lib/compat/ivykis_fd_windows.c
+    lib/compat/ivykis_fd_windows.c	\
+	lib/compat/mmap_win.c
 
 include lib/compat/tests/Makefile.am

--- a/lib/compat/Makefile.am
+++ b/lib/compat/Makefile.am
@@ -28,7 +28,8 @@ compatinclude_HEADERS		= 	\
 	lib/compat/uio.h	\
 	lib/compat/syslog.h	\
 	lib/compat/alarm.h	\
-	lib/compat/glob.h
+	lib/compat/glob.h	\
+	lib/compat/ivykis_fd.h
 
 compat_sources			= 	\
 	lib/compat/getutent.c		\
@@ -45,6 +46,7 @@ compat_sources			= 	\
 	lib/compat/getent-sun.c		\
 	lib/compat/getent-openbsd.c	\
 	lib/compat/getent-generic.c	\
-	lib/compat/glob-win.c
+	lib/compat/glob-win.c	\
+    lib/compat/ivykis_fd_windows.c
 
 include lib/compat/tests/Makefile.am

--- a/lib/compat/Makefile.am
+++ b/lib/compat/Makefile.am
@@ -23,7 +23,8 @@ compatinclude_HEADERS		= 	\
 	lib/compat/cpp-start.h	\
 	lib/compat/cpp-end.h	\
 	lib/compat/curl.h	\
-	lib/compat/inttypes.h
+	lib/compat/inttypes.h	\
+	lib/compat/gprocess-compat.h
 
 compat_sources			= 	\
 	lib/compat/getutent.c		\

--- a/lib/compat/Makefile.am
+++ b/lib/compat/Makefile.am
@@ -29,7 +29,9 @@ compatinclude_HEADERS		= 	\
 	lib/compat/syslog.h	\
 	lib/compat/alarm.h	\
 	lib/compat/glob.h	\
-	lib/compat/ivykis_fd.h
+	lib/compat/ivykis_fd.h	\
+	lib/compat/ivykis_signal.h
+
 
 compat_sources			= 	\
 	lib/compat/getutent.c		\

--- a/lib/compat/Makefile.am
+++ b/lib/compat/Makefile.am
@@ -27,7 +27,8 @@ compatinclude_HEADERS		= 	\
 	lib/compat/gprocess-compat.h	\
 	lib/compat/uio.h	\
 	lib/compat/syslog.h	\
-	lib/compat/alarm.h
+	lib/compat/alarm.h	\
+	lib/compat/glob.h
 
 compat_sources			= 	\
 	lib/compat/getutent.c		\
@@ -43,6 +44,7 @@ compat_sources			= 	\
 	lib/compat/openssl_support.c	\
 	lib/compat/getent-sun.c		\
 	lib/compat/getent-openbsd.c	\
-	lib/compat/getent-generic.c
+	lib/compat/getent-generic.c	\
+	lib/compat/glob-win.c
 
 include lib/compat/tests/Makefile.am

--- a/lib/compat/Makefile.am
+++ b/lib/compat/Makefile.am
@@ -30,7 +30,8 @@ compatinclude_HEADERS		= 	\
 	lib/compat/alarm.h	\
 	lib/compat/glob.h	\
 	lib/compat/ivykis_fd.h	\
-	lib/compat/ivykis_signal.h
+	lib/compat/ivykis_signal.h	\
+	lib/compat/realpath.h
 
 
 compat_sources			= 	\

--- a/lib/compat/alarm.h
+++ b/lib/compat/alarm.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2002-2010 Balabit
- * Copyright (c) 1998-2010 Balázs Scheidler
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -22,18 +21,15 @@
  *
  */
 
-#ifndef ALARMS_H_INCLUDED
-#define ALARMS_H_INCLUDED
+#pragma once
 
-#include "syslog-ng.h"
-#include "compat/alarm.h"
-
-void alarm_set(int timeout);
-void alarm_cancel(void);
-gboolean alarm_has_fired(void);
-
-void alarm_init(void);
-
-
+#if defined(_WIN32)
+/* Minimal stub: do nothing, return 0 (no previous alarm) */
+static inline unsigned int alarm(unsigned int seconds)
+{
+  (void)seconds;
+  return 0;
+}
+#else
+# include <unistd.h>   /* alarm() on POSIX */
 #endif
-

--- a/lib/compat/getent-generic.h
+++ b/lib/compat/getent-generic.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017 Balabit
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -28,10 +29,14 @@
 
 #if ! SYSLOG_NG_HAVE_GETPROTOBYNUMBER_R
 
+#ifdef _WIN32
+#include "compat/socket.h"
+#else
 #include <sys/types.h>
 #include <grp.h>
 #include <pwd.h>
 #include <netdb.h>
+#endif
 
 int _compat_generic__getprotobynumber_r(int proto,
                                         struct protoent *result_buf, char *buf,

--- a/lib/compat/getutent.h
+++ b/lib/compat/getutent.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2014 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -29,6 +30,24 @@
 #include <inttypes.h>
 #include <time.h>
 
+#ifdef _WIN32
+/* Windows: no utmp/utmpx — provide minimal stubs */
+typedef struct
+{
+  int _unused;
+} utmp;
+
+static inline struct utmp *getutent(void)
+{
+  return NULL;
+}
+static inline void endutent(void)
+{
+  return;
+}
+
+#else  /* POSIX */
+
 #if SYSLOG_NG_HAVE_UTMPX_H
 #include <utmpx.h>
 #else
@@ -40,4 +59,6 @@ struct utmp *getutent(void);
 void endutent(void);
 #endif
 
-#endif
+#endif /* _WIN32 */
+
+#endif /* COMPAT_GETUTENT_H_INCLUDED */

--- a/lib/compat/glob-win.c
+++ b/lib/compat/glob-win.c
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2025 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#if defined(_WIN32)
+#include "glob.h"
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static char *dupstr(const char *s) {
+  size_t n = strlen(s) + 1;
+  char *p = (char *)malloc(n);
+  if (p) memcpy(p, s, n);
+  return p;
+}
+
+static void slash_to_backslash(char *s) {
+  for (; *s; ++s) if (*s == '/') *s = '\\';
+}
+static void backslash_to_slash(char *s) {
+  for (; *s; ++s) if (*s == '\\') *s = '/';
+}
+
+static int push_path(glob_t *g, const char *path) {
+  size_t newc = g->gl_pathc + 1;
+  char **nv = (char **)realloc(g->gl_pathv, newc * sizeof(char *));
+  if (!nv) return 0;
+  g->gl_pathv = nv;
+  g->gl_pathv[g->gl_pathc++] = dupstr(path);
+  return g->gl_pathv[g->gl_pathc-1] != NULL;
+}
+
+static int cmp_str(const void *a, const void *b) {
+  const char *sa = *(const char * const *)a;
+  const char *sb = *(const char * const *)b;
+  return strcmp(sa, sb);
+}
+
+int glob(const char *pattern, int flags, int (*errfunc)(const char *, int), glob_t *pglob)
+{
+  (void)errfunc;
+  if (!pglob) return GLOB_ABORTED;
+
+  if (!(flags & GLOB_APPEND)) {
+    pglob->gl_pathc = 0;
+    pglob->gl_pathv = NULL;
+    pglob->gl_offs  = 0;
+  }
+
+  /* Make a WinAPI-friendly copy of the pattern */
+  char *pat_bs = dupstr(pattern);
+  if (!pat_bs) return GLOB_NOSPACE;
+  slash_to_backslash(pat_bs);
+
+  /* Split dir + mask */
+  const char *last = strrchr(pat_bs, '\\');
+  size_t dlen = last ? (size_t)(last - pat_bs + 1) : 0;
+
+  WIN32_FIND_DATAA fd;
+  HANDLE h = FindFirstFileA(pat_bs, &fd);
+  if (h == INVALID_HANDLE_VALUE) {
+    free(pat_bs);
+    if (flags & GLOB_NOCHECK) {
+      /* Return the pattern itself */
+      if (!push_path(pglob, pattern)) return GLOB_NOSPACE;
+      return 0;
+    }
+    return GLOB_NOMATCH;
+  }
+
+  int rc = 0;
+  do {
+    /* Skip '.' and '..' */
+    if (fd.cFileName[0] == '.' &&
+        (fd.cFileName[1] == '\0' || (fd.cFileName[1]=='.' && fd.cFileName[2]=='\0')))
+      continue;
+
+    /* Build full path using dir prefix + file name (use forward slashes for consistency) */
+    size_t plen = dlen + strlen(fd.cFileName) + 2;
+    char *full = (char *)malloc(plen);
+    if (!full) { rc = GLOB_NOSPACE; break; }
+
+    if (dlen) {
+      memcpy(full, pat_bs, dlen);
+      strcpy(full + dlen, fd.cFileName);
+    } else {
+      strcpy(full, fd.cFileName);
+    }
+    backslash_to_slash(full);
+
+    if ((flags & GLOB_MARK) && (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
+      size_t L = strlen(full);
+      if (L == 0 || full[L-1] != '/')
+        full = (char *)realloc(full, L + 2), strcpy(full + L, "/");
+    }
+
+    if (!push_path(pglob, full)) { free(full); rc = GLOB_NOSPACE; break; }
+    free(full);
+  } while (FindNextFileA(h, &fd));
+
+  FindClose(h);
+  free(pat_bs);
+
+  if (rc != 0) return rc;
+
+  if (pglob->gl_pathc == 0) {
+    if (flags & GLOB_NOCHECK) {
+      if (!push_path(pglob, pattern)) return GLOB_NOSPACE;
+      return 0;
+    }
+    return GLOB_NOMATCH;
+  }
+
+  if (!(flags & GLOB_NOSORT) && pglob->gl_pathc > 1)
+    qsort(pglob->gl_pathv, pglob->gl_pathc, sizeof(char *), cmp_str);
+
+  return 0;
+}
+
+void globfree(glob_t *pglob)
+{
+  if (!pglob) return;
+  for (size_t i = 0; i < pglob->gl_pathc; ++i) free(pglob->gl_pathv[i]);
+  free(pglob->gl_pathv);
+  pglob->gl_pathv = NULL;
+  pglob->gl_pathc = 0;
+}
+#endif

--- a/lib/compat/glob-win.c
+++ b/lib/compat/glob-win.c
@@ -28,21 +28,25 @@
 #include <stdlib.h>
 #include <string.h>
 
-static char *dupstr(const char *s) {
+static char *dupstr(const char *s)
+{
   size_t n = strlen(s) + 1;
   char *p = (char *)malloc(n);
   if (p) memcpy(p, s, n);
   return p;
 }
 
-static void slash_to_backslash(char *s) {
+static void slash_to_backslash(char *s)
+{
   for (; *s; ++s) if (*s == '/') *s = '\\';
 }
-static void backslash_to_slash(char *s) {
+static void backslash_to_slash(char *s)
+{
   for (; *s; ++s) if (*s == '\\') *s = '/';
 }
 
-static int push_path(glob_t *g, const char *path) {
+static int push_path(glob_t *g, const char *path)
+{
   size_t newc = g->gl_pathc + 1;
   char **nv = (char **)realloc(g->gl_pathv, newc * sizeof(char *));
   if (!nv) return 0;
@@ -51,9 +55,10 @@ static int push_path(glob_t *g, const char *path) {
   return g->gl_pathv[g->gl_pathc-1] != NULL;
 }
 
-static int cmp_str(const void *a, const void *b) {
-  const char *sa = *(const char * const *)a;
-  const char *sb = *(const char * const *)b;
+static int cmp_str(const void *a, const void *b)
+{
+  const char *sa = *(const char *const *)a;
+  const char *sb = *(const char *const *)b;
   return strcmp(sa, sb);
 }
 
@@ -62,11 +67,12 @@ int glob(const char *pattern, int flags, int (*errfunc)(const char *, int), glob
   (void)errfunc;
   if (!pglob) return GLOB_ABORTED;
 
-  if (!(flags & GLOB_APPEND)) {
-    pglob->gl_pathc = 0;
-    pglob->gl_pathv = NULL;
-    pglob->gl_offs  = 0;
-  }
+  if (!(flags & GLOB_APPEND))
+    {
+      pglob->gl_pathc = 0;
+      pglob->gl_pathv = NULL;
+      pglob->gl_offs  = 0;
+    }
 
   /* Make a WinAPI-friendly copy of the pattern */
   char *pat_bs = dupstr(pattern);
@@ -79,58 +85,77 @@ int glob(const char *pattern, int flags, int (*errfunc)(const char *, int), glob
 
   WIN32_FIND_DATAA fd;
   HANDLE h = FindFirstFileA(pat_bs, &fd);
-  if (h == INVALID_HANDLE_VALUE) {
-    free(pat_bs);
-    if (flags & GLOB_NOCHECK) {
-      /* Return the pattern itself */
-      if (!push_path(pglob, pattern)) return GLOB_NOSPACE;
-      return 0;
+  if (h == INVALID_HANDLE_VALUE)
+    {
+      free(pat_bs);
+      if (flags & GLOB_NOCHECK)
+        {
+          /* Return the pattern itself */
+          if (!push_path(pglob, pattern)) return GLOB_NOSPACE;
+          return 0;
+        }
+      return GLOB_NOMATCH;
     }
-    return GLOB_NOMATCH;
-  }
 
   int rc = 0;
-  do {
-    /* Skip '.' and '..' */
-    if (fd.cFileName[0] == '.' &&
-        (fd.cFileName[1] == '\0' || (fd.cFileName[1]=='.' && fd.cFileName[2]=='\0')))
-      continue;
+  do
+    {
+      /* Skip '.' and '..' */
+      if (fd.cFileName[0] == '.' &&
+          (fd.cFileName[1] == '\0' || (fd.cFileName[1]=='.' && fd.cFileName[2]=='\0')))
+        continue;
 
-    /* Build full path using dir prefix + file name (use forward slashes for consistency) */
-    size_t plen = dlen + strlen(fd.cFileName) + 2;
-    char *full = (char *)malloc(plen);
-    if (!full) { rc = GLOB_NOSPACE; break; }
+      /* Build full path using dir prefix + file name (use forward slashes for consistency) */
+      size_t plen = dlen + strlen(fd.cFileName) + 2;
+      char *full = (char *)malloc(plen);
+      if (!full)
+        {
+          rc = GLOB_NOSPACE;
+          break;
+        }
 
-    if (dlen) {
-      memcpy(full, pat_bs, dlen);
-      strcpy(full + dlen, fd.cFileName);
-    } else {
-      strcpy(full, fd.cFileName);
+      if (dlen)
+        {
+          memcpy(full, pat_bs, dlen);
+          strcpy(full + dlen, fd.cFileName);
+        }
+      else
+        {
+          strcpy(full, fd.cFileName);
+        }
+      backslash_to_slash(full);
+
+      if ((flags & GLOB_MARK) && (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
+        {
+          size_t L = strlen(full);
+          if (L == 0 || full[L-1] != '/')
+            full = (char *)realloc(full, L + 2), strcpy(full + L, "/");
+        }
+
+      if (!push_path(pglob, full))
+        {
+          free(full);
+          rc = GLOB_NOSPACE;
+          break;
+        }
+      free(full);
     }
-    backslash_to_slash(full);
-
-    if ((flags & GLOB_MARK) && (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
-      size_t L = strlen(full);
-      if (L == 0 || full[L-1] != '/')
-        full = (char *)realloc(full, L + 2), strcpy(full + L, "/");
-    }
-
-    if (!push_path(pglob, full)) { free(full); rc = GLOB_NOSPACE; break; }
-    free(full);
-  } while (FindNextFileA(h, &fd));
+  while (FindNextFileA(h, &fd));
 
   FindClose(h);
   free(pat_bs);
 
   if (rc != 0) return rc;
 
-  if (pglob->gl_pathc == 0) {
-    if (flags & GLOB_NOCHECK) {
-      if (!push_path(pglob, pattern)) return GLOB_NOSPACE;
-      return 0;
+  if (pglob->gl_pathc == 0)
+    {
+      if (flags & GLOB_NOCHECK)
+        {
+          if (!push_path(pglob, pattern)) return GLOB_NOSPACE;
+          return 0;
+        }
+      return GLOB_NOMATCH;
     }
-    return GLOB_NOMATCH;
-  }
 
   if (!(flags & GLOB_NOSORT) && pglob->gl_pathc > 1)
     qsort(pglob->gl_pathv, pglob->gl_pathc, sizeof(char *), cmp_str);

--- a/lib/compat/glob.h
+++ b/lib/compat/glob.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2002-2010 Balabit
- * Copyright (c) 1998-2010 Balázs Scheidler
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -22,18 +21,31 @@
  *
  */
 
-#ifndef ALARMS_H_INCLUDED
-#define ALARMS_H_INCLUDED
+#pragma once
+#if !defined(_WIN32)
+  #include <glob.h>
+#else
+  #include <stddef.h>
 
-#include "syslog-ng.h"
-#include "compat/alarm.h"
+  typedef struct {
+    size_t gl_pathc;   /* # of matched paths */
+    char **gl_pathv;   /* vector of paths (NULL-terminated not required here) */
+    size_t gl_offs;    /* ignored by our shim */
+  } glob_t;
 
-void alarm_set(int timeout);
-void alarm_cancel(void);
-gboolean alarm_has_fired(void);
+  /* flags we (partially) support */
+  #define GLOB_ERR      0x01
+  #define GLOB_MARK     0x02   /* append '/' to directories */
+  #define GLOB_NOSORT   0x04   /* don't sort */
+  #define GLOB_NOCHECK  0x08   /* if no match, return pattern itself */
+  #define GLOB_APPEND   0x10   /* append to existing gl_pathv (basic support) */
+  #define GLOB_DOOFFS   0x20   /* ignored */
 
-void alarm_init(void);
+  /* return codes */
+  #define GLOB_NOSPACE  1
+  #define GLOB_ABORTED  2
+  #define GLOB_NOMATCH  3
 
-
+  int glob(const char *pattern, int flags, int (*errfunc)(const char *, int), glob_t *pglob);
+  void globfree(glob_t *pglob);
 #endif
-

--- a/lib/compat/glob.h
+++ b/lib/compat/glob.h
@@ -23,29 +23,30 @@
 
 #pragma once
 #if !defined(_WIN32)
-  #include <glob.h>
+#include <glob.h>
 #else
-  #include <stddef.h>
+#include <stddef.h>
 
-  typedef struct {
-    size_t gl_pathc;   /* # of matched paths */
-    char **gl_pathv;   /* vector of paths (NULL-terminated not required here) */
-    size_t gl_offs;    /* ignored by our shim */
-  } glob_t;
+typedef struct
+{
+  size_t gl_pathc;   /* # of matched paths */
+  char **gl_pathv;   /* vector of paths (NULL-terminated not required here) */
+  size_t gl_offs;    /* ignored by our shim */
+} glob_t;
 
-  /* flags we (partially) support */
-  #define GLOB_ERR      0x01
-  #define GLOB_MARK     0x02   /* append '/' to directories */
-  #define GLOB_NOSORT   0x04   /* don't sort */
-  #define GLOB_NOCHECK  0x08   /* if no match, return pattern itself */
-  #define GLOB_APPEND   0x10   /* append to existing gl_pathv (basic support) */
-  #define GLOB_DOOFFS   0x20   /* ignored */
+/* flags we (partially) support */
+#define GLOB_ERR      0x01
+#define GLOB_MARK     0x02   /* append '/' to directories */
+#define GLOB_NOSORT   0x04   /* don't sort */
+#define GLOB_NOCHECK  0x08   /* if no match, return pattern itself */
+#define GLOB_APPEND   0x10   /* append to existing gl_pathv (basic support) */
+#define GLOB_DOOFFS   0x20   /* ignored */
 
-  /* return codes */
-  #define GLOB_NOSPACE  1
-  #define GLOB_ABORTED  2
-  #define GLOB_NOMATCH  3
+/* return codes */
+#define GLOB_NOSPACE  1
+#define GLOB_ABORTED  2
+#define GLOB_NOMATCH  3
 
-  int glob(const char *pattern, int flags, int (*errfunc)(const char *, int), glob_t *pglob);
-  void globfree(glob_t *pglob);
+int glob(const char *pattern, int flags, int (*errfunc)(const char *, int), glob_t *pglob);
+void globfree(glob_t *pglob);
 #endif

--- a/lib/compat/gprocess-compat.h
+++ b/lib/compat/gprocess-compat.h
@@ -24,57 +24,94 @@
 #pragma once
 
 #ifndef _WIN32
-  /* POSIX path: nothing to do */
-  #include <sys/ioctl.h>
-    #include <sys/resource.h>
-    #include <sys/wait.h>
-    #include <unistd.h>
-    #include <fcntl.h>
-    #include <termios.h>
-    #include <signal.h>
-    #include <pwd.h>
-    #include <grp.h>
+/* POSIX path: nothing to do */
+#include <sys/ioctl.h>
+#include <sys/resource.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <termios.h>
+#include <signal.h>
+#include <pwd.h>
+#include <grp.h>
 #else
-  /* Windows: minimal equivalents + stubs */
-  #define WIN32_LEAN_AND_MEAN 1
-  #define NOGDI 1
-  #include <windows.h>
-  #include <io.h>
-  #include <fcntl.h>
-  #include <direct.h>
-  #include <process.h>
-  #include <errno.h>
-  #include <stdlib.h>
+/* Windows: minimal equivalents + stubs */
+#define WIN32_LEAN_AND_MEAN 1
+#define NOGDI 1
+#include <windows.h>
+#include <io.h>
+#include <fcntl.h>
+#include <direct.h>
+#include <process.h>
+#include <errno.h>
+#include <stdlib.h>
 
-  /* session */
-  static inline int setsid(void) { return 0; }
+/* session */
+static inline int setsid(void)
+{
+  return 0;
+}
 
-  /* rlimit stubs */
-  typedef unsigned long rlim_t;
-  struct rlimit { rlim_t rlim_cur, rlim_max; };
-  #ifndef RLIM_INFINITY
-  # define RLIM_INFINITY ((rlim_t)-1)
-  #endif
-  #ifndef RLIMIT_NOFILE
-  # define RLIMIT_NOFILE 7
-  #endif
-  #ifndef RLIMIT_CORE
-  # define RLIMIT_CORE 4
-  #endif
-  static inline int getrlimit(int, struct rlimit *rl) { if (rl) rl->rlim_cur = rl->rlim_max = 16384; return 0; }
-  static inline int setrlimit(int, const struct rlimit *) { return 0; }
+/* rlimit stubs */
+typedef unsigned long rlim_t;
+struct rlimit
+{
+  rlim_t rlim_cur, rlim_max;
+};
+#ifndef RLIM_INFINITY
+# define RLIM_INFINITY ((rlim_t)-1)
+#endif
+#ifndef RLIMIT_NOFILE
+# define RLIMIT_NOFILE 7
+#endif
+#ifndef RLIMIT_CORE
+# define RLIMIT_CORE 4
+#endif
+static inline int getrlimit(int, struct rlimit *rl)
+{
+  if (rl) rl->rlim_cur = rl->rlim_max = 16384;
+  return 0;
+}
+static inline int setrlimit(int, const struct rlimit *)
+{
+  return 0;
+}
 
-  /* ids/chroot (no real support on Windows) */
-  typedef int uid_t; typedef int gid_t;
-  static inline int chroot(const char *) { errno = ENOSYS; return -1; }
-  static inline int setuid(uid_t) { return 0; }
-  static inline int setgid(gid_t) { return 0; }
-  static inline int initgroups(const char *, gid_t) { return 0; }
-  static inline int getuid(void) { return 0; }
+/* ids/chroot (no real support on Windows) */
+typedef int uid_t;
+typedef int gid_t;
+static inline int chroot(const char *)
+{
+  errno = ENOSYS;
+  return -1;
+}
+static inline int setuid(uid_t)
+{
+  return 0;
+}
+static inline int setgid(gid_t)
+{
+  return 0;
+}
+static inline int initgroups(const char *, gid_t)
+{
+  return 0;
+}
+static inline int getuid(void)
+{
+  return 0;
+}
 
-  /* small libc diffs */
-  static inline int pipe(int fds[2]) { return _pipe(fds, 4096, _O_BINARY); }
-  static inline unsigned int sleep(unsigned int s) { Sleep(s*1000u); return 0; }
+/* small libc diffs */
+static inline int pipe(int fds[2])
+{
+  return _pipe(fds, 4096, _O_BINARY);
+}
+static inline unsigned int sleep(unsigned int s)
+{
+  Sleep(s*1000u);
+  return 0;
+}
 
-  /* signals/waitpid/kill macros don’t exist -> keep POSIX code guarded in .c */
+/* signals/waitpid/kill macros don’t exist -> keep POSIX code guarded in .c */
 #endif

--- a/lib/compat/gprocess-compat.h
+++ b/lib/compat/gprocess-compat.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2025 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#pragma once
+
+#ifndef _WIN32
+  /* POSIX path: nothing to do */
+  #include <sys/ioctl.h>
+    #include <sys/resource.h>
+    #include <sys/wait.h>
+    #include <unistd.h>
+    #include <fcntl.h>
+    #include <termios.h>
+    #include <signal.h>
+    #include <pwd.h>
+    #include <grp.h>
+#else
+  /* Windows: minimal equivalents + stubs */
+  #define WIN32_LEAN_AND_MEAN 1
+  #define NOGDI 1
+  #include <windows.h>
+  #include <io.h>
+  #include <fcntl.h>
+  #include <direct.h>
+  #include <process.h>
+  #include <errno.h>
+  #include <stdlib.h>
+
+  /* session */
+  static inline int setsid(void) { return 0; }
+
+  /* rlimit stubs */
+  typedef unsigned long rlim_t;
+  struct rlimit { rlim_t rlim_cur, rlim_max; };
+  #ifndef RLIM_INFINITY
+  # define RLIM_INFINITY ((rlim_t)-1)
+  #endif
+  #ifndef RLIMIT_NOFILE
+  # define RLIMIT_NOFILE 7
+  #endif
+  #ifndef RLIMIT_CORE
+  # define RLIMIT_CORE 4
+  #endif
+  static inline int getrlimit(int, struct rlimit *rl) { if (rl) rl->rlim_cur = rl->rlim_max = 16384; return 0; }
+  static inline int setrlimit(int, const struct rlimit *) { return 0; }
+
+  /* ids/chroot (no real support on Windows) */
+  typedef int uid_t; typedef int gid_t;
+  static inline int chroot(const char *) { errno = ENOSYS; return -1; }
+  static inline int setuid(uid_t) { return 0; }
+  static inline int setgid(gid_t) { return 0; }
+  static inline int initgroups(const char *, gid_t) { return 0; }
+  static inline int getuid(void) { return 0; }
+
+  /* small libc diffs */
+  static inline int pipe(int fds[2]) { return _pipe(fds, 4096, _O_BINARY); }
+  static inline unsigned int sleep(unsigned int s) { Sleep(s*1000u); return 0; }
+
+  /* signals/waitpid/kill macros don’t exist -> keep POSIX code guarded in .c */
+#endif

--- a/lib/compat/ivykis_fd.h
+++ b/lib/compat/ivykis_fd.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#pragma once
+
+#include <string.h>
+
+#ifdef _WIN32
+
+/* Windows: real compat struct + functions */
+struct compat_iv_fd
+{
+  int   fd;
+  void *cookie;
+  void (*handler_in)(void *);
+  void (*handler_out)(void *);
+  void (*handler_err)(void *);
+  /* impl is private to the platform .c file */
+  void *impl;
+};
+
+typedef struct compat_iv_fd compat_iv_fd;
+
+void compat_iv_fd_init(compat_iv_fd *w);
+
+void compat_iv_fd_set_handler_in (compat_iv_fd *w, void (*fn)(void *));
+void compat_iv_fd_set_handler_out(compat_iv_fd *w, void (*fn)(void *));
+void compat_iv_fd_set_handler_err(compat_iv_fd *w, void (*fn)(void *));
+
+int  compat_iv_fd_register_try (compat_iv_fd *w); /* 0=success (pollable), nonzero=fallback */
+void compat_iv_fd_register     (compat_iv_fd *w);
+void compat_iv_fd_unregister   (compat_iv_fd *w);
+int  compat_iv_fd_registered   (compat_iv_fd *w); /* boolean */
+
+void compat_iv_fd_deinit(compat_iv_fd *w);
+
+static inline void compat_iv_fd_init_wrap(compat_iv_fd *w)
+{
+  memset(w, 0, sizeof(*w));
+  compat_iv_fd_init(w);
+}
+
+/* Keep the call-site macro shape similar to IV_FD_INIT */
+#define COMPAT_IV_FD_INIT(w) compat_iv_fd_init_wrap((w))
+
+#else
+
+/* POSIX: zero-overhead aliases to ivykis */
+#include <iv.h>
+
+typedef struct iv_fd compat_iv_fd;
+
+#define compat_iv_fd_set_handler_in   iv_fd_set_handler_in
+#define compat_iv_fd_set_handler_out  iv_fd_set_handler_out
+#define compat_iv_fd_set_handler_err  iv_fd_set_handler_err
+#define compat_iv_fd_register_try     iv_fd_register_try
+#define compat_iv_fd_register         iv_fd_register
+#define compat_iv_fd_unregister       iv_fd_unregister
+#define compat_iv_fd_registered       iv_fd_registered
+#define compat_iv_fd_deinit(w)        ((void)0)
+
+#define COMPAT_IV_FD_INIT(w)          IV_FD_INIT((w))
+
+#endif /* _WIN32 */

--- a/lib/compat/ivykis_fd_windows.c
+++ b/lib/compat/ivykis_fd_windows.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2025 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifdef _WIN32
+
+#include "compat/ivykis_fd.h"
+#include <iv.h>
+#include <iv_timer.h>
+#include <iv_task.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct win_impl
+{
+  int registered;
+  struct iv_timer tick;
+  struct iv_task  immed;
+};
+
+static void tick_cb(void *cookie)
+{
+  struct compat_iv_fd *w = (struct compat_iv_fd *)cookie;
+  /* call out if handlers are set; you can refine readiness checks later */
+  if (w->handler_in)  w->handler_in(w->cookie);
+  if (w->handler_out) w->handler_out(w->cookie);
+  if (w->handler_err) { /* no explicit ERR trigger here; keep for future */ }
+  /* rearm timer for a short interval */
+  iv_validate_now();
+  ((struct win_impl *)w->impl)->tick.expires = iv_now;
+  ((struct win_impl *)w->impl)->tick.expires.tv_sec  += 0;
+  ((struct win_impl *)w->impl)->tick.expires.tv_nsec += 50 * 1000 * 1000; /* 50ms */
+  iv_timer_register(&((struct win_impl *)w->impl)->tick);
+}
+
+void compat_iv_fd_init(struct compat_iv_fd *w)
+{
+  struct win_impl *impl = (struct win_impl *)malloc(sizeof(*impl));
+  memset(impl, 0, sizeof(*impl));
+  w->impl = impl;
+  IV_TIMER_INIT(&impl->tick);
+  impl->tick.cookie  = w;
+  impl->tick.handler = tick_cb;
+
+  IV_TASK_INIT(&impl->immed);
+  impl->immed.cookie  = w;
+  impl->immed.handler = NULL; /* not used yet */
+}
+
+void compat_iv_fd_set_handler_in (struct compat_iv_fd *w, void (*fn)(void *))
+{
+  w->handler_in  = fn;
+}
+void compat_iv_fd_set_handler_out(struct compat_iv_fd *w, void (*fn)(void *))
+{
+  w->handler_out = fn;
+}
+void compat_iv_fd_set_handler_err(struct compat_iv_fd *w, void (*fn)(void *))
+{
+  w->handler_err = fn;
+}
+
+int  compat_iv_fd_register_try(struct compat_iv_fd *w)
+{
+  /* Not pollable on Windows: don't arm our timer; let logwriter use its
+     non-pollable (task/timer) path. */
+  ((struct win_impl *)w->impl)->registered = 0;
+  return -1;
+}
+
+void compat_iv_fd_register(struct compat_iv_fd *w)
+{
+  ((struct win_impl *)w->impl)->registered = 1;
+  tick_cb(w);
+}
+
+void compat_iv_fd_unregister(struct compat_iv_fd *w)
+{
+  struct win_impl *impl = (struct win_impl *)w->impl;
+  if (iv_timer_registered(&impl->tick)) iv_timer_unregister(&impl->tick);
+  ((struct win_impl *)w->impl)->registered = 0;
+}
+
+int  compat_iv_fd_registered(struct compat_iv_fd *w)
+{
+  return ((struct win_impl *)w->impl)->registered;
+}
+
+void compat_iv_fd_deinit(struct compat_iv_fd *w)
+{
+  struct win_impl *impl = (struct win_impl *)w->impl;
+  if (!impl) return;
+  if (iv_timer_registered(&impl->tick)) iv_timer_unregister(&impl->tick);
+  free(impl);
+  w->impl = NULL;
+}
+
+#endif

--- a/lib/compat/ivykis_signal.h
+++ b/lib/compat/ivykis_signal.h
@@ -35,22 +35,10 @@ typedef struct compat_iv_signal
   void *impl;                      /* private */
 } compat_iv_signal;
 
-static inline void compat_iv_signal_init(compat_iv_signal *s)
-{
-  memset(s, 0, sizeof(*s));
-}
-static inline void compat_iv_signal_register(compat_iv_signal *s)
-{
-  return;
-}
-static inline void compat_iv_signal_unregister(compat_iv_signal *s)
-{
-  return;
-}
-static inline void compat_ignore_signal(int signum)
-{
-  return;
-}
+static inline void compat_iv_signal_init(compat_iv_signal *s);
+static inline void compat_iv_signal_register(compat_iv_signal *s);
+static inline void compat_iv_signal_unregister(compat_iv_signal *s);
+static inline void compat_ignore_signal(int signum);
 
 #define COMPAT_IV_SIGNAL_INIT(s) do { memset((s), 0, sizeof(*(s))); } while (0)
 

--- a/lib/compat/ivykis_signal.h
+++ b/lib/compat/ivykis_signal.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2025 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#pragma once
+
+#include <string.h>
+
+#ifdef _WIN32
+
+typedef struct compat_iv_signal
+{
+  void *cookie;
+  void (*handler)(void *cookie);   /* same sig as ivykis */
+  int   signum;                    /* ignored on Win */
+  void *impl;                      /* private */
+} compat_iv_signal;
+
+static inline void compat_iv_signal_init(compat_iv_signal *s)
+{
+  memset(s, 0, sizeof(*s));
+}
+static inline void compat_iv_signal_register(compat_iv_signal *s)
+{
+  return;
+}
+static inline void compat_iv_signal_unregister(compat_iv_signal *s)
+{
+  return;
+}
+static inline void compat_ignore_signal(int signum)
+{
+  return;
+}
+
+#define COMPAT_IV_SIGNAL_INIT(s) do { memset((s), 0, sizeof(*(s))); } while (0)
+
+#else /* _WIN32 */
+
+#include <iv.h>
+#include <iv_signal.h>
+#include <signal.h>
+
+typedef struct iv_signal compat_iv_signal;
+
+static inline void compat_iv_signal_init(compat_iv_signal *s)
+{
+  IV_SIGNAL_INIT(s);
+}
+static inline void compat_iv_signal_register(compat_iv_signal *s)
+{
+  iv_signal_register(s);
+}
+static inline void compat_iv_signal_unregister(compat_iv_signal *s)
+{
+  iv_signal_unregister(s);
+}
+static inline void compat_ignore_signal(int signum)
+{
+  struct sigaction sa;
+  memset(&sa, 0, sizeof(sa));
+  sa.sa_handler = SIG_IGN;
+  sigaction(signum, &sa, NULL);
+}
+
+#define COMPAT_HAVE_POSIX_SIGNALS
+#define COMPAT_IV_SIGNAL_INIT(s)  IV_SIGNAL_INIT((s))
+
+#endif
+
+/* Helper to mirror your local helper, so mainloop doesn't need its own */
+static inline void compat_register_signal_handler(compat_iv_signal *sig, int signum,
+                                                  void (*handler)(void *), void *cookie)
+{
+  COMPAT_IV_SIGNAL_INIT(sig);
+  sig->signum  = signum;
+  sig->cookie  = cookie;
+  sig->handler = handler;
+  compat_iv_signal_register(sig);
+}

--- a/lib/compat/mmap.h
+++ b/lib/compat/mmap.h
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
@@ -21,30 +20,41 @@
  * COPYING for details.
  *
  */
-#ifndef COMPAT_PIO_H_INCLUDED
-#define COMPAT_PIO_H_INCLUDED 1
 
-#include "compat.h"
+#pragma once
 
-#include <sys/types.h>
-#include <unistd.h>
+#ifndef _WIN32
 
-/* NOTE: bb__ prefix is used for function names that might clash with system
- * supplied symbols. */
+#include <sys/mman.h>
 
-#if ! SYSLOG_NG_HAVE_PREAD || SYSLOG_NG_HAVE_BROKEN_PREAD
-# ifdef pread
-#  undef pread
-# endif
-# ifdef pwrite
-#  undef pwrite
-# endif
-#define pread bb__pread
-#define pwrite bb__pwrite
+#else /* POSIX */
 
-ssize_t bb__pread(int fd, void *buf, size_t count, off_t offset);
-ssize_t bb__pwrite(int fd, const void *buf, size_t count, off_t offset);
+#include <stddef.h>
+#include <stdint.h>
 
+/* flags/prot (minimal) */
+#ifndef PROT_READ
+#define PROT_READ   0x1
 #endif
+#ifndef PROT_WRITE
+#define PROT_WRITE  0x2
+#endif
+#ifndef MAP_SHARED
+#define MAP_SHARED  0x01
+#endif
+#ifndef MAP_PRIVATE
+#define MAP_PRIVATE 0x02
+#endif
+#ifndef MAP_FAILED
+#define MAP_FAILED ((void *)-1)
+#endif
+#ifndef MS_SYNC
+#define MS_SYNC 0x4
+#endif
+
+/* POSIX-like signatures */
+void *mmap(void *addr, size_t length, int prot, int flags, int fd, long long offset);
+int   munmap(void *addr, size_t length);
+int   msync(void *addr, size_t length, int flags);
 
 #endif

--- a/lib/compat/mmap_win.c
+++ b/lib/compat/mmap_win.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifdef _WIN32
+
+#include "mmap.h"
+#include <windows.h>
+#include <io.h>       /* _get_osfhandle */
+#include <stdlib.h>
+
+/* track mapping handles so we can CloseHandle() at munmap() */
+typedef struct MapNode
+{
+  void *base;
+  HANDLE hmap;
+  struct MapNode *next;
+} MapNode;
+
+static MapNode *g_maps;
+
+static void add_map(void *base, HANDLE hmap)
+{
+  MapNode *n = (MapNode *)malloc(sizeof(*n));
+  n->base = base;
+  n->hmap = hmap;
+  n->next = g_maps;
+  g_maps = n;
+}
+
+static HANDLE take_map(void *base)
+{
+  MapNode **pp=&g_maps;
+  while (*pp)
+    {
+      if ((*pp)->base == base)
+        {
+          MapNode *n=*pp;
+          *pp=n->next;
+          HANDLE h=n->hmap;
+          free(n);
+          return h;
+        }
+      pp=&(*pp)->next;
+    }
+  return NULL;
+}
+
+void *mmap(void *addr, size_t length, int prot, int flags, int fd, long long offset)
+{
+  DWORD protect = (prot & PROT_WRITE) ? PAGE_READWRITE : PAGE_READONLY;
+  DWORD access  = (prot & PROT_WRITE) ? FILE_MAP_WRITE  : FILE_MAP_READ;
+
+  HANDLE hfile = (HANDLE)_get_osfhandle(fd);
+  if (hfile == INVALID_HANDLE_VALUE)
+    return MAP_FAILED;
+
+  LARGE_INTEGER maxsz;
+  maxsz.QuadPart = offset + (long long)length;
+  HANDLE hmap = CreateFileMappingW(hfile, NULL, protect, maxsz.HighPart, maxsz.LowPart, NULL);
+  if (!hmap)
+    return MAP_FAILED;
+
+  LARGE_INTEGER off;
+  off.QuadPart = offset;
+  void *base = MapViewOfFile(hmap, access, off.HighPart, off.LowPart, length);
+  if (!base)
+    {
+      CloseHandle(hmap);
+      return MAP_FAILED;
+    }
+
+  add_map(base, hmap);
+  return base;
+}
+
+int munmap(void *addr, size_t length)
+{
+  HANDLE hmap = take_map(addr);
+  BOOL ok1 = UnmapViewOfFile(addr);
+  if (hmap) CloseHandle(hmap);
+  return ok1 ? 0 : -1;
+}
+
+int msync(void *addr, size_t length, int flags)
+{
+  (void)flags;
+  /* Flush the view; flushing the file handle is usually unnecessary here */
+  return FlushViewOfFile(addr, length) ? 0 : -1;
+}
+
+#endif

--- a/lib/compat/pagesize.h
+++ b/lib/compat/pagesize.h
@@ -1,5 +1,4 @@
 /*
- * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
@@ -21,29 +20,39 @@
  * COPYING for details.
  *
  */
-#ifndef COMPAT_PIO_H_INCLUDED
-#define COMPAT_PIO_H_INCLUDED 1
 
-#include "compat.h"
+#pragma once
 
-#include <sys/types.h>
+#ifdef _WIN32
+
+#include <windows.h>
+
+static inline int compat_getpagesize(void)
+{
+  SYSTEM_INFO si;
+  GetSystemInfo(&si);
+  return (int)si.dwPageSize;
+}
+
+#define getpagesize compat_getpagesize
+
+#else
+
 #include <unistd.h>
 
-/* NOTE: bb__ prefix is used for function names that might clash with system
- * supplied symbols. */
+#if !defined(getpagesize)
 
-#if ! SYSLOG_NG_HAVE_PREAD || SYSLOG_NG_HAVE_BROKEN_PREAD
-# ifdef pread
-#  undef pread
-# endif
-# ifdef pwrite
-#  undef pwrite
-# endif
-#define pread bb__pread
-#define pwrite bb__pwrite
+static inline int compat_getpagesize(void)
+{
+#ifdef _SC_PAGESIZE
+  long s = sysconf(_SC_PAGESIZE);
+#else
+  long s = sysconf(_SC_PAGE_SIZE);
+#endif
+  return (int)s;
+}
 
-ssize_t bb__pread(int fd, void *buf, size_t count, off_t offset);
-ssize_t bb__pwrite(int fd, const void *buf, size_t count, off_t offset);
+#define getpagesize compat_getpagesize
 
 #endif
 

--- a/lib/compat/realpath.h
+++ b/lib/compat/realpath.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#pragma once
+
+#ifndef _WIN32
+
+/* POSIX: just use the real one */
+#include <stdlib.h>
+#define compat_realpath realpath
+
+#else
+
+/* Windows: emulate POSIX realpath() via _fullpath() */
+#include <stdlib.h>
+#include <string.h>
+
+/* Behaves like POSIX realpath():
+ * - If resolved_path == NULL, returns a newly malloc'ed absolute path.
+ * - If resolved_path != NULL, writes into it and returns resolved_path.
+ *   (Caller must ensure the buffer is large enough, e.g. PATH_MAX.)
+ * On failure, returns NULL and sets errno.
+ */
+static inline char *compat_realpath(const char *path, char *resolved_path)
+{
+  /* Let CRT allocate if caller passed NULL (mirrors POSIX malloc behavior). */
+  char *tmp = _fullpath(NULL, path, 0);
+  if (!tmp)
+    return NULL;
+
+  if (resolved_path)
+    {
+      /* Caller promised enough space; copy and free temp. */
+      strcpy(resolved_path, tmp);
+      free(tmp);
+      return resolved_path;
+    }
+
+  /* Caller wanted an allocated buffer; hand tmp back. */
+  return tmp;
+}
+
+#endif /* _WIN32 */

--- a/lib/compat/socket.h
+++ b/lib/compat/socket.h
@@ -63,6 +63,7 @@ typedef int socklen_t;
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <unistd.h>
 
 #if ! SYSLOG_NG_HAVE_STRUCT_SOCKADDR_STORAGE
 struct sockaddr_storage

--- a/lib/compat/socket.h
+++ b/lib/compat/socket.h
@@ -49,6 +49,10 @@
 typedef int socklen_t;
 #endif
 
+#ifndef in_addr_t
+typedef u_long in_addr_t;
+#endif
+
 #ifndef MSG_NOSIGNAL
 #define MSG_NOSIGNAL 0
 #endif
@@ -82,7 +86,7 @@ struct sockaddr_storage
 };
 #endif /* !SYSLOG_NG_HAVE_STRUCT_SOCKADDR_STORAGE */
 
-#endif
+#endif /* POSIX */
 
 #if ! SYSLOG_NG_HAVE_INET_ATON
 int inet_aton(const char *cp, struct in_addr *dst);

--- a/lib/compat/socket.h
+++ b/lib/compat/socket.h
@@ -23,7 +23,40 @@
 #ifndef COMPAT_SOCKET_H_INCLUDED
 #define COMPAT_SOCKET_H_INCLUDED 1
 
-#include "compat/compat.h"
+#include "compat.h"
+
+#if defined(_WIN32)
+
+/* keep windows.h lean, and exclude GDI (defines Arc) */
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN 1
+#endif
+#ifndef NOGDI
+#define NOGDI 1
+#endif
+
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
+#endif
+
+/* Winsock first (must precede <windows.h> anywhere) */
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+/* POSIX-ish bits commonly used in the tree */
+#ifndef socklen_t
+typedef int socklen_t;
+#endif
+
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#endif
+
+/* On Windows we rely on ws2tcpip’s struct sockaddr_storage.
+ * Don’t provide our own fallback here to avoid redefinition.
+ */
+
+#else  /* POSIX */
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -45,6 +78,8 @@ struct sockaddr_storage
 #endif
   };
 };
+#endif /* !SYSLOG_NG_HAVE_STRUCT_SOCKADDR_STORAGE */
+
 #endif
 
 #if ! SYSLOG_NG_HAVE_INET_ATON

--- a/lib/compat/socket.h
+++ b/lib/compat/socket.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2002-2013 Balabit
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/compat/syslog.h
+++ b/lib/compat/syslog.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#pragma once
+
+#include <stdarg.h>
+
+/* Priorities */
+#define LOG_EMERG   0
+#define LOG_ALERT   1
+#define LOG_CRIT    2
+#define LOG_ERR     3
+#define LOG_WARNING 4
+#define LOG_NOTICE  5
+#define LOG_INFO    6
+#define LOG_DEBUG   7
+#define LOG_PRIMASK 0x07
+#define LOG_PRI(p)  ((p) & LOG_PRIMASK)
+#define LOG_MAKEPRI(fac, pri) ((fac) | (pri))
+#define LOG_NFACILITIES 24 /* current number of facilities */
+
+/* Facilities */
+#define LOG_KERN    (0<<3)
+#define LOG_USER    (1<<3)
+#define LOG_MAIL    (2<<3)
+#define LOG_DAEMON  (3<<3)
+#define LOG_AUTH    (4<<3)
+#define LOG_SYSLOG  (5<<3)
+#define LOG_LPR     (6<<3)
+#define LOG_NEWS    (7<<3)
+#define LOG_UUCP    (8<<3)
+#define LOG_CRON    (9<<3)
+#define LOG_AUTHPRIV (10<<3)
+#define LOG_FTP     (11<<3)
+#define LOG_LOCAL0  (16<<3)
+#define LOG_LOCAL1  (17<<3)
+#define LOG_LOCAL2  (18<<3)
+#define LOG_LOCAL3  (19<<3)
+#define LOG_LOCAL4  (20<<3)
+#define LOG_LOCAL5  (21<<3)
+#define LOG_LOCAL6  (22<<3)
+#define LOG_LOCAL7  (23<<3)
+#define LOG_FACMASK 0x03f8
+#define LOG_FAC(p)  (((p) & LOG_FACMASK) >> 3)
+
+#ifdef SYSLOG_NAMES
+
+#define INTERNAL_NOPRI 0x10        /* the "no priority" priority */
+#define        INTERNAL_MARK        LOG_MAKEPRI(LOG_NFACILITIES, 0)
+typedef struct _code {
+        char        *c_name;
+        int        c_val;
+} CODE;
+
+extern const CODE prioritynames[];
+extern const CODE facilitynames[];
+#endif
+
+#define LOG_MASK(pri) (1 << (pri))
+#define LOG_UPTO(pri) ((1 << ((pri)+1)) - 1)
+
+/*
+ * Option flags for openlog.
+ *
+ * LOG_ODELAY no longer does anything.
+ * LOG_NDELAY is the inverse of what it used to be.
+ */
+#define        LOG_PID                0x01        /* log the pid with each message */
+#define        LOG_CONS        0x02        /* log on the console if errors in sending */
+#define        LOG_ODELAY        0x04        /* delay open until first syslog() (default) */
+#define        LOG_NDELAY        0x08        /* don't delay open */
+#define        LOG_NOWAIT        0x10        /* don't wait for console forks: DEPRECATED */
+#define        LOG_PERROR        0x20        /* log to stderr as well */
+
+/* Optional prototypes (only used if someone actually calls them) */
+void openlog(const char *ident, int option, int facility);
+void syslog(int priority, const char *fmt, ...);
+void closelog(void);

--- a/lib/compat/syslog.h
+++ b/lib/compat/syslog.h
@@ -66,9 +66,10 @@
 
 #define INTERNAL_NOPRI 0x10        /* the "no priority" priority */
 #define        INTERNAL_MARK        LOG_MAKEPRI(LOG_NFACILITIES, 0)
-typedef struct _code {
-        char        *c_name;
-        int        c_val;
+typedef struct _code
+{
+  char        *c_name;
+  int        c_val;
 } CODE;
 
 extern const CODE prioritynames[];

--- a/lib/compat/syslog.h
+++ b/lib/compat/syslog.h
@@ -22,6 +22,8 @@
  */
 #pragma once
 
+#ifdef _WIN32
+
 #include <stdarg.h>
 
 /* Priorities */
@@ -96,3 +98,9 @@ extern const CODE facilitynames[];
 void openlog(const char *ident, int option, int facility);
 void syslog(int priority, const char *fmt, ...);
 void closelog(void);
+
+#else
+
+#include <syslog.h>
+
+#endif

--- a/lib/compat/uio.h
+++ b/lib/compat/uio.h
@@ -31,4 +31,8 @@ struct iovec
   size_t iov_len;
 };
 
+#else
+
+#include <sys/uio.h>
+
 #endif

--- a/lib/compat/uio.h
+++ b/lib/compat/uio.h
@@ -25,6 +25,10 @@
 #if defined(_WIN32)
 #include <stddef.h>
 
-struct iovec { void *iov_base; size_t iov_len; };
+struct iovec
+{
+  void *iov_base;
+  size_t iov_len;
+};
 
 #endif

--- a/lib/compat/uio.h
+++ b/lib/compat/uio.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2002-2010 Balabit
- * Copyright (c) 1998-2010 Balázs Scheidler
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -22,18 +21,10 @@
  *
  */
 
-#ifndef ALARMS_H_INCLUDED
-#define ALARMS_H_INCLUDED
+#pragma once
+#if defined(_WIN32)
+#include <stddef.h>
 
-#include "syslog-ng.h"
-#include "compat/alarm.h"
-
-void alarm_set(int timeout);
-void alarm_cancel(void);
-gboolean alarm_has_fired(void);
-
-void alarm_init(void);
-
+struct iovec { void *iov_base; size_t iov_len; };
 
 #endif
-

--- a/lib/compat/un.h
+++ b/lib/compat/un.h
@@ -23,6 +23,15 @@
 #ifndef COMPAT_UN_H_INCLUDED
 #define COMPAT_UN_H_INCLUDED 1
 
+#if defined(_WIN32)
+
+  #ifndef SUN_LEN
+  # include <string.h>
+  # define SUN_LEN(ptr) ((socklen_t)(sizeof(*(ptr)) - sizeof((ptr)->sun_path) + strlen((ptr)->sun_path)))
+  #endif
+
+#else /* POSIX */
+
 #include <sys/un.h>
 
 /*
@@ -34,4 +43,6 @@
 #define SUN_LEN(ptr) ((size_t) (((struct sockaddr_un *) 0)->sun_path) + strlen ((ptr)->sun_path))
 #endif
 
-#endif
+#endif /* SYS_CHECK */
+
+#endif /* COMPAT_UN_H_INCLUDED */

--- a/lib/compat/un.h
+++ b/lib/compat/un.h
@@ -25,9 +25,27 @@
 
 #if defined(_WIN32)
 
+  /* Make AF_UNIX visible (Vista+) and ensure include order */
+  #ifndef _WIN32_WINNT
+    #define _WIN32_WINNT 0x0600
+  #endif
+  #ifndef WINVER
+    #define WINVER 0x0600
+  #endif
+
+  /* winsock2 must come before afunix/windows.h */
+  #ifndef _WINSOCKAPI_
+    #include <winsock2.h>
+  #endif
+
+  /* Try the official Windows header (MSYS2 MinGW provides this) */
+  #if __has_include(<afunix.h>)
+    #include <afunix.h>
+  #endif
+  
   #ifndef SUN_LEN
-  # include <string.h>
-  # define SUN_LEN(ptr) ((socklen_t)(sizeof(*(ptr)) - sizeof((ptr)->sun_path) + strlen((ptr)->sun_path)))
+    #include <string.h>
+    #define SUN_LEN(ptr) ((size_t)(((struct sockaddr_un *)0)->sun_path) + strlen((ptr)->sun_path))
   #endif
 
 #else /* POSIX */

--- a/lib/compat/un.h
+++ b/lib/compat/un.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2002-2018 Balabit
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -42,7 +43,7 @@
   #if __has_include(<afunix.h>)
     #include <afunix.h>
   #endif
-  
+
   #ifndef SUN_LEN
     #include <string.h>
     #define SUN_LEN(ptr) ((size_t)(((struct sockaddr_un *)0)->sun_path) + strlen((ptr)->sun_path))

--- a/lib/compat/un.h
+++ b/lib/compat/un.h
@@ -26,28 +26,28 @@
 
 #if defined(_WIN32)
 
-  /* Make AF_UNIX visible (Vista+) and ensure include order */
-  #ifndef _WIN32_WINNT
-    #define _WIN32_WINNT 0x0600
-  #endif
-  #ifndef WINVER
-    #define WINVER 0x0600
-  #endif
+/* Make AF_UNIX visible (Vista+) and ensure include order */
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
+#endif
+#ifndef WINVER
+#define WINVER 0x0600
+#endif
 
-  /* winsock2 must come before afunix/windows.h */
-  #ifndef _WINSOCKAPI_
-    #include <winsock2.h>
-  #endif
+/* winsock2 must come before afunix/windows.h */
+#ifndef _WINSOCKAPI_
+#include <winsock2.h>
+#endif
 
-  /* Try the official Windows header (MSYS2 MinGW provides this) */
-  #if __has_include(<afunix.h>)
-    #include <afunix.h>
-  #endif
+/* Try the official Windows header (MSYS2 MinGW provides this) */
+#if __has_include(<afunix.h>)
+#include <afunix.h>
+#endif
 
-  #ifndef SUN_LEN
-    #include <string.h>
-    #define SUN_LEN(ptr) ((size_t)(((struct sockaddr_un *)0)->sun_path) + strlen((ptr)->sun_path))
-  #endif
+#ifndef SUN_LEN
+#include <string.h>
+#define SUN_LEN(ptr) ((size_t)(((struct sockaddr_un *)0)->sun_path) + strlen((ptr)->sun_path))
+#endif
 
 #else /* POSIX */
 

--- a/lib/console.c
+++ b/lib/console.c
@@ -31,9 +31,9 @@
 #include <errno.h>
 
 #ifndef _WIN32
-  #include <syslog.h>
+#include <syslog.h>
 #else
-  #include "compat/syslog.h"
+#include "compat/syslog.h"
 #endif
 
 GMutex console_lock;

--- a/lib/console.c
+++ b/lib/console.c
@@ -27,8 +27,13 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <syslog.h>
 #include <errno.h>
+
+#ifndef _WIN32
+  #include <syslog.h>
+#else
+  #include "compat/syslog.h"
+#endif
 
 GMutex console_lock;
 gboolean using_initial_console = TRUE;

--- a/lib/console.c
+++ b/lib/console.c
@@ -3,6 +3,7 @@
  * Copyright (c) 1998-2012 Balázs Scheidler
  * Copyright (c) 2024 Balázs Scheidler <balazs.scheidler@axoflow.com>
  * Copyright (c) 2025 Hofi <hofione@gmail.com>
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/dnscache.c
+++ b/lib/dnscache.c
@@ -29,9 +29,6 @@
 
 #include <sys/types.h>
 #include "compat/socket.h"
-#ifndef _WIN32
-  #include <netinet/in.h>
-#endif
 #include <sys/stat.h>
 #include <stdio.h>
 #include <errno.h>

--- a/lib/dnscache.c
+++ b/lib/dnscache.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/dnscache.c
+++ b/lib/dnscache.c
@@ -28,9 +28,10 @@
 #include "tls-support.h"
 
 #include <sys/types.h>
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <arpa/inet.h>
+#include "compat/socket.h"
+#ifndef _WIN32
+  #include <netinet/in.h>
+#endif
 #include <sys/stat.h>
 #include <stdio.h>
 #include <errno.h>

--- a/lib/eventlog/CMakeLists.txt
+++ b/lib/eventlog/CMakeLists.txt
@@ -6,10 +6,13 @@ add_library(eventlog SHARED
   src/evtstr.c
   src/evtsyslog.c
   src/evttags.c
+  compat/syslog.c
 )
 
 target_include_directories(eventlog
   SYSTEM
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/compat
   INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
@@ -18,6 +21,11 @@ target_link_libraries(eventlog
   PRIVATE
     GLib::GLib
 )
+
+if (WIN32)
+  target_compile_definitions(eventlog PRIVATE _WIN32_WINNT=0x0600)
+  target_link_libraries(eventlog PRIVATE ws2_32) # sockets on Windows
+endif()
 
 install(TARGETS eventlog DESTINATION lib)
 

--- a/lib/eventlog/CMakeLists.txt
+++ b/lib/eventlog/CMakeLists.txt
@@ -6,13 +6,11 @@ add_library(eventlog SHARED
   src/evtstr.c
   src/evtsyslog.c
   src/evttags.c
-  compat/syslog.c
+  src/compat/syslog.c
 )
 
 target_include_directories(eventlog
   SYSTEM
-  PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/compat
   INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )

--- a/lib/eventlog/compat/socket.h
+++ b/lib/eventlog/compat/socket.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+ #pragma once
+
+#include <stddef.h>
+
+#if defined(_WIN32)
+
+/* Needs to be defined before including ws2tcpip.h for inet_ntop/pton */
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
+#endif
+
+/* Winsock first (must precede <windows.h> anywhere) */
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+/* POSIX-ish bits commonly used in the tree */
+#ifndef socklen_t
+typedef int socklen_t;
+#endif
+
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#endif
+
+#endif

--- a/lib/eventlog/compat/socket.h
+++ b/lib/eventlog/compat/socket.h
@@ -20,7 +20,7 @@
  * COPYING for details.
  *
  */
- #pragma once
+#pragma once
 
 #include <stddef.h>
 

--- a/lib/eventlog/compat/syslog.c
+++ b/lib/eventlog/compat/syslog.c
@@ -36,48 +36,48 @@
 
 #ifdef SYSLOG_NAMES
 extern const CODE prioritynames[] =
-  {
-    { "alert", LOG_ALERT },
-    { "crit", LOG_CRIT },
-    { "debug", LOG_DEBUG },
-    { "emerg", LOG_EMERG },
-    { "err", LOG_ERR },
-    { "error", LOG_ERR },                /* DEPRECATED */
-    { "info", LOG_INFO },
-    { "none", INTERNAL_NOPRI },                /* INTERNAL */
-    { "notice", LOG_NOTICE },
-    { "panic", LOG_EMERG },                /* DEPRECATED */
-    { "warn", LOG_WARNING },                /* DEPRECATED */
-    { "warning", LOG_WARNING },
-    { NULL, -1 }
-  };
+{
+  { "alert", LOG_ALERT },
+  { "crit", LOG_CRIT },
+  { "debug", LOG_DEBUG },
+  { "emerg", LOG_EMERG },
+  { "err", LOG_ERR },
+  { "error", LOG_ERR },                /* DEPRECATED */
+  { "info", LOG_INFO },
+  { "none", INTERNAL_NOPRI },                /* INTERNAL */
+  { "notice", LOG_NOTICE },
+  { "panic", LOG_EMERG },                /* DEPRECATED */
+  { "warn", LOG_WARNING },                /* DEPRECATED */
+  { "warning", LOG_WARNING },
+  { NULL, -1 }
+};
 
 extern const CODE facilitynames[] =
-  {
-    { "auth", LOG_AUTH },
-    { "authpriv", LOG_AUTHPRIV },
-    { "cron", LOG_CRON },
-    { "daemon", LOG_DAEMON },
-    { "ftp", LOG_FTP },
-    { "kern", LOG_KERN },
-    { "lpr", LOG_LPR },
-    { "mail", LOG_MAIL },
-    { "mark", INTERNAL_MARK },                /* INTERNAL */
-    { "news", LOG_NEWS },
-    { "security", LOG_AUTH },                /* DEPRECATED */
-    { "syslog", LOG_SYSLOG },
-    { "user", LOG_USER },
-    { "uucp", LOG_UUCP },
-    { "local0", LOG_LOCAL0 },
-    { "local1", LOG_LOCAL1 },
-    { "local2", LOG_LOCAL2 },
-    { "local3", LOG_LOCAL3 },
-    { "local4", LOG_LOCAL4 },
-    { "local5", LOG_LOCAL5 },
-    { "local6", LOG_LOCAL6 },
-    { "local7", LOG_LOCAL7 },
-    { NULL, -1 }
-  };
+{
+  { "auth", LOG_AUTH },
+  { "authpriv", LOG_AUTHPRIV },
+  { "cron", LOG_CRON },
+  { "daemon", LOG_DAEMON },
+  { "ftp", LOG_FTP },
+  { "kern", LOG_KERN },
+  { "lpr", LOG_LPR },
+  { "mail", LOG_MAIL },
+  { "mark", INTERNAL_MARK },                /* INTERNAL */
+  { "news", LOG_NEWS },
+  { "security", LOG_AUTH },                /* DEPRECATED */
+  { "syslog", LOG_SYSLOG },
+  { "user", LOG_USER },
+  { "uucp", LOG_UUCP },
+  { "local0", LOG_LOCAL0 },
+  { "local1", LOG_LOCAL1 },
+  { "local2", LOG_LOCAL2 },
+  { "local3", LOG_LOCAL3 },
+  { "local4", LOG_LOCAL4 },
+  { "local5", LOG_LOCAL5 },
+  { "local6", LOG_LOCAL6 },
+  { "local7", LOG_LOCAL7 },
+  { NULL, -1 }
+};
 #endif
 
 static char *g_ident   = NULL;
@@ -86,7 +86,8 @@ static int   g_facility = LOG_USER; /* kept for API parity */
 
 static void _syslog_vwrite(int priority, const char *fmt, va_list ap)
 {
-  (void)priority; (void)g_facility;
+  (void)priority;
+  (void)g_facility;
 
   char buf[1024];
   int n = vsnprintf(buf, sizeof(buf), fmt ? fmt : "", ap);
@@ -94,14 +95,17 @@ static void _syslog_vwrite(int priority, const char *fmt, va_list ap)
 
   /* LOG_PERROR => always stderr here; LOG_CONS ignored on Windows */
   FILE *out = stderr;
-  if (g_ident) {
-    if (g_options & LOG_PID)
-      fprintf(out, "%s[%d]: %s\n", g_ident, _getpid(), buf);
-    else
-      fprintf(out, "%s: %s\n", g_ident, buf);
-  } else {
-    fprintf(out, "%s\n", buf);
-  }
+  if (g_ident)
+    {
+      if (g_options & LOG_PID)
+        fprintf(out, "%s[%d]: %s\n", g_ident, _getpid(), buf);
+      else
+        fprintf(out, "%s: %s\n", g_ident, buf);
+    }
+  else
+    {
+      fprintf(out, "%s\n", buf);
+    }
   fflush(out);
 
   /* also send to debugger */

--- a/lib/eventlog/compat/syslog.c
+++ b/lib/eventlog/compat/syslog.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2025 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#include "syslog.h"
+
+#if defined(_WIN32)
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <process.h>
+
+#if defined(_MSC_VER)
+#define strdup _strdup
+#endif
+
+#ifdef SYSLOG_NAMES
+extern const CODE prioritynames[] =
+  {
+    { "alert", LOG_ALERT },
+    { "crit", LOG_CRIT },
+    { "debug", LOG_DEBUG },
+    { "emerg", LOG_EMERG },
+    { "err", LOG_ERR },
+    { "error", LOG_ERR },                /* DEPRECATED */
+    { "info", LOG_INFO },
+    { "none", INTERNAL_NOPRI },                /* INTERNAL */
+    { "notice", LOG_NOTICE },
+    { "panic", LOG_EMERG },                /* DEPRECATED */
+    { "warn", LOG_WARNING },                /* DEPRECATED */
+    { "warning", LOG_WARNING },
+    { NULL, -1 }
+  };
+
+extern const CODE facilitynames[] =
+  {
+    { "auth", LOG_AUTH },
+    { "authpriv", LOG_AUTHPRIV },
+    { "cron", LOG_CRON },
+    { "daemon", LOG_DAEMON },
+    { "ftp", LOG_FTP },
+    { "kern", LOG_KERN },
+    { "lpr", LOG_LPR },
+    { "mail", LOG_MAIL },
+    { "mark", INTERNAL_MARK },                /* INTERNAL */
+    { "news", LOG_NEWS },
+    { "security", LOG_AUTH },                /* DEPRECATED */
+    { "syslog", LOG_SYSLOG },
+    { "user", LOG_USER },
+    { "uucp", LOG_UUCP },
+    { "local0", LOG_LOCAL0 },
+    { "local1", LOG_LOCAL1 },
+    { "local2", LOG_LOCAL2 },
+    { "local3", LOG_LOCAL3 },
+    { "local4", LOG_LOCAL4 },
+    { "local5", LOG_LOCAL5 },
+    { "local6", LOG_LOCAL6 },
+    { "local7", LOG_LOCAL7 },
+    { NULL, -1 }
+  };
+#endif
+
+static char *g_ident   = NULL;
+static int   g_options = 0;
+static int   g_facility = LOG_USER; /* kept for API parity */
+
+static void _syslog_vwrite(int priority, const char *fmt, va_list ap)
+{
+  (void)priority; (void)g_facility;
+
+  char buf[1024];
+  int n = vsnprintf(buf, sizeof(buf), fmt ? fmt : "", ap);
+  if (n < 0) return;
+
+  /* LOG_PERROR => always stderr here; LOG_CONS ignored on Windows */
+  FILE *out = stderr;
+  if (g_ident) {
+    if (g_options & LOG_PID)
+      fprintf(out, "%s[%d]: %s\n", g_ident, _getpid(), buf);
+    else
+      fprintf(out, "%s: %s\n", g_ident, buf);
+  } else {
+    fprintf(out, "%s\n", buf);
+  }
+  fflush(out);
+
+  /* also send to debugger */
+  OutputDebugStringA(buf);
+  OutputDebugStringA("\n");
+}
+
+void openlog(const char *ident, int option, int facility)
+{
+  free(g_ident);
+  g_ident   = ident ? strdup(ident) : NULL;
+  g_options = option;
+  g_facility = facility;
+}
+
+void syslog(int priority, const char *fmt, ...)
+{
+  va_list ap;
+  va_start(ap, fmt);
+  _syslog_vwrite(priority, fmt, ap);
+  va_end(ap);
+}
+
+void closelog(void)
+{
+  free(g_ident);
+  g_ident = NULL;
+  g_options = 0;
+  g_facility = LOG_USER;
+}
+#endif /* _WIN32 */

--- a/lib/eventlog/compat/syslog.h
+++ b/lib/eventlog/compat/syslog.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#pragma once
+
+#include <stdarg.h>
+
+/* Priorities */
+#define LOG_EMERG   0
+#define LOG_ALERT   1
+#define LOG_CRIT    2
+#define LOG_ERR     3
+#define LOG_WARNING 4
+#define LOG_NOTICE  5
+#define LOG_INFO    6
+#define LOG_DEBUG   7
+#define LOG_PRIMASK 0x07
+#define LOG_PRI(p)  ((p) & LOG_PRIMASK)
+#define LOG_MAKEPRI(fac, pri) ((fac) | (pri))
+#define LOG_NFACILITIES 24 /* current number of facilities */
+
+/* Facilities */
+#define LOG_KERN    (0<<3)
+#define LOG_USER    (1<<3)
+#define LOG_MAIL    (2<<3)
+#define LOG_DAEMON  (3<<3)
+#define LOG_AUTH    (4<<3)
+#define LOG_SYSLOG  (5<<3)
+#define LOG_LPR     (6<<3)
+#define LOG_NEWS    (7<<3)
+#define LOG_UUCP    (8<<3)
+#define LOG_CRON    (9<<3)
+#define LOG_AUTHPRIV (10<<3)
+#define LOG_FTP     (11<<3)
+#define LOG_LOCAL0  (16<<3)
+#define LOG_LOCAL1  (17<<3)
+#define LOG_LOCAL2  (18<<3)
+#define LOG_LOCAL3  (19<<3)
+#define LOG_LOCAL4  (20<<3)
+#define LOG_LOCAL5  (21<<3)
+#define LOG_LOCAL6  (22<<3)
+#define LOG_LOCAL7  (23<<3)
+#define LOG_FACMASK 0x03f8
+#define LOG_FAC(p)  (((p) & LOG_FACMASK) >> 3)
+
+#ifdef SYSLOG_NAMES
+
+#define INTERNAL_NOPRI 0x10        /* the "no priority" priority */
+#define        INTERNAL_MARK        LOG_MAKEPRI(LOG_NFACILITIES, 0)
+typedef struct _code {
+        char        *c_name;
+        int        c_val;
+} CODE;
+
+extern const CODE prioritynames[];
+extern const CODE facilitynames[];
+#endif
+
+#define LOG_MASK(pri) (1 << (pri))
+#define LOG_UPTO(pri) ((1 << ((pri)+1)) - 1)
+
+/*
+ * Option flags for openlog.
+ *
+ * LOG_ODELAY no longer does anything.
+ * LOG_NDELAY is the inverse of what it used to be.
+ */
+#define        LOG_PID                0x01        /* log the pid with each message */
+#define        LOG_CONS        0x02        /* log on the console if errors in sending */
+#define        LOG_ODELAY        0x04        /* delay open until first syslog() (default) */
+#define        LOG_NDELAY        0x08        /* don't delay open */
+#define        LOG_NOWAIT        0x10        /* don't wait for console forks: DEPRECATED */
+#define        LOG_PERROR        0x20        /* log to stderr as well */
+
+/* Optional prototypes (only used if someone actually calls them) */
+void openlog(const char *ident, int option, int facility);
+void syslog(int priority, const char *fmt, ...);
+void closelog(void);

--- a/lib/eventlog/compat/syslog.h
+++ b/lib/eventlog/compat/syslog.h
@@ -66,9 +66,10 @@
 
 #define INTERNAL_NOPRI 0x10        /* the "no priority" priority */
 #define        INTERNAL_MARK        LOG_MAKEPRI(LOG_NFACILITIES, 0)
-typedef struct _code {
-        char        *c_name;
-        int        c_val;
+typedef struct _code
+{
+  char        *c_name;
+  int        c_val;
 } CODE;
 
 extern const CODE prioritynames[];

--- a/lib/eventlog/src/Makefile.am
+++ b/lib/eventlog/src/Makefile.am
@@ -20,7 +20,8 @@ lib_eventlog_src_libevtlog_la_SOURCES = \
 		lib/eventlog/src/evtstr.c \
 		lib/eventlog/src/evtctx.c \
 		lib/eventlog/src/evttags.c \
-		lib/eventlog/src/evtsyslog.c
+		lib/eventlog/src/evtsyslog.c \
+		lib/eventlog/src/compat/syslog.c
 
 lib_eventlog_src_libevtlog_la_LDFLAGS = -no-undefined -release ${LSNG_RELEASE} \
 					-version-info ${LSNG_CURRENT}:${LSNG_REVISION}:${LSNG_AGE}
@@ -34,4 +35,6 @@ noinst_HEADERS = lib/eventlog/src/evt_internals.h
 
 pkginclude_HEADERS += \
 		lib/eventlog/src/evtmaps.h \
-		lib/eventlog/src/evtlog.h
+		lib/eventlog/src/evtlog.h \
+		lib/eventlog/src/compat/socket.h \
+		lib/eventlog/src/compat/syslog.h

--- a/lib/eventlog/src/compat/socket.h
+++ b/lib/eventlog/src/compat/socket.h
@@ -44,4 +44,13 @@ typedef int socklen_t;
 #define MSG_NOSIGNAL 0
 #endif
 
+#else /* WIN32 */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <unistd.h>
+
 #endif

--- a/lib/eventlog/src/compat/syslog.c
+++ b/lib/eventlog/src/compat/syslog.c
@@ -23,6 +23,7 @@
 #include "syslog.h"
 
 #if defined(_WIN32)
+
 #include <windows.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -136,4 +137,5 @@ void closelog(void)
   g_options = 0;
   g_facility = LOG_USER;
 }
+
 #endif /* _WIN32 */

--- a/lib/eventlog/src/compat/syslog.h
+++ b/lib/eventlog/src/compat/syslog.h
@@ -22,6 +22,8 @@
  */
 #pragma once
 
+#if defined(_WIN32)
+
 #include <stdarg.h>
 
 /* Priorities */
@@ -96,3 +98,9 @@ extern const CODE facilitynames[];
 void openlog(const char *ident, int option, int facility);
 void syslog(int priority, const char *fmt, ...);
 void closelog(void);
+
+#else
+
+#include <syslog.h>
+
+#endif

--- a/lib/eventlog/src/evtlog.h
+++ b/lib/eventlog/src/evtlog.h
@@ -1,6 +1,7 @@
 /*
  * Event Logging API
  * Copyright (c) 2003 BalaBit IT Ltd.
+ * Copyright (c) 2025 One Identity
  * All rights reserved.
  * Author: Balazs Scheidler
  *

--- a/lib/eventlog/src/evtlog.h
+++ b/lib/eventlog/src/evtlog.h
@@ -41,15 +41,8 @@
 #ifndef __EVTLOG_H_INCLUDED
 #define __EVTLOG_H_INCLUDED
 
-#if defined(_WIN32) || defined(_MSC_VER)
-#include "../compat/syslog.h"
-#else
-#include <syslog.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#endif
+#include "compat/syslog.h"
+#include "compat/socket.h"
 #include <stdarg.h>
 #include <glib.h>
 

--- a/lib/eventlog/src/evtlog.h
+++ b/lib/eventlog/src/evtlog.h
@@ -42,13 +42,13 @@
 #define __EVTLOG_H_INCLUDED
 
 #if defined(_WIN32) || defined(_MSC_VER)
-  #include "../compat/syslog.h"
+#include "../compat/syslog.h"
 #else
-  #include <syslog.h>
-  #include <sys/types.h>
-  #include <sys/socket.h>
-  #include <netinet/in.h>
-  #include <arpa/inet.h>
+#include <syslog.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
 #endif
 #include <stdarg.h>
 #include <glib.h>

--- a/lib/eventlog/src/evtlog.h
+++ b/lib/eventlog/src/evtlog.h
@@ -40,14 +40,16 @@
 #ifndef __EVTLOG_H_INCLUDED
 #define __EVTLOG_H_INCLUDED
 
-#ifndef _MSC_VER
-# include <syslog.h>
+#if defined(_WIN32) || defined(_MSC_VER)
+  #include "../compat/syslog.h"
+#else
+  #include <syslog.h>
+  #include <sys/types.h>
+  #include <sys/socket.h>
+  #include <netinet/in.h>
+  #include <arpa/inet.h>
 #endif
 #include <stdarg.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
 #include <glib.h>
 
 #include "evtmaps.h"
@@ -145,9 +147,10 @@ EVTTAG *evt_tag_int(const char *tag, int value);
 EVTTAG *evt_tag_long(const char *tag, long long value);
 EVTTAG *evt_tag_errno(const char *tag, int err);
 EVTTAG *evt_tag_printf(const char *tag, const char *format, ...) G_GNUC_PRINTF(2, 3);
+#ifndef _WIN32
 EVTTAG *evt_tag_inaddr(const char *tag, const struct in_addr *addr);
 EVTTAG *evt_tag_inaddr6(const char *tag, const struct in6_addr *addr);
-
+#endif
 /**
  * evt_format:
  * @e: event record

--- a/lib/eventlog/src/evtout.c
+++ b/lib/eventlog/src/evtout.c
@@ -1,6 +1,7 @@
 /*
  * Event Logging API
  * Copyright (c) 2003 BalaBit IT Ltd.
+ * Copyright (c) 2025 One Identity
  * All rights reserved.
  * Author: Balazs Scheidler
  *

--- a/lib/eventlog/src/evtout.c
+++ b/lib/eventlog/src/evtout.c
@@ -42,8 +42,12 @@
  */
 #include "evt_internals.h"
 
+#if defined(_WIN32)
+  #include "../compat/syslog.h"
+#else
+  #include <syslog.h>
+#endif
 #include <stdlib.h>
-#include <syslog.h>
 #include <string.h>
 
 /* local method implementation */

--- a/lib/eventlog/src/evtout.c
+++ b/lib/eventlog/src/evtout.c
@@ -44,9 +44,9 @@
 #include "evt_internals.h"
 
 #if defined(_WIN32)
-  #include "../compat/syslog.h"
+#include "../compat/syslog.h"
 #else
-  #include <syslog.h>
+#include <syslog.h>
 #endif
 #include <stdlib.h>
 #include <string.h>

--- a/lib/eventlog/src/evtout.c
+++ b/lib/eventlog/src/evtout.c
@@ -43,11 +43,7 @@
  */
 #include "evt_internals.h"
 
-#if defined(_WIN32)
-#include "../compat/syslog.h"
-#else
-#include <syslog.h>
-#endif
+#include "compat/syslog.h"
 #include <stdlib.h>
 #include <string.h>
 

--- a/lib/eventlog/src/evtsyslog.c
+++ b/lib/eventlog/src/evtsyslog.c
@@ -39,7 +39,7 @@
 
 #include <stdarg.h>
 #include <stdio.h>
-#include <syslog.h>
+#include "compat/syslog.h"
 
 EVTCONTEXT *syslog_context;
 EVTSYSLOGOPTS syslog_opts;

--- a/lib/eventlog/src/evttags.c
+++ b/lib/eventlog/src/evttags.c
@@ -42,7 +42,7 @@
 
 #include "evt_internals.h"
 
-#include "../compat/socket.h"
+#include "compat/socket.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/lib/eventlog/src/evttags.c
+++ b/lib/eventlog/src/evttags.c
@@ -1,6 +1,7 @@
 /*
  * Event Logging API
  * Copyright (c) 2003 BalaBit IT Ltd.
+ * Copyright (c) 2025 One Identity
  * All rights reserved.
  * Author: Balazs Scheidler
  *

--- a/lib/eventlog/src/evttags.c
+++ b/lib/eventlog/src/evttags.c
@@ -41,6 +41,8 @@
 
 #include "evt_internals.h"
 
+#include "../compat/socket.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/lib/eventlog/tests/test_evtsyslog.c
+++ b/lib/eventlog/tests/test_evtsyslog.c
@@ -1,4 +1,4 @@
-#include <syslog.h>
+#include "compat/syslog.h"
 
 #ifdef EVENTLOG_SYSLOG_MACROS
 #include <evtlog.h>

--- a/lib/fdhelpers.c
+++ b/lib/fdhelpers.c
@@ -23,12 +23,21 @@
  */
 #include "fdhelpers.h"
 
-#include <unistd.h>
-#include <fcntl.h>
+#ifndef _WIN32
+  #include <unistd.h>
+  #include <fcntl.h>
+#else
+  #include <winsock2.h>
+  #include <ws2tcpip.h>
+  #include <windows.h>
+  #include <io.h>
+  #include <errno.h>
+#endif
 
 gboolean
 g_fd_set_nonblock(int fd, gboolean enable)
 {
+#ifndef _WIN32
   int flags;
 
   if ((flags = fcntl(fd, F_GETFL)) == -1)
@@ -43,11 +52,22 @@ g_fd_set_nonblock(int fd, gboolean enable)
       return FALSE;
     }
   return TRUE;
+#else
+  /* Windows: only sockets support nonblocking reliably */
+  u_long mode = enable ? 1UL : 0UL;
+  if (ioctlsocket((SOCKET)(uintptr_t)fd, FIONBIO, &mode) == 0)
+    return TRUE;
+
+  /* Not a socket (or invalid): no generic nonblocking for files/pipes */
+  errno = ENOSYS;
+  return FALSE;
+#endif
 }
 
 gboolean
 g_fd_set_cloexec(int fd, gboolean enable)
 {
+#ifndef _WIN32
   int flags;
 
   if ((flags = fcntl(fd, F_GETFD)) == -1)
@@ -62,4 +82,22 @@ g_fd_set_cloexec(int fd, gboolean enable)
       return FALSE;
     }
   return TRUE;
+#else
+  /* Best effort: set/clear inherit flag on underlying OS handle (files/pipes) */
+  intptr_t osfh = _get_osfhandle(fd);
+  if (osfh != -1 && osfh != (intptr_t)INVALID_HANDLE_VALUE)
+    {
+      DWORD cur = 0;
+      if (!GetHandleInformation((HANDLE)osfh, &cur))
+        return FALSE;
+      DWORD want = enable ? (cur | HANDLE_FLAG_INHERIT) : (cur & ~HANDLE_FLAG_INHERIT);
+      return SetHandleInformation((HANDLE)osfh, HANDLE_FLAG_INHERIT, want & HANDLE_FLAG_INHERIT) ? TRUE : FALSE;
+    }
+
+  /* If it's actually a SOCKET disguised as an int, try best-effort */
+  HANDLE h = (HANDLE)(uintptr_t)fd;
+  SetHandleInformation(h, HANDLE_FLAG_INHERIT, enable ? HANDLE_FLAG_INHERIT : 0);
+  /* Don’t fail hard: inheritance of sockets is rare in this codebase */
+  return TRUE;
+#endif
 }

--- a/lib/fdhelpers.c
+++ b/lib/fdhelpers.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/fdhelpers.c
+++ b/lib/fdhelpers.c
@@ -25,14 +25,14 @@
 #include "fdhelpers.h"
 
 #ifndef _WIN32
-  #include <unistd.h>
-  #include <fcntl.h>
+#include <unistd.h>
+#include <fcntl.h>
 #else
-  #include <winsock2.h>
-  #include <ws2tcpip.h>
-  #include <windows.h>
-  #include <io.h>
-  #include <errno.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
+#include <io.h>
+#include <errno.h>
 #endif
 
 gboolean

--- a/lib/file-perms.c
+++ b/lib/file-perms.c
@@ -28,10 +28,19 @@
 #include "cfg.h"
 #include "gprocess.h"
 
-#include <unistd.h>
 #include <sys/stat.h>
 #include <string.h>
 #include <errno.h>
+
+#ifndef _WIN32
+  #include <unistd.h>
+#else
+  #include <windows.h>
+  #include <io.h>
+  #include <direct.h>
+  typedef int uid_t;      /* stubs for API parity */
+  typedef int gid_t;
+#endif
 
 #define DONTCHANGE -2
 
@@ -181,23 +190,29 @@ file_perm_options_inherit_dont_change(FilePermOptions *self)
 gboolean
 file_perm_options_apply_file(const FilePermOptions *self, const gchar *path)
 {
-#ifndef _MSC_VER
   gboolean result = TRUE;
-
+#ifdef _WIN32
+  /* chown/lchown unsupported -> ignore uid/gid */
+  if (self->file_perm >= 0 && chmod(path, (mode_t) self->file_perm) < 0)
+    result = FALSE;
+#elif defined(_MSC_VER)
   if (self->file_uid >= 0 && chown(path, (uid_t) self->file_uid, -1) < 0)
     result = FALSE;
   if (self->file_gid >= 0 && chown(path, -1, (gid_t) self->file_gid) < 0)
     result = FALSE;
   if (self->file_perm >= 0 && chmod(path, (mode_t) self->file_perm) < 0)
     result = FALSE;
-  return result;
 #endif
+  return result;
 }
 
 gboolean
 file_perm_options_apply_symlink(const FilePermOptions *self, const gchar *path)
 {
-#ifndef _MSC_VER
+#ifdef _WIN32
+  /* no fchown/fchmod; treat as success */
+  return TRUE;
+#elif defined(_MSC_VER)
   gboolean result = TRUE;
 
   if (self->file_uid >= 0 && lchown(path, (uid_t) self->file_uid, -1) < 0)
@@ -211,23 +226,29 @@ file_perm_options_apply_symlink(const FilePermOptions *self, const gchar *path)
 gboolean
 file_perm_options_apply_dir(const FilePermOptions *self, const gchar *path)
 {
-#ifndef _MSC_VER
   gboolean result = TRUE;
-
+#ifdef _WIN32
+  /* chown ignored; chmod applied if requested */
+  if (self->dir_perm >= 0 && chmod(path, (mode_t) self->dir_perm) < 0)
+    result = FALSE;
+#elif defined(_MSC_VER)
   if (self->dir_uid >= 0 && chown(path, (uid_t) self->dir_uid, -1) < 0)
     result = FALSE;
   if (self->dir_gid >= 0 && chown(path, -1, (gid_t) self->dir_gid) < 0)
     result = FALSE;
   if (self->dir_perm >= 0 && chmod(path, (mode_t) self->dir_perm) < 0)
     result = FALSE;
-  return result;
 #endif
+  return result;
 }
 
 gboolean
 file_perm_options_apply_fd(const FilePermOptions *self, gint fd)
 {
-#ifndef _MSC_VER
+#ifdef _WIN32
+  /* no fchown/fchmod; treat as success */
+  return TRUE;
+#elif defined(_MSC_VER)
   gboolean result = TRUE;
 
   if (self->file_uid >= 0 && fchown(fd, (uid_t) self->file_uid, -1) < 0)
@@ -238,6 +259,18 @@ file_perm_options_apply_fd(const FilePermOptions *self, gint fd)
     result = FALSE;
 
   return result;
+#endif
+}
+
+static gboolean
+_make_dir_with_mode(const gchar *path, mode_t mode)
+{
+#ifndef _WIN32
+  return mkdir(path, mode) == 0 || errno == EEXIST;
+#else
+  (void)mode;
+  int rc = _mkdir(path);
+  return rc == 0 || errno == EEXIST;
 #endif
 }
 
@@ -295,7 +328,7 @@ file_perm_options_create_containing_directory(const FilePermOptions *self, const
         }
       else if (errno == ENOENT)
         {
-          if (mkdir(_path, self->dir_perm < 0 ? 0700 : (mode_t) self->dir_perm) == -1)
+          if (!_make_dir_with_mode(_path, self->dir_perm < 0 ? 0700 : (mode_t) self->dir_perm))
             {
               result = FALSE;
               goto finish;

--- a/lib/file-perms.c
+++ b/lib/file-perms.c
@@ -210,9 +210,10 @@ file_perm_options_apply_file(const FilePermOptions *self, const gchar *path)
 gboolean
 file_perm_options_apply_symlink(const FilePermOptions *self, const gchar *path)
 {
+  gboolean result = TRUE;
 #ifdef _WIN32
   /* no fchown/fchmod; treat as success */
-  return TRUE;
+  return result;
 #elif defined(_MSC_VER)
   gboolean result = TRUE;
 
@@ -220,8 +221,8 @@ file_perm_options_apply_symlink(const FilePermOptions *self, const gchar *path)
     result = FALSE;
   if (self->file_gid >= 0 && lchown(path, -1, (gid_t) self->file_gid) < 0)
     result = FALSE;
-  return result;
 #endif
+  return result;
 }
 
 gboolean
@@ -246,21 +247,19 @@ file_perm_options_apply_dir(const FilePermOptions *self, const gchar *path)
 gboolean
 file_perm_options_apply_fd(const FilePermOptions *self, gint fd)
 {
+  gboolean result = TRUE;
 #ifdef _WIN32
   /* no fchown/fchmod; treat as success */
-  return TRUE;
+  return result;
 #elif defined(_MSC_VER)
-  gboolean result = TRUE;
-
   if (self->file_uid >= 0 && fchown(fd, (uid_t) self->file_uid, -1) < 0)
     result = FALSE;
   if (self->file_gid >= 0 && fchown(fd, -1, (gid_t) self->file_gid) < 0)
     result = FALSE;
   if (self->file_perm >= 0 && fchmod(fd, (mode_t) self->file_perm) < 0)
     result = FALSE;
-
-  return result;
 #endif
+  return result;
 }
 
 static gboolean

--- a/lib/file-perms.c
+++ b/lib/file-perms.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2012 Balabit
  * Copyright (c) 2012 Balazs Scheidler <bazsi@balabit.hu>
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/file-perms.c
+++ b/lib/file-perms.c
@@ -34,13 +34,13 @@
 #include <errno.h>
 
 #ifndef _WIN32
-  #include <unistd.h>
+#include <unistd.h>
 #else
-  #include <windows.h>
-  #include <io.h>
-  #include <direct.h>
-  typedef int uid_t;      /* stubs for API parity */
-  typedef int gid_t;
+#include <windows.h>
+#include <io.h>
+#include <direct.h>
+typedef int uid_t;      /* stubs for API parity */
+typedef int gid_t;
 #endif
 
 #define DONTCHANGE -2

--- a/lib/gprocess.c
+++ b/lib/gprocess.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/gsockaddr.c
+++ b/lib/gsockaddr.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2011 Balabit
  * Copyright (c) 1998-2011 Balázs Scheidler
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/gsockaddr.c
+++ b/lib/gsockaddr.c
@@ -26,18 +26,14 @@
 #include "gsocket.h"
 
 #include <sys/types.h>
-#include <sys/socket.h>
 #include <sys/stat.h>
-#include <unistd.h>
 #include <errno.h>
-#include <netinet/in.h>
-#include <sys/un.h>
-#include <arpa/inet.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <netdb.h>
 
+#include "compat/socket.h"
+#include "compat/un.h"
 
 /* general GSockAddr functions */
 
@@ -220,7 +216,11 @@ g_sockaddr_inet_bind_prepare(int sock, GSockAddr *addr)
 {
   int tmp = 1;
 
+#ifdef _WIN32
+  setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char *)&tmp, sizeof(tmp));
+#else
   setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &tmp, sizeof(tmp));
+#endif
   return G_IO_STATUS_NORMAL;
 }
 
@@ -624,9 +624,11 @@ g_sockaddr_unix_bind_prepare(int sock, GSockAddr *addr)
   if (unix_addr->saun.sun_path[0] == 0)
     return G_IO_STATUS_NORMAL;
 
+#ifndef _WIN32
   if (stat(unix_addr->saun.sun_path, &st) == -1 ||
       !S_ISSOCK(st.st_mode))
     return G_IO_STATUS_NORMAL;
+#endif
 
   unlink(unix_addr->saun.sun_path);
   return G_IO_STATUS_NORMAL;

--- a/lib/gsockaddr.h
+++ b/lib/gsockaddr.h
@@ -29,9 +29,11 @@
 #include "atomic.h"
 
 #include <sys/types.h>
-#include <sys/socket.h>
+#include <compat/socket.h>
 #include <compat/un.h>
-#include <netinet/in.h>
+#ifndef _WIN32
+#include <netinet/in.h>   /* POSIX only; Windows gets this via compat/socket.h */
+#endif
 
 /* sockaddr public interface */
 

--- a/lib/gsockaddr.h
+++ b/lib/gsockaddr.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/gsocket.c
+++ b/lib/gsocket.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2010 Balabit
  * Copyright (c) 1998-2010 Balázs Scheidler
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/gsocket.c
+++ b/lib/gsocket.c
@@ -25,7 +25,7 @@
 #include "gsocket.h"
 
 #include <errno.h>
-#include <arpa/inet.h>
+#include "compat/socket.h"
 
 /**
  * g_inet_ntoa:

--- a/lib/host-resolve.c
+++ b/lib/host-resolve.c
@@ -33,7 +33,13 @@
 #include <iv.h>
 
 #include <string.h>
+
+#ifndef _WIN32
 #include <resolv.h>
+#else
+#include <windns.h>     /* DnsQuery_*, DNS_RECORD, etc. (if you need raw DNS) */
+/* ws2tcpip is already reachable via compat/socket.h for getaddrinfo/getnameinfo */
+#endif
 
 #ifndef AI_V4MAPPED
 #define AI_V4MAPPED 0
@@ -475,7 +481,10 @@ host_resolve_options_destroy(HostResolveOptions *options)
 static void
 _reinit_resolver(gint type, gpointer user_data)
 {
+  /* Windows: no-op; DNS Client service updates automatically. DnsFlushResolverCache() for an immediate refresh can be used.*/
+#ifndef _WIN32
   res_init();
+#endif
 }
 
 void

--- a/lib/host-resolve.c
+++ b/lib/host-resolve.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2002-2013 Balabit
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/host-resolve.c
+++ b/lib/host-resolve.c
@@ -31,8 +31,6 @@
 
 #include <iv.h>
 
-#include <arpa/inet.h>
-#include <netdb.h>
 #include <string.h>
 #include <resolv.h>
 

--- a/lib/hostname-unix.c
+++ b/lib/hostname-unix.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2002-2013 Balabit
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/hostname-unix.c
+++ b/lib/hostname-unix.c
@@ -25,6 +25,8 @@
 /* NOTE: this file is included directly into hostname.c so the set of
  * includes here only add system dependent headers and not the full set
  */
+#ifndef _WIN32
+
 #include <netdb.h>
 
 static struct hostent *
@@ -72,3 +74,5 @@ get_local_fqdn_hostname_from_dns(void)
 
   return NULL;
 }
+
+#endif

--- a/lib/hostname-windows.c
+++ b/lib/hostname-windows.c
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+ 
+/* NOTE: this file is included directly into hostname.c so the set of
+ * includes here only add system dependent headers and not the full set
+ */
+#ifdef _WIN32
+
+#include "compat/socket.h"
+#include <string.h>
+
+static struct addrinfo *
+_resolve_localhost_from_dns(void)
+{
+  char host[256] = {0};
+  if (gethostname(host, sizeof(host)-1) != 0 || !host[0])
+    return NULL;
+
+  struct addrinfo hints;
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family   = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+  hints.ai_flags    = AI_CANONNAME;
+
+  struct addrinfo *res = NULL;
+  if (getaddrinfo(host, NULL, &hints, &res) != 0)
+    return NULL;
+  return res; /* caller frees with freeaddrinfo() */
+}
+
+static gchar *
+_extract_fqdn_from_addrinfo(struct addrinfo *res)
+{
+  /* 1) Prefer canonical name if it looks FQDN */
+  if (res && res->ai_canonname && strchr(res->ai_canonname, '.'))
+    return g_strdup(res->ai_canonname);
+
+  /* 2) fallback: reverse lookup first address and require dot */
+  if (res && res->ai_addr) {
+    char fqdn[NI_MAXHOST] = {0};
+    if (getnameinfo(res->ai_addr, (socklen_t)res->ai_addrlen,
+                    fqdn, sizeof(fqdn), NULL, 0, NI_NAMEREQD) == 0 &&
+        strchr(fqdn, '.'))
+      return g_strdup(fqdn);
+  }
+  return NULL;
+}
+
+gchar *
+get_local_fqdn_hostname_from_dns(void)
+{
+  struct addrinfo *res = _resolve_localhost_from_dns();
+  if (!res) return NULL;
+
+  gchar *ret = _extract_fqdn_from_addrinfo(res);
+  freeaddrinfo(res);
+  return ret; /* may be NULL; caller handles */
+}
+
+#endif

--- a/lib/hostname-windows.c
+++ b/lib/hostname-windows.c
@@ -21,7 +21,7 @@
  *
  */
 
- 
+
 /* NOTE: this file is included directly into hostname.c so the set of
  * includes here only add system dependent headers and not the full set
  */
@@ -57,13 +57,14 @@ _extract_fqdn_from_addrinfo(struct addrinfo *res)
     return g_strdup(res->ai_canonname);
 
   /* 2) fallback: reverse lookup first address and require dot */
-  if (res && res->ai_addr) {
-    char fqdn[NI_MAXHOST] = {0};
-    if (getnameinfo(res->ai_addr, (socklen_t)res->ai_addrlen,
-                    fqdn, sizeof(fqdn), NULL, 0, NI_NAMEREQD) == 0 &&
-        strchr(fqdn, '.'))
-      return g_strdup(fqdn);
-  }
+  if (res && res->ai_addr)
+    {
+      char fqdn[NI_MAXHOST] = {0};
+      if (getnameinfo(res->ai_addr, (socklen_t)res->ai_addrlen,
+                      fqdn, sizeof(fqdn), NULL, 0, NI_NAMEREQD) == 0 &&
+          strchr(fqdn, '.'))
+        return g_strdup(fqdn);
+    }
   return NULL;
 }
 

--- a/lib/hostname.c
+++ b/lib/hostname.c
@@ -64,9 +64,9 @@ extract_domain_from_fqdn(const gchar *hostname)
 }
 
 #ifndef _WIN32
-  #include "hostname-unix.c"
+#include "hostname-unix.c"
 #else
-  #include "hostname-windows.c"
+#include "hostname-windows.c"
 #endif
 
 static void

--- a/lib/hostname.c
+++ b/lib/hostname.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2015 Balabit
  * Copyright (c) 1998-2015 Balázs Scheidler
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/hostname.c
+++ b/lib/hostname.c
@@ -28,8 +28,7 @@
 #include "messages.h"
 #include "dnscache.h"
 
-#include <unistd.h>
-#include <arpa/inet.h>
+#include "compat/socket.h"
 #include <string.h>
 
 static gchar local_hostname_fqdn[256];
@@ -63,7 +62,11 @@ extract_domain_from_fqdn(const gchar *hostname)
   return NULL;
 }
 
-#include "hostname-unix.c"
+#ifndef _WIN32
+  #include "hostname-unix.c"
+#else
+  #include "hostname-windows.c"
+#endif
 
 static void
 validate_hostname_cache(void)

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -38,10 +38,10 @@
 #include <sys/types.h>
 #include <compat/socket.h>
 #ifndef _WIN32
-  #include <netinet/in.h>   /* POSIX only; Windows gets this via compat/socket.h */
-  #include <sys/time.h>
+#include <netinet/in.h>   /* POSIX only; Windows gets this via compat/socket.h */
+#include <sys/time.h>
 #else
-  #include "compat/time.h"
+#include "compat/time.h"
 #endif
 #include <iv_list.h>
 

--- a/lib/logmsg/logmsg.h
+++ b/lib/logmsg/logmsg.h
@@ -35,9 +35,13 @@
 #include "messages.h"
 
 #include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
-#include <sys/time.h>
+#include <compat/socket.h>
+#ifndef _WIN32
+  #include <netinet/in.h>   /* POSIX only; Windows gets this via compat/socket.h */
+  #include <sys/time.h>
+#else
+  #include "compat/time.h"
+#endif
 #include <iv_list.h>
 
 typedef enum

--- a/lib/pathutils.c
+++ b/lib/pathutils.c
@@ -1,7 +1,8 @@
 /*
  * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 2013 Viktor Juhasz
- * Copyright (c) 2013 Viktor Tusa
+ * Copyright (c) 2013 Viktor
+ * Copyright (c) 2013-2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -27,6 +28,7 @@
 #include "messages.h"
 #include <sys/stat.h>
 #include <string.h>
+#include "compat/realpath.h"
 
 gboolean
 is_file_directory(const char *filename)
@@ -147,7 +149,7 @@ resolve_to_absolute_path(const gchar *basedir, const gchar *path)
   w_name = build_filename(basedir, path);
   res = (char *)g_malloc(path_max);
 
-  if (!realpath(w_name, res))
+  if (!compat_realpath(w_name, res))
     {
       g_free(res);
       if (errno == ENOENT)

--- a/lib/persist-state.c
+++ b/lib/persist-state.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 One Identity LLC.
+ * Copyright (c) 2023-2025 One Identity LLC.
  * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
  *
@@ -31,10 +31,12 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <sys/mman.h>
+#include "compat/mmap.h"
 #include <errno.h>
 #include <string.h>
 #include <signal.h>
+#include "compat/pio.h"
+#include "compat/pagesize.h"
 
 #define PERSIST_FILE_INITIAL_SIZE 16384
 #define PERSIST_STATE_KEY_BLOCK_SIZE 4096

--- a/lib/poll-fd-events.c
+++ b/lib/poll-fd-events.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -37,7 +38,7 @@ poll_fd_events_start_watches(PollEvents *s)
 {
   PollFdEvents *self = (PollFdEvents *) s;
 
-  iv_fd_register(&self->fd_watch);
+  compat_iv_fd_register(&self->fd_watch);
 }
 
 static void
@@ -45,8 +46,8 @@ poll_fd_events_stop_watches(PollEvents *s)
 {
   PollFdEvents *self = (PollFdEvents *) s;
 
-  if (iv_fd_registered(&self->fd_watch))
-    iv_fd_unregister(&self->fd_watch);
+  if (compat_iv_fd_registered(&self->fd_watch))
+    compat_iv_fd_unregister(&self->fd_watch);
 }
 
 static void
@@ -54,9 +55,9 @@ poll_fd_events_suspend_watches(PollEvents *s)
 {
   PollFdEvents *self = (PollFdEvents *) s;
 
-  iv_fd_set_handler_in(&self->fd_watch, NULL);
-  iv_fd_set_handler_out(&self->fd_watch, NULL);
-  iv_fd_set_handler_err(&self->fd_watch, NULL);
+  compat_iv_fd_set_handler_in(&self->fd_watch, NULL);
+  compat_iv_fd_set_handler_out(&self->fd_watch, NULL);
+  compat_iv_fd_set_handler_err(&self->fd_watch, NULL);
 }
 
 
@@ -70,13 +71,13 @@ poll_fd_events_update_watches(PollEvents *s, GIOCondition cond)
   if (poll_events_check_watches(s) && FALSE == poll_events_system_notified(s))
     {
       if (cond & G_IO_IN)
-        iv_fd_set_handler_in(&self->fd_watch, IV_FD_CALLBACK(poll_events_invoke_callback));
+        compat_iv_fd_set_handler_in(&self->fd_watch, IV_FD_CALLBACK(poll_events_invoke_callback));
 
       if (cond & G_IO_OUT)
-        iv_fd_set_handler_out(&self->fd_watch, IV_FD_CALLBACK(poll_events_invoke_callback));
+        compat_iv_fd_set_handler_out(&self->fd_watch, IV_FD_CALLBACK(poll_events_invoke_callback));
 
       if (cond & (G_IO_IN + G_IO_OUT))
-        iv_fd_set_handler_err(&self->fd_watch, IV_FD_CALLBACK(poll_events_invoke_callback));
+        compat_iv_fd_set_handler_err(&self->fd_watch, IV_FD_CALLBACK(poll_events_invoke_callback));
     }
 }
 
@@ -94,7 +95,7 @@ poll_fd_events_new(gint fd)
   self->super.type = FM_SYSTEM_POLL;
   self->super.get_fd = _get_fd;
 
-  IV_FD_INIT(&self->fd_watch);
+  COMPAT_IV_FD_INIT(&self->fd_watch);
   self->fd_watch.fd = fd;
   self->fd_watch.cookie = self;
 

--- a/lib/poll-fd-events.h
+++ b/lib/poll-fd-events.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -25,12 +26,12 @@
 #define POLL_FD_EVENTS_H_INCLUDED
 
 #include "poll-events.h"
-#include <iv.h>
+#include "compat/ivykis_fd.h"
 
 typedef struct _PollFdEvents
 {
   PollEvents super;
-  struct iv_fd fd_watch;
+  compat_iv_fd fd_watch;
 } PollFdEvents;
 
 PollEvents *poll_fd_events_new(gint fd);

--- a/lib/secret-storage/CMakeLists.txt
+++ b/lib/secret-storage/CMakeLists.txt
@@ -1,9 +1,14 @@
 set(SECRET_STORAGE_SOURCES
   secret-storage.c
-  nondumpable-allocator.c)
+  nondumpable-allocator.c
+  compat/secure-mem-posix.c
+  compat/secure-mem-windows.c)
 set(SECRET_STORAGE_HEADERS
   secret-storage.h
-  nondumpable-allocator.h)
+  nondumpable-allocator.h
+  compat/secure-mem.h
+  compat/secure-mem-posix.h
+  compat/secure-mem-windows.h)
 
 add_library(secret-storage SHARED ${SECRET_STORAGE_SOURCES})
 

--- a/lib/secret-storage/Makefile.am
+++ b/lib/secret-storage/Makefile.am
@@ -6,11 +6,16 @@ lib_secret_storageincludedir = $(pkgincludedir)
 
 lib_secret_storageinclude_HEADERS =     \
   lib/secret-storage/secret-storage.h	\
-  lib/secret-storage/nondumpable-allocator.h
+  lib/secret-storage/nondumpable-allocator.h \
+  lib/secret-storage/compat/secure-mem.h \
+  lib/secret-storage/compat/secure-mem-posix.h \
+  lib/secret-storage/compat/secure-mem-windows.h
 
 lib_secret_storage_libsecret_storage_la_SOURCES =             \
   lib/secret-storage/secret-storage.c	\
-  lib/secret-storage/nondumpable-allocator.c
+  lib/secret-storage/nondumpable-allocator.c \
+  lib/secret-storage/compat/secure-mem-posix.c \
+  lib/secret-storage/compat/secure-mem-windows.c
 
 lib_secret_storage_libsecret_storage_la_CFLAGS = $(AM_CFLAGS) -fvisibility=hidden
 lib_secret_storage_libsecret_storage_la_LIBADD = @GLIB_LIBS@

--- a/lib/secret-storage/compat/secure-mem-posix.c
+++ b/lib/secret-storage/compat/secure-mem-posix.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+
+#include "secure-mem-posix.h"
+
+#include <sys/mman.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+
+#if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+
+#ifndef _SC_PAGE_SIZE
+#define _SC_PAGE_SIZE _SC_PAGESIZE
+#endif
+
+gsize
+secure_mem_get_page_size(void)
+{
+  long ps = sysconf(_SC_PAGE_SIZE);
+  if (ps <= 0) ps = 4096;
+  return (gsize) ps;
+}
+
+gpointer
+secure_mem_mmap_anon_rw(gsize len)
+{
+  void *area = mmap(NULL, len, PROT_READ | PROT_WRITE,
+                    MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+  if (area == MAP_FAILED)
+    return NULL;
+  return area;
+}
+
+gboolean
+secure_mem_exclude_from_core_dump(gpointer area, gsize len)
+{
+#ifdef MADV_DONTDUMP
+  if (madvise(area, len, MADV_DONTDUMP) < 0)
+    {
+      if (errno == EINVAL)
+        return TRUE;
+      return FALSE;
+    }
+#endif
+  return TRUE;
+}
+
+int
+secure_mem_mlock(gpointer area, gsize len)
+{
+  return mlock(area, len);
+}
+
+int
+secure_mem_munlock(gpointer area, gsize len)
+{
+  return munlock(area, len);
+}
+
+int
+secure_mem_munmap(gpointer area, gsize len)
+{
+  return munmap(area, len);
+}
+
+void
+secure_mem_zero(volatile void *p, gsize len)
+{
+  if (!p || !len) return;
+  volatile unsigned char *q = (volatile unsigned char *) p;
+  while (len--) *q++ = 0;
+}
+
+#endif

--- a/lib/secret-storage/compat/secure-mem-posix.h
+++ b/lib/secret-storage/compat/secure-mem-posix.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#pragma once
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+gsize secure_mem_get_page_size(void);
+gpointer secure_mem_mmap_anon_rw(gsize len);
+gboolean secure_mem_exclude_from_core_dump(gpointer area, gsize len);
+int secure_mem_mlock(gpointer area, gsize len);
+int secure_mem_munlock(gpointer area, gsize len);
+int secure_mem_munmap(gpointer area, gsize len);
+void secure_mem_zero(volatile void *p, gsize len);
+
+G_END_DECLS

--- a/lib/secret-storage/compat/secure-mem-windows.c
+++ b/lib/secret-storage/compat/secure-mem-windows.c
@@ -50,7 +50,8 @@ secure_mem_mmap_anon_rw(gsize len)
 gboolean
 secure_mem_exclude_from_core_dump(gpointer area, gsize len)
 {
-  (void)area; (void)len;
+  (void)area;
+  (void)len;
   return TRUE;
 }
 

--- a/lib/secret-storage/compat/secure-mem-windows.c
+++ b/lib/secret-storage/compat/secure-mem-windows.c
@@ -20,7 +20,7 @@
  * COPYING for details.
  *
  */
-//#if defined (_WIN32)
+#if defined (_WIN32)
 
 #include "secure-mem-windows.h"
 #define WIN32_LEAN_AND_MEAN
@@ -84,4 +84,4 @@ secure_mem_zero(volatile void *p, gsize len)
   SecureZeroMemory((PVOID)p, (SIZE_T)len);
 }
 
-//#endif
+#endif

--- a/lib/secret-storage/compat/secure-mem-windows.c
+++ b/lib/secret-storage/compat/secure-mem-windows.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+//#if defined (_WIN32)
+
+#include "secure-mem-windows.h"
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <errno.h>
+
+#ifndef SecureZeroMemory
+#define SecureZeroMemory RtlSecureZeroMemory
+#endif
+
+gsize
+secure_mem_get_page_size(void)
+{
+  SYSTEM_INFO si;
+  GetSystemInfo(&si);
+  return (gsize) si.dwPageSize;
+}
+
+gpointer
+secure_mem_mmap_anon_rw(gsize len)
+{
+  if (!len) return NULL;
+  void *p = VirtualAlloc(NULL, (SIZE_T)len, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+  return p ? p : NULL;
+}
+
+gboolean
+secure_mem_exclude_from_core_dump(gpointer area, gsize len)
+{
+  (void)area; (void)len;
+  return TRUE;
+}
+
+int
+secure_mem_mlock(gpointer area, gsize len)
+{
+  if (!area || !len) return 0;
+  return VirtualLock(area, (SIZE_T)len) ? 0 : -1;
+}
+
+int
+secure_mem_munlock(gpointer area, gsize len)
+{
+  if (!area || !len) return 0;
+  return VirtualUnlock(area, (SIZE_T)len) ? 0 : -1;
+}
+
+int
+secure_mem_munmap(gpointer area, gsize len)
+{
+  (void)len;
+  if (!area) return 0;
+  return VirtualFree(area, 0, MEM_RELEASE) ? 0 : -1;
+}
+
+void
+secure_mem_zero(volatile void *p, gsize len)
+{
+  if (!p || !len) return;
+  SecureZeroMemory((PVOID)p, (SIZE_T)len);
+}
+
+//#endif

--- a/lib/secret-storage/compat/secure-mem-windows.h
+++ b/lib/secret-storage/compat/secure-mem-windows.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#pragma once
+#include <glib.h>
+
+//G_BEGIN_DECLS
+
+gsize secure_mem_get_page_size(void);
+gpointer secure_mem_mmap_anon_rw(gsize len);
+gboolean secure_mem_exclude_from_core_dump(gpointer area, gsize len);
+int secure_mem_mlock(gpointer area, gsize len);
+int secure_mem_munlock(gpointer area, gsize len);
+int secure_mem_munmap(gpointer area, gsize len);
+void secure_mem_zero(volatile void *p, gsize len);
+
+//G_END_DECLS

--- a/lib/secret-storage/compat/secure-mem.h
+++ b/lib/secret-storage/compat/secure-mem.h
@@ -24,7 +24,7 @@
 #pragma once
 
 //#if defined(_WIN32)
-  #include "secure-mem-windows.h"
+#include "secure-mem-windows.h"
 // #else
 //   #include "secure-mem-posix.h"
 // #endif

--- a/lib/secret-storage/compat/secure-mem.h
+++ b/lib/secret-storage/compat/secure-mem.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#pragma once
+
+//#if defined(_WIN32)
+  #include "secure-mem-windows.h"
+// #else
+//   #include "secure-mem-posix.h"
+// #endif

--- a/lib/secret-storage/compat/secure-mem.h
+++ b/lib/secret-storage/compat/secure-mem.h
@@ -23,8 +23,8 @@
 
 #pragma once
 
-//#if defined(_WIN32)
+#if defined(_WIN32)
 #include "secure-mem-windows.h"
-// #else
-//   #include "secure-mem-posix.h"
-// #endif
+#else
+#include "secure-mem-posix.h"
+#endif

--- a/lib/secret-storage/nondumpable-allocator.c
+++ b/lib/secret-storage/nondumpable-allocator.c
@@ -21,12 +21,10 @@
  *
  */
 
-#include <sys/mman.h>
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <unistd.h>
-#include <stdio.h>
+#include "compat/secure-mem.h"
 
 /* For compatibility with e.g. older macOS. */
 #if !defined(MAP_ANONYMOUS) && defined(MAP_ANON)
@@ -74,53 +72,32 @@ typedef struct
   guint8 user_data[];
 } Allocation;
 
-static gboolean
-_exclude_memory_from_core_dump(gpointer area, gsize len)
-{
-#if defined(MADV_DONTDUMP)
-  if (madvise(area, len, MADV_DONTDUMP) < 0)
-    {
-
-      if (errno == EINVAL)
-        {
-          logger_debug("secret storage: MADV_DONTDUMP not supported",
-                       "len: %"G_GSIZE_FORMAT", errno: %d\n", len, errno);
-          return TRUE;
-        }
-
-      logger_fatal("secret storage: cannot madvise buffer", "errno: %d\n", errno);
-      return FALSE;
-    }
-#endif
-  return TRUE;
-}
-
 static gpointer
-_mmap(gsize len)
+_alloc_locked(gsize len)
 {
-  gpointer area = mmap(NULL, len, PROT_READ|PROT_WRITE, MAP_ANONYMOUS|MAP_PRIVATE, -1, 0);
-  if (area == MAP_FAILED)
+  gpointer area = secure_mem_mmap_anon_rw(len);
+  if (!area)
     {
       logger_fatal("secret storage: cannot mmap buffer",
                    "len: %"G_GSIZE_FORMAT", errno: %d\n", len, errno);
-      return MAP_FAILED;
+      return NULL;
     }
 
-  if (!_exclude_memory_from_core_dump(area, len))
-    goto err_munmap;
+  if (!secure_mem_exclude_from_core_dump(area, len))
+    goto err_unmap;
 
-  if (mlock(area, len) < 0)
+  if (secure_mem_mlock(area, len) < 0)
     {
       gchar *hint = (errno == ENOMEM) ? ". Maybe RLIMIT_MEMLOCK is too small?" : "";
-      logger_fatal("secret storage: cannot lock buffer", "len: %"G_GSIZE_FORMAT", errno: %d%s\n", len, errno, hint);
-
-      goto err_munmap;
+      logger_fatal("secret storage: cannot lock buffer",
+                   "len: %"G_GSIZE_FORMAT", errno: %d%s\n", len, errno, hint);
+      goto err_unmap;
     }
 
   return area;
-err_munmap:
-  munmap(area, len);
-  return MAP_FAILED;
+err_unmap:
+  secure_mem_munmap(area, len);
+  return NULL;
 }
 
 static gsize
@@ -133,11 +110,11 @@ gpointer
 nondumpable_buffer_alloc(gsize len)
 {
   gsize minimum_size = len + ALLOCATION_HEADER_SIZE;
-  gsize pagesize = sysconf(_SC_PAGE_SIZE);
+  gsize pagesize = secure_mem_get_page_size();
   gsize alloc_size = round_to_nearest(minimum_size, pagesize);
 
-  Allocation *buffer = _mmap(alloc_size);
-  if (buffer == MAP_FAILED)
+  Allocation *buffer = _alloc_locked(alloc_size);
+  if (!buffer)
     return NULL;
 
   buffer->alloc_size = alloc_size;
@@ -148,10 +125,7 @@ nondumpable_buffer_alloc(gsize len)
 void
 nondumpable_mem_zero(gpointer s, gsize len)
 {
-  volatile guchar *p = s;
-
-  for (gsize i = 0; i < len; ++i)
-    p[i] = 0;
+  secure_mem_zero(s, len);
 }
 
 void
@@ -159,7 +133,7 @@ nondumpable_buffer_free(gpointer buffer)
 {
   Allocation *allocation = BUFFER_TO_ALLOCATION(buffer);
   nondumpable_mem_zero(allocation->user_data, allocation->data_len);
-  munmap(allocation, allocation->alloc_size);
+  secure_mem_munmap(allocation, allocation->alloc_size);
 }
 
 gpointer

--- a/lib/secret-storage/nondumpable-allocator.c
+++ b/lib/secret-storage/nondumpable-allocator.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018 Balabit
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/signal-handler.c
+++ b/lib/signal-handler.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018 Balabit
  * Copyright (c) 2018 Kokan
+ * Copyright (c) 2018-2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -24,8 +25,10 @@
 
 #include "syslog-ng.h"
 
-#include <signal.h>
+#include "compat/ivykis_signal.h"
 #include <string.h>
+
+#ifdef COMPAT_HAVE_POSIX_SIGNALS
 
 #if defined(NSIG)
 #  define SIGNAL_HANDLER_ARRAY_SIZE NSIG
@@ -154,6 +157,16 @@ sigaction(int signum, const struct sigaction *act, struct sigaction *oldact)
   _save_external_sigaction_handler(signum, act);
 
   return 0;
+}
+
+#endif
+
+#else  /* !COMPAT_HAVE_POSIX_SIGNALS (Windows) */
+
+/* Keep the exported function, but as a no-op on Windows */
+void signal_handler_exec_external_handler(gint signum)
+{
+  return;
 }
 
 #endif

--- a/lib/stats/stats-counter.h
+++ b/lib/stats/stats-counter.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/stats/stats-counter.h
+++ b/lib/stats/stats-counter.h
@@ -70,8 +70,6 @@
 #define STATS_COUNTER_MAX_VALUE G_MAXSIZE
 #endif
 
-#define STATS_COUNTER_MAX_VALUE G_MAXSIZE
-
 typedef struct _StatsCounterItem
 {
   union

--- a/lib/stats/stats-counter.h
+++ b/lib/stats/stats-counter.h
@@ -61,6 +61,14 @@
 # endif
 #endif
 
+/* On Windows, prefer a plain integer-constant for preprocessor use. */
+#if defined(_WIN32)
+  #include <stdint.h>
+  #define STATS_COUNTER_MAX_VALUE UINT64_MAX
+#else
+  #define STATS_COUNTER_MAX_VALUE G_MAXSIZE
+#endif
+
 #define STATS_COUNTER_MAX_VALUE G_MAXSIZE
 
 typedef struct _StatsCounterItem

--- a/lib/stats/stats-counter.h
+++ b/lib/stats/stats-counter.h
@@ -64,10 +64,10 @@
 
 /* On Windows, prefer a plain integer-constant for preprocessor use. */
 #if defined(_WIN32)
-  #include <stdint.h>
-  #define STATS_COUNTER_MAX_VALUE UINT64_MAX
+#include <stdint.h>
+#define STATS_COUNTER_MAX_VALUE UINT64_MAX
 #else
-  #define STATS_COUNTER_MAX_VALUE G_MAXSIZE
+#define STATS_COUNTER_MAX_VALUE G_MAXSIZE
 #endif
 
 #define STATS_COUNTER_MAX_VALUE G_MAXSIZE

--- a/lib/thread-utils.h
+++ b/lib/thread-utils.h
@@ -23,11 +23,21 @@
 #define THREAD_UTILS_H_INCLUDED
 
 #include "syslog-ng.h"
-#include <pthread.h>
 
 #ifdef _WIN32
+/* Avoid pulling old winsock.h and min/max macros */
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>            /* DWORD, HANDLE, THREAD_TERMINATE, CloseHandle */
+#include <processthreadsapi.h>  /* OpenThread, GetCurrentThreadId */
+#include <stdint.h>             /* uintptr_t for the cast */
 typedef DWORD ThreadId;
 #else
+#include <pthread.h>
 typedef pthread_t ThreadId;
 #endif
 
@@ -57,7 +67,13 @@ thread_cancel(ThreadId tid)
 #ifndef _WIN32
   pthread_cancel(tid);
 #else
-  TerminateThread(tid, 0);
+  /* Convert thread ID -> HANDLE, then terminate */
+  HANDLE h = OpenThread(THREAD_TERMINATE, FALSE, (DWORD)(uintptr_t)tid);
+  if (h)
+    {
+      TerminateThread(h, 0);
+      CloseHandle(h);
+    }
 #endif
 }
 

--- a/lib/thread-utils.h
+++ b/lib/thread-utils.h
@@ -33,6 +33,9 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
+#ifndef NOGDI
+#define NOGDI
+#endif
 #include <windows.h>            /* DWORD, HANDLE, THREAD_TERMINATE, CloseHandle */
 #include <processthreadsapi.h>  /* OpenThread, GetCurrentThreadId */
 #include <stdint.h>             /* uintptr_t for the cast */

--- a/lib/thread-utils.h
+++ b/lib/thread-utils.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2002-2013 Balabit
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/transport/logtransport.h
+++ b/lib/transport/logtransport.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2013 Balabit
  * Copyright (c) 1998-2013 Balázs Scheidler
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/transport/logtransport.h
+++ b/lib/transport/logtransport.h
@@ -27,6 +27,7 @@
 
 #include "syslog-ng.h"
 #include "transport/transport-aux-data.h"
+#include "compat/uio.h"
 
 typedef enum _LogTransportIOCond
 {

--- a/lib/transport/transport-aux-data.c
+++ b/lib/transport/transport-aux-data.c
@@ -23,7 +23,7 @@
 #include "transport-aux-data.h"
 #include "messages.h"
 
-#include <sys/uio.h>
+#include "compat/uio.h"
 
 void
 log_transport_aux_data_add_nv_pair(LogTransportAuxData *self, const gchar *name, const gchar *value)

--- a/lib/transport/transport-file.c
+++ b/lib/transport/transport-file.c
@@ -25,7 +25,7 @@
 
 #include <errno.h>
 #include <unistd.h>
-#include <sys/uio.h>
+#include "compat/uio.h"
 
 gssize
 log_transport_file_read_method(LogTransport *self, gpointer buf, gsize buflen, LogTransportAuxData *aux)

--- a/lib/transport/transport-stack.h
+++ b/lib/transport/transport-stack.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2018 Balabit
  * Copyright (c) 2018 Laszlo Budai <laszlo.budai@balabit.com>
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/transport/transport-stack.h
+++ b/lib/transport/transport-stack.h
@@ -26,6 +26,7 @@
 #define TRANSPORT_STACK_H_INCLUDED
 
 #include "transport/logtransport.h"
+#include "compat/uio.h"
 
 typedef struct _LogTransportFactory LogTransportFactory;
 

--- a/lib/userdb.c
+++ b/lib/userdb.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2002-2012 Balabit
  * Copyright (c) 1998-2012 Balázs Scheidler
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -24,8 +25,12 @@
 #include "userdb.h"
 
 #include <sys/types.h>
+
+#ifndef _WIN32
 #include <pwd.h>
 #include <grp.h>
+#endif
+
 #include <string.h>
 #include <stdlib.h>
 
@@ -40,13 +45,19 @@ resolve_user(const char *user, gint *uid)
     return FALSE;
 
   *uid = strtol(user, &endptr, 0);
+
   if (*endptr)
     {
+#ifndef _WIN32
       pw = getpwnam(user);
       if (!pw)
         return FALSE;
 
       *uid = pw->pw_uid;
+#else
+      /* Windows: no POSIX user DB → accept only numeric UIDs */
+      return FALSE;
+#endif
     }
   return TRUE;
 }
@@ -64,11 +75,16 @@ resolve_group(const char *group, gint *gid)
   *gid = strtol(group, &endptr, 0);
   if (*endptr)
     {
+#ifndef _WIN32
       gr = getgrnam(group);
       if (!gr)
         return FALSE;
 
       *gid = gr->gr_gid;
+#else
+      /* Windows: accept only numeric GIDs */
+      return FALSE;
+#endif
     }
   return TRUE;
 }

--- a/lib/uuid.c
+++ b/lib/uuid.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2010-2012 Balabit
  * Copyright (c) 2010-2012 Balázs Scheidler
  * Copyright (c) 2012 Gergely Nagy <algernon@balabit.hu>
+ * Copyright (c) 2025 One Identity
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -25,7 +26,7 @@
 #include "uuid.h"
 
 #include <openssl/rand.h>
-#include <arpa/inet.h>
+#include "compat/socket.h"
 
 void
 uuid_gen_random(gchar *buf, gsize buflen)


### PR DESCRIPTION
### Windows compatibility: initial port (ivykis, eventlog, compat, build fixes)

**What this PR does**

- Brings up an initial Windows (MSYS2/MinGW-w64) build path while preserving Linux behavior.
- Adds a small compat layer and targeted build tweaks instead of invasive changes.

**Highlights**

- ivykis: external-project bootstrap on Windows (bash wrapper + autoreconf) with --disable-shared --enable-static.
- eventlog: Windows-safe syslog() stub + socket compat; link against ws2_32.
- compat/ (new/extended):
    - secure-mem-{windows,posix}.c and allocator shims for secret-storage.
    - syslog.h (minimal API), uio.h (iovec), socket.h/un.h (AF_UNIX & winsock glue), alarm.h, gprocess-compat.h, glob-win.c.
- Build tooling:
    - GenerateYFromYm.cmake: CRLF-safe grammar merge on Windows.
    - gperf input (severity-aliases.table) handled with line-ending normalization.
- Source fixes:
    - Guard Linux-only includes/calls; route through compat headers (e.g., netinet/in.h, arpa/inet.h, sys/un.h, glob.h, syslog.h, signals, fork()/waitpid() usage).
    - Keep POSIX paths unchanged where possible.

**Rationale**

- Enable iterative Windows port without breaking existing platforms.
- Keep changes localized (compat layer + CMake) to minimize risk.

**Testing**

- Linux: builds locally; CI should confirm (style + unit tests).
- Windows: MSYS2/MinGW-w64 build completes for the covered targets (ivykis, eventlog, core libs); basic runtime smoke tested (where applicable).

**Follow-ups (planned)**

- Broader test coverage on Windows, especially for networking & file perms.
- Reduce conditional code where future upstream libraries cover Windows.
- Review/align error paths & logging parity with POSIX.
- NEWS entry once feature set is user-visible.

**Notes**

- Formatting complies with repo .astylerc.
- Commit messages follow syslog-ng guidelines (subsys: summary).
- No behavior changes intended for Linux builds.