### PR TITLE
Switch to reopen in logrotate configurations

### DIFF
--- a/packaging/debian/syslog-ng-core.syslog-ng.logrotate
+++ b/packaging/debian/syslog-ng-core.syslog-ng.logrotate
@@ -7,7 +7,7 @@
 	delaycompress
 	compress
 	postrotate
-		syslog-ng-ctl reload > /dev/null
+		syslog-ng-ctl reopen > /dev/null
 	endscript
 }
 
@@ -33,6 +33,6 @@
 	delaycompress
 	sharedscripts
 	postrotate
-		syslog-ng-ctl reload > /dev/null
+		syslog-ng-ctl reopen > /dev/null
 	endscript
 }

--- a/packaging/rhel/syslog-ng.logrotate
+++ b/packaging/rhel/syslog-ng.logrotate
@@ -7,6 +7,6 @@
     missingok
     sharedscripts
     postrotate
-	/usr/bin/systemctl kill -s HUP syslog-ng.service >/dev/null 2>&1 || true
+	    syslog-ng-ctl reopen > /dev/null
     endscript
 }

--- a/packaging/rhel/syslog-ng.logrotate7
+++ b/packaging/rhel/syslog-ng.logrotate7
@@ -7,6 +7,6 @@
     missingok
     sharedscripts
     postrotate
-	/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true
+	    syslog-ng-ctl reopen > /dev/null
     endscript
 }


### PR DESCRIPTION
Issues: #5541

## Problem

As it was mentioned earlier, `logrotate` configurations were a bit left out recently and unfortunately still use signals and `syslog-ng-ctl reload`, considering lightweight `syslog-ng-ctl reopen` has become available back in 2017 (I think).

## Overview

Just replace postrotate section with `syslog-ng-ctl reopen` . Unfortunately, I'm not really familiar with RHEL and their distribution files - can you advice me if current command (similar to Debian) will work there? Previous postrotate section with signals and absolute paths gave me chills.


