### PR TITLE
package-indexer: properly cull old RPM packages

### DIFF
--- a/packaging/package-indexer/indexer/rpm_indexer.py
+++ b/packaging/package-indexer/indexer/rpm_indexer.py
@@ -264,12 +264,13 @@ class NightlyRPMIndexer(RPMIndexer):
         )
 
     def __get_pkg_timestamps_in_dir(self, directory: Path) -> List[str]:
-        timestamp_regexp = re.compile(r"\+([^_]+)_")
+        timestamp_regexp = re.compile(r"\+([^.]+)\.")
         pkg_timestamps: List[str] = []
 
-        for rpm_file in directory.rglob("syslog-ng-core*.rpm"):
+        for rpm_file in directory.rglob("syslog-ng-[1-9].*.rpm"):
             pkg_timestamp = timestamp_regexp.findall(rpm_file.name)[0]
-            pkg_timestamps.append(pkg_timestamp)
+            if pkg_timestamp not in pkg_timestamps:
+                pkg_timestamps.append(pkg_timestamp)
         pkg_timestamps.sort()
 
         return pkg_timestamps


### PR DESCRIPTION
<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
