### PR TITLE
package-indexer: Run the CDN cache flushing operations asynchronously

### DIFF
--- a/packaging/package-indexer/cdn/cdn.py
+++ b/packaging/package-indexer/cdn/cdn.py
@@ -42,7 +42,7 @@ class CDN(ABC):
         pass
 
     @abstractmethod
-    def refresh_cache(self, path: Path) -> None:
+    def refresh_cache(self, path: Path, wait: bool) -> None:
         pass
 
     @staticmethod

--- a/packaging/package-indexer/indexer/indexer.py
+++ b/packaging/package-indexer/indexer/indexer.py
@@ -24,6 +24,7 @@ import logging
 import os
 from abc import ABC, abstractmethod
 from pathlib import Path
+from typing import Any
 
 from cdn import CDN
 from remote_storage_synchronizer import RemoteStorageSynchronizer
@@ -71,11 +72,11 @@ class Indexer(ABC):
         self.__incoming_remote_storage_synchronizer.sync_to_remote()
         self.__indexed_remote_storage_synchronizer.sync_to_remote()
 
-    def __refresh_cdn_cache(self) -> None:
+    def __refresh_cdn_cache(self, wait: bool = False) -> Any:
         path = Path(self.__indexed_remote_storage_synchronizer.remote_dir.working_dir, "*")
-        self.__cdn.refresh_cache(path)
+        return self.__cdn.refresh_cache(path, wait=wait)
 
-    def index(self) -> None:
+    def index(self) -> Any:
         self.__sync_from_remote()
 
         incoming_dir = self.__incoming_remote_storage_synchronizer.local_dir.working_dir
@@ -88,10 +89,10 @@ class Indexer(ABC):
 
         self.__create_snapshot_of_indexed()
         self.__sync_to_remote()
-        self.__refresh_cdn_cache()
+        return self.__refresh_cdn_cache()
 
-    def flush_cdn_cache(self) -> None:
-        self.__refresh_cdn_cache()
+    def flush_cdn_cache(self) -> Any:
+        return self.__refresh_cdn_cache(wait=True)
 
     @staticmethod
     def __create_logger() -> logging.Logger:


### PR DESCRIPTION
They take a long time, the script can safely work on another part of the storage in the meantime. The script will wait until all running cache operations will finish at the end of the run.

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
