### PR TITLE
package-indexer: only flush the cache for the whole site, once

### DIFF
--- a/packaging/package-indexer/cdn/azure_cdn.py
+++ b/packaging/package-indexer/cdn/azure_cdn.py
@@ -99,7 +99,7 @@ class AzureCDN(CDN):
             domains=cfg["domains"],
         )
 
-    def refresh_cache(self, path: Path, wait: bool = False) -> LROPoller | None:
+    def refresh_cache(self, path: Path) -> None:
         path_str = str(Path("/", path))
 
         self._log_info("Refreshing CDN cache.", path=path_str, domains=str(self.__domains))
@@ -110,13 +110,7 @@ class AzureCDN(CDN):
                 endpoint_name=self.__endpoint_name,
                 contents={"contentPaths": [path_str], "domains": self.__domains},
             )
-            if wait is True:
-                poller.wait()
-            else:
-                poller.wait(5)
-                if not poller.done():
-                    self._log_info("CDN cache purge job still runs in the background. Returning ...")
-                    return poller
+            poller.wait()
             status = poller.status()
 
             if not status == "Succeeded":
@@ -129,4 +123,3 @@ class AzureCDN(CDN):
                 self._log_info("%s Skipping changes." % err.message)
             else:
                 raise err
-        return None

--- a/packaging/package-indexer/cdn/cdn.py
+++ b/packaging/package-indexer/cdn/cdn.py
@@ -42,7 +42,7 @@ class CDN(ABC):
         pass
 
     @abstractmethod
-    def refresh_cache(self, path: Path, wait: bool) -> None:
+    def refresh_cache(self, path: Path) -> None:
         pass
 
     @staticmethod

--- a/packaging/package-indexer/indexer/deb_indexer.py
+++ b/packaging/package-indexer/indexer/deb_indexer.py
@@ -28,7 +28,6 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import List, Optional
 
-from cdn import CDN
 from remote_storage_synchronizer import RemoteStorageSynchronizer
 
 from indexer import Indexer
@@ -45,7 +44,6 @@ class DebIndexer(Indexer):
         indexed_remote_storage_synchronizer: RemoteStorageSynchronizer,
         incoming_sub_dir: Path,
         dist_dir: Path,
-        cdn: CDN,
         apt_conf_file_path: Path,
         gpg_key_path: Path,
         gpg_key_passphrase: Optional[str],
@@ -58,7 +56,6 @@ class DebIndexer(Indexer):
             indexed_remote_storage_synchronizer=indexed_remote_storage_synchronizer,
             incoming_sub_dir=incoming_sub_dir,
             indexed_sub_dir=Path("apt", "dists", dist_dir),
-            cdn=cdn,
         )
 
     def __move_files_from_incoming_to_indexed(self, incoming_dir: Path, indexed_dir: Path) -> None:
@@ -235,7 +232,6 @@ class StableDebIndexer(DebIndexer):
         incoming_remote_storage_synchronizer: RemoteStorageSynchronizer,
         indexed_remote_storage_synchronizer: RemoteStorageSynchronizer,
         run_id: str,
-        cdn: CDN,
         gpg_key_path: Path,
         gpg_key_passphrase: Optional[str],
     ) -> None:
@@ -244,7 +240,6 @@ class StableDebIndexer(DebIndexer):
             indexed_remote_storage_synchronizer=indexed_remote_storage_synchronizer,
             incoming_sub_dir=Path("stable", run_id),
             dist_dir=Path("stable"),
-            cdn=cdn,
             apt_conf_file_path=Path(CURRENT_DIR, "apt_conf", "stable.conf"),
             gpg_key_path=gpg_key_path,
             gpg_key_passphrase=gpg_key_passphrase,
@@ -258,7 +253,6 @@ class NightlyDebIndexer(DebIndexer):
         self,
         incoming_remote_storage_synchronizer: RemoteStorageSynchronizer,
         indexed_remote_storage_synchronizer: RemoteStorageSynchronizer,
-        cdn: CDN,
         run_id: str,
         gpg_key_path: Path,
         gpg_key_passphrase: Optional[str],
@@ -268,7 +262,6 @@ class NightlyDebIndexer(DebIndexer):
             indexed_remote_storage_synchronizer=indexed_remote_storage_synchronizer,
             incoming_sub_dir=Path("nightly", run_id),
             dist_dir=Path("nightly"),
-            cdn=cdn,
             apt_conf_file_path=Path(CURRENT_DIR, "apt_conf", "nightly.conf"),
             gpg_key_path=gpg_key_path,
             gpg_key_passphrase=gpg_key_passphrase,

--- a/packaging/package-indexer/indexer/indexer.py
+++ b/packaging/package-indexer/indexer/indexer.py
@@ -24,9 +24,7 @@ import logging
 import os
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any
 
-from cdn import CDN
 from remote_storage_synchronizer import RemoteStorageSynchronizer
 
 
@@ -37,14 +35,12 @@ class Indexer(ABC):
         incoming_sub_dir: Path,
         indexed_remote_storage_synchronizer: RemoteStorageSynchronizer,
         indexed_sub_dir: Path,
-        cdn: CDN,
     ) -> None:
         self.__incoming_remote_storage_synchronizer = incoming_remote_storage_synchronizer
         self.__indexed_remote_storage_synchronizer = indexed_remote_storage_synchronizer
         self._incoming_sub_dir = incoming_sub_dir
         self._indexed_sub_dir = indexed_sub_dir
 
-        self.__cdn = cdn
         self.__logger = Indexer.__create_logger()
 
     def __sync_from_remote(self) -> None:
@@ -72,11 +68,7 @@ class Indexer(ABC):
         self.__incoming_remote_storage_synchronizer.sync_to_remote()
         self.__indexed_remote_storage_synchronizer.sync_to_remote()
 
-    def __refresh_cdn_cache(self, wait: bool = False) -> Any:
-        path = Path(self.__indexed_remote_storage_synchronizer.remote_dir.working_dir, "*")
-        return self.__cdn.refresh_cache(path, wait=wait)
-
-    def index(self) -> Any:
+    def index(self) -> None:
         self.__sync_from_remote()
 
         incoming_dir = self.__incoming_remote_storage_synchronizer.local_dir.working_dir
@@ -89,10 +81,6 @@ class Indexer(ABC):
 
         self.__create_snapshot_of_indexed()
         self.__sync_to_remote()
-        return self.__refresh_cdn_cache()
-
-    def flush_cdn_cache(self) -> Any:
-        return self.__refresh_cdn_cache(wait=True)
 
     @staticmethod
     def __create_logger() -> logging.Logger:

--- a/packaging/package-indexer/indexer/rpm_indexer.py
+++ b/packaging/package-indexer/indexer/rpm_indexer.py
@@ -26,7 +26,6 @@ from typing import List, Optional
 import pexpect
 import sys
 
-from cdn import CDN
 from remote_storage_synchronizer import RemoteStorageSynchronizer
 
 from indexer import Indexer
@@ -52,7 +51,6 @@ class RPMIndexer(Indexer):
         indexed_remote_storage_synchronizer: RemoteStorageSynchronizer,
         incoming_sub_dir: Path,
         dist_dir: Path,
-        cdn: CDN,
         gpg_key_path: Path,
         gpg_key_passphrase: Optional[str],
         gpg_key_name: Optional[str],
@@ -62,7 +60,6 @@ class RPMIndexer(Indexer):
             indexed_remote_storage_synchronizer=indexed_remote_storage_synchronizer,
             incoming_sub_dir=incoming_sub_dir,
             indexed_sub_dir=Path("yum", dist_dir),
-            cdn=cdn,
         )
         self.__gpg_key_path = gpg_key_path.expanduser()
         self.__gpg_key_passphrase = gpg_key_passphrase
@@ -222,7 +219,6 @@ class StableRPMIndexer(RPMIndexer):
         incoming_remote_storage_synchronizer: RemoteStorageSynchronizer,
         indexed_remote_storage_synchronizer: RemoteStorageSynchronizer,
         run_id: str,
-        cdn: CDN,
         gpg_key_path: Path,
         gpg_key_passphrase: Optional[str],
         gpg_key_name: Optional[str],
@@ -232,7 +228,6 @@ class StableRPMIndexer(RPMIndexer):
             indexed_remote_storage_synchronizer=indexed_remote_storage_synchronizer,
             incoming_sub_dir=Path("stable", run_id),
             dist_dir=Path("stable"),
-            cdn=cdn,
             gpg_key_path=gpg_key_path,
             gpg_key_passphrase=gpg_key_passphrase,
             gpg_key_name=gpg_key_name,
@@ -246,7 +241,6 @@ class NightlyRPMIndexer(RPMIndexer):
         self,
         incoming_remote_storage_synchronizer: RemoteStorageSynchronizer,
         indexed_remote_storage_synchronizer: RemoteStorageSynchronizer,
-        cdn: CDN,
         run_id: str,
         gpg_key_path: Path,
         gpg_key_passphrase: Optional[str],
@@ -257,7 +251,6 @@ class NightlyRPMIndexer(RPMIndexer):
             indexed_remote_storage_synchronizer=indexed_remote_storage_synchronizer,
             incoming_sub_dir=Path("nightly", run_id),
             dist_dir=Path("nightly"),
-            cdn=cdn,
             gpg_key_path=gpg_key_path,
             gpg_key_passphrase=gpg_key_passphrase,
             gpg_key_name=gpg_key_name,


### PR DESCRIPTION
It looks like, no parallel jobs for cache flushing,  so no need to do it for the different repo spaces separately

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
