### PR TITLE
dbld: disable stackdump in the generated packages

### DIFF
--- a/dbld/build.manifest
+++ b/dbld/build.manifest
@@ -31,17 +31,16 @@
 #         commandline-options line is needed
 #
 
-# kafka support needs librdkafka >= 1.0.0, which is only available on ubuntu-bionic
-# on Debian we don't build java and use Python3 _after_ buster
-# libcriterion-dev is available starting with bullseye
+# - on Debian we don't build java and use Python3 _after_ buster
+# - libcriterion-dev is available starting with bullseye
 debian-bullseye		python3,nojava,notzdatalegacy
 debian-bookworm		python3,nojava,notzdatalegacy
 debian-trixie		python3,nojava,notzdatalegacy
 debian-testing		python3,nojava,nocriterion
 debian-sid			python3,nojava
 
-# on ubuntu, we start using Python3 at focal onwards.
-# libcriterion-dev is available starting with 21.04
+# - on ubuntu, we start using Python3 at focal onwards.
+# - libcriterion-dev is available starting with 21.04
 ubuntu-focal		python3,nocriterion,nomqtt,nogrpc,notzdatalegacy
 ubuntu-jammy		python3,notzdatalegacy
 ubuntu-noble		python3,notzdatalegacy

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -132,6 +132,7 @@ override_dh_auto_configure:
 		--enable-mqtt=auto \
 		--enable-grpc=auto \
 		--enable-cloud-auth=auto \
+		--disable-stackdump \
 		\
 		--with-mongoc=system \
 		--with-ivykis=internal \

--- a/packaging/rhel/syslog-ng.spec
+++ b/packaging/rhel/syslog-ng.spec
@@ -469,6 +469,7 @@ ryslog is not on the system.
 %if %{with grpc}
     --enable-cpp --enable-grpc \
 %endif
+    --disable-stackdump \
     --disable-java-modules \
     --with-python=%{py_ver} \
     %{?with_kafka:--enable-kafka} \


### PR DESCRIPTION
Disable it temporarily
- we do not save the debug symbols yet
- adds a dependency that is not on all the supported OS versions presented by default