### PR TITLE
cloud-auth: Add generic OAuth2 authentication module

### DIFF
--- a/modules/cloud-auth/CMakeLists.txt
+++ b/modules/cloud-auth/CMakeLists.txt
@@ -29,6 +29,9 @@ set(CLOUD_AUTH_CPP_SOURCES
   azure-auth.h
   azure-auth.cpp
   azure-auth.hpp
+  oauth2-auth.h
+  oauth2-auth.cpp
+  oauth2-auth.hpp
 )
 
 set(OTEL_SOURCES

--- a/modules/cloud-auth/Makefile.am
+++ b/modules/cloud-auth/Makefile.am
@@ -8,7 +8,9 @@ modules_cloud_auth_libcloud_auth_cpp_la_SOURCES = \
   modules/cloud-auth/google-auth.hpp \
   modules/cloud-auth/google-auth.cpp \
   modules/cloud-auth/azure-auth.hpp \
-  modules/cloud-auth/azure-auth.cpp
+  modules/cloud-auth/azure-auth.cpp \
+  modules/cloud-auth/oauth2-auth.hpp \
+  modules/cloud-auth/oauth2-auth.cpp
 
 modules_cloud_auth_libcloud_auth_cpp_la_CXXFLAGS = \
   $(AM_CXXFLAGS) \
@@ -32,7 +34,8 @@ modules_cloud_auth_libcloud_auth_la_SOURCES = \
   modules/cloud-auth/cloud-auth.h \
   modules/cloud-auth/cloud-auth.c \
   modules/cloud-auth/google-auth.h \
-  modules/cloud-auth/azure-auth.h
+  modules/cloud-auth/azure-auth.h \
+  modules/cloud-auth/oauth2-auth.h
 
 modules_cloud_auth_libcloud_auth_la_CPPFLAGS = \
   $(AM_CPPFLAGS) \

--- a/modules/cloud-auth/azure-auth.cpp
+++ b/modules/cloud-auth/azure-auth.cpp
@@ -22,185 +22,25 @@
  */
 #include "azure-auth.hpp"
 
-#include "compat/cpp-start.h"
-#include "scratch-buffers.h"
-#include "compat/cpp-end.h"
-
-#include <fstream>
-
 using namespace syslogng::cloud_auth::azure;
+using namespace syslogng::cloud_auth::oauth2;
 
-AzureMonitorAuthenticator::AzureMonitorAuthenticator(const char *tenant_id,
-                                                     const char *app_id,
-                                                     const char *app_secret,
-                                                     const char *scope)
+AzureMonitorAuthenticator::AzureMonitorAuthenticator(const char *tenant_id_,
+                                                     const char *app_id_,
+                                                     const char *app_secret_,
+                                                     const char *scope_)
+  : OAuth2Authenticator(
+      app_id_,                                                            // client_id
+      app_secret_,                                                        // client_secret
+      (std::string("https://login.microsoftonline.com/") + tenant_id_ +
+       "/oauth2/v2.0/token").c_str(),                                    // token_url
+      scope_,                                                             // scope
+      nullptr,                                                           // resource (not used)
+      nullptr,                                                           // authorization_details (not used)
+      60,                                                                // refresh_offset (60s before expiry)
+      OAUTH2_AUTH_METHOD_POST_BODY                                       // auth_method
+    )
 {
-  auth_url = "https://login.microsoftonline.com/";
-  auth_url.append(tenant_id);
-  auth_url.append("/oauth2/v2.0/token");
-
-  auth_body = "grant_type=client_credentials&client_id=";
-  auth_body.append(app_id);
-  auth_body.append("&client_secret=");
-  auth_body.append(app_secret);
-  auth_body.append("&scope=");
-  auth_body.append(scope);
-}
-
-void AzureMonitorAuthenticator::handle_http_header_request(HttpHeaderRequestSignalData *data)
-{
-  std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
-
-  lock.lock();
-
-  if (now <= refresh_token_after && !cached_token.empty())
-    {
-      add_token_to_header(data);
-      lock.unlock();
-
-      data->result = HTTP_SLOT_SUCCESS;
-      return;
-    }
-
-  cached_token.clear();
-
-  std::string response_payload_buffer;
-  if (!send_token_post_request(response_payload_buffer))
-    {
-      lock.unlock();
-
-      data->result = HTTP_SLOT_CRITICAL_ERROR;
-      return;
-    }
-
-  long expiry;
-  if (!parse_token_and_expiry_from_response(response_payload_buffer, cached_token, &expiry))
-    {
-      lock.unlock();
-
-      data->result = HTTP_SLOT_CRITICAL_ERROR;
-      return;
-    }
-
-  refresh_token_after = now + std::chrono::seconds{expiry - 60};
-  add_token_to_header(data);
-
-  lock.unlock();
-
-  data->result = HTTP_SLOT_SUCCESS;
-}
-
-void
-AzureMonitorAuthenticator::add_token_to_header(HttpHeaderRequestSignalData *data)
-{
-  /* Scratch Buffers are marked at this point in http-worker.c */
-  GString *auth_buffer = scratch_buffers_alloc();
-  g_string_append(auth_buffer, "Authorization: Bearer ");
-  g_string_append(auth_buffer, cached_token.c_str());
-
-  list_append(data->request_headers, auth_buffer->str);
-}
-
-bool
-AzureMonitorAuthenticator::send_token_post_request(std::string &response_payload_buffer)
-{
-  CURLcode ret;
-  CURL *hnd = curl_easy_init();
-
-  if (!hnd)
-    {
-      msg_error("cloud_auth::azure::AzureMonitorAuthenticator: "
-                "failed to init cURL handle",
-                evt_tag_str("url", auth_url.c_str()));
-      goto error;
-    }
-
-  curl_easy_setopt(hnd, CURLOPT_URL, auth_url.c_str());
-  curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "POST");
-  curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, auth_body.c_str());
-  curl_easy_setopt(hnd, CURLOPT_WRITEFUNCTION, curl_write_callback);
-  curl_easy_setopt(hnd, CURLOPT_WRITEDATA, (void *) &response_payload_buffer);
-
-  ret = curl_easy_perform(hnd);
-  if (ret != CURLE_OK)
-    {
-      msg_error("cloud_auth::azure::AzureMonitorAuthenticator: "
-                "error sending HTTP request to metadata server",
-                evt_tag_str("url", auth_url.c_str()),
-                evt_tag_str("error", curl_easy_strerror(ret)));
-      goto error;
-    }
-
-  long http_result_code;
-  ret = curl_easy_getinfo(hnd, CURLINFO_RESPONSE_CODE, &http_result_code);
-  if (ret != CURLE_OK)
-    {
-      msg_error("cloud_auth::azure::AzureMonitorAuthenticator: "
-                "failed to get HTTP result code",
-                evt_tag_str("url", auth_url.c_str()),
-                evt_tag_str("error", curl_easy_strerror(ret)));
-      goto error;
-    }
-
-  if (http_result_code != 200)
-    {
-      msg_error("cloud_auth::azure::AzureMonitorAuthenticator: "
-                "non 200 HTTP result code received",
-                evt_tag_str("url", auth_url.c_str()),
-                evt_tag_int("http_result_code", http_result_code));
-      goto error;
-    }
-
-  curl_easy_cleanup(hnd);
-  return true;
-
-error:
-  if (hnd)
-    {
-      curl_easy_cleanup(hnd);
-    }
-  return false;
-}
-
-bool
-AzureMonitorAuthenticator::parse_token_and_expiry_from_response(const std::string &response_payload,
-    std::string &token, long *expiry)
-{
-  picojson::value json;
-  std::string json_parse_error = picojson::parse(json, response_payload);
-  if (!json_parse_error.empty())
-    {
-      msg_error("cloud_auth::azure::AzureMonitorAuthenticator: "
-                "failed to parse response JSON",
-                evt_tag_str("url", auth_url.c_str()),
-                evt_tag_str("response_json", response_payload.c_str()));
-      return false;
-    }
-
-  if (!json.is<picojson::object>() || !json.contains("access_token") || !json.contains("expires_in"))
-    {
-      msg_error("cloud_auth::azure::AzureMonitorAuthenticator: "
-                "unexpected response JSON",
-                evt_tag_str("url", auth_url.c_str()),
-                evt_tag_str("response_json", response_payload.c_str()));
-      return false;
-    }
-
-  token.assign(json.get("access_token").get<std::string>());
-  *expiry = lround(json.get("expires_in").get<double>()); /* getting a long from picojson is not always available */
-  return true;
-}
-
-size_t
-AzureMonitorAuthenticator::curl_write_callback(void *contents, size_t size, size_t nmemb, void *userp)
-{
-  const char *data = (const char *) contents;
-  std::string *response_payload_buffer = (std::string *) userp;
-
-  size_t real_size = size * nmemb;
-  response_payload_buffer->append(data, real_size);
-
-  return real_size;
 }
 
 /* C Wrappers */

--- a/modules/cloud-auth/azure-auth.hpp
+++ b/modules/cloud-auth/azure-auth.hpp
@@ -25,37 +25,18 @@
 #define AZURE_AUTH_HPP
 
 #include "azure-auth.h"
-#include "cloud-auth.hpp"
-
-#include <mutex>
-#include <jwt-cpp/jwt.h>
+#include "oauth2-auth.hpp"
 
 namespace syslogng {
 namespace cloud_auth {
 namespace azure {
 
-class AzureMonitorAuthenticator: public syslogng::cloud_auth::Authenticator
+class AzureMonitorAuthenticator: public syslogng::cloud_auth::oauth2::OAuth2Authenticator
 {
 public:
   AzureMonitorAuthenticator(const char *tenant_id, const char *app_id,
-                            const char *app_secret, const char *scope);
+                            const char *app_secret, const char *scope_);
   ~AzureMonitorAuthenticator() {};
-
-  void handle_http_header_request(HttpHeaderRequestSignalData *data);
-
-private:
-  std::string auth_url;
-  std::string auth_body;
-
-  std::mutex lock;
-  std::string cached_token;
-  std::chrono::system_clock::time_point refresh_token_after;
-
-  void add_token_to_header(HttpHeaderRequestSignalData *data);
-  bool parse_token_and_expiry_from_response(const std::string &response_payload,
-                                            std::string &token, long *expiry);
-  static size_t curl_write_callback(void *contents, size_t size, size_t nmemb, void *userp);
-  bool send_token_post_request(std::string &response_payload_buffer);
 };
 
 }

--- a/modules/cloud-auth/cloud-auth-grammar.ym
+++ b/modules/cloud-auth/cloud-auth-grammar.ym
@@ -30,6 +30,7 @@
 #include "cloud-auth.h"
 #include "google-auth.h"
 #include "azure-auth.h"
+#include "oauth2-auth.h"
 
 LogDriverPlugin *last_plugin;
 CloudAuthenticator *last_authenticator;
@@ -62,6 +63,16 @@ CloudAuthenticator *last_authenticator;
 %token KW_APP_ID
 %token KW_APP_SECRET
 %token KW_SCOPE
+%token KW_CLIENT_ID
+%token KW_CLIENT_SECRET
+%token KW_TOKEN_URL
+%token KW_RESOURCE
+%token KW_AUTHORIZATION_DETAILS
+%token KW_REFRESH_OFFSET
+%token KW_OAUTH2
+%token KW_AUTH_METHOD
+%token KW_BASIC
+%token KW_POST_BODY
 
 %%
 
@@ -92,6 +103,14 @@ inner_destination_cloud_auth_option
       last_authenticator = azure_authenticator_new();
     }
     '(' azure_dest_auth_options ')'
+    {
+      cloud_auth_dest_plugin_set_authenticator(last_plugin, last_authenticator);
+    }
+  | KW_OAUTH2
+    {
+      last_authenticator = oauth2_authenticator_new();
+    }
+    '(' oauth2_dest_auth_options ')'
     {
       cloud_auth_dest_plugin_set_authenticator(last_plugin, last_authenticator);
     }
@@ -159,6 +178,27 @@ azure_dest_monitor_option
   | KW_APP_ID '(' string ')' {azure_authenticator_set_app_id(last_authenticator, $3); free($3);}
   | KW_APP_SECRET '(' string ')' {azure_authenticator_set_app_secret(last_authenticator, $3); free($3);}
   | KW_SCOPE '(' string ')' {azure_authenticator_set_scope(last_authenticator, $3); free($3);}
+  ;
+
+oauth2_dest_auth_options
+  : oauth2_dest_auth_option oauth2_dest_auth_options
+  |
+  ;
+
+oauth2_dest_auth_option
+  : KW_CLIENT_ID '(' string ')' {oauth2_authenticator_set_client_id(last_authenticator, $3); free($3);}
+  | KW_CLIENT_SECRET '(' string ')' {oauth2_authenticator_set_client_secret(last_authenticator, $3); free($3);}
+  | KW_TOKEN_URL '(' string ')' {oauth2_authenticator_set_token_url(last_authenticator, $3); free($3);}
+  | KW_SCOPE '(' string ')' {oauth2_authenticator_set_scope(last_authenticator, $3); free($3);}
+  | KW_RESOURCE '(' string ')' {oauth2_authenticator_set_resource(last_authenticator, $3); free($3);}
+  | KW_AUTHORIZATION_DETAILS '(' string ')' {oauth2_authenticator_set_authorization_details(last_authenticator, $3); free($3);}
+  | KW_REFRESH_OFFSET '(' nonnegative_integer64 ')' {oauth2_authenticator_set_refresh_offset(last_authenticator, $3);}
+  | KW_AUTH_METHOD '(' oauth2_auth_method_value ')' 
+  ;
+
+oauth2_auth_method_value
+  : KW_BASIC { oauth2_authenticator_set_auth_method(last_authenticator, OAUTH2_AUTH_METHOD_BASIC); }
+  | KW_POST_BODY { oauth2_authenticator_set_auth_method(last_authenticator, OAUTH2_AUTH_METHOD_POST_BODY); }
   ;
 
 /* INCLUDE_RULES */

--- a/modules/cloud-auth/cloud-auth-parser.c
+++ b/modules/cloud-auth/cloud-auth-parser.c
@@ -44,6 +44,16 @@ static CfgLexerKeyword cloud_auth_keywords[] =
   { "app_id",                        KW_APP_ID },
   { "app_secret",                    KW_APP_SECRET },
   { "scope",                         KW_SCOPE },
+  { "client_id",                     KW_CLIENT_ID },
+  { "client_secret",                 KW_CLIENT_SECRET },
+  { "token_url",                     KW_TOKEN_URL },
+  { "resource",                      KW_RESOURCE },
+  { "authorization_details",         KW_AUTHORIZATION_DETAILS },
+  { "refresh_offset",                KW_REFRESH_OFFSET },
+  { "oauth2",                        KW_OAUTH2 },
+  { "auth_method",                   KW_AUTH_METHOD },
+  { "basic",                         KW_BASIC },
+  { "post_body",                     KW_POST_BODY },
   { NULL }
 };
 

--- a/modules/cloud-auth/oauth2-auth.cpp
+++ b/modules/cloud-auth/oauth2-auth.cpp
@@ -1,0 +1,458 @@
+/*
+ * Copyright (c) 2025 Databricks
+ * Copyright (c) 2025 David Tosovic <david.tosovic@databricks.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "oauth2-auth.hpp"
+#include "compat/cpp-start.h"
+#include "messages.h"
+#include "scratch-buffers.h"
+#include "compat/cpp-end.h"
+
+#include <chrono>
+#include <sstream>
+
+using namespace syslogng::cloud_auth;
+using namespace syslogng::cloud_auth::oauth2;
+
+OAuth2Authenticator::OAuth2Authenticator(
+  const char *client_id_,
+  const char *client_secret_,
+  const char *token_url_,
+  const char *scope_,
+  const char *resource_,
+  const char *authorization_details_,
+  uint64_t refresh_offset_seconds_,
+  OAuth2AuthMethod auth_method_
+)
+  : client_id(client_id_ ? client_id_ : ""),
+    client_secret(client_secret_ ? client_secret_ : ""),
+    token_url(token_url_ ? token_url_ : ""),
+    scope(scope_ ? scope_ : ""),
+    resource(resource_ ? resource_ : ""),
+    authorization_details(authorization_details_ ? authorization_details_ : ""),
+    refresh_offset_seconds(refresh_offset_seconds_),
+    auth_method(auth_method_),
+    refresh_token_after(std::chrono::system_clock::now())
+{
+}
+
+void
+OAuth2Authenticator::handle_http_header_request(HttpHeaderRequestSignalData *data)
+{
+  lock.lock();
+
+  if (std::chrono::system_clock::now() <= refresh_token_after && !cached_token.empty())
+    {
+      add_token_to_header(data);
+      lock.unlock();
+
+      data->result = HTTP_SLOT_SUCCESS;
+      return;
+    }
+
+  cached_token.clear();
+
+  std::string response_payload_buffer;
+  if (!send_token_post_request(response_payload_buffer))
+    {
+      lock.unlock();
+
+      data->result = HTTP_SLOT_CRITICAL_ERROR;
+      return;
+    }
+
+  if (!extract_token_from_response(response_payload_buffer))
+    {
+      lock.unlock();
+
+      data->result = HTTP_SLOT_CRITICAL_ERROR;
+      return;
+    }
+
+  add_token_to_header(data);
+
+  lock.unlock();
+
+  data->result = HTTP_SLOT_SUCCESS;
+}
+
+void
+OAuth2Authenticator::add_token_to_header(HttpHeaderRequestSignalData *data)
+{
+  GString *auth_buffer = scratch_buffers_alloc();
+  g_string_append(auth_buffer, "Authorization: Bearer ");
+  g_string_append(auth_buffer, cached_token.c_str());
+
+  list_append(data->request_headers, auth_buffer->str);
+}
+
+std::string
+OAuth2Authenticator::build_post_body()
+{
+  CURL *hnd = curl_easy_init();
+  if (!hnd)
+    return "";
+
+  std::string post_body = "grant_type=client_credentials";
+
+  // Note: Credentials are NOT added here - see prepare_auth_credentials()
+  // which handles credentials based on auth_method (Basic Auth vs POST body)
+
+  // Add scope if provided
+  if (!scope.empty())
+    {
+      post_body += "&scope=" + url_encode(hnd, scope);
+    }
+
+  // Add resource if provided
+  if (!resource.empty())
+    {
+      post_body += "&resource=" + url_encode(hnd, resource);
+    }
+
+  // Add authorization_details if provided (RFC 9396)
+  if (!authorization_details.empty())
+    {
+      post_body += "&authorization_details=" + url_encode(hnd, authorization_details);
+    }
+
+  curl_easy_cleanup(hnd);
+  return post_body;
+}
+
+void
+OAuth2Authenticator::prepare_auth_credentials(CURL *hnd, std::string &post_body)
+{
+  switch (auth_method)
+    {
+    case OAUTH2_AUTH_METHOD_BASIC:
+    {
+      // Method 1: Use HTTP Basic Auth header
+      // Credentials sent as: Authorization: Basic base64(client_id:client_secret)
+      std::string userpwd = client_id + ":" + client_secret;
+      curl_easy_setopt(hnd, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+      curl_easy_setopt(hnd, CURLOPT_USERPWD, userpwd.c_str());
+      break;
+    }
+    case OAUTH2_AUTH_METHOD_POST_BODY:
+    {
+      // Method 2: Add credentials to POST body
+      // Credentials sent as: ...&client_id=...&client_secret=...
+      CURL *encode_hnd = curl_easy_init();
+      if (encode_hnd)
+        {
+          post_body += "&client_id=" + url_encode(encode_hnd, client_id);
+          post_body += "&client_secret=" + url_encode(encode_hnd, client_secret);
+          curl_easy_cleanup(encode_hnd);
+        }
+      break;
+    }
+    case OAUTH2_AUTH_METHOD_CUSTOM:
+    {
+      // Subclasses must override this method if using CUSTOM
+      msg_error("cloud_auth::oauth2::OAuth2Authenticator: "
+                "CUSTOM auth method requires subclass to override prepare_auth_credentials()");
+      break;
+    }
+    default:
+    {
+      g_assert_not_reached();
+    }
+    }
+}
+
+std::string
+OAuth2Authenticator::url_encode(CURL *hnd, const std::string &value)
+{
+  char *encoded = curl_easy_escape(hnd, value.c_str(), value.length());
+  if (!encoded)
+    return "";
+
+  std::string result(encoded);
+  curl_free(encoded);
+  return result;
+}
+
+size_t
+OAuth2Authenticator::curl_write_callback(void *ptr, size_t size, size_t nmemb, void *userdata)
+{
+  std::string *response = static_cast<std::string *>(userdata);
+  response->append(static_cast<char *>(ptr), size * nmemb);
+  return size * nmemb;
+}
+
+bool
+OAuth2Authenticator::send_token_post_request(std::string &response_payload_buffer)
+{
+  CURLcode ret;
+  CURL *hnd = curl_easy_init();
+
+  if (!hnd)
+    {
+      msg_error("cloud_auth::oauth2::OAuth2Authenticator: "
+                "failed to init cURL handle",
+                evt_tag_str("url", token_url.c_str()));
+      return false;
+    }
+
+  std::string post_body = build_post_body();
+
+  prepare_auth_credentials(hnd, post_body);
+
+  curl_easy_setopt(hnd, CURLOPT_URL, token_url.c_str());
+  curl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "POST");
+  curl_easy_setopt(hnd, CURLOPT_POSTFIELDS, post_body.c_str());
+  curl_easy_setopt(hnd, CURLOPT_WRITEFUNCTION, curl_write_callback);
+  curl_easy_setopt(hnd, CURLOPT_WRITEDATA, (void *) &response_payload_buffer);
+
+  ret = curl_easy_perform(hnd);
+  if (ret != CURLE_OK)
+    {
+      msg_error("cloud_auth::oauth2::OAuth2Authenticator: "
+                "error sending HTTP request to OAuth token endpoint",
+                evt_tag_str("url", token_url.c_str()),
+                evt_tag_str("error", curl_easy_strerror(ret)));
+      curl_easy_cleanup(hnd);
+      return false;
+    }
+
+  long http_result_code;
+  ret = curl_easy_getinfo(hnd, CURLINFO_RESPONSE_CODE, &http_result_code);
+  if (ret != CURLE_OK)
+    {
+      msg_error("cloud_auth::oauth2::OAuth2Authenticator: "
+                "failed to get HTTP result code",
+                evt_tag_str("url", token_url.c_str()),
+                evt_tag_str("error", curl_easy_strerror(ret)));
+      curl_easy_cleanup(hnd);
+      return false;
+    }
+
+  if (http_result_code != 200)
+    {
+      msg_error("cloud_auth::oauth2::OAuth2Authenticator: "
+                "non 200 HTTP result code received",
+                evt_tag_str("url", token_url.c_str()),
+                evt_tag_int("http_result_code", http_result_code),
+                evt_tag_str("response", response_payload_buffer.c_str()));
+      curl_easy_cleanup(hnd);
+      return false;
+    }
+
+  curl_easy_cleanup(hnd);
+  return true;
+}
+
+bool
+OAuth2Authenticator::extract_token_from_response(const std::string &response)
+{
+  // Parse JSON response
+  picojson::value json;
+  std::string parse_error = picojson::parse(json, response);
+
+  if (!parse_error.empty())
+    {
+      msg_error("cloud_auth::oauth2::OAuth2Authenticator: "
+                "failed to parse JSON response from OAuth token endpoint",
+                evt_tag_str("error", parse_error.c_str()),
+                evt_tag_str("response", response.c_str()));
+      return false;
+    }
+
+  if (!json.is<picojson::object>())
+    {
+      msg_error("cloud_auth::oauth2::OAuth2Authenticator: "
+                "JSON response is not an object",
+                evt_tag_str("response", response.c_str()));
+      return false;
+    }
+
+  picojson::object obj = json.get<picojson::object>();
+
+  // Extract access_token
+  if (obj.find("access_token") == obj.end() || !obj["access_token"].is<std::string>())
+    {
+      msg_error("cloud_auth::oauth2::OAuth2Authenticator: "
+                "access_token field not found or not a string in JSON response",
+                evt_tag_str("response", response.c_str()));
+      return false;
+    }
+
+  // Extract expires_in (seconds until token expiry)
+  if (obj.find("expires_in") == obj.end() || !obj["expires_in"].is<double>())
+    {
+      msg_error("cloud_auth::oauth2::OAuth2Authenticator: "
+                "expires_in field not found or not a number in JSON response",
+                evt_tag_str("response", response.c_str()));
+      return false;
+    }
+
+  // Store token in cache and calculate refresh time
+  cached_token = obj["access_token"].get<std::string>();
+  long expires_in_seconds = (long)obj["expires_in"].get<double>();
+
+  std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
+  refresh_token_after = now + std::chrono::seconds{expires_in_seconds - (long)refresh_offset_seconds};
+
+  return true;
+}
+
+/* C Wrappers */
+
+typedef struct OAuth2Auth
+{
+  CloudAuthenticator super;
+
+  gchar *client_id;
+  gchar *client_secret;
+  gchar *token_url;
+  gchar *scope;
+  gchar *resource;
+  gchar *authorization_details;
+  guint64 refresh_offset_seconds;
+  OAuth2AuthMethod auth_method;
+} _OAuth2Auth;
+
+void
+oauth2_authenticator_set_client_id(CloudAuthenticator *s, const gchar *client_id)
+{
+  OAuth2Auth *self = (OAuth2Auth *) s;
+
+  g_free(self->client_id);
+  self->client_id = g_strdup(client_id);
+}
+
+void
+oauth2_authenticator_set_client_secret(CloudAuthenticator *s, const gchar *client_secret)
+{
+  OAuth2Auth *self = (OAuth2Auth *) s;
+
+  g_free(self->client_secret);
+  self->client_secret = g_strdup(client_secret);
+}
+
+void
+oauth2_authenticator_set_token_url(CloudAuthenticator *s, const gchar *token_url)
+{
+  OAuth2Auth *self = (OAuth2Auth *) s;
+
+  g_free(self->token_url);
+  self->token_url = g_strdup(token_url);
+}
+
+void
+oauth2_authenticator_set_scope(CloudAuthenticator *s, const gchar *scope)
+{
+  OAuth2Auth *self = (OAuth2Auth *) s;
+
+  g_free(self->scope);
+  self->scope = g_strdup(scope);
+}
+
+void
+oauth2_authenticator_set_resource(CloudAuthenticator *s, const gchar *resource)
+{
+  OAuth2Auth *self = (OAuth2Auth *) s;
+
+  g_free(self->resource);
+  self->resource = g_strdup(resource);
+}
+
+void
+oauth2_authenticator_set_authorization_details(CloudAuthenticator *s, const gchar *authorization_details)
+{
+  OAuth2Auth *self = (OAuth2Auth *) s;
+
+  g_free(self->authorization_details);
+  self->authorization_details = g_strdup(authorization_details);
+}
+
+void
+oauth2_authenticator_set_refresh_offset(CloudAuthenticator *s, guint64 refresh_offset_seconds)
+{
+  OAuth2Auth *self = (OAuth2Auth *) s;
+
+  self->refresh_offset_seconds = refresh_offset_seconds;
+}
+
+void
+oauth2_authenticator_set_auth_method(CloudAuthenticator *s, OAuth2AuthMethod auth_method)
+{
+  OAuth2Auth *self = (OAuth2Auth *) s;
+
+  self->auth_method = auth_method;
+}
+
+static gboolean
+_init(CloudAuthenticator *s)
+{
+  OAuth2Auth *self = (OAuth2Auth *) s;
+
+  try
+    {
+      self->super.cpp = new syslogng::cloud_auth::oauth2::OAuth2Authenticator(
+        self->client_id ? self->client_id : "",
+        self->client_secret ? self->client_secret : "",
+        self->token_url ? self->token_url : "",
+        self->scope ? self->scope : "",
+        self->resource ? self->resource : "",
+        self->authorization_details ? self->authorization_details : "",
+        self->refresh_offset_seconds,
+        self->auth_method
+      );
+    }
+  catch (const std::runtime_error &e)
+    {
+      msg_error("cloud_auth::oauth2: Failed to initialize OAuth2Authenticator",
+                evt_tag_str("error", e.what()));
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+static void
+_free(CloudAuthenticator *s)
+{
+  OAuth2Auth *self = (OAuth2Auth *) s;
+
+  g_free(self->client_id);
+  g_free(self->client_secret);
+  g_free(self->token_url);
+  g_free(self->scope);
+  g_free(self->resource);
+  g_free(self->authorization_details);
+}
+
+CloudAuthenticator *
+oauth2_authenticator_new(void)
+{
+  OAuth2Auth *self = g_new0(OAuth2Auth, 1);
+
+  self->super.init = _init;
+  self->super.free_fn = _free;
+  self->refresh_offset_seconds = 1800; // Default: 30 minutes
+  self->auth_method = OAUTH2_AUTH_METHOD_BASIC;  // Default: use HTTP Basic Auth
+
+  return &self->super;
+}
+

--- a/modules/cloud-auth/oauth2-auth.h
+++ b/modules/cloud-auth/oauth2-auth.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025 Databricks
+ * Copyright (c) 2025 David Tosovic <david.tosovic@databricks.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef OAUTH2_AUTH_H
+#define OAUTH2_AUTH_H
+
+#include "cloud-auth.h"
+
+#include "compat/cpp-start.h"
+
+typedef enum
+{
+  OAUTH2_AUTH_METHOD_BASIC,
+  OAUTH2_AUTH_METHOD_POST_BODY,
+  OAUTH2_AUTH_METHOD_CUSTOM
+} OAuth2AuthMethod;
+
+CloudAuthenticator *oauth2_authenticator_new(void);
+void oauth2_authenticator_set_client_id(CloudAuthenticator *s, const gchar *client_id);
+void oauth2_authenticator_set_client_secret(CloudAuthenticator *s, const gchar *client_secret);
+void oauth2_authenticator_set_token_url(CloudAuthenticator *s, const gchar *token_url);
+void oauth2_authenticator_set_scope(CloudAuthenticator *s, const gchar *scope);
+void oauth2_authenticator_set_resource(CloudAuthenticator *s, const gchar *resource);
+void oauth2_authenticator_set_authorization_details(CloudAuthenticator *s, const gchar *authorization_details);
+void oauth2_authenticator_set_refresh_offset(CloudAuthenticator *s, guint64 refresh_offset_seconds);
+void oauth2_authenticator_set_auth_method(CloudAuthenticator *s, OAuth2AuthMethod auth_method);
+
+#include "compat/cpp-end.h"
+
+#endif
+

--- a/modules/cloud-auth/oauth2-auth.hpp
+++ b/modules/cloud-auth/oauth2-auth.hpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025 Databricks
+ * Copyright (c) 2025 David Tosovic <david.tosovic@databricks.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef OAUTH2_AUTH_HPP
+#define OAUTH2_AUTH_HPP
+
+#include "oauth2-auth.h"
+#include "cloud-auth.hpp"
+
+#include <mutex>
+#include <string>
+#include <jwt-cpp/jwt.h>
+#include "compat/curl.h"
+
+namespace syslogng {
+namespace cloud_auth {
+namespace oauth2 {
+
+class OAuth2Authenticator: public syslogng::cloud_auth::Authenticator
+{
+public:
+  OAuth2Authenticator(
+    const char *client_id,
+    const char *client_secret,
+    const char *token_url,
+    const char *scope,
+    const char *resource,
+    const char *authorization_details,
+    uint64_t refresh_offset_seconds,
+    OAuth2AuthMethod auth_method
+  );
+
+  void handle_http_header_request(HttpHeaderRequestSignalData *data);
+
+protected:
+  std::string client_id;
+  std::string client_secret;
+  std::string token_url;
+  std::string scope;
+  std::string resource;
+  std::string authorization_details;
+  uint64_t refresh_offset_seconds;
+  OAuth2AuthMethod auth_method;
+
+  std::mutex lock;
+  std::string cached_token;
+  std::chrono::system_clock::time_point refresh_token_after;
+
+  void add_token_to_header(HttpHeaderRequestSignalData *data);
+  bool send_token_post_request(std::string &response_payload_buffer);
+  bool extract_token_from_response(const std::string &response);
+  std::string build_post_body();
+  std::string url_encode(CURL *hnd, const std::string &value);
+
+  // Virtual method for subclasses to override auth credential preparation
+  virtual void prepare_auth_credentials(CURL *hnd, std::string &post_body);
+
+  static size_t curl_write_callback(void *ptr, size_t size, size_t nmemb, void *userdata);
+};
+
+}
+}
+}
+
+#endif
+

--- a/news/feature-5571.md
+++ b/news/feature-5571.md
@@ -1,0 +1,3 @@
+`cloud-auth`: Add generic OAuth2 authentication module
+
+A generic OAuth2 authentication module supporting client credentials flow with configurable authentication methods (HTTP Basic Auth or POST body credentials) has been added. The module is extensible via virtual methods, allowing future authenticators to inherit common OAuth2 token management logic.

--- a/tests/copyright/policy
+++ b/tests/copyright/policy
@@ -218,6 +218,7 @@ modules/grpc/protos/apphook\.(cpp|h)$
 modules/cloud-auth/cloud-auth(|-grammar|-parser|-plugin)\.(c|h|cpp|hpp|ym)$
 modules/cloud-auth/google-auth\.(h|cpp|hpp)$
 modules/cloud-auth/azure-auth\.(h|cpp|hpp)$
+modules/cloud-auth/oauth2-auth\.(h|cpp|hpp)$
 modules/examples/inner-destinations/tls-test-validation
 modules/examples/sources/random-choice-generator
 modules/python/python-options.(c|h)$


### PR DESCRIPTION
## Motivation

Enable clients to specify a destination with an `oauth2` cloud-auth module that handles OAuth token fetching and refresh logic.

Currently, the only OAuth2 support in syslog-ng is inside the `azure-auth` module, which is Azure-specific and cannot be used with other cloud providers. This limits the destinations syslog-ng can target with OAuth2 tokens.
Apart from that, if new cloud-provider specific implementations were needed, we'd have code duplication when adding new OAuth2-based authenticators.

## Changes

This PR introduces a generic OAuth2 authentication module that implements the client credentials flow with configurable authentication methods (HTTP Basic Auth or POST body credentials). The module provides a reusable foundation for cloud service authenticators that use OAuth2.

### Key Features:
- Token fetching, caching, and automatic refresh based on expiry
- Configurable authentication method via `auth-method()` parameter
- Support for optional `scope`, `resource`, and `authorization_details` parameters
- Extensible via virtual methods for service-specific customization

### Implementation Details:
- **New generic OAuth2 module** (`oauth2-auth.{h,hpp,cpp}`):
  - Handles all common OAuth2 client credentials flow logic
  - Reduces code duplication across cloud auth modules
  
- **Refactored Azure module** (`azure-auth.{h,hpp,cpp}`):
  - Now inherits from the generic `OAuth2Authenticator`
  - Maintains 100% backward compatibility with existing configurations
  - Eliminates duplicated logic from azure-auth module

## Configuration

### Using the new generic OAuth2 module:

```
destination d_http_oauth2 {
  http(
    url("https://api.example.com/logs")
    cloud-auth(
      oauth2(
        client-id("your-client-id")
        client-secret("your-secret")
        token-url("https://login.example.com/oauth2/token")
        scope("https://api.example.com/.default")
        auth-method("post-body")  # or "basic"
      )
    )
  );
};
```

### Existing Azure configuration (unchanged):

```
destination d_azure {
  http(
    url("https://...")
    cloud-auth(
      azure(
        monitor(
          tenant-id("...")
          app-id("...")
          app-secret("...")
          scope("...")
        )
      )
    )
  );
};
```

## Testing

- Verified the new generic OAuth2 module by targeting an HTTP endpoint
- Verified Azure authentication still works and successfully fetches OAuth2 tokens from Azure
- Verified token fetching, caching, and refresh work correctly

## Notes

- The generic OAuth2 module is designed to be extended by future authenticators
- No breaking changes to existing configurations
- News file added: `news/feature-5571.md`
Solves: https://github.com/syslog-ng/syslog-ng/issues/5571