### PR TITLE
scl: add support for opensearch data-streams

### DIFF
--- a/scl/opensearch/opensearch.conf
+++ b/scl/opensearch/opensearch.conf
@@ -34,6 +34,7 @@ block destination opensearch(
   template("$(format-json --scope rfc5424 --exclude DATE --key ISODATE @timestamp=${ISODATE})")
   headers("Content-Type: application/x-ndjson")
   body_suffix("\n")
+  op_type("index")
   ...)
 {
 
@@ -46,7 +47,7 @@ block destination opensearch(
         batch_lines(`batch_lines`)
         timeout(`timeout`)
         body_suffix(`body_suffix`)
-        body("$(format-json --scope none --omit-empty-values index._index=\"`index`\" index._id=\"`custom_id`\")\n`template`")
+        body("$(format-json --scope none --omit-empty-values `op_type`._index=\"`index`\" `op_type`._id=\"`custom_id`\")\n`template`")
         `__VARARGS__`
     );
 };


### PR DESCRIPTION
This adds support for `op_type` used by OpenSearch _bulk API in order to support data_streams

Fixes: #5577