### PR TITLE
cloud-auth, grpc: Add OAuth2 support for gRPC destinations

### DIFF
--- a/modules/cloud-auth/cloud-auth.c
+++ b/modules/cloud-auth/cloud-auth.c
@@ -42,6 +42,9 @@ _attach(LogDriverPlugin *s, LogDriver *d)
   CONNECT(d->signal_slot_connector, signal_http_header_request, cloud_authenticator_handle_http_header_request,
           self->authenticator);
 
+  CONNECT(d->signal_slot_connector, signal_grpc_metadata_request, cloud_authenticator_handle_grpc_metadata_request,
+          self->authenticator);
+
   return TRUE;
 }
 
@@ -53,6 +56,9 @@ _detach(LogDriverPlugin *s, LogDriver *d)
   cloud_authenticator_deinit(self->authenticator);
 
   DISCONNECT(d->signal_slot_connector, signal_http_header_request, cloud_authenticator_handle_http_header_request,
+             self->authenticator);
+
+  DISCONNECT(d->signal_slot_connector, signal_grpc_metadata_request, cloud_authenticator_handle_grpc_metadata_request,
              self->authenticator);
 }
 

--- a/modules/cloud-auth/cloud-auth.cpp
+++ b/modules/cloud-auth/cloud-auth.cpp
@@ -60,3 +60,9 @@ cloud_authenticator_handle_http_header_request(CloudAuthenticator *s, HttpHeader
 {
   s->cpp->handle_http_header_request(data);
 }
+
+void
+cloud_authenticator_handle_grpc_metadata_request(CloudAuthenticator *s, GrpcMetadataRequestSignalData *data)
+{
+  s->cpp->handle_grpc_metadata_request(data);
+}

--- a/modules/cloud-auth/cloud-auth.h
+++ b/modules/cloud-auth/cloud-auth.h
@@ -31,6 +31,7 @@
 #include "driver.h"
 
 #include "modules/http/http-signals.h"
+#include "modules/grpc/common/grpc-signals.h"
 
 /* Authenticator interface */
 
@@ -40,6 +41,7 @@ gboolean cloud_authenticator_init(CloudAuthenticator *s);
 void cloud_authenticator_deinit(CloudAuthenticator *s);
 void cloud_authenticator_free(CloudAuthenticator *s);
 void cloud_authenticator_handle_http_header_request(CloudAuthenticator *s, HttpHeaderRequestSignalData *data);
+void cloud_authenticator_handle_grpc_metadata_request(CloudAuthenticator *s, GrpcMetadataRequestSignalData *data);
 
 /* Plugins */
 

--- a/modules/cloud-auth/cloud-auth.hpp
+++ b/modules/cloud-auth/cloud-auth.hpp
@@ -33,6 +33,11 @@ class Authenticator
 public:
   virtual ~Authenticator() {};
   virtual void handle_http_header_request(HttpHeaderRequestSignalData *data) = 0;
+
+  virtual void handle_grpc_metadata_request(GrpcMetadataRequestSignalData *data)
+  {
+    data->result = GRPC_SLOT_PLUGIN_ERROR;
+  }
 };
 
 }

--- a/modules/cloud-auth/oauth2-auth.hpp
+++ b/modules/cloud-auth/oauth2-auth.hpp
@@ -51,6 +51,7 @@ public:
   );
 
   void handle_http_header_request(HttpHeaderRequestSignalData *data);
+  void handle_grpc_metadata_request(GrpcMetadataRequestSignalData *data);
 
 protected:
   std::string client_id;
@@ -67,6 +68,7 @@ protected:
   std::chrono::system_clock::time_point refresh_token_after;
 
   void add_token_to_header(HttpHeaderRequestSignalData *data);
+  void add_token_to_grpc_metadata(GrpcMetadataRequestSignalData *data);
   bool send_token_post_request(std::string &response_payload_buffer);
   bool extract_token_from_response(const std::string &response);
   std::string build_post_body();
@@ -76,6 +78,11 @@ protected:
   virtual void prepare_auth_credentials(CURL *hnd, std::string &post_body);
 
   static size_t curl_write_callback(void *ptr, size_t size, size_t nmemb, void *userdata);
+
+private:
+  template<typename SignalDataT, typename ResultT, typename AddTokenFn>
+  void handle_token_request_impl(SignalDataT *data, AddTokenFn add_token_fn,
+                                 ResultT success_code, ResultT error_code);
 };
 
 }

--- a/modules/grpc/common/CMakeLists.txt
+++ b/modules/grpc/common/CMakeLists.txt
@@ -7,6 +7,7 @@ set(GRPC_COMMON_CPP_SOURCES
   ${GRPC_METRICS_SOURCES}
   ${GRPC_SCHEMA_SOURCES}
   grpc-parser.h
+  grpc-signals.h
   grpc-dest.hpp
   grpc-dest.cpp
   grpc-dest.h

--- a/modules/grpc/common/Makefile.am
+++ b/modules/grpc/common/Makefile.am
@@ -18,6 +18,7 @@ modules_grpc_common_libgrpc_common_la_SOURCES = \
   $(grpc_metrics_sources) \
   $(grpc_schema_sources) \
   modules/grpc/common/grpc-parser.h \
+  modules/grpc/common/grpc-signals.h \
   modules/grpc/common/grpc-dest.h \
   modules/grpc/common/grpc-dest.hpp \
   modules/grpc/common/grpc-dest.cpp \

--- a/modules/grpc/common/grpc-signals.h
+++ b/modules/grpc/common/grpc-signals.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 Databricks
+ * Copyright (c) 2025 David Tosovic <david.tosovic@databricks.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef SIGNAL_SLOT_CONNECTOR_GRPC_SIGNALS_H_INCLUDED
+#define SIGNAL_SLOT_CONNECTOR_GRPC_SIGNALS_H_INCLUDED
+
+#include "signal-slot-connector/signal-slot-connector.h"
+#include <glib.h>
+
+typedef struct _GrpcMetadataRequestSignalData GrpcMetadataRequestSignalData;
+typedef struct _GrpcResponseReceivedSignalData GrpcResponseReceivedSignalData;
+
+typedef enum
+{
+  GRPC_SLOT_SUCCESS,
+  GRPC_SLOT_RESOLVED,
+  GRPC_SLOT_CRITICAL_ERROR,
+  GRPC_SLOT_PLUGIN_ERROR,
+} GrpcSlotResultType;
+
+struct _GrpcMetadataRequestSignalData
+{
+  GrpcSlotResultType result;
+  GList *metadata_list;
+};
+
+struct _GrpcResponseReceivedSignalData
+{
+  GrpcSlotResultType result;
+  gint error_code;
+};
+
+#define signal_grpc_metadata_request SIGNAL(grpc, metadata_request, GrpcMetadataRequestSignalData *)
+
+#define signal_grpc_response_received SIGNAL(grpc, response_received, GrpcResponseReceivedSignalData *)
+
+#endif
+

--- a/news/feature-5584.md
+++ b/news/feature-5584.md
@@ -1,0 +1,26 @@
+`cloud-auth`, `grpc`: Add OAuth2 support for gRPC destinations
+
+The `cloud-auth()` plugin now supports gRPC destinations in addition to HTTP
+destinations. This enables OAuth2 token management for any gRPC-based
+destination driver (such as `bigquery()`, `opentelemetry()`, `loki()`, etc.).
+
+The implementation uses the same signal/slot pattern as HTTP.
+
+Example configuration:
+
+```
+destination d_grpc {
+  opentelemetry(
+    url("example.com:443")
+    cloud-auth(
+      oauth2(
+        client_id("client-id")
+        client_secret("client-secret")
+        token_url("https://auth.example.com/token")
+        scope("api-scope")
+      )
+    )
+  );
+}
+```
+


### PR DESCRIPTION
## Motivation
With [PR #5570](https://github.com/syslog-ng/syslog-ng/pull/5570), OAuth2 authentication is available to HTTP based destinations. Currently, OAuth2 authentication is not available for gRPC-based destinations.

## Changes
This change extends the OAuth2 authentication support introduced in [PR #5570](https://github.com/syslog-ng/syslog-ng/pull/5570) to gRPC-based destinations (opentelemetry, loki, bigquery, pubsub, clickhouse, etc.).

The implementation mirrors the existing HTTP pattern by introducing a signal/slot mechanism for gRPC metadata injection, allowing the cloud-auth module to inject OAuth2 tokens into gRPC requests.

## Key Features
- New `grpc-signals.h` header defining `GrpcMetadataRequestSignalData` for plugin communication.
- Signal emission in `grpc-dest-worker.cpp` to collect metadata from authentication plugins.
- gRPC signal handlers in `cloud-auth` module for token injection.

## Configuration
```
destination d_grpc {
  opentelemetry(
    url("example.com:443")
    cloud-auth(
      oauth2(
        client_id("client-id")
        client_secret("client-secret")
        token_url("https://auth.example.com/token")
        scope("api-scope")
      )
    )
  );
};
```

## Testing
- Verified the OAuth2 module works with existing HTTP destinations to verify no regressions are introduced.
- Verified the OAuth2 module works with gRPC destinations to verify the newly added functionality works.

## Notes
- The signal/slot mechanism enables future extensibility for gRPC destinations.
- All existing and future gRPC destinations automatically gain OAuth2 support.
- Google authentication (`google-auth`) can be extended to support gRPC destinations using the same pattern if needed.
- No breaking changes to existing configurations.
- Follows the design pattern established in [PR #5570](https://github.com/syslog-ng/syslog-ng/pull/5570).