### PR TITLE
elasticsearch: update scl to support datastreams

### DIFF
--- a/scl/elasticsearch/elastic-http.conf
+++ b/scl/elasticsearch/elastic-http.conf
@@ -22,7 +22,7 @@
 
 @requires json-plugin
 
-block destination elasticsearch(
+block destination elasticsearch-http(
   url()
   index()
   custom_id("")
@@ -37,7 +37,7 @@ block destination elasticsearch(
   ...)
 {
 
-@requires http "The elasticsearch() driver depends on the syslog-ng http module, please install the syslog-ng-mod-http (Debian & derivatives) or the syslog-ng-http (RHEL & co) package"
+@requires http "The elasticsearch-http() driver depends on the syslog-ng http module, please install the syslog-ng-mod-http (Debian & derivatives) or the syslog-ng-http (RHEL & co) package"
 
     http(
         url(`url`)


### PR DESCRIPTION
Small elasticsearch-http() refactor based on recent changes to the opensearch() destination. Fixes the syslog-ng side of https://github.com/syslog-ng/syslog-ng/issues/5583
- elasticsearch-http() now supports data streams when using the op_type("create") parameter
- the type("") parameter can be now omitted, and its value is silently discarded