### PR TITLE
Add back the "Replace _syslogng.Logger class with InternalHandler" PR

### DIFF
--- a/modules/python-modules/syslogng/__init__.py
+++ b/modules/python-modules/syslogng/__init__.py
@@ -27,7 +27,7 @@ from .source import LogSource, LogFetcher, InstantAckTracker, ConsecutiveAckTrac
 from .parser import LogParser
 from .template import LogTemplate, LogTemplateOptions, LogTemplateException, LTZ_SEND, LTZ_LOCAL
 from .message import LogMessage
-from .logger import Logger
+from .logger import InternalHandler, TRACE, Logger
 from .persist import Persist
 from .confgen import register_config_generator
 from .reloc import get_installation_path_for

--- a/modules/python-modules/syslogng/logger.py
+++ b/modules/python-modules/syslogng/logger.py
@@ -24,49 +24,31 @@
 
 import logging
 
-try:
-    from _syslogng import Logger
 
-    FAKE_LOGGER = False
+class InternalLogger(logging.Logger):
+    def trace(self, msg, *args, **kwargs):
+        if self.isEnabledFor(TRACE):
+            self._log(TRACE, msg, args, **kwargs)
+
+
+try:
+    from _syslogng import InternalHandler, TRACE, Logger
+
 except ImportError:
     import warnings
     warnings.warn("You have imported the syslogng package outside of syslog-ng, "
                   "thus some of the functionality is not available. "
                   "Defining fake classes for those exported by the underlying syslog-ng code")
 
-    FAKE_LOGGER = True
-
-    def Logger():
-        return logging.getLogger()
-    logging.basicConfig()
+    InternalHandler = logging.NullHandler
+    TRACE = logging.DEBUG // 2
+    Logger = InternalLogger
 
 
-class SyslogNGInternalLogHandler(logging.Handler):
-    syslogng_logger = Logger()
-
-    def emit(self, record):
-
-        msg = self.format(record)
-        if record.levelno >= logging.ERROR:
-            self.syslogng_logger.error(msg)
-        elif record.levelno >= logging.WARNING:
-            self.syslogng_logger.warning(msg)
-        elif record.levelno >= logging.INFO:
-            self.syslogng_logger.info(msg)
-        elif record.levelno >= logging.DEBUG:
-            self.syslogng_logger.debug(msg)
-        else:
-            self.syslogng_logger.trace(msg)
-
-
-def setup_logging():
+if InternalHandler is not logging.NullHandler:
+    logging.setLoggerClass(InternalLogger)
     logger = logging.getLogger()
-    logger.setLevel(logging.DEBUG)
-    sh = SyslogNGInternalLogHandler()
-    formatter = logging.Formatter('python-%(name)s: %(message)s')
-    sh.setFormatter(formatter)
-    logger.addHandler(sh)
-
-
-if not FAKE_LOGGER:
-    setup_logging()
+    handler = InternalHandler()
+    logger.setLevel(handler.level)
+    handler.setFormatter(logging.Formatter('python-%(name)s: %(message)s'))
+    logger.addHandler(handler)

--- a/modules/python-modules/syslogng/modules/kubernetes/__init__.py
+++ b/modules/python-modules/syslogng/modules/kubernetes/__init__.py
@@ -21,7 +21,7 @@
 #############################################################################
 
 from kubernetes.client.rest import ApiException
-from syslogng import Logger, LogParser
+from syslogng import LogParser
 import kubernetes
 import logging
 

--- a/modules/python/CMakeLists.txt
+++ b/modules/python/CMakeLists.txt
@@ -47,6 +47,8 @@ set(PYTHON_SOURCES
   python-integerpointer.c
   python-logger.h
   python-logger.c
+  python-loghandler.h
+  python-loghandler.c
   python-source.h
   python-source.c
   python-fetcher.h

--- a/modules/python/Makefile.am
+++ b/modules/python/Makefile.am
@@ -58,6 +58,8 @@ modules_python_libmod_python_la_SOURCES		= \
 	modules/python/python-integerpointer.h    \
 	modules/python/python-logger.c    \
 	modules/python/python-logger.h    \
+	modules/python/python-loghandler.c    \
+	modules/python/python-loghandler.h    \
 	modules/python/python-global-code-loader.h\
 	modules/python/python-global-code-loader.c\
 	modules/python/python-debugger.h	  \

--- a/modules/python/python-helpers.c
+++ b/modules/python/python-helpers.c
@@ -369,10 +369,20 @@ _py_invoke_method_by_name(PyObject *instance, const gchar *method_name, PyObject
 void
 _py_invoke_void_method_by_name(PyObject *instance, const gchar *method_name, const gchar *class, const gchar *module)
 {
+  _py_invoke_void_method_by_name_with_options(instance, method_name, NULL, class, module);
+}
+
+void
+_py_invoke_void_method_by_name_with_options(PyObject *instance, const gchar *method_name,
+                                            const PythonOptions *options, const gchar *class, const gchar *module)
+{
   PyObject *method = _py_get_optional_method(instance, class, method_name, module);
   if (method)
     {
-      _py_invoke_void_function(method, NULL, class, module);
+      PyObject *py_options_dict = options ? python_options_create_py_dict(options) : NULL;
+      _py_invoke_void_function(method, py_options_dict, class, module);
+
+      Py_XDECREF(py_options_dict);
       Py_DECREF(method);
     }
 }

--- a/modules/python/python-helpers.h
+++ b/modules/python/python-helpers.h
@@ -41,11 +41,12 @@ PyObject *_py_invoke_function_with_args(PyObject *func, PyObject *args, const gc
                                         const gchar *caller_context);
 void _py_invoke_void_function(PyObject *func, PyObject *arg, const gchar *class, const gchar *caller_context);
 gboolean _py_invoke_bool_function(PyObject *func, PyObject *arg, const gchar *class, const gchar *caller_context);
-PyObject *_py_get_method(PyObject *instance, const gchar *method_name, const gchar *module);
 PyObject *_py_invoke_method_by_name(PyObject *instance, const gchar *method_name, PyObject *arg, const gchar *class,
                                     const gchar *module);
 void _py_invoke_void_method_by_name(PyObject *instance, const gchar *method_name, const gchar *class,
                                     const gchar *module);
+void _py_invoke_void_method_by_name_with_options(PyObject *instance, const gchar *method_name,
+                                                 const PythonOptions *options, const gchar *class, const gchar *module);
 gboolean _py_invoke_bool_method_by_name_with_options(PyObject *instance, const gchar *method_name,
                                                      const PythonOptions *options, const gchar *class,
                                                      const gchar *module);

--- a/modules/python/python-logger.c
+++ b/modules/python/python-logger.c
@@ -91,7 +91,11 @@ py_msg_trace(PyObject *obj, PyObject *args)
   Py_RETURN_NONE;
 }
 
-
+int py_logger_init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+  msg_warning("WARNING: " VERSION_4_0 " deprecates usage of Logger class. Use default python logging facilities instead");
+  return 0;
+}
 
 static PyMethodDef py_logger_methods[] =
 {
@@ -114,6 +118,7 @@ PyTypeObject py_logger_type =
   .tp_methods = py_logger_methods,
   .tp_name = "Logger",
   .tp_new = PyType_GenericNew,
+  .tp_init = (initproc) py_logger_init,
   0
 };
 

--- a/modules/python/python-loghandler.c
+++ b/modules/python/python-loghandler.c
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2025 One Identity
+ * Copyright (c) 2025 Narkhov Evgeny <evgenynarkhov2@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include "python-loghandler.h"
+
+#include "messages.h"
+#include "python-helpers.h"
+
+typedef struct _PyLogLevels
+{
+  glong error;
+  glong warning;
+  glong info;
+  glong debug;
+  glong trace;
+} PyLogLevels;
+
+static PyLogLevels py_log_levels;
+static PyType_Spec py_handler_spec;
+
+static glong _py_fetch_log_level(PyObject *obj, const gchar *level)
+{
+  PyObject *py_level_value = NULL;
+  // Log Levels must have positive integer values. Negative values can be used
+  // to indicate a error.
+  glong level_value = -1;
+
+  py_level_value = PyObject_GetAttrString(obj, level);
+  if (!py_level_value)
+    {
+      gchar buf[256];
+      msg_error(
+        "could not find log level as object attribute",
+        evt_tag_str("level", level),
+        evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+      _py_finish_exception_handling();
+      goto exit;
+    }
+
+  level_value = PyLong_AsLong(py_level_value);
+
+  if (PyErr_Occurred())
+    {
+      gchar buf[256];
+      msg_error(
+        "failed to parse log level constant as glong",
+        evt_tag_str("level", level),
+        evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+      _py_finish_exception_handling();
+    }
+
+exit:
+  Py_XDECREF(py_level_value);
+  return level_value;
+}
+
+static void _py_add_logging_level(PyObject *m, const gchar *level_name, glong level_value)
+{
+  PyObject *add_level_function = NULL;
+  PyObject *add_level_retval = NULL;
+
+  msg_debug("registering new logging level with addLevelName()", evt_tag_str("level_name", level_name),
+            evt_tag_long("level_value", level_value));
+
+  add_level_function = _py_get_attr_or_null(m, "addLevelName");
+  if (!add_level_function)
+    {
+      msg_error("failed to add new logging level with addLevelName(): missing method", evt_tag_str("level_name", level_name),
+                evt_tag_long("level_value", level_value));
+      goto exit;
+    }
+
+  add_level_retval = PyObject_CallFunction(add_level_function, "(ls)", level_value, level_name);
+  if (PyErr_Occurred())
+    {
+      gchar buf[256];
+      msg_error("failed to add new logging level with addLevelName(): method raised exception", evt_tag_str("exception",
+                _py_format_exception_text(buf, sizeof(buf))), evt_tag_str("level_name", level_name), evt_tag_long("level_value",
+                    level_value));
+      _py_finish_exception_handling();
+    }
+
+exit:
+  Py_XDECREF(add_level_retval);
+  Py_XDECREF(add_level_function);
+}
+
+int py_loghandler_init(PyObject *self, PyObject *args, PyObject *kwds)
+{
+  int ret = -1;
+
+  PyObject *logging_module = NULL;
+  PyObject *super = NULL;
+  PyObject *init_function = NULL;
+  PyObject *py_level_value = NULL;
+
+  logging_module = _py_do_import("logging");
+  if (!logging_module)
+    return ret;
+
+  // super(InternalHandler, self)
+  super = PyObject_CallFunctionObjArgs(
+            (PyObject *)&PySuper_Type, (PyObject *)Py_TYPE(self), self, NULL);
+  if (!super)
+    goto exit;
+
+  init_function = _py_get_attr_or_null(super, "__init__");
+  if (!init_function)
+    goto exit;
+
+  glong level_value;
+  if (trace_flag)
+    level_value = py_log_levels.trace;
+  else if (debug_flag)
+    level_value = py_log_levels.debug;
+  else
+    level_value = py_log_levels.info;
+
+  py_level_value = PyLong_FromLong(level_value);
+  if (!py_level_value)
+    goto exit;
+
+  PyObject *init_ret = PyObject_CallOneArg(init_function, py_level_value);
+  ret = init_ret ? 0 : -1;
+  Py_DECREF(init_ret);
+
+exit:
+  Py_XDECREF(py_level_value);
+  Py_XDECREF(init_function);
+  Py_XDECREF(super);
+  Py_XDECREF(logging_module);
+
+  return ret;
+}
+
+PyObject *py_loghandler_emit(PyObject *self, PyObject *args)
+{
+  PyObject *formatted = NULL;
+
+  PyObject *record;
+  if (!PyArg_ParseTuple(args, "O", &record))
+    return NULL;
+
+  formatted = PyObject_CallMethod(self, "format", "(O)", record);
+  if (!formatted)
+    goto exit_error;
+
+  const char *message = PyUnicode_AsUTF8AndSize(formatted, NULL);
+  if (!message)
+    goto exit_error;
+
+  glong level = _py_fetch_log_level(record, "levelno");
+  if (level < 0)
+    goto exit_normal;
+
+  if (level >= py_log_levels.error)
+    msg_error(message);
+  else if (level >= py_log_levels.warning)
+    msg_warning(message);
+  else if (level >= py_log_levels.info)
+    msg_info(message);
+  else if (level >= py_log_levels.debug && debug_flag)
+    msg_debug(message);
+  else if (level >= py_log_levels.trace && trace_flag)
+    msg_trace(message);
+
+exit_normal:
+  Py_XDECREF(formatted);
+  Py_RETURN_NONE;
+
+exit_error:
+  Py_XDECREF(formatted);
+  return NULL;
+}
+
+static PyMethodDef py_handler_methods[] =
+{
+  {"emit", (PyCFunction)py_loghandler_emit, METH_VARARGS, "emit a log record"},
+  {NULL}
+};
+
+static PyType_Slot py_handler_slots[] =
+{
+  {Py_tp_doc,     "Those messages can be captured by internal() source."},
+  {Py_tp_new,     PyType_GenericNew},
+  {Py_tp_init, (initproc)py_loghandler_init},
+  {Py_tp_methods, py_handler_methods},
+  {0, 0}
+};
+
+static PyType_Spec py_handler_spec =
+{
+  .name = "InternalHandler",
+  .flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+  .slots = py_handler_slots,
+};
+
+void py_loghandler_global_init(void)
+{
+  PyObject *logging_module = NULL;
+  PyObject *bases = NULL;
+  PyObject *handler = NULL;
+  logging_module = _py_do_import("logging");
+  if (!logging_module)
+    goto exit;
+
+  handler = PyObject_GetAttrString(logging_module, "Handler");
+  if (!handler)
+    {
+      gchar buf[256];
+      msg_error(
+        "could not find logging.Handler class",
+        evt_tag_str("exception", _py_format_exception_text(buf, sizeof(buf))));
+      goto exit;
+    }
+
+  bases = PyTuple_Pack(1, handler);
+  if (!bases)
+    {
+      goto exit;
+    }
+
+  PyType_Spec spec = py_handler_spec;
+  spec.basicsize = ((PyTypeObject *)handler)->tp_basicsize;
+
+  PyObject *internal_handler = PyType_FromSpecWithBases(&spec, bases);
+  if (!internal_handler)
+    goto exit;
+
+  PyObject *m = PyImport_AddModule("_syslogng");
+  PyModule_AddObject(m, "InternalHandler", internal_handler);
+
+  py_log_levels.debug = _py_fetch_log_level(logging_module, "DEBUG");
+  if (py_log_levels.debug < 0)
+    goto exit;
+
+  py_log_levels.trace = py_log_levels.debug / 2;
+  if (py_log_levels.trace == py_log_levels.debug)
+    {
+      // Generally log levels are defined with gaps, so the above formula should
+      // work. This is just a safeguard to avoid incorrect configuration.
+      msg_error("DEBUG and TRACE levels received equal values",
+                evt_tag_long("debug_level", py_log_levels.trace),
+                evt_tag_long("trace_level", py_log_levels.trace));
+      goto exit;
+    }
+
+  PyModule_AddIntConstant(m, "TRACE", py_log_levels.trace);
+
+  _py_add_logging_level(logging_module, "TRACE", py_log_levels.trace);
+
+  py_log_levels.error = _py_fetch_log_level(logging_module, "ERROR");
+  py_log_levels.warning = _py_fetch_log_level(logging_module, "WARNING");
+  py_log_levels.info = _py_fetch_log_level(logging_module, "INFO");
+
+exit:
+  Py_XDECREF(bases);
+  Py_XDECREF(handler);
+  Py_XDECREF(logging_module);
+}

--- a/modules/python/python-loghandler.h
+++ b/modules/python/python-loghandler.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025 One Identity
+ * Copyright (c) 2025 Narkhov Evgeny <evgenynarkhov2@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#ifndef _SNG_PYTHON_LOGHANDLER_H
+#define _SNG_PYTHON_LOGHANDLER_H
+
+#include "python-module.h"
+
+void py_loghandler_global_init(void);
+
+#endif

--- a/modules/python/python-startup.c
+++ b/modules/python/python-startup.c
@@ -24,6 +24,7 @@
  */
 #include "python-startup.h"
 #include "python-dest.h"
+#include "python-loghandler.h"
 #include "python-source.h"
 #include "python-fetcher.h"
 #include "python-logparser.h"
@@ -416,6 +417,7 @@ _py_initialize_builtin_modules(void)
   py_reloc_global_init();
   py_global_code_loader_global_init();
   py_logger_global_init();
+  py_loghandler_global_init();
 }
 
 gboolean

--- a/news/feature-5526.md
+++ b/news/feature-5526.md
@@ -1,0 +1,6 @@
+mod-python: replace `Logger` class with internal log handler
+
+Previous `Logger` python class is replaced with internal messages handler, which is installed
+into logging pipeline, allowing python modules to log messages via default logging facilities.
+Also, `TRACE` log level is now explicitly exported and could be used with `log()` methods or `trace()`
+call directly.

--- a/tests/light/functional_tests/Makefile.am
+++ b/tests/light/functional_tests/Makefile.am
@@ -1,6 +1,11 @@
 
 #find -name '*.py'|awk '{ print "\ttests/light/functional_tests/"substr($0,3); }'|sort
 EXTRA_DIST += \
+	tests/light/functional_tests/bindings/python/conftest.py \
+	tests/light/functional_tests/bindings/python/logger/parser.py \
+	tests/light/functional_tests/bindings/python/logger/test_internal_logging.py \
+	tests/light/functional_tests/bindings/python/parser/parser.py \
+	tests/light/functional_tests/bindings/python/parser/test_python_parser.py \
 	tests/light/functional_tests/config_change/test_backtick_substitution.py \
 	tests/light/functional_tests/config_change/test_confgen_network_load_balancer.py \
 	tests/light/functional_tests/config_change/test_manipulating_config_between_reload.py \

--- a/tests/light/functional_tests/bindings/python/conftest.py
+++ b/tests/light/functional_tests/bindings/python/conftest.py
@@ -1,0 +1,33 @@
+#############################################################################
+# Copyright (c) 2025 One Identity
+# Copyright (c) 2025 Narkhov Evgeny <evgenynarkhov2@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import pytest
+
+import src.testcase_parameters.testcase_parameters as tc_parameters
+from src.bindings.python.python_module import DummyPythonModule
+
+
+@pytest.fixture
+def python_module(testcase_parameters):
+    module = DummyPythonModule(tc_parameters.INSTANCE_PATH.get_python_source_dir())
+    yield module
+    module.teardown()

--- a/tests/light/functional_tests/bindings/python/logger/parser.py
+++ b/tests/light/functional_tests/bindings/python/logger/parser.py
@@ -1,0 +1,57 @@
+#############################################################################
+# Copyright (c) 2025 One Identity
+# Copyright (c) 2025 Narkhov Evgeny <evgenynarkhov2@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import logging
+from typing import Dict
+
+try:
+    from syslogng import LogParser, LogMessage, TRACE
+except ImportError:
+    raise RuntimeError(
+        "This code was designed to run with syslog-ng runtime python bindings. "
+        "You probably imported it without syslog-ng installed!",
+    )
+
+
+class ParserThatLogsToInternal(LogParser):
+    """ This python parser just logs messages to internal() source. """
+
+    def __init__(self):
+        self.__logger = logging.getLogger("parser-that-logs-to-internal")
+
+    def init(self, _options: Dict[str, str]) -> bool:
+        return True
+
+    def deinit(self) -> bool:
+        return True
+
+    def parse(self, msg: LogMessage) -> bool:
+        if b"MESSAGE" in msg.keys():
+            for log_level in (TRACE, logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR):
+                self.__logger.log(log_level, "hey, this is parser-that-logs-to-internal, here is the message: %s", msg["MESSAGE"].decode())
+
+            # syslog-ng bound logging should provide this additional method.
+            self.__logger.trace("hey again, here is the bound trace method of internal logger!")
+            # Logs should be filtered by effective level, that is set by syslogng package.
+            self.__logger.info("the log level is %s" % self.__logger.getEffectiveLevel())
+
+        return True

--- a/tests/light/functional_tests/bindings/python/logger/test_internal_logging.py
+++ b/tests/light/functional_tests/bindings/python/logger/test_internal_logging.py
@@ -1,0 +1,100 @@
+#############################################################################
+# Copyright (c) 2025 One Identity
+# Copyright (c) 2025 Narkhov Evgeny <evgenynarkhov2@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import logging
+import re
+from pathlib import Path
+
+import pytest
+
+from src.bindings.python.python_module import DummyPythonModule
+from src.syslog_ng.syslog_ng import SyslogNg
+from src.syslog_ng_config.syslog_ng_config import SyslogNgConfig
+
+
+class TestPythonInternalLogging:
+    @pytest.fixture(autouse=True)
+    def current_module(self, python_module: DummyPythonModule) -> DummyPythonModule:
+        python_module.add_file(Path(__file__).parent / "parser.py")
+        return python_module
+
+    def __create_common_log_path(self, config: SyslogNgConfig, current_module: DummyPythonModule):
+        source = config.create_example_msg_generator_source(num=1, template=config.stringify("hello, world!"))
+        parser = config.create_python_parser(**{"class": "%s.parser.ParserThatLogsToInternal" % current_module.module_name})
+        config.create_logpath(statements=[source, parser])
+
+    def __wait_and_extract_effective_log_level(self, syslog_ng: SyslogNg) -> int:
+        level_line = syslog_ng.wait_for_message_in_console_log("the log level is")[0]
+        matched = re.match(r".* (\d+);", level_line)
+
+        assert matched is not None
+        return int(matched.group(1))
+
+    def test_trace_logs_get_to_stderr(self, config: SyslogNgConfig, syslog_ng: SyslogNg, current_module: DummyPythonModule):
+        """ Test that internal python logger logs trace messages. """
+
+        self.__create_common_log_path(config, current_module)
+        syslog_ng.start_params.trace = True
+        syslog_ng.start_params.debug = True
+
+        syslog_ng.start(config)
+        # We expect one message for each log level present: TRACE, DEBUG, INFO, WARNING and ERROR.
+        # Last one comes from trace() method.
+        syslog_ng.wait_for_messages_in_console_log([
+            "hey, this is parser-that-logs-to-internal, here is the message: hello, world!" for _ in range(5)
+        ] + [
+            "hey again, here is the bound trace method of internal logger!",
+        ])
+
+        assert self.__wait_and_extract_effective_log_level(syslog_ng) < logging.DEBUG
+
+    def test_debug_logs_get_to_stderr(self, config: SyslogNgConfig, syslog_ng: SyslogNg, current_module: DummyPythonModule):
+        """ Test that internal python logger filters trace messages with effective log level. """
+
+        self.__create_common_log_path(config, current_module)
+        syslog_ng.start_params.trace = False
+        syslog_ng.start_params.debug = True
+
+        syslog_ng.start(config)
+        # Now, TRACE is left out.
+        syslog_ng.wait_for_messages_in_console_log([
+            "hey, this is parser-that-logs-to-internal, here is the message: hello, world!" for _ in range(4)
+        ])
+
+        assert self.__wait_and_extract_effective_log_level(syslog_ng) < logging.INFO
+
+    def test_info_plus_logs_get_to_stderr(self, config: SyslogNgConfig, syslog_ng: SyslogNg, current_module: DummyPythonModule):
+        """ Test that internal python logger filters trace messages with effective log level. """
+
+        self.__create_common_log_path(config, current_module)
+        syslog_ng.start_params.trace = False
+        syslog_ng.start_params.debug = False
+        # This flag turns off logging to standard error if debug is not present, so turn this off, too.
+        syslog_ng.start_params.startup_debug = False
+
+        syslog_ng.start(config)
+        # DEBUG is also gone now.
+        syslog_ng.wait_for_messages_in_console_log([
+            "hey, this is parser-that-logs-to-internal, here is the message: hello, world!" for _ in range(3)
+        ])
+
+        assert self.__wait_and_extract_effective_log_level(syslog_ng) == logging.INFO

--- a/tests/light/functional_tests/bindings/python/parser/parser.py
+++ b/tests/light/functional_tests/bindings/python/parser/parser.py
@@ -1,0 +1,83 @@
+#############################################################################
+# Copyright (c) 2025 One Identity
+# Copyright (c) 2025 Narkhov Evgeny <evgenynarkhov2@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import logging
+from typing import Dict
+from typing import Optional
+
+try:
+    from syslogng import LogParser, LogMessage
+except ImportError:
+    raise RuntimeError(
+        "This code was designed to run with syslog-ng runtime python bindings. "
+        "You probably imported it without syslog-ng installed!",
+    )
+
+
+class CopyParser(LogParser):
+    """
+    This python parser copies MSG field into a new one,
+    specified by `__target_field` option. It also drops
+    messages that start with `__drop_prefix`.
+    """
+
+    __target_field_option = "target_field"
+    __drop_prefix_option = "drop_prefix"
+
+    def __init__(self):
+        self.__logger = logging.getLogger("copy-parser")
+        self.__target_field: Optional[str] = None
+        self.__drop_prefix: Optional[str] = None
+
+    def __error(self, message: str, *args: str) -> bool:
+        self.__logger.error(message, *args)
+        return False
+
+    def __missing_option(self, option: str, options: Dict[str, str]) -> bool:
+        return self.__error("could not find %s key in options: %s", option, ', '.join(options))
+
+    def init(self, options: Dict[str, str]) -> bool:
+        if self.__target_field_option not in options:
+            return self.__missing_option(self.__target_field_option, options)
+
+        if self.__drop_prefix_option not in options:
+            return self.__missing_option(self.__drop_prefix_option, options)
+
+        self.__target_field = options[self.__target_field_option]
+        self.__drop_prefix = options[self.__drop_prefix_option]
+        return True
+
+    def deinit(self) -> bool:
+        return True
+
+    def parse(self, msg: LogMessage) -> bool:
+        if any(f is None for f in (self.__target_field, self.__drop_prefix)):
+            return self.__error("some required fields were not initialized. Probably init() did not run?")
+
+        if b"MESSAGE" not in msg.keys():
+            return self.__error("failed to get MESSAGE field from message instance: key not found")
+
+        if msg["MESSAGE"].startswith(self.__drop_prefix.encode()):
+            return False
+
+        msg[self.__target_field] = msg["MESSAGE"]
+        return True

--- a/tests/light/functional_tests/bindings/python/parser/test_python_parser.py
+++ b/tests/light/functional_tests/bindings/python/parser/test_python_parser.py
@@ -1,0 +1,57 @@
+#############################################################################
+# Copyright (c) 2025 One Identity
+# Copyright (c) 2025 Narkhov Evgeny <evgenynarkhov2@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+from pathlib import Path
+
+import pytest
+
+from src.syslog_ng.syslog_ng import SyslogNg
+from src.syslog_ng_config.statements import ArrowedOptions
+from src.syslog_ng_config.syslog_ng_config import SyslogNgConfig
+
+
+class TestPythonParser:
+    @pytest.fixture
+    def current_module(self, python_module):
+        python_module.add_file(Path(__file__).parent / "parser.py")
+        return python_module
+
+    def test_parser_copies_and_drops_messages(self, config: SyslogNgConfig, syslog_ng: SyslogNg, current_module):
+        """
+        Test that python `CopyParser` can read options, successfully `init()` and then copy **MSG** field with `parse()` method.
+        """
+
+        bye_source = config.create_example_msg_generator_source(num=1, template=config.stringify("bye, world!"))
+        hello_source = config.create_example_msg_generator_source(num=1, template=config.stringify("hello, world!"))
+
+        parser_cls_options = ArrowedOptions({"target_field": "\"FOO\"", "drop_prefix": "\"bye\""})
+        # Unfortunately, class is reserved name in python, so I have to do this little trick
+        parser = config.create_python_parser(**{"class": "%s.parser.CopyParser" % current_module.module_name, "options": parser_cls_options})
+        destination = config.create_file_destination(file_name="output.log", template=config.stringify("$FOO\n"))
+        config.create_logpath(statements=[bye_source, hello_source, parser, destination])
+
+        syslog_ng.start(config)
+
+        logs = destination.read_log().strip()
+
+        assert "hello, world!" in logs
+        assert "bye, world!" not in logs

--- a/tests/light/src/Makefile.am
+++ b/tests/light/src/Makefile.am
@@ -1,6 +1,8 @@
 
 #find -name '*.py'|awk '{ print "\ttests/light/src/"substr($0,3); }'|sort
 EXTRA_DIST += \
+	tests/light/src/bindings/python/__init__.py \
+    tests/light/src/bindings/python/python_module.py \
 	tests/light/src/common/asynchronous.py \
 	tests/light/src/common/blocking.py \
 	tests/light/src/common/file.py \

--- a/tests/light/src/bindings/python/python_module.py
+++ b/tests/light/src/bindings/python/python_module.py
@@ -1,0 +1,67 @@
+#############################################################################
+# Copyright (c) 2025 One Identity
+# Copyright (c) 2025 Narkhov Evgeny <evgenynarkhov2@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+import shutil
+import string
+from pathlib import Path
+from random import choice
+from typing import Dict
+
+from src.common.file import copy_file
+
+
+class DummyPythonModule(object):
+    """ Provides paths for dummy python module used in testing. """
+
+    def __init__(self, source_dir: Path, random_postfix_len: int = 10):
+        module_name = 'test_%s' % ''.join(choice(string.ascii_letters) for _ in range(random_postfix_len))
+        self.module_path = source_dir / module_name
+        self.init_file = self.module_path / "__init__.py"
+        self.files: Dict[str, Path] = {}
+
+        self.module_path.mkdir()
+        self.init_file.touch()
+
+    def add_file(self, file: Path):
+        """ Adds file to a module. File will be removed once all python tests are complete. """
+
+        if file.stem in self.files:
+            raise FileExistsError("the file %s cannot be copied since it clashes with %s under %s" % (file, file.stem, self.files[file.stem]))
+
+        self.files[file.stem] = file
+        copy_file(file, (self.module_path / file.stem).with_suffix(".py"))
+
+    def replace_file(self, file: Path, stem: str):
+        """ Similar to add_file(), but overrides existing file in self.files under **stem**. """
+
+        if stem not in self.files:
+            raise KeyError
+
+        self.files.pop(stem).unlink()
+        self.add_file(file)
+
+    @property
+    def module_name(self):
+        return self.module_path.stem
+
+    def teardown(self):
+        shutil.rmtree(self.module_path)

--- a/tests/light/src/syslog_ng/syslog_ng_paths.py
+++ b/tests/light/src/syslog_ng/syslog_ng_paths.py
@@ -40,7 +40,10 @@ class SyslogNgPaths(object):
             raise ValueError("Missing --installdir start parameter")
 
         self.__syslog_ng_paths = {
-            "dirs": {"install_dir": Path(install_dir)},
+            "dirs": {
+                "install_dir": Path(install_dir),
+                "python_source_dir": Path(install_dir) / "lib/syslog-ng/python",
+            },
             "file_paths": {
                 "config_path": Path("syslog_ng_{}.conf".format(instance_name)),
                 "persist_path": Path("syslog_ng_{}.persist".format(instance_name)),
@@ -64,6 +67,9 @@ class SyslogNgPaths(object):
 
     def get_install_dir(self):
         return self.__syslog_ng_paths["dirs"]["install_dir"]
+
+    def get_python_source_dir(self):
+        return self.__syslog_ng_paths["dirs"]["python_source_dir"]
 
     def get_config_path(self):
         return self.__syslog_ng_paths["file_paths"]["config_path"]

--- a/tests/light/src/syslog_ng/tests/test_syslog_ng_paths.py
+++ b/tests/light/src/syslog_ng/tests/test_syslog_ng_paths.py
@@ -31,7 +31,7 @@ def test_syslog_ng_paths(fake_testcase_parameters):
     syslog_ng_paths = SyslogNgPaths(fake_testcase_parameters)
     syslog_ng_paths.set_syslog_ng_paths(instance_name="server")
     assert set(list(syslog_ng_paths._SyslogNgPaths__syslog_ng_paths)) == {"dirs", "file_paths", "binary_file_paths"}
-    assert set(list(syslog_ng_paths._SyslogNgPaths__syslog_ng_paths["dirs"])) == {"install_dir"}
+    assert set(list(syslog_ng_paths._SyslogNgPaths__syslog_ng_paths["dirs"])) == {"install_dir", "python_source_dir"}
     assert set(list(syslog_ng_paths._SyslogNgPaths__syslog_ng_paths["file_paths"])) == {
         "config_path",
         "persist_path",

--- a/tests/light/src/syslog_ng_config/syslog_ng_config.py
+++ b/tests/light/src/syslog_ng_config/syslog_ng_config.py
@@ -184,6 +184,9 @@ class SyslogNgConfig(object):
     def create_csv_parser(self, **options):
         return Parser("csv-parser", self.__stats_handler, self.__prometheus_stats_handler, **options)
 
+    def create_python_parser(self, **options):
+        return Parser("python", self.__stats_handler, self.__prometheus_stats_handler, **options)
+
     def create_metrics_probe(self, **options):
         return Parser("metrics_probe", self.__stats_handler, self.__prometheus_stats_handler, **options)
 


### PR DESCRIPTION
Unfortunately, the [PR](https://github.com/syslog-ng/syslog-ng/pull/5526) had issues in Kira because of differences in the Python versions used.
For some reason, the Kira tests are not running on all GitHub PRs, which we have to investigate separately; therefore, the problem was not discovered during the CI runs (now it can be seen in the failing Kira test runs).

This PR just re-applies https://github.com/syslog-ng/syslog-ng/pull/5526.