### PR TITLE
tests: commit check can ignore whitelisted commits which are noncompliant

### DIFF
--- a/tests/commits/check.sh
+++ b/tests/commits/check.sh
@@ -23,6 +23,9 @@
 
 commit_range=origin/master..HEAD
 
+root=$(dirname $0)
+commit_check_whitelist=$root/commit_check_whitelist.txt
+
 if [ $# -gt 0 ]; then
   commit_range=$1
 fi
@@ -35,12 +38,16 @@ fi
 
     subject=$(git show -s --format='%s' $commit)
 
-    if ! echo "$subject" | egrep -q '^Revert |^([a-zA-Z0-9/(){}$,._-]{1,}\s*){1,}:'; then
-      commit_has_valid_subject=0
-    fi
+    if [ -f "$commit_check_whitelist" ] && grep -q "^$commit$" $commit_check_whitelist; then
+      :
+    else
+      if ! echo "$subject" | egrep -q '^Revert |^([a-zA-Z0-9/(){}$,._-]{1,}\s*){1,}:'; then
+        commit_has_valid_subject=0
+      fi
 
-    if ! git show -s --format='%(trailers)' $commit | grep -q 'Signed-off-by:'; then
-      commit_has_signed_off_by=0
+      if ! git show -s --format='%(trailers)' $commit | grep -q 'Signed-off-by:'; then
+        commit_has_signed_off_by=0
+      fi
     fi
 
     if [ $commit_has_valid_subject = 1 -a \

--- a/tests/commits/commit_check_whitelist.txt
+++ b/tests/commits/commit_check_whitelist.txt
@@ -1,0 +1,2 @@
+# list of commit ids to ignore. one per line, no spaces.
+d91deb50624b80799d7a300512f53e39656ba567


### PR DESCRIPTION
<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
