### PR TITLE
Fix parsing JSON array of string with comma

### DIFF
--- a/modules/json/json-parser.c
+++ b/modules/json/json-parser.c
@@ -210,7 +210,7 @@ json_parser_extract_values_from_complex_json_object(JSONParser *self,
               const gchar *element_value = json_object_get_string(el);
               if (i != 0)
                 g_string_append_c(value, ',');
-              str_repr_encode_append(value, element_value, -1, NULL);
+              str_repr_encode_append(value, element_value, -1, ",");
             }
           else
             {

--- a/modules/json/tests/test_json_parser.c
+++ b/modules/json/tests/test_json_parser.c
@@ -168,13 +168,13 @@ Test(json_parser, test_json_parser_different_type_arrays)
 
   json_parser_set_prefix(json_parser, ".prefix.");
   msg = parse_json_into_log_message("{'intarray': [1, 2, 3],"
-                                    " 'strarray': ['foo', 'bar', 'baz'],"
+                                    " 'strarray': ['foo', 'bar', 'baz', 'foo,bar,baz'],"
                                     " 'boolarray': [true,false,true],"
                                     " 'dblarray': [1.234,1e6,5.6789],"
                                     " 'nullarray': [null,null,null,null]}",
                                     json_parser);
   assert_log_message_value_and_type_by_name(msg, ".prefix.intarray", "[1,2,3]", LM_VT_JSON);
-  assert_log_message_value_and_type_by_name(msg, ".prefix.strarray", "foo,bar,baz", LM_VT_LIST);
+  assert_log_message_value_and_type_by_name(msg, ".prefix.strarray", "foo,bar,baz,\"foo,bar,baz\"", LM_VT_LIST);
   assert_log_message_value_and_type_by_name(msg, ".prefix.boolarray", "[true,false,true]", LM_VT_JSON);
   assert_log_message_value_and_type_by_name(msg, ".prefix.dblarray", "[1.234,1e6,5.6789]", LM_VT_JSON);
   assert_log_message_value_and_type_by_name(msg, ".prefix.nullarray", "[null,null,null,null]", LM_VT_JSON);


### PR DESCRIPTION
When a JSON array is parsed, a string value containing a comma and no single or double quote is kept as-is and added to a list.  The comma being a delimiter for list items, when the list is serialized to JSON again, that comma is not treated as a part of the original string, but as a separator:

```
["a", "b", "c,d"]    -> "a,b,c,d"
["a", "b", "c", "d"] <- "a,b,c,d"
```

Add the comma to the list of forbidden symbols in a string to force quoting of the value,preventing this bug:

```
["a", "b", "c,d"] -> "a,b,\"c,d\""
["a", "b", "c,d"] <- "a,b,\"c,d\""
```