### PR TITLE
slog: New implementation of the pseudo-random function and enhancements

### DIFF
--- a/modules/secure-logging/Makefile.am
+++ b/modules/secure-logging/Makefile.am
@@ -1,19 +1,24 @@
+# File: syslog-ng/modules/secure-logging/Makefile.am
+
 noinst_LTLIBRARIES += modules/secure-logging/libsyslog-ng-secure-logging.la
 module_LTLIBRARIES += modules/secure-logging/libsecure-logging.la
 
 modules_secure_logging_libsyslog_ng_secure_logging_la_SOURCES =	\
-	modules/secure-logging/slog.c                           \
+	modules/secure-logging/slog.c \
 	modules/secure-logging/slog.h
 
 modules_secure_logging_libsyslog_ng_secure_logging_la_CFLAGS = \
-	$(AM_CFLAGS)                                 \
-	-I$(top_srcdir)/modules/secure-logging	     \
+	$(AM_CFLAGS) \
+	-I$(top_srcdir)/modules/secure-logging \
 	-I$(top_builddir)/modules/secure-logging
-modules_secure_logging_libsyslog_ng_secure_logging_la_LIBADD		=	\
+
+modules_secure_logging_libsyslog_ng_secure_logging_la_LIBADD = \
 	$(MODULE_DEPS_LIBS) $(OPENSSL_LIBS)
-modules_secure_logging_libsyslog_ng_secure_logging_la_LDFLAGS		=	\
+
+modules_secure_logging_libsyslog_ng_secure_logging_la_LDFLAGS = \
 	$(MODULE_LDFLAGS) $(OPENSSL_CFLAGS)
-EXTRA_modules_secure_logging_libsyslog_ng_secure_logging_la_DEPENDENCIES	=	\
+
+EXTRA_modules_secure_logging_libsyslog_ng_secure_logging_la_DEPENDENCIES = \
 	$(MODULE_DEPS_LIBS)
 
 LIBSYSLOG_SECURE_LOGGING = $(top_builddir)/modules/secure-logging/libsyslog-ng-secure-logging.la
@@ -22,19 +27,22 @@ modules_secure_logging_libsecure_logging_la_SOURCES = \
 	modules/secure-logging/secure-logging.c
 
 modules_secure_logging_libsecure_logging_la_CFLAGS = \
-	$(AM_CFLAGS)                                 \
-	-I$(top_srcdir)/modules/secure-logging	     \
+	$(AM_CFLAGS) \
+	-I$(top_srcdir)/modules/secure-logging  \
 	-I$(top_builddir)/modules/secure-logging
+
 modules_secure_logging_libsecure_logging_la_LIBADD = $(MODULE_DEPS_LIBS) $(OPENSSL_LIBS) $(LIBSYSLOG_SECURE_LOGGING)
+
 modules_secure_logging_libsecure_logging_la_LDFLAGS = $(MODULE_LDFLAGS) $(OPENSSL_CFLAGS)
+
 EXTRA_modules_secure_logging_libsecure_logging_la_DEPENDENCIES = $(MODULE_DEPS_LIBS) $(LIBSYSLOG_SECURE_LOGGING)
 
 EXTRA_DIST += modules/secure-logging/CMakeLists.txt
 
 modules/secure-logging modules/secure-logging/ mod-secure-logging: \
-	modules/secure-logging/libsyslog-ng-secure-logging.la      \
-	modules/secure-logging/slogkey/slogkey                     \
-	modules/secure-logging/slogencrypt/slogencrypt               \
+	modules/secure-logging/libsyslog-ng-secure-logging.la \
+	modules/secure-logging/slogkey/slogkey \
+	modules/secure-logging/slogencrypt/slogencrypt \
 	modules/secure-logging/slogverify/slogverify
 
 .PHONY: modules/secure-logging/ mod-secure-logging

--- a/modules/secure-logging/secure-logging.c
+++ b/modules/secure-logging/secure-logging.c
@@ -120,6 +120,8 @@ tf_slog_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, gint
         }
 
       g_option_context_free(ctx);
+      munlock(state->key, KEY_LENGTH);
+      munlock(state->aggMAC, CMAC_LENGTH);
       return FALSE;
     }
 
@@ -130,6 +132,8 @@ tf_slog_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, gint
                   SLOG_ERROR_PREFIX
                   ": Template parsing failed. Invalid number of arguments. Usage: $(slog --key-file FILE --mac-file FILE $RAWMSG)\\n");
       g_option_context_free(ctx);
+      munlock(state->key, KEY_LENGTH);
+      munlock(state->aggMAC, CMAC_LENGTH);
       return FALSE;
     }
 
@@ -141,6 +145,8 @@ tf_slog_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, gint
       g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
                   SLOG_ERROR_PREFIX ": Template parsing failed. Invalid or missing key file");
       g_option_context_free(ctx);
+      munlock(state->key, KEY_LENGTH);
+      munlock(state->aggMAC, CMAC_LENGTH);
       return FALSE;
     }
 
@@ -150,6 +156,8 @@ tf_slog_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, gint
       g_set_error(error, LOG_TEMPLATE_ERROR, LOG_TEMPLATE_ERROR_COMPILE,
                   SLOG_ERROR_PREFIX ": Template parsing failed. Invalid or missing MAC file");
       g_option_context_free(ctx);
+      munlock(state->key, KEY_LENGTH);
+      munlock(state->aggMAC, CMAC_LENGTH);
       return FALSE;
     }
 
@@ -157,6 +165,8 @@ tf_slog_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, gint
     {
       state->badKey = TRUE;
       g_option_context_free(ctx);
+      munlock(state->key, KEY_LENGTH);
+      munlock(state->aggMAC, CMAC_LENGTH);
       return FALSE;
     }
 
@@ -364,11 +374,17 @@ tf_slog_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent, gint
       state->badKey = TRUE;
       msg_error(SLOG_ERROR_PREFIX,
                 evt_tag_str("Reason", "Template parsing failed, key file not found or invalid. Reverting to clear text logging!"));
+      munlock(state->key, KEY_LENGTH);
+      munlock(state->aggMAC, CMAC_LENGTH);
       return TRUE;
+
     }
 
   msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Key successfully loaded"));
-
+  OPENSSL_cleanse(key, sizeof key);
+  OPENSSL_cleanse(mac, sizeof mac);
+  munlock(state->key, KEY_LENGTH);
+  munlock(state->aggMAC, CMAC_LENGTH);
   return TRUE;
 }
 
@@ -434,8 +450,11 @@ tf_slog_func_free_state(gpointer s)
 {
   TFSlogState *state = (TFSlogState *) s;
 
-  free(state->keypath);
-  free(state->macpath);
+  g_free(state->keypath);
+  state->keypath = NULL;
+
+  g_free(state->macpath);
+  state->macpath = NULL;
 
   tf_simple_func_free_state((gpointer)&state->super);
 }

--- a/modules/secure-logging/slog.c
+++ b/modules/secure-logging/slog.c
@@ -2099,10 +2099,14 @@ gboolean validFileNameArg(const gchar *option_name, const gchar *value, gpointer
   if (!isValid)
     {
       *error = g_error_new(G_FILE_ERROR, G_OPTION_ERROR_FAILED, "Invalid path or non existing regular file: %s", value);
+      g_string_free(currentValue, TRUE);
+    }
+  else
+    {
+      g_string_free(currentValue, FALSE); //-- caller has to call g_free
     }
 
   g_string_free(currentOption, TRUE);
-  g_string_free(currentValue, FALSE);
   g_string_free(longOption, TRUE);
   g_string_free(shortOption, TRUE);
 
@@ -2168,10 +2172,14 @@ gboolean validFileNameArgCheckDirOnly(const gchar *option_name, const gchar *val
   if (!isValid)
     {
       *error = g_error_new(G_FILE_ERROR, G_OPTION_ERROR_FAILED, "Invalid path or non existing regular file: %s", value);
+      g_string_free(currentValue, TRUE);
+    }
+  else
+    {
+      g_string_free(currentValue, FALSE); //-- caller has to call g_free
     }
 
   g_string_free(currentOption, TRUE);
-  g_string_free(currentValue, FALSE);
   g_string_free(longOption, TRUE);
   g_string_free(shortOption, TRUE);
 

--- a/modules/secure-logging/slog.c
+++ b/modules/secure-logging/slog.c
@@ -1,6 +1,6 @@
 /*
+ * Copyright (c) 2019-2025 Airbus Commercial Aircraft
  * Copyright (c) 2024 Gergo Ferenc Kovacs
- * Copyright (c) 2019 Airbus Commercial Aircraft
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -22,11 +22,11 @@
  *
  */
 
+#include <glib.h>
+
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <glib.h>
 
 #include <openssl/cmac.h>
 #include <openssl/rand.h>
@@ -46,29 +46,31 @@
 #define SHORT_OPT_INDICATOR "-"
 
 // This initialization only works with GCC.
-static unsigned char KEYPATTERN[AES_BLOCKSIZE] = { [0 ... (AES_BLOCKSIZE - 1) ] = IPAD };
-static unsigned char MACPATTERN[AES_BLOCKSIZE] = { [0 ... (AES_BLOCKSIZE - 1) ] = OPAD };
-static unsigned char GAMMA[AES_BLOCKSIZE] = { [0 ... (AES_BLOCKSIZE - 1) ] =  EPAD};
+static guchar KEYPATTERN[AES_BLOCKSIZE] = { [0 ... (AES_BLOCKSIZE - 1) ] = IPAD };
+static guchar MACPATTERN[AES_BLOCKSIZE] = { [0 ... (AES_BLOCKSIZE - 1) ] = OPAD };
+static guchar GAMMA[AES_BLOCKSIZE] = { [0 ... (AES_BLOCKSIZE - 1) ] =  EPAD};
 
-/*
- * Conditional msg_error output.
- *
- * 1. Parameter: error variable (input)
- * 2. Parameter: main error string to output (input)
- */
-void cond_msg_error(GError *myError, char *errorMsg)
-{
+// File access modes
+static const char modes[NUM_MODES][LEN_MODES] = { "r", "r+", "w", "w+", "a", "a+" };
+static gboolean close_channel(SLogFile *f);
 
-  if (myError == NULL)
-    {
-      msg_error(errorMsg);
-    }
-  else
-    {
-      msg_error(errorMsg, evt_tag_str("error", myError->message));
-    }
+// Retrieve counter from encrypted log entry
+static gboolean getCounter(GString *entry, guint64 *logEntryOnDisk);
 
-}
+// Check whether value is contained in table
+static gboolean tableContainsKey(GHashTable *table, guint64 value);
+
+// Add new value to table
+static gboolean addValueToTable(GHashTable *table, guint64 value);
+
+// Get a single line from a log file
+static GString *getLogEntry(SLogFile *f);
+
+// Put a single line into a log file
+static gboolean putLogEntry(SLogFile *f, GString *line);
+
+// Clean up routine for GPtrArray
+static void SLogStringFree(gpointer *arg);
 
 /*
  * Create specific sub-keys for encryption and CMAC generation from key.
@@ -79,20 +81,113 @@ void cond_msg_error(GError *myError, char *errorMsg)
  *
  * Note: encKey and MACKey must have space to hold KEY_LENGTH many bytes.
  */
-void deriveSubKeys(unsigned char *mainKey, unsigned char *encKey, unsigned char *MACKey)
+gboolean deriveSubKeys(guchar *mainKey, guchar *encKey, guchar *MACKey)
 {
-  deriveEncSubKey(mainKey, encKey);
-  deriveMACSubKey(mainKey, MACKey);
+  return deriveEncSubKey(mainKey, encKey) && deriveMACSubKey(mainKey, MACKey);
 }
 
-void deriveEncSubKey(unsigned char *mainKey, unsigned char *encKey)
+gboolean deriveEncSubKey(guchar *mainKey, guchar *encKey)
 {
-  PRF(mainKey, KEYPATTERN, sizeof(KEYPATTERN), encKey, KEY_LENGTH);
+  return PRF(mainKey, KEYPATTERN, sizeof(KEYPATTERN), encKey, KEY_LENGTH);
 }
 
-void deriveMACSubKey(unsigned char *mainKey, unsigned char *MACKey)
+gboolean deriveMACSubKey(guchar *mainKey, guchar *MACKey)
 {
-  PRF(mainKey, MACPATTERN, sizeof(MACPATTERN), MACKey, KEY_LENGTH);
+  return PRF(mainKey, MACPATTERN, sizeof(MACPATTERN), MACKey, KEY_LENGTH);
+}
+
+
+// return TRUE on success, else FALSE
+gboolean create_initial_mac0(guchar mainKey[KEY_LENGTH], guchar mac[CMAC_LENGTH])
+{
+  guchar encKey[KEY_LENGTH];
+  guchar MACKey[KEY_LENGTH];
+  memset(encKey, 0, G_N_ELEMENTS(encKey));
+  memset(MACKey, 0, G_N_ELEMENTS(MACKey));
+
+  if (!deriveSubKeys(mainKey, encKey, MACKey))
+    {
+      return FALSE;
+    }
+  gsize outlen = 0;
+
+  // This buffer holds everything: AggregatedMAC, IV, Tag, and CText
+  // Binary data cannot be larger than its base64 encoding
+  guchar bigBuf[AES_BLOCKSIZE + IV_LENGTH + AES_BLOCKSIZE];
+  gsize nb = G_N_ELEMENTS(bigBuf);
+  memset(bigBuf, 0, nb);
+
+  // This is where are ciphertext related data starts
+  guchar *ctBuf = &bigBuf[AES_BLOCKSIZE];
+  guchar *iv = ctBuf;
+
+  guchar outputBigMac[CMAC_LENGTH];
+  gsize outputBigMac_capacity = G_N_ELEMENTS(outputBigMac);
+  memset(outputBigMac, 0, outputBigMac_capacity);
+
+  // Generate random nonce
+  if (RAND_bytes(iv, IV_LENGTH) == 1)
+    {
+      if (!cmac(MACKey, &bigBuf[AES_BLOCKSIZE], IV_LENGTH + AES_BLOCKSIZE, outputBigMac, &outlen,
+                outputBigMac_capacity))
+        {
+          msg_error(SLOG_ERROR_PREFIX,
+                    evt_tag_str("File: ", __FILE__),
+                    evt_tag_long("Line: ", __LINE__),
+                    evt_tag_long("Code: ", SLOG_MEM_ALLOC_ERROR),
+                    evt_tag_str("Reason: ", "Bad CMAC")
+                   );
+          return FALSE;
+        }
+      memcpy(mac, outputBigMac, CMAC_LENGTH);
+      msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "MAC0 has been created"));
+    }
+  return TRUE;
+}
+
+
+
+/**
+ * Gets the path to mac0.dat based on the directory of pathAggMac.
+ * Returns TRUE on success, FALSE otherwise.
+ */
+gboolean get_path_mac0(const gchar *pathAggMac, gchar *pathMac0, size_t sizePathMac0)
+{
+  gboolean retval = FALSE;
+  if (pathAggMac == NULL || pathMac0 == NULL || sizePathMac0 == 0)
+    {
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Invalid path: pathAggMac or pathMac0 or sizePathMac0"));
+      return retval;
+    }
+  gchar *dirname = g_path_get_dirname(pathAggMac);
+  //-- Check if dirname is valid and actually exists on the system
+  if (dirname != NULL && g_file_test(dirname, G_FILE_TEST_IS_DIR))
+    {
+      //-- Build the full path using GLib (handles '/' automatically)
+      gchar *full_path = g_build_filename(dirname, "mac0.dat", NULL);
+      if (full_path != NULL)
+        {
+          //-- Safely copy to the output buffer
+          if (strlen(full_path) < sizePathMac0)
+            {
+              g_strlcpy(pathMac0, full_path, sizePathMac0);
+              retval = TRUE;
+            }
+          else
+            {
+              msg_warning(SLOG_WARNING_PREFIX, evt_tag_str("Reason", "Destination buffer too small for path"));
+            }
+          g_free(full_path);
+        }
+    }
+  else
+    {
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("Reason", "Directory does not exist!"),
+                evt_tag_str("Path", dirname)); //-- dirname NULL is handled
+    }
+  g_free(dirname);
+  return retval;
 }
 
 
@@ -114,9 +209,9 @@ void deriveMACSubKey(unsigned char *mainKey, unsigned char *MACKey)
  * Length of ciphertext (>0)
  * 0 on error
  */
-int sLogEncrypt(unsigned char *plaintext, int plaintext_len,
-                unsigned char *key, unsigned char *iv,
-                unsigned char *ciphertext, unsigned char *tag)
+int sLogEncrypt(guchar *plaintext, int plaintext_len,
+                guchar *key, guchar *iv,
+                guchar *ciphertext, guchar *tag)
 {
   /*
    * This function is largely borrowed from
@@ -124,23 +219,24 @@ int sLogEncrypt(unsigned char *plaintext, int plaintext_len,
    * https://wiki.openssl.org/index.php/EVP_Authenticated_Encryption_and_Decryption#Authenticated_Encryption_using_GCM_mode
    *
    */
-  EVP_CIPHER_CTX *ctx;
+  EVP_CIPHER_CTX *ctx = NULL;
 
   int len;
   int ciphertext_len;
+  int result = 0; //-- default in case of error
 
   /* Create and initialise the context */
-  if (!(ctx = EVP_CIPHER_CTX_new()))
+  if ( !(ctx = EVP_CIPHER_CTX_new()) )
     {
-      msg_error("[SLOG] ERROR: Unable to initialize OpenSSL context");
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to initialize OpenSSL contex"));
+      return result;
     }
 
   /* Initialise the encryption operation. */
   if (1 != EVP_EncryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL))
     {
-      msg_error("[SLOG] ERROR: Unable to initialize OpenSSL context");
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to initialize OpenSSL contex"));
+      goto CLEANUP_SLOGENCRYPT;
     }
 
   if (IV_LENGTH != 12)
@@ -148,16 +244,16 @@ int sLogEncrypt(unsigned char *plaintext, int plaintext_len,
       /* Set IV length if default 12 bytes (96 bits) is not appropriate */
       if (1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, IV_LENGTH, NULL))
         {
-          msg_error("[SLOG] ERROR: Unable to set IV length");
-          return 0;
+          msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to set IV length"));
+          goto CLEANUP_SLOGENCRYPT;
         }
     }
 
   /* Initialise key and IV */
   if (1 != EVP_EncryptInit_ex(ctx, NULL, NULL, key, iv))
     {
-      msg_error("[SLOG] ERROR: Unable to initialize encryption key and IV");
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to initialize encryption key and IV"));
+      goto CLEANUP_SLOGENCRYPT;
     }
 
   /* Provide the message to be encrypted, and obtain the encrypted output.
@@ -165,8 +261,8 @@ int sLogEncrypt(unsigned char *plaintext, int plaintext_len,
    */
   if (1 != EVP_EncryptUpdate(ctx, ciphertext, &len, plaintext, plaintext_len))
     {
-      msg_error("[SLOG] ERROR: Unable to encrypt data");
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to encrypt data"));
+      goto CLEANUP_SLOGENCRYPT;
     }
 
   ciphertext_len = len;
@@ -176,8 +272,8 @@ int sLogEncrypt(unsigned char *plaintext, int plaintext_len,
    */
   if (1 != EVP_EncryptFinal_ex(ctx, ciphertext + len, &len))
     {
-      msg_error("[SLOG] ERROR: Unable to complete encryption of data");
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to complete encryption of data"));
+      goto CLEANUP_SLOGENCRYPT;
     }
 
   ciphertext_len += len;
@@ -185,14 +281,19 @@ int sLogEncrypt(unsigned char *plaintext, int plaintext_len,
   /* Get the tag */
   if (1 != EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, AES_BLOCKSIZE, tag))
     {
-      msg_error("[SLOG] ERROR: Unable to acquire encryption tag");
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to acquire encryption tag"));
+      goto CLEANUP_SLOGENCRYPT;
     }
 
-  /* Clean up */
-  EVP_CIPHER_CTX_free(ctx);
+  result = ciphertext_len;
 
-  return ciphertext_len;
+CLEANUP_SLOGENCRYPT:
+
+  if (ctx)
+    {
+      EVP_CIPHER_CTX_free(ctx);
+    }
+  return result;
 }
 
 /*
@@ -211,27 +312,30 @@ int sLogEncrypt(unsigned char *plaintext, int plaintext_len,
  * -1 in case verification fails
  * 0 on error
  */
-int sLogDecrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *tag, unsigned char *key,
-                unsigned char *iv,
-                unsigned char *plaintext)
+int sLogDecrypt(guchar *ciphertext,
+                int ciphertext_len,
+                guchar *tag,
+                guchar *key,
+                guchar *iv,
+                guchar *plaintext)
 {
-  EVP_CIPHER_CTX *ctx;
+  EVP_CIPHER_CTX *ctx = NULL;
   int len;
   int plaintext_len;
-  int ret;
+  int result = 0; //-- 0: ERROR
 
   /* Create and initialise the context */
   if (!(ctx = EVP_CIPHER_CTX_new()))
     {
-      msg_error("[SLOG] ERROR: Unable to initialize OpenSSL context");
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to initialize OpenSSL context"));
       return 0;
     }
 
   /* Initialise the decryption operation. */
   if (!EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), NULL, NULL, NULL))
     {
-      msg_error("[SLOG] ERROR: Unable initiate decryption operation");
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable initiate decryption operation"));
+      goto CLEANUP_SLOGDECRYPT;
     }
 
   if (IV_LENGTH != 12)
@@ -239,16 +343,16 @@ int sLogDecrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *ta
       /* Set IV length. Not necessary if this is 12 bytes (96 bits) */
       if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, IV_LENGTH, NULL))
         {
-          msg_error("[SLOG] ERROR: Unable set IV length");
-          return 0;
+          msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable set IV length"));
+          goto CLEANUP_SLOGDECRYPT;
         }
     }
 
   /* Initialise key and IV */
   if (!EVP_DecryptInit_ex(ctx, NULL, NULL, key, iv))
     {
-      msg_error("[SLOG] ERROR: Unable to initialize key and IV");
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to initialize key and IV"));
+      goto CLEANUP_SLOGDECRYPT;
     }
 
   /* Provide the message to be decrypted, and obtain the plaintext output.
@@ -256,8 +360,8 @@ int sLogDecrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *ta
    */
   if (!EVP_DecryptUpdate(ctx, plaintext, &len, ciphertext, ciphertext_len))
     {
-      msg_error("Unable to decrypt");
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to decrypt"));
+      goto CLEANUP_SLOGDECRYPT;
     }
 
   plaintext_len = len;
@@ -265,30 +369,33 @@ int sLogDecrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *ta
   /* Set expected tag value. Works in OpenSSL 1.0.1d and later */
   if (!EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, AES_BLOCKSIZE, tag))
     {
-      msg_error("[SLOG] ERROR: Unable set tag value");
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable set tag value"));
+      goto CLEANUP_SLOGDECRYPT;
     }
 
   /* Finalise the decryption. A positive return value indicates success,
    * anything else is a failure - the plaintext is not trustworthy.
    */
-  ret = EVP_DecryptFinal_ex(ctx, plaintext + len, &len);
-
-  /* Clean up */
-  EVP_CIPHER_CTX_free(ctx);
-  if (ret > 0)
+  if (EVP_DecryptFinal_ex(ctx, plaintext + len, &len) > 0)
     {
       /* Success */
       plaintext_len += len;
-      return plaintext_len;
+      result = plaintext_len;
     }
   else
     {
       /* Verify failed */
-      return -1;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Decryption/Tag verification failed"));
+      result = -1;
     }
-}
 
+CLEANUP_SLOGDECRYPT:
+  if (ctx)
+    {
+      EVP_CIPHER_CTX_free(ctx);
+    }
+  return result;
+}
 
 /*
  *  Create new forward-secure log entry
@@ -303,85 +410,89 @@ int sLogDecrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *ta
  * 6. Parameter: The newly updated MAC
  * 7. Parameter: The capacity of the newly updated MAC buffer
 */
-void sLogEntry(guint64 numberOfLogEntries, GString *text, unsigned char *mainKey, unsigned char *inputBigMac,
-               GString *output, unsigned char *outputBigMac, gsize outputBigMac_capacity)
+gboolean sLogEntry(
+  guint64 numberOfLogEntries,
+  GString *text,
+  guchar *mainKey,
+  guchar *inputBigMac,
+  GString *output,
+  guchar *outputBigMac,
+  gsize outputBigMac_capacity)
 {
+  guchar encKey[KEY_LENGTH];
+  guchar MACKey[KEY_LENGTH];
 
-  unsigned char encKey[KEY_LENGTH];
-  unsigned char MACKey[KEY_LENGTH];
-  deriveSubKeys(mainKey, encKey, MACKey);
+  //-- according sub functions mainKey is also  most likely of length KEY_LENGTH
+  if (!deriveSubKeys(mainKey, encKey, MACKey))
+    {
+      return FALSE;
+    }
 
   // Compute current log entry number
-  gchar *counterString = convertToBase64((unsigned char *)&numberOfLogEntries, sizeof(numberOfLogEntries));
+  gchar *counterString = g_base64_encode((const guchar *)&numberOfLogEntries, sizeof(numberOfLogEntries));
 
   int slen = (int) text->len;
 
   // This buffer holds everything: AggregatedMAC, IV, Tag, and CText
   // Binary data cannot be larger than its base64 encoding
-  unsigned char bigBuf[AES_BLOCKSIZE + IV_LENGTH + AES_BLOCKSIZE + slen];
+  guchar bigBuf[AES_BLOCKSIZE + IV_LENGTH + AES_BLOCKSIZE + slen];
 
   // This is where are ciphertext related data starts
-  unsigned char *ctBuf = &bigBuf[AES_BLOCKSIZE];
-  unsigned char *iv = ctBuf;
-  unsigned char *tag = &bigBuf[AES_BLOCKSIZE + IV_LENGTH];
-  unsigned char *ciphertext = &bigBuf[AES_BLOCKSIZE + IV_LENGTH + AES_BLOCKSIZE];
+  guchar *ctBuf = &bigBuf[AES_BLOCKSIZE];
+  guchar *iv = ctBuf;
+  guchar *tag = &bigBuf[AES_BLOCKSIZE + IV_LENGTH];
+  guchar *ciphertext = &bigBuf[AES_BLOCKSIZE + IV_LENGTH + AES_BLOCKSIZE];
 
-  // Generate random nonce
+// Generate random nonce
   if (RAND_bytes(iv, IV_LENGTH) == 1)
     {
-
       // Encrypt log data
       int ct_length = sLogEncrypt((guchar *)text->str, slen, encKey, iv, ciphertext, tag);
       if (ct_length <= 0)
         {
-          msg_error("[SLOG] ERROR: Unable to correctly encrypt log message");
-
+          msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to correctly encrypt log message"));
           g_string_printf(output, "%*.*s:%s: %s", COUNTER_LENGTH, COUNTER_LENGTH, counterString,
-                          "[SLOG] ERROR: Unable to correctly encrypt the following log message:", text->str);
+                          SLOG_ERROR_PREFIX ": Unable to correctly encrypt the following log message:", text->str);
           g_free(counterString);
-
-          return;
+          return FALSE;
         }
 
       // Write current log entry number
       g_string_printf (output, "%*.*s:", COUNTER_LENGTH, COUNTER_LENGTH, counterString);
       g_free(counterString);
 
-
       // Write IV, tag, and ciphertext at once
-      gchar *encodedCtBuf = convertToBase64(ctBuf, IV_LENGTH + AES_BLOCKSIZE + ct_length);
+      gchar *encodedCtBuf = g_base64_encode(ctBuf, IV_LENGTH + AES_BLOCKSIZE + ct_length);
       g_string_append(output, encodedCtBuf);
       g_free(encodedCtBuf);
 
       // Compute aggregated MAC
-      // Not the first aggregated MAC
-      if (numberOfLogEntries > 0)
+      gsize outlen = 0;
+      //-- The initial MAC file has been created, so there is no need
+      //   anymore to check whether this is the very first encryption.
+      memcpy(bigBuf, inputBigMac, AES_BLOCKSIZE);
+      if (!cmac(MACKey, bigBuf, AES_BLOCKSIZE + IV_LENGTH + AES_BLOCKSIZE + ct_length, outputBigMac, &outlen,
+                outputBigMac_capacity))
         {
-          memcpy(bigBuf, inputBigMac, AES_BLOCKSIZE);
-
-          gsize outlen;
-          cmac(MACKey, bigBuf, AES_BLOCKSIZE + IV_LENGTH + AES_BLOCKSIZE + ct_length, outputBigMac, &outlen,
-               outputBigMac_capacity);
-        }
-      else   // First aggregated MAC
-        {
-          gsize outlen = 0;
-
-          cmac(MACKey, &bigBuf[AES_BLOCKSIZE], IV_LENGTH + AES_BLOCKSIZE + ct_length, outputBigMac, &outlen,
-               outputBigMac_capacity);
+          msg_error(SLOG_ERROR_PREFIX,
+                    evt_tag_str("File: ", __FILE__),
+                    evt_tag_long("Line: ", __LINE__),
+                    evt_tag_long("Code: ", SLOG_MEM_ALLOC_ERROR),
+                    evt_tag_str("Reason: ", "Bad CMAC")
+                   );
+          return FALSE;
         }
     }
   else
     {
       // We did not get enough random bytes
-      msg_error("[SLOG] ERROR: Could not obtain enough random bytes");
-
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Could not obtain enough random bytes"));
       g_string_printf(output, "%*.*s:%s: %s", COUNTER_LENGTH, COUNTER_LENGTH, counterString,
-                      "[SLOG] ERROR: Could not obtain enough random bytes for the following log message:", text->str);
+                      SLOG_ERROR_PREFIX ": Could not obtain enough random bytes for the following log message:", text->str);
       g_free(counterString);
-
-      return;
+      return FALSE;
     }
+  return TRUE;
 }
 
 /*
@@ -393,23 +504,22 @@ void sLogEntry(guint64 numberOfLogEntries, GString *text, unsigned char *mainKey
  *
  * Note: Caller must take care of memory management.
  *
+ * Returns TRUE on success when all evolveKey calls are successful
+ *         FALSE when one call of evolveKey fails
  */
-void deriveKey(unsigned char *dst, guint64 index, guint64 currentKey)
+gboolean deriveKey(guchar *dst, guint64 index, guint64 currentKey)
 {
+  gboolean result = TRUE;
+
   for (guint64 i = currentKey; i < index; i++)
     {
-      evolveKey(dst);
+      if (FALSE == evolveKey(dst) )
+        {
+          //--  called PRF function provides logging
+          result = FALSE; //-- do not return yet
+        }
     }
-}
-
-guchar *convertToBin(char *input, gsize *outLen)
-{
-  return g_base64_decode ((const gchar *) input, outLen);
-}
-
-gchar *convertToBase64(unsigned char *input, gsize len)
-{
-  return  g_base64_encode ((const guchar *) input, len);
+  return result;
 }
 
 /*
@@ -426,39 +536,172 @@ gchar *convertToBase64(unsigned char *input, gsize len)
  *
  * If Parameter 5 == 0, there was an error.
  *
+ * Return:
+ *   TRUE on success
+ *   FALSE on error
+ *
  */
-void cmac(unsigned char *key, const void *input, gsize length, unsigned char *out, gsize *outlen, gsize out_capacity)
+gboolean cmac(guchar *key, const void *input,
+              gsize length, guchar *out,
+              gsize *outlen, gsize out_capacity)
 {
+  size_t output_len;
+  gboolean success = FALSE;
+
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+
   EVP_MAC *mac = EVP_MAC_fetch(NULL, "CMAC", NULL);
+  EVP_MAC_CTX *ctx = NULL;
+  if (mac == NULL)
+    {
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("File: ", __FILE__),
+                evt_tag_long("Line: ", __LINE__),
+                evt_tag_long("Code: ", SLOG_MEM_ALLOC_ERROR),
+                evt_tag_str("Reason: ", "EVP_MAC_fetch() returned NULL")
+               );
+      return FALSE;
+    }
+
   OSSL_PARAM params[] =
   {
     OSSL_PARAM_utf8_string("cipher", "aes-256-cbc", 0),
     OSSL_PARAM_END,
   };
 
-  EVP_MAC_CTX *ctx = EVP_MAC_CTX_new(mac);
+  ctx = EVP_MAC_CTX_new(mac);
+  if (ctx == NULL)
+    {
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("File: ", __FILE__),
+                evt_tag_long("Line: ", __LINE__),
+                evt_tag_long("Code: ", SLOG_MEM_ALLOC_ERROR),
+                evt_tag_str("Reason: ", "EVP_MAC_CTX_new() returned NULL")
+               );
+      goto CLEANUP_CMAC;
+    }
 
-  EVP_MAC_init(ctx, key, KEY_LENGTH, params);
-  EVP_MAC_update(ctx, input, length);
-  size_t out_len;
-  EVP_MAC_final(ctx, out, &out_len, out_capacity);
+  if (EVP_MAC_init(ctx, key, KEY_LENGTH, params) == 0)
+    {
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("File: ", __FILE__),
+                evt_tag_long("Line: ", __LINE__),
+                evt_tag_long("Code: ", SLOG_OPENSSL_LIBRARY_ERROR),
+                evt_tag_str("Reason: ", "EVP_MAC_init() returned 0")
+               );
+      goto CLEANUP_CMAC;
+    }
 
-  EVP_MAC_CTX_free(ctx);
-  EVP_MAC_free(mac);
-#else
+  if (EVP_MAC_update(ctx, input, length) == 0)
+    {
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("File: ", __FILE__),
+                evt_tag_long("Line: ", __LINE__),
+                evt_tag_long("Code: ", SLOG_OPENSSL_LIBRARY_ERROR),
+                evt_tag_str("Reason: ", "EVP_MAC_update() returned 0")
+               );
+      goto CLEANUP_CMAC;
+    }
+
+  if (EVP_MAC_final(ctx, out, &output_len, out_capacity) == 0)
+    {
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("File: ", __FILE__),
+                evt_tag_long("Line: ", __LINE__),
+                evt_tag_long("Code: ", SLOG_OPENSSL_LIBRARY_ERROR),
+                evt_tag_str("Reason: ", "EVP_MAC_final() returned 0")
+               );
+      goto CLEANUP_CMAC;
+    }
+
+#else //-- OPENSSL_VERSION_NUMBER
+
   CMAC_CTX *ctx = CMAC_CTX_new();
+  if (ctx == NULL)
+    {
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("File: ", __FILE__),
+                evt_tag_long("Line: ", __LINE__),
+                evt_tag_long("Code: ", SLOG_MEM_ALLOC_ERROR),
+                evt_tag_str("Reason: ", "CMAC_CTX_new() returned NULL")
+               );
+      return FALSE;
+    }
 
-  CMAC_Init(ctx, key, KEY_LENGTH, EVP_aes_256_cbc(), NULL);
-  CMAC_Update(ctx, input, length);
+  if (CMAC_Init(ctx, key, KEY_LENGTH, EVP_aes_256_cbc(), NULL) == 0)
+    {
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("File: ", __FILE__),
+                evt_tag_long("Line: ", __LINE__),
+                evt_tag_long("Code: ", SLOG_OPENSSL_LIBRARY_ERROR),
+                evt_tag_str("Reason: ", "CMAC_Init() returned 0")
+               );
+      goto CLEANUP_CMAC;
+    }
 
-  size_t out_len;
-  CMAC_Final(ctx, out, &out_len);
-  *outlen = out_len;
-  CMAC_CTX_free(ctx);
+  if (CMAC_Update(ctx, input, length) == 0)
+    {
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("File: ", __FILE__),
+                evt_tag_long("Line: ", __LINE__),
+                evt_tag_long("Code: ", SLOG_OPENSSL_LIBRARY_ERROR),
+                evt_tag_str("Reason: ", "CMAC_Update() returned 0")
+               );
+      goto CLEANUP_CMAC;
+    }
+
+  if (CMAC_Final(ctx, out, &output_len) == 0)
+    {
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("File: ", __FILE__),
+                evt_tag_long("Line: ", __LINE__),
+                evt_tag_long("Code: ", SLOG_OPENSSL_LIBRARY_ERROR),
+                evt_tag_str("Reason: ", "CMAC_Final() returned 0")
+               );
+      goto CLEANUP_CMAC;
+    }
+
+#endif //-- OPENSSL_VERSION_NUMBER
+
+  // CMAC length must be 16 bytes
+  if (output_len != CMAC_LENGTH)
+    {
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("File: ", __FILE__),
+                evt_tag_long("Line: ", __LINE__),
+                evt_tag_long("Code: ", SLOG_OPENSSL_LIBRARY_ERROR),
+                evt_tag_str("Reason: ", "CMAC output incorrect"),
+                evt_tag_long("Expected bytes: ", CMAC_LENGTH),
+                evt_tag_long("Got bytes: ", output_len)
+               );
+      goto CLEANUP_CMAC;
+    }
+
+  *outlen = (gsize)output_len;
+  success = TRUE;
+
+CLEANUP_CMAC:
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+  if (ctx)
+    {
+      EVP_MAC_CTX_free(ctx);
+      ctx = NULL;
+    }
+  if (mac)
+    {
+      EVP_MAC_free(mac);
+      mac = NULL;
+    }
+#else
+  if (ctx)
+    {
+      CMAC_CTX_free(ctx);
+      ctx = NULL;
+    }
 #endif
+  return success;
 }
-
 
 /*
  *  Evolve key
@@ -466,17 +709,25 @@ void cmac(unsigned char *key, const void *input, gsize length, unsigned char *ou
  * 1. Parameter: Pointer to key (input/output)
  *
  */
-
-void evolveKey(unsigned char *key)
+gboolean evolveKey(guchar *key)
 {
-
-  unsigned char buf[KEY_LENGTH];
-  PRF(key, GAMMA, sizeof(GAMMA), buf, KEY_LENGTH);
-  memcpy(key, buf, KEY_LENGTH);
+  guchar buf[KEY_LENGTH];
+  if (PRF(key, GAMMA, sizeof(GAMMA), buf, KEY_LENGTH))
+    {
+      memcpy(key, buf, KEY_LENGTH);
+      return TRUE;
+    }
+  else
+    {
+      return FALSE;
+    }
 }
 
 /*
- * AES-CMAC based pseudo-random function (with variable input length and output length)
+ * AES-CMAC based pseudo-random function (with variable input length and variable output length)
+ *
+ * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Cr2.pdf
+ * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-108r1-upd1.pdf
  *
  * 1. Parameter: Pointer to key (input)
  * 2. Parameter: Pointer to input (input)
@@ -484,37 +735,96 @@ void evolveKey(unsigned char *key)
  * 4. Parameter: Pointer to output (output)
  * 5. Parameter: Required output length (input)
  *
- * Note: For security, outputLength must be less than 255 * AES_BLOCKSIZE.
+ * Note: For security reasons, outputLength must be less than 255 * AES_BLOCKSIZE
+ *
+ * Return:
+ *  TRUE on success
+ *  FALSE on error
  *
  */
-void PRF(unsigned char *key, unsigned char *originalInput, guint64 inputLength, unsigned char *output,
-         guint64 outputLength)
+gboolean PRF(guchar *key, guchar *originalInput,
+             guint64 originalInputLength, guchar *output,
+             guint64 outputLength)
 {
+  // First, extraction
+  guchar ktmp[KEY_LENGTH];
+  // Initialize to all zero, in case CMAC_LENGTH < KEY_LENGTH
+  memset(ktmp, 0, KEY_LENGTH);
+  gsize outlen = -1;
 
-  unsigned char input[inputLength];
-  memcpy(input, originalInput, inputLength);
-
-  // Make sure that temporary buffer can hold at least outputLength bytes, rounded up to a multiple of AES_BLOCKSIZE
-  unsigned char buf[outputLength + AES_BLOCKSIZE];
-  gsize buf_capacity = G_N_ELEMENTS(buf);
-  // Prepare plaintext
-  for (int i = 0; i < outputLength / AES_BLOCKSIZE; i++)
+  // Assume KEY_LENGTH >= CMAC_LENGTH
+  if (!cmac(key, originalInput, originalInputLength, ktmp, &outlen, CMAC_LENGTH))
     {
-      gsize outlen;
-      cmac(key, input, AES_BLOCKSIZE, buf + (i * AES_BLOCKSIZE), &outlen, buf_capacity - (i * AES_BLOCKSIZE));
-      input[inputLength - 1]++;
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("Reason", "Bad CMAC"),
+                evt_tag_str("File: ", __FILE__),
+                evt_tag_long("Line: ", __LINE__));
+      return FALSE;
     }
 
-  if (outputLength % AES_BLOCKSIZE != 0)
+  // Then, expansion
+  gsize n = outputLength / CMAC_LENGTH;
+
+  gchar label[] = "key-expansion";
+  gchar context[] = "context";
+
+  size_t label_len = strlen(label);
+  size_t context_len = strlen(context);
+  size_t output_len = sizeof(outputLength);
+  size_t gsize_len = sizeof(gsize);
+
+  // i || Label || 00 || Context || outputLength;
+  gsize myInputLength = sizeof(gsize) + label_len + 1 + context_len + output_len;
+
+  guchar *input = g_new0(guchar, myInputLength);
+
+  for (gsize i = 0 ; i < n ; i++)
     {
-      int index = outputLength / AES_BLOCKSIZE;
-      gsize outlen;
-      cmac(key, input, AES_BLOCKSIZE, buf + (index * AES_BLOCKSIZE), &outlen, buf_capacity - (index * AES_BLOCKSIZE));
+      // input = i || Label || 00 || Context || outputLength;
+      memcpy(input, &i, gsize_len);
+      memcpy(input + gsize_len, label, label_len);
+      input[gsize_len + label_len] = 0;
+
+      memcpy(input + gsize_len + label_len + 1, context, context_len);
+      memcpy(input + gsize_len + label_len + 1 + context_len, &outputLength, output_len);
+
+      if (!cmac(ktmp, input, myInputLength, output + i * CMAC_LENGTH, &outlen, CMAC_LENGTH))
+        {
+          msg_error(SLOG_ERROR_PREFIX,
+                    evt_tag_str("Reason", "Bad CMAC"),
+                    evt_tag_str("File: ", __FILE__),
+                    evt_tag_long("Line: ", __LINE__));
+          g_free(input);
+          return FALSE;
+        }
+
     }
 
-  memcpy(output, buf, outputLength);
+  if (outputLength % CMAC_LENGTH != 0)
+    {
+      guchar buf[CMAC_LENGTH];
+
+      memcpy (input, &n, gsize_len);
+      memcpy(input + gsize_len, label, label_len);
+      input[gsize_len + label_len] = 0;
+      memcpy(input + gsize_len + label_len + 1, context, context_len);
+      memcpy(input + gsize_len + label_len + 1 + context_len, &outputLength, output_len);
+
+      if (!cmac(ktmp, input, myInputLength, buf, &outlen, CMAC_LENGTH))
+        {
+          msg_error(SLOG_ERROR_PREFIX,
+                    evt_tag_str("Reason", "Bad CMAC"),
+                    evt_tag_str("File: ", __FILE__),
+                    evt_tag_long("Line: ", __LINE__));
+          g_free(input);
+          return FALSE;
+        }
+
+      memcpy(output + n * CMAC_LENGTH, buf, outputLength % CMAC_LENGTH);
+    }
+  g_free(input);
+  return TRUE;
 }
-
 
 /*
  * Generate a master key
@@ -523,586 +833,464 @@ void PRF(unsigned char *key, unsigned char *originalInput, guint64 inputLength, 
  * The caller has to allocate this memory.
  *
  * Return:
- * 1 on success
- * 0 on error
+ * TRUE on success
+ * FALSE on error
  */
-int generateMasterKey(guchar *masterkey)
+gboolean generateMasterKey(guchar *masterkey)
 {
-  return RAND_bytes(masterkey, KEY_LENGTH);
+  return RAND_bytes(masterkey, KEY_LENGTH) == 1 ? TRUE : FALSE;
 }
 
 /*
  * Generate a host key based on a previously created master key
  *
- * 1. Parameter: master key
- * 2. Parameter: Host MAC address
- * 3. Parameter: Host S/N
+ * 1. Parameter: master key (input)
+ * 2. Parameter: Host MAC address (input)
+ * 3. Parameter: Host S/N (input)
+ * 4. Parameter: Host key (output)
  *
- * The specific unique host key k_0 is k_0 = H(master key|| MAC address || S/N)
- * and requires 48 bytes of storage. Additional 8 bytes need to be allocated to store
- * the serial number of the host key. The caller has to allocate this memory.
- *
- * Return:
- * 1 on success
- * 0 on error
+ * The specific unique host key k_0 is k_0 = PRF_{master_key}(MAC address ||
+ * S/N) and requires 32 bytes of storage. The caller has to allocate this
+ * memory.
  */
-int deriveHostKey(guchar *masterkey, gchar *macAddr, gchar *serial, guchar *hostkey)
+
+gboolean deriveHostKey(guchar *masterkey, gchar *macAddr, gchar *serial, guchar *hostkey)
 {
-  EVP_MD_CTX *ctx;
-
-  if ((ctx = EVP_MD_CTX_create()) == NULL)
-    return 0;
-
-  if (1 != EVP_DigestInit_ex(ctx, EVP_sha256(), NULL))
-    return 0;
-
-  if (1 != EVP_DigestUpdate(ctx, masterkey, KEY_LENGTH))
-    return 0;
-
-  if (1 != EVP_DigestUpdate(ctx, macAddr, strlen(macAddr)))
-    return 0;
-
-  if (1 != EVP_DigestUpdate(ctx, serial, strlen(serial)))
-    return 0;
-
-  if (KEY_LENGTH != SHA256_DIGEST_LENGTH)
-    {
-      msg_error("[SLOG] ERROR: Error in updating digest");
-      g_assert_not_reached();
-      return 0;
-    }
-
-  guint digest_len = KEY_LENGTH;
-
-  if (1 != EVP_DigestFinal_ex(ctx, hostkey, &digest_len))
-    return 0;
-
-  EVP_MD_CTX_destroy(ctx);
-
-  return 1;
+  gchar concatString[strlen(macAddr) + strlen(serial) + 1];
+  concatString[0] = 0;
+  strncat(concatString, macAddr, sizeof(concatString) - strlen(concatString) - 1);
+  strncat(concatString, serial, sizeof(concatString) - strlen(concatString) - 1);
+  return PRF(masterkey, (guchar *) concatString, strlen(concatString), hostkey, KEY_LENGTH);
 }
+
 
 /*
  *  Write whole log MAC to file
  *
  * Return:
- * 1 on success
- * 0 on error
+ * TRUE on success
+ * FALSE on error
  */
-int writeBigMAC(gchar *filename, char *outputBuffer)
+gboolean writeAggregatedMAC(gchar *filename, guchar *outputBuffer)
 {
-  GError *error = NULL;
+  SLogFile *f = create_file(filename, "w+");
 
-  GIOChannel *macfile = g_io_channel_new_file(filename, "w+", &error);
-  if (!macfile)
+  if (f == NULL)
     {
-      msg_error("[SLOG] ERROR: Unable open MAC file",
-                evt_tag_str("base_dir", filename));
-      cond_msg_error(error, "Additional Information");
-
-      g_clear_error(&error);
-
-      return 0;
+      return FALSE; //-- ERROR
     }
 
-  GIOStatus status = g_io_channel_set_encoding(macfile, NULL, &error);
-  if (status != G_IO_STATUS_NORMAL)
+  gboolean volatile result = TRUE;
+  gboolean volatile cmacOk = TRUE;
+
+  result = open_file(f);
+  if (!result)
     {
-      msg_error("[SLOG] ERROR: Unable to set encoding for MAC data",
-                evt_tag_str("File", filename));
-      cond_msg_error(error, "Additional information");
-
-      g_clear_error(&error);
-
-      g_io_channel_shutdown(macfile, TRUE, &error);
-      g_io_channel_unref(macfile);
-
-      g_clear_error(&error);
-
-      return 0;
+      g_free(f);
+      return FALSE; //-- ERROR
     }
 
-  gsize outlen = 0;
-  status = g_io_channel_write_chars(macfile, outputBuffer, CMAC_LENGTH, &outlen, &error);
-  if (status != G_IO_STATUS_NORMAL)
+  // Write aggregated MAC
+  result = write_to_file(f, (gchar *) outputBuffer, CMAC_LENGTH);
+  if (!result)
     {
-      msg_error("[SLOG] ERROR: Unable to write big MAC data",
-                evt_tag_str("File", filename));
-      cond_msg_error(error, "Additional information");
-
-      g_clear_error(&error);
-
-      g_io_channel_shutdown(macfile, TRUE, &error);
-      g_io_channel_unref(macfile);
-
-      g_clear_error(&error);
-
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error aggregated MAC write_to_file"));
+      (void) close_file(f);
+      g_free(f);
+      return FALSE; //-- ERROR
     }
 
-  // Compute aggregated MAC
+  // Compute new aggregated MAC
   gchar outputmacdata[CMAC_LENGTH];
+  gsize outlen;
   gsize outputmacdata_capacity = G_N_ELEMENTS(outputmacdata);
-  unsigned char keyBuffer[KEY_LENGTH];
-  bzero(keyBuffer, KEY_LENGTH);
-  unsigned char zeroBuffer[CMAC_LENGTH];
-  bzero(zeroBuffer, CMAC_LENGTH);
+  guchar keyBuffer[KEY_LENGTH];
+  memset(keyBuffer, 0, KEY_LENGTH);
+  guchar zeroBuffer[CMAC_LENGTH];
+  memset(zeroBuffer, 0, CMAC_LENGTH);
   memcpy(keyBuffer, outputBuffer, MIN(CMAC_LENGTH, KEY_LENGTH));
-  cmac(keyBuffer, zeroBuffer, CMAC_LENGTH, (guchar *)outputmacdata, &outlen, outputmacdata_capacity);
 
-  status = g_io_channel_write_chars(macfile, outputmacdata, CMAC_LENGTH, &outlen, &error);
-
-  if (status != G_IO_STATUS_NORMAL)
+  if (!cmac(keyBuffer, zeroBuffer, CMAC_LENGTH, (guchar *)outputmacdata, &outlen, outputmacdata_capacity))
     {
-      msg_error("[SLOG] ERROR: Unable to write aggregated MAC",
-                evt_tag_str("File", filename));
-      cond_msg_error(error, "Additional information");
-
-      g_clear_error(&error);
-
-      g_io_channel_shutdown(macfile, TRUE, &error);
-      g_io_channel_unref(macfile);
-
-      g_clear_error(&error);
-
-      return 0;
-    }
-  status = g_io_channel_shutdown(macfile, TRUE, &error);
-  g_io_channel_unref(macfile);
-
-  if (status != G_IO_STATUS_NORMAL)
-    {
-      cond_msg_error(error, "[SLOG] ERROR: Cannot close aggregated MAC");
-
-      g_clear_error(&error);
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Bad CMAC"));
+      cmacOk = FALSE;
     }
 
-  return 1;
+  // Write new aggregated MAC to file
+  result = write_to_file(f, outputmacdata, CMAC_LENGTH);
+  if (!result)
+    {
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error new MAC write_to_file"));
+      (void) close_file(f);
+      g_free(f);
+      return FALSE; //-- ERROR
+    }
+
+  result = close_file(f);
+  if (!result)
+    {
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error close_file"));
+    }
+  g_free(f);
+
+  return result && cmacOk;
 }
 
 /*
  * Read whole log MAC from file
  *
  * Return:
- * 1 on success
- * 0 on error
+ * TRUE on success
+ * FALSE on error
  */
-int readBigMAC(gchar *filename, char *outputBuffer)
+gboolean readAggregatedMAC(gchar *filename, guchar *outputBuffer)
 {
-  GError *myError = NULL;
+  SLogFile *f = create_file(filename, "r");
 
-  GIOChannel *macfile = g_io_channel_new_file(filename, "r", &myError);
-
-  if (!macfile)
+  if (f == NULL)
     {
-      // MAC file does not exist -> New MAC file will be created
-      g_clear_error(&myError);
-
-      return 0;
+      return FALSE;
     }
 
-  GIOStatus status = g_io_channel_set_encoding(macfile, NULL, &myError);
-  if (status != G_IO_STATUS_NORMAL)
-    {
-      cond_msg_error(myError, "[SLOG] ERROR: Cannot set encoding of MAC file");
-      g_clear_error(&myError);
-
-      g_io_channel_shutdown(macfile, TRUE, &myError);
-      g_io_channel_unref(macfile);
-
-      g_clear_error(&myError);
-
-      return 0;
-    }
-
+  gboolean volatile result = TRUE;
+  gboolean volatile cmacOk = TRUE;
   gchar macdata[2 * CMAC_LENGTH];
-  gsize mac_bytes_read = 0;
 
-  status = g_io_channel_read_chars(macfile, macdata, 2 * CMAC_LENGTH, &mac_bytes_read, &myError);
-  if (status != G_IO_STATUS_NORMAL)
+  // If file does not exist there is nothing to do
+  if (!g_file_test(filename, G_FILE_TEST_IS_REGULAR))
     {
-      cond_msg_error(myError, "[SLOG] ERROR: Cannot read MAC file");
-
-      g_clear_error(&myError);
-
-      g_io_channel_shutdown(macfile, TRUE, &myError);
-      g_io_channel_unref(macfile);
-
-      g_clear_error(&myError);
-
-      return 0;
+      msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "MAC does not yet exist and will be created"));
+      g_free(f);
+      return TRUE;
     }
 
-  status = g_io_channel_shutdown(macfile, TRUE, &myError);
-  g_io_channel_unref(macfile);
-
-  if (status != G_IO_STATUS_NORMAL)
+  result = open_file(f);
+  if (!result)
     {
-      msg_error("[SLOG] ERROR: Cannot close MAC file");
-
-      g_clear_error(&myError);
-
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error open_file"));
+      g_free(f);
+      return FALSE; //-- ERROR
     }
 
-  if (mac_bytes_read != 2 * CMAC_LENGTH)
+  result = read_from_file(f, macdata, 2 * CMAC_LENGTH);
+  if (!result)
     {
-      msg_error("[SLOG] ERROR: $(slog) parsing failed, invalid size of MAC file");
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error read_from_file"));
+      (void) close_file(f);
+      g_free(f);
+      return FALSE; //-- ERROR
     }
 
   gsize outlen = 0;
-  unsigned char keyBuffer[KEY_LENGTH];
-  bzero(keyBuffer, KEY_LENGTH);
-  unsigned char zeroBuffer[CMAC_LENGTH];
-  bzero(zeroBuffer, CMAC_LENGTH);
+  guchar keyBuffer[KEY_LENGTH];
+  memset(keyBuffer, 0, KEY_LENGTH);
+  guchar zeroBuffer[CMAC_LENGTH];
+  memset(zeroBuffer, 0, CMAC_LENGTH);
   memcpy(keyBuffer, macdata, MIN(CMAC_LENGTH, KEY_LENGTH));
 
-  unsigned char testOutput[CMAC_LENGTH];
+  guchar testOutput[CMAC_LENGTH];
   gsize testOutput_capacity = G_N_ELEMENTS(testOutput);
-  cmac(keyBuffer, zeroBuffer, CMAC_LENGTH, testOutput, &outlen, testOutput_capacity);
+
+  if (!cmac(keyBuffer, zeroBuffer, CMAC_LENGTH, testOutput, &outlen, testOutput_capacity))
+    {
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("File: ", __FILE__),
+                evt_tag_long("Line: ", __LINE__),
+                evt_tag_str("Reason", "Bad CMAC"));
+      cmacOk = FALSE;
+    }
 
   if (0 != memcmp(testOutput, &macdata[CMAC_LENGTH], CMAC_LENGTH))
     {
-      msg_warning("[SLOG] ERROR: MAC computation invalid");
-      return 0;
+      msg_warning(SLOG_WARNING_PREFIX, evt_tag_str("Reason", "MAC computation invalid"));
+      cmacOk = FALSE;
     }
   else
     {
-      msg_info("[SLOG] INFO: MAC successfully loaded");
+      msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "MAC successfully loaded"));
     }
 
   memcpy(outputBuffer, macdata, CMAC_LENGTH);
 
-  return 1;
+  result = close_file(f);
+  if (!result)
+    {
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error close_file"));
+    }
+  g_free(f);
+
+  return result && cmacOk;
 }
 
 /*
  *  Read key from file
  *
  * Return:
- * 1 on success
- * 0 on error
+ * TRUE on success
+ * FALSE on error
  */
-int readKey(char *destKey, guint64 *destCounter, gchar *keypath)
+gboolean readKey(guchar *destKey, guint64 *destCounter, gchar *keypath)
 {
+  SLogFile *f = create_file(keypath, "r");
 
-  GError *myError = NULL;
-
-  GIOChannel *keyfile = g_io_channel_new_file(keypath, "r", &myError);
-
-  if (!keyfile)
+  if (f == NULL)
     {
-      cond_msg_error(myError, "[SLOG] ERROR: Key file not found");
-      g_clear_error(&myError);
-
-      return 0;
+      return FALSE; //-- ERROR
     }
 
-  GIOStatus status = g_io_channel_set_encoding(keyfile, NULL, &myError);
+  gboolean volatile result = TRUE;
+  gboolean volatile cmacOk = TRUE;
+  gchar keydata[KEY_LENGTH + CMAC_LENGTH];
+  guint64 littleEndianCounter;
 
-  if (status != G_IO_STATUS_NORMAL)
+  result = open_file(f);
+  if (!result)
     {
-      cond_msg_error(myError, "[SLOG] ERROR: Unable to set encoding for key file");
-      g_clear_error(&myError);
-
-      g_io_channel_shutdown(keyfile, TRUE, &myError);
-      g_io_channel_unref(keyfile);
-
-      g_clear_error(&myError);
-
-
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error open_file"));
+      g_free(f);
+      return FALSE; //-- ERROR
     }
 
   // Key file contains
-  // 1. the number of log entries already logged (and therewith the index of the key); this is at the end of the key file
-  // 2. the actual 32 byte key, this is at the beginning of the key file
-  // 3. a 16 byte CMAC of the two previous data, this is stored after the key
+  // 1. The number of log entries already logged (and therefore the
+  //    index of the key). This is at the end of the key file
+  // 2. The actual 32 byte key stored this is at the beginning of the key file
+  // 3. A 16 byte CMAC of the two previous data stored after the actual key
 
-  gchar keydata[KEY_LENGTH + CMAC_LENGTH];
-  gsize key_bytes_read = 0;
-
-  status = g_io_channel_read_chars(keyfile, keydata, KEY_LENGTH + CMAC_LENGTH, &key_bytes_read, &myError);
-
-  if (status != G_IO_STATUS_NORMAL)
+  result = read_from_file(f, keydata, KEY_LENGTH + CMAC_LENGTH);
+  if (!result)
     {
-      cond_msg_error(myError, "[SLOG] ERROR: Cannot read from key file");
-
-      g_clear_error(&myError);
-
-      g_io_channel_shutdown(keyfile, TRUE, &myError);
-      g_io_channel_unref(keyfile);
-
-      g_clear_error(&myError);
-
-      return 0;
-
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error keydata read_from_file"));
+      (void) close_file(f);
+      g_free(f);
+      return FALSE; //-- ERROR
     }
 
-  if (key_bytes_read != KEY_LENGTH + CMAC_LENGTH)
+  result = read_from_file(f, (gchar *)&littleEndianCounter, sizeof(littleEndianCounter));
+  if (!result)
     {
-      msg_error("[SLOG] ERROR: Invalid key file. Missing CMAC");
-
-      status = g_io_channel_shutdown(keyfile, TRUE, &myError);
-      g_io_channel_unref(keyfile);
-
-      g_clear_error(&myError);
-
-      return 0;
-    }
-
-  guint64 littleEndianCounter;
-
-  status = g_io_channel_read_chars(keyfile, (gchar *) &littleEndianCounter, sizeof(littleEndianCounter), &key_bytes_read,
-                                   &myError);
-  if (status != G_IO_STATUS_NORMAL)
-    {
-      cond_msg_error(myError, "[SLOG] ERROR: Cannot read counter from key file");
-
-      g_clear_error(&myError);
-
-      g_io_channel_shutdown(keyfile, TRUE, &myError);
-      g_io_channel_unref(keyfile);
-
-      g_clear_error(&myError);
-
-      return 0;
-    }
-
-  status = g_io_channel_shutdown(keyfile, TRUE, &myError);
-  g_io_channel_unref(keyfile);
-
-  g_clear_error(&myError);
-
-  if (key_bytes_read != sizeof(littleEndianCounter))
-    {
-      msg_error("[SLOG] ERROR: $(slog) parsing failed, key file invalid while reading counter");
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error littleEndianCounter read_from_file"));
+      (void) close_file(f);
+      g_free(f);
+      return FALSE; //-- ERROR
     }
 
   gsize outlen = 0;
-  unsigned char testOutput[CMAC_LENGTH];
+  guchar testOutput[CMAC_LENGTH];
   gsize testOutputCapacity = G_N_ELEMENTS(testOutput);
 
-  cmac((guchar *)keydata, &(littleEndianCounter), sizeof(littleEndianCounter), testOutput, &outlen, testOutputCapacity);
+  if (!cmac((guchar *)keydata, &(littleEndianCounter), sizeof(littleEndianCounter), testOutput, &outlen,
+            testOutputCapacity))
+    {
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("File: ", __FILE__),
+                evt_tag_long("Line: ", __LINE__),
+                evt_tag_str("Reason", "Bad CMAC"));
+      cmacOk = FALSE;
+    }
 
   if (0 != memcmp(testOutput, &keydata[KEY_LENGTH], CMAC_LENGTH))
     {
-      msg_warning("[SLOG] ERROR: Host key corrupted. CMAC in key file not matching");
-      return 0;
+      msg_warning(SLOG_WARNING_PREFIX, evt_tag_str("Reason", "Host key corrupted. CMAC in key file not matching"));
+      result = FALSE;
     }
 
   memcpy(destKey, keydata, KEY_LENGTH);
   *destCounter = GUINT64_FROM_LE(littleEndianCounter);
-
-  return 1;
+  result = close_file(f);
+  if (!result)
+    {
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error close_file"));
+    }
+  g_free(f);
+  return result && cmacOk;
 }
 
 /*
  * Write key to file
  *
  * Return:
- * 1 on success
- * 0 on error
+ * TRUE on success
+ * FALSE on error
  */
-int writeKey(char *key, guint64 counter, gchar *keypath)
+gboolean writeKey(guchar *key, guint64 counter, gchar *keypath)
 {
-  GError *error = NULL;
-  GIOChannel *keyfile = g_io_channel_new_file(keypath, "w+", &error);
+  SLogFile *f = create_file(keypath, "w+");
 
-  if (!keyfile)
+  if (f == NULL)
     {
-      cond_msg_error(error, "[SLOG] ERROR: Cannot open key file");
-
-      g_clear_error(&error);
-
-      return 0;
+      return FALSE; //-- ERROR
     }
 
-  GIOStatus status = g_io_channel_set_encoding(keyfile, NULL, &error);
-  if (status != G_IO_STATUS_NORMAL)
+  gboolean volatile result = TRUE;
+  gboolean volatile cmacOk = TRUE;
+
+  result = open_file(f);
+  if (!result)
     {
-      cond_msg_error(error, "[SLOG] ERROR: Unable to set encoding for key file");
-
-      g_clear_error(&error);
-
-      g_io_channel_shutdown(keyfile, TRUE, &error);
-      g_io_channel_unref(keyfile);
-
-      g_clear_error(&error);
-
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error open_file"));
+      g_free(f);
+      return FALSE; //-- ERROR
     }
 
-  gsize outlen = 0;
   // Write key
-  status = g_io_channel_write_chars(keyfile, key, KEY_LENGTH, &outlen, &error);
-  if (status != G_IO_STATUS_NORMAL)
+  result = write_to_file(f, (gchar *) key, KEY_LENGTH);
+  if (!result)
     {
-      cond_msg_error(error, "[SLOG] ERROR: Unable to write updated key");
-
-      g_clear_error(&error);
-
-      g_io_channel_shutdown(keyfile, TRUE, &error);
-      g_io_channel_unref(keyfile);
-
-      g_clear_error(&error);
-
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error key write_to_file"));
+      (void) close_file(f);
+      g_free(f);
+      return FALSE; //-- ERROR
     }
 
   guint64 littleEndianCounter = GINT64_TO_LE(counter);
   gchar outputmacdata[CMAC_LENGTH];
   gsize outputmacdata_capacity = G_N_ELEMENTS(outputmacdata);
-  cmac((guchar *)key, &littleEndianCounter, sizeof(littleEndianCounter), (guchar *)outputmacdata, &outlen,
-       outputmacdata_capacity);
+  gsize outlen = 0;
+
+  // Create CMAC for key
+  if (!cmac((guchar *)key, &littleEndianCounter, sizeof(littleEndianCounter),
+            (guchar *)outputmacdata, &outlen, outputmacdata_capacity))
+    {
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("File: ", __FILE__),
+                evt_tag_long("Line: ", __LINE__),
+                evt_tag_str("Reason", "Bad CMAC"));
+      cmacOk = FALSE;
+    }
 
   // Write CMAC
-  status = g_io_channel_write_chars(keyfile, outputmacdata, CMAC_LENGTH, &outlen, &error);
-  if (status != G_IO_STATUS_NORMAL)
+  result = write_to_file(f, outputmacdata, CMAC_LENGTH);
+  if (!result)
     {
-      cond_msg_error(error, "[SLOG] ERROR: Unable to write key CMAC");
-
-      g_clear_error(&error);
-
-      g_io_channel_shutdown(keyfile, TRUE, &error);
-      g_io_channel_unref(keyfile);
-
-      g_clear_error(&error);
-
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error MAC write_to_file"));
+      (void) close_file(f);
+      g_free(f);
+      return FALSE; //-- ERROR
     }
 
   // Write counter
-  status = g_io_channel_write_chars(keyfile, (gchar *) &littleEndianCounter, sizeof(littleEndianCounter), &outlen,
-                                    &error);
-  if (status != G_IO_STATUS_NORMAL)
+  result = write_to_file(f, (gchar *)&littleEndianCounter,  sizeof(littleEndianCounter));
+  if (!result)
     {
-      cond_msg_error(error, "[SLOG] ERROR: Unable to write key counter");
-
-      g_clear_error(&error);
-
-      g_io_channel_shutdown(keyfile, TRUE, &error);
-      g_io_channel_unref(keyfile);
-
-      g_clear_error(&error);
-
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error littleEndianCounter write_to_file"));
+      (void) close_file(f);
+      g_free(f);
+      return FALSE; //-- ERROR
     }
 
-  status = g_io_channel_shutdown(keyfile, TRUE, &error);
-  g_io_channel_unref(keyfile);
-
-  if (status != G_IO_STATUS_NORMAL)
+  result = close_file(f);
+  if (!result)
     {
-      cond_msg_error(error, "[SLOG] ERROR: Cannot close key file");
-
-      g_clear_error(&error);
-
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error close_file"));
     }
-
-  return 1;
-
+  g_free(f);
+  return result && cmacOk;
 }
 
-int iterateBuffer(guint64 entriesInBuffer, GString **input, guint64 *nextLogEntry, unsigned char *mainKey,
-                  unsigned char *keyZero, guint keyNumber, GString **output, guint64 *numberOfLogEntries, unsigned char *cmac_tag,
-                  gsize cmac_tag_capacity, GHashTable *tab)
+// Iterate through log entries contained in a buffer and verify them
+gboolean iterateBuffer(
+  guint64 entriesInBuffer,
+  GPtrArray *input,
+  guint64 *nextLogEntry,
+  guchar *mainKey,
+  guchar *keyZero,
+  guint keyNumber,
+  GPtrArray *output,
+  guint64 *numberOfLogEntries,
+  guchar *cmac_tag,
+  gsize cmac_tag_capacity,
+  GHashTable *tab)
 {
-
-  int ret = 1;
+  gboolean result = TRUE;
   for (guint64 i = 0; i < entriesInBuffer; i++)
     {
+      g_ptr_array_add(output, g_string_new(NULL));
 
-      output[i] = g_string_new(NULL);
+      GString *entry = (GString *)g_ptr_array_index(input, i);
+      guint64 len = entry->len;
+      guint64 logEntryOnDisk;
 
-      guint64 len = input[i]->len;
       if (len > (COUNTER_LENGTH + 1))
         {
-          // Interpret the first COUNTER_LENGTH+1 characters
-          char ctrbuf[COUNTER_LENGTH + 1];
-          memcpy(ctrbuf, input[i]->str, COUNTER_LENGTH);
-          ctrbuf[COUNTER_LENGTH] = 0;
-
-          gsize outLen;
-          guchar *tmp = convertToBin(ctrbuf, &outLen);
-
-          guint64 logEntryOnDisk;
-          if (outLen != sizeof(guint64))
+          if (!getCounter(entry, &logEntryOnDisk))
             {
-              msg_error("[SLOG] ERROR: Cannot derive integer value from counter field", evt_tag_long("Log entry number",
-                        *nextLogEntry));
+              // Cannot determine counter value -> Jump to next entry
               logEntryOnDisk = *nextLogEntry;
-              g_free(tmp);
-            }
-          else
-            {
-              memcpy(&logEntryOnDisk, tmp, sizeof(logEntryOnDisk));
-              g_free(tmp);
             }
 
+          // Subtract counter from log entry
           len = len - (COUNTER_LENGTH + 1);
 
-          if (logEntryOnDisk != *nextLogEntry)
+          if (logEntryOnDisk != *nextLogEntry) //-- not equal
             {
-              if (tab != NULL)
+              //-- This branch is not the normal expected case
+
+              if (tableContainsKey(tab, logEntryOnDisk))
                 {
-                  char key[CTR_LEN_SIMPLE + 1];
-                  snprintf(key, CTR_LEN_SIMPLE + 1, "%"G_GUINT64_FORMAT, logEntryOnDisk);
-                  if (g_hash_table_contains(tab, key) == TRUE)
-                    {
-                      msg_error("[SLOG] ERROR: Duplicate entry detected", evt_tag_long("entry", logEntryOnDisk));
-                      ret = 0;
-                    }
+                  msg_error(SLOG_ERROR_PREFIX,
+                            evt_tag_str("Reason", "Duplicate entry detected"),
+                            evt_tag_long("entry", logEntryOnDisk));
+                  result = FALSE;
                 }
-              if (logEntryOnDisk < (*nextLogEntry))
+
+              if (logEntryOnDisk < (*nextLogEntry)) //-- Case 1 less
                 {
                   if (logEntryOnDisk < keyNumber)
                     {
-                      msg_error("[SLOG] ERROR: Log claims to be past entry from past archive. We cannot rewind back to this key without key0. This is going to fail.",
+                      msg_error(SLOG_ERROR_PREFIX,
+                                evt_tag_str("Reason",
+                                            "Log claims to be past entry from past archive. We cannot rewind back to this key without key0. This is going to fail"),
                                 evt_tag_long("entry", logEntryOnDisk));
-                      ret = 0;
+                      result = FALSE;
                     }
                   else
                     {
-                      msg_error("[SLOG] ERROR: Log claims to be past entry. We rewind from first known key, this might take some time",
+                      msg_error(SLOG_ERROR_PREFIX,
+                                evt_tag_str("Reason", "Log claims to be past entry. We rewind from first known key, this might take some time"),
                                 evt_tag_long("entry", logEntryOnDisk));
                       // Rewind key to k0
                       memcpy(mainKey, keyZero, KEY_LENGTH);
-                      deriveKey(mainKey, logEntryOnDisk, keyNumber);
+                      (void) deriveKey(mainKey, logEntryOnDisk, keyNumber);
                       *nextLogEntry = logEntryOnDisk;
-                      ret = 0;
+                      result = FALSE;
                     }
                 }
-              if (logEntryOnDisk - (*nextLogEntry) > 1000000)
-                {
-                  msg_info("[SLOG] INFO: Deriving key for distant future. This might take some time.",
-                           evt_tag_long("next log entry should be", *nextLogEntry), evt_tag_long("key to derive to", logEntryOnDisk),
-                           evt_tag_long("number of log entries", *numberOfLogEntries));
-                }
-              deriveKey(mainKey, logEntryOnDisk, *nextLogEntry);
-              *nextLogEntry = logEntryOnDisk;
-            }
 
-          GString *line = input[i];
+              else  //-- Case 2 greater
+                {
+                  if (logEntryOnDisk - (*nextLogEntry) > 1000000)
+                    {
+                      //-- info for user because this might take some time
+                      msg_info(SLOG_INFO_PREFIX,
+                               evt_tag_str("Reason", "Deriving key for distant future. This might take some time."),
+                               evt_tag_long("next log entry should be", *nextLogEntry),
+                               evt_tag_long("key to derive to", logEntryOnDisk),
+                               evt_tag_long("number of log entries", *numberOfLogEntries));
+                    }
+
+                  (void) deriveKey(mainKey, logEntryOnDisk, *nextLogEntry);
+                  *nextLogEntry = logEntryOnDisk;
+                }
+
+            } //-- not equal
+
+          GString *line = (GString *)g_ptr_array_index(input, i);
+          GString *out = (GString *)g_ptr_array_index(output, i);
 
           char *ct = &(line->str)[COUNTER_LENGTH + 1];
           gsize outputLength;
 
           // binBuf = IV + TAG + CT
-          guchar *binBuf = convertToBin(ct, &outputLength);
+          guchar *binBuf = g_base64_decode(ct, &outputLength);
           int pt_length = 0;
 
           // Check whether something weird has happened during conversion
           if (outputLength > IV_LENGTH + AES_BLOCKSIZE)
             {
-              unsigned char pt[outputLength - IV_LENGTH - AES_BLOCKSIZE];
-
-              unsigned char encKey[KEY_LENGTH];
+              guchar pt[outputLength - IV_LENGTH - AES_BLOCKSIZE];
+              guchar encKey[KEY_LENGTH];
               deriveEncSubKey(mainKey, encKey);
-
               pt_length = sLogDecrypt(&binBuf[IV_LENGTH + AES_BLOCKSIZE], outputLength - IV_LENGTH - AES_BLOCKSIZE,
                                       &binBuf[IV_LENGTH],
                                       encKey, binBuf, pt);
@@ -1110,58 +1298,43 @@ int iterateBuffer(guint64 entriesInBuffer, GString **input, guint64 *nextLogEntr
               if (pt_length > 0)
                 {
                   // Include colon, whitespace, and \0
-                  g_string_append_printf(output[i], "%0*"G_GINT64_MODIFIER"x: %.*s", CTR_LEN_SIMPLE, logEntryOnDisk, pt_length, pt);
+                  g_string_append_printf(out, "%0*"G_GINT64_MODIFIER"x: %.*s", CTR_LEN_SIMPLE, logEntryOnDisk, pt_length, pt);
 
-                  if (tab != NULL)
+                  // Add to table
+                  if (!addValueToTable(tab, logEntryOnDisk))
                     {
-                      char *key = g_new0(char, CTR_LEN_SIMPLE + 1);
-                      snprintf(key, CTR_LEN_SIMPLE + 1, "%"G_GUINT64_FORMAT, logEntryOnDisk);
-
-                      if (logEntryOnDisk > G_MAXUINT)
-                        {
-                          msg_error("[SLOG] ERROR: Log entry id does not fit into pointer-sized integer storage", evt_tag_long("entry",
-                                    logEntryOnDisk));
-                          ret = 0;
-                        }
-                      else if (g_hash_table_insert(tab, key, GUINT_TO_POINTER((guint)logEntryOnDisk)) == FALSE)
-                        {
-                          msg_warning("[SLOG] WARNING: Unable to process hash table while entering decrypted log entry", evt_tag_long("entry",
-                                      logEntryOnDisk));
-                          ret = 0;
-                        }
+                      msg_warning(SLOG_WARNING_PREFIX,
+                                  evt_tag_str("Reason", "Table entry exists"),
+                                  evt_tag_long("Entry: ", logEntryOnDisk));
+                      result = FALSE;
                     }
 
                   // Update BigHMAC
-                  if ((*numberOfLogEntries) == 0UL)   // First aggregated MAC
+                  gsize outlen = 0;
+                  guchar MACKey[KEY_LENGTH];
+                  deriveMACSubKey(mainKey, MACKey);
+                  //-- now that an inital aggregated MAC exists, do the
+                  //   same for first entry as for any other entries!
+                  guchar bigBuf[AES_BLOCKSIZE + IV_LENGTH + AES_BLOCKSIZE + pt_length];
+                  memcpy(bigBuf, cmac_tag, AES_BLOCKSIZE);
+                  memcpy(&bigBuf[AES_BLOCKSIZE], binBuf, IV_LENGTH + AES_BLOCKSIZE + pt_length);
+                  if (!cmac(MACKey, bigBuf, AES_BLOCKSIZE + IV_LENGTH + AES_BLOCKSIZE + pt_length, cmac_tag, &outlen, cmac_tag_capacity))
                     {
-                      gsize outlen = 0;
-
-                      unsigned char MACKey[KEY_LENGTH];
-                      deriveMACSubKey(mainKey, MACKey);
-
-                      cmac(MACKey, binBuf, IV_LENGTH + AES_BLOCKSIZE + pt_length, cmac_tag, &outlen, cmac_tag_capacity);
-                    }
-                  else
-                    {
-                      // numberOfEntries > 0
-                      gsize outlen;
-                      unsigned char bigBuf[AES_BLOCKSIZE + IV_LENGTH + AES_BLOCKSIZE + pt_length];
-                      memcpy(bigBuf, cmac_tag, AES_BLOCKSIZE);
-                      memcpy(&bigBuf[AES_BLOCKSIZE], binBuf, IV_LENGTH + AES_BLOCKSIZE + pt_length);
-
-                      unsigned char MACKey[KEY_LENGTH];
-                      deriveMACSubKey(mainKey, MACKey);
-
-                      cmac(MACKey, bigBuf, AES_BLOCKSIZE + IV_LENGTH + AES_BLOCKSIZE + pt_length, cmac_tag, &outlen, cmac_tag_capacity);
+                      msg_error(SLOG_ERROR_PREFIX,
+                                evt_tag_str("Reason", "Bad CMAC"),
+                                evt_tag_str("File: ", __FILE__),
+                                evt_tag_long("Line: ", __LINE__));
+                      result = FALSE;
                     }
                 }
             }
 
           if (pt_length <= 0)
             {
-              msg_warning("[SLOG] WARNING: Decryption not successful",
+              msg_warning(SLOG_WARNING_PREFIX,
+                          evt_tag_str("Reason", "Decryption not successful"),
                           evt_tag_long("entry", logEntryOnDisk));
-              ret = 0;
+              result = FALSE;
             }
 
           g_free(binBuf);
@@ -1169,92 +1342,102 @@ int iterateBuffer(guint64 entriesInBuffer, GString **input, guint64 *nextLogEntr
           evolveKey(mainKey);
           (*numberOfLogEntries)++;
           (*nextLogEntry)++;
-
         }
       else
         {
-          msg_error("[SLOG] ERROR: Cannot read log entry", evt_tag_long("", *nextLogEntry));
-          ret = 0;
+          msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Cannot read log entry"), evt_tag_long("", *nextLogEntry));
+          result = FALSE;
         }
 
     } // for
 
-  return ret;
+  return result;
 }
 
 // Perform the final verification step
-int finalizeVerify(guint64 startingEntry, guint64 entriesInFile, unsigned char *bigMac, unsigned char *cmac_tag,
-                   GHashTable *tab)
+gboolean finalizeVerify(
+  guint64 startingEntry,
+  guint64 entriesInFile,
+  guchar *aggMAC,
+  guchar *cmac_tag,
+  GHashTable **tab)
 {
+  if (tab == NULL || *tab == NULL)
+    {
+      msg_warning(SLOG_WARNING_PREFIX,
+                  evt_tag_str("Reason",
+                              "finalizeVerify: hash table already destroyed or not provided"));
+      return FALSE;
+    }
 
-  int ret = 1;
+  int ret = TRUE;
 
   // Check which entries are missing
   guint64 notRecovered = 0;
   for (guint64 i = startingEntry; i < startingEntry + entriesInFile; i++)
     {
-      if (tab != NULL)
+      // Hashtable key
+      char key[CTR_LEN_SIMPLE + 1];
+      snprintf(key, CTR_LEN_SIMPLE + 1, "%"G_GUINT64_FORMAT, i);
+      if (!g_hash_table_contains(*tab, key))
         {
-          // Hashtable key
-          char key[CTR_LEN_SIMPLE + 1];
-          snprintf(key, CTR_LEN_SIMPLE + 1, "%"G_GUINT64_FORMAT, i);
-
-          if (g_hash_table_contains(tab, key) == FALSE)
-            {
-              notRecovered++;
-              msg_warning("[SLOG] WARNING: Unable to recover", evt_tag_long("entry", i));
-              ret = 0;
-            }
+          notRecovered++;
+          msg_warning(SLOG_WARNING_PREFIX, evt_tag_str("Reason", "Unable to recover"), evt_tag_long("entry", i));
+          ret = FALSE;
         }
     }
 
-  if ((notRecovered == 0) && (tab != NULL))
+  if (notRecovered == 0)
     {
-      msg_info("[SLOG] INFO: All entries recovered successfully");
+      msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "All entries recovered successfully"));
     }
 
-  int equal = memcmp(bigMac, cmac_tag, CMAC_LENGTH);
+  int equal = memcmp(aggMAC, cmac_tag, CMAC_LENGTH);
 
   if (equal != 0)
     {
-      msg_warning("[SLOG] WARNING: Aggregated MAC mismatch. Log might be incomplete");
-      ret = 0;
+      msg_warning(SLOG_WARNING_PREFIX, evt_tag_str("Reason", "Aggregated MAC mismatch. Log might be incomplete"));
+      ret = FALSE;
     }
   else
     {
-      msg_info("[SLOG] Aggregated MAC matches. Log contains all expected log messages.");
+      msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Aggregated MAC matches. Log contains all expected log messages."));
     }
 
-  g_hash_table_unref(tab);
+  g_hash_table_destroy(*tab);
+  *tab = NULL;
 
   return ret;
 }
 
 // Initialize log verification
-int initVerify(guint64 entriesInFile, unsigned char *mainKey, guint64 *nextLogEntry, guint64 *startingEntry,
-               GString **input, GHashTable **tab)
+gboolean initVerify(
+  guint64 entriesInFile,
+  guchar *mainKey,
+  guint64 *nextLogEntry,
+  guint64 *startingEntry,
+  GPtrArray *input)
 {
-  // Create hash table
-  *tab = g_hash_table_new(g_str_hash, g_str_equal);
-  if (*tab == NULL)
+  if (entriesInFile == 0)
     {
-      msg_error("[SLOG] ERROR: Cannot create hash table");
-      return 0;
+      return FALSE;
     }
 
-  if (input[0]->len > (COUNTER_LENGTH + 1))
+  GString *str = (GString *)g_ptr_array_index(input, 0);
+
+  if (str->len > (COUNTER_LENGTH + 1))
     {
       gsize outLen;
       char buf[COUNTER_LENGTH + 1];
-      memcpy(buf, input[0]->str, COUNTER_LENGTH);
+      memcpy(buf, str->str, COUNTER_LENGTH);
       buf[COUNTER_LENGTH] = 0;
-      guchar *tempInt = convertToBin(buf, &outLen);
+      guchar *tempInt = g_base64_decode(buf, &outLen);
       if (outLen != sizeof(guint64))
         {
-          msg_warning("[SLOG] WARNING: Cannot derive integer value from first input line counter");
+          msg_warning(SLOG_WARNING_PREFIX, evt_tag_str("Reason", "Cannot derive integer value from first input line counter"));
           (*startingEntry) = 0UL;
           g_free(tempInt);
-          return 0;
+          return FALSE;
         }
       else
         {
@@ -1264,20 +1447,21 @@ int initVerify(guint64 entriesInFile, unsigned char *mainKey, guint64 *nextLogEn
 
       if ((*startingEntry) > 0)
         {
-          msg_warning("[SLOG] WARNING: Log does not start with index 0",
+          msg_warning(SLOG_WARNING_PREFIX,
+                      evt_tag_str("Reason", "Log does not start with index 0"),
                       evt_tag_long("index", (*startingEntry)));
           (*nextLogEntry) = (*startingEntry);
           deriveKey(mainKey, (*nextLogEntry), 0);
-          return 0;
+          return FALSE;
         }
     }
   else
     {
-      msg_warning("[SLOG] WARNING: Problems reading log entry at first line.");
-      return 0;
+      msg_warning(SLOG_WARNING_PREFIX, evt_tag_str("Reason", "Problems reading log entry at first line."));
+      return FALSE;
     }
 
-  return 1;
+  return TRUE;
 }
 
 
@@ -1285,117 +1469,101 @@ int initVerify(guint64 entriesInFile, unsigned char *mainKey, guint64 *nextLogEn
  * Iteratively verify the integrity of an existing log file
  *
  * Return:
- * 1 on success
- * 0 on error
+ * TRUE on success
+ * FALSE on error
  */
-int iterativeFileVerify(unsigned char *previousMAC, unsigned char *mainKey, char *inputFileName, unsigned char *bigMAC,
-                        char *outputFileName, guint64 entriesInFile, int chunkLength, guint64 keyNumber)
+gboolean iterativeFileVerify(
+  guchar *previousMAC,
+  guchar *mainKey,
+  char *inputFileName,
+  guchar *aggMAC,
+  char *outputFileName,
+  guint64 entriesInFile,
+  guint64 chunkLength,
+  guint64 keyNumber)
 {
-
   if (entriesInFile == 0)
     {
-      msg_error("[SLOG] ERROR: Nothing to verify");
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Nothing to verify"));
+      return FALSE;
     }
 
-  unsigned char keyZero[KEY_LENGTH];
+  guchar keyZero[KEY_LENGTH];
   memcpy(keyZero, mainKey, KEY_LENGTH);
   int startedWithZero = 0;
 
   if (keyNumber != 0)
     {
-      msg_info("[SLOG] INFO: Verification using a key different from k0", evt_tag_long("key number", keyNumber));
+      msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Verification using a key different from k0."),
+               evt_tag_long("Key number: ", keyNumber));
     }
   else
     {
-      msg_info("[SLOG] INFO: Verification starting with k0. Is this really what you want?");
+      msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Verification starting with k0. Is this really what you want?"));
       startedWithZero = 1;
     }
-  int ret = 1;
 
-  GError *myError = NULL;
-  GIOChannel *input = g_io_channel_new_file(inputFileName, "r", &myError);
-  if (!input)
+  GHashTable *tab = g_hash_table_new_full(g_str_hash, g_str_equal, (GDestroyNotify)g_free, NULL);
+  if (tab == NULL)
     {
-      cond_msg_error (myError, "[SLOG] ERROR: Cannot open input file");
-
-      g_clear_error(&myError);
-
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Cannot create hash table"));
+      return FALSE; //-- ERROR
     }
 
-  GIOStatus status = g_io_channel_set_encoding(input, NULL, &myError);
-  if (status != G_IO_STATUS_NORMAL)
+  gboolean volatile result = TRUE;
+  SLogFile *inf = NULL;
+  SLogFile *outf = NULL;
+  GPtrArray *inputBuffer = NULL;
+  GPtrArray *outputBuffer = NULL;
+
+  // Create input and output files
+  inf = create_file(inputFileName, "r");
+  if (inf == NULL)
     {
-      cond_msg_error (myError, "[SLOG] ERROR: set encoding for input file");
-
-      g_clear_error(&myError);
-
-      g_io_channel_shutdown(input, TRUE, &myError);
-      g_io_channel_unref(input);
-
-      g_clear_error(&myError);
-
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Can not create inf."));
+      result = FALSE; //-- ERROR
+      goto CLEANUP_ITERATIVEFILEVERIFY;
+    }
+  outf = create_file(outputFileName, "w+");
+  if (outf == NULL)
+    {
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Can not create out."));
+      result = FALSE; //-- ERROR
+      goto CLEANUP_ITERATIVEFILEVERIFY;
     }
 
-  GIOChannel *output = g_io_channel_new_file(outputFileName, "w+", &myError);
-
-  if (!output)
+  // Allocate buffers
+  inputBuffer = g_ptr_array_new_with_free_func((GDestroyNotify)SLogStringFree);
+  if (inputBuffer == NULL)
     {
-      cond_msg_error(myError, "[SLOG] ERROR: Cannot open output file");
-
-      g_clear_error(&myError);
-
-      g_io_channel_shutdown(input, TRUE, &myError);
-      g_io_channel_unref(input);
-
-      g_clear_error(&myError);
-
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Can not allocate inputBuffer."));
+      result = FALSE; //-- ERROR
+      goto CLEANUP_ITERATIVEFILEVERIFY;
     }
-  status = g_io_channel_set_encoding(output, NULL, &myError);
-  if (status != G_IO_STATUS_NORMAL)
+  outputBuffer = g_ptr_array_new_with_free_func((GDestroyNotify)SLogStringFree);
+  if (outputBuffer == NULL)
     {
-      cond_msg_error(myError, "[SLOG] ERROR: Cannot set output file encoding");
-      g_clear_error(&myError);
-
-      g_io_channel_shutdown(input, TRUE, &myError);
-      g_io_channel_unref(input);
-
-      g_clear_error(&myError);
-
-      g_io_channel_shutdown(output, TRUE, &myError);
-      g_io_channel_unref(output);
-
-      g_clear_error(&myError);
-
-      return  0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Can not allocate outputBuffer."));
+      result = FALSE; //-- ERROR
+      goto CLEANUP_ITERATIVEFILEVERIFY;
     }
 
-
-  GString **inputBuffer = g_new0(GString *, chunkLength);
-  GString **outputBuffer = g_new0(GString *, chunkLength);
-
-  if ((outputBuffer == NULL) || (inputBuffer == NULL))
+  // Open input and output files
+  result = open_file(inf);
+  if (!result)
     {
-      msg_error("[SLOG] ERROR: [iterativeFileVerify] cannot allocate memory");
-
-      g_io_channel_shutdown(input, TRUE, &myError);
-      g_io_channel_unref(input);
-      g_clear_error(&myError);
-
-      g_io_channel_shutdown(output, TRUE, &myError);
-      g_io_channel_unref(output);
-      g_clear_error(&myError);
-
-      g_free(inputBuffer);
-      g_free(outputBuffer);
-
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "iterativeFileVerify, open_file(inf)"));
+      goto CLEANUP_ITERATIVEFILEVERIFY;
     }
 
-  unsigned char cmac_tag[CMAC_LENGTH];
+  result = open_file(outf);
+  if (!result)
+    {
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "iterativeFileVerify, open_file(out)"));
+      goto CLEANUP_ITERATIVEFILEVERIFY;
+    }
+
+  guchar cmac_tag[CMAC_LENGTH];
   gsize cmac_tag_capacity = G_N_ELEMENTS(cmac_tag);
   memcpy(cmac_tag, previousMAC, CMAC_LENGTH);
 
@@ -1403,7 +1571,8 @@ int iterativeFileVerify(unsigned char *previousMAC, unsigned char *mainKey, char
   guint64 startingEntry = keyNumber;
   guint64 numberOfLogEntries = keyNumber;
 
-  // This is only to avoid updating BigMAC during the first iteration
+  // This is only to avoid updating the aggregated MAC during the first iteration
+  //
   if (keyNumber == 0)
     {
       numberOfLogEntries = 1;
@@ -1414,296 +1583,237 @@ int iterativeFileVerify(unsigned char *previousMAC, unsigned char *mainKey, char
       chunkLength = entriesInFile;
     }
 
-  // Create the hash table
-  GHashTable *tab = g_hash_table_new(g_str_hash, g_str_equal);
-  if (tab == NULL)
-    {
-      msg_error("[SLOG] ERROR: Cannot create hash table");
-      return 0;
-    }
-
   // Process file in chunks
-  for (int j = 0; j < (entriesInFile / chunkLength); j++)
+  for (guint64 j = 0; j < (entriesInFile / chunkLength); j++)
     {
       for (guint64 i = 0; i < chunkLength; i++)
         {
-          inputBuffer[i] = g_string_new(NULL);
-          status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
-          if (status != G_IO_STATUS_NORMAL)
+          GString *line = getLogEntry(inf);
+
+          if (line != NULL)
             {
-              cond_msg_error(myError, "[SLOG] ERROR: reading from input file");
-
-              g_clear_error(&myError);
-
-              g_io_channel_shutdown(input, TRUE, &myError);
-              g_io_channel_unref(input);
-
-              g_clear_error(&myError);
-
-              g_io_channel_shutdown(output, TRUE, &myError);
-              g_io_channel_unref(output);
-
-              g_clear_error(&myError);
-
-              g_free(inputBuffer);
-              g_free(outputBuffer);
-
-              return  0;
+              // Add line to buffer
+              g_ptr_array_add(inputBuffer, line);
             }
-
-          // Cut last character to remove the trailing new line...
-          g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
+          else
+            {
+              msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Invalid log entry (= NULL)"));
+              result = FALSE;
+              // Cannot continue -> Release memory and file resources prematurely
+              goto CLEANUP_ITERATIVEFILEVERIFY;
+            }
         }
-      ret = ret * iterateBuffer(chunkLength, inputBuffer, &nextLogEntry, mainKey, keyZero, keyNumber, outputBuffer,
-                                &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
+      result = iterateBuffer(chunkLength, inputBuffer, &nextLogEntry, mainKey, keyZero, keyNumber, outputBuffer,
+                             &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
 
       // ...and write to file
       for (guint64 i = 0; i < chunkLength; i++)
         {
-          if (outputBuffer[i]->len != 0)
+          GString *line = (GString *)g_ptr_array_index(outputBuffer, i);
+          if (NULL == line)
             {
-              gsize size;
-              //Add newline
-              g_string_append(outputBuffer[i], "\n");
-              status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
-
-              if (status != G_IO_STATUS_NORMAL)
+              msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "iterativeFileVerify, Invalid output buffer, NULL == line"));
+              result = FALSE; //-- ERROR
+              goto CLEANUP_ITERATIVEFILEVERIFY;
+            }
+          if (line->len != 0)
+            {
+              result = putLogEntry(outf, line);
+              if (!result)
                 {
-                  cond_msg_error(myError, "[SLOG] ERROR: writing to output file");
-
-                  g_clear_error(&myError);
-
-                  g_io_channel_shutdown(input, TRUE, &myError);
-                  g_io_channel_unref(input);
-
-                  g_clear_error(&myError);
-
-                  g_io_channel_shutdown(output, TRUE, &myError);
-                  g_io_channel_unref(output);
-
-                  g_clear_error(&myError);
-
-                  g_free(inputBuffer);
-                  g_free(outputBuffer);
-
-                  return  0;
+                  msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "iterativeFileVerify, putLogEntry(outf, line)"));
+                  goto CLEANUP_ITERATIVEFILEVERIFY;
                 }
             }
-          g_string_free(outputBuffer[i], TRUE);
-          g_string_free(inputBuffer[i], TRUE);
         }
     }
+  g_ptr_array_set_size(outputBuffer, 0);
+  g_ptr_array_set_size(inputBuffer, 0);
+
 
   if ((entriesInFile % chunkLength) > 0)
     {
       for (guint64 i = 0; i < (entriesInFile % chunkLength); i++)
         {
-          inputBuffer[i] = g_string_new(NULL);
-          status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
-          if (status != G_IO_STATUS_NORMAL)
+          GString *line = getLogEntry(inf);
+
+          if (line != NULL)
             {
-              cond_msg_error(myError, "[SLOG] ERROR: reading from input file");
-
-              g_clear_error(&myError);
-
-              g_io_channel_shutdown(input, TRUE, &myError);
-              g_io_channel_unref(input);
-
-              g_clear_error(&myError);
-
-              g_io_channel_shutdown(output, TRUE, &myError);
-              g_io_channel_unref(output);
-
-              g_clear_error(&myError);
-
-              g_free(inputBuffer);
-              g_free(outputBuffer);
-
-
-              return  0;
+              // Add line to buffer
+              g_ptr_array_add(inputBuffer, line);
             }
-
-          // Cut last character to remove the trailing new line
-          g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
+          else
+            {
+              msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Invalid log entry (= NULL)"));
+              result = FALSE;
+              // Cannot continue -> Release memory and file resources prematurely
+              goto CLEANUP_ITERATIVEFILEVERIFY;
+            }
         }
-      ret = ret * iterateBuffer((entriesInFile % chunkLength), inputBuffer, &nextLogEntry, mainKey, keyZero, keyNumber,
-                                outputBuffer, &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
+
+      result = iterateBuffer((entriesInFile % chunkLength), inputBuffer, &nextLogEntry, mainKey, keyZero, keyNumber,
+                             outputBuffer, &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
 
       for (guint64 i = 0; i < (entriesInFile % chunkLength); i++)
         {
-          if (outputBuffer[i]->len != 0)
+          GString *line = (GString *)g_ptr_array_index(outputBuffer, i);
+          if (NULL == line)
             {
-
-              gsize size;
-
-              //Add newline
-              g_string_append(outputBuffer[i], "\n");
-              status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
-              if (status != G_IO_STATUS_NORMAL)
-                {
-                  cond_msg_error(myError, "[SLOG] ERROR: writing to output file");
-
-                  g_clear_error(&myError);
-
-                  g_io_channel_shutdown(input, TRUE, &myError);
-                  g_io_channel_unref(input);
-
-                  g_clear_error(&myError);
-
-                  g_io_channel_shutdown(output, TRUE, &myError);
-                  g_io_channel_unref(output);
-
-                  g_clear_error(&myError);
-
-                  g_free(inputBuffer);
-                  g_free(outputBuffer);
-
-                  return  0;
-                }
-
+              msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "iterativeFileVerify, Invalid output buffer: NULL == line"));
+              result = FALSE; //-- ERROR
+              goto CLEANUP_ITERATIVEFILEVERIFY;
             }
-          g_string_free(outputBuffer[i], TRUE);
-          g_string_free(inputBuffer[i], TRUE);
+          if (line->len != 0)
+            {
+              result = putLogEntry(outf, line);
+              if (!result)
+                {
+                  msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "iterativeFileVerify, putLogEntry(outf, line)"));
+                  goto CLEANUP_ITERATIVEFILEVERIFY;
+                }
+            }
         }
+      g_ptr_array_set_size(outputBuffer, 0);
+      g_ptr_array_set_size(inputBuffer, 0);
     }
 
   if (startedWithZero == 1)
     {
-      msg_info("[SLOG] INFO: We started with key key0. There might be a lot of warnings about missing log entries.");
+      msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason",
+                                             "We started with key key0. There might be a lot of warnings about missing log entries."));
+    }
+  if (!finalizeVerify(startingEntry, entriesInFile, aggMAC, cmac_tag, &tab))
+    {
+      result = FALSE;
     }
 
-  ret = ret * finalizeVerify(startingEntry, entriesInFile, bigMAC, cmac_tag, tab);
+CLEANUP_ITERATIVEFILEVERIFY:
 
-  g_free(inputBuffer);
-  g_free(outputBuffer);
+  if (tab != NULL)
+    {
+      g_hash_table_destroy(tab);
+      tab = NULL;
+    }
 
-  g_io_channel_shutdown(input, TRUE, &myError);
-  g_io_channel_unref(input);
+  //-- Release memory
+  if (NULL != outputBuffer)
+    {
+      g_ptr_array_free(outputBuffer, TRUE);
+      outputBuffer = NULL;
+    }
 
-  g_clear_error(&myError);
+  if (NULL != inputBuffer)
+    {
+      g_ptr_array_free(inputBuffer, TRUE);
+      inputBuffer = NULL;
+    }
 
-  g_io_channel_shutdown(output, TRUE, &myError);
-  g_io_channel_unref(output);
+  if (NULL != outf)
+    {
+      (void) close_file(outf);
+      g_free(outf);
+      outf = NULL;
+    }
 
-  g_clear_error(&myError);
+  if (NULL != inf)
+    {
+      (void) close_file(inf);
+      g_free(inf);
+      inf = NULL;
+    }
 
-  return ret;
-
+  return result;
 }
 
 /*
  * Verify the integrity of an existing log file
  *
  * Return:
- * 1 on success
- * 0 on error
+ * TRUE on success
+ * FALSE on error
  */
-int fileVerify(unsigned char *mainKey, char *inputFileName, char *outputFileName, unsigned char *bigMac,
-               guint64 entriesInFile, int chunkLength)
+gboolean fileVerify(guchar *mainKey, char *inputFileName,
+                    char *outputFileName, guchar *aggMAC,
+                    guint64 entriesInFile, guint64 chunkLength, guchar mac0[CMAC_LENGTH])
 {
-
-  unsigned char keyZero[KEY_LENGTH];
-  memcpy(keyZero, mainKey, KEY_LENGTH);
-
-  GHashTable *tab = NULL;
-
-  int ret = 1;
+  gboolean volatile result = TRUE; //-- SUCCSS
 
   if (entriesInFile == 0)
     {
-      msg_error("[SLOG] ERROR: Nothing to verify");
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Nothing to verify"));
+      return FALSE; //-- ERROR
     }
 
-  GError *myError = NULL;
-  GIOChannel *input = g_io_channel_new_file(inputFileName, "r", &myError);
-  if (!input)
+  GHashTable *tab = g_hash_table_new_full(g_str_hash, g_str_equal, (GDestroyNotify)g_free, NULL);
+  if (tab == NULL)
     {
-      cond_msg_error (myError, "[SLOG] ERROR: Cannot open input file");
-
-      g_clear_error(&myError);
-
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Cannot create hash table"));
+      return FALSE; //-- ERROR
     }
 
-  GIOStatus status =  g_io_channel_set_encoding(input, NULL, &myError);
-  if (status != G_IO_STATUS_NORMAL)
+  SLogFile *inf = NULL;
+  SLogFile *outf = NULL;
+  GPtrArray *inputBuffer = NULL;
+  GPtrArray *outputBuffer = NULL;
+
+  inf = create_file(inputFileName, "r");
+  if (inf == NULL)
     {
-      cond_msg_error (myError, "[SLOG] ERROR: Cannot set input file encoding");
-
-      g_clear_error(&myError);
-
-      g_io_channel_shutdown(input, TRUE, &myError);
-      g_io_channel_unref(input);
-
-      g_clear_error(&myError);
-
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Can not create inf."));
+      result = FALSE; //-- ERROR
+      goto CLEANUP_FILEVERIFY;
+    }
+  outf = create_file(outputFileName, "w+");
+  if (outf == NULL)
+    {
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Can not create outf."));
+      result = FALSE; //-- ERROR
+      goto CLEANUP_FILEVERIFY;
     }
 
-  GIOChannel *output = g_io_channel_new_file(outputFileName, "w+", &myError);
+  guchar keyZero[KEY_LENGTH];
+  memcpy(keyZero, mainKey, KEY_LENGTH);
 
-  if (!output)
+  // Allocate input buffer
+  inputBuffer = g_ptr_array_new_with_free_func((GDestroyNotify)SLogStringFree);
+  if (inputBuffer == NULL)
     {
-      cond_msg_error (myError, "[SLOG] ERROR: Cannot open output file");
-
-      g_clear_error(&myError);
-
-      g_io_channel_shutdown(input, TRUE, &myError);
-      g_io_channel_unref(input);
-
-      g_clear_error(&myError);
-
-
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Can not allocate inputBuffer."));
+      result = FALSE; //-- ERROR
+      goto CLEANUP_FILEVERIFY;
     }
 
-  status = g_io_channel_set_encoding(output, NULL, &myError);
-
-  if (status != G_IO_STATUS_NORMAL)
+  // Allocate output buffer
+  outputBuffer = g_ptr_array_new_with_free_func((GDestroyNotify)SLogStringFree);
+  if (outputBuffer == NULL)
     {
-      cond_msg_error (myError, "[SLOG] ERROR: Cannot set output file encoding");
-
-      g_clear_error(&myError);
-
-      g_io_channel_shutdown(input, TRUE, &myError);
-      g_io_channel_unref(input);
-
-      g_clear_error(&myError);
-
-      g_io_channel_shutdown(output, TRUE, &myError);
-      g_io_channel_unref(output);
-
-      g_clear_error(&myError);
-
-      return 0;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Can not allocate outputBuffer."));
+      result = FALSE; //-- ERROR
+      goto CLEANUP_FILEVERIFY;
     }
 
-  GString **inputBuffer = g_new0(GString *, chunkLength);
-  GString **outputBuffer = g_new0(GString *, chunkLength);
-
-  if ((outputBuffer == NULL) || (inputBuffer == NULL))
+  // Open input and output files
+  result = open_file(inf);
+  if (!result)
     {
-      msg_error("[SLOG] ERROR: [fileVerify] cannot allocate memory");
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "fileVerify, open_file(inf)"));
+      goto CLEANUP_FILEVERIFY;
+    }
 
-      g_io_channel_shutdown(input, TRUE, &myError);
-      g_io_channel_unref(input);
-
-      g_clear_error(&myError);
-
-      g_io_channel_shutdown(output, TRUE, &myError);
-      g_io_channel_unref(output);
-
-      g_clear_error(&myError);
-
-      return 0;
+  result = open_file(outf);
+  if (!result)
+    {
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "fileVerify, open_file(outf)"));
+      goto CLEANUP_FILEVERIFY;
     }
 
   guint64 nextLogEntry = 0UL;
   guint64 startingEntry = 0UL;
-  unsigned char cmac_tag[CMAC_LENGTH];
+  guchar cmac_tag[CMAC_LENGTH];
   gsize cmac_tag_capacity = G_N_ELEMENTS(cmac_tag);
   guint64 numberOfLogEntries = 0UL;
+
+  memcpy(cmac_tag, mac0, CMAC_LENGTH); //-- here the initial MAC file content is needed now
 
   if (chunkLength > entriesInFile)
     {
@@ -1712,228 +1822,196 @@ int fileVerify(unsigned char *mainKey, char *inputFileName, char *outputFileName
 
   for (guint64 i = 0; i < chunkLength; i++)
     {
-      inputBuffer[i] = g_string_new(NULL);
-      status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
-      if (status != G_IO_STATUS_NORMAL)
+      g_ptr_array_add(inputBuffer, g_string_new(NULL));
+      result = read_line_from_file(inf,  (GString *)g_ptr_array_index(inputBuffer, i));
+      if (!result)
         {
-          cond_msg_error (myError, "[SLOG] ERROR: Cannot read from input file");
-
-          g_clear_error(&myError);
-
-          g_io_channel_shutdown(input, TRUE, &myError);
-          g_io_channel_unref(input);
-
-          g_clear_error(&myError);
-
-          g_io_channel_shutdown(output, TRUE, &myError);
-          g_io_channel_unref(output);
-
-          g_clear_error(&myError);
-
-          g_free(inputBuffer);
-          g_free(outputBuffer);
-
-          return 0;
+          msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "fileVerify, read_line_from_file(inf, ...)"));
+          goto CLEANUP_FILEVERIFY;
         }
-
       // Cut last character to remove the trailing new line
-      g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
+      GString *str = (GString *)g_ptr_array_index(inputBuffer, i);
+      g_string_truncate(str, (str->len) - 1);
     }
 
-  ret = ret * initVerify(entriesInFile, mainKey, &nextLogEntry, &startingEntry, inputBuffer, &tab);
-  ret = ret * iterateBuffer(chunkLength, inputBuffer, &nextLogEntry, mainKey, keyZero, 0, outputBuffer,
-                            &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
+  if (!initVerify(entriesInFile, mainKey, &nextLogEntry, &startingEntry, inputBuffer))
+    {
+      result = FALSE;
+      g_print ("\nERROR: Function initVerify fails!\n");
+      goto CLEANUP_FILEVERIFY;
+    }
+
+  if (!iterateBuffer(chunkLength, inputBuffer, &nextLogEntry, mainKey, keyZero, 0, outputBuffer,
+                     &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab))
+    {
+      result = FALSE; //-- ERROR
+    }
 
   // Write to file
   for (guint64 i = 0; i < chunkLength; i++)
     {
-      if (outputBuffer[i]->len != 0)
+      GString *str = (GString *)g_ptr_array_index(outputBuffer, i);
+      if (NULL == str)
         {
-          gsize size;
-          //Add newline
-          g_string_append(outputBuffer[i], "\n");
-          status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
-          if (status != G_IO_STATUS_NORMAL)
+          msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "fileVerify, Invalid output buffer: NULL == str"));
+          result = FALSE; //-- ERROR
+          goto CLEANUP_FILEVERIFY;
+        }
+      if (str->len != 0)
+        {
+          // Add newline
+          g_string_append(str, "\n");
+          result = write_to_file(outf, str->str, str->len);
+          if (!result)
             {
-              cond_msg_error (myError, "[SLOG] ERROR: writing to output file");
-              g_clear_error(&myError);
-
-              g_io_channel_shutdown(input, TRUE, &myError);
-              g_io_channel_unref(input);
-
-              g_clear_error(&myError);
-
-              g_io_channel_shutdown(output, TRUE, &myError);
-              g_io_channel_unref(output);
-
-              g_clear_error(&myError);
-
-              g_free(inputBuffer);
-              g_free(outputBuffer);
-
-              return 0;
+              msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "fileVerify, write_to_file(outf, ...)"));
+              goto CLEANUP_FILEVERIFY;
             }
         }
-
-      g_string_free(outputBuffer[i], TRUE);
-      g_string_free(inputBuffer[i], TRUE);
-
     }
+  g_ptr_array_set_size(outputBuffer, 0);
+  g_ptr_array_set_size(inputBuffer, 0);
 
   // Process file in chunks
-  for (int j = 0; j < (entriesInFile / chunkLength) -1; j++)
+  for (guint64 j = 0; j < (entriesInFile / chunkLength) - 1; j++)
     {
       for (guint64 i = 0; i < chunkLength; i++)
         {
-          inputBuffer[i] = g_string_new(NULL);
-          status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
-          if (status != G_IO_STATUS_NORMAL)
+          g_ptr_array_add(inputBuffer, g_string_new(NULL));
+          result = read_line_from_file(inf,  (GString *)g_ptr_array_index(inputBuffer, i));
+
+          if (!result)
             {
-              cond_msg_error (myError, "[SLOG] ERROR: Cannot read from input file");
-              g_clear_error(&myError);
-
-              g_io_channel_shutdown(input, TRUE, &myError);
-              g_io_channel_unref(input);
-
-              g_clear_error(&myError);
-
-              g_io_channel_shutdown(output, TRUE, &myError);
-              g_io_channel_unref(output);
-
-              g_clear_error(&myError);
-
-              g_free(inputBuffer);
-              g_free(outputBuffer);
-
-              return 0;
+              msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "fileVerify, read_line_from_file(info, ...)"));
+              goto CLEANUP_FILEVERIFY;
             }
+
           // Cut last character to remove the trailing new line...
-          g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
+          GString *str = (GString *)g_ptr_array_index(inputBuffer, i);
+          g_string_truncate(str, (str->len) - 1);
         }
-      ret = ret * iterateBuffer(chunkLength, inputBuffer, &nextLogEntry, mainKey, keyZero, 0, outputBuffer,
-                                &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
+
+      if (!iterateBuffer(chunkLength, inputBuffer, &nextLogEntry, mainKey, keyZero, 0, outputBuffer,
+                         &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab))
+        {
+          result = FALSE; //-- ERROR
+        }
 
       // ...and write to file
       for (guint64 i = 0; i < chunkLength; i++)
         {
-          if (outputBuffer[i]->len != 0)
+          GString *str = (GString *)g_ptr_array_index(outputBuffer, i);
+          if (NULL == str)
             {
-              gsize size;
-              //Add newline
-              g_string_append(outputBuffer[i], "\n");
-              status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
-              if (status != G_IO_STATUS_NORMAL)
-                {
-                  cond_msg_error (myError, "[SLOG] ERROR: writing to output file");
-
-                  g_clear_error(&myError);
-
-                  g_io_channel_shutdown(input, TRUE, &myError);
-                  g_io_channel_unref(input);
-
-                  g_clear_error(&myError);
-
-                  g_io_channel_shutdown(output, TRUE, &myError);
-                  g_io_channel_unref(output);
-
-                  g_clear_error(&myError);
-
-                  g_free(inputBuffer);
-                  g_free(outputBuffer);
-
-                  return 0;
-                }
-
+              msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "fileVerify, Invalid output buffer, str == NULL"));
+              result = FALSE; //-- ERROR
+              goto CLEANUP_FILEVERIFY;
             }
-          g_string_free(outputBuffer[i], TRUE);
-          g_string_free(inputBuffer[i], TRUE);
+          if (str->len != 0)
+            {
+              // Add newline
+              g_string_append(str, "\n");
+              result = write_to_file(outf, str->str, str->len);
+              if (!result)
+                {
+                  msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "fileVerify, write_to_file(outf, ... )"));
+                  goto CLEANUP_FILEVERIFY;
+                }
+            }
         }
+      g_ptr_array_set_size(outputBuffer, 0);
+      g_ptr_array_set_size(inputBuffer, 0);
+
     }
 
   if ((entriesInFile % chunkLength) > 0)
     {
       for (guint64 i = 0; i < (entriesInFile % chunkLength); i++)
         {
-          inputBuffer[i] = g_string_new(NULL);
-          status = g_io_channel_read_line_string(input, inputBuffer[i], NULL, &myError);
-          if (status != G_IO_STATUS_NORMAL)
+          g_ptr_array_add(inputBuffer, g_string_new(NULL));
+          result = read_line_from_file(inf,  (GString *)g_ptr_array_index(inputBuffer, i));
+          if (!result)
             {
-              cond_msg_error (myError, "[SLOG] ERROR: Cannot read from input file");
-              g_clear_error(&myError);
-
-              g_io_channel_shutdown(input, TRUE, &myError);
-              g_io_channel_unref(input);
-
-              g_clear_error(&myError);
-
-              g_io_channel_shutdown(output, TRUE, &myError);
-              g_io_channel_unref(output);
-
-              g_clear_error(&myError);
-
-              g_free(inputBuffer);
-              g_free(outputBuffer);
-
-              return 0;
+              msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "fileVerify,i read_line_from_file(inf, ...)"));
+              goto CLEANUP_FILEVERIFY;
             }
           // Cut last character to remove the trailing new line
-          g_string_truncate(inputBuffer[i], (inputBuffer[i]->len) - 1);
+          GString *str = (GString *)g_ptr_array_index(inputBuffer, i);
+          g_string_truncate(str, (str->len) - 1);
         }
-      ret = ret * iterateBuffer((entriesInFile % chunkLength), inputBuffer, &nextLogEntry, mainKey, keyZero, 0, outputBuffer,
-                                &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
+
+      if (!iterateBuffer((entriesInFile % chunkLength), inputBuffer, &nextLogEntry, mainKey, keyZero, 0, outputBuffer,
+                         &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab))
+        {
+          result = FALSE; //-- ERROR
+        }
 
       for (guint64 i = 0; i < (entriesInFile % chunkLength); i++)
         {
-          if (outputBuffer[i]->len != 0)
+          GString *str = (GString *)g_ptr_array_index(outputBuffer, i);
+          if (NULL == str)
             {
-
-              gsize size;
-              //Add newline
-              g_string_append(outputBuffer[i], "\n");
-              status = g_io_channel_write_chars(output, (outputBuffer[i])->str, (outputBuffer[i])->len, &size, &myError);
-              if (status != G_IO_STATUS_NORMAL)
+              msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "fileVerify, Invalid output buffer, NULL == str"));
+              result = FALSE; //-- ERROR
+              goto CLEANUP_FILEVERIFY;
+            }
+          if (str->len != 0)
+            {
+              // Add newline
+              g_string_append(str, "\n");
+              result = write_to_file(outf, str->str, str->len);
+              if (!result)
                 {
-                  cond_msg_error (myError, "[SLOG] ERROR: Cannot write to output file");
-                  g_clear_error(&myError);
-
-                  g_io_channel_shutdown(input, TRUE, &myError);
-                  g_io_channel_unref(input);
-
-                  g_clear_error(&myError);
-
-                  g_io_channel_shutdown(output, TRUE, &myError);
-                  g_io_channel_unref(output);
-
-                  g_clear_error(&myError);
-
-                  g_free(inputBuffer);
-                  g_free(outputBuffer);
-
-                  return 0;
+                  msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "fileVerify, write_to_file(outf, ...)"));
+                  goto CLEANUP_FILEVERIFY;
                 }
             }
-          g_string_free(outputBuffer[i], TRUE);
-          g_string_free(inputBuffer[i], TRUE);
         }
+    }
+  g_ptr_array_set_size(outputBuffer, 0);
+  g_ptr_array_set_size(inputBuffer, 0);
 
+  if (!finalizeVerify(startingEntry, entriesInFile, aggMAC, cmac_tag, &tab))
+    {
+      result = FALSE;
     }
 
-  ret = ret * finalizeVerify(startingEntry, entriesInFile, bigMac, cmac_tag, tab);
+CLEANUP_FILEVERIFY:
 
-  g_free(inputBuffer);
-  g_free(outputBuffer);
+  if (tab != NULL)
+    {
+      g_hash_table_destroy(tab);
+      tab = NULL;
+    }
 
-  g_io_channel_shutdown(input, TRUE, &myError);
-  g_io_channel_unref(input);
+  //-- Release memory
+  if (NULL != outputBuffer)
+    {
+      g_ptr_array_free(outputBuffer, TRUE);
+      outputBuffer = NULL;
+    }
 
-  g_clear_error(&myError);
+  if (NULL != inputBuffer)
+    {
+      g_ptr_array_free(inputBuffer, TRUE);
+      inputBuffer = NULL;
+    }
 
-  g_io_channel_shutdown(output, TRUE, &myError);
-  g_io_channel_unref(output);
+  if (NULL != outf)
+    {
+      (void) close_file(outf);
+      g_free(outf);
+      outf = NULL;
+    }
 
-  g_clear_error(&myError);
+  if (NULL != inf)
+    {
+      (void) close_file(inf);
+      g_free(inf);
+      inf = NULL;
+    }
 
-  return ret;
+  return result;
 }
 
 // Print usage message and clean up
@@ -1944,10 +2022,15 @@ int slog_usage(GOptionContext *ctx, GOptionGroup *grp, GString *errormsg)
       g_print ("\nERROR: %s\n\n", errormsg->str);
       g_string_free(errormsg, TRUE);
     }
-
-  g_print("%s", g_option_context_get_help(ctx, TRUE, NULL));
-  g_option_context_free(ctx);
-
+  if (NULL != ctx)
+    {
+      g_print("%s", g_option_context_get_help(ctx, TRUE, NULL));
+      g_option_context_free(ctx);
+    }
+  else
+    {
+      g_print ("\nERROR: invalid context in slog_usage!\n");
+    }
   return 1;
 }
 
@@ -2000,3 +2083,421 @@ gboolean validFileNameArg(const gchar *option_name, const gchar *value, gpointer
 
   return isValid;
 }
+
+
+
+/*
+ * Callback function to check whether a command line argument provides a valid directory with given full file name
+ *
+ * Return:
+ * TRUE on success
+ * FALSE on error
+ */
+gboolean validFileNameArgCheckDirOnly(const gchar *option_name, const gchar *value, gpointer data, GError **error)
+{
+  gboolean isValid = FALSE;
+  GString *currentOption = g_string_new(option_name);
+  GString *currentValue = g_string_new(value);
+  GString *longOption = g_string_new(LONG_OPT_INDICATOR);
+  GString *shortOption = g_string_new(SHORT_OPT_INDICATOR);
+
+  SLogOptions *opts = (SLogOptions *)data;
+
+  for (SLogOptions *option = opts; option != NULL && option->longname != NULL; option++)
+    {
+      g_string_append(longOption, option->longname);
+      g_string_append_c(shortOption, option->shortname);
+
+      if (g_string_equal(currentOption, longOption) || g_string_equal(currentOption, shortOption))
+        {
+          if (g_file_test(value, G_FILE_TEST_IS_REGULAR))
+            {
+              option->arg = currentValue->str;
+              isValid = TRUE;
+              break;
+            }
+
+          // If isValid is still FALSE check whether directory exits.
+          // This is usefull when a file shall be created, e.g. in case of mac dat
+          gchar *dirname = g_path_get_dirname(value);
+          if (NULL != dirname)
+            {
+              if (g_file_test(dirname, G_FILE_TEST_IS_DIR))
+                {
+                  option->arg = currentValue->str;
+                  isValid = TRUE;
+                  g_print("directory exits: %s\n", dirname);
+                  g_free (dirname);
+                  dirname = NULL;
+                  break;
+                }
+            }
+          g_free (dirname);
+
+        }
+
+      // Reset for next option argument to check
+      g_string_assign(longOption, LONG_OPT_INDICATOR);
+      g_string_assign(shortOption, SHORT_OPT_INDICATOR);
+    }
+
+  if (!isValid)
+    {
+      *error = g_error_new(G_FILE_ERROR, G_OPTION_ERROR_FAILED, "Invalid path or non existing regular file: %s", value);
+    }
+
+  g_string_free(currentOption, TRUE);
+  g_string_free(currentValue, FALSE);
+  g_string_free(longOption, TRUE);
+  g_string_free(shortOption, TRUE);
+
+  return isValid;
+}
+
+
+// Retrieve counter from encrypted log entry
+gboolean getCounter(GString *entry, guint64 *logEntryOnDisk)
+{
+  if (G_UNLIKELY(!entry || !logEntryOnDisk || entry->len < COUNTER_LENGTH))
+    {
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Insufficient data"));
+      return FALSE;
+    }
+  // Allocate the decode buffer on the stack to avoid heap allocation entirely.
+  guchar decoded_buffer[16];
+  gint state = 0;
+  guint save = 0;
+  gsize out_len = g_base64_decode_step(entry->str, COUNTER_LENGTH, decoded_buffer, &state, &save);
+  if (G_UNLIKELY(out_len != sizeof(guint64)))
+    {
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Base64 decode length mismatch"));
+      return FALSE;
+    }
+  // Extract the value directly from the stack buffer.
+  guint64 raw_val;
+  memcpy(&raw_val, decoded_buffer, sizeof(guint64));
+  *logEntryOnDisk = GUINT64_FROM_LE(raw_val);
+  return TRUE;
+}
+
+
+// Check whether value is contained in table
+gboolean tableContainsKey(GHashTable *table, guint64 key)
+{
+  if (table == NULL)
+    {
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("File: ", __FILE__),
+                evt_tag_long("Line: ", __LINE__),
+                evt_tag_long("Code: ", SLOG_MEM_ALLOC_ERROR),
+                evt_tag_str("Reason: ", "Table == NULL")
+               );
+      return FALSE;
+    }
+
+  // Convert to string
+  char keystr[CTR_LEN_SIMPLE + 1];
+  snprintf(keystr, CTR_LEN_SIMPLE + 1, "%"G_GUINT64_FORMAT, key);
+
+  return g_hash_table_contains(table, keystr);
+}
+
+// Add new value to table
+gboolean addValueToTable(GHashTable *table, guint64 value)
+{
+  if (G_UNLIKELY(table == NULL))
+    {
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("File: ", __FILE__),
+                evt_tag_long("Line: ", __LINE__),
+                evt_tag_long("Code: ", SLOG_MEM_ALLOC_ERROR),
+                evt_tag_str("Reason: ", "Table == NULL")
+               );
+      return FALSE;
+    }
+  //-- Create new key to string and use value as key
+  char *key = g_strdup_printf("%" G_GUINT64_FORMAT, value);
+  return g_hash_table_insert(table, key, GUINT_TO_POINTER(value));
+}
+
+// Get a single line from a log file
+GString *getLogEntry(SLogFile *f)
+{
+  GString *line = g_string_new(NULL);
+
+  if (!read_line_from_file(f, line))
+    {
+      g_string_free(line, TRUE);
+      line = NULL;
+    }
+  else
+    {
+      // Cut last character to remove the trailing new line...
+      g_string_truncate(line, line->len - 1);
+    }
+
+  return line;
+}
+
+// Put a single line into a log file
+gboolean putLogEntry(SLogFile *f, GString *line)
+{
+  if (line == NULL)
+    {
+      return FALSE;
+    }
+
+  if (line->len != 0)
+    {
+      // Add newline
+      g_string_append(line, "\n");
+    }
+
+  return write_to_file(f, line->str, line->len);
+}
+
+// Clean up routine for GPtrArray
+void SLogStringFree(gpointer *arg)
+{
+  (void) g_string_free((GString *)arg, TRUE);
+}
+
+
+//----------------------------------------------------------------------
+// truncate_uft8_gstring
+//
+// Ensures that when a log string must be truncated, no invalid
+// UTF-8 characters is created.
+// Also ensured: When truncation takes place, a '\n' character is added
+// at the new end of the string.
+//
+// in/out gslog: GString to be truncated in a valid way
+// in max_octet_len: Maximal allowed count of octets in gslog
+// return -
+
+void truncate_utf8_gstring(GString *gslog, gsize max_octet_len)
+{
+  if (NULL == gslog)
+    {
+      return;
+    }
+  if (gslog->len <= max_octet_len)
+    {
+      return;
+    }
+  if (0 == max_octet_len)
+    {
+      g_string_truncate(gslog, 0);
+      return;
+    }
+  gsize max_text_len = max_octet_len - 1; //-- reserve one byte for '\n'
+  gsize new_len = max_text_len;
+  //--Walk backwards to find a valid UTF-8 character / Symbol (Emoij) boundary.
+  while (new_len > 0 && (gslog->str[new_len] & 0xC0) == 0x80)
+    {
+      new_len--;
+    }
+  g_string_truncate(gslog, new_len);
+  g_string_append_c(gslog, '\n');
+}
+
+SLogFile *create_file(const gchar *filename, const gchar *mode)
+{
+  SLogFile *f = g_new0(SLogFile, 1);
+
+  if (f == NULL)
+    {
+      return NULL;
+    }
+
+  f->filename = filename;
+  f->channel = NULL;
+  f->mode = mode;
+  f->status = G_IO_STATUS_NORMAL;
+  f->error = NULL;
+  f->message = g_string_new(SLOG_INFO_PREFIX);
+  f->state = SLOG_FILE_READY;
+  return f;
+}
+
+gboolean open_file(SLogFile *f)
+{
+  if (f == NULL || f->state != SLOG_FILE_READY)
+    {
+      return FALSE;
+    }
+
+  gboolean result = TRUE;
+  gboolean found = FALSE;
+  for (int i = 0; i < NUM_MODES; i++)
+    {
+      if (strncmp(modes[i], f->mode, LEN_MODES) == 0)
+        {
+          found = TRUE;
+          break;
+        }
+    }
+
+  if (!found)
+    {
+      g_set_error (&f->error,
+                   SLOG_FILE_DOMAIN,          // Error domain
+                   SLOG_FILE_INVALID_MODE,    // Error code
+                   "Invalid mode: %s",        // Error message format string
+                   f->mode);
+      f->status = G_IO_STATUS_ERROR;
+      f->state = SLOG_FILE_INVALID_MODE;
+    }
+  else
+    {
+      f->channel = g_io_channel_new_file(f->filename, f->mode, &f->error);
+      if (!f->channel)
+        {
+          f->status = G_IO_STATUS_ERROR;
+          f->state = SLOG_FILE_GENERAL_ERROR;
+        }
+      else
+        {
+          f->status = g_io_channel_set_encoding(f->channel, NULL, &f->error); // NULL means encoding for binary data
+        }
+    }
+
+  // Assemble status message
+  if (f->status != G_IO_STATUS_NORMAL)
+    {
+      switch (f->status)
+        {
+        case G_IO_STATUS_ERROR:
+          g_string_assign(f->message, "G_IO_STATUS_ERROR -");
+          f->state = SLOG_FILE_GENERAL_ERROR;
+          break;
+        case G_IO_STATUS_EOF:
+          g_string_assign(f->message, "G_IO_STATUS_EOF -");
+          f->state = SLOG_FILE_EOF;
+          break;
+        case G_IO_STATUS_AGAIN:
+          g_string_assign(f->message, "G_IO_STATUS_AGAIN -");
+          f->state = SLOG_FILE_RESOURCE_UNAVAILABLE;
+          break;
+        default:
+          break;
+        }
+      result = FALSE;
+    }
+  else
+    {
+      g_string_append_printf(f->message, "File: %s, Mode: %s, Status: G_IO_STATUS_NORMAL (%d)",
+                             f->filename, f->mode, f->status);
+      f->state = SLOG_FILE_OPEN;
+    }
+
+  if (f->error != NULL)
+    {
+      g_string_append_printf(f->message, " %s %s", f->error->message, f->filename);
+      g_clear_error(&f->error);
+    }
+
+  return result;
+}
+
+gboolean write_to_file(SLogFile *f, const gchar *data, gsize len)
+{
+  // File must be open
+  if (f == NULL || f->state != SLOG_FILE_OPEN)
+    {
+      return FALSE;
+    }
+  gsize chars_written = 0;
+  f->status = g_io_channel_write_chars(f->channel, data, len, &chars_written, &f->error);
+  gboolean result = f->status == G_IO_STATUS_NORMAL;
+  if (chars_written != len)
+    {
+      g_string_assign(f->message, SLOG_ERROR_PREFIX);
+      g_string_append_printf(f->message,
+                             "File: %s, Mode: %s, Only %zu bytes written. Expected %zu bytes",
+                             f->filename,
+                             f->mode,
+                             chars_written,
+                             len);
+      result = FALSE;
+      f->state = SLOG_FILE_INCOMPLETE_WRITE;
+    }
+  return result;
+}
+
+gboolean read_from_file(SLogFile *f, gchar *data, gsize len)
+{
+  // File must be open
+  if (f == NULL || f->state != SLOG_FILE_OPEN)
+    {
+      return FALSE;
+    }
+  gsize chars_read = 0;
+  f->status = g_io_channel_read_chars(f->channel, data, len, &chars_read, &f->error);
+  gboolean result = f->status == G_IO_STATUS_NORMAL;
+  if (chars_read != len)
+    {
+      g_string_assign(f->message, SLOG_ERROR_PREFIX);
+      g_string_append_printf(f->message,
+                             "File: %s, Mode: %s -> Only %zu bytes read. Expected %zu bytes",
+                             f->filename,
+                             f->mode,
+                             chars_read,
+                             len);
+      result = FALSE;
+      f->state = SLOG_FILE_INCOMPLETE_READ;
+    }
+  return result;
+}
+
+gboolean read_line_from_file(SLogFile *f, GString *line)
+{
+  // File must be open
+  if (f == NULL || f->state != SLOG_FILE_OPEN)
+    {
+      return FALSE;
+    }
+  f->status =  g_io_channel_read_line_string(f->channel, line, NULL, &f->error);
+  gboolean result = f->status == G_IO_STATUS_NORMAL;
+  return result;
+}
+
+gboolean close_channel(SLogFile *f)
+{
+  if (NULL == f)
+    {
+      return FALSE;
+    }
+  if (NULL == f->channel)
+    {
+      f->state = SLOG_FILE_GENERAL_ERROR;
+      return FALSE;
+    }
+  // TRUE means flush the channel
+  f->status = g_io_channel_shutdown(f->channel, TRUE, &f->error);
+  g_io_channel_unref(f->channel);
+  f->channel = NULL;
+  if (f->status != G_IO_STATUS_NORMAL)
+    {
+      f->state = SLOG_FILE_SHUTDOWN_ERROR;
+      return FALSE;
+    }
+  else
+    {
+      f->state = SLOG_FILE_CLOSED;
+      return TRUE;
+    }
+}
+
+gboolean close_file(SLogFile *f)
+{
+  if (f == NULL)
+    {
+      return FALSE;
+    }
+  gboolean result = close_channel(f);
+  // Release resources
+  g_string_free(f->message, TRUE);
+  return result;
+}
+

--- a/modules/secure-logging/slog.c
+++ b/modules/secure-logging/slog.c
@@ -186,7 +186,7 @@ gboolean get_path_mac0(const gchar *pathAggMac, gchar *pathMac0, size_t sizePath
             }
           else
             {
-              msg_warning(SLOG_WARNING_PREFIX, evt_tag_str("Reason", "Destination buffer too small for path"));
+              msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Destination buffer too small for path"));
             }
           g_free(full_path);
         }
@@ -562,7 +562,6 @@ gboolean cmac(guchar *key, const void *input,
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 
   EVP_MAC *mac = EVP_MAC_fetch(NULL, "CMAC", NULL);
-  EVP_MAC_CTX *ctx = NULL;
   if (mac == NULL)
     {
       msg_error(SLOG_ERROR_PREFIX,
@@ -580,7 +579,7 @@ gboolean cmac(guchar *key, const void *input,
     OSSL_PARAM_END,
   };
 
-  ctx = EVP_MAC_CTX_new(mac);
+  EVP_MAC_CTX *ctx = EVP_MAC_CTX_new(mac);
   if (ctx == NULL)
     {
       msg_error(SLOG_ERROR_PREFIX,
@@ -1014,18 +1013,23 @@ gboolean readAggregatedMAC(gchar *filename, guchar *outputBuffer)
       cmacOk = FALSE;
     }
 
-  if (0 != memcmp(testOutput, &macdata[CMAC_LENGTH], CMAC_LENGTH))
+  if (TRUE == cmacOk)
     {
-      msg_warning(SLOG_WARNING_PREFIX, evt_tag_str("Reason", "MAC computation invalid"));
-      cmacOk = FALSE;
-    }
-  else
-    {
-      msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "MAC successfully loaded"));
+      if (0 != memcmp(testOutput, &macdata[CMAC_LENGTH], CMAC_LENGTH))
+        {
+          msg_warning(SLOG_WARNING_PREFIX, evt_tag_str("Reason", "MAC computation invalid"));
+          cmacOk = FALSE;
+        }
+      else
+        {
+          msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "MAC successfully loaded"));
+        }
     }
 
-  memcpy(outputBuffer, macdata, CMAC_LENGTH);
-
+  if (TRUE == cmacOk)
+    {
+      memcpy(outputBuffer, macdata, CMAC_LENGTH);
+    }
   result = close_file(f);
   if (!result)
     {
@@ -1103,14 +1107,21 @@ gboolean readKey(guchar *destKey, guint64 *destCounter, gchar *keypath)
       cmacOk = FALSE;
     }
 
-  if (0 != memcmp(testOutput, &keydata[KEY_LENGTH], CMAC_LENGTH))
+  if (TRUE == cmacOk)
     {
-      msg_warning(SLOG_WARNING_PREFIX, evt_tag_str("Reason", "Host key corrupted. CMAC in key file not matching"));
-      result = FALSE;
+      if (0 != memcmp(testOutput, &keydata[KEY_LENGTH], CMAC_LENGTH))
+        {
+          msg_warning(SLOG_WARNING_PREFIX, evt_tag_str("Reason", "Host key corrupted. CMAC in key file not matching"));
+          result = FALSE;
+        }
     }
 
-  memcpy(destKey, keydata, KEY_LENGTH);
-  *destCounter = GUINT64_FROM_LE(littleEndianCounter);
+  if (TRUE == cmacOk)
+    {
+      memcpy(destKey, keydata, KEY_LENGTH);
+      *destCounter = GUINT64_FROM_LE(littleEndianCounter);
+    }
+
   result = close_file(f);
   if (!result)
     {
@@ -1188,8 +1199,7 @@ gboolean writeKey(guchar *key, guint64 counter, gchar *keypath)
     }
 
 CLEANUP_WRITEKEY:
-  gboolean result2 = close_file(f);
-  if (!result2)
+  if (!close_file(f))
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error close_file"));
       result = FALSE; //-- ERROR

--- a/modules/secure-logging/slog.c
+++ b/modules/secure-logging/slog.c
@@ -42,16 +42,11 @@
 #endif
 
 #include "messages.h"
-
 #include "slog.h"
 
 // Argument indicators for command line utilities
 #define LONG_OPT_INDICATOR "--"
 #define SHORT_OPT_INDICATOR "-"
-
-/* static guchar KEYPATTERN[AES_BLOCKSIZE] = { [0 ... (AES_BLOCKSIZE - 1) ] = IPAD }; */
-/* static guchar MACPATTERN[AES_BLOCKSIZE] = { [0 ... (AES_BLOCKSIZE - 1) ] = OPAD }; */
-/* static guchar GAMMA[AES_BLOCKSIZE] = { [0 ... (AES_BLOCKSIZE - 1) ] =  EPAD}; */
 
 SLOG_STATIC_ASSERT(AES_BLOCKSIZE == 16, "Wrong_AES_Block_Size_for_provided_KEY_MAC_GAMMA_initialization");
 
@@ -61,9 +56,6 @@ SLOG_STATIC_ASSERT(AES_BLOCKSIZE == 16, "Wrong_AES_Block_Size_for_provided_KEY_M
 static guchar KEYPATTERN[AES_BLOCKSIZE] = { FILL_S16(IPAD) };
 static guchar MACPATTERN[AES_BLOCKSIZE] = { FILL_S16(OPAD) };
 static guchar GAMMA_SL[AES_BLOCKSIZE] = { FILL_S16(EPAD) };
-
-
-
 
 // File access modes
 static const char modes[NUM_MODES][LEN_MODES] = { "r", "r+", "w", "w+", "a", "a+" };

--- a/modules/secure-logging/slog.c
+++ b/modules/secure-logging/slog.c
@@ -49,19 +49,21 @@
 #define LONG_OPT_INDICATOR "--"
 #define SHORT_OPT_INDICATOR "-"
 
-// This initialization works for C99 or newer and it might not
-// be supported by all compilers!
-//
-// Tested successfully with
-// gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-11)
-// clang version 20.1.8 (RESF 20.1.8-3.el9)
-// and
-// gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
-// Ubuntu clang version 18.1.3 (1ubuntu1)
-//
-static guchar KEYPATTERN[AES_BLOCKSIZE] = { [0 ... (AES_BLOCKSIZE - 1) ] = IPAD };
-static guchar MACPATTERN[AES_BLOCKSIZE] = { [0 ... (AES_BLOCKSIZE - 1) ] = OPAD };
-static guchar GAMMA[AES_BLOCKSIZE] = { [0 ... (AES_BLOCKSIZE - 1) ] =  EPAD};
+/* static guchar KEYPATTERN[AES_BLOCKSIZE] = { [0 ... (AES_BLOCKSIZE - 1) ] = IPAD }; */
+/* static guchar MACPATTERN[AES_BLOCKSIZE] = { [0 ... (AES_BLOCKSIZE - 1) ] = OPAD }; */
+/* static guchar GAMMA[AES_BLOCKSIZE] = { [0 ... (AES_BLOCKSIZE - 1) ] =  EPAD}; */
+
+SLOG_STATIC_ASSERT(AES_BLOCKSIZE == 16, "Wrong_AES_Block_Size_for_provided_KEY_MAC_GAMMA_initialization");
+
+#define FILL_S16(val) val, val, val, val, val, val, val, val, \
+                      val, val, val, val, val, val, val, val
+
+static guchar KEYPATTERN[AES_BLOCKSIZE] = { FILL_S16(IPAD) };
+static guchar MACPATTERN[AES_BLOCKSIZE] = { FILL_S16(OPAD) };
+static guchar GAMMA_SL[AES_BLOCKSIZE] = { FILL_S16(EPAD) };
+
+
+
 
 // File access modes
 static const char modes[NUM_MODES][LEN_MODES] = { "r", "r+", "w", "w+", "a", "a+" };
@@ -410,6 +412,7 @@ CLEANUP_SLOGDECRYPT:
   return result;
 }
 
+
 /*
  *  Create new forward-secure log entry
  *
@@ -724,7 +727,7 @@ CLEANUP_CMAC:
 gboolean evolveKey(guchar *key)
 {
   guchar buf[KEY_LENGTH];
-  if (PRF(key, GAMMA, sizeof(GAMMA), buf, KEY_LENGTH))
+  if (PRF(key, GAMMA_SL, sizeof(GAMMA_SL), buf, KEY_LENGTH))
     {
       memcpy(key, buf, KEY_LENGTH);
       return TRUE;
@@ -2327,7 +2330,7 @@ void truncate_utf8_gstring(GString *gslog, gsize max_octet_len)
 // is_file_path_safe_and_valid
 //
 // Checks wether a file path argument is safe and valid.
-// It does NOT check if the file exists.
+// It does NOT check if the file exists and it SHALL NOT check.
 // Only the existens of extracted directory is verified because the file
 // might be created.
 //
@@ -2336,29 +2339,45 @@ void truncate_utf8_gstring(GString *gslog, gsize max_octet_len)
 
 gboolean is_file_path_safe_and_valid(const gchar *input_path)
 {
-  if (input_path == NULL || *input_path == '\0') return FALSE;
-  g_autofree gchar *safe_path = g_strndup(input_path, PATH_MAX - 1);
-  g_autofree gchar *dir_name = g_path_get_dirname(safe_path);
-  g_autofree gchar *base_name = g_path_get_basename(safe_path);
+  gboolean retval = FALSE;
+  gchar *safe_path = NULL;
+  gchar *dir_name = NULL;
+  gchar *base_name = NULL;
+
+  if (input_path == NULL || *input_path == '\0')
+    {
+      return FALSE;
+    }
+  safe_path = g_strndup(input_path, PATH_MAX - 1);
+  dir_name = g_path_get_dirname(safe_path);
+  base_name = g_path_get_basename(safe_path);
+
   if (!g_file_test(dir_name, G_FILE_TEST_IS_DIR))
     {
       g_warning("Parent directory does not exist or is inaccessible: %s", dir_name);
-      return FALSE;
+      goto CLEANUP_IFPSAV;
     }
+
   if (g_strcmp0(base_name, ".") == 0 || g_strcmp0(base_name, "..") == 0)
     {
       g_warning("Invalid filename: %s", base_name);
-      return FALSE;
+      goto CLEANUP_IFPSAV;
     }
+
   if (access(dir_name, W_OK | X_OK) != 0)
     {
       g_warning("No write permissions in directory: %s", dir_name);
-      return FALSE;
+      goto CLEANUP_IFPSAV;
     }
-  return TRUE;
+
+  retval = TRUE;
+
+CLEANUP_IFPSAV:
+  g_free(safe_path);
+  g_free(dir_name);
+  g_free(base_name);
+  return retval;
 }
-
-
 
 SLogFile *create_file(const gchar *filename, const gchar *mode)
 {

--- a/modules/secure-logging/slog.c
+++ b/modules/secure-logging/slog.c
@@ -1116,7 +1116,6 @@ gboolean readKey(guchar *destKey, guint64 *destCounter, gchar *keypath)
 gboolean writeKey(guchar *key, guint64 counter, gchar *keypath)
 {
   SLogFile *f = create_file(keypath, "w+");
-
   if (f == NULL)
     {
       return FALSE; //-- ERROR
@@ -1138,9 +1137,7 @@ gboolean writeKey(guchar *key, guint64 counter, gchar *keypath)
   if (!result)
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error key write_to_file"));
-      (void) close_file(f);
-      g_free(f);
-      return FALSE; //-- ERROR
+      goto CLEANUP_WRITEKEY; //-- ERROR
     }
 
   guint64 littleEndianCounter = GINT64_TO_LE(counter);
@@ -1157,6 +1154,7 @@ gboolean writeKey(guchar *key, guint64 counter, gchar *keypath)
                 evt_tag_long("Line: ", __LINE__),
                 evt_tag_str("Reason", "Bad CMAC"));
       cmacOk = FALSE;
+      goto CLEANUP_WRITEKEY; //-- ERROR
     }
 
   // Write CMAC
@@ -1164,9 +1162,7 @@ gboolean writeKey(guchar *key, guint64 counter, gchar *keypath)
   if (!result)
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error MAC write_to_file"));
-      (void) close_file(f);
-      g_free(f);
-      return FALSE; //-- ERROR
+      goto CLEANUP_WRITEKEY; //-- ERROR
     }
 
   // Write counter
@@ -1174,15 +1170,15 @@ gboolean writeKey(guchar *key, guint64 counter, gchar *keypath)
   if (!result)
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error littleEndianCounter write_to_file"));
-      (void) close_file(f);
-      g_free(f);
-      return FALSE; //-- ERROR
+      goto CLEANUP_WRITEKEY; //-- ERROR
     }
 
-  result = close_file(f);
-  if (!result)
+CLEANUP_WRITEKEY:
+  gboolean result2 = close_file(f);
+  if (!result2)
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error close_file"));
+      result = FALSE; //-- ERROR
     }
   g_free(f);
   return result && cmacOk;
@@ -2131,9 +2127,8 @@ gboolean validFileNameArgCheckDirOnly(const gchar *option_name, const gchar *val
                   dirname = NULL;
                   break;
                 }
+              g_free (dirname);
             }
-          g_free (dirname);
-
         }
 
       // Reset for next option argument to check

--- a/modules/secure-logging/slog.c
+++ b/modules/secure-logging/slog.c
@@ -785,14 +785,14 @@ gboolean PRF(guchar *key, guchar *originalInput,
   size_t output_len = sizeof(outputLength);
   size_t gsize_len = sizeof(gsize);
 
-  //-- content:  i || Label || 00 || Context || outputLength;
+  //-- content:  i || Label || 00 || Context || outputLength
   gsize myInputLength = gsize_len + label_len + 1 + context_len + output_len;
 
   guchar *input = g_new0(guchar, myInputLength);
 
   for (gsize i = 0 ; i < n ; i++)
     {
-      //-- content of input:  i || Label || 00 || Context || outputLength;
+      //-- content of input:  i || Label || 00 || Context || outputLength
       memcpy(input, &i, gsize_len);
       memcpy(input + gsize_len, label, label_len);
       input[gsize_len + label_len] = 0;

--- a/modules/secure-logging/slog.c
+++ b/modules/secure-logging/slog.c
@@ -47,7 +47,16 @@
 #define LONG_OPT_INDICATOR "--"
 #define SHORT_OPT_INDICATOR "-"
 
-// This initialization only works with GCC.
+// This initialization works for C99 or newer and it might not
+// be supported by all compilers!
+//
+// Tested successfully with
+// gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-11)
+// clang version 20.1.8 (RESF 20.1.8-3.el9)
+// and
+// gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0
+// Ubuntu clang version 18.1.3 (1ubuntu1)
+//
 static guchar KEYPATTERN[AES_BLOCKSIZE] = { [0 ... (AES_BLOCKSIZE - 1) ] = IPAD };
 static guchar MACPATTERN[AES_BLOCKSIZE] = { [0 ... (AES_BLOCKSIZE - 1) ] = OPAD };
 static guchar GAMMA[AES_BLOCKSIZE] = { [0 ... (AES_BLOCKSIZE - 1) ] =  EPAD};
@@ -776,7 +785,7 @@ gboolean PRF(guchar *key, guchar *originalInput,
   size_t gsize_len = sizeof(gsize);
 
   // i || Label || 00 || Context || outputLength;
-  gsize myInputLength = sizeof(gsize) + label_len + 1 + context_len + output_len;
+  gsize myInputLength = gsize_len + label_len + 1 + context_len + output_len;
 
   guchar *input = g_new0(guchar, myInputLength);
 
@@ -918,14 +927,17 @@ gboolean writeAggregatedMAC(gchar *filename, guchar *outputBuffer)
       cmacOk = FALSE;
     }
 
-  // Write new aggregated MAC to file
-  result = write_to_file(f, outputmacdata, CMAC_LENGTH);
-  if (!result)
+  if (TRUE == cmacOk)
     {
-      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error new MAC write_to_file"));
-      (void) close_file(f);
-      g_free(f);
-      return FALSE; //-- ERROR
+      // Write new aggregated MAC to file
+      result = write_to_file(f, outputmacdata, CMAC_LENGTH);
+      if (!result)
+        {
+          msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Error new MAC write_to_file"));
+          (void) close_file(f);
+          g_free(f);
+          return FALSE; //-- ERROR
+        }
     }
 
   result = close_file(f);

--- a/modules/secure-logging/slog.c
+++ b/modules/secure-logging/slog.c
@@ -27,6 +27,8 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
+#include <locale.h>
 
 #include <openssl/cmac.h>
 #include <openssl/rand.h>
@@ -146,11 +148,11 @@ gboolean create_initial_mac0(guchar mainKey[KEY_LENGTH], guchar mac[CMAC_LENGTH]
 }
 
 
-
 /**
- * Gets the path to mac0.dat based on the directory of pathAggMac.
+ * Gets the path for MAC0 based on pathAggMac.
  * Returns TRUE on success, FALSE otherwise.
  */
+
 gboolean get_path_mac0(const gchar *pathAggMac, gchar *pathMac0, size_t sizePathMac0)
 {
   gboolean retval = FALSE;

--- a/modules/secure-logging/slog.c
+++ b/modules/secure-logging/slog.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025 Airbus Commercial Aircraft
+ * Copyright (c) 2019-2026 Airbus Commercial Aircraft
  * Copyright (c) 2024 Gergo Ferenc Kovacs
  *
  * This library is free software; you can redistribute it and/or
@@ -24,6 +24,8 @@
 
 #include <glib.h>
 
+#include <limits.h>
+#include <errno.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
@@ -2319,6 +2321,44 @@ void truncate_utf8_gstring(GString *gslog, gsize max_octet_len)
   g_string_truncate(gslog, new_len);
   g_string_append_c(gslog, '\n');
 }
+
+
+//----------------------------------------------------------------------
+// is_file_path_safe_and_valid
+//
+// Checks wether a file path argument is safe and valid.
+// It does NOT check if the file exists.
+// Only the existens of extracted directory is verified because the file
+// might be created.
+//
+// in input_path: zero terminated path string
+// return TRUE when valid and usable else FALSE
+
+gboolean is_file_path_safe_and_valid(const gchar *input_path)
+{
+  if (input_path == NULL || *input_path == '\0') return FALSE;
+  g_autofree gchar *safe_path = g_strndup(input_path, PATH_MAX - 1);
+  g_autofree gchar *dir_name = g_path_get_dirname(safe_path);
+  g_autofree gchar *base_name = g_path_get_basename(safe_path);
+  if (!g_file_test(dir_name, G_FILE_TEST_IS_DIR))
+    {
+      g_warning("Parent directory does not exist or is inaccessible: %s", dir_name);
+      return FALSE;
+    }
+  if (g_strcmp0(base_name, ".") == 0 || g_strcmp0(base_name, "..") == 0)
+    {
+      g_warning("Invalid filename: %s", base_name);
+      return FALSE;
+    }
+  if (access(dir_name, W_OK | X_OK) != 0)
+    {
+      g_warning("No write permissions in directory: %s", dir_name);
+      return FALSE;
+    }
+  return TRUE;
+}
+
+
 
 SLogFile *create_file(const gchar *filename, const gchar *mode)
 {

--- a/modules/secure-logging/slog.c
+++ b/modules/secure-logging/slog.c
@@ -783,14 +783,14 @@ gboolean PRF(guchar *key, guchar *originalInput,
   size_t output_len = sizeof(outputLength);
   size_t gsize_len = sizeof(gsize);
 
-  // i || Label || 00 || Context || outputLength;
+  //-- content:  i || Label || 00 || Context || outputLength;
   gsize myInputLength = gsize_len + label_len + 1 + context_len + output_len;
 
   guchar *input = g_new0(guchar, myInputLength);
 
   for (gsize i = 0 ; i < n ; i++)
     {
-      // input = i || Label || 00 || Context || outputLength;
+      //-- content of input:  i || Label || 00 || Context || outputLength;
       memcpy(input, &i, gsize_len);
       memcpy(input + gsize_len, label, label_len);
       input[gsize_len + label_len] = 0;

--- a/modules/secure-logging/slog.h
+++ b/modules/secure-logging/slog.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Airbus Commercial Aircraft
+ * Copyright (c) 2019-2025 Airbus Commercial Aircraft
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -24,6 +24,36 @@
 #ifndef SLOG_H_INCLUDED
 #define SLOG_H_INCLUDED 1
 
+//-- logging
+#define SLOG_INFO_PREFIX "[SLOG] INFO"
+#define SLOG_WARNING_PREFIX "[SLOG] WARNING"
+#define SLOG_ERROR_PREFIX "[SLOG] ERROR"
+
+//-- errors
+#define SLOG_MEM_ALLOC_ERROR 3000
+#define SLOG_OPENSSL_LIBRARY_ERROR 4000
+
+//-- file handling
+#define NUM_MODES 6
+#define LEN_MODES 2
+#define SLOG_FILE_DOMAIN 100
+#define SLOG_FILE_READY 1000
+#define SLOG_FILE_OPEN 1001
+#define SLOG_FILE_CLOSED 1002
+#define SLOG_FILE_GENERAL_ERROR 2000
+#define SLOG_FILE_INVALID_MODE 2001
+#define SLOG_FILE_EOF 2002
+#define SLOG_FILE_RESOURCE_UNAVAILABLE 2003
+#define SLOG_FILE_INCOMPLETE_READ 2004
+#define SLOG_FILE_INCOMPLETE_WRITE 2005
+#define SLOG_FILE_SHUTDOWN_ERROR 2006
+
+//-- 2025-10-20, The code is designed to work with any length of log line.
+//   For security reason the length of the utf-8 string is limited.
+#define MESSAGE_LEN 2048 //-- The max length in bytes (octets) of a log line
+//-- 2025-12-04
+#define IS_LIMIT_LOGSTR 0 //-- 0: Do not truncate log string to length of MESSAGE_LEN octets
+
 #define AES_BLOCKSIZE 16
 #define IV_LENGTH 12
 #define KEY_LENGTH 32
@@ -45,12 +75,12 @@
 // Buffer size for import and verification
 #define MIN_BUF_SIZE 10
 #define MAX_BUF_SIZE 1073741823 // INT_MAX/2
-#define DEF_BUF_SIZE 1000
+#define DEF_BUF_SIZE 1000  // Default size
 
 // Error message in case of invalid file
 #define FILE_ERROR "Invalid path or non existing regular file: "
 
-// Structure for command line arguments of template and utilities
+// Command line arguments of template and utilities
 typedef struct
 {
   char *longname;
@@ -60,11 +90,25 @@ typedef struct
   char *arg;
 } SLogOptions;
 
-// Dump contents of an array on STDOUT, byte by byte, converting to hex.
-void outputByteBuffer(unsigned char *buf, int length);
+// File abstraction
+typedef struct
+{
+  const gchar *filename;
+  const gchar *mode;
+  GIOChannel *channel;
+  GError *error;
+  GIOStatus status;
+  GString *message;
+  unsigned int state;
+} SLogFile;
 
-
-void evolveKey(unsigned char *key);
+// File operations
+SLogFile *create_file(const gchar *filename, const gchar *mode);
+gboolean open_file(SLogFile *f);
+gboolean write_to_file(SLogFile *f, const gchar *data, gsize len);
+gboolean read_from_file(SLogFile *f, gchar *data, gsize len);
+gboolean read_line_from_file(SLogFile *f, GString *line);
+gboolean close_file(SLogFile *f);
 
 /*
  *  Encrypts plaintext
@@ -82,9 +126,9 @@ void evolveKey(unsigned char *key);
  * Length of ciphertext (>0)
  * 0 on error
  */
-int sLogEncrypt(unsigned char *plaintext, int plaintext_len,
-                unsigned char *key, unsigned char *iv,
-                unsigned char *ciphertext, unsigned char *tag);
+int sLogEncrypt(guchar *plaintext, int plaintext_len,
+                guchar *key, guchar *iv,
+                guchar *ciphertext, guchar *tag);
 /*
  * Decrypt ciphertext and verify integrity
  *
@@ -101,9 +145,9 @@ int sLogEncrypt(unsigned char *plaintext, int plaintext_len,
  * -1 in case verification fails
  * 0 on error
  */
-int sLogDecrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *tag, unsigned char *key,
-                unsigned char *iv,
-                unsigned char *plaintext);
+int sLogDecrypt(guchar *ciphertext, int ciphertext_len,
+                guchar *tag, guchar *key,
+                guchar *iv, guchar *plaintext);
 
 /*
  * Compute AES256 CMAC of input
@@ -120,11 +164,9 @@ int sLogDecrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *ta
  *
  * Note: Caller must take care of memory management.
  */
-void cmac(unsigned char *key, const void *input, gsize length, unsigned char *out, gsize *outlen, gsize out_capacity);
-
-
-gchar *convertToBase64(unsigned char *input, gsize len);
-guchar *convertToBin(char *input, gsize *outLen);
+gboolean cmac(guchar *key, const void *input,
+              gsize length, guchar *out,
+              gsize *outlen, gsize out_capacity);
 
 /*
  * Derive key = evolve key multiple times
@@ -136,7 +178,7 @@ guchar *convertToBin(char *input, gsize *outLen);
  *
  * Note: Caller must take care of memory management.
  */
-void deriveKey(unsigned char *dst, guint64 index, guint64 currentKey);
+gboolean deriveKey(guchar *dst, guint64 index, guint64 currentKey);
 
 /*
  * Create a new encrypted log entry
@@ -150,9 +192,15 @@ void deriveKey(unsigned char *dst, guint64 index, guint64 currentKey);
  * 5. Parameter: The resulting encrypted log entry
  * 6. Parameter: The newly updated MAC
  * 7. Parameter: The capacity of the newly updated MAC buffer
+ *
+ * Return:
+ *   TRUE on success
+ *   FALSE on error
  */
-void sLogEntry(guint64 numberOfLogEntries, GString *text, unsigned char *key, unsigned char *inputBigMac,
-               GString *output, unsigned char *outputBigMac, gsize outputBigMac_capacity);
+gboolean sLogEntry(guint64 numberOfLogEntries, GString *text,
+                   guchar *key, guchar *inputBigMac,
+                   GString *output, guchar *outputBigMac,
+                   gsize outputBigMac_capacity);
 
 /*
  * Generate a master key
@@ -161,10 +209,10 @@ void sLogEntry(guint64 numberOfLogEntries, GString *text, unsigned char *key, un
  * The caller has to allocate this memory.
  *
  * Return:
- * 1 on success
- * 0 on error
+ * TRUE on success
+ * FALSE on error
  */
-int generateMasterKey(guchar *masterkey);
+gboolean generateMasterKey(guchar *masterkey);
 
 /*
  * Generate a host key based on a previously created master key
@@ -175,62 +223,104 @@ int generateMasterKey(guchar *masterkey);
  *
  * The specific unique host key k_0 is k_0 = H(master key|| MAC address || S/N)
  * and requires 48 bytes of storage. Additional 8 bytes need to be allocated to store
- * the serial number of the host key. The caller has to allocate this memory.
+ * the serial number of the host key. The caller has to allocate this
+ * memory.
  *
  * Return:
- * 1 on success
- * 0 on error
+ * TRUE on success
+ * FALSE on error
  */
-int deriveHostKey(guchar *masterkey, gchar *macAddr, gchar *serial, guchar *hostkey);
+gboolean deriveHostKey(guchar *masterkey, gchar *macAddr, gchar *serial, guchar *hostkey);
 
-int readBigMAC(gchar *filename, char *outputBuffer);
-int writeBigMAC(gchar *filename, char *outputBuffer);
+/*
+ * Read and write aggregated MAC from and to file.
+ *
+ * Return
+ * TRUE on success
+ * FALSE on error
+ */
+gboolean readAggregatedMAC(gchar *filename, guchar *outputBuffer);
+gboolean writeAggregatedMAC(gchar *filename, guchar *outputBuffer);
 
 /*
  * Read key from file
  *
  * Return:
- * 1 on success
- * 0 on error
+ * TRUE on success
+ * FALSE on error
  */
-int readKey(char *destKey, guint64 *destCounter, gchar *keypath);
+gboolean readKey(guchar *destKey, guint64 *destCounter, gchar *keypath);
 
 /*
  * Write key to file
  *
  * Return:
- * 1 on success
- * 0 on error
+ * TRUE on success
+ * FALSE on error
  */
-int writeKey(char *key, guint64 counter, gchar *keypath);
+gboolean writeKey(guchar *key, guint64 counter, gchar *keypath);
 
 /*
  * Verify the integrity of an existing log file
  *
  * Return:
- * 1 on success
- * 0 on error
+ * TRUE on success
+ * FALSE on error
  */
-int fileVerify(unsigned char *key, char *inputFileName, char *outputFileName, unsigned char *bigMac,
-               guint64 entriesInFile, int chunkLength);
+gboolean fileVerify(guchar *key, char *inputFileName,
+                    char *outputFileName, guchar *bigMac,
+                    guint64 entriesInFile, guint64 chunkLength,
+                    guchar mac0[CMAC_LENGTH]);
 
-int initVerify(guint64 entriesInFile, unsigned char *key, guint64 *nextLogEntry, guint64 *startingEntry,
-               GString **input, GHashTable **tab);
+/*
+ * Iteratively verify the integrity of a log archive
+ *
+ * Return:
+ * TRUE on success
+ * FALSE on error
+ */
+gboolean iterativeFileVerify(guchar *previousMAC, guchar *previousKey,
+                             char *inputFileName, guchar *currentMAC,
+                             char *outputFileName, guint64 entriesInFile,
+                             guint64 chunkLength, guint64 keyNumber);
 
-int iterateBuffer(guint64 entriesInBuffer, GString **input, guint64 *nextLogEntry, unsigned char *key,
-                  unsigned char *keyZero, guint keyNumber, GString **output, guint64 *numberOfLogEntries, unsigned char *cmac_tag,
-                  gsize cmac_tag_capacity, GHashTable *tab);
+// Set up log verification
+gboolean initVerify(guint64 entriesInFile, guchar *key,
+                    guint64 *nextLogEntry, guint64 *startingEntry,
+                    GPtrArray *input);
 
-int finalizeVerify(guint64 startingEntry, guint64 entriesInFile, unsigned char *bigMac, unsigned char *cmac_tag,
-                   GHashTable *tab);
+// Iterate through log entries contained in a buffer and verify them
+gboolean iterateBuffer(guint64 entriesInBuffer, GPtrArray *input,
+                       guint64 *nextLogEntry, guchar *key,
+                       guchar *keyZero, guint keyNumber,
+                       GPtrArray *output, guint64 *numberOfLogEntries,
+                       guchar *cmac_tag, gsize cmac_tag_capacity, GHashTable *tab);
 
-int iterativeFileVerify(unsigned char *previousMAC, unsigned char *previousKey, char *inputFileName,
-                        unsigned char *currentMAC, char *outputFileName, guint64 entriesInFile, int chunkLength, guint64 keyNumber);
+// Finalize the verification
+gboolean finalizeVerify(guint64 startingEntry, guint64 entriesInFile,
+                        guchar *aggMac, guchar *cmac_tag,
+                        GHashTable **tab);
 
-void deriveEncSubKey(unsigned char *mainKey, unsigned char *encKey);
-void deriveMACSubKey(unsigned char *mainKey, unsigned char *MACKey);
-void PRF(unsigned char *key, unsigned char *originalInput, guint64 inputLength, unsigned char *output,
-         guint64 outputLength);
+// Create a new key based on an existing key
+gboolean evolveKey(guchar *key);
+
+// Key derivation for encryption key
+gboolean deriveEncSubKey(guchar *mainKey, guchar *encKey);
+
+// Key derivation for HMAC
+gboolean deriveMACSubKey(guchar *mainKey, guchar *MACKey);
+
+// Create initial MAC mac0 before first encryption happens to provide this data
+// later for verification. Note: Does not write the file mac0.dat.
+gboolean create_initial_mac0(guchar mainKey[KEY_LENGTH], guchar mac[CMAC_LENGTH]);
+
+// Get path of aggregated MAC file and provides full file name for mac0.dat
+gboolean get_path_mac0(const char *pathAggMac, char *pathMac0, size_t sizePathMac0);
+
+// Pseudo-random function implementation
+gboolean PRF(guchar *key, guchar *originalInput,
+             guint64 inputLength, guchar *output,
+             guint64 outputLength);
 
 // Print usage message and clean up
 int slog_usage(GOptionContext *ctx, GOptionGroup *grp, GString *errormsg);
@@ -243,5 +333,24 @@ int slog_usage(GOptionContext *ctx, GOptionGroup *grp, GString *errormsg);
  * FALSE on error
  */
 gboolean validFileNameArg(const gchar *option_name, const gchar *value, gpointer data, GError **error);
+
+/*
+ * Callback function to check whether a command line argument represents a valid directory
+ *
+ * Return:
+ * TRUE on success
+ * FALSE on error
+ */
+gboolean validFileNameArgCheckDirOnly(const gchar *option_name, const gchar *value, gpointer data, GError **error);
+
+// Error handlers
+void handleFileError(const char *file, int line, int code, void *object);
+void handleGPtrArrayMemoryError(const char *file, int line, int code, void *object);
+
+
+/** Miscellaneous helper functions */
+
+// Limit length of an utf-8 log line, in a way, that no invalid character / symbol is created.
+void truncate_utf8_gstring(GString *gslog, gsize max_octet_len);
 
 #endif

--- a/modules/secure-logging/slog.h
+++ b/modules/secure-logging/slog.h
@@ -81,6 +81,15 @@
 #define FILE_ERROR "Invalid path or non existing regular file: "
 
 /* --- Static Assert Abstraction --- */
+
+/* Example how to use SLOG_STATIC_ASSERT */
+
+/* Test 1: Passing assertion (should compile silently) */
+/* SLOG_STATIC_ASSERT(1, "This should always pass"); */
+
+/* Test 2: Failing assertion (compile-time error) */
+/* SLOG_STATIC_ASSERT(0, "This should fail at compile time!"); */
+
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 /* Modern C11 approach */
 #include <assert.h>
@@ -102,15 +111,7 @@
 
 #endif
 
-/* Example how to use SLOG_STATIC_ASSERT */
-
-/* Test 1: Passing assertion (should compile silently) */
-/* SLOG_STATIC_ASSERT(1, "This should always pass"); */
-
-/* Test 2: Failing assertion (compile-time error) */
-/* SLOG_STATIC_ASSERT(0, "This should fail at compile time!"); */
-
-/* --- End of Macro --- */
+/* --- End of Macro Static Assert Abstraction --- */
 
 // Command line arguments of template and utilities
 typedef struct

--- a/modules/secure-logging/slog.h
+++ b/modules/secure-logging/slog.h
@@ -80,6 +80,38 @@
 // Error message in case of invalid file
 #define FILE_ERROR "Invalid path or non existing regular file: "
 
+/* --- Static Assert Abstraction --- */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+/* Modern C11 approach */
+#include <assert.h>
+#define SLOG_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
+
+#elif defined(__GNUC__) || defined(__clang__)
+/* GCC/Clang extension for older standards */
+#define SLOG_CONCAT_HELPER(a, b) a##b
+#define SLOG_CONCAT(a, b) SLOG_CONCAT_HELPER(a, b)
+#define SLOG_STATIC_ASSERT(cond, msg) \
+    typedef char SLOG_CONCAT(slog_static_assertion_, __LINE__)[(cond) ? 1 : -1] __attribute__((unused))
+
+#else
+/* Basic C89/C99 fallback */
+#define SLOG_CONCAT_HELPER(a, b) a##b
+#define SLOG_CONCAT(a, b) SLOG_CONCAT_HELPER(a, b)
+#define SLOG_STATIC_ASSERT(cond, msg) \
+    typedef char SLOG_CONCAT(slog_static_assertion_, __LINE__)[(cond) ? 1 : -1]
+
+#endif
+
+/* Example how to use SLOG_STATIC_ASSERT */
+
+/* Test 1: Passing assertion (should compile silently) */
+/* SLOG_STATIC_ASSERT(1, "This should always pass"); */
+
+/* Test 2: Failing assertion (compile-time error) */
+/* SLOG_STATIC_ASSERT(0, "This should fail at compile time!"); */
+
+/* --- End of Macro --- */
+
 // Command line arguments of template and utilities
 typedef struct
 {

--- a/modules/secure-logging/slog.h
+++ b/modules/secure-logging/slog.h
@@ -353,4 +353,7 @@ void handleGPtrArrayMemoryError(const char *file, int line, int code, void *obje
 // Limit length of an utf-8 log line, in a way, that no invalid character / symbol is created.
 void truncate_utf8_gstring(GString *gslog, gsize max_octet_len);
 
+//-- helper to check file path argument
+gboolean is_file_path_safe_and_valid(const gchar *input_path);
+
 #endif

--- a/modules/secure-logging/slogencrypt/Makefile.am
+++ b/modules/secure-logging/slogencrypt/Makefile.am
@@ -1,14 +1,18 @@
-bin_PROGRAMS				+= modules/secure-logging/slogencrypt/slogencrypt
+# File: syslog-ng/modules/secure-logging/slogencrypt/Makefile.am
+
+bin_PROGRAMS += modules/secure-logging/slogencrypt/slogencrypt
 
 EXTRA_DIST += modules/secure-logging/slogencrypt/CMakeLists.txt
 
-modules_secure_logging_slogencrypt_slogencrypt_SOURCES =	\
+modules_secure_logging_slogencrypt_slogencrypt_SOURCES = \
 	modules/secure-logging/slogencrypt/slogencrypt.c
-modules_secure_logging_slogencrypt_slogencrypt_CPPFLAGS=	\
-	$(AM_CPPFLAGS)				\
-	-I$(top_srcdir)/modules/secure-logging	\
+
+modules_secure_logging_slogencrypt_slogencrypt_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	-I$(top_srcdir)/modules/secure-logging \
 	-I$(top_builddir)/modules/secure-logging
-modules_secure_logging_slogencrypt_slogencrypt_LDADD	=	\
-	$(top_builddir)/lib/libsyslog-ng.la	\
-	$(top_builddir)/modules/secure-logging/libsyslog-ng-secure-logging.la	\
+
+modules_secure_logging_slogencrypt_slogencrypt_LDADD = \
+	$(top_builddir)/lib/libsyslog-ng.la \
+	$(top_builddir)/modules/secure-logging/libsyslog-ng-secure-logging.la \
 	@TOOL_DEPS_LIBS@

--- a/modules/secure-logging/slogencrypt/slogencrypt.c
+++ b/modules/secure-logging/slogencrypt/slogencrypt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Airbus Commercial Aircraft
+ * Copyright (c) 2019-2025 Airbus Commercial Aircraft
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -33,14 +33,18 @@
 #include "compat/string.h"
 
 // Arguments and options
-static char *hostkey = NULL;
-static char *newhostKey = NULL;
-static char *inputMAC = NULL;
-static char *outputMAC = NULL;
-static char *inputlog = NULL;
-static char *outputlog = NULL;
+static char *hostkeypath = NULL;
+static char *newhostKeypath = NULL;
+static char *inputMACpath = NULL;
+static char *outputMACpath = NULL;
+static char *inputlogpath = NULL;
+static char *outputlogpath = NULL;
 static guint64 bufSize = DEF_BUF_SIZE;
 
+
+//
+// main logic: 0 usually indicates success, and non-zero values indicate an error
+//
 int main(int argc, char *argv[])
 {
   int index = 0;
@@ -54,7 +58,7 @@ int main(int argc, char *argv[])
   GOptionEntry entries[] =
   {
     { options[0].longname, options[0].shortname, 0, G_OPTION_ARG_CALLBACK, &validFileNameArg, options[0].description, options[0].type },
-    { options[1].longname, options[1].shortname, 0, G_OPTION_ARG_CALLBACK, &validFileNameArg, options[1].description, options[1].type },
+    { options[1].longname, options[1].shortname, 0, G_OPTION_ARG_CALLBACK, &validFileNameArgCheckDirOnly, options[1].description, options[1].type },
     { NULL }
   };
 
@@ -66,160 +70,336 @@ int main(int argc, char *argv[])
   g_option_group_add_entries(group, entries);
   g_option_context_set_main_group(context, group);
 
+
   if (!g_option_context_parse (context, &argc, &argv, &error))
     {
-      GString *errorMsg = g_string_new(error->message);
+      // Fix: In case there is no mac file yet available, this tool shall not
+      // fail. Therefore only given mac file folder is checked instead full
+      // file name. This is done by replacement of validFileNameArg by validFileNameArgCheckDirOnly
 
-      return slog_usage(context, group, errorMsg);
+      g_print("!g_opton_context_parse, argc: %d\n", argc);
+      GString *errorMsg = g_string_new(error->message);
+      (void) slog_usage(context, group, errorMsg);
+      return 1; //-- ERROR
     }
 
+  // Note: When Options -k, --key-file or -m, --mac-file are not provided, the
+  // corresponding validFileNameArg is not called and therefore no check is
+  // performed!
+  // The argument checks therefore must be done by checking for NULL or by verifying
+  // argc in case of ordered arguments.
+
+  // Note: When all data is provided correctly, argc is 5 or 6 after parsing
   if (argc < 5 || argc > 6)
     {
-      return slog_usage(context, group, NULL);
+      g_print("ERROR: Count of arguments is out of range!\n\n");
+      (void) slog_usage(context, group, NULL);
+      return 1; //-- ERROR
     }
 
   // Initialize internal messaging
   msg_init(TRUE);
 
-  char key[KEY_LENGTH];
-  char mac[CMAC_LENGTH];
+  guchar key[KEY_LENGTH];
+  guchar mac[CMAC_LENGTH];
+  gsize nk = G_N_ELEMENTS(key);
+  memset(key, 0, nk);
+  gsize nm = G_N_ELEMENTS(mac);
+  memset(mac, 0, nm);
 
   // Assign option arguments
   index = 0;
-  hostkey = options[index].arg;
+  hostkeypath = options[index].arg;
+  if (NULL == hostkeypath)
+    {
+      g_print("ERROR: Option --key-file or -k with a valid path to a Host key is missing!\n\n");
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("Reason",
+                            "Option --key-file or -k with a valid path to a Host key is missing!"));
+      (void) slog_usage(context, group, NULL);
+      return 1; //-- ERROR
+    }
+
   index++;
-  inputMAC = options[index].arg;
+  inputMACpath = options[index].arg;
+  if (NULL == inputMACpath)
+    {
+      g_print("ERROR: Option --mac-file or -m does not provide a valid path to a MAC file!\n\n");
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("Reason",
+                            "Option --mac-file or -m does not provide a valid path to a MAC file!"));
+      (void) slog_usage(context, group, NULL);
+      return 1; //-- ERROR
+    }
 
   // Input and output file arguments
   index = 1;
-  newhostKey = argv[index];
-  index++;
-  if (newhostKey == NULL)
+  newhostKeypath = argv[index];
+  if (newhostKeypath == NULL)
     {
-      return slog_usage(context, group, NULL);
+      // Safe. Will not be reached due check of argc above
+      g_print("ERROR: Path to new host key is missing!\n\n");
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Path to new host key is missing!"));
+      (void) slog_usage(context, group, NULL);
+      g_assert_not_reached();
+      return 1; //-- ERROR
     }
-
-  outputMAC = argv[index];
   index++;
-  if (outputMAC == NULL)
+
+  outputMACpath = argv[index];
+  if (outputMACpath == NULL)
     {
-      return slog_usage(context, group, NULL);
+      // Safe. Will not be reached due check of argc above
+      g_print("ERROR: Path to new MAC file is missing!\n\n");
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Path to new MAC file is missing!"));
+      (void) slog_usage(context, group, NULL);
+      g_assert_not_reached();
+      return 1; //-- ERROR
     }
-
-  inputlog = argv[index];
   index++;
-  if (!g_file_test(inputlog, G_FILE_TEST_IS_REGULAR))
+
+  inputlogpath = argv[index];
+  index++;
+  if (!g_file_test(inputlogpath, G_FILE_TEST_IS_REGULAR))
     {
       GString *errorMsg = g_string_new(FILE_ERROR);
-      g_string_append(errorMsg, inputlog);
-      return slog_usage(context, group, errorMsg);
+      g_string_append(errorMsg, inputlogpath);
+      (void) slog_usage(context, group, errorMsg);
+      g_string_free(errorMsg, TRUE);
+      return 1; //-- ERROR
     }
 
-  outputlog = argv[index];
+  outputlogpath = argv[index];
   index++;
-  if (outputlog == NULL)
+  if (outputlogpath == NULL)
     {
-      return slog_usage(context, group, NULL);
+      // Safe. Will not be reached due check of argc above
+      g_print("ERROR: Path to output log is missing!\n\n");
+      (void) slog_usage(context, group, NULL);
+      g_assert_not_reached();
+      return 1; //-- ERROR
     }
 
   // Read key and counter
   guint64 counter;
-  int ret = readKey(key, &counter, hostkey);
-  if (ret != 1)
+  gboolean ret = readKey(key, &counter, hostkeypath);
+  if (!ret)
     {
-      msg_error("[SLOG] ERROR: Unable to read host key", evt_tag_str("file", hostkey));
-      return -1;
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("Reason", "Unable to read host key!"),
+                evt_tag_str("file", hostkeypath));
+      g_option_context_free(context);
+      return -1; //-- ERROR
     }
 
   // Buffer size arguments if applicable
   if (argc == 6)
     {
-      sscanf(argv[index], "%"G_GUINT64_FORMAT, &bufSize);
+      int result = sscanf(argv[index], "%"G_GUINT64_FORMAT, &bufSize);
 
-      if (bufSize <= MIN_BUF_SIZE || bufSize > MAX_BUF_SIZE)
+      if (result == EOF || bufSize <= MIN_BUF_SIZE || bufSize > MAX_BUF_SIZE)
         {
-          msg_error("[SLOG] ERROR: Invalid buffer size.", evt_tag_int("Size", bufSize),
-                    evt_tag_int("Minimum buffer size", MIN_BUF_SIZE), evt_tag_int("Maximum buffer size", MAX_BUF_SIZE));
+          msg_error(SLOG_ERROR_PREFIX,
+                    evt_tag_str("Reason", "Invalid buffer size."),
+                    evt_tag_int("Size", bufSize),
+                    evt_tag_int("Minimum buffer size", MIN_BUF_SIZE),
+                    evt_tag_int("Maximum buffer size", MAX_BUF_SIZE));
           g_option_context_free(context);
-          return 0;
+          return -1; //-- ERROR
         }
     }
 
   // Open input file
-  FILE *inputFile = fopen(inputlog, "r");
+  FILE *inputFile = fopen(inputlogpath, "r");
   if (inputFile == NULL)
     {
-      msg_error("[SLOG] ERROR: Unable to open input log file", evt_tag_str("file", inputlog));
-      return -1;
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("Reason", "Unable to open input log file!"),
+                evt_tag_str("file", inputlogpath));
+      g_option_context_free(context);
+      return -1; //-- ERROR
     }
 
   // Open output file
-  FILE *outputFile = fopen(outputlog, "w");
+  FILE *outputFile = fopen(outputlogpath,  "w");
   if (outputFile == NULL)
     {
-      msg_error("[SLOG] ERROR: Unable to open output log file", evt_tag_str("file", outputlog));
-      return -1;
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("Reason", "Unable to open output log file!"),
+                evt_tag_str("file", outputlogpath));
+      fclose(inputFile);
+      g_option_context_free(context);
+      return -1; //-- ERROR
+    }
+
+  //-- initial MAC file ---
+  if (!g_file_test(inputMACpath, G_FILE_TEST_IS_REGULAR))
+    {
+      //-- This is normal the first time, slogencrypt is called.
+      msg_info(SLOG_INFO_PREFIX,
+               evt_tag_str("Reason", "MAC file, specified by parameter -m, was not found and is created now (initial MAC file)."),
+               evt_tag_str("file", inputMACpath));
+      create_initial_mac0(key, mac);
+      if (writeAggregatedMAC(inputMACpath, mac) == FALSE)
+        {
+          //-- ERROR: file was not written. Anyhow do not exit here.
+          msg_warning(SLOG_WARNING_PREFIX,
+                      evt_tag_str("Reason", "writeAggregatedMAC was not successful!"),
+                      evt_tag_str("file", inputMACpath));
+        }
+      if (!g_file_test(inputMACpath, G_FILE_TEST_IS_REGULAR))
+        {
+          //-- ERROR: file not found. Anyhow do not exit here.
+          msg_warning(SLOG_WARNING_PREFIX,
+                      evt_tag_str("Reason", "Initial MAC file was not written as expected!"),
+                      evt_tag_str("file", inputMACpath));
+        }
     }
 
   // Read MAC (if possible)
-  if (readBigMAC(inputMAC, mac) == 0)
+  if (readAggregatedMAC(inputMACpath, mac) == 0)
     {
-      msg_warning("[SLOG] ERROR: Unable to open input MAC file", evt_tag_str("file", inputMAC));
+      msg_warning(SLOG_WARNING_PREFIX,
+                  evt_tag_str("Reason", "Unable to open input MAC file!"),
+                  evt_tag_str("file", inputMACpath));
+      // This is an error but we can proceed anyhow. But later, when
+      // slogverify is used, a dummy mac file must be provided for the first verification instead
+      // and this will cause an verification error.
     }
 
   size_t readLen = 0;
   char *line = NULL;
+  gboolean outcome = TRUE;
 
-  msg_info("Importing data...");
+  msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Importing data..."));
 
   // Parse data
   while (getline(&line, &readLen, inputFile) != -1)
     {
-      char outputmacdata[CMAC_LENGTH];
-
+      guchar outputmacdata[CMAC_LENGTH];
       GString *result = g_string_new(NULL);
       GString *inputGString = g_string_new(line);
 
+#if defined(IS_LIMIT_LOGSTR) && ((IS_LIMIT_LOGSTR) == 1)
+
+      //-- 2025-12-03
+      //   In the classic secure logging (not the crash recovery variant)
+      //   there shall be no limitation in regard to the length of a
+      //   log string.
+      //   No truncation might be a security risk and this might also cause
+      //   a problem when buffers are created on the stack instead of the heap.
+
+      //-- 2025-10-20, The code is designed to work with any length of log line.
+      //   For security reason the length of the utf-8 string is limited.
+      //   Later, Crash Recovery shall be integrated and there, the length
+      //   is limited to 2048 bytes (MESSAGE_LEN, slog.h).
+      truncate_utf8_gstring(inputGString, MESSAGE_LEN);
+
+#endif /* IS_LIMIT_LOGSTR, see slog.h */
+
       // Remove trailing '\n' from string
-      g_string_truncate(inputGString, (inputGString->len) -1);
+      g_string_truncate(inputGString, (inputGString->len) - 1);
 
       gsize outputmacdata_capacity = G_N_ELEMENTS(outputmacdata);
-      sLogEntry(counter, inputGString, (unsigned char *)key, (unsigned char *)mac, result, (unsigned char *)outputmacdata,
-                outputmacdata_capacity);
+
+      outcome = sLogEntry(counter, inputGString, key, mac, result,
+                          outputmacdata,
+                          outputmacdata_capacity);
+      if (!outcome)
+        {
+          msg_warning(SLOG_WARNING_PREFIX,
+                      evt_tag_str("Reason", "Unable to encrypt log entry!"),
+                      evt_tag_str("line", inputGString->str));
+
+          fclose(inputFile);
+          fclose(outputFile);
+          g_option_context_free(context);
+          g_string_free(result, TRUE);
+          g_string_free(inputGString, TRUE);
+          if (NULL != line)
+            {
+              free(line);
+              line = NULL;
+            }
+          return -1; //-- ERROR;
+        }
 
       fprintf(outputFile, "%s\n", result->str);
 
       // Update keys, MAC, etc
       memcpy(mac, outputmacdata, CMAC_LENGTH);
-      evolveKey((unsigned char *)key);
-      counter++;
+      outcome = evolveKey(key);
+      if (!outcome)
+        {
+          msg_warning(SLOG_WARNING_PREFIX, evt_tag_str("Reason", "Unable to evolve key!"));
+          fclose(inputFile);
+          fclose(outputFile);
+          g_option_context_free(context);
+          g_string_free(result, TRUE);
+          g_string_free(inputGString, TRUE);
+          if (NULL != line)
+            {
+              free(line);
+              line = NULL;
+            }
+          return -1; //-- ERROR
+        }
 
-      readLen = 0;
-      free(line);
       g_string_free(result, TRUE);
       g_string_free(inputGString, TRUE);
-      line = NULL;
+      if (NULL != line)
+        {
+          free(line);
+          line = NULL;
+        }
+
+      counter++;
+      readLen = 0;
     }
 
-
   // Write whole log MAC
-  if (writeBigMAC(outputMAC, mac) == 0)
+  if (!writeAggregatedMAC(outputMACpath, mac))
     {
-      msg_error("Problem with output MAC file");
-      return -1;
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Problem with output MAC file!"));
+      fclose(inputFile);
+      fclose(outputFile);
+      g_option_context_free(context);
+      if (NULL != line)
+        {
+          free(line);
+          line = NULL;
+        }
+      return -1; //-- ERROR
     }
 
   // Write key
-  ret = writeKey(key, counter, newhostKey);
-  if (ret != 1)
+  ret = writeKey(key, counter, newhostKeypath);
+  if (!ret)
     {
-      msg_error("[SLOG] ERROR: Unable to write new host key", evt_tag_str("file", outputlog));
-      return -1;
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("Reason", "Unable to write new host key"),
+                evt_tag_str("file", outputlogpath));
+      fclose(inputFile);
+      fclose(outputFile);
+      g_option_context_free(context);
+      if (NULL != line)
+        {
+          free(line);
+          line = NULL;
+        }
+      return -1; //-- ERROR
     }
 
+  fclose(inputFile);
   fclose(outputFile);
+  g_option_context_free(context);
+  if (NULL != line)
+    {
+      free(line);
+      line = NULL;
+    }
 
   msg_info("All data successfully imported.");
 
-  return 1;
+  return 0; //-- SUCCESS
 }

--- a/modules/secure-logging/slogencrypt/slogencrypt.c
+++ b/modules/secure-logging/slogencrypt/slogencrypt.c
@@ -126,11 +126,13 @@ int main(int argc, char *argv[])
       goto CLEANUP_SLOGENCRYPT;
     }
   {
-    g_autofree char *p_temp = g_strndup(options[index].arg, PATH_MAX - 1); //-- limit buffer
+    char *p_temp = g_strndup(options[index].arg, PATH_MAX - 1); //-- limit buffer
     g_free(options[index].arg);
     options[index++].arg = NULL; //-- inc
-    g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+    char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
     g_string_assign(gstr_path_hostkey, p_canon ? p_canon : "");
+    g_free(p_temp);
+    g_free(p_canon);
     if (gstr_path_hostkey->len == 0 ||
         !is_file_path_safe_and_valid(gstr_path_hostkey->str) ||
         !g_file_test(gstr_path_hostkey->str, G_FILE_TEST_IS_REGULAR))
@@ -155,11 +157,13 @@ int main(int argc, char *argv[])
       goto CLEANUP_SLOGENCRYPT;
     }
   {
-    g_autofree char *p_temp = g_strndup(options[index].arg, PATH_MAX - 1); //-- limit buffer
+    char *p_temp = g_strndup(options[index].arg, PATH_MAX - 1); //-- limit buffer
     g_free(options[index].arg);
     options[index++].arg = NULL; //-- inc
-    g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+    char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
     g_string_assign(gstr_path_inputMAC, p_canon ? p_canon : "");
+    g_free(p_temp);
+    g_free(p_canon);
     if (gstr_path_inputMAC->len == 0 ||
         !is_file_path_safe_and_valid(gstr_path_inputMAC->str)) //-- file might not exists yet
       {
@@ -186,9 +190,11 @@ int main(int argc, char *argv[])
       goto CLEANUP_SLOGENCRYPT;
     }
   {
-    g_autofree char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
-    g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+    char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
+    char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
     g_string_assign(gstr_path_newhostKey, p_canon ? p_canon : "");
+    g_free(p_temp);
+    g_free(p_canon);
     if (gstr_path_newhostKey->len == 0 ||
         !is_file_path_safe_and_valid(gstr_path_newhostKey->str)) //-- file might not exists yet
       {
@@ -211,9 +217,11 @@ int main(int argc, char *argv[])
       goto CLEANUP_SLOGENCRYPT;
     }
   {
-    g_autofree char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
-    g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+    char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
+    char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
     g_string_assign(gstr_path_outputMAC, p_canon ? p_canon : "");
+    g_free(p_temp);
+    g_free(p_canon);
     if (gstr_path_outputMAC->len == 0 ||
         !is_file_path_safe_and_valid(gstr_path_outputMAC->str)) //-- file might not exists yet
       {
@@ -236,9 +244,11 @@ int main(int argc, char *argv[])
       goto CLEANUP_SLOGENCRYPT;
     }
   {
-    g_autofree char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
-    g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+    char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
+    char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
     g_string_assign(gstr_path_inputlog, p_canon ? p_canon : "");
+    g_free(p_temp);
+    g_free(p_canon);
     if (gstr_path_inputlog->len == 0 ||
         !is_file_path_safe_and_valid(gstr_path_inputlog->str) ||
         !g_file_test(gstr_path_inputlog->str, G_FILE_TEST_IS_REGULAR))
@@ -262,9 +272,11 @@ int main(int argc, char *argv[])
       goto CLEANUP_SLOGENCRYPT;
     }
   {
-    g_autofree char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
-    g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+    char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
+    char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
     g_string_assign(gstr_path_outputlog, p_canon ? p_canon : "");
+    g_free(p_temp);
+    g_free(p_canon);
     if (gstr_path_outputlog->len == 0 ||
         !is_file_path_safe_and_valid(gstr_path_outputlog->str)) //-- file might not exists yet
       {

--- a/modules/secure-logging/slogencrypt/slogencrypt.c
+++ b/modules/secure-logging/slogencrypt/slogencrypt.c
@@ -105,7 +105,6 @@ int main(int argc, char *argv[])
   memset(key, 0, nk);
   gsize nm = G_N_ELEMENTS(mac);
   memset(mac, 0, nm);
-  char *p_path_check = NULL;
 
   int index = 0;
 

--- a/modules/secure-logging/slogencrypt/slogencrypt.c
+++ b/modules/secure-logging/slogencrypt/slogencrypt.c
@@ -216,6 +216,7 @@ int main(int argc, char *argv[])
 
   char *line = NULL;
   FILE *outputFile = NULL;
+  FILE *inputFile = NULL;
 
   p_path_check = realpath(inputlogpath, NULL);
   if (NULL == p_path_check)
@@ -229,7 +230,7 @@ int main(int argc, char *argv[])
   free(p_path_check);
   p_path_check = NULL;
   // Open input file
-  FILE *inputFile = fopen(inputlogpath, "r");
+  inputFile = fopen(inputlogpath, "r");
   if (inputFile == NULL)
     {
       msg_error(SLOG_ERROR_PREFIX,

--- a/modules/secure-logging/slogencrypt/slogencrypt.c
+++ b/modules/secure-logging/slogencrypt/slogencrypt.c
@@ -130,22 +130,16 @@ int main(int argc, char *argv[])
     g_free(options[index].arg);
     options[index++].arg = NULL; //-- inc
     g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
-    gboolean is_ok = is_file_path_safe_and_valid(p_canon); //-- file is expected to exist
-    if (FALSE == is_ok)
+    g_string_assign(gstr_path_hostkey, p_canon ? p_canon : "");
+    if (gstr_path_hostkey->len == 0 ||
+        !is_file_path_safe_and_valid(gstr_path_hostkey->str) ||
+        !g_file_test(gstr_path_hostkey->str, G_FILE_TEST_IS_REGULAR))
       {
-        msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of key-file failed"));
+        msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Key-file validation failed"));
         (void) slog_usage(context, group, NULL);
-        retval = 1; //-- ERROR
+        retval = 1;
         goto CLEANUP_SLOGENCRYPT;
       }
-    if (!g_file_test(p_canon, G_FILE_TEST_IS_REGULAR)) //-- check if file exists
-      {
-        msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of key-file failed"));
-        (void) slog_usage(context, group, NULL);
-        retval = 1; //-- ERROR
-        goto CLEANUP_SLOGENCRYPT;
-      }
-    g_string_assign(gstr_path_hostkey, p_canon);
   }
   msg_info(SLOG_INFO_PREFIX, evt_tag_str("key-file", gstr_path_hostkey->str));
 
@@ -165,15 +159,15 @@ int main(int argc, char *argv[])
     g_free(options[index].arg);
     options[index++].arg = NULL; //-- inc
     g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
-    gboolean is_ok = is_file_path_safe_and_valid(p_canon); //-- file might yet not exist
-    if (FALSE == is_ok)
+    g_string_assign(gstr_path_inputMAC, p_canon ? p_canon : "");
+    if (gstr_path_inputMAC->len == 0 ||
+        !is_file_path_safe_and_valid(gstr_path_inputMAC->str)) //-- file might not exists yet
       {
         msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of mac-file failed"));
         (void) slog_usage(context, group, NULL);
         retval = 1; //-- ERROR
         goto CLEANUP_SLOGENCRYPT;
       }
-    g_string_assign(gstr_path_inputMAC, p_canon);
   }
   msg_info(SLOG_INFO_PREFIX, evt_tag_str("mac-file", gstr_path_inputMAC->str));
 
@@ -194,15 +188,15 @@ int main(int argc, char *argv[])
   {
     g_autofree char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
     g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
-    gboolean is_ok = is_file_path_safe_and_valid(p_canon); //-- file does yet not exist
-    if (FALSE == is_ok)
+    g_string_assign(gstr_path_newhostKey, p_canon ? p_canon : "");
+    if (gstr_path_newhostKey->len == 0 ||
+        !is_file_path_safe_and_valid(gstr_path_newhostKey->str)) //-- file might not exists yet
       {
         msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of NEWKEY failed"));
         (void) slog_usage(context, group, NULL);
         retval = 1; //-- ERROR
         goto CLEANUP_SLOGENCRYPT;
       }
-    g_string_assign(gstr_path_newhostKey, p_canon);
   }
   msg_info(SLOG_INFO_PREFIX, evt_tag_str("NEWKEY", gstr_path_newhostKey->str));
 
@@ -219,15 +213,15 @@ int main(int argc, char *argv[])
   {
     g_autofree char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
     g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
-    gboolean is_ok = is_file_path_safe_and_valid(p_canon); //-- file does yet not exist
-    if (FALSE == is_ok)
+    g_string_assign(gstr_path_outputMAC, p_canon ? p_canon : "");
+    if (gstr_path_outputMAC->len == 0 ||
+        !is_file_path_safe_and_valid(gstr_path_outputMAC->str)) //-- file might not exists yet
       {
         msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of NEWMAC failed"));
         (void) slog_usage(context, group, NULL);
         retval = 1; //-- ERROR
         goto CLEANUP_SLOGENCRYPT;
       }
-    g_string_assign(gstr_path_outputMAC, p_canon);
   }
   msg_info(SLOG_INFO_PREFIX, evt_tag_str("NEWMAC", gstr_path_outputMAC->str));
 
@@ -244,24 +238,16 @@ int main(int argc, char *argv[])
   {
     g_autofree char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
     g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
-    gboolean is_ok = is_file_path_safe_and_valid(p_canon); //-- file is expected to exist
-    if (FALSE == is_ok)
+    g_string_assign(gstr_path_inputlog, p_canon ? p_canon : "");
+    if (gstr_path_inputlog->len == 0 ||
+        !is_file_path_safe_and_valid(gstr_path_inputlog->str) ||
+        !g_file_test(gstr_path_inputlog->str, G_FILE_TEST_IS_REGULAR))
       {
         msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of INPUTLOG failed"));
         (void) slog_usage(context, group, NULL);
         retval = 1; //-- ERROR
         goto CLEANUP_SLOGENCRYPT;
       }
-    if (!g_file_test(p_canon, G_FILE_TEST_IS_REGULAR)) //-- check if file exists
-      {
-        GString *errorMsg = g_string_new(FILE_ERROR);
-        g_string_append(errorMsg, p_canon);
-        (void) slog_usage(context, group, errorMsg);
-        g_string_free(errorMsg, TRUE);
-        retval = 1; //-- ERROR
-        goto CLEANUP_SLOGENCRYPT;
-      }
-    g_string_assign(gstr_path_inputlog, p_canon);
   }
   msg_info(SLOG_INFO_PREFIX, evt_tag_str("INPUTLOG", gstr_path_inputlog->str));
 
@@ -278,15 +264,15 @@ int main(int argc, char *argv[])
   {
     g_autofree char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
     g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
-    gboolean is_ok = is_file_path_safe_and_valid(p_canon); //-- file does yet not exist
-    if (FALSE == is_ok)
+    g_string_assign(gstr_path_outputlog, p_canon ? p_canon : "");
+    if (gstr_path_outputlog->len == 0 ||
+        !is_file_path_safe_and_valid(gstr_path_outputlog->str)) //-- file might not exists yet
       {
         msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of OUTPUTLOG failed"));
         (void) slog_usage(context, group, NULL);
         retval = 1; //-- ERROR
         goto CLEANUP_SLOGENCRYPT;
       }
-    g_string_assign(gstr_path_outputlog, p_canon);
   }
   msg_info(SLOG_INFO_PREFIX, evt_tag_str("OUTPUTLOG", gstr_path_outputlog->str));
 

--- a/modules/secure-logging/slogencrypt/slogencrypt.c
+++ b/modules/secure-logging/slogencrypt/slogencrypt.c
@@ -27,11 +27,13 @@
 #include <string.h>
 #include <errno.h>
 #include <locale.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <openssl/crypto.h>
+
 #include "messages.h"
 #include "slog.h"
 #include "compat/string.h"
-#include <fcntl.h>
-#include <sys/stat.h>
 
 //
 // main logic: 0 usually indicates success, and non-zero values indicate an error
@@ -81,6 +83,7 @@ int main(int argc, char *argv[])
       g_print("!g_opton_context_parse, argc: %d\n", argc);
       GString *errorMsg = g_string_new(error->message);
       (void) slog_usage(context, group, errorMsg);
+      g_error_free(error);
       return 1; //-- ERROR
     }
 
@@ -97,6 +100,7 @@ int main(int argc, char *argv[])
 
   //-- When error then goto cleanup section -----
   char *line = NULL;
+  int f_descriptor = -1;
   FILE *fp_outputFile = NULL;
   FILE *fp_inputFile = NULL;
   guchar key[KEY_LENGTH];
@@ -122,6 +126,7 @@ int main(int argc, char *argv[])
                 evt_tag_str("Reason",
                             "Option --mac-file or -m does not provide a valid path to a MAC file!"));
       (void) slog_usage(context, group, NULL);
+      context = NULL;
       retval = 1; //-- ERROR
       goto CLEANUP_SLOGENCRYPT;
     }
@@ -139,6 +144,7 @@ int main(int argc, char *argv[])
       {
         msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Key-file validation failed"));
         (void) slog_usage(context, group, NULL);
+        context = NULL;
         retval = 1;
         goto CLEANUP_SLOGENCRYPT;
       }
@@ -153,6 +159,7 @@ int main(int argc, char *argv[])
                 evt_tag_str("Reason",
                             "Option --mac-file or -m does not provide a valid path to a MAC file!"));
       (void) slog_usage(context, group, NULL);
+      context = NULL;
       retval = 1; //-- ERROR
       goto CLEANUP_SLOGENCRYPT;
     }
@@ -169,6 +176,7 @@ int main(int argc, char *argv[])
       {
         msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of mac-file failed"));
         (void) slog_usage(context, group, NULL);
+        context = NULL;
         retval = 1; //-- ERROR
         goto CLEANUP_SLOGENCRYPT;
       }
@@ -182,10 +190,9 @@ int main(int argc, char *argv[])
   index = 1;
   if (NULL == argv[index])
     {
-      // Safe. Will not be reached due check of argc above
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Path to NEWKEY is missing!"));
       (void) slog_usage(context, group, NULL);
-      g_assert_not_reached();
+      context = NULL;
       retval = 1; //-- ERROR
       goto CLEANUP_SLOGENCRYPT;
     }
@@ -200,6 +207,7 @@ int main(int argc, char *argv[])
       {
         msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of NEWKEY failed"));
         (void) slog_usage(context, group, NULL);
+        context = NULL;
         retval = 1; //-- ERROR
         goto CLEANUP_SLOGENCRYPT;
       }
@@ -209,10 +217,9 @@ int main(int argc, char *argv[])
   //-- NEWMAC (outputMAC) ---
   if (NULL == argv[index])
     {
-      // Safe. Will not be reached due check of argc above
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Path to NEWMAC is missing"));
       (void) slog_usage(context, group, NULL);
-      g_assert_not_reached();
+      context = NULL;
       retval = 1; //-- ERROR
       goto CLEANUP_SLOGENCRYPT;
     }
@@ -227,6 +234,7 @@ int main(int argc, char *argv[])
       {
         msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of NEWMAC failed"));
         (void) slog_usage(context, group, NULL);
+        context = NULL;
         retval = 1; //-- ERROR
         goto CLEANUP_SLOGENCRYPT;
       }
@@ -236,10 +244,9 @@ int main(int argc, char *argv[])
   //-- INPUTLOG ---
   if (NULL == argv[index])
     {
-      // Safe. Will not be reached due check of argc above
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Path to INPUTLOG is missing"));
       (void) slog_usage(context, group, NULL);
-      g_assert_not_reached();
+      context = NULL;
       retval = 1; //-- ERROR
       goto CLEANUP_SLOGENCRYPT;
     }
@@ -255,6 +262,7 @@ int main(int argc, char *argv[])
       {
         msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of INPUTLOG failed"));
         (void) slog_usage(context, group, NULL);
+        context = NULL;
         retval = 1; //-- ERROR
         goto CLEANUP_SLOGENCRYPT;
       }
@@ -264,10 +272,9 @@ int main(int argc, char *argv[])
   //-- OUTPUTLOG ---
   if (NULL == argv[index])
     {
-      // Safe. Will not be reached due check of argc above
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Path to OUTPUTLOG is missing"));
       (void) slog_usage(context, group, NULL);
-      g_assert_not_reached();
+      context = NULL;
       retval = 1; //-- ERROR
       goto CLEANUP_SLOGENCRYPT;
     }
@@ -282,6 +289,7 @@ int main(int argc, char *argv[])
       {
         msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of OUTPUTLOG failed"));
         (void) slog_usage(context, group, NULL);
+        context = NULL;
         retval = 1; //-- ERROR
         goto CLEANUP_SLOGENCRYPT;
       }
@@ -335,10 +343,10 @@ int main(int argc, char *argv[])
   // Open output file
   // CI GitHub CodeQL / File created without restricting permissions:
   // outputFile = fopen(outputlogpath,  "w");
-  int fd = open(gstr_path_outputlog->str, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
-  if (fd != -1)
+  f_descriptor = open(gstr_path_outputlog->str, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+  if (f_descriptor != -1)
     {
-      fp_outputFile = fdopen(fd, "w");
+      fp_outputFile = fdopen(f_descriptor, "w");
     }
   if (NULL == fp_outputFile)
     {
@@ -459,7 +467,18 @@ int main(int argc, char *argv[])
           goto CLEANUP_SLOGENCRYPT;
         }
 
-      fprintf(fp_outputFile, "%s\n", result->str);
+      int ret_fprintf = fprintf(fp_outputFile, "%s\n", result->str);
+      if (ret_fprintf < 0)
+        {
+          GString *gstr_error_msg = g_string_new(NULL);
+          g_string_printf(gstr_error_msg, "fprintf failed! Error: %s (code %d)\n", strerror(errno), errno);
+          msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", gstr_error_msg->str));
+          g_string_free(gstr_error_msg, TRUE);
+          g_string_free(result, TRUE);
+          g_string_free(inputGString, TRUE);
+          retval = -1; //-- ERROR, failed to write file
+          goto CLEANUP_SLOGENCRYPT;
+        }
 
       // Update keys, MAC, etc
       memcpy(mac, outputmacdata, CMAC_LENGTH);
@@ -508,23 +527,45 @@ int main(int argc, char *argv[])
 
 CLEANUP_SLOGENCRYPT:
 
+  //-- erasure of sensitive data
+  OPENSSL_cleanse(key, sizeof key);
+  OPENSSL_cleanse(mac, sizeof mac);
+
   if (NULL != fp_inputFile)
     {
       fclose(fp_inputFile);
       fp_inputFile = NULL;
     }
+
   if (NULL != fp_outputFile)
     {
+      fflush(fp_outputFile);
+      int fd = fileno(fp_outputFile);
+      if (-1 != fd)
+        {
+          fsync(fd);
+        }
       fclose(fp_outputFile);
       fp_outputFile = NULL;
     }
-  g_option_context_free(context);
-  context = NULL;
+  else if (f_descriptor >= 0)
+    {
+      //-- fd was opened but not wrapped in a stream
+      close(f_descriptor);
+      f_descriptor = -1;
+    }
+
+  if (NULL != context)
+    {
+      g_option_context_free(context);
+      context = NULL;
+    }
   if (NULL != line)
     {
       free(line);
       line = NULL;
     }
+
   g_string_free(gstr_path_hostkey, TRUE);
   gstr_path_hostkey = NULL;
   g_string_free(gstr_path_inputMAC, TRUE);
@@ -546,6 +587,9 @@ CLEANUP_SLOGENCRYPT:
     {
       msg_info("slogencrypt: Error occurred.");
     }
+
+  //-- Release messaging resources
+  msg_deinit();
 
   return retval; //-- 0 when SUCCES
 }

--- a/modules/secure-logging/slogencrypt/slogencrypt.c
+++ b/modules/secure-logging/slogencrypt/slogencrypt.c
@@ -30,6 +30,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <openssl/crypto.h>
+#include <unistd.h> //-- fsync + close for macOS
 
 #include "messages.h"
 #include "slog.h"

--- a/modules/secure-logging/slogencrypt/slogencrypt.c
+++ b/modules/secure-logging/slogencrypt/slogencrypt.c
@@ -33,22 +33,13 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 
-// Arguments and options
-static char *hostkeypath = NULL;
-static char *newhostKeypath = NULL;
-static char *inputMACpath = NULL;
-static char *outputMACpath = NULL;
-static char *inputlogpath = NULL;
-static char *outputlogpath = NULL;
-
-static guint64 bufSize = DEF_BUF_SIZE;
-
 //
 // main logic: 0 usually indicates success, and non-zero values indicate an error
 //
 int main(int argc, char *argv[])
 {
   gint retval = 0; //-- 0: SUCCESS, main logic
+  guint64 bufSize = DEF_BUF_SIZE;
 
   setlocale(LC_ALL, "");
 
@@ -104,94 +95,212 @@ int main(int argc, char *argv[])
   // Initialize internal messaging
   msg_init(TRUE);
 
+  //-- When error then goto cleanup section -----
+  char *line = NULL;
+  FILE *fp_outputFile = NULL;
+  FILE *fp_inputFile = NULL;
   guchar key[KEY_LENGTH];
   guchar mac[CMAC_LENGTH];
   gsize nk = G_N_ELEMENTS(key);
   memset(key, 0, nk);
   gsize nm = G_N_ELEMENTS(mac);
   memset(mac, 0, nm);
-
-  // Assign option arguments
   char *p_path_check = NULL;
+
   int index = 0;
 
-  hostkeypath = options[index++].arg;
-  p_path_check = realpath(hostkeypath, NULL);
-  if (NULL == p_path_check)
-    {
-      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Failed to check key-file!"));
-      (void) slog_usage(context, group, NULL);
-      return 1; //-- ERROR
-    }
-  free(p_path_check);
-  p_path_check = NULL;
+  GString *gstr_path_hostkey = g_string_new(NULL); //-- key-file
+  GString *gstr_path_inputMAC = g_string_new(NULL); //-- mac-file
+  GString *gstr_path_newhostKey = g_string_new(NULL); //-- NEWKEY
+  GString *gstr_path_outputMAC = g_string_new(NULL); //-- NEWMAC
+  GString *gstr_path_inputlog = g_string_new(NULL); //-- INPUTLOG
+  GString *gstr_path_outputlog = g_string_new(NULL); //-- OUTPUTLOG
 
-  inputMACpath = options[index].arg;
-  if (NULL == inputMACpath)
+  //-- key-file (hostkey) ---
+  if (NULL == options[index].arg)
     {
-      //-- Note: might be generated
-      g_print("ERROR: Option --mac-file or -m does not provide a valid path to a MAC file!\n\n");
       msg_error(SLOG_ERROR_PREFIX,
                 evt_tag_str("Reason",
                             "Option --mac-file or -m does not provide a valid path to a MAC file!"));
       (void) slog_usage(context, group, NULL);
-      return 1; //-- ERROR
+      retval = 1; //-- ERROR
+      goto CLEANUP_SLOGENCRYPT;
     }
+  {
+    g_autofree char *p_temp = g_strndup(options[index].arg, PATH_MAX - 1); //-- limit buffer
+    g_free(options[index].arg);
+    options[index++].arg = NULL; //-- inc
+    g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+    gboolean is_ok = is_file_path_safe_and_valid(p_canon); //-- file is expected to exist
+    if (FALSE == is_ok)
+      {
+        msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of key-file failed"));
+        (void) slog_usage(context, group, NULL);
+        retval = 1; //-- ERROR
+        goto CLEANUP_SLOGENCRYPT;
+      }
+    if (!g_file_test(p_canon, G_FILE_TEST_IS_REGULAR)) //-- check if file exists
+      {
+        msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of key-file failed"));
+        (void) slog_usage(context, group, NULL);
+        retval = 1; //-- ERROR
+        goto CLEANUP_SLOGENCRYPT;
+      }
+    g_string_assign(gstr_path_hostkey, p_canon);
+  }
+  msg_info(SLOG_INFO_PREFIX, evt_tag_str("key-file", gstr_path_hostkey->str));
 
-  // Input and output file arguments
+
+  //-- mac-file (inputMAC) ---
+  if (NULL == options[index].arg)
+    {
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("Reason",
+                            "Option --mac-file or -m does not provide a valid path to a MAC file!"));
+      (void) slog_usage(context, group, NULL);
+      retval = 1; //-- ERROR
+      goto CLEANUP_SLOGENCRYPT;
+    }
+  {
+    g_autofree char *p_temp = g_strndup(options[index].arg, PATH_MAX - 1); //-- limit buffer
+    g_free(options[index].arg);
+    options[index++].arg = NULL; //-- inc
+    g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+    gboolean is_ok = is_file_path_safe_and_valid(p_canon); //-- file might yet not exist
+    if (FALSE == is_ok)
+      {
+        msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of mac-file failed"));
+        (void) slog_usage(context, group, NULL);
+        retval = 1; //-- ERROR
+        goto CLEANUP_SLOGENCRYPT;
+      }
+    g_string_assign(gstr_path_inputMAC, p_canon);
+  }
+  msg_info(SLOG_INFO_PREFIX, evt_tag_str("mac-file", gstr_path_inputMAC->str));
+
+
+  //-- Input and output file arguments -----
+
+  //-- NEWKEY (newhostKey) ---
   index = 1;
-  newhostKeypath = argv[index++];
-  if (newhostKeypath == NULL)
+  if (NULL == argv[index])
     {
       // Safe. Will not be reached due check of argc above
-      g_print("ERROR: Path to new host key is missing!\n\n");
-      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Path to new host key is missing!"));
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Path to NEWKEY is missing!"));
       (void) slog_usage(context, group, NULL);
       g_assert_not_reached();
-      return 1; //-- ERROR
+      retval = 1; //-- ERROR
+      goto CLEANUP_SLOGENCRYPT;
     }
+  {
+    g_autofree char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
+    g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+    gboolean is_ok = is_file_path_safe_and_valid(p_canon); //-- file does yet not exist
+    if (FALSE == is_ok)
+      {
+        msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of NEWKEY failed"));
+        (void) slog_usage(context, group, NULL);
+        retval = 1; //-- ERROR
+        goto CLEANUP_SLOGENCRYPT;
+      }
+    g_string_assign(gstr_path_newhostKey, p_canon);
+  }
+  msg_info(SLOG_INFO_PREFIX, evt_tag_str("NEWKEY", gstr_path_newhostKey->str));
 
-  outputMACpath = argv[index++];
-  if (outputMACpath == NULL)
+  //-- NEWMAC (outputMAC) ---
+  if (NULL == argv[index])
     {
       // Safe. Will not be reached due check of argc above
-      g_print("ERROR: Path to new MAC file is missing!\n\n");
-      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Path to new MAC file is missing!"));
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Path to NEWMAC is missing"));
       (void) slog_usage(context, group, NULL);
       g_assert_not_reached();
-      return 1; //-- ERROR
+      retval = 1; //-- ERROR
+      goto CLEANUP_SLOGENCRYPT;
     }
+  {
+    g_autofree char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
+    g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+    gboolean is_ok = is_file_path_safe_and_valid(p_canon); //-- file does yet not exist
+    if (FALSE == is_ok)
+      {
+        msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of NEWMAC failed"));
+        (void) slog_usage(context, group, NULL);
+        retval = 1; //-- ERROR
+        goto CLEANUP_SLOGENCRYPT;
+      }
+    g_string_assign(gstr_path_outputMAC, p_canon);
+  }
+  msg_info(SLOG_INFO_PREFIX, evt_tag_str("NEWMAC", gstr_path_outputMAC->str));
 
-  inputlogpath = argv[index++];
-  if (!g_file_test(inputlogpath, G_FILE_TEST_IS_REGULAR))
-    {
-      GString *errorMsg = g_string_new(FILE_ERROR);
-      g_string_append(errorMsg, inputlogpath);
-      (void) slog_usage(context, group, errorMsg);
-      g_string_free(errorMsg, TRUE);
-      return 1; //-- ERROR
-    }
-
-  outputlogpath = argv[index++];
-  if (outputlogpath == NULL)
+  //-- INPUTLOG ---
+  if (NULL == argv[index])
     {
       // Safe. Will not be reached due check of argc above
-      g_print("ERROR: Path to output log is missing!\n\n");
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Path to INPUTLOG is missing"));
       (void) slog_usage(context, group, NULL);
       g_assert_not_reached();
-      return 1; //-- ERROR
+      retval = 1; //-- ERROR
+      goto CLEANUP_SLOGENCRYPT;
     }
+  {
+    g_autofree char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
+    g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+    gboolean is_ok = is_file_path_safe_and_valid(p_canon); //-- file is expected to exist
+    if (FALSE == is_ok)
+      {
+        msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of INPUTLOG failed"));
+        (void) slog_usage(context, group, NULL);
+        retval = 1; //-- ERROR
+        goto CLEANUP_SLOGENCRYPT;
+      }
+    if (!g_file_test(p_canon, G_FILE_TEST_IS_REGULAR)) //-- check if file exists
+      {
+        GString *errorMsg = g_string_new(FILE_ERROR);
+        g_string_append(errorMsg, p_canon);
+        (void) slog_usage(context, group, errorMsg);
+        g_string_free(errorMsg, TRUE);
+        retval = 1; //-- ERROR
+        goto CLEANUP_SLOGENCRYPT;
+      }
+    g_string_assign(gstr_path_inputlog, p_canon);
+  }
+  msg_info(SLOG_INFO_PREFIX, evt_tag_str("INPUTLOG", gstr_path_inputlog->str));
+
+  //-- OUTPUTLOG ---
+  if (NULL == argv[index])
+    {
+      // Safe. Will not be reached due check of argc above
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Path to OUTPUTLOG is missing"));
+      (void) slog_usage(context, group, NULL);
+      g_assert_not_reached();
+      retval = 1; //-- ERROR
+      goto CLEANUP_SLOGENCRYPT;
+    }
+  {
+    g_autofree char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
+    g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+    gboolean is_ok = is_file_path_safe_and_valid(p_canon); //-- file does yet not exist
+    if (FALSE == is_ok)
+      {
+        msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of OUTPUTLOG failed"));
+        (void) slog_usage(context, group, NULL);
+        retval = 1; //-- ERROR
+        goto CLEANUP_SLOGENCRYPT;
+      }
+    g_string_assign(gstr_path_outputlog, p_canon);
+  }
+  msg_info(SLOG_INFO_PREFIX, evt_tag_str("OUTPUTLOG", gstr_path_outputlog->str));
 
   // Read key and counter
   guint64 counter;
-  gboolean ret = readKey(key, &counter, hostkeypath);
+  gboolean ret = readKey(key, &counter, gstr_path_hostkey->str);
   if (!ret)
     {
       msg_error(SLOG_ERROR_PREFIX,
                 evt_tag_str("Reason", "Unable to read host key!"),
-                evt_tag_str("file", hostkeypath));
-      g_option_context_free(context);
-      return -1; //-- ERROR
+                evt_tag_str("file", gstr_path_hostkey->str));
+      retval = 1; //-- ERROR
+      goto CLEANUP_SLOGENCRYPT;
     }
 
   // Buffer size arguments if applicable
@@ -205,37 +314,23 @@ int main(int argc, char *argv[])
                     evt_tag_int("Size", bufSize),
                     evt_tag_int("Minimum buffer size", MIN_BUF_SIZE),
                     evt_tag_int("Maximum buffer size", MAX_BUF_SIZE));
-          g_option_context_free(context);
-          return -1; //-- ERROR
+          retval = 1; //-- ERROR
+          goto CLEANUP_SLOGENCRYPT;
         }
     }
 
+
   //
-  //-- Done argument parsing ---
+  //-- Done argument parsing and validation -----
   //
 
-  char *line = NULL;
-  FILE *outputFile = NULL;
-  FILE *inputFile = NULL;
-
-  p_path_check = realpath(inputlogpath, NULL);
-  if (NULL == p_path_check)
-    {
-      msg_error(SLOG_ERROR_PREFIX,
-                evt_tag_str("Reason", "Failed to check inputlogpath!"),
-                evt_tag_str("file", inputlogpath));
-      retval = -1; //-- ERROR
-      goto CLEANUP_SLOGENCRYPT;
-    }
-  free(p_path_check);
-  p_path_check = NULL;
   // Open input file
-  inputFile = fopen(inputlogpath, "r");
-  if (inputFile == NULL)
+  fp_inputFile = fopen(gstr_path_inputlog->str, "r");
+  if (NULL == fp_inputFile)
     {
       msg_error(SLOG_ERROR_PREFIX,
                 evt_tag_str("Reason", "Unable to open input log file!"),
-                evt_tag_str("file", inputlogpath));
+                evt_tag_str("file", gstr_path_inputlog->str));
       retval = -1; //-- ERROR
       goto CLEANUP_SLOGENCRYPT;
     }
@@ -243,43 +338,43 @@ int main(int argc, char *argv[])
   // Open output file
   // CI GitHub CodeQL / File created without restricting permissions:
   // outputFile = fopen(outputlogpath,  "w");
-  int fd = open(outputlogpath, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+  int fd = open(gstr_path_outputlog->str, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
   if (fd != -1)
     {
-      outputFile = fdopen(fd, "w");
+      fp_outputFile = fdopen(fd, "w");
     }
-  if (outputFile == NULL)
+  if (NULL == fp_outputFile)
     {
       msg_error(SLOG_ERROR_PREFIX,
                 evt_tag_str("Reason", "Unable to open output log file!"),
-                evt_tag_str("file", outputlogpath));
+                evt_tag_str("file", gstr_path_outputlog->str));
       retval = -1; //-- ERROR
       goto CLEANUP_SLOGENCRYPT;
     }
 
   //-- initial MAC file ---
-  if (!g_file_test(inputMACpath, G_FILE_TEST_IS_REGULAR))
+  if (!g_file_test(gstr_path_inputMAC->str, G_FILE_TEST_IS_REGULAR))
     {
       //-- This is normal the first time, slogencrypt is called.
       msg_info(SLOG_INFO_PREFIX,
                evt_tag_str("Reason", "MAC file was not found and is created now (initial MAC file)."),
-               evt_tag_str("file", inputMACpath));
+               evt_tag_str("file", gstr_path_inputMAC->str));
       create_initial_mac0(key, mac);
-      if (writeAggregatedMAC(inputMACpath, mac) == FALSE)
+      if (writeAggregatedMAC(gstr_path_inputMAC->str, mac) == FALSE)
         {
           //-- ERROR: File was not written!
           msg_error(SLOG_ERROR_PREFIX,
                     evt_tag_str("Reason", "writeAggregatedMAC was not successful!"),
-                    evt_tag_str("file", inputMACpath));
+                    evt_tag_str("file", gstr_path_inputMAC->str));
           retval = -1; //-- ERROR
           goto CLEANUP_SLOGENCRYPT;
         }
       char pathMac0[PATH_MAX]; //-- full path of MAC0 file mac0.dat
-      if (get_path_mac0(inputMACpath, pathMac0, PATH_MAX) == FALSE)
+      if (get_path_mac0(gstr_path_inputMAC->str, pathMac0, PATH_MAX) == FALSE)
         {
           msg_error(SLOG_ERROR_PREFIX,
                     evt_tag_str("Reason", "unable to extract path for MAC0!"),
-                    evt_tag_str("file", inputMACpath));
+                    evt_tag_str("file", gstr_path_inputMAC->str));
           retval = -1; //-- ERROR
           goto CLEANUP_SLOGENCRYPT;
         }
@@ -287,27 +382,27 @@ int main(int argc, char *argv[])
         {
           msg_error(SLOG_ERROR_PREFIX,
                     evt_tag_str("Reason", "writeAggregatedMAC (MAC0) was not successful!"),
-                    evt_tag_str("file", inputMACpath));
+                    evt_tag_str("file", gstr_path_inputMAC->str));
 
           retval = -1; //-- ERROR, file not written
           goto CLEANUP_SLOGENCRYPT;
         }
-      if (!g_file_test(inputMACpath, G_FILE_TEST_IS_REGULAR))
+      if (!g_file_test(gstr_path_inputMAC->str, G_FILE_TEST_IS_REGULAR))
         {
           msg_error(SLOG_ERROR_PREFIX,
                     evt_tag_str("Reason", "Initial MAC file was not written as expected!"),
-                    evt_tag_str("file", inputMACpath));
+                    evt_tag_str("file", gstr_path_inputMAC->str));
           retval = -1; //-- ERROR, File not found!
           goto CLEANUP_SLOGENCRYPT;
         }
     }
 
   // Read MAC (if possible)
-  if (readAggregatedMAC(inputMACpath, mac) == 0)
+  if (readAggregatedMAC(gstr_path_inputMAC->str, mac) == 0)
     {
       msg_error(SLOG_ERROR_PREFIX,
                 evt_tag_str("Reason", "Unable to open input MAC file!"),
-                evt_tag_str("file", inputMACpath));
+                evt_tag_str("file", gstr_path_inputMAC->str));
 
       retval = -1; //-- ERROR, File not found!
       goto CLEANUP_SLOGENCRYPT;
@@ -323,7 +418,7 @@ int main(int argc, char *argv[])
   // Parse data
   size_t readLen = 0;
   gboolean outcome = TRUE;
-  while (getline(&line, &readLen, inputFile) != -1)
+  while (getline(&line, &readLen, fp_inputFile) != -1)
     {
       guchar outputmacdata[CMAC_LENGTH];
       GString *result = g_string_new(NULL);
@@ -367,7 +462,7 @@ int main(int argc, char *argv[])
           goto CLEANUP_SLOGENCRYPT;
         }
 
-      fprintf(outputFile, "%s\n", result->str);
+      fprintf(fp_outputFile, "%s\n", result->str);
 
       // Update keys, MAC, etc
       memcpy(mac, outputmacdata, CMAC_LENGTH);
@@ -395,7 +490,7 @@ int main(int argc, char *argv[])
 
 
   // Write whole log MAC
-  if (!writeAggregatedMAC(outputMACpath, mac))
+  if (!writeAggregatedMAC(gstr_path_outputMAC->str, mac))
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Problem with output MAC file!"));
       retval = -1; //-- ERROR
@@ -403,12 +498,12 @@ int main(int argc, char *argv[])
     }
 
   // Write key
-  ret = writeKey(key, counter, newhostKeypath);
+  ret = writeKey(key, counter, gstr_path_newhostKey->str);
   if (!ret)
     {
       msg_error(SLOG_ERROR_PREFIX,
                 evt_tag_str("Reason", "Unable to write new host key"),
-                evt_tag_str("file", outputlogpath));
+                evt_tag_str("file", gstr_path_outputlog->str));
       retval = -1; //-- ERROR
       goto CLEANUP_SLOGENCRYPT;
     }
@@ -416,22 +511,36 @@ int main(int argc, char *argv[])
 
 CLEANUP_SLOGENCRYPT:
 
-  if (NULL != inputFile)
+  if (NULL != fp_inputFile)
     {
-      fclose(inputFile);
-      inputFile = NULL;
+      fclose(fp_inputFile);
+      fp_inputFile = NULL;
     }
-  if (NULL != outputFile)
+  if (NULL != fp_outputFile)
     {
-      fclose(outputFile);
-      outputFile = NULL;
+      fclose(fp_outputFile);
+      fp_outputFile = NULL;
     }
   g_option_context_free(context);
+  context = NULL;
   if (NULL != line)
     {
       free(line);
       line = NULL;
     }
+  g_string_free(gstr_path_hostkey, TRUE);
+  gstr_path_hostkey = NULL;
+  g_string_free(gstr_path_inputMAC, TRUE);
+  gstr_path_inputMAC = NULL;
+  g_string_free(gstr_path_newhostKey, TRUE);
+  gstr_path_newhostKey = NULL;
+  g_string_free(gstr_path_outputMAC, TRUE);
+  gstr_path_outputMAC = NULL;
+  g_string_free(gstr_path_inputlog, TRUE);
+  gstr_path_inputlog = NULL;
+  g_string_free(gstr_path_outputlog, TRUE);
+  gstr_path_outputlog = NULL;
+
   if (0 == retval)
     {
       msg_info("slogencrypt: All data successfully imported.");

--- a/modules/secure-logging/slogencrypt/slogencrypt.c
+++ b/modules/secure-logging/slogencrypt/slogencrypt.c
@@ -30,6 +30,8 @@
 #include "messages.h"
 #include "slog.h"
 #include "compat/string.h"
+#include <fcntl.h>
+#include <sys/stat.h>
 
 // Arguments and options
 static char *hostkeypath = NULL;
@@ -199,6 +201,17 @@ int main(int argc, char *argv[])
 
   char *line = NULL;
   FILE *outputFile = NULL;
+  char *p_path_check = realpath(inputlogpath, NULL);
+  if (NULL == p_path_check)
+    {
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("Reason", "Failed to check inputlogpath!"),
+                evt_tag_str("file", inputlogpath));
+      retval = -1; //-- ERROR
+      goto CLEANUP_SLOGENCRYPT;
+    }
+  free(p_path_check);
+  p_path_check = NULL;
   // Open input file
   FILE *inputFile = fopen(inputlogpath, "r");
   if (inputFile == NULL)
@@ -211,7 +224,13 @@ int main(int argc, char *argv[])
     }
 
   // Open output file
-  outputFile = fopen(outputlogpath,  "w");
+  // CI GitHub CodeQL / File created without restricting permissions:
+  // outputFile = fopen(outputlogpath,  "w");
+  int fd = open(outputlogpath, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+  if (fd != -1)
+    {
+      outputFile = fdopen(fd, "w");
+    }
   if (outputFile == NULL)
     {
       msg_error(SLOG_ERROR_PREFIX,

--- a/modules/secure-logging/slogencrypt/slogencrypt.c
+++ b/modules/secure-logging/slogencrypt/slogencrypt.c
@@ -46,6 +46,8 @@ static guint64 bufSize = DEF_BUF_SIZE;
 //
 int main(int argc, char *argv[])
 {
+  int retval = 0; //-- 0: SUCCESS (no error)
+
   setlocale(LC_ALL, "");
 
   SLogOptions options[] =
@@ -69,25 +71,13 @@ int main(int argc, char *argv[])
 
   g_option_group_add_entries(group, entries);
   g_option_context_set_main_group(context, group);
-
-
   if (!g_option_context_parse (context, &argc, &argv, &error))
     {
-      // Fix: In case there is no mac file yet available, this tool shall not
-      // fail. Therefore only given mac file folder is checked instead full
-      // file name. This is done by replacement of validFileNameArg by validFileNameArgCheckDirOnly
-
       g_print("!g_opton_context_parse, argc: %d\n", argc);
       GString *errorMsg = g_string_new(error->message);
       (void) slog_usage(context, group, errorMsg);
       return 1; //-- ERROR
     }
-
-  // Note: When Options -k, --key-file or -m, --mac-file are not provided, the
-  // corresponding validFileNameArg is not called and therefore no check is
-  // performed!
-  // The argument checks therefore must be done by checking for NULL or by verifying
-  // argc in case of ordered arguments.
 
   // Note: When all data is provided correctly, argc is 5 or 6 after parsing
   if (argc < 5 || argc > 6)
@@ -133,7 +123,6 @@ int main(int argc, char *argv[])
 
   // Input and output file arguments
   index = 1;
-
   newhostKeypath = argv[index++];
   if (newhostKeypath == NULL)
     {
@@ -192,7 +181,6 @@ int main(int argc, char *argv[])
   if (argc == 6)
     {
       int result = sscanf(argv[index], "%"G_GUINT64_FORMAT, &bufSize);
-
       if (result == EOF || bufSize <= MIN_BUF_SIZE || bufSize > MAX_BUF_SIZE)
         {
           msg_error(SLOG_ERROR_PREFIX,
@@ -205,6 +193,12 @@ int main(int argc, char *argv[])
         }
     }
 
+  //
+  //-- Done argument parsing ---
+  //
+
+  char *line = NULL;
+  FILE *outputFile = NULL;
   // Open input file
   FILE *inputFile = fopen(inputlogpath, "r");
   if (inputFile == NULL)
@@ -212,20 +206,19 @@ int main(int argc, char *argv[])
       msg_error(SLOG_ERROR_PREFIX,
                 evt_tag_str("Reason", "Unable to open input log file!"),
                 evt_tag_str("file", inputlogpath));
-      g_option_context_free(context);
-      return -1; //-- ERROR
+      retval = -1; //-- ERROR
+      goto CLEANUP_SLOGENCRYPT;
     }
 
   // Open output file
-  FILE *outputFile = fopen(outputlogpath,  "w");
+  outputFile = fopen(outputlogpath,  "w");
   if (outputFile == NULL)
     {
       msg_error(SLOG_ERROR_PREFIX,
                 evt_tag_str("Reason", "Unable to open output log file!"),
                 evt_tag_str("file", outputlogpath));
-      fclose(inputFile);
-      g_option_context_free(context);
-      return -1; //-- ERROR
+      retval = -1; //-- ERROR
+      goto CLEANUP_SLOGENCRYPT;
     }
 
   //-- initial MAC file ---
@@ -242,10 +235,8 @@ int main(int argc, char *argv[])
           msg_error(SLOG_ERROR_PREFIX,
                     evt_tag_str("Reason", "writeAggregatedMAC was not successful!"),
                     evt_tag_str("file", inputMACpath));
-          fclose(inputFile);
-          fclose(outputFile);
-          g_option_context_free(context);
-          return -1; //-- ERROR
+          retval = -1; //-- ERROR
+          goto CLEANUP_SLOGENCRYPT;
         }
       char pathMac0[PATH_MAX]; //-- full path of MAC0 file mac0.dat
       if (get_path_mac0(inputMACpath, pathMac0, PATH_MAX) == FALSE)
@@ -253,32 +244,25 @@ int main(int argc, char *argv[])
           msg_error(SLOG_ERROR_PREFIX,
                     evt_tag_str("Reason", "unable to extract path for MAC0!"),
                     evt_tag_str("file", inputMACpath));
-          fclose(inputFile);
-          fclose(outputFile);
-          g_option_context_free(context);
-          return -1; //-- ERROR
+          retval = -1; //-- ERROR
+          goto CLEANUP_SLOGENCRYPT;
         }
       if (writeAggregatedMAC(pathMac0, mac) == FALSE)
         {
-          //-- ERROR: file was not written.
           msg_error(SLOG_ERROR_PREFIX,
                     evt_tag_str("Reason", "writeAggregatedMAC (MAC0) was not successful!"),
                     evt_tag_str("file", inputMACpath));
-          fclose(inputFile);
-          fclose(outputFile);
-          g_option_context_free(context);
-          return -1; //-- ERROR
+
+          retval = -1; //-- ERROR, file not written
+          goto CLEANUP_SLOGENCRYPT;
         }
       if (!g_file_test(inputMACpath, G_FILE_TEST_IS_REGULAR))
         {
-          //-- ERROR: File not found!
           msg_error(SLOG_ERROR_PREFIX,
                     evt_tag_str("Reason", "Initial MAC file was not written as expected!"),
                     evt_tag_str("file", inputMACpath));
-          fclose(inputFile);
-          fclose(outputFile);
-          g_option_context_free(context);
-          return -1; //-- ERROR
+          retval = -1; //-- ERROR, File not found!
+          goto CLEANUP_SLOGENCRYPT;
         }
     }
 
@@ -288,19 +272,21 @@ int main(int argc, char *argv[])
       msg_error(SLOG_ERROR_PREFIX,
                 evt_tag_str("Reason", "Unable to open input MAC file!"),
                 evt_tag_str("file", inputMACpath));
-      fclose(inputFile);
-      fclose(outputFile);
-      g_option_context_free(context);
-      return -1; //-- ERROR
+
+      retval = -1; //-- ERROR, File not found!
+      goto CLEANUP_SLOGENCRYPT;
     }
 
-  size_t readLen = 0;
-  char *line = NULL;
-  gboolean outcome = TRUE;
+
+  //
+  //-- Read and process input file
+  //
 
   msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Importing data..."));
 
   // Parse data
+  size_t readLen = 0;
+  gboolean outcome = TRUE;
   while (getline(&line, &readLen, inputFile) != -1)
     {
       guchar outputmacdata[CMAC_LENGTH];
@@ -339,17 +325,10 @@ int main(int argc, char *argv[])
           msg_warning(SLOG_WARNING_PREFIX,
                       evt_tag_str("Reason", "Unable to encrypt log entry!"),
                       evt_tag_str("line", inputGString->str));
-          fclose(inputFile);
-          fclose(outputFile);
-          g_option_context_free(context);
           g_string_free(result, TRUE);
           g_string_free(inputGString, TRUE);
-          if (NULL != line)
-            {
-              free(line);
-              line = NULL;
-            }
-          return -1; //-- ERROR;
+          retval = -1; //-- ERROR
+          goto CLEANUP_SLOGENCRYPT;
         }
 
       fprintf(outputFile, "%s\n", result->str);
@@ -360,17 +339,10 @@ int main(int argc, char *argv[])
       if (!outcome)
         {
           msg_warning(SLOG_WARNING_PREFIX, evt_tag_str("Reason", "Unable to evolve key!"));
-          fclose(inputFile);
-          fclose(outputFile);
-          g_option_context_free(context);
           g_string_free(result, TRUE);
           g_string_free(inputGString, TRUE);
-          if (NULL != line)
-            {
-              free(line);
-              line = NULL;
-            }
-          return -1; //-- ERROR
+          retval = -1; //-- ERROR, failed to evolve key!
+          goto CLEANUP_SLOGENCRYPT;
         }
 
       g_string_free(result, TRUE);
@@ -380,24 +352,18 @@ int main(int argc, char *argv[])
           free(line);
           line = NULL;
         }
-
       counter++;
       readLen = 0;
-    }
+
+    } //-- while (getline
+
 
   // Write whole log MAC
   if (!writeAggregatedMAC(outputMACpath, mac))
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Problem with output MAC file!"));
-      fclose(inputFile);
-      fclose(outputFile);
-      g_option_context_free(context);
-      if (NULL != line)
-        {
-          free(line);
-          line = NULL;
-        }
-      return -1; //-- ERROR
+      retval = -1; //-- ERROR
+      goto CLEANUP_SLOGENCRYPT;
     }
 
   // Write key
@@ -407,27 +373,37 @@ int main(int argc, char *argv[])
       msg_error(SLOG_ERROR_PREFIX,
                 evt_tag_str("Reason", "Unable to write new host key"),
                 evt_tag_str("file", outputlogpath));
-      fclose(inputFile);
-      fclose(outputFile);
-      g_option_context_free(context);
-      if (NULL != line)
-        {
-          free(line);
-          line = NULL;
-        }
-      return -1; //-- ERROR
+      retval = -1; //-- ERROR
+      goto CLEANUP_SLOGENCRYPT;
     }
 
-  fclose(inputFile);
-  fclose(outputFile);
+
+CLEANUP_SLOGENCRYPT:
+
+  if (NULL != inputFile)
+    {
+      fclose(inputFile);
+      inputFile = NULL;
+    }
+  if (NULL != outputFile)
+    {
+      fclose(outputFile);
+      outputFile = NULL;
+    }
   g_option_context_free(context);
   if (NULL != line)
     {
       free(line);
       line = NULL;
     }
+  if (0 == retval)
+    {
+      msg_info("slogencrypt: All data successfully imported.");
+    }
+  else
+    {
+      msg_info("slogencrypt: Error occurred.");
+    }
 
-  msg_info("All data successfully imported.");
-
-  return 0; //-- SUCCESS
+  return retval; //-- 0 when SUCCES
 }

--- a/modules/secure-logging/slogencrypt/slogencrypt.c
+++ b/modules/secure-logging/slogencrypt/slogencrypt.c
@@ -48,7 +48,7 @@ static guint64 bufSize = DEF_BUF_SIZE;
 //
 int main(int argc, char *argv[])
 {
-  int retval = 0; //-- 0: SUCCESS (no error)
+  gint retval = 0; //-- 0: SUCCESS, main logic
 
   setlocale(LC_ALL, "");
 
@@ -68,11 +68,23 @@ int main(int argc, char *argv[])
 
   GError *error = NULL;
   GOptionContext *context =
-    g_option_context_new("NEWKEY NEWMAC INPUTLOG OUTPUTLOG [COUNTER] - Encrypt log files using secure logging");
+    g_option_context_new("NEWKEY NEWMAC INPUTLOG OUTPUTLOG [COUNTER] - Encrypt log files using secure logging\n\n" \
+                         "Example:\n" \
+                         "  ./slogencrypt\n" \
+                         "  --key-file ./current_host.key\n" \
+                         "  --mac-file ./current_mac.dat\n" \
+                         "  ./new_host.key\n" \
+                         "  ./new_mac.dat\n" \
+                         "  ./input_log.txt\n" \
+                         "  ./output_log.out\n"
+                        );
+
   GOptionGroup *group = g_option_group_new("Basic options", "Basic log encryption options", "basic", &options, NULL);
 
   g_option_group_add_entries(group, entries);
   g_option_context_set_main_group(context, group);
+
+
   if (!g_option_context_parse (context, &argc, &argv, &error))
     {
       g_print("!g_opton_context_parse, argc: %d\n", argc);
@@ -100,21 +112,24 @@ int main(int argc, char *argv[])
   memset(mac, 0, nm);
 
   // Assign option arguments
+  char *p_path_check = NULL;
   int index = 0;
+
   hostkeypath = options[index++].arg;
-  if (NULL == hostkeypath)
+  p_path_check = realpath(hostkeypath, NULL);
+  if (NULL == p_path_check)
     {
-      g_print("ERROR: Option --key-file or -k with a valid path to a Host key is missing!\n\n");
-      msg_error(SLOG_ERROR_PREFIX,
-                evt_tag_str("Reason",
-                            "Option --key-file or -k with a valid path to a Host key is missing!"));
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Failed to check key-file!"));
       (void) slog_usage(context, group, NULL);
       return 1; //-- ERROR
     }
+  free(p_path_check);
+  p_path_check = NULL;
 
   inputMACpath = options[index].arg;
   if (NULL == inputMACpath)
     {
+      //-- Note: might be generated
       g_print("ERROR: Option --mac-file or -m does not provide a valid path to a MAC file!\n\n");
       msg_error(SLOG_ERROR_PREFIX,
                 evt_tag_str("Reason",
@@ -201,7 +216,8 @@ int main(int argc, char *argv[])
 
   char *line = NULL;
   FILE *outputFile = NULL;
-  char *p_path_check = realpath(inputlogpath, NULL);
+
+  p_path_check = realpath(inputlogpath, NULL);
   if (NULL == p_path_check)
     {
       msg_error(SLOG_ERROR_PREFIX,

--- a/modules/secure-logging/slogencrypt/slogencrypt.c
+++ b/modules/secure-logging/slogencrypt/slogencrypt.c
@@ -21,13 +21,12 @@
  *
  */
 
+#include <glib.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
-
-#include <glib.h>
-
+#include <locale.h>
 #include "messages.h"
 #include "slog.h"
 #include "compat/string.h"
@@ -39,14 +38,16 @@ static char *inputMACpath = NULL;
 static char *outputMACpath = NULL;
 static char *inputlogpath = NULL;
 static char *outputlogpath = NULL;
-static guint64 bufSize = DEF_BUF_SIZE;
 
+static guint64 bufSize = DEF_BUF_SIZE;
 
 //
 // main logic: 0 usually indicates success, and non-zero values indicate an error
 //
 int main(int argc, char *argv[])
 {
+  setlocale(LC_ALL, "");
+
   SLogOptions options[] =
   {
     { "key-file", 'k', "Current host key file", "FILE", NULL },
@@ -232,7 +233,7 @@ int main(int argc, char *argv[])
     {
       //-- This is normal the first time, slogencrypt is called.
       msg_info(SLOG_INFO_PREFIX,
-               evt_tag_str("Reason", "MAC file, specified by parameter -m, was not found and is created now (initial MAC file)."),
+               evt_tag_str("Reason", "MAC file was not found and is created now (initial MAC file)."),
                evt_tag_str("file", inputMACpath));
       create_initial_mac0(key, mac);
       if (writeAggregatedMAC(inputMACpath, mac) == FALSE)
@@ -240,6 +241,28 @@ int main(int argc, char *argv[])
           //-- ERROR: File was not written!
           msg_error(SLOG_ERROR_PREFIX,
                     evt_tag_str("Reason", "writeAggregatedMAC was not successful!"),
+                    evt_tag_str("file", inputMACpath));
+          fclose(inputFile);
+          fclose(outputFile);
+          g_option_context_free(context);
+          return -1; //-- ERROR
+        }
+      char pathMac0[PATH_MAX]; //-- full path of MAC0 file mac0.dat
+      if (get_path_mac0(inputMACpath, pathMac0, PATH_MAX) == FALSE)
+        {
+          msg_error(SLOG_ERROR_PREFIX,
+                    evt_tag_str("Reason", "unable to extract path for MAC0!"),
+                    evt_tag_str("file", inputMACpath));
+          fclose(inputFile);
+          fclose(outputFile);
+          g_option_context_free(context);
+          return -1; //-- ERROR
+        }
+      if (writeAggregatedMAC(pathMac0, mac) == FALSE)
+        {
+          //-- ERROR: file was not written.
+          msg_error(SLOG_ERROR_PREFIX,
+                    evt_tag_str("Reason", "writeAggregatedMAC (MAC0) was not successful!"),
                     evt_tag_str("file", inputMACpath));
           fclose(inputFile);
           fclose(outputFile);
@@ -303,10 +326,12 @@ int main(int argc, char *argv[])
 
       // Remove trailing '\n' from string
       g_string_truncate(inputGString, (inputGString->len) - 1);
-
       gsize outputmacdata_capacity = G_N_ELEMENTS(outputmacdata);
-
-      outcome = sLogEntry(counter, inputGString, key, mac, result,
+      outcome = sLogEntry(counter,
+                          inputGString,
+                          key,
+                          mac,
+                          result,
                           outputmacdata,
                           outputmacdata_capacity);
       if (!outcome)

--- a/modules/secure-logging/slogencrypt/slogencrypt.c
+++ b/modules/secure-logging/slogencrypt/slogencrypt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025 Airbus Commercial Aircraft
+ * Copyright (c) 2019-2026 Airbus Commercial Aircraft
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -47,7 +47,6 @@ static guint64 bufSize = DEF_BUF_SIZE;
 //
 int main(int argc, char *argv[])
 {
-  int index = 0;
   SLogOptions options[] =
   {
     { "key-file", 'k', "Current host key file", "FILE", NULL },
@@ -108,8 +107,8 @@ int main(int argc, char *argv[])
   memset(mac, 0, nm);
 
   // Assign option arguments
-  index = 0;
-  hostkeypath = options[index].arg;
+  int index = 0;
+  hostkeypath = options[index++].arg;
   if (NULL == hostkeypath)
     {
       g_print("ERROR: Option --key-file or -k with a valid path to a Host key is missing!\n\n");
@@ -120,7 +119,6 @@ int main(int argc, char *argv[])
       return 1; //-- ERROR
     }
 
-  index++;
   inputMACpath = options[index].arg;
   if (NULL == inputMACpath)
     {
@@ -134,7 +132,8 @@ int main(int argc, char *argv[])
 
   // Input and output file arguments
   index = 1;
-  newhostKeypath = argv[index];
+
+  newhostKeypath = argv[index++];
   if (newhostKeypath == NULL)
     {
       // Safe. Will not be reached due check of argc above
@@ -144,9 +143,8 @@ int main(int argc, char *argv[])
       g_assert_not_reached();
       return 1; //-- ERROR
     }
-  index++;
 
-  outputMACpath = argv[index];
+  outputMACpath = argv[index++];
   if (outputMACpath == NULL)
     {
       // Safe. Will not be reached due check of argc above
@@ -156,10 +154,8 @@ int main(int argc, char *argv[])
       g_assert_not_reached();
       return 1; //-- ERROR
     }
-  index++;
 
-  inputlogpath = argv[index];
-  index++;
+  inputlogpath = argv[index++];
   if (!g_file_test(inputlogpath, G_FILE_TEST_IS_REGULAR))
     {
       GString *errorMsg = g_string_new(FILE_ERROR);
@@ -169,8 +165,7 @@ int main(int argc, char *argv[])
       return 1; //-- ERROR
     }
 
-  outputlogpath = argv[index];
-  index++;
+  outputlogpath = argv[index++];
   if (outputlogpath == NULL)
     {
       // Safe. Will not be reached due check of argc above
@@ -242,29 +237,38 @@ int main(int argc, char *argv[])
       create_initial_mac0(key, mac);
       if (writeAggregatedMAC(inputMACpath, mac) == FALSE)
         {
-          //-- ERROR: file was not written. Anyhow do not exit here.
-          msg_warning(SLOG_WARNING_PREFIX,
-                      evt_tag_str("Reason", "writeAggregatedMAC was not successful!"),
-                      evt_tag_str("file", inputMACpath));
+          //-- ERROR: File was not written!
+          msg_error(SLOG_ERROR_PREFIX,
+                    evt_tag_str("Reason", "writeAggregatedMAC was not successful!"),
+                    evt_tag_str("file", inputMACpath));
+          fclose(inputFile);
+          fclose(outputFile);
+          g_option_context_free(context);
+          return -1; //-- ERROR
         }
       if (!g_file_test(inputMACpath, G_FILE_TEST_IS_REGULAR))
         {
-          //-- ERROR: file not found. Anyhow do not exit here.
-          msg_warning(SLOG_WARNING_PREFIX,
-                      evt_tag_str("Reason", "Initial MAC file was not written as expected!"),
-                      evt_tag_str("file", inputMACpath));
+          //-- ERROR: File not found!
+          msg_error(SLOG_ERROR_PREFIX,
+                    evt_tag_str("Reason", "Initial MAC file was not written as expected!"),
+                    evt_tag_str("file", inputMACpath));
+          fclose(inputFile);
+          fclose(outputFile);
+          g_option_context_free(context);
+          return -1; //-- ERROR
         }
     }
 
   // Read MAC (if possible)
   if (readAggregatedMAC(inputMACpath, mac) == 0)
     {
-      msg_warning(SLOG_WARNING_PREFIX,
-                  evt_tag_str("Reason", "Unable to open input MAC file!"),
-                  evt_tag_str("file", inputMACpath));
-      // This is an error but we can proceed anyhow. But later, when
-      // slogverify is used, a dummy mac file must be provided for the first verification instead
-      // and this will cause an verification error.
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("Reason", "Unable to open input MAC file!"),
+                evt_tag_str("file", inputMACpath));
+      fclose(inputFile);
+      fclose(outputFile);
+      g_option_context_free(context);
+      return -1; //-- ERROR
     }
 
   size_t readLen = 0;
@@ -280,7 +284,7 @@ int main(int argc, char *argv[])
       GString *result = g_string_new(NULL);
       GString *inputGString = g_string_new(line);
 
-#if defined(IS_LIMIT_LOGSTR) && ((IS_LIMIT_LOGSTR) == 1)
+#if IS_LIMIT_LOGSTR
 
       //-- 2025-12-03
       //   In the classic secure logging (not the crash recovery variant)
@@ -310,7 +314,6 @@ int main(int argc, char *argv[])
           msg_warning(SLOG_WARNING_PREFIX,
                       evt_tag_str("Reason", "Unable to encrypt log entry!"),
                       evt_tag_str("line", inputGString->str));
-
           fclose(inputFile);
           fclose(outputFile);
           g_option_context_free(context);

--- a/modules/secure-logging/slogkey/Makefile.am
+++ b/modules/secure-logging/slogkey/Makefile.am
@@ -1,14 +1,18 @@
-bin_PROGRAMS				+= modules/secure-logging/slogkey/slogkey
+# File syslog-ng/modules/secure-logging/slogkey/Makefile.am
+
+bin_PROGRAMS += modules/secure-logging/slogkey/slogkey
 
 EXTRA_DIST += modules/secure-logging/slogkey/CMakeLists.txt
 
-modules_secure_logging_slogkey_slogkey_SOURCES =	\
+modules_secure_logging_slogkey_slogkey_SOURCES = \
 	modules/secure-logging/slogkey/slogkey.c
-modules_secure_logging_slogkey_slogkey_CPPFLAGS=	\
-	$(AM_CPPFLAGS)				\
-	-I$(top_srcdir)/modules/secure-logging	\
+
+modules_secure_logging_slogkey_slogkey_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	-I$(top_srcdir)/modules/secure-logging \
 	-I$(top_builddir)/modules/secure-logging
-modules_secure_logging_slogkey_slogkey_LDADD	=	\
-	$(top_builddir)/lib/libsyslog-ng.la	\
-	$(top_builddir)/modules/secure-logging/libsyslog-ng-secure-logging.la	\
+
+modules_secure_logging_slogkey_slogkey_LDADD = \
+	$(top_builddir)/lib/libsyslog-ng.la \
+	$(top_builddir)/modules/secure-logging/libsyslog-ng-secure-logging.la \
 	@TOOL_DEPS_LIBS@

--- a/modules/secure-logging/slogkey/slogkey.c
+++ b/modules/secure-logging/slogkey/slogkey.c
@@ -32,6 +32,7 @@
 #include <openssl/rand.h>
 #include <openssl/evp.h>
 #include <openssl/sha.h>
+#include <openssl/crypto.h>
 
 #include "messages.h"
 #include "slog.h"
@@ -68,6 +69,7 @@ int main(int argc, char **argv)
     {
       g_print("Invalid option: %s\n", error->message);
       g_error_free(error);
+      g_option_context_free(context);
       exit (1);
     }
 
@@ -147,6 +149,8 @@ int main(int argc, char **argv)
               ret = -1; //-- ERROR
             }
         }
+      msg_deinit();
+      OPENSSL_cleanse(masterkey, sizeof masterkey); //-- erasure of sensitive data
       return ret;
     }
   else if (counter)
@@ -159,10 +163,11 @@ int main(int argc, char **argv)
       if (!success)
         {
           msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read key file"), evt_tag_str("file", keyfile));
-          // bug wrong value assigned  return ret;
+          msg_deinit();
           return -1; //-- ERROR
         }
       g_print("counter=%" G_GUINT64_FORMAT "\n", counterValue);
+      OPENSSL_cleanse(key, sizeof key); //-- erasure of sensitive data
     }
   else if (host)
     {
@@ -203,8 +208,11 @@ int main(int argc, char **argv)
                   ret = -1; //-- ERROR
                 }
             }
+          OPENSSL_cleanse(hostKey, sizeof hostKey); //-- erasure of sensitive data
         }
+      OPENSSL_cleanse(masterKey, sizeof masterKey); //-- erasure of sensitive data
     }
+
 
   // Release messaging resources
   msg_deinit();

--- a/modules/secure-logging/slogkey/slogkey.c
+++ b/modules/secure-logging/slogkey/slogkey.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025 Airbus Commercial Aircraft
+ * Copyright (c) 2019-2026 Airbus Commercial Aircraft
  * Copyright (c) 2024 Gergo Ferenc Kovacs
  *
  * This library is free software; you can redistribute it and/or
@@ -166,12 +166,9 @@ int main(int argc, char **argv)
   else if (host)
     {
       // Arguments
-      gchar *masterKeyFileName = argv[index];
-      index++;
-      gchar *macAddr = argv[index];
-      index++;
-      gchar *serial = argv[index];
-      index++;
+      gchar *masterKeyFileName = argv[index++];
+      gchar *macAddr = argv[index++];
+      gchar *serial = argv[index++];
       gchar *hostKeyFileName = argv[index];
 
       guchar masterKey[KEY_LENGTH] = { 0 };

--- a/modules/secure-logging/slogkey/slogkey.c
+++ b/modules/secure-logging/slogkey/slogkey.c
@@ -28,7 +28,7 @@
 #include <stdlib.h>
 
 #include <glib.h>
-
+#include <locale.h>
 #include <openssl/rand.h>
 #include <openssl/evp.h>
 #include <openssl/sha.h>
@@ -56,6 +56,7 @@ static GOptionEntry entries[] =
 //
 int main(int argc, char **argv)
 {
+  setlocale(LC_ALL, "");
   GError *error = NULL;
   GOptionContext *context = g_option_context_new("- secure logging key management\n\n  " \
                                                  "Master key generation:\tslogkey -m MASTERKEY\n  " \

--- a/modules/secure-logging/slogverify/Makefile.am
+++ b/modules/secure-logging/slogverify/Makefile.am
@@ -1,14 +1,18 @@
+# File: modules/secure-logging/slogverify/Makefile.am
+
 bin_PROGRAMS += modules/secure-logging/slogverify/slogverify
 
 EXTRA_DIST += modules/secure-logging/slogverify/CMakeLists.txt
 
-modules_secure_logging_slogverify_slogverify_SOURCES =	\
+modules_secure_logging_slogverify_slogverify_SOURCES = \
 	modules/secure-logging/slogverify/slogverify.c
-modules_secure_logging_slogverify_slogverify_CPPFLAGS=	\
-	$(AM_CPPFLAGS)				\
-	-I$(top_srcdir)/modules/secure-logging	\
+
+modules_secure_logging_slogverify_slogverify_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	-I$(top_srcdir)/modules/secure-logging \
 	-I$(top_builddir)/modules/secure-logging
+
 modules_secure_logging_slogverify_slogverify_LDADD = \
-	$(top_builddir)/lib/libsyslog-ng.la	     \
+	$(top_builddir)/lib/libsyslog-ng.la \
 	$(top_builddir)/modules/secure-logging/libsyslog-ng-secure-logging.la \
 	@TOOL_DEPS_LIBS@

--- a/modules/secure-logging/slogverify/slogverify.c
+++ b/modules/secure-logging/slogverify/slogverify.c
@@ -28,6 +28,8 @@
 
 #include <glib.h>
 #include <locale.h>
+#include <openssl/crypto.h>
+
 #include "messages.h"
 #include "slog.h"
 
@@ -50,26 +52,23 @@ gboolean normalMode(char *path_hostkey, char *path_MACfile, char *path_inputlog,
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason",
                                                "Initial key k0 is required for verification and decryption but the supplied key read has a counter > 0."),
                 evt_tag_long("Counter", counter));
+      OPENSSL_cleanse(key, sizeof key);
       return FALSE; //-- ERROR
     }
 
   msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Reading MAC file"), evt_tag_str("name", path_MACfile));
-  FILE *fp_bigMAC = fopen(path_MACfile, "r");
-  if (fp_bigMAC == NULL)
+  if ( ! g_file_test(path_MACfile, G_FILE_TEST_IS_REGULAR))
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read MAC"), evt_tag_str("file", path_MACfile));
+      OPENSSL_cleanse(key, sizeof key);
       return FALSE; //-- ERROR
-    }
-  else
-    {
-      fclose(fp_bigMAC);
-      fp_bigMAC = NULL;
     }
 
   guchar MAC[CMAC_LENGTH]; //-- aggregated MAC
   if (!readAggregatedMAC(path_MACfile, MAC))
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read MAC"), evt_tag_str("file", path_MACfile));
+      OPENSSL_cleanse(key, sizeof key);
       return FALSE; //-- ERROR
     }
 
@@ -92,6 +91,9 @@ gboolean normalMode(char *path_hostkey, char *path_MACfile, char *path_inputlog,
   else
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Invalid pathMac0")); //-- fileVerify will fail later
+      OPENSSL_cleanse(MAC0, sizeof MAC0);
+      OPENSSL_cleanse(MAC, sizeof MAC);
+      OPENSSL_cleanse(key, sizeof key);
       return FALSE; //-- ERROR
     }
 
@@ -100,19 +102,23 @@ gboolean normalMode(char *path_hostkey, char *path_MACfile, char *path_inputlog,
   if (fp_input == NULL)
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to open inputlog"), evt_tag_str("file", path_inputlog));
+      OPENSSL_cleanse(MAC0, sizeof MAC0);
+      OPENSSL_cleanse(MAC, sizeof MAC);
+      OPENSSL_cleanse(key, sizeof key);
       return FALSE; //-- ERROR
     }
 
   // Scan through file ones
   guint64 entries = 0;
-  while (!feof(fp_input))
+  int c;
+  while ((c = fgetc(fp_input)) != EOF)
     {
-      char c = fgetc(fp_input);
       if (c == '\n')
         {
           entries++;
         }
     }
+
   fclose(fp_input);
   fp_input = NULL;
 
@@ -126,6 +132,10 @@ gboolean normalMode(char *path_hostkey, char *path_MACfile, char *path_inputlog,
                                entries,
                                bufsize,
                                MAC0);
+
+  OPENSSL_cleanse(key, sizeof key);
+  OPENSSL_cleanse(MAC, sizeof MAC);
+  OPENSSL_cleanse(MAC0, sizeof MAC0);
   if (!result)
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason",
@@ -154,42 +164,36 @@ gboolean iterativeMode(char *path_prevKey, char *path_prevMAC, char *path_curMAC
     }
 
   msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Reading previous MAC file"), evt_tag_str("name", path_prevMAC));
-  FILE *fp_previousBigMAC = fopen(path_prevMAC, "r");
-  if (fp_previousBigMAC == NULL)
+  if ( ! g_file_test(path_prevMAC, G_FILE_TEST_IS_REGULAR))
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to readprevious MAC"), evt_tag_str("file", path_prevMAC));
+      OPENSSL_cleanse(previousKey, sizeof previousKey);
       return FALSE; //-- ERROR
-    }
-  else
-    {
-      fclose(fp_previousBigMAC);
-      fp_previousBigMAC = NULL;
     }
 
   guchar previousMAC[CMAC_LENGTH];
   if (!readAggregatedMAC(path_prevMAC, previousMAC))
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read previous MAC"), evt_tag_str("file", path_prevMAC));
+      OPENSSL_cleanse(previousKey, sizeof previousKey);
       return FALSE; //-- ERROR
     }
 
   msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Reading current MAC file"), evt_tag_str("name", path_curMAC));
-  FILE *fp_currentBigMAC = fopen(path_curMAC, "r");
-  if (fp_currentBigMAC == NULL)
+  if ( ! g_file_test(path_curMAC, G_FILE_TEST_IS_REGULAR))
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read current MAC"), evt_tag_str("file", path_curMAC));
+      OPENSSL_cleanse(previousKey, sizeof previousKey);
+      OPENSSL_cleanse(previousMAC, sizeof previousMAC);
       return FALSE; //-- ERROR
-    }
-  else
-    {
-      fclose(fp_currentBigMAC);
-      fp_currentBigMAC = NULL;
     }
 
   guchar currentMAC[CMAC_LENGTH];
   if (!readAggregatedMAC(path_curMAC, currentMAC))
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read current MAC"), evt_tag_str("file", path_curMAC));
+      OPENSSL_cleanse(previousKey, sizeof previousKey);
+      OPENSSL_cleanse(previousMAC, sizeof previousMAC);
       return FALSE; //-- ERROR
     }
 
@@ -197,19 +201,23 @@ gboolean iterativeMode(char *path_prevKey, char *path_prevMAC, char *path_curMAC
   if (fp_input == NULL)
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to open input log"), evt_tag_str("file", path_inputlog));
+      OPENSSL_cleanse(previousKey, sizeof previousKey);
+      OPENSSL_cleanse(previousMAC, sizeof previousMAC);
+      OPENSSL_cleanse(currentMAC, sizeof currentMAC);
       return FALSE; //-- ERROR
     }
 
   // Scan through file ones
   guint64 entries = 0;
-  while (!feof(fp_input))
+  int c;
+  while ((c = fgetc(fp_input)) != EOF)
     {
-      char c = fgetc(fp_input);
       if (c == '\n')
         {
           entries++;
         }
     }
+
   fclose(fp_input);
   fp_input = NULL;
 
@@ -225,6 +233,9 @@ gboolean iterativeMode(char *path_prevKey, char *path_prevMAC, char *path_curMAC
                                         bufsize,
                                         previousKeyCounter);
 
+  OPENSSL_cleanse(previousKey, sizeof previousKey);
+  OPENSSL_cleanse(previousMAC, sizeof previousMAC);
+  OPENSSL_cleanse(currentMAC, sizeof currentMAC);
   if (!result)
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason",
@@ -295,6 +306,7 @@ int main(int argc, char *argv[])
     {
       GString *errorMsg = g_string_new(error->message);
       (void) slog_usage(context, group, errorMsg);
+      g_error_free(error);
       return 1; //-- ERROR
     }
 
@@ -326,6 +338,7 @@ int main(int argc, char *argv[])
                     evt_tag_str("Reason",
                                 "Option --key-file or -k does not provide a valid path to a key file!"));
           (void) slog_usage(context, group, NULL);
+          context = NULL;
           retval = 1; //-- ERROR
           goto CLEANUP_SLOGVERIFY;
         }
@@ -343,6 +356,7 @@ int main(int argc, char *argv[])
           {
             msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Key-file validation failed"));
             (void) slog_usage(context, group, NULL);
+            context = NULL;
             retval = 1;
             goto CLEANUP_SLOGVERIFY;
           }
@@ -362,6 +376,7 @@ int main(int argc, char *argv[])
                 evt_tag_str("Reason",
                             "Option --mac-file or -m does not provide a valid path to a mac file!"));
       (void) slog_usage(context, group, NULL);
+      context = NULL;
       retval = 1; //-- ERROR
       goto CLEANUP_SLOGVERIFY;
     }
@@ -379,6 +394,7 @@ int main(int argc, char *argv[])
       {
         msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "mac-file validation failed"));
         (void) slog_usage(context, group, NULL);
+        context = NULL;
         retval = 1;
         goto CLEANUP_SLOGVERIFY;
       }
@@ -395,6 +411,7 @@ int main(int argc, char *argv[])
                                 "Option --prev-key-file or -p does not provide a valid path to a prev key file!"));
 
           (void) slog_usage(context, group, NULL);
+          context = NULL;
           retval = 1; //-- ERROR
           goto CLEANUP_SLOGVERIFY;
         }
@@ -412,6 +429,7 @@ int main(int argc, char *argv[])
           {
             msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "prev-key-file validation failed"));
             (void) slog_usage(context, group, NULL);
+            context = NULL;
             retval = 1;
             goto CLEANUP_SLOGVERIFY;
           }
@@ -434,6 +452,7 @@ int main(int argc, char *argv[])
                                 "Option --prev-mac-file or -r does not provide valid path to a prev MAC file!"));
 
           (void) slog_usage(context, group, NULL);
+          context = NULL;
           retval = 1; //-- ERROR
           goto CLEANUP_SLOGVERIFY;
         }
@@ -451,6 +470,7 @@ int main(int argc, char *argv[])
           {
             msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "prev-mac-file validation failed"));
             (void) slog_usage(context, group, NULL);
+            context = NULL;
             retval = 1;
             goto CLEANUP_SLOGVERIFY;
           }
@@ -467,6 +487,7 @@ int main(int argc, char *argv[])
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Path to INPUTLOG is missing"));
       (void) slog_usage(context, group, NULL);
+      context = NULL;
       retval = 1; //-- ERROR
       goto CLEANUP_SLOGVERIFY;
     }
@@ -482,6 +503,7 @@ int main(int argc, char *argv[])
       {
         msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of INPUTLOG failed"));
         (void) slog_usage(context, group, NULL);
+        context = NULL;
         retval = 1; //-- ERROR
         goto CLEANUP_SLOGVERIFY;
       }
@@ -493,6 +515,7 @@ int main(int argc, char *argv[])
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Path to OUTPUTLOG is missing"));
       (void) slog_usage(context, group, NULL);
+      context = NULL;
       retval = 1; //-- ERROR
       goto CLEANUP_SLOGVERIFY;
     }
@@ -507,6 +530,7 @@ int main(int argc, char *argv[])
       {
         msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of OUTPUTLOG failed"));
         (void) slog_usage(context, group, NULL);
+        context = NULL;
         retval = 1; //-- ERROR
         goto CLEANUP_SLOGVERIFY;
       }
@@ -586,6 +610,12 @@ CLEANUP_SLOGVERIFY:
 
   // Release messaging resources
   msg_deinit();
-  g_option_context_free(context);
+
+  if (NULL != context)
+    {
+      g_option_context_free(context);
+      context = NULL;
+    }
+
   return retval;
 }

--- a/modules/secure-logging/slogverify/slogverify.c
+++ b/modules/secure-logging/slogverify/slogverify.c
@@ -70,11 +70,16 @@ gboolean normalMode(char *hostkey, char *MACfile, char *inputlog, char *outputlo
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read MAC"), evt_tag_str("file", MACfile));
       return FALSE; //-- ERROR
     }
+  else
+    {
+      fclose(bigMAC);
+      bigMAC = NULL;
+    }
 
   guchar MAC[CMAC_LENGTH]; //-- aggregated MAC
   if (!readAggregatedMAC(MACfile, MAC))
     {
-      msg_warning(SLOG_WARNING_PREFIX, evt_tag_str("Reason", "Unable to read MAC"), evt_tag_str("file", MACfile));
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read MAC"), evt_tag_str("file", MACfile));
     }
 
   //-- initial MAC0 ---
@@ -85,7 +90,7 @@ gboolean normalMode(char *hostkey, char *MACfile, char *inputlog, char *outputlo
     {
       if (!readAggregatedMAC(pathMac0, MAC0))
         {
-          msg_warning(SLOG_WARNING_PREFIX, evt_tag_str("Reason", "Unable to read MAC0"), evt_tag_str("file", pathMac0));
+          msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read MAC0"), evt_tag_str("file", pathMac0));
         }
       else
         {
@@ -94,7 +99,7 @@ gboolean normalMode(char *hostkey, char *MACfile, char *inputlog, char *outputlo
     }
   else
     {
-      msg_warning(SLOG_WARNING_PREFIX, evt_tag_str("Reason", "Invalid pathMac0")); //-- fileVerify will fail later
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Invalid pathMac0")); //-- fileVerify will fail later
     }
 
 
@@ -154,6 +159,11 @@ gboolean iterativeMode(char *prevKey, char *prevMAC, char *curMAC, char *inputlo
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read previous MAC"), evt_tag_str("file", prevMAC));
       return FALSE; //-- ERROR
     }
+  else
+    {
+      fclose(previousBigMAC);
+      previousBigMAC = NULL;
+    }
 
   guchar previousMAC[CMAC_LENGTH];
   if (!readAggregatedMAC(prevMAC, previousMAC))
@@ -167,6 +177,11 @@ gboolean iterativeMode(char *prevKey, char *prevMAC, char *curMAC, char *inputlo
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read current MAC"), evt_tag_str("file", curMAC));
       return FALSE; //-- ERROR
+    }
+  else
+    {
+      fclose(currentBigMAC);
+      currentBigMAC = NULL;
     }
 
   guchar currentMAC[CMAC_LENGTH];

--- a/modules/secure-logging/slogverify/slogverify.c
+++ b/modules/secure-logging/slogverify/slogverify.c
@@ -80,6 +80,7 @@ gboolean normalMode(char *hostkey, char *MACfile, char *inputlog, char *outputlo
   if (!readAggregatedMAC(MACfile, MAC))
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read MAC"), evt_tag_str("file", MACfile));
+      return FALSE; //-- ERROR
     }
 
   //-- initial MAC0 ---
@@ -91,6 +92,7 @@ gboolean normalMode(char *hostkey, char *MACfile, char *inputlog, char *outputlo
       if (!readAggregatedMAC(pathMac0, MAC0))
         {
           msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read MAC0"), evt_tag_str("file", pathMac0));
+          return FALSE; //-- ERROR
         }
       else
         {
@@ -100,6 +102,7 @@ gboolean normalMode(char *hostkey, char *MACfile, char *inputlog, char *outputlo
   else
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Invalid pathMac0")); //-- fileVerify will fail later
+      return FALSE; //-- ERROR
     }
 
 
@@ -168,7 +171,8 @@ gboolean iterativeMode(char *prevKey, char *prevMAC, char *curMAC, char *inputlo
   guchar previousMAC[CMAC_LENGTH];
   if (!readAggregatedMAC(prevMAC, previousMAC))
     {
-      msg_warning(SLOG_WARNING_PREFIX, evt_tag_str("Reason", "Unable to read previous MAC"), evt_tag_str("file", prevMAC));
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read previous MAC"), evt_tag_str("file", prevMAC));
+      return FALSE; //-- ERROR
     }
 
   msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Reading current MAC file"), evt_tag_str("name", curMAC));
@@ -187,7 +191,8 @@ gboolean iterativeMode(char *prevKey, char *prevMAC, char *curMAC, char *inputlo
   guchar currentMAC[CMAC_LENGTH];
   if (!readAggregatedMAC(curMAC, currentMAC))
     {
-      msg_warning(SLOG_WARNING_PREFIX, evt_tag_str("Reason", "Unable to read current MAC"), evt_tag_str("file", curMAC));
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read current MAC"), evt_tag_str("file", curMAC));
+      return FALSE; //-- ERROR
     }
 
   FILE *input = fopen(inputlog, "r");

--- a/modules/secure-logging/slogverify/slogverify.c
+++ b/modules/secure-logging/slogverify/slogverify.c
@@ -41,7 +41,7 @@ gboolean normalMode(char *path_hostkey, char *path_MACfile, char *path_inputlog,
   gboolean success = readKey(key, &counter, path_hostkey);
   if (!success)
     {
-      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read hostkey"), evt_tag_str("file", path_hostkey));
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read host key"), evt_tag_str("file", path_hostkey));
       return FALSE; //-- ERROR
     }
 
@@ -330,11 +330,13 @@ int main(int argc, char *argv[])
           goto CLEANUP_SLOGVERIFY;
         }
       {
-        g_autofree char *p_temp = g_strndup(options[index].arg, PATH_MAX - 1); //-- limit buffer
+        char *p_temp = g_strndup(options[index].arg, PATH_MAX - 1); //-- limit buffer
         g_free(options[index].arg);
         options[index++].arg = NULL; //-- inc
-        g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+        char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
         g_string_assign(gstr_path_hostkey, p_canon ? p_canon : "");
+        g_free(p_temp);
+        g_free(p_canon);
         if (gstr_path_hostkey->len == 0 ||
             !is_file_path_safe_and_valid(gstr_path_hostkey->str) ||
             !g_file_test(gstr_path_hostkey->str, G_FILE_TEST_IS_REGULAR))
@@ -352,6 +354,7 @@ int main(int argc, char *argv[])
       index++;
     }
 
+
   //-- mac-file, both iterative and normal mode argument
   if (NULL == options[index].arg)
     {
@@ -363,11 +366,13 @@ int main(int argc, char *argv[])
       goto CLEANUP_SLOGVERIFY;
     }
   {
-    g_autofree char *p_temp = g_strndup(options[index].arg, PATH_MAX - 1); //-- limit buffer
+    char *p_temp = g_strndup(options[index].arg, PATH_MAX - 1); //-- limit buffer
     g_free(options[index].arg);
     options[index++].arg = NULL; //-- inc
-    g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+    char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
     g_string_assign(gstr_path_curMAC, p_canon ? p_canon : "");
+    g_free(p_temp);
+    g_free(p_canon);
     if (gstr_path_curMAC->len == 0 ||
         !is_file_path_safe_and_valid(gstr_path_curMAC->str) ||
         !g_file_test(gstr_path_curMAC->str, G_FILE_TEST_IS_REGULAR))
@@ -394,11 +399,13 @@ int main(int argc, char *argv[])
           goto CLEANUP_SLOGVERIFY;
         }
       {
-        g_autofree char *p_temp = g_strndup(options[index].arg, PATH_MAX - 1); //-- limit buffer
+        char *p_temp = g_strndup(options[index].arg, PATH_MAX - 1); //-- limit buffer
         g_free(options[index].arg);
         options[index++].arg = NULL; //-- inc
-        g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+        char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
         g_string_assign(gstr_path_prevhostkey, p_canon ? p_canon : "");
+        g_free(p_temp);
+        g_free(p_canon);
         if (gstr_path_prevhostkey->len == 0 ||
             !is_file_path_safe_and_valid(gstr_path_prevhostkey->str) ||
             !g_file_test(gstr_path_prevhostkey->str, G_FILE_TEST_IS_REGULAR))
@@ -416,6 +423,7 @@ int main(int argc, char *argv[])
       index++;
     }
 
+
   //-- prev-mac-file (prevMAC), only iterative mode ---
   if (iterative)
     {
@@ -430,11 +438,13 @@ int main(int argc, char *argv[])
           goto CLEANUP_SLOGVERIFY;
         }
       {
-        g_autofree char *p_temp = g_strndup(options[index].arg, PATH_MAX - 1); //-- limit buffer
+        char *p_temp = g_strndup(options[index].arg, PATH_MAX - 1); //-- limit buffer
         g_free(options[index].arg);
         options[index++].arg = NULL; //-- inc
-        g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+        char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
         g_string_assign(gstr_path_prevMAC, p_canon ? p_canon : "");
+        g_free(p_temp);
+        g_free(p_canon);
         if (gstr_path_prevMAC->len == 0 ||
             !is_file_path_safe_and_valid(gstr_path_prevMAC->str) ||
             !g_file_test(gstr_path_prevMAC->str, G_FILE_TEST_IS_REGULAR))
@@ -461,9 +471,11 @@ int main(int argc, char *argv[])
       goto CLEANUP_SLOGVERIFY;
     }
   {
-    g_autofree char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
-    g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+    char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
+    char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
     g_string_assign(gstr_path_inputlog, p_canon ? p_canon : "");
+    g_free(p_temp);
+    g_free(p_canon);
     if (gstr_path_inputlog->len == 0 ||
         !is_file_path_safe_and_valid(gstr_path_inputlog->str) ||
         !g_file_test(gstr_path_inputlog->str, G_FILE_TEST_IS_REGULAR))
@@ -485,9 +497,11 @@ int main(int argc, char *argv[])
       goto CLEANUP_SLOGVERIFY;
     }
   {
-    g_autofree char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
-    g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+    char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
+    char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
     g_string_assign(gstr_path_outputlog, p_canon ? p_canon : "");
+    g_free(p_temp);
+    g_free(p_canon);
     if (gstr_path_outputlog->len == 0 ||
         !is_file_path_safe_and_valid(gstr_path_outputlog->str)) //-- file might not exists yet
       {

--- a/modules/secure-logging/slogverify/slogverify.c
+++ b/modules/secure-logging/slogverify/slogverify.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025 Airbus Commercial Aircraft
+ * Copyright (c) 2019-2026 Airbus Commercial Aircraft
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -218,7 +218,6 @@ gboolean iterativeMode(char *prevKey, char *prevMAC, char *curMAC, char *inputlo
 //
 int main(int argc, char *argv[])
 {
-  int index = 0;
   SLogOptions options[] =
   {
     { "iterative", 'i', "Iterative verification", NULL, NULL },
@@ -264,20 +263,15 @@ int main(int argc, char *argv[])
   msg_init(TRUE);
 
   // Assign option arguments
-  index = 1;
-  hostKey = options[index].arg;
-  index++;
-  curMacFile = options[index].arg;
-  index++;
-  prevHostKey = options[index].arg;
-  index++;
-  prevMacFile = options[index].arg;
-  index++;
+  int index = 1;
+  hostKey = options[index++].arg;
+  curMacFile = options[index++].arg;
+  prevHostKey = options[index++].arg;
+  prevMacFile = options[index++].arg;
 
   // Input and output file arguments
   index = 1;
-  inputLog = argv[index];
-  index++;
+  inputLog = argv[index++];
   if (!g_file_test(inputLog, G_FILE_TEST_IS_REGULAR))
     {
       GString *errorMsg = g_string_new(FILE_ERROR);
@@ -286,8 +280,7 @@ int main(int argc, char *argv[])
       return 1; //-- ERROR
     }
 
-  outputLog = argv[index];
-  index++;
+  outputLog = argv[index++];
   if (outputLog == NULL)
     {
       (void) slog_usage(context, group, NULL);
@@ -338,7 +331,7 @@ int main(int argc, char *argv[])
       gboolean result = normalMode(hostKey, curMacFile, inputLog, outputLog, bufSize);
       if (!result)
         {
-          ret = 1; // ERROR
+          ret = 1; //-- ERROR
         }
     }
 

--- a/modules/secure-logging/slogverify/slogverify.c
+++ b/modules/secure-logging/slogverify/slogverify.c
@@ -31,16 +31,6 @@
 #include "messages.h"
 #include "slog.h"
 
-// Arguments and options
-static gboolean iterative = FALSE;
-static char *hostKeyPath = NULL;
-static char *prevHostKeyPath = NULL;
-static char *curMacFilePath = NULL;
-static char *prevMacFilePath = NULL;
-static char *inputLogPath = NULL;
-static char *outputLogPath = NULL;
-static int bufSize = DEF_BUF_SIZE;
-
 // Return TRUE on success, FALSE on error
 gboolean normalMode(char *path_hostkey, char *path_MACfile, char *path_inputlog, char *path_outputlog, int bufsize)
 {
@@ -129,7 +119,13 @@ gboolean normalMode(char *path_hostkey, char *path_MACfile, char *path_inputlog,
   msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Number of lines in file"), evt_tag_long("number", entries));
   msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Restoring and verifying log entries"), evt_tag_int("buffer size",
            bufsize));
-  gboolean result = fileVerify(key, path_inputlog, path_outputlog, MAC, entries, bufsize, MAC0);
+  gboolean result = fileVerify(key,
+                               path_inputlog,
+                               path_outputlog,
+                               MAC,
+                               entries,
+                               bufsize,
+                               MAC0);
   if (!result)
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason",
@@ -215,13 +211,19 @@ gboolean iterativeMode(char *path_prevKey, char *path_prevMAC, char *path_curMAC
         }
     }
   fclose(fp_input);
+  fp_input = NULL;
 
   msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Number of lines in file"), evt_tag_long("number", entries));
   msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Restoring and verifying log entries"), evt_tag_int("buffer size",
            bufsize));
-  gboolean result = iterativeFileVerify(previousMAC, previousKey, path_inputlog, currentMAC, path_outputlog,
+  gboolean result = iterativeFileVerify(previousMAC,
+                                        previousKey,
+                                        path_inputlog,
+                                        currentMAC,
+                                        path_outputlog,
                                         entries,
-                                        bufsize, previousKeyCounter);
+                                        bufsize,
+                                        previousKeyCounter);
 
   if (!result)
     {
@@ -240,6 +242,10 @@ gboolean iterativeMode(char *path_prevKey, char *path_prevMAC, char *path_curMAC
 int main(int argc, char *argv[])
 {
   setlocale(LC_ALL, "");
+
+  gint retval = 0; //-- 0: SUCCESS, main logic
+  gboolean iterative = FALSE;
+  int bufSize = DEF_BUF_SIZE;
 
   SLogOptions options[] =
   {
@@ -301,97 +307,197 @@ int main(int argc, char *argv[])
   // Initialize internal messaging
   msg_init(TRUE);
 
+  GString *gstr_path_hostkey = g_string_new(NULL); //-- key-file
+  GString *gstr_path_curMAC = g_string_new(NULL); //-- mac-file
+  GString *gstr_path_prevhostkey = g_string_new(NULL); //-- prev-key-file
+  GString *gstr_path_prevMAC = g_string_new(NULL); //-- prev-mac-file
+  GString *gstr_path_inputlog = g_string_new(NULL); //-- INPUTLOG
+  GString *gstr_path_outputlog = g_string_new(NULL); //-- OUTPUTLOG
+
   // Assign option arguments
   int index = 1;
-  hostKeyPath = options[index++].arg;
+
+  //-- key-file (hostkey), normal mode ---
   if (!iterative)
     {
-      char *p_path_check = realpath(hostKeyPath, NULL);
-      if (NULL == p_path_check)
+      if (NULL == options[index].arg)
         {
-          msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Failed to check key-file!"));
+          msg_error(SLOG_ERROR_PREFIX,
+                    evt_tag_str("Reason",
+                                "Option --key-file or -k does not provide a valid path to a key file!"));
           (void) slog_usage(context, group, NULL);
-          return 1; //-- ERROR
+          retval = 1; //-- ERROR
+          goto CLEANUP_SLOGVERIFY;
         }
-      free(p_path_check);
-      p_path_check = NULL;
-    } //-- not iterative
-
-  curMacFilePath = options[index++].arg;
-  if (!iterative)
+      {
+        g_autofree char *p_temp = g_strndup(options[index].arg, PATH_MAX - 1); //-- limit buffer
+        g_free(options[index].arg);
+        options[index++].arg = NULL; //-- inc
+        g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+        g_string_assign(gstr_path_hostkey, p_canon ? p_canon : "");
+        if (gstr_path_hostkey->len == 0 ||
+            !is_file_path_safe_and_valid(gstr_path_hostkey->str) ||
+            !g_file_test(gstr_path_hostkey->str, G_FILE_TEST_IS_REGULAR))
+          {
+            msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Key-file validation failed"));
+            (void) slog_usage(context, group, NULL);
+            retval = 1;
+            goto CLEANUP_SLOGVERIFY;
+          }
+      }
+      msg_info(SLOG_INFO_PREFIX, evt_tag_str("key-file", gstr_path_hostkey->str));
+    }
+  else
     {
-      char *p_path_check = realpath(curMacFilePath, NULL);
-      if (NULL == p_path_check)
-        {
-          msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Failed to check mac-file!"));
-          (void) slog_usage(context, group, NULL);
-          return 1; //-- ERROR
-        }
-      free(p_path_check);
-      p_path_check = NULL;
-    } //-- not iterative
+      index++;
+    }
 
-  prevHostKeyPath = options[index++].arg;
+  //-- mac-file, both iterative and normal mode argument
+  if (NULL == options[index].arg)
+    {
+      msg_error(SLOG_ERROR_PREFIX,
+                evt_tag_str("Reason",
+                            "Option --mac-file or -m does not provide a valid path to a mac file!"));
+      (void) slog_usage(context, group, NULL);
+      retval = 1; //-- ERROR
+      goto CLEANUP_SLOGVERIFY;
+    }
+  {
+    g_autofree char *p_temp = g_strndup(options[index].arg, PATH_MAX - 1); //-- limit buffer
+    g_free(options[index].arg);
+    options[index++].arg = NULL; //-- inc
+    g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+    g_string_assign(gstr_path_curMAC, p_canon ? p_canon : "");
+    if (gstr_path_curMAC->len == 0 ||
+        !is_file_path_safe_and_valid(gstr_path_curMAC->str) ||
+        !g_file_test(gstr_path_curMAC->str, G_FILE_TEST_IS_REGULAR))
+      {
+        msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "mac-file validation failed"));
+        (void) slog_usage(context, group, NULL);
+        retval = 1;
+        goto CLEANUP_SLOGVERIFY;
+      }
+  }
+  msg_info(SLOG_INFO_PREFIX, evt_tag_str("mac-file", gstr_path_curMAC->str));
+
+  //-- prev-key-file (prevhostkey), only iterative mode ---
   if (iterative)
     {
-      char *p_path_check = realpath(prevHostKeyPath, NULL);
-      if (NULL == p_path_check)
+      if (NULL == options[index].arg)
         {
-          msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Failed to check prev-key-file!"));
-          (void) slog_usage(context, group, NULL);
-          return 1; //-- ERROR
-        }
-      free(p_path_check);
-      p_path_check = NULL;
-    } //-- iterative
+          msg_error(SLOG_ERROR_PREFIX,
+                    evt_tag_str("Reason",
+                                "Option --prev-key-file or -p does not provide a valid path to a prev key file!"));
 
-  prevMacFilePath = options[index++].arg;
-  if (iterative )
-    {
-      char *p_path_check = realpath(prevMacFilePath, NULL);
-      if (NULL == p_path_check)
-        {
-          msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Failed to check prev-mac-file!"));
           (void) slog_usage(context, group, NULL);
-          return 1; //-- ERROR
+          retval = 1; //-- ERROR
+          goto CLEANUP_SLOGVERIFY;
         }
-      free(p_path_check);
-      p_path_check = NULL;
-    } //-- iterative
+      {
+        g_autofree char *p_temp = g_strndup(options[index].arg, PATH_MAX - 1); //-- limit buffer
+        g_free(options[index].arg);
+        options[index++].arg = NULL; //-- inc
+        g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+        g_string_assign(gstr_path_prevhostkey, p_canon ? p_canon : "");
+        if (gstr_path_prevhostkey->len == 0 ||
+            !is_file_path_safe_and_valid(gstr_path_prevhostkey->str) ||
+            !g_file_test(gstr_path_prevhostkey->str, G_FILE_TEST_IS_REGULAR))
+          {
+            msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "prev-key-file validation failed"));
+            (void) slog_usage(context, group, NULL);
+            retval = 1;
+            goto CLEANUP_SLOGVERIFY;
+          }
+      }
+      msg_info(SLOG_INFO_PREFIX, evt_tag_str("prev-key-file", gstr_path_prevhostkey->str));
+    }
+  else
+    {
+      index++;
+    }
+
+  //-- prev-mac-file (prevMAC), only iterative mode ---
+  if (iterative)
+    {
+      if (NULL == options[index].arg)
+        {
+          msg_error(SLOG_ERROR_PREFIX,
+                    evt_tag_str("Reason",
+                                "Option --prev-mac-file or -r does not provide valid path to a prev MAC file!"));
+
+          (void) slog_usage(context, group, NULL);
+          retval = 1; //-- ERROR
+          goto CLEANUP_SLOGVERIFY;
+        }
+      {
+        g_autofree char *p_temp = g_strndup(options[index].arg, PATH_MAX - 1); //-- limit buffer
+        g_free(options[index].arg);
+        options[index++].arg = NULL; //-- inc
+        g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+        g_string_assign(gstr_path_prevMAC, p_canon ? p_canon : "");
+        if (gstr_path_prevMAC->len == 0 ||
+            !is_file_path_safe_and_valid(gstr_path_prevMAC->str) ||
+            !g_file_test(gstr_path_prevMAC->str, G_FILE_TEST_IS_REGULAR))
+          {
+            msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "prev-mac-file validation failed"));
+            (void) slog_usage(context, group, NULL);
+            retval = 1;
+            goto CLEANUP_SLOGVERIFY;
+          }
+      }
+      msg_info(SLOG_INFO_PREFIX, evt_tag_str("prev-mac-file", gstr_path_prevMAC->str));
+    }
+
 
   // Input and output file arguments
   index = 1;
-  inputLogPath = argv[index++];
-  if (!g_file_test(inputLogPath, G_FILE_TEST_IS_REGULAR))
-    {
-      GString *errorMsg = g_string_new(FILE_ERROR);
-      g_string_append(errorMsg, inputLogPath);
-      (void) slog_usage(context, group, errorMsg);
-      return 1; //-- ERROR
-    }
 
-  outputLogPath = argv[index++];
-  gchar *dir_part = g_path_get_dirname(outputLogPath);
-  if (NULL != dir_part)
+  //-- INPUTLOG ---
+  if (NULL == argv[index])
     {
-      char *dir_check = realpath(dir_part, NULL);
-      if (NULL == dir_check)
-        {
-          msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Failed to check OUTPUTLOG file!"));
-          g_free(dir_part);
-          dir_part = NULL;
-          (void) slog_usage(context, group, NULL);
-          return 1; //-- ERROR
-        }
-      free(dir_check);
-      g_free(dir_part);
-      dir_part = NULL;
-    }
-  if (outputLogPath == NULL)
-    {
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Path to INPUTLOG is missing"));
       (void) slog_usage(context, group, NULL);
-      return 1; //-- ERROR
+      retval = 1; //-- ERROR
+      goto CLEANUP_SLOGVERIFY;
     }
+  {
+    g_autofree char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
+    g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+    g_string_assign(gstr_path_inputlog, p_canon ? p_canon : "");
+    if (gstr_path_inputlog->len == 0 ||
+        !is_file_path_safe_and_valid(gstr_path_inputlog->str) ||
+        !g_file_test(gstr_path_inputlog->str, G_FILE_TEST_IS_REGULAR))
+      {
+        msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of INPUTLOG failed"));
+        (void) slog_usage(context, group, NULL);
+        retval = 1; //-- ERROR
+        goto CLEANUP_SLOGVERIFY;
+      }
+  }
+  msg_info(SLOG_INFO_PREFIX, evt_tag_str("INPUTLOG", gstr_path_inputlog->str));
+
+  //-- OUTPUTLOG ---
+  if (NULL == argv[index])
+    {
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Path to OUTPUTLOG is missing"));
+      (void) slog_usage(context, group, NULL);
+      retval = 1; //-- ERROR
+      goto CLEANUP_SLOGVERIFY;
+    }
+  {
+    g_autofree char *p_temp = g_strndup(argv[index++], PATH_MAX - 1); //-- limit buffer, inc
+    g_autofree char *p_canon = g_canonicalize_filename(p_temp, NULL); //-- normalize
+    g_string_assign(gstr_path_outputlog, p_canon ? p_canon : "");
+    if (gstr_path_outputlog->len == 0 ||
+        !is_file_path_safe_and_valid(gstr_path_outputlog->str)) //-- file might not exists yet
+      {
+        msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Check of OUTPUTLOG failed"));
+        (void) slog_usage(context, group, NULL);
+        retval = 1; //-- ERROR
+        goto CLEANUP_SLOGVERIFY;
+      }
+  }
+  msg_info(SLOG_INFO_PREFIX, evt_tag_str("OUTPUTLOG", gstr_path_outputlog->str));
 
   // Buffer size arguments if applicable
   if (argc == 4)
@@ -404,44 +510,68 @@ int main(int argc, char *argv[])
                     evt_tag_int("Size", bufSize),
                     evt_tag_int("Minimum buffer size", MIN_BUF_SIZE),
                     evt_tag_int("Maximum buffer size", MAX_BUF_SIZE));
-          g_option_context_free(context);
-          return 1; //-- ERROR
+          retval = 1; //-- ERROR
+          goto CLEANUP_SLOGVERIFY;
         }
     }
 
-  int ret = 0; //-- main logic, 0 errors
   if (iterative)
     {
-      if (prevHostKeyPath == NULL || prevMacFilePath == NULL || curMacFilePath == NULL)
+      if (gstr_path_prevhostkey->len == 0 || gstr_path_prevMAC->len == 0 || gstr_path_curMAC->len == 0)
         {
           g_print("%s", g_option_context_get_help(context, TRUE, NULL));
-          g_option_context_free(context);
-          return 1; //-- ERROR
+          retval = 1; //-- ERROR
+          goto CLEANUP_SLOGVERIFY;
         }
-
-      gboolean result = iterativeMode(prevHostKeyPath, prevMacFilePath, curMacFilePath, inputLogPath, outputLogPath, bufSize);
+      gboolean result = iterativeMode(gstr_path_prevhostkey->str,
+                                      gstr_path_prevMAC->str,
+                                      gstr_path_curMAC->str,
+                                      gstr_path_inputlog->str,
+                                      gstr_path_outputlog->str,
+                                      bufSize);
       if (!result)
         {
-          ret = 1; //-- ERROR
+          retval = 1; //-- ERROR
         }
     }
   else
     {
-      if (hostKeyPath == NULL || curMacFilePath  == NULL)
+      if (gstr_path_hostkey->len == 0 || gstr_path_curMAC->len == 0)
         {
           g_print("%s", g_option_context_get_help(context, TRUE, NULL));
-          g_option_context_free(context);
-          return 1; //-- ERROR
+          retval = 1; //-- ERROR
+          goto CLEANUP_SLOGVERIFY;
         }
-      gboolean result = normalMode(hostKeyPath, curMacFilePath, inputLogPath, outputLogPath, bufSize);
+      gboolean result = normalMode(gstr_path_hostkey->str,
+                                   gstr_path_curMAC->str,
+                                   gstr_path_inputlog->str,
+                                   gstr_path_outputlog->str,
+                                   bufSize);
       if (!result)
         {
-          ret = 1; //-- ERROR
+          retval = 1; //-- ERROR
         }
     }
+
+
+
+CLEANUP_SLOGVERIFY:
+
+  g_string_free(gstr_path_hostkey, TRUE);
+  gstr_path_hostkey = NULL;
+  g_string_free(gstr_path_curMAC, TRUE);
+  gstr_path_curMAC = NULL;
+  g_string_free(gstr_path_prevhostkey, TRUE);
+  gstr_path_prevhostkey = NULL;
+  g_string_free(gstr_path_prevMAC, TRUE);
+  gstr_path_prevMAC = NULL;
+  g_string_free(gstr_path_inputlog, TRUE);
+  gstr_path_inputlog = NULL;
+  g_string_free(gstr_path_outputlog, TRUE);
+  gstr_path_outputlog = NULL;
 
   // Release messaging resources
   msg_deinit();
   g_option_context_free(context);
-  return ret;
+  return retval;
 }

--- a/modules/secure-logging/slogverify/slogverify.c
+++ b/modules/secure-logging/slogverify/slogverify.c
@@ -33,25 +33,25 @@
 
 // Arguments and options
 static gboolean iterative = FALSE;
-static char *hostKey = NULL;
-static char *prevHostKey = NULL;
-static char *curMacFile = NULL;
-static char *prevMacFile = NULL;
-static char *inputLog = NULL;
-static char *outputLog = NULL;
+static char *hostKeyPath = NULL;
+static char *prevHostKeyPath = NULL;
+static char *curMacFilePath = NULL;
+static char *prevMacFilePath = NULL;
+static char *inputLogPath = NULL;
+static char *outputLogPath = NULL;
 static int bufSize = DEF_BUF_SIZE;
 
 // Return TRUE on success, FALSE on error
-gboolean normalMode(char *hostkey, char *MACfile, char *inputlog, char *outputlog, int bufsize)
+gboolean normalMode(char *path_hostkey, char *path_MACfile, char *path_inputlog, char *path_outputlog, int bufsize)
 {
   guchar key[KEY_LENGTH];
   guint64 counter;
 
-  msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Reading key file"), evt_tag_str("name", hostkey));
-  gboolean success = readKey(key, &counter, hostkey);
+  msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Reading key file"), evt_tag_str("name", path_hostkey));
+  gboolean success = readKey(key, &counter, path_hostkey);
   if (!success)
     {
-      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read host key"), evt_tag_str("file", hostkey));
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read hostkey"), evt_tag_str("file", path_hostkey));
       return FALSE; //-- ERROR
     }
 
@@ -63,23 +63,23 @@ gboolean normalMode(char *hostkey, char *MACfile, char *inputlog, char *outputlo
       return FALSE; //-- ERROR
     }
 
-  msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Reading MAC file"), evt_tag_str("name", MACfile));
-  FILE *bigMAC = fopen(MACfile, "r");
-  if (bigMAC == NULL)
+  msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Reading MAC file"), evt_tag_str("name", path_MACfile));
+  FILE *fp_bigMAC = fopen(path_MACfile, "r");
+  if (fp_bigMAC == NULL)
     {
-      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read MAC"), evt_tag_str("file", MACfile));
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read MAC"), evt_tag_str("file", path_MACfile));
       return FALSE; //-- ERROR
     }
   else
     {
-      fclose(bigMAC);
-      bigMAC = NULL;
+      fclose(fp_bigMAC);
+      fp_bigMAC = NULL;
     }
 
   guchar MAC[CMAC_LENGTH]; //-- aggregated MAC
-  if (!readAggregatedMAC(MACfile, MAC))
+  if (!readAggregatedMAC(path_MACfile, MAC))
     {
-      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read MAC"), evt_tag_str("file", MACfile));
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read MAC"), evt_tag_str("file", path_MACfile));
       return FALSE; //-- ERROR
     }
 
@@ -87,7 +87,7 @@ gboolean normalMode(char *hostkey, char *MACfile, char *inputlog, char *outputlo
   char pathMac0[PATH_MAX]; //-- full path of MAC0 file mac0.dat
   guchar MAC0[CMAC_LENGTH]; //-- initial MAC
   memset(MAC0, 0, CMAC_LENGTH);
-  if (TRUE == get_path_mac0(MACfile, pathMac0, PATH_MAX))
+  if (TRUE == get_path_mac0(path_MACfile, pathMac0, PATH_MAX))
     {
       if (!readAggregatedMAC(pathMac0, MAC0))
         {
@@ -106,30 +106,30 @@ gboolean normalMode(char *hostkey, char *MACfile, char *inputlog, char *outputlo
     }
 
 
-  FILE *input = fopen(inputlog, "r");
-
-  if (input == NULL)
+  FILE *fp_input = fopen(path_inputlog, "r");
+  if (fp_input == NULL)
     {
-      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to open input log"), evt_tag_str("file", inputlog));
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to open inputlog"), evt_tag_str("file", path_inputlog));
       return FALSE; //-- ERROR
     }
 
   // Scan through file ones
   guint64 entries = 0;
-  while (!feof(input))
+  while (!feof(fp_input))
     {
-      char c = fgetc(input);
+      char c = fgetc(fp_input);
       if (c == '\n')
         {
           entries++;
         }
     }
-  fclose(input);
+  fclose(fp_input);
+  fp_input = NULL;
 
   msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Number of lines in file"), evt_tag_long("number", entries));
   msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Restoring and verifying log entries"), evt_tag_int("buffer size",
            bufsize));
-  gboolean result = fileVerify(key, inputlog, outputlog, MAC, entries, bufsize, MAC0);
+  gboolean result = fileVerify(key, path_inputlog, path_outputlog, MAC, entries, bufsize, MAC0);
   if (!result)
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason",
@@ -142,82 +142,84 @@ gboolean normalMode(char *hostkey, char *MACfile, char *inputlog, char *outputlo
 
 
 // Return TRUE on success, FALSE on error
-gboolean iterativeMode(char *prevKey, char *prevMAC, char *curMAC, char *inputlog, char *outputlog, int bufsize)
+gboolean iterativeMode(char *path_prevKey, char *path_prevMAC, char *path_curMAC, char *path_inputlog,
+                       char *path_outputlog, int bufsize)
 {
   guchar previousKey[KEY_LENGTH];
   guint64 previousKeyCounter = 0;
 
-  msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Reading previous key file"), evt_tag_str("name", prevKey));
-  gboolean success = readKey(previousKey, &previousKeyCounter, prevKey);
+  msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Reading previous keyfile"), evt_tag_str("name", path_prevKey));
+  gboolean success = readKey(previousKey, &previousKeyCounter, path_prevKey);
   if (!success)
     {
-      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Previous key could not be loaded."), evt_tag_str("file", prevKey));
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Previous key could not be loaded."), evt_tag_str("file",
+                path_prevKey));
       return FALSE; //-- ERROR
     }
 
-  msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Reading previous MAC file"), evt_tag_str("name", prevMAC));
-  FILE *previousBigMAC = fopen(prevMAC, "r");
-  if (previousBigMAC == NULL)
+  msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Reading previous MACfile"), evt_tag_str("name", path_prevMAC));
+  FILE *fp_previousBigMAC = fopen(path_prevMAC, "r");
+  if (fp_previousBigMAC == NULL)
     {
-      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read previous MAC"), evt_tag_str("file", prevMAC));
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to readprevious MAC"), evt_tag_str("file", path_prevMAC));
       return FALSE; //-- ERROR
     }
   else
     {
-      fclose(previousBigMAC);
-      previousBigMAC = NULL;
+      fclose(fp_previousBigMAC);
+      fp_previousBigMAC = NULL;
     }
 
   guchar previousMAC[CMAC_LENGTH];
-  if (!readAggregatedMAC(prevMAC, previousMAC))
+  if (!readAggregatedMAC(path_prevMAC, previousMAC))
     {
-      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read previous MAC"), evt_tag_str("file", prevMAC));
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read previous MAC"), evt_tag_str("file", path_prevMAC));
       return FALSE; //-- ERROR
     }
 
-  msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Reading current MAC file"), evt_tag_str("name", curMAC));
-  FILE *currentBigMAC = fopen(curMAC, "r");
-  if (currentBigMAC == NULL)
+  msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Reading current MAC file"), evt_tag_str("name", path_curMAC));
+  FILE *fp_currentBigMAC = fopen(path_curMAC, "r");
+  if (fp_currentBigMAC == NULL)
     {
-      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read current MAC"), evt_tag_str("file", curMAC));
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read current MAC"), evt_tag_str("file", path_curMAC));
       return FALSE; //-- ERROR
     }
   else
     {
-      fclose(currentBigMAC);
-      currentBigMAC = NULL;
+      fclose(fp_currentBigMAC);
+      fp_currentBigMAC = NULL;
     }
 
   guchar currentMAC[CMAC_LENGTH];
-  if (!readAggregatedMAC(curMAC, currentMAC))
+  if (!readAggregatedMAC(path_curMAC, currentMAC))
     {
-      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read current MAC"), evt_tag_str("file", curMAC));
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to read current MAC"), evt_tag_str("file", path_curMAC));
       return FALSE; //-- ERROR
     }
 
-  FILE *input = fopen(inputlog, "r");
-  if (input == NULL)
+  FILE *fp_input = fopen(path_inputlog, "r");
+  if (fp_input == NULL)
     {
-      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to open input log"), evt_tag_str("file", inputlog));
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to open inputlog"), evt_tag_str("file", path_inputlog));
       return FALSE; //-- ERROR
     }
 
   // Scan through file ones
   guint64 entries = 0;
-  while (!feof(input))
+  while (!feof(fp_input))
     {
-      char c = fgetc(input);
+      char c = fgetc(fp_input);
       if (c == '\n')
         {
           entries++;
         }
     }
-  fclose(input);
+  fclose(fp_input);
 
   msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Number of lines in file"), evt_tag_long("number", entries));
   msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Restoring and verifying log entries"), evt_tag_int("buffer size",
-           bufSize));
-  gboolean result = iterativeFileVerify(previousMAC, previousKey, inputlog, currentMAC, outputlog,
+           bufsize));
+  gboolean result = iterativeFileVerify(previousMAC, previousKey, path_inputlog, currentMAC, path_outputlog,
                                         entries,
                                         bufsize, previousKeyCounter);
 
@@ -226,7 +228,6 @@ gboolean iterativeMode(char *prevKey, char *prevMAC, char *curMAC, char *inputlo
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason",
                                                "There is a problem with log verification. Please check log manually"));
       return FALSE; //-- ERROR
-
     }
 
   return TRUE; //-- SUCCESS
@@ -286,24 +287,98 @@ int main(int argc, char *argv[])
 
   // Assign option arguments
   int index = 1;
-  hostKey = options[index++].arg;
-  curMacFile = options[index++].arg;
-  prevHostKey = options[index++].arg;
-  prevMacFile = options[index++].arg;
+  hostKeyPath = options[index++].arg;
+  if (!iterative)
+    {
+      g_print("hostKeyPath: %s\n", hostKeyPath);
+      char *p_path_check = realpath(hostKeyPath, NULL);
+      if (NULL == p_path_check)
+        {
+          msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Failed to check key-file!"));
+          (void) slog_usage(context, group, NULL);
+          return 1; //-- ERROR
+        }
+      free(p_path_check);
+      p_path_check = NULL;
+    } //-- not iterative
+
+  curMacFilePath = options[index++].arg;
+  if (!iterative)
+    {
+      g_print("curMacFilePath: %s\n", curMacFilePath);
+      char *p_path_check = realpath(curMacFilePath, NULL);
+      if (NULL == p_path_check)
+        {
+          msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Failed to check mac-file!"));
+          (void) slog_usage(context, group, NULL);
+          return 1; //-- ERROR
+        }
+      free(p_path_check);
+      p_path_check = NULL;
+    } //-- not iterative
+
+  prevHostKeyPath = options[index++].arg;
+  if (iterative)
+    {
+      g_print("prevHostKeyPath: %s\n", prevHostKeyPath);
+      char *p_path_check = realpath(prevHostKeyPath, NULL);
+      if (NULL == p_path_check)
+        {
+          msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Failed to check prev-key-file!"));
+          (void) slog_usage(context, group, NULL);
+          return 1; //-- ERROR
+        }
+      free(p_path_check);
+      p_path_check = NULL;
+    } //-- iterative
+
+  prevMacFilePath = options[index++].arg;
+  if (iterative )
+    {
+      g_print("prevMacFilePath: %s\n", prevMacFilePath);
+      char *p_path_check = realpath(prevMacFilePath, NULL);
+      if (NULL == p_path_check)
+        {
+          msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Failed to check prev-mac-file!"));
+          (void) slog_usage(context, group, NULL);
+          return 1; //-- ERROR
+        }
+      free(p_path_check);
+      p_path_check = NULL;
+    } //-- iterative
 
   // Input and output file arguments
   index = 1;
-  inputLog = argv[index++];
-  if (!g_file_test(inputLog, G_FILE_TEST_IS_REGULAR))
+  inputLogPath = argv[index++];
+  g_print("inputLogPath: %s\n", inputLogPath);
+  if (!g_file_test(inputLogPath, G_FILE_TEST_IS_REGULAR))
     {
       GString *errorMsg = g_string_new(FILE_ERROR);
-      g_string_append(errorMsg, inputLog);
+      g_string_append(errorMsg, inputLogPath);
       (void) slog_usage(context, group, errorMsg);
       return 1; //-- ERROR
     }
 
-  outputLog = argv[index++];
-  if (outputLog == NULL)
+  outputLogPath = argv[index++];
+  g_print("outputLogPath: %s\n", outputLogPath);
+  gchar *dir_part = g_path_get_dirname(outputLogPath);
+  if (NULL != dir_part)
+    {
+      g_print("dir_part: %s\n", dir_part);
+      char *dir_check = realpath(dir_part, NULL);
+      if (NULL == dir_check)
+        {
+          msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Failed to check OUTPUTLOG file!"));
+          g_free(dir_part);
+          dir_part = NULL;
+          (void) slog_usage(context, group, NULL);
+          return 1; //-- ERROR
+        }
+      free(dir_check);
+      g_free(dir_part);
+      dir_part = NULL;
+    }
+  if (outputLogPath == NULL)
     {
       (void) slog_usage(context, group, NULL);
       return 1; //-- ERROR
@@ -329,14 +404,14 @@ int main(int argc, char *argv[])
   int ret = 0; //-- main logic, 0 errors
   if (iterative)
     {
-      if (prevHostKey == NULL || prevMacFile == NULL || curMacFile == NULL)
+      if (prevHostKeyPath == NULL || prevMacFilePath == NULL || curMacFilePath == NULL)
         {
           g_print("%s", g_option_context_get_help(context, TRUE, NULL));
           g_option_context_free(context);
           return 1; //-- ERROR
         }
 
-      gboolean result = iterativeMode(prevHostKey, prevMacFile, curMacFile, inputLog, outputLog, bufSize);
+      gboolean result = iterativeMode(prevHostKeyPath, prevMacFilePath, curMacFilePath, inputLogPath, outputLogPath, bufSize);
       if (!result)
         {
           ret = 1; //-- ERROR
@@ -344,13 +419,13 @@ int main(int argc, char *argv[])
     }
   else
     {
-      if (hostKey == NULL || curMacFile == NULL)
+      if (hostKeyPath == NULL || curMacFilePath  == NULL)
         {
           g_print("%s", g_option_context_get_help(context, TRUE, NULL));
           g_option_context_free(context);
           return 1; //-- ERROR
         }
-      gboolean result = normalMode(hostKey, curMacFile, inputLog, outputLog, bufSize);
+      gboolean result = normalMode(hostKeyPath, curMacFilePath, inputLogPath, outputLogPath, bufSize);
       if (!result)
         {
           ret = 1; //-- ERROR

--- a/modules/secure-logging/slogverify/slogverify.c
+++ b/modules/secure-logging/slogverify/slogverify.c
@@ -27,7 +27,7 @@
 #include <errno.h>
 
 #include <glib.h>
-
+#include <locale.h>
 #include "messages.h"
 #include "slog.h"
 
@@ -205,7 +205,7 @@ gboolean iterativeMode(char *prevKey, char *prevMAC, char *curMAC, char *inputlo
     {
       msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason",
                                                "There is a problem with log verification. Please check log manually"));
-      return FALSE; //-- ERROR (note: fix bug, was 1)
+      return FALSE; //-- ERROR
 
     }
 
@@ -218,6 +218,8 @@ gboolean iterativeMode(char *prevKey, char *prevMAC, char *curMAC, char *inputlo
 //
 int main(int argc, char *argv[])
 {
+  setlocale(LC_ALL, "");
+
   SLogOptions options[] =
   {
     { "iterative", 'i', "Iterative verification", NULL, NULL },

--- a/modules/secure-logging/slogverify/slogverify.c
+++ b/modules/secure-logging/slogverify/slogverify.c
@@ -148,7 +148,7 @@ gboolean iterativeMode(char *path_prevKey, char *path_prevMAC, char *path_curMAC
   guchar previousKey[KEY_LENGTH];
   guint64 previousKeyCounter = 0;
 
-  msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Reading previous keyfile"), evt_tag_str("name", path_prevKey));
+  msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Reading previous key file"), evt_tag_str("name", path_prevKey));
   gboolean success = readKey(previousKey, &previousKeyCounter, path_prevKey);
   if (!success)
     {
@@ -157,7 +157,7 @@ gboolean iterativeMode(char *path_prevKey, char *path_prevMAC, char *path_curMAC
       return FALSE; //-- ERROR
     }
 
-  msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Reading previous MACfile"), evt_tag_str("name", path_prevMAC));
+  msg_info(SLOG_INFO_PREFIX, evt_tag_str("Reason", "Reading previous MAC file"), evt_tag_str("name", path_prevMAC));
   FILE *fp_previousBigMAC = fopen(path_prevMAC, "r");
   if (fp_previousBigMAC == NULL)
     {
@@ -200,7 +200,7 @@ gboolean iterativeMode(char *path_prevKey, char *path_prevMAC, char *path_curMAC
   FILE *fp_input = fopen(path_inputlog, "r");
   if (fp_input == NULL)
     {
-      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to open inputlog"), evt_tag_str("file", path_inputlog));
+      msg_error(SLOG_ERROR_PREFIX, evt_tag_str("Reason", "Unable to open input log"), evt_tag_str("file", path_inputlog));
       return FALSE; //-- ERROR
     }
 
@@ -262,7 +262,23 @@ int main(int argc, char *argv[])
   };
 
   GError *error = NULL;
-  GOptionContext *context = g_option_context_new("INPUTLOG OUTPUTLOG [COUNTER] - Log archive verification");
+  GOptionContext *context = g_option_context_new("INPUTLOG OUTPUTLOG [COUNTER] - Log archive verification\n\n" \
+                                                 "Examples:\n" \
+                                                 "  normal mode:\n" \
+                                                 "    ./slogverify\n" \
+                                                 "    --key-file ./host.key\n" \
+                                                 "    --mac-file ./mac.dat\n" \
+                                                 "    ./messages.slog\n" \
+                                                 "    ./messages_verified.txt\n\n"
+                                                 "  iterative mode:\n" \
+                                                 "    ./slogverify -i\n" \
+                                                 "    --prev-key-file ./host0.key\n" \
+                                                 "    --prev-mac-file ./mac0.dat\n" \
+                                                 "    --mac-file ./mac1.dat\n" \
+                                                 "    ./plainlog_1.out\n" \
+                                                 "    ./plainlog_1.chk\n"
+                                                );
+
   GOptionGroup *group = g_option_group_new("Basic options", "Basic log archive verification options", "basic", &options,
                                            NULL);
 
@@ -290,7 +306,6 @@ int main(int argc, char *argv[])
   hostKeyPath = options[index++].arg;
   if (!iterative)
     {
-      g_print("hostKeyPath: %s\n", hostKeyPath);
       char *p_path_check = realpath(hostKeyPath, NULL);
       if (NULL == p_path_check)
         {
@@ -305,7 +320,6 @@ int main(int argc, char *argv[])
   curMacFilePath = options[index++].arg;
   if (!iterative)
     {
-      g_print("curMacFilePath: %s\n", curMacFilePath);
       char *p_path_check = realpath(curMacFilePath, NULL);
       if (NULL == p_path_check)
         {
@@ -320,7 +334,6 @@ int main(int argc, char *argv[])
   prevHostKeyPath = options[index++].arg;
   if (iterative)
     {
-      g_print("prevHostKeyPath: %s\n", prevHostKeyPath);
       char *p_path_check = realpath(prevHostKeyPath, NULL);
       if (NULL == p_path_check)
         {
@@ -335,7 +348,6 @@ int main(int argc, char *argv[])
   prevMacFilePath = options[index++].arg;
   if (iterative )
     {
-      g_print("prevMacFilePath: %s\n", prevMacFilePath);
       char *p_path_check = realpath(prevMacFilePath, NULL);
       if (NULL == p_path_check)
         {
@@ -350,7 +362,6 @@ int main(int argc, char *argv[])
   // Input and output file arguments
   index = 1;
   inputLogPath = argv[index++];
-  g_print("inputLogPath: %s\n", inputLogPath);
   if (!g_file_test(inputLogPath, G_FILE_TEST_IS_REGULAR))
     {
       GString *errorMsg = g_string_new(FILE_ERROR);
@@ -360,11 +371,9 @@ int main(int argc, char *argv[])
     }
 
   outputLogPath = argv[index++];
-  g_print("outputLogPath: %s\n", outputLogPath);
   gchar *dir_part = g_path_get_dirname(outputLogPath);
   if (NULL != dir_part)
     {
-      g_print("dir_part: %s\n", dir_part);
       char *dir_check = realpath(dir_part, NULL);
       if (NULL == dir_check)
         {
@@ -388,7 +397,6 @@ int main(int argc, char *argv[])
   if (argc == 4)
     {
       bufSize = atoi(argv[index]);
-
       if (bufSize <= MIN_BUF_SIZE || bufSize > MAX_BUF_SIZE)
         {
           msg_error(SLOG_ERROR_PREFIX,

--- a/modules/secure-logging/tests/Makefile.am
+++ b/modules/secure-logging/tests/Makefile.am
@@ -1,15 +1,19 @@
-modules_secure_logging_tests_TESTS				=	\
+# File: syslog-ng/modules/secure-logging/tests/Makefile.am
+
+modules_secure_logging_tests_TESTS = \
 	modules/secure-logging/tests/test_secure_logging
-check_PROGRAMS						+=	\
+
+check_PROGRAMS += \
 	${modules_secure_logging_tests_TESTS}
 
 EXTRA_DIST += modules/secure-logging/tests/CMakeLists.txt
 
-modules_secure_logging_tests_test_secure_logging_CFLAGS	=	\
-	$(TEST_CFLAGS)                                          \
-        -I${top_srcdir}/modules/secure-logging                  \
-        -I${top_builddir}/modules/secure-logging
-modules_secure_logging_tests_test_secure_logging_LDADD	=	\
-	$(TEST_LDADD)						\
+modules_secure_logging_tests_test_secure_logging_CFLAGS	= \
+	$(TEST_CFLAGS) \
+	-I${top_srcdir}/modules/secure-logging \
+	-I${top_builddir}/modules/secure-logging
+
+modules_secure_logging_tests_test_secure_logging_LDADD = \
+	$(TEST_LDADD) \
 	-dlpreopen ${top_builddir}/modules/secure-logging/libsecure-logging.la \
 	-dlpreopen ${top_builddir}/modules/syslogformat/libsyslogformat.la	

--- a/modules/secure-logging/tests/test_secure_logging.c
+++ b/modules/secure-logging/tests/test_secure_logging.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2024 Gergo Ferenc Kovacs
- * Copyright (c) 2019 Airbus Commercial Aircraft
+ * Copyright (c) 2025 Airbus Commercial Aircraft
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -30,7 +30,6 @@
 // Secure logging functions
 #include "slog.h"
 
-
 #include "apphook.h"
 #include "cfg.h"
 #include "logmatcher.h"
@@ -39,6 +38,13 @@
 #include <errno.h>
 #include <string.h>
 #include <unistd.h>
+#include <limits.h>
+#include <glib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <errno.h>
 
 
 #define MAX_TEST_MESSAGES 1000
@@ -52,6 +58,7 @@ static MsgFormatOptions test_parse_options;
 static gchar *testDirTmpl = "/tmp/slog-XXXXXX/";
 static gchar *hostKeyFile = "host.key";
 static gchar *macFile = "mac.dat";
+static gchar *mac0File = "mac0.dat";
 
 // Test data for secure logging
 static gchar *macAddr = "a08cefa7b520";
@@ -66,6 +73,7 @@ typedef struct _testData
   GString *testName;
   GString *keyFile;
   GString *macFile;
+  GString *mac0File;
   GString *testDir;
 } TestData;
 
@@ -152,7 +160,7 @@ GString *applyTemplate(LogTemplate *templ, LogMessage *msg)
 {
   GString *output = g_string_new(prefix);
 
-  LogTemplateEvalOptions options = {NULL, LTZ_LOCAL, 999, context_id, LM_VT_STRING};
+  LogTemplateEvalOptions options = {NULL, LTZ_LOCAL, 999, context_id, LM_VT_STRING, log_template_default_escape_method}; //-- TODO clarify escape
   // Execute secure logging template
   log_template_append_format_with_context(
     templ,       // Secure logging template
@@ -177,14 +185,20 @@ int findInArray(int index, int *buffer, int size)
   return 0;
 }
 
+// helper for verifyMaliciousMessages and verifyMessages to clean-up correctly
+static void gstring_destroy (gpointer data)
+{
+  g_string_free (data, TRUE); //-- TRUE -> also free the underlying buffer
+}
+
 // Verify messages with malicious modification and detect which entry is corrupted
 GString **verifyMaliciousMessages(guchar *hostkey, gchar *macFileName, GString **templateOutput,
                                   size_t totalNumberOfMessages, int *brokenEntries)
 {
-  unsigned char keyZero[KEY_LENGTH];
-  memcpy(keyZero, hostkey, KEY_LENGTH);
+  cr_assert(totalNumberOfMessages > 0, "Total number of message must be >0");
 
-  GHashTable *tab = NULL;
+  guchar keyZero[KEY_LENGTH];
+  memcpy(keyZero, hostkey, KEY_LENGTH);
 
   guint64 next = 0;
   guint64 start = 0;
@@ -192,76 +206,119 @@ GString **verifyMaliciousMessages(guchar *hostkey, gchar *macFileName, GString *
 
   GString **outputBuffer = g_new0(GString *, totalNumberOfMessages);
 
-  gchar mac[CMAC_LENGTH];
+  guchar mac[CMAC_LENGTH];
 
-  int ret = readBigMAC(macFileName, mac);
-  cr_assert(ret == 1, "Unable to read aggregated MAC from file %s", macFileName);
+  gboolean ret = readAggregatedMAC(macFileName, mac);
+  cr_assert(ret == TRUE, "Unable to read aggregated MAC from file %s", macFileName);
+
   int problemsFound = 0;
-  unsigned char cmac_tag[CMAC_LENGTH];
+  guchar cmac_tag[CMAC_LENGTH];
   gsize cmac_tag_capacity = G_N_ELEMENTS(cmac_tag);
-  initVerify(totalNumberOfMessages, hostkey, &next, &start, templateOutput, &tab);
 
-  for (int i = 0; i < totalNumberOfMessages; i++)
+  GPtrArray *tmpTemplate = g_ptr_array_new();
+  g_ptr_array_add(tmpTemplate, templateOutput[0]);
+
+  GHashTable *tab = g_hash_table_new_full(g_str_hash, g_str_equal, (GDestroyNotify)g_free, NULL);
+  cr_assert_not_null(tab, "Can not create GHashTable");
+
+  initVerify(totalNumberOfMessages, hostkey, &next, &start, tmpTemplate);
+  g_ptr_array_free(tmpTemplate, TRUE);
+
+  GPtrArray *template = g_ptr_array_new();
+  GPtrArray *output = g_ptr_array_new_with_free_func (gstring_destroy);
+
+  for (size_t i = 0; i < totalNumberOfMessages; i++)
     {
-      ret = iterateBuffer(1, &templateOutput[i], &next, hostkey, keyZero, 0, &outputBuffer[i], &numberOfLogEntries, cmac_tag,
+      g_ptr_array_add(template, templateOutput[i]);
+      g_ptr_array_add(output, g_string_new(NULL));
+
+      ret = iterateBuffer(1, template, &next, hostkey, keyZero, 0, output, &numberOfLogEntries, cmac_tag,
                           cmac_tag_capacity, tab);
-      if (ret == 0)
+      if (ret == FALSE)
         {
           brokenEntries[problemsFound] = i;
           problemsFound++;
         }
+      g_ptr_array_remove_index(template, 0);
+      g_ptr_array_remove_index(output, 0);
     }
-  ret = finalizeVerify(start, totalNumberOfMessages, (guchar *)mac, cmac_tag, tab);
 
-  cr_assert(ret == 0, "Aggregated MAC is correct.");
+  ret = finalizeVerify(start, totalNumberOfMessages, mac, cmac_tag, &tab);
+
+  cr_assert(ret == FALSE, "Aggregated MAC is correct.");
+
+  g_ptr_array_free(template, FALSE);
+  g_ptr_array_free(output, TRUE);
 
   return outputBuffer;
 }
 
 // Verify log messages and compare them with the original
 void verifyMessages(guchar *hostkey, gchar *macFileName, GString **templateOutput, LogMessage **original,
-                    size_t totalNumberOfMessages)
+                    gsize totalNumberOfMessages)
 {
-  unsigned char keyZero[KEY_LENGTH];
+  guchar keyZero[KEY_LENGTH];
   memcpy(keyZero, hostkey, KEY_LENGTH);
-
-  GHashTable *tab = NULL;
 
   guint64 next = 0;
   guint64 start = 0;
   guint64 numberOfLogEntries = 0UL;
 
-  GString **outputBuffer = g_new0(GString *, totalNumberOfMessages);
+  GPtrArray *template = g_ptr_array_new();
 
-  gchar mac[CMAC_LENGTH];
-
-  int ret =  readBigMAC(macFileName, mac);
-  cr_assert(ret == 1, "Unable to read aggregated MAC from file %s", macFileName);
-
-  unsigned char cmac_tag[CMAC_LENGTH];
-  gsize cmac_tag_capacity = G_N_ELEMENTS(cmac_tag);
-  ret = initVerify(totalNumberOfMessages, hostkey, &next, &start, templateOutput, &tab);
-  cr_assert(ret == 1, "initVerify failed");
-
-  ret = iterateBuffer(totalNumberOfMessages, templateOutput, &next, hostkey, keyZero, 0, outputBuffer,
-                      &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
-  cr_assert(ret == 1, "iterateBuffer failed");
-
-  ret = finalizeVerify(start, totalNumberOfMessages, (guchar *)mac, cmac_tag, tab);
-  cr_assert(ret == 1, "finalizeVerify failed");
-
-
-  for (int i = 0; i < totalNumberOfMessages; i++)
+  for (gsize i = 0; i < totalNumberOfMessages; i++)
     {
-      char *plaintextMessage = (outputBuffer[i]->str) + CTR_LEN_SIMPLE + COLON + BLANK;
+      g_ptr_array_add(template, templateOutput[i]);
+    }
+
+  GHashTable *tab = g_hash_table_new_full(g_str_hash, g_str_equal, (GDestroyNotify)g_free, NULL);
+  cr_assert_not_null(tab, "Can not create GHashTable");
+
+  gboolean b = initVerify(totalNumberOfMessages, hostkey, &next, &start, template);
+  cr_assert(b == TRUE, "Init verify returns FALSE.");
+
+  GPtrArray *output = g_ptr_array_new_with_free_func (gstring_destroy);
+
+  guchar mac[CMAC_LENGTH];
+
+  gboolean ret = readAggregatedMAC(macFileName, mac);
+  cr_assert(ret == TRUE, "Unable to read aggregated MAC from file %s", macFileName);
+
+  guchar cmac_tag[CMAC_LENGTH];
+  gsize cmac_tag_capacity = G_N_ELEMENTS(cmac_tag);
+  ret = initVerify(totalNumberOfMessages, hostkey, &next, &start, template);
+  cr_assert(ret == TRUE, "initVerify failed");
+
+  //------------ initial MAC file, mac0.dat
+  char pathMac0[PATH_MAX]; //-- full path of MAC0 file mac0.dat
+  ret = get_path_mac0(macFileName, pathMac0, PATH_MAX);
+  cr_assert(ret == TRUE, "Unable to get path of mac0.dat");
+  guchar MAC0[CMAC_LENGTH]; //-- initial MAC
+  memset(MAC0, 0, CMAC_LENGTH);
+  ret = readAggregatedMAC(pathMac0, MAC0);
+  cr_assert(ret == TRUE, "Unable to read initial MAC from file %s", pathMac0);
+  memcpy(cmac_tag, MAC0, CMAC_LENGTH); //-- cmac_tag provides the initial MAC mac0
+  //------------
+
+  ret = iterateBuffer(totalNumberOfMessages, template, &next, hostkey, keyZero, 0, output,
+                      &numberOfLogEntries, cmac_tag, cmac_tag_capacity, tab);
+  cr_assert(ret == TRUE, "iterateBuffer failed");
+
+  ret = finalizeVerify(start, totalNumberOfMessages, (guchar *)mac, cmac_tag, &tab);
+  cr_assert(ret == TRUE, "finalizeVerify failed");
+
+  for (size_t i = 0; i < totalNumberOfMessages; i++)
+    {
+      GString *str = (GString *)g_ptr_array_index(output, i);
+      char *plaintextMessage = (str->str) + CTR_LEN_SIMPLE + COLON + BLANK;
       LogMessage *result = msg_format_parse(&test_parse_options, (const guchar *) plaintextMessage, strlen(plaintextMessage));
       log_msg_set_saddr(result, original[i]->saddr);
       assert_log_messages_equal(original[i], result);
-      g_string_free(outputBuffer[i], TRUE);
       log_msg_unref(result);
     }
 
-  g_free(outputBuffer);
+  g_ptr_array_free(template, FALSE);
+  g_ptr_array_free(output, TRUE);
 }
 
 // Generate keys to be used for the tests
@@ -269,14 +326,15 @@ void generateHostKey(guchar *hostkey, gchar *hostKeyFileName)
 {
   // Create keys for the test
   guchar masterkey[KEY_LENGTH];
-  int ret = generateMasterKey(masterkey);
-  cr_assert(ret == 1, "Unable to generate master key");
+  gboolean ret = generateMasterKey(masterkey);
+  cr_assert(ret, "Unable to generate master key");
 
-  ret = deriveHostKey(masterkey, macAddr, serial, hostkey);
-  cr_assert(ret == 1, "Unable to derive host key from master key for addr %s and serial number %s", macAddr, serial);
+  deriveHostKey(masterkey, macAddr, serial, hostkey);
+  cr_assert(hostkey != NULL, "Unable to derive host key from master key for addr %s and serial number %s", macAddr,
+            serial);
 
-  ret = writeKey((gchar *)hostkey, 0, hostKeyFileName);
-  cr_assert(ret == 1, "Unable to write host key to file %s", hostKeyFileName);
+  ret = writeKey(hostkey, 0, hostKeyFileName);
+  cr_assert(ret, "Unable to write host key to file %s", hostKeyFileName);
 }
 
 // Create a temporary directory
@@ -285,7 +343,7 @@ GString *createTemporaryDirectory(gchar *template)
   gchar buf[PATH_MAX];
 
   // Buffer for temporary path
-  g_strlcpy(buf, template, strlen(template) +1);
+  g_strlcpy(buf, template, strlen(template) + 1);
 
   // Create random directory
   gchar *tmpDir = g_mkdtemp(buf);
@@ -327,6 +385,35 @@ void removeTemporaryDirectory(gchar *dirName, gboolean force)
     {
       cr_log_info("removeTemporaryDirectory %s: %s", strerror(errno), dirName);
     }
+  if (g_file_test(dirName, G_FILE_TEST_IS_DIR) && (TRUE == force))
+    {
+      //-- another way to remove a directory ---
+      char szCmd[PATH_MAX];
+      g_snprintf(szCmd, sizeof(szCmd), "sync");
+      ret = system(szCmd);
+      if (0 == ret)
+        {
+          cr_log_info("Command %s executed successfully.", szCmd);
+        }
+      else
+        {
+          cr_log_info("Command %s returns %d", szCmd, ret);
+        }
+      g_snprintf(szCmd, sizeof(szCmd), "rm -rf %s", dirName);
+      ret = system(szCmd);
+      if (0 == ret)
+        {
+          cr_log_info("Command %s executed successfully.", szCmd);
+        }
+      else
+        {
+          cr_log_info("Command %s returns %d", szCmd, ret);
+        }
+      if (g_file_test(dirName, G_FILE_TEST_IS_DIR))
+        {
+          cr_log_info("Temporary directory was not deleted: %s", dirName);
+        }
+    }
 }
 
 // Initialize a test
@@ -340,7 +427,7 @@ TestData *initialize(gchar *name)
   testData->testDir = createTemporaryDirectory(testDirTmpl);
   testData->keyFile = createTemporaryFilePath(testData->testDir, hostKeyFile);
   testData->macFile = createTemporaryFilePath(testData->testDir, macFile);
-
+  testData->mac0File = createTemporaryFilePath(testData->testDir, mac0File);
   generateHostKey(testData->hostKey, testData->keyFile->str);
 
   return testData;
@@ -353,12 +440,14 @@ void closure(TestData *testData)
 
   removeTemporaryFile(testData->keyFile->str, TRUE);
   removeTemporaryFile(testData->macFile->str, TRUE);
+  removeTemporaryFile(testData->mac0File->str, TRUE);
   removeTemporaryDirectory(testData->testDir->str, TRUE);
 
   g_string_free(testData->testName, TRUE);
   g_string_free(testData->testDir, TRUE);
   g_string_free(testData->keyFile, TRUE);
   g_string_free(testData->macFile, TRUE);
+  g_string_free(testData->mac0File, TRUE);
 
   g_free(testData);
 }
@@ -438,13 +527,15 @@ TestSuite(secure_logging, .init = setup, .fini = teardown);
 
 void test_slog_template_format(void)
 {
+  g_print("-- test_slog_template_format\n");
+
   TestData *testData = initialize("test_slog_template_format");
 
   GString *templ = g_string_new("");
 
   // $(slog -k keyfile)
   g_string_printf(templ, "$(slog -k %s)", testData->keyFile->str);
-  assert_template_failure(templ->str, "[SLOG] ERROR: Template parsing failed. Invalid number of arguments");
+  assert_template_failure(templ->str, SLOG_ERROR_PREFIX ": Template parsing failed. Invalid number of arguments");
 
   // $(slog -k keyfile -m)
   g_string_printf(templ, "$(slog -k %s -m)", testData->keyFile->str);
@@ -456,7 +547,7 @@ void test_slog_template_format(void)
 
   // $(slog -k keyfile -m macfile)
   g_string_printf(templ, "$(slog -k %s -m %s)", testData->keyFile->str, testData->macFile->str);
-  assert_template_failure(templ->str, "[SLOG] ERROR: Template parsing failed. Invalid number of arguments");
+  assert_template_failure(templ->str, SLOG_ERROR_PREFIX ": Template parsing failed. Invalid number of arguments");
 
   g_string_free(templ, TRUE);
 
@@ -465,6 +556,7 @@ void test_slog_template_format(void)
 
 void test_slog_verification(void)
 {
+  g_print("-- test_slog_verification\n");
   TestData *testData = initialize("test_slog_verification");
 
   LogMessage *msg = create_random_sample_message();
@@ -482,6 +574,7 @@ void test_slog_verification(void)
 
 void test_slog_verification_bulk(void)
 {
+  g_print("-- test_slog_verification_bulk\n");
   TestData *testData = initialize("test_slog_verification_bulk");
 
   LogTemplate *slog_templ = createTemplate(testData);
@@ -520,6 +613,7 @@ void test_slog_verification_bulk(void)
 
 void test_slog_corrupted_key(void)
 {
+  g_print("-- test_slog_corrupted_key\n");
   TestData *testData = initialize("test_slog_corrupted_key");
 
   // Part 1: Log several messages -> They must be encrypted
@@ -606,6 +700,7 @@ void test_slog_corrupted_key(void)
 
 void test_slog_malicious_modifications(void)
 {
+  g_print("-- test_slog_malicious_modifications\n");
   TestData *testData = initialize("test_slog_malicious_modifications");
 
   LogTemplate *slog_templ = createTemplate(testData);
@@ -614,7 +709,7 @@ void test_slog_malicious_modifications(void)
   size_t num = randomNumber(MIN_TEST_MESSAGES, MAX_TEST_MESSAGES);
 
   LogMessage **logs = g_new0(LogMessage *, num);
-
+  g_print("Num: %lu\n", num);
   createLogMessages(num, logs);
 
   // Template output
@@ -626,17 +721,22 @@ void test_slog_malicious_modifications(void)
       output[i] = applyTemplate(slog_templ, logs[i]);
     }
 
+
   int mods = randomNumber(1, num - 1);
   int entriesToModify[mods];
+
+  mods = 1;
 
   // We might modify the same entry twice
   for (int i = 0; i < mods; i++)
     {
       entriesToModify[i] = randomNumber(0, num - 1);
+      g_print("MODIFYING ENTRY %d\n", entriesToModify[i]);
+
 
       // Overwrite with invalid string (invalid with high probability!)
       g_string_overwrite(output[entriesToModify[i]], randomNumber(COUNTER_LENGTH + COLON,
-                                                                  (output[entriesToModify[i]]->len) -1), "999999999999999999999999999999999999999999999999999999999999999");
+                                                                  (output[entriesToModify[i]]->len) - 1), "999999999999999999999999999999999999999999999999999999999999999");
     }
 
   // Verify the previously created log
@@ -647,15 +747,15 @@ void test_slog_malicious_modifications(void)
     }
   GString **ob = verifyMaliciousMessages(testData->hostKey, testData->macFile->str, output, num, brokenEntries);
 
-  for (int i = 0; i < num; i++)
+  for (gsize i = 0; i < num; i++)
     {
       if (1 == findInArray(i, entriesToModify, mods))
         {
-          cr_assert(1 == findInArray(i, brokenEntries, mods), "Modified entry %d not detected.", i);
+          cr_assert(1 == findInArray(i, brokenEntries, mods), "Modified entry %lu not detected.", i);
         }
       else
         {
-          cr_assert(0 == findInArray(i, brokenEntries, mods), "Unmodified entry %d detected as modified.", i);
+          cr_assert(0 == findInArray(i, brokenEntries, mods), "Unmodified entry %lu detected as modified.", i);
         }
     }
 
@@ -676,6 +776,9 @@ void test_slog_malicious_modifications(void)
 
 void test_slog_performance(void)
 {
+  LogTemplateEvalOptions my_default_template_eval_optons = {NULL, LTZ_LOCAL, 999, context_id, LM_VT_STRING, log_template_default_escape_method}; //-- TODO clarify escape
+
+  g_print("-- test_slog_performance\n");
   TestData *testData = initialize("test_slog_performance");
 
   LogTemplate *slog_templ = createTemplate(testData);
@@ -688,7 +791,10 @@ void test_slog_performance(void)
   start_stopwatch();
   for (i = 0; i < PERFORMANCE_COUNTER; i++)
     {
-      log_template_format(slog_templ, msg, &DEFAULT_TEMPLATE_EVAL_OPTIONS, res);
+      //-- DEFAULT_TEMPLATE_EVAL_OPTIONS seems to miss escape
+      //-- log_template_format(slog_templ, msg, &DEFAULT_TEMPLATE_EVAL_OPTIONS, res);
+      log_template_format(slog_templ, msg, &my_default_template_eval_optons, res);
+
     }
   stop_stopwatch_and_display_result(PERFORMANCE_COUNTER, "%-90.*s", (int)strlen(slog_templ->template_str) - 1,
                                     slog_templ->template_str);

--- a/modules/secure-logging/tests/test_secure_logging.c
+++ b/modules/secure-logging/tests/test_secure_logging.c
@@ -807,14 +807,43 @@ void test_slog_performance(void)
   closure(testData);
 }
 
+
+
+void test_slog_helper_path_validation(void)
+{
+  gchar path_no[256] = "/usr/wtf33/bingo.txt";
+  gchar path_yes[256] = "/tmp/bingo_test015708705702374095273094.txt";
+  gboolean is_ok = is_file_path_safe_and_valid(path_no);
+  cr_assert(FALSE == is_ok, "Given path is not valid because the directoy is invalid");
+  is_ok = is_file_path_safe_and_valid(path_yes);
+  cr_assert(TRUE == is_ok, "Given path is valid even the file does not exist");
+  GError *error = NULL;
+  gchar *path_yes2 = NULL;
+  gint fd = g_file_open_tmp("test_path_val_XXXXXX", &path_yes2, &error);
+  if (fd != -1)
+    {
+      //-- e.g.: "/tmp/test_path_val_A1B2C3"
+      is_ok = is_file_path_safe_and_valid(path_yes2);
+      cr_assert(TRUE == is_ok, "Given path is valid and the file does exist");
+      g_free(path_yes2);
+      close(fd);
+    }
+}
+
 Test(secure_logging, test_slog_template_format)
 {
   test_slog_template_format();
 }
 
+
 Test(secure_logging, test_slog_performance)
 {
   test_slog_performance();
+}
+
+Test(secure_logging, test_slog_helper_path_validation)
+{
+  test_slog_helper_path_validation();
 }
 
 Test(secure_logging, test_slog_verification_bulk)


### PR DESCRIPTION
The previous implementation allowed an attacker to distinguish between the pseudo-random function (PRF) and a real random function by supplying specially crafted inputs to it. This leads to a predictable way of how the PRF is generating output which should not by allowed by a good PRF. The new implementation provides a variable input length and constant output length PRF based on AES CMAC for key derivation using the current key Ki, i.e. a key expansion of Ki using multiple iterations is performed. Subsequently, with Ki as the key used in the PRF, the input is defined as

(i || label || 0x00 || context || L)

with i as the number of the current iteration, L as the total length of the requested output, label and context for parametrization of the PRF output based on the intended purpose. See NIST reports SP-800-56cr2 and SP.800-108r1 for more information on key derivation schemes with a PRF.

In the previous implementation, the input length was fixed at 16 bytes regardless of the actual length of the input data. This is also fixed in the new implementation.

Minor changes:
    - MAC verification fix
    - error logging macros
    - clean-up
    - file handling (DRY)
    - return values
    - source code formatting
    - use of GLib types

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
