### PR TITLE
log-scheduler: Use common, already existing keywords for parallelize() sub-options

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -289,9 +289,9 @@
 %token KW_TIME_REAP                   10211
 %token KW_TIME_SLEEP                  10212
 
-%token KW_PARTITIONS                  10213
-%token KW_PARTITION_KEY               10214
 %token KW_PARALLELIZE                 10215
+%token KW_PARTITIONS                  10216
+%token KW_PARTITION_KEY               10217
 
 /* destination options */
 %token KW_TMPL_ESCAPE                 10220
@@ -761,6 +761,14 @@ log_scheduler_option
             last_scheduler_options->num_partitions = $3;
           }
         | KW_PARTITION_KEY '(' template_content ')'
+          {
+            log_scheduler_options_set_partition_key_ref(last_scheduler_options, $3);
+          }
+        | KW_WORKERS '(' nonnegative_integer ')'
+          {
+            last_scheduler_options->num_partitions = $3;
+          }
+        | KW_WORKER_PARTITION_KEY '(' template_content ')'
           {
             log_scheduler_options_set_partition_key_ref(last_scheduler_options, $3);
           }

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -190,6 +190,9 @@ static CfgLexerKeyword main_keywords[] =
   { "retries",            KW_RETRIES },
   { "workers",            KW_WORKERS },
   { "worker_partition_key", KW_WORKER_PARTITION_KEY },
+  { "parallelize",        KW_PARALLELIZE },
+  { "partitions",         KW_PARTITIONS, KWS_OBSOLETE, "workers" },
+  { "partition_key",      KW_PARTITION_KEY, KWS_OBSOLETE, "worker_partition_key" },
   { "batch_lines",        KW_BATCH_LINES },
   { "batch_timeout",      KW_BATCH_TIMEOUT },
 
@@ -204,9 +207,6 @@ static CfgLexerKeyword main_keywords[] =
   { "multi_line_prefix",  KW_MULTI_LINE_PREFIX },
   { "multi_line_garbage", KW_MULTI_LINE_GARBAGE },
   { "multi_line_suffix",  KW_MULTI_LINE_GARBAGE },
-  { "parallelize",        KW_PARALLELIZE },
-  { "partitions",         KW_PARTITIONS },
-  { "partition_key",      KW_PARTITION_KEY },
 
   /* filter items */
   { "type",               KW_TYPE },


### PR DESCRIPTION
Doc PR: https://github.com/syslog-ng/syslog-ng.github.io/pull/285