### PR TITLE
Improve `@NUMBER@` / `@DOUBLE@` support for numbers with signs

### DIFF
--- a/modules/correlation/radix.c
+++ b/modules/correlation/radix.c
@@ -618,11 +618,18 @@ r_parser_float(gchar *str, gint *len, const gchar *param, gpointer state, RParse
 gboolean
 r_parser_number(gchar *str, gint *len, const gchar *param, gpointer state, RParserMatch *match)
 {
+  *len = 0;
   gint min_len = 1;
 
-  if (g_str_has_prefix(str, "0x") || g_str_has_prefix(str, "0X"))
+  if ((str[*len] == '-') || (str[*len] == '+'))
     {
-      *len = 2;
+      (*len)++;
+      min_len++;
+    }
+
+  if (g_str_has_prefix(str + *len, "0x") || g_str_has_prefix(str + *len, "0X"))
+    {
+      *len += 2;
       min_len += 2;
 
       while (g_ascii_isxdigit(str[*len]))
@@ -631,14 +638,6 @@ r_parser_number(gchar *str, gint *len, const gchar *param, gpointer state, RPars
     }
   else
     {
-      *len = 0;
-
-      if ((str[*len] == '-') || (str[*len] == '+'))
-        {
-          (*len)++;
-          min_len++;
-        }
-
       while (g_ascii_isdigit(str[*len]))
         (*len)++;
     }

--- a/modules/correlation/tests/test_radix.c
+++ b/modules/correlation/tests/test_radix.c
@@ -706,6 +706,16 @@ ParameterizedTestParameters(dbparser, test_radix_search_matches)
     },
     {
       .node_to_insert = {"@NUMBER:number@", NULL},
+      .key = "+0xAF12345 hihihi",
+      .expected_pattern = {"number", "+0xAF12345", NULL}
+    },
+    {
+      .node_to_insert = {"@NUMBER:number@", NULL},
+      .key = "-0xAF12345 hihihi",
+      .expected_pattern = {"number", "-0xAF12345", NULL}
+    },
+    {
+      .node_to_insert = {"@NUMBER:number@", NULL},
       .key = "0x12345 hihihi",
       .expected_pattern = {"number", "0x12345", NULL}
     },


### PR DESCRIPTION
When parsing numbers using the `@NUMBER@` or `@DOUBLE@` pattern parsers, some sign are not allowed making PatternDB reject expressions that are properly formatted numbers:

* Explicit `+` signs are rejected at the beginning of a number / exponent part of a number:
  * `+1000`
  * `+1.5`
  * `1e+3`
  * `+0xFF`
* A `-` sign before an hexadecimal value is also rejected:
  * `-0xFF`

Make sure these value are properly parsed.

Fixes #5406
