### PR TITLE
Improve build on FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ find_package(WRAP)
 external_or_find_package(JSONC REQUIRED)
 include(find_python_and_build_venv)
 include(find_ivykis)
-pkg_check_modules(LIBPCRE REQUIRED libpcre2-8)
+pkg_check_modules(LIBPCRE REQUIRED IMPORTED_TARGET libpcre2-8)
 
 include(detect_features)
 include(platform_options)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -383,7 +383,7 @@ target_link_libraries(
     ${Gettext_LIBRARIES}
     ${IVYKIS_LIBRARIES}
     ${JSONC_LIBRARY}
-    ${LIBPCRE_LIBRARIES}
+    PkgConfig::LIBPCRE
     ${Libsystemd_LIBRARIES}
     ${LIBUNWIND_LIBRARIES}
     resolv


### PR DESCRIPTION
When building with CMake on FreeBSD, compilation fail when linking libsyslog-ng.so with this message:

```
[  1%] Linking C shared library libsyslog-ng.so
ld: error: unable to find library -lpcre2-8
cc: error: linker command failed with exit code 1 (use -v to see invocation)
gmake[2]: *** [lib/CMakeFiles/syslog-ng.dir/build.make:4435: lib/libsyslog-ng.so.4.10.2] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:6103: lib/CMakeFiles/syslog-ng.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```

libpcre is found by pkg-config, but is located in `/usr/local/lib` on FreeBSD, which is not included in the default library search path.  The required `-L/usr/local/lib` is known to pkg-config, but it is not used when building syslog-ng:

```
$ pkg-config --libs libpcre2-8
-L/usr/local/lib -lpcre2-8
```

Add an `IMPORTED_TARGET` argument to `pkg_check_modules`.  This allows us to reference `PkgConfig::LIBPCRE` to build the expected link library command as shown in the CMake documentation:
https://cmake.org/cmake/help/latest/module/FindPkgConfig.html#example-creating-imported-target
