### PR TITLE
afsql: fix missing break in LM_VT_BOOLEAN case causing fallthrough to LM_VT_NULL

### DIFF
--- a/modules/afsql/afsql.c
+++ b/modules/afsql/afsql.c
@@ -867,6 +867,7 @@ afsql_dd_append_value_to_be_inserted(AFSqlDestDriver *self,
           if (fallback)
             afsql_dd_append_quoted_value(self, value, insert_command);
         }
+      break;
     }
     case LM_VT_NULL:
       g_string_append(insert_command, "NULL");


### PR DESCRIPTION
## Summary

The `LM_VT_BOOLEAN` case in the SQL INSERT value builder (`modules/afsql/afsql.c`) is missing a `break` statement, causing execution to fall through into the `LM_VT_NULL` case. This unconditionally appends `NULL` after the boolean value, producing malformed SQL values like `TRUENULL` or `FALSENULL` in every INSERT containing a boolean field.

## The Bug

In the switch statement that builds SQL INSERT values from log message fields, every other case (`LM_VT_INTEGER`, `LM_VT_DOUBLE`, `LM_VT_NULL`, `LM_VT_BYTES`, etc.) properly terminates with `break;`. The `LM_VT_BOOLEAN` case does not, so after appending `TRUE` or `FALSE`, control falls through to `case LM_VT_NULL:` which unconditionally appends `NULL`.

**Before (buggy):**
```c
    case LM_VT_BOOLEAN:
    {
      // ... appends "TRUE" or "FALSE" ...
    }
    case LM_VT_NULL:        // <-- falls through here
      g_string_append(insert_command, "NULL");
      break;
```

**After (fixed):**
```c
    case LM_VT_BOOLEAN:
    {
      // ... appends "TRUE" or "FALSE" ...
      break;                // <-- added
    }
    case LM_VT_NULL:
      g_string_append(insert_command, "NULL");
      break;
```

## Impact

Any SQL destination (`d_sql`) receiving boolean-typed fields produces corrupted INSERT statements. For example, a boolean field with value `true` would generate `TRUENULL` instead of `TRUE` in the SQL query, causing database errors or silent data corruption depending on the RDBMS.

## Fix

Add the missing `break;` statement after the `LM_VT_BOOLEAN` case block, consistent with all other cases in the same switch.