### PR TITLE
tls: add NULL check after SSL_new() in tls_context_setup_session

### DIFF
--- a/lib/transport/tls-context.c
+++ b/lib/transport/tls-context.c
@@ -651,6 +651,8 @@ tls_context_setup_session(TLSContext *self)
     return NULL;
 
   SSL *ssl = SSL_new(self->ssl_ctx);
+  if (!ssl)
+    return NULL;
 
   if (self->mode == TM_CLIENT)
     SSL_set_connect_state(ssl);


### PR DESCRIPTION
## Summary

`SSL_new()` can return `NULL` on memory exhaustion or internal OpenSSL errors. The return value in `tls_context_setup_session()` is used without a NULL check, causing a NULL pointer dereference (SIGSEGV).

## The Bug

In `lib/transport/tls-context.c`, `tls_context_setup_session()` calls `SSL_new(self->ssl_ctx)` and immediately passes the result to `SSL_set_connect_state()` or `SSL_set_accept_state()` without checking for NULL:

```c
SSL *ssl = SSL_new(self->ssl_ctx);

if (self->mode == TM_CLIENT)
    SSL_set_connect_state(ssl);   // SIGSEGV if ssl == NULL
else
    SSL_set_accept_state(ssl);    // SIGSEGV if ssl == NULL
```

## Impact

- **Denial-of-service** on any TLS-enabled source/destination under memory pressure
- The existing NULL check for `self->ssl_ctx` (line 650–651) shows this pattern is expected but was missed for the `SSL_new()` return value

## Fix

Add a standard NULL guard after `SSL_new()`, consistent with the existing `ssl_ctx` check immediately above:

```c
SSL *ssl = SSL_new(self->ssl_ctx);
if (!ssl)
    return NULL;
```

No behavioral change when `SSL_new()` succeeds.