### PR TITLE
CI: add back the lost -Werror flag to the FreeBSD builds

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -104,7 +104,7 @@ jobs:
 
         echo -e "\nBuilding...\n"
         if [[ "${{ matrix.language }}" == "c-cpp" ]]; then
-          cmake -B build . -Wno-dev -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_BUILD_TYPE=Release -DIVYKIS_SOURCE=internal -DBUILD_TESTING=ON -DENABLE_FORCE_GNU99=ON -DSUMMARY_LEVEL=0 -DENABLE_EXTRA_WARNINGS=ON -Werror --fresh
+          cmake -B build . -Wno-dev -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_BUILD_TYPE=Release -DIVYKIS_SOURCE=internal -DBUILD_TESTING=ON -DENABLE_FORCE_GNU99=ON -DSUMMARY_LEVEL=0 -DENABLE_EXTRA_WARNINGS=ON -DENABLE_WERROR=ON --fresh
         elif [[ "${{ matrix.language }}" == "java-kotlin" ]]; then
           # The CodeQL runner uses its own JDK distribution inside the CodeQL Action environment.
           # That JDK is stricter about module encapsulation, so reflective access to com.sun.tools.javac.api fails unless you explicitly open the module.
@@ -112,7 +112,7 @@ jobs:
           export ORG_GRADLE_PROJECT_org_gradle_jvmargs="--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
             --add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED \
             --add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
-          cmake -B build . -Wno-dev -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_BUILD_TYPE=Release -DIVYKIS_SOURCE=internal -DDISABLE_ALL_MODULES=ON -DENABLE_JAVA=ON -DENABLE_JAVA_MODULES=ON -DENABLE_FORCE_GNU99=ON -DSUMMARY_LEVEL=0 -DENABLE_EXTRA_WARNINGS=ON -Werror --fresh
+          cmake -B build . -Wno-dev -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_BUILD_TYPE=Release -DIVYKIS_SOURCE=internal -DDISABLE_ALL_MODULES=ON -DENABLE_JAVA=ON -DENABLE_JAVA_MODULES=ON -DENABLE_FORCE_GNU99=ON -DSUMMARY_LEVEL=0 -DENABLE_EXTRA_WARNINGS=ON -DENABLE_WERROR=ON --fresh
         fi
         cmake --build ./build -j$(nproc) --target all
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -104,7 +104,7 @@ jobs:
 
         echo -e "\nBuilding...\n"
         if [[ "${{ matrix.language }}" == "c-cpp" ]]; then
-          cmake -B build . -Wno-dev -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_BUILD_TYPE=Release -DIVYKIS_SOURCE=internal -DBUILD_TESTING=ON -DENABLE_FORCE_GNU99=ON -DSUMMARY_LEVEL=0 -DENABLE_EXTRA_WARNINGS=ON -DENABLE_WERROR=ON --fresh
+          cmake -B build . -Wno-dev -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF -DCMAKE_BUILD_TYPE=Release -DIVYKIS_SOURCE=internal -DENABLE_TESTING=ON -DENABLE_FORCE_GNU99=ON -DSUMMARY_LEVEL=0 -DENABLE_EXTRA_WARNINGS=ON -DENABLE_WERROR=ON --fresh
         elif [[ "${{ matrix.language }}" == "java-kotlin" ]]; then
           # The CodeQL runner uses its own JDK distribution inside the CodeQL Action environment.
           # That JDK is stricter about module encapsulation, so reflective access to com.sun.tools.javac.api fails unless you explicitly open the module.

--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -213,8 +213,8 @@ jobs:
           CXXFLAGS="${CFLAGS}"
           SYSLOG_NG_INSTALL_DIR=${HOME}/install/syslog-ng
           CONFIGURE_FLAGS="
-            `[ $CC = clang ] && echo '--enable-force-gnu99' || true`
             --enable-colored-log
+            `[ $CC = clang ] && echo '--enable-force-gnu99' || true`
             --enable-extra-warnings
             --enable-debug
             --prefix=${SYSLOG_NG_INSTALL_DIR}

--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -234,7 +234,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug
             -DCMAKE_INSTALL_PREFIX=${SYSLOG_NG_INSTALL_DIR}
             -DSUMMARY_LEVEL=1
-            -DBUILD_TESTING=ON
+            -DENABLE_TESTING=ON
             -DPYTHON_VERSION=3
             -DIVYKIS_SOURCE=internal
             -DENABLE_JAVA=OFF

--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -120,7 +120,8 @@ jobs:
           # --------------------------------------------------------------------
           - name: devshell
             # Now only for devsell we support -Werror, all other none-packaged targets are just best efforts
-            cflags: "-Werror"
+            configure_flags: "--enable-werror"
+            cmake_configure_flags: "-DENABLE_WERROR=ON"
           # --------------------------------------------------------------------
         exclude:
           - platform: ubuntu-24.04-arm
@@ -229,16 +230,17 @@ jobs:
           "
           CMAKE_CONFIGURE_FLAGS="
             `[ $CC = clang ] && echo '-DENABLE_FORCE_GNU99=ON' || true`
-            -DSUMMARY_VERBOSE=ON
+            -DENABLE_EXTRA_WARNINGS=ON
             -DCMAKE_BUILD_TYPE=Debug
             -DCMAKE_INSTALL_PREFIX=${SYSLOG_NG_INSTALL_DIR}
+            -DSUMMARY_LEVEL=1
             -DBUILD_TESTING=ON
             -DPYTHON_VERSION=3
             -DIVYKIS_SOURCE=internal
             -DENABLE_JAVA=OFF
             -DENABLE_JAVA_MODULES=OFF
-            -DENABLE_EBPF=ON
             -DENABLE_STACKDUMP=ON
+            -DENABLE_EBPF=ON
             ${{ matrix.image.cmake_configure_flags }}
           "
           gh_export COREFILES_DIR PYTHONUSERBASE CC CXX SYSLOG_NG_INSTALL_DIR CFLAGS CXXFLAGS CONFIGURE_FLAGS CMAKE_CONFIGURE_FLAGS
@@ -365,9 +367,8 @@ jobs:
           . .github/workflows/gh-tools.sh
 
           DISTCHECK_CONFIGURE_FLAGS="
-            CFLAGS=-Werror
-            CXXFLAGS=-Werror
             --prefix=${HOME}/install/syslog-ng
+            --enable-werror
             --with-ivykis=internal
             --with-jsonc=system
             --enable-tcp-wrapper

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -56,11 +56,12 @@ jobs:
           CFLAGS="-I${BSDPORTS_PREFIX}/include/ ${WARNING_FLAGS}"
           CXXFLAGS="${CFLAGS}"
           LDFLAGS="-L${BSDPORTS_PREFIX}/lib"
-          # -DIVYKIS_SOURCE=internal is switched to system temporally as of https://github.com/buytenh/ivykis/pulls
           CONFIGURE_FLAGS="
+            --enable-colored-log
             `[ $CC = clang ] && echo '--enable-force-gnu99' || true`
             --enable-extra-warnings
             --enable-debug
+            --disable-dependency-tracking
             --prefix=${SYSLOG_NG_INSTALL_DIR}
             --enable-tests
             --disable-stackdump
@@ -174,7 +175,7 @@ jobs:
           ./autogen.sh
           mkdir build
           cd build
-          ../configure --disable-dependency-tracking ${CONFIGURE_FLAGS}
+          ../configure ${CONFIGURE_FLAGS}
           cd ..
           /usr/local/bin/gmake -C build install -j ${THREADS}
 

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -52,7 +52,7 @@ jobs:
           #THREADS=$(sysctl -n hw.ncpu) # TODO: Check how to get it on the FreeBSD VM
           BSDPORTS_PREFIX=/usr/local
           SYSLOG_NG_INSTALL_DIR="${HOME}/install/syslog-ng"
-          WARNING_FLAGS="-DNO_PTHREAD_SELF_USAGE_WARNING=1 -Wno-unused-command-line-argument" # FIXME: -Werror must be re-added
+          WARNING_FLAGS="-DNO_PTHREAD_SELF_USAGE_WARNING=1 -Wno-unused-command-line-argument"
           # All pkgconfig isses are fixed now, we do not have to use the BSDPORTS_PREFIX provided pats to point to the correct include path, but keep it here for reference
           #CFLAGS="-I${BSDPORTS_PREFIX}/include/ ${WARNING_FLAGS}"
           CFLAGS="${WARNING_FLAGS}"
@@ -63,6 +63,7 @@ jobs:
             --enable-colored-log
             `[ $CC = clang ] && echo '--enable-force-gnu99' || true`
             --enable-extra-warnings
+            --enable-werror
             --enable-debug
             --disable-dependency-tracking
             --prefix=${SYSLOG_NG_INSTALL_DIR}
@@ -77,8 +78,9 @@ jobs:
           CMAKE_CONFIGURE_FLAGS="
             `[ $CC = clang ] && echo '-DENABLE_FORCE_GNU99=ON' || true`
             -DENABLE_EXTRA_WARNINGS=ON
-            -DSUMMARY_LEVEL=1
+            -DENABLE_WERROR=ON
             -DCMAKE_BUILD_TYPE=Debug
+            -DSUMMARY_LEVEL=1
             -DCMAKE_INSTALL_PREFIX=${SYSLOG_NG_INSTALL_DIR}
             -DBUILD_TESTING=ON
             -DENABLE_STACKDUMP=OFF

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -59,11 +59,13 @@ jobs:
           CXXFLAGS="${CFLAGS}"
           # All pkgconfig isses are fixed now, we do not have to use the LDFLAGS to point to the correct library path, but keep it here for reference
           #LDFLAGS="-L${BSDPORTS_PREFIX}/lib"
+          # FIXME: The autotools used libtool will invoke clang with -Werror even for linking, which causes
+          #        the build to fail when unsupported options passed to the linker (with unused command line arguments, which normally just warnings)
+          #        so, for now not providing --enable-werror for autotools builds
           CONFIGURE_FLAGS="
             --enable-colored-log
             `[ $CC = clang ] && echo '--enable-force-gnu99' || true`
             --enable-extra-warnings
-            --enable-werror
             --enable-debug
             --disable-dependency-tracking
             --prefix=${SYSLOG_NG_INSTALL_DIR}

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -84,7 +84,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug
             -DSUMMARY_LEVEL=1
             -DCMAKE_INSTALL_PREFIX=${SYSLOG_NG_INSTALL_DIR}
-            -DBUILD_TESTING=ON
+            -DENABLE_TESTING=ON
             -DENABLE_STACKDUMP=OFF
             -DPYTHON_VERSION=3
             -DIVYKIS_SOURCE=internal

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -53,9 +53,12 @@ jobs:
           BSDPORTS_PREFIX=/usr/local
           SYSLOG_NG_INSTALL_DIR="${HOME}/install/syslog-ng"
           WARNING_FLAGS="-DNO_PTHREAD_SELF_USAGE_WARNING=1 -Wno-unused-command-line-argument" # FIXME: -Werror must be re-added
-          CFLAGS="-I${BSDPORTS_PREFIX}/include/ ${WARNING_FLAGS}"
+          # All pkgconfig isses are fixed now, we do not have to use the BSDPORTS_PREFIX provided pats to point to the correct include path, but keep it here for reference
+          #CFLAGS="-I${BSDPORTS_PREFIX}/include/ ${WARNING_FLAGS}"
+          CFLAGS="${WARNING_FLAGS}"
           CXXFLAGS="${CFLAGS}"
-          LDFLAGS="-L${BSDPORTS_PREFIX}/lib"
+          # All pkgconfig isses are fixed now, we do not have to use the LDFLAGS to point to the correct library path, but keep it here for reference
+          #LDFLAGS="-L${BSDPORTS_PREFIX}/lib"
           CONFIGURE_FLAGS="
             --enable-colored-log
             `[ $CC = clang ] && echo '--enable-force-gnu99' || true`

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -219,8 +219,8 @@ jobs:
           fi
           LDFLAGS="-L${HOMEBREW_PREFIX}/lib -L${MACPORTS_PREFIX}/lib"
           CONFIGURE_FLAGS="
-            `[ $CC = clang ] && echo '--enable-force-gnu99' || true`
             --enable-colored-log
+            `[ $CC = clang ] && echo '--enable-force-gnu99' || true`
             --enable-extra-warnings
             --enable-debug
             --prefix=${SYSLOG_NG_INSTALL_DIR}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -240,7 +240,7 @@ jobs:
             -DSUMMARY_LEVEL=1
             -DCMAKE_BUILD_TYPE=Debug
             -DCMAKE_INSTALL_PREFIX=${SYSLOG_NG_INSTALL_DIR}
-            -DBUILD_TESTING=ON
+            -DENABLE_TESTING=ON
             -DPYTHON_VERSION=3
             -DIVYKIS_SOURCE=internal
             -DENABLE_JOURNALD=OFF

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -208,7 +208,7 @@ jobs:
           SYSLOG_NG_INSTALL_DIR="${HOME}/install/syslog-ng"
           PYTHONUSERBASE="${HOME}/python_packages"
           THREADS="$(sysctl -n hw.physicalcpu)"
-          WARNING_FLAGS="-DNO_PTHREAD_SELF_USAGE_WARNING=1 -Wno-unused-command-line-argument -Werror"
+          WARNING_FLAGS="-DNO_PTHREAD_SELF_USAGE_WARNING=1 -Wno-unused-command-line-argument"
           CFLAGS="-I${HOMEBREW_PREFIX}/include/ -I${MACPORTS_PREFIX}/include ${WARNING_FLAGS}"
           CXXFLAGS="${CFLAGS}"
           # brew has an old autoconf-archive -> ax_cxx_compile_stdcxx.m4 version, which cannot detect
@@ -222,6 +222,7 @@ jobs:
             --enable-colored-log
             `[ $CC = clang ] && echo '--enable-force-gnu99' || true`
             --enable-extra-warnings
+            --enable-werror
             --enable-debug
             --prefix=${SYSLOG_NG_INSTALL_DIR}
             --enable-tests
@@ -235,6 +236,7 @@ jobs:
           CMAKE_CONFIGURE_FLAGS="
             `[ $CC = clang ] && echo '-DENABLE_FORCE_GNU99=ON' || true`
             -DENABLE_EXTRA_WARNINGS=ON
+            -DENABLE_WERROR=ON
             -DSUMMARY_LEVEL=1
             -DCMAKE_BUILD_TYPE=Debug
             -DCMAKE_INSTALL_PREFIX=${SYSLOG_NG_INSTALL_DIR}

--- a/Makefile.am
+++ b/Makefile.am
@@ -78,9 +78,9 @@ AM_CXXFLAGS += \
 
 if ENABLE_EXTRA_WARNINGS
 AM_CFLAGS += \
-	-Wimplicit-function-declaration \
 	$(CFLAGS_W_NO_INITIALIZER_OVERRIDES) \
 	$(CFLAGS_W_OLD_STYLE_DECLARATION) \
+	-Wimplicit-function-declaration \
 	-Wnested-externs \
 	-Wstrict-prototypes \
 	-Wswitch-default \

--- a/Makefile.am
+++ b/Makefile.am
@@ -120,6 +120,11 @@ AM_CXXFLAGS += \
 	-Wunused-but-set-parameter
 endif
 
+if ENABLE_WERROR
+AM_CFLAGS += -Werror
+AM_CXXFLAGS += -Werror
+endif
+
 if ENABLE_DEBUG
 AM_CFLAGS += -DYYDEBUG=1
 endif

--- a/cmake/Modules/FindCurl.cmake
+++ b/cmake/Modules/FindCurl.cmake
@@ -26,7 +26,7 @@ include(LibFindMacros)
 
 libfind_pkg_check_modules(Curl_PKGCONF libcurl)
 
-libfind_pkg_detect(Curl libcurl FIND_PATH curl.h PATH_SUFFIXES curl FIND_LIBRARY curl)
+libfind_pkg_detect(Curl libcurl FIND_PATH curl/curl.h FIND_LIBRARY curl)
 set(Curl_PROCESS_INCLUDES Curl_INCLUDE_DIR)
 set(Curl_PROCESS_LIBS Curl_LIBRARY)
 

--- a/cmake/print_config_summary.cmake
+++ b/cmake/print_config_summary.cmake
@@ -250,7 +250,12 @@ function(print_config_summary)
   _print_compilers_info("${_variableNames}" "${_compilersInfo}")
 
   _print_separator("Compilation")
-  list(APPEND _compilationOptions "CMAKE_BUILD_TYPE" "CXX_STANDARD_USED" "^ENABLE_CPP" "ENABLE_EXTRA_WARNINGS" "ENABLE_WERROR" "ENABLE_FORCE_GNU99" "ENV_LD_LIBRARY_PATH")
+  list(APPEND _compilationOptions "CMAKE_BUILD_TYPE" "CXX_STANDARD_USED" "^ENABLE_CPP" "ENABLE_EXTRA_WARNINGS" "ENABLE_WERROR" "ENABLE_FORCE_GNU99" "ENV_LD_LIBRARY_PATH" "^CMAKE_C_FLAGS$" "^CMAKE_CXX_FLAGS$" "^CMAKE_EXE_LINKER_FLAGS$" "^CMAKE_SHARED_LINKER_FLAGS$" "^CMAKE_MODULE_LINKER_FLAGS$" "^IMPORTANT_WARNINGS$" "^ACCEPTABLE_WARNINGS$" "^EXTRA_WARNINGS$")
+  if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    list(APPEND _compilationOptions " ^CMAKE_C_FLAGS_DEBUG$" "^CMAKE_CXX_FLAGS_DEBUG$ ")
+  else()
+    list(APPEND _compilationOptions " ^CMAKE_C_FLAGS_RELEASE$" "^CMAKE_CXX_FLAGS_RELEASE$ ")
+  endif()
 
   if(APPLE)
     list(APPEND _compilationOptions "FORCE_CLASSIC_LINKING")

--- a/cmake/print_config_summary.cmake
+++ b/cmake/print_config_summary.cmake
@@ -250,7 +250,7 @@ function(print_config_summary)
   _print_compilers_info("${_variableNames}" "${_compilersInfo}")
 
   _print_separator("Compilation")
-  list(APPEND _compilationOptions "CMAKE_BUILD_TYPE" "CXX_STANDARD_USED" "^ENABLE_CPP" "ENABLE_EXTRA_WARNINGS" "ENABLE_FORCE_GNU99" "ENV_LD_LIBRARY_PATH")
+  list(APPEND _compilationOptions "CMAKE_BUILD_TYPE" "CXX_STANDARD_USED" "^ENABLE_CPP" "ENABLE_EXTRA_WARNINGS" "ENABLE_WERROR" "ENABLE_FORCE_GNU99" "ENV_LD_LIBRARY_PATH")
 
   if(APPLE)
     list(APPEND _compilationOptions "FORCE_CLASSIC_LINKING")

--- a/cmake/set_compile_options.cmake
+++ b/cmake/set_compile_options.cmake
@@ -23,6 +23,11 @@
 #
 # ############################################################################
 
+include(CheckCCompilerFlag)
+
+check_c_compiler_flag("-Wno-initializer-overrides" CMAKE_HAVE_W_NO_INITIALIZER_OVERRIDES)
+check_c_compiler_flag("-Wold-style-declaration" CMAKE_HAVE_W_OLD_STYLE_DECLARATION)
+
 set(IMPORTANT_WARNINGS
   -Wshadow)
 
@@ -34,13 +39,47 @@ set(ACCEPTABLE_WARNINGS
 option(ENABLE_EXTRA_WARNINGS "Enable extra warnings" ON)
 option(ENABLE_WERROR "Enable -Werror" OFF)
 
+set(EXTRA_WARNINGS)
+
 if(ENABLE_EXTRA_WARNINGS)
-  set(EXTRA_WARNINGS
-    $<$<COMPILE_LANGUAGE:C>:-Wimplicit-function-declaration>
-    $<$<COMPILE_LANGUAGE:C>:-Wnested-externs>
-    $<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes>
+  set(C_EXTRA_WARNINGS)
+
+  if(CMAKE_HAVE_W_NO_INITIALIZER_OVERRIDES)
+    list(APPEND C_EXTRA_WARNINGS
+      -Wno-initializer-overrides)
+  endif()
+
+  if(CMAKE_HAVE_W_OLD_STYLE_DECLARATION)
+    list(APPEND C_EXTRA_WARNINGS
+      -Wold-style-declaration)
+  endif()
+
+  list(APPEND C_EXTRA_WARNINGS
+    -Wimplicit-function-declaration
+    -Wnested-externs
+    -Wstrict-prototypes
     -Wswitch-default
-    $<$<COMPILE_LANGUAGE:C>:-Wimplicit-int>
+    -Wimplicit-int
+    -Wall
+    -Wuninitialized
+    -Wunused-but-set-parameter
+    -Wdeprecated
+    -Wdeprecated-declarations
+    -Woverflow
+    -Wdouble-promotion
+    -Wfloat-equal
+    -Wpointer-arith
+    -Wpointer-sign
+    -Wmissing-format-attribute
+    -Wold-style-definition
+    -Wundef
+    -Wignored-qualifiers
+    -Woverride-init
+    -Wfloat-conversion
+    -Wbad-function-cast)
+
+  set(CXX_EXTRA_WARNINGS
+    -Wswitch-default
     -Wall
     -Wuninitialized
     -Wdeprecated
@@ -49,26 +88,21 @@ if(ENABLE_EXTRA_WARNINGS)
     -Wdouble-promotion
     -Wfloat-equal
     -Wpointer-arith
-    $<$<COMPILE_LANGUAGE:C>:-Wpointer-sign>
     -Wmissing-format-attribute
-    $<$<COMPILE_LANGUAGE:C>:-Wold-style-definition>
     -Wundef
     -Wignored-qualifiers
     -Wfloat-conversion
-    $<$<COMPILE_LANGUAGE:C>:-Wbad-function-cast>)
+    -Wunused-but-set-parameter)
 
-  if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
-    set(EXTRA_WARNINGS
-      ${EXTRA_WARNINGS}
-    )
-  else()
-    set(EXTRA_WARNINGS
-      $<$<COMPILE_LANGUAGE:C>:-Wold-style-declaration>
-      -Wunused-but-set-parameter
-      $<$<COMPILE_LANGUAGE:C>:-Woverride-init>
-      ${EXTRA_WARNINGS}
-    )
-  endif()
+  foreach(flag IN LISTS C_EXTRA_WARNINGS)
+    list(APPEND EXTRA_WARNINGS
+      $<$<COMPILE_LANGUAGE:C>:${flag}>)
+  endforeach()
+
+  foreach(flag IN LISTS CXX_EXTRA_WARNINGS)
+    list(APPEND EXTRA_WARNINGS
+      $<$<COMPILE_LANGUAGE:CXX>:${flag}>)
+  endforeach()
 endif()
 
 if(ENABLE_WERROR)

--- a/cmake/set_compile_options.cmake
+++ b/cmake/set_compile_options.cmake
@@ -32,6 +32,7 @@ set(ACCEPTABLE_WARNINGS
   -Wno-variadic-macros)
 
 option(ENABLE_EXTRA_WARNINGS "Enable extra warnings" ON)
+option(ENABLE_WERROR "Enable -Werror" OFF)
 
 if(ENABLE_EXTRA_WARNINGS)
   set(EXTRA_WARNINGS
@@ -68,6 +69,10 @@ if(ENABLE_EXTRA_WARNINGS)
       ${EXTRA_WARNINGS}
     )
   endif()
+endif()
+
+if(ENABLE_WERROR)
+  set(EXTRA_WARNINGS ${EXTRA_WARNINGS} -Werror)
 endif()
 
 add_compile_options(${IMPORTANT_WARNINGS} ${ACCEPTABLE_WARNINGS} ${EXTRA_WARNINGS})

--- a/cmake/set_testing.cmake
+++ b/cmake/set_testing.cmake
@@ -23,7 +23,16 @@
 #
 # ############################################################################
 
-option(BUILD_TESTING "Enable unit tests" ON)
+# Support both BUILD_TESTING (CMake standard) and ENABLE_TESTING (autotools naming)
+# If ENABLE_TESTING is set by user, use it as default for BUILD_TESTING
+if(DEFINED ENABLE_TESTING)
+  option(BUILD_TESTING "Enable unit tests" ${ENABLE_TESTING})
+else()
+  option(BUILD_TESTING "Enable unit tests" ON)
+endif()
+
+# Keep both variables in sync
+set(ENABLE_TESTING ${BUILD_TESTING})
 
 if(BUILD_TESTING)
   find_package(criterion)

--- a/configure.ac
+++ b/configure.ac
@@ -37,16 +37,38 @@ AC_CONFIG_SRCDIR([syslog-ng/main.c])
 AC_CONFIG_MACRO_DIR([m4])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
+dnl ============================================================
+dnl Check for tput and if it is working, to be able to use
+dnl colored output in the configure script
+dnl ============================================================
+AC_PATH_PROG([TPUT], [tput])
+AC_MSG_CHECKING([whether tput is available and working])
+if test -n "$TPUT" && "$TPUT" setaf 1 >/dev/null 2>&1; then
+    TPUT_WORKING=yes
+    AC_MSG_RESULT([yes])
+else
+    TPUT_WORKING=no
+    AC_MSG_RESULT([no])
+fi
+
 # ANSI color codes
 AC_CONFIG_COMMANDS_PRE([
+if test "x$TPUT_WORKING" = "xyes"; then
+    color_red=$($TPUT setaf 1 2>/dev/null || true)
+    color_green=$($TPUT setaf 2 2>/dev/null || true)
+    color_yellow=$($TPUT setaf 3 2>/dev/null || true)
+    color_blue=$($TPUT setaf 4 2>/dev/null || true)
+    color_reset=$($TPUT sgr0 2>/dev/null || true)
+else
     ESC=$(printf '\033')          # ASCII ESC
-    LBRACKET=$(printf '\x5B')     # ASCII square bracket
+    LBRACKET=$(printf '\133')     # ASCII square bracket (portable octal)
     color_red="${ESC}${LBRACKET}31m"
     color_green="${ESC}${LBRACKET}32m"
     color_yellow="${ESC}${LBRACKET}33m"
     color_blue="${ESC}${LBRACKET}34m"
     color_reset="${ESC}${LBRACKET}0m"
-    export color_red color_green color_yellow color_blue color_reset
+fi
+export color_red color_green color_yellow color_blue color_reset
 ])
 
 dnl ***************************************************************************
@@ -614,8 +636,7 @@ AC_ARG_ENABLE(afsnmp,
 
 AC_ARG_ENABLE([colored-log],
     AS_HELP_STRING([--enable-colored-log], [Enable colorized output in configure summary (default: no)]),
-    [enable_colored_log=yes],
-    [enable_colored_log=no])
+    , enable_colored_log="no")
 
 AC_ARG_ENABLE(tests,
     AS_HELP_STRING([--enable-tests], [Enable unit tests (default: auto)]),
@@ -2772,6 +2793,7 @@ print_config_line() {
 
     if test "x$enable_colored_log" = "xyes"; then
         local color_code=$color_blue
+
         case "$value" in
             yes*|YES*|true*|TRUE*) color_code=$color_green ;;
             no*|NO*|false*|FALSE*) color_code=$color_red ;;

--- a/configure.ac
+++ b/configure.ac
@@ -2859,7 +2859,7 @@ print_config_line "compiler options" "$CFLAGS $CPPFLAGS"
 print_config_line "ObjC compiler" "$OBJC - $($OBJC -v 2>&1 | grep -i ' version ') - $(command -v $OBJC)"
 print_config_line "C++ enabled" "${enable_cpp:=no}"
 if test "x$enable_cpp" = "xyes"; then
-    print_config_line "C++ compiler" "$CXX - $($CXX -v 2>&1 | grep -i ' version ') - $(command -v $CXX)"
+    print_config_line "C++ compiler" "$CXX - $($CXX -v 2>&1 | grep -i ' version ') - $(command -v "${CXX%% *}")"
     print_config_line "C++ compiler options" "$CXXFLAGS"
 fi
 print_config_line "linker flags" "$LDFLAGS $LIBS"

--- a/configure.ac
+++ b/configure.ac
@@ -2696,6 +2696,7 @@ AM_CONDITIONAL(ENABLE_MANPAGES_INSTALL, [test "$enable_manpages_install" != "no"
 AM_CONDITIONAL(MANPAGES_REMOTE, [test "x$with_manpages" = "xremote"])
 AM_CONDITIONAL(ENABLE_NATIVE, [test "$enable_native" != "no"])
 AM_CONDITIONAL(ENABLE_EXTRA_WARNINGS, [test "$enable_extra_warnings" = "yes"])
+AM_CONDITIONAL(ENABLE_WERROR, [test "$enable_werror" = "yes"])
 AM_CONDITIONAL(ENABLE_TESTING, [test "$enable_tests" != "no"])
 AM_CONDITIONAL(ENABLE_EXAMPLE_MODULES, [test "$enable_example_modules" = "yes"])
 AM_CONDITIONAL(ENABLE_SANITIZER, [test "$with_sanitizer" != "no"])

--- a/dbld/distcheck
+++ b/dbld/distcheck
@@ -16,5 +16,5 @@ cd /build/dist-build
 /source/configure --enable-manpages --disable-all-modules
 
 rm -rf /install/dist-check
-export DISTCHECK_CONFIGURE_FLAGS="CFLAGS=-Werror --prefix=/install/dist-check --with-ivykis=internal --with-jsonc=system --enable-tcp-wrapper --enable-linux-caps --enable-manpages --enable-all-modules --disable-java --disable-java-modules --with-python=3"
+export DISTCHECK_CONFIGURE_FLAGS="--prefix=/install/dist-check --enable-werror --with-ivykis=internal --with-jsonc=system --enable-tcp-wrapper --enable-linux-caps --enable-manpages --enable-all-modules --disable-java --disable-java-modules --with-python=3"
 make -j V=1 distcheck || echo "FAILED to run distcheck"

--- a/modules/grpc/bigquery/bigquery-worker.cpp
+++ b/modules/grpc/bigquery/bigquery-worker.cpp
@@ -163,7 +163,10 @@ DestinationWorker::insert(LogMessage *msg)
 
   this->batch_size++;
 
-  message->SerializePartialToString(&serialized_row);
+  {
+    bool result = message->SerializePartialToString(&serialized_row);
+    (void) result;
+  }
   row_bytes = serialized_row.size();
   rows->add_serialized_rows(std::move(serialized_row));
 

--- a/modules/grpc/otel/otel-protobuf-formatter.cpp
+++ b/modules/grpc/otel/otel-protobuf-formatter.cpp
@@ -220,8 +220,11 @@ _set_AnyValue(const gchar *value, gssize len, LogMessageValueType type, AnyValue
   switch (type)
     {
     case LM_VT_PROTOBUF:
-      any_value->ParsePartialFromArray(value, len);
+    {
+      bool result = any_value->ParsePartialFromArray(value, len);
+      (void) result;
       break;
+    }
     case LM_VT_BYTES:
       any_value->set_bytes_value(value, len);
       break;

--- a/modules/grpc/otel/otel-protobuf-parser.cpp
+++ b/modules/grpc/otel/otel-protobuf-parser.cpp
@@ -123,7 +123,8 @@ _serialize_ArrayValue(const AnyValue &value, LogMessageValueType *type, std::str
   if (!is_all_strings)
     {
       *type = LM_VT_PROTOBUF;
-      value.SerializePartialToString(buffer);
+      bool result = value.SerializePartialToString(buffer);
+      (void) result;
       return *buffer;
     }
 
@@ -158,7 +159,10 @@ _serialize_AnyValue(const AnyValue &value, LogMessageValueType *type, std::strin
       return _serialize_ArrayValue(value, type, buffer);
     case AnyValue::kKvlistValue:
       *type = LM_VT_PROTOBUF;
-      value.SerializePartialToString(buffer);
+      {
+        bool result = value.SerializePartialToString(buffer);
+        (void) result;
+      }
       return *buffer;
     case AnyValue::kBytesValue:
       *type = LM_VT_BYTES;
@@ -1126,14 +1130,16 @@ syslogng::grpc::otel::ProtobufParser::store_raw_metadata(LogMessage *msg, const 
   msg->saddr = _extract_saddr(peer);
 
   /* .otel_raw.resource */
-  resource.SerializePartialToString(&serialized);
+  bool result = resource.SerializePartialToString(&serialized);
+  (void) result;
   _set_value(msg, logmsg_handle::RAW_RESOURCE, serialized, LM_VT_PROTOBUF);
 
   /* .otel_raw.resource_schema_url */
   _set_value(msg, logmsg_handle::RAW_RESOURCE_SCHEMA_URL, resource_schema_url, LM_VT_STRING);
 
   /* .otel_raw.scope */
-  scope.SerializePartialToString(&serialized);
+  result = scope.SerializePartialToString(&serialized);
+  (void) result;
   _set_value(msg, logmsg_handle::RAW_SCOPE, serialized, LM_VT_PROTOBUF);
 
   /* .otel_raw.scope_schema_url */

--- a/modules/secure-logging/slog.c
+++ b/modules/secure-logging/slog.c
@@ -1117,7 +1117,13 @@ int iterateBuffer(guint64 entriesInBuffer, GString **input, guint64 *nextLogEntr
                       char *key = g_new0(char, CTR_LEN_SIMPLE + 1);
                       snprintf(key, CTR_LEN_SIMPLE + 1, "%"G_GUINT64_FORMAT, logEntryOnDisk);
 
-                      if (g_hash_table_insert(tab, key, (gpointer)logEntryOnDisk) == FALSE)
+                      if (logEntryOnDisk > G_MAXUINT)
+                        {
+                          msg_error("[SLOG] ERROR: Log entry id does not fit into pointer-sized integer storage", evt_tag_long("entry",
+                                    logEntryOnDisk));
+                          ret = 0;
+                        }
+                      else if (g_hash_table_insert(tab, key, GUINT_TO_POINTER((guint)logEntryOnDisk)) == FALSE)
                         {
                           msg_warning("[SLOG] WARNING: Unable to process hash table while entering decrypted log entry", evt_tag_long("entry",
                                       logEntryOnDisk));


### PR DESCRIPTION
macOS build failures can be ignored for now; we need to wait for Homebrew gRPC to be updated to use the latest protobuf version