### PR TITLE
tls-verifier: fix leak in tls_verify_certificate_name

### DIFF
--- a/lib/transport/tls-verifier.c
+++ b/lib/transport/tls-verifier.c
@@ -231,7 +231,7 @@ tls_verify_certificate_name(X509 *cert, const gchar *host_name)
                     }
                 }
             }
-          sk_GENERAL_NAME_free(alt_names);
+          sk_GENERAL_NAME_pop_free(alt_names, GENERAL_NAME_free);
         }
     }
   if (!found)


### PR DESCRIPTION
See here: #5634

With these change it can be verified that the memory leak is gone when instrumented with valgrind.

If needed I can provide some references from other projects doing the same thing.