### PR TITLE
logrotate: allow size to exceed a 32-bit integer

### DIFF
--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -641,7 +641,7 @@ void affile_dd_set_logrotate_rotations(LogDriver *s, gint max_rotations)
   self->logrotate_options.max_rotations = max_rotations;
 }
 
-void affile_dd_set_logrotate_size(LogDriver *s, gint size)
+void affile_dd_set_logrotate_size(LogDriver *s, gsize size)
 {
   AFFileDestDriver *self = (AFFileDestDriver *) s;
 

--- a/modules/affile/affile-dest.h
+++ b/modules/affile/affile-dest.h
@@ -64,7 +64,7 @@ void affile_dd_set_local_time_zone(LogDriver *s, const gchar *local_time_zone);
 void affile_dd_set_time_reap(LogDriver *s, gint time_reap);
 void affile_dd_set_logrotate_enable(LogDriver *s, gboolean enable);
 void affile_dd_set_logrotate_rotations(LogDriver *s, gint max_rotations);
-void affile_dd_set_logrotate_size(LogDriver *s, gint size);
+void affile_dd_set_logrotate_size(LogDriver *s, gsize size);
 void affile_dd_global_init(void);
 
 #endif

--- a/modules/affile/affile-grammar.ym
+++ b/modules/affile/affile-grammar.ym
@@ -301,7 +301,7 @@ dest_affile_logrotate_options
 
 dest_affile_logrotate_option
 	: KW_LOGROTATE_ENABLE '(' yesno ')' { affile_dd_set_logrotate_enable(last_driver, $3); }
-	| KW_LOGROTATE_SIZE '(' positive_integer ')' { affile_dd_set_logrotate_size(last_driver, $3); }
+	| KW_LOGROTATE_SIZE '(' positive_integer64 ')' { affile_dd_set_logrotate_size(last_driver, $3); }
 	| KW_LOGROTATE_ROTATIONS '(' positive_integer ')' { affile_dd_set_logrotate_rotations(last_driver, $3); }
 
 dest_afpipe_params


### PR DESCRIPTION
Fixes: https://github.com/syslog-ng/syslog-ng/issues/5636