### PR TITLE
Run grpc tests on FreeBSD

### DIFF
--- a/modules/grpc/otel/tests/CMakeLists.txt
+++ b/modules/grpc/otel/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-if (NOT APPLE AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+if (NOT APPLE)
   add_unit_test (
     CRITERION
     TARGET test_otel_protobuf_parser

--- a/modules/grpc/otel/tests/Makefile.am
+++ b/modules/grpc/otel/tests/Makefile.am
@@ -1,6 +1,5 @@
 if ENABLE_GRPC
 
-if ! OS_TYPE_FREEBSD
 if ! OS_TYPE_MACOS
 modules_grpc_otel_tests_TESTS = \
   modules/grpc/otel/tests/test_otel_protobuf_parser \
@@ -8,7 +7,6 @@ modules_grpc_otel_tests_TESTS = \
   modules/grpc/otel/tests/test_syslog_ng_otlp
 
 check_PROGRAMS += ${modules_grpc_otel_tests_TESTS}
-endif
 endif
 
 modules_grpc_otel_tests_test_otel_protobuf_parser_SOURCES = \


### PR DESCRIPTION
While working on #5644 where I have nothing to test changes to the opentelemetry parser, I realized that the tests where not building on my FreeBSD machine.
After unabling them, they build and run successfuly, so I guess it is time to stop skipping them.
