### PR TITLE
http: fixed a crash when syslog-ng built with http compression disabled

### DIFF
--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -296,7 +296,9 @@ _setup_static_options_in_curl(HTTPDestinationWorker *self)
   if (owner->method_type == METHOD_TYPE_PUT)
     curl_easy_setopt(self->curl, CURLOPT_CUSTOMREQUEST, "PUT");
 
+#if SYSLOG_NG_HTTP_COMPRESSION_ENABLED
   curl_easy_setopt(self->curl, CURLOPT_ACCEPT_ENCODING, owner->accept_encoding->str);
+#endif
 
   curl_easy_setopt(self->curl, CURLOPT_NOSIGNAL, 1L);
 }

--- a/modules/http/http.c
+++ b/modules/http/http.c
@@ -289,9 +289,9 @@ http_dd_set_accept_encoding(LogDriver *d, const gchar *encoding)
 {
   HTTPDestinationDriver *self = (HTTPDestinationDriver *) d;
 
-  if (self->accept_encoding != NULL)
-    g_string_free(self->accept_encoding, TRUE);
 #if SYSLOG_NG_HTTP_COMPRESSION_ENABLED
+  if (self->accept_encoding)
+    g_string_free(self->accept_encoding, TRUE);
   if (strcmp(encoding, CURL_COMPRESSION_LITERAL_ALL) == 0)
     self->accept_encoding = g_string_new("");
   else
@@ -485,7 +485,8 @@ http_dd_free(LogPipe *s)
   g_string_free(self->delimiter, TRUE);
   g_string_free(self->body_prefix, TRUE);
   g_string_free(self->body_suffix, TRUE);
-  g_string_free(self->accept_encoding, TRUE);
+  if (self->accept_encoding)
+    g_string_free(self->accept_encoding, TRUE);
   log_template_unref(self->body_template);
 
   curl_global_cleanup();
@@ -534,7 +535,7 @@ http_dd_new(GlobalConfig *cfg)
   self->body_prefix = g_string_new("");
   self->body_suffix = g_string_new("");
   self->delimiter = g_string_new("\n");
-  self->accept_encoding = g_string_new("");
+  self->accept_encoding = (SYSLOG_NG_HTTP_COMPRESSION_ENABLED ? g_string_new("") : NULL);
   self->load_balancer = http_load_balancer_new();
   curl_version_info_data *curl_info = curl_version_info(CURLVERSION_NOW);
   if (!self->user_agent)


### PR DESCRIPTION
related doc change https://github.com/syslog-ng/syslog-ng.github.io/pull/300/changes/7354d3bb7321f17799d80513d3228bb0751ce82e