### PR TITLE
Logscheduler enhancements

### DIFF
--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -190,25 +190,25 @@
 %token KW_SYSLOG                      10060
 
 /* option items */
-%token KW_MARK_FREQ                   10071
-%token KW_STATS_FREQ                  10072
-%token KW_STATS_LEVEL                 10073
-%token KW_STATS_LIFETIME              10074
-%token KW_FLUSH_LINES                 10075
-%token KW_SUPPRESS                    10076
-%token KW_FLUSH_TIMEOUT               10077
-%token KW_LOG_MSG_SIZE                10078
-%token KW_FILE_TEMPLATE               10079
-%token KW_PROTO_TEMPLATE              10080
-%token KW_MARK_MODE                   10081
-%token KW_ENCODING                    10082
-%token KW_TYPE                        10083
-%token KW_STATS_MAX_DYNAMIC           10084
-%token KW_MIN_IW_SIZE_PER_READER      10085
-%token KW_WORKERS                     10086
+%token KW_MARK_FREQ                   10070
+%token KW_STATS_FREQ                  10071
+%token KW_STATS_LEVEL                 10072
+%token KW_STATS_LIFETIME              10073
+%token KW_FLUSH_LINES                 10074
+%token KW_SUPPRESS                    10075
+%token KW_FLUSH_TIMEOUT               10076
+%token KW_LOG_MSG_SIZE                10077
+%token KW_FILE_TEMPLATE               10078
+%token KW_PROTO_TEMPLATE              10079
+%token KW_MARK_MODE                   10080
+%token KW_ENCODING                    10081
+%token KW_TYPE                        10082
+%token KW_STATS_MAX_DYNAMIC           10083
+%token KW_MIN_IW_SIZE_PER_READER      10084
+%token KW_WORKERS                     10085
+%token KW_WORKER_PARTITION_KEY        10086
 %token KW_BATCH_LINES                 10087
 %token KW_BATCH_TIMEOUT               10088
-%token KW_TRIM_LARGE_MESSAGES         10089
 
 %token KW_STATS                       10400
 %token KW_FREQ                        10401
@@ -217,7 +217,6 @@
 %token KW_MAX_DYNAMIC                 10404
 %token KW_SYSLOG_STATS                10405
 %token KW_HEALTHCHECK_FREQ            10406
-%token KW_WORKER_PARTITION_KEY        10407
 
 %token KW_CHAIN_HOSTNAMES             10090
 %token KW_NORMALIZE_HOSTNAMES         10091
@@ -227,6 +226,7 @@
 %token KW_LOG_LEVEL                   10095
 %token KW_IDLE_TIMEOUT                10096
 %token KW_CHECK_PROGRAM               10097
+%token KW_TRIM_LARGE_MESSAGES         10098
 
 %token KW_KEEP_TIMESTAMP              10100
 

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -727,18 +727,18 @@ log_items
 	;
 
 log_item
-        : KW_SOURCE '(' string ')'		{ $$ = log_expr_node_new_source_reference($3, &@$); free($3); }
+        : KW_SOURCE '(' string ')'		          { $$ = log_expr_node_new_source_reference($3, &@$); free($3); }
         | KW_SOURCE '{' source_content '}'      { $$ = log_expr_node_new_source(NULL, $3, &@$); }
-        | KW_FILTER '(' string ')'		{ $$ = log_expr_node_new_filter_reference($3, &@$); free($3); }
+        | KW_FILTER '(' string ')'		          { $$ = log_expr_node_new_filter_reference($3, &@$); free($3); }
         | KW_FILTER '{' filter_content '}'      { $$ = log_expr_node_new_filter(NULL, $3, &@$); }
         | KW_PARSER '(' string ')'              { $$ = log_expr_node_new_parser_reference($3, &@$); free($3); }
         | KW_PARSER '{' parser_content '}'      { $$ = log_expr_node_new_parser(NULL, $3, &@$); }
         | KW_REWRITE '(' string ')'             { $$ = log_expr_node_new_rewrite_reference($3, &@$); free($3); }
         | KW_REWRITE '{' rewrite_content '}'    { $$ = log_expr_node_new_rewrite(NULL, $3, &@$); }
-        | KW_DESTINATION '(' string ')'		{ $$ = log_expr_node_new_destination_reference($3, &@$); free($3); }
+        | KW_DESTINATION '(' string ')'		      { $$ = log_expr_node_new_destination_reference($3, &@$); free($3); }
         | KW_DESTINATION '{' dest_content '}'   { $$ = log_expr_node_new_destination(NULL, $3, &@$); }
         | log_scheduler                         { $$ = $1; }
-        | log_conditional			{ $$ = $1; }
+        | log_conditional			                  { $$ = $1; }
         | log_junction                          { $$ = $1; }
 	;
 

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -209,6 +209,7 @@
 %token KW_WORKER_PARTITION_KEY        10086
 %token KW_BATCH_LINES                 10087
 %token KW_BATCH_TIMEOUT               10088
+%token KW_BATCH_SIZE                  10089
 
 %token KW_STATS                       10400
 %token KW_FREQ                        10401
@@ -773,6 +774,10 @@ log_scheduler_option
         | KW_WORKER_PARTITION_KEY '(' template_content ')'
           {
             log_scheduler_options_set_partition_key_ref(last_scheduler_options, $3);
+          }
+        | KW_BATCH_SIZE '(' nonnegative_integer ')'
+          {
+            log_scheduler_options_set_batch_size(last_scheduler_options, $3);
           }
         ;
 

--- a/lib/cfg-grammar.y
+++ b/lib/cfg-grammar.y
@@ -760,7 +760,7 @@ log_scheduler_options
 log_scheduler_option
         : KW_PARTITIONS '(' nonnegative_integer ')'
           {
-            last_scheduler_options->num_partitions = $3;
+            log_scheduler_options_set_num_partitions(last_scheduler_options, $3);
           }
         | KW_PARTITION_KEY '(' template_content ')'
           {
@@ -768,7 +768,7 @@ log_scheduler_option
           }
         | KW_WORKERS '(' nonnegative_integer ')'
           {
-            last_scheduler_options->num_partitions = $3;
+            log_scheduler_options_set_num_partitions(last_scheduler_options, $3);
           }
         | KW_WORKER_PARTITION_KEY '(' template_content ')'
           {

--- a/lib/cfg-parser.c
+++ b/lib/cfg-parser.c
@@ -194,6 +194,7 @@ static CfgLexerKeyword main_keywords[] =
   { "partitions",         KW_PARTITIONS, KWS_OBSOLETE, "workers" },
   { "partition_key",      KW_PARTITION_KEY, KWS_OBSOLETE, "worker_partition_key" },
   { "batch_lines",        KW_BATCH_LINES },
+  { "batch_size",         KW_BATCH_SIZE },
   { "batch_timeout",      KW_BATCH_TIMEOUT },
 
   { "read_old_records",       KW_READ_OLD_RECORDS},

--- a/lib/logscheduler.c
+++ b/lib/logscheduler.c
@@ -250,6 +250,7 @@ _init_thread_states(LogScheduler *self)
 static void
 _init_partitions(LogScheduler *self)
 {
+  self->partitions = g_new0(LogSchedulerPartition, self->options->num_partitions);
   for (gint i = 0; i < self->options->num_partitions; i++)
     _partition_init(&self->partitions[i], self->front_pipe);
 }
@@ -259,6 +260,8 @@ _free_partitions(LogScheduler *self)
 {
   for (gint i = 0; i < self->options->num_partitions; i++)
     _partition_clear(&self->partitions[i]);
+  g_free(self->partitions);
+  self->partitions = NULL;
 }
 
 gboolean
@@ -365,6 +368,41 @@ log_scheduler_options_set_partition_key_ref(LogSchedulerOptions *options, LogTem
 }
 
 void
+_log_scheduler_readjust_num_partitions(LogSchedulerOptions *options, gint num_partitions)
+{
+  gint max_threads = main_loop_worker_get_max_number_of_threads();
+
+  if (num_partitions > max_threads)
+    {
+      msg_warning("The partitions() setting exceeds the maximum number of worker threads, "
+                  "clamping to worker thread count for optimal performance",
+                  evt_tag_int("partitions", num_partitions),
+                  evt_tag_int("max-worker-threads", max_threads));
+      num_partitions = max_threads;
+    }
+
+  gint optimal_partitions = max_threads / 2;
+  if (num_partitions > optimal_partitions)
+    {
+      gint memory_per_thread_bytes = num_partitions * sizeof(struct iv_list_head);
+      msg_info("High partitions() setting increases memory usage and lock contention; "
+               "consider using half the worker thread count for optimal balance",
+               evt_tag_int("partitions", num_partitions),
+               evt_tag_int("max-threads", max_threads),
+               evt_tag_int("recommended-optimal", optimal_partitions),
+               evt_tag_int("memory-per-active-thread-bytes", memory_per_thread_bytes));
+    }
+}
+
+void
+log_scheduler_options_set_num_partitions(LogSchedulerOptions *options, gint num_partitions)
+{
+  /* NOTE: we cannot readjust the number of partitions here as main_loop_worker_get_max_number_of_threads may not be finalized yet */
+  // _log_scheduler_readjust_num_partitions(options, num_partitions);
+  options->num_partitions = num_partitions;
+}
+
+void
 log_scheduler_options_defaults(LogSchedulerOptions *options)
 {
   options->num_partitions = -1;
@@ -376,8 +414,7 @@ log_scheduler_options_init(LogSchedulerOptions *options, GlobalConfig *cfg)
 {
   if (options->num_partitions == -1)
     options->num_partitions = 0;
-  if (options->num_partitions > LOGSCHEDULER_MAX_PARTITIONS)
-    options->num_partitions = LOGSCHEDULER_MAX_PARTITIONS;
+  _log_scheduler_readjust_num_partitions(options, options->num_partitions);
   return TRUE;
 }
 

--- a/lib/logscheduler.c
+++ b/lib/logscheduler.c
@@ -121,7 +121,6 @@ _complete(gpointer s, gpointer arg)
     }
   else
     partition->flush_running = FALSE;
-
   g_mutex_unlock(&partition->batches_lock);
 
   if (needs_restart)
@@ -144,10 +143,7 @@ _partition_add_batch(LogSchedulerPartition *partition, LogSchedulerBatch *batch)
   g_mutex_unlock(&partition->batches_lock);
 
   if (trigger_flush)
-    {
-      main_loop_io_worker_job_submit_continuation(&partition->io_job, NULL);
-    }
-
+    main_loop_io_worker_job_submit_continuation(&partition->io_job, NULL);
 }
 
 static void
@@ -210,12 +206,8 @@ _flush_batch(gpointer s)
       INIT_IV_LIST_HEAD(&thread_state->batch_by_partition[partition_index]);
 
       /* add the new batch to the target partition */
-
       LogSchedulerPartition *partition = &self->partitions[partition_index];
-
       _partition_add_batch(partition, batch);
-
-
     }
   thread_state->num_messages = 0;
   return NULL;
@@ -237,7 +229,6 @@ _queue_thread(LogScheduler *self, LogSchedulerThreadState *thread_state, LogMess
   log_msg_unref(msg);
 }
 
-
 static void
 _thread_state_init(LogScheduler *self, LogSchedulerThreadState *state)
 {
@@ -253,27 +244,21 @@ static void
 _init_thread_states(LogScheduler *self)
 {
   for (gint i = 0; i < self->num_threads; i++)
-    {
-      _thread_state_init(self, &self->thread_states[i]);
-    }
+    _thread_state_init(self, &self->thread_states[i]);
 }
 
 static void
 _init_partitions(LogScheduler *self)
 {
   for (gint i = 0; i < self->options->num_partitions; i++)
-    {
-      _partition_init(&self->partitions[i], self->front_pipe);
-    }
+    _partition_init(&self->partitions[i], self->front_pipe);
 }
 
 static void
 _free_partitions(LogScheduler *self)
 {
   for (gint i = 0; i < self->options->num_partitions; i++)
-    {
-      _partition_clear(&self->partitions[i]);
-    }
+    _partition_clear(&self->partitions[i]);
 }
 
 gboolean

--- a/lib/logscheduler.c
+++ b/lib/logscheduler.c
@@ -170,20 +170,32 @@ _partition_clear(LogSchedulerPartition *partition)
 
 /* LogSchedulerThreadState */
 
+static inline void
+_advance_partition(gint *partition, gint num_partitions)
+{
+  if (++(*partition) >= num_partitions)
+    *partition = 0;
+}
+
 static guint
 _get_partition_index(LogScheduler *self, LogSchedulerThreadState *thread_state, LogMessage *msg)
 {
-  if (!self->options->partition_key)
-    {
-      gint partition_index = thread_state->last_partition;
-      thread_state->last_partition = (thread_state->last_partition + 1) % self->options->num_partitions;
-      return partition_index;
-    }
-  else
+  if (self->options->partition_key)
     {
       LogTemplateEvalOptions options = DEFAULT_TEMPLATE_EVAL_OPTIONS;
       return log_template_hash(self->options->partition_key, msg, &options) % self->options->num_partitions;
     }
+
+  if (self->options->batch_size > 0)
+    {
+      if (--thread_state->batch_countdown > 0)
+        return thread_state->last_partition;
+      thread_state->batch_countdown = self->options->batch_size;
+    }
+
+  gint partition_index = thread_state->last_partition;
+  _advance_partition(&thread_state->last_partition, self->options->num_partitions);
+  return partition_index;
 }
 
 static gpointer
@@ -245,6 +257,8 @@ _thread_state_init(LogScheduler *self, LogSchedulerThreadState *state, gint thre
     state->last_partition = thread_index % self->options->num_partitions;
   else
     state->last_partition = 0;
+
+  state->batch_countdown = self->options->batch_size;
 }
 
 static LogSchedulerThreadState *
@@ -439,9 +453,16 @@ log_scheduler_options_set_num_partitions(LogSchedulerOptions *options, gint num_
 }
 
 void
+log_scheduler_options_set_batch_size(LogSchedulerOptions *options, gint batch_size)
+{
+  options->batch_size = batch_size;
+}
+
+void
 log_scheduler_options_defaults(LogSchedulerOptions *options)
 {
   options->num_partitions = -1;
+  options->batch_size = 0;
   options->partition_key = NULL;
 }
 
@@ -450,6 +471,13 @@ log_scheduler_options_init(LogSchedulerOptions *options, GlobalConfig *cfg)
 {
   if (options->num_partitions == -1)
     options->num_partitions = 0;
+
+  if (options->batch_size > 0 && options->partition_key)
+    {
+      msg_error("parallelize(): batch_size() and worker_partition_key() are mutually exclusive");
+      return FALSE;
+    }
+
   _log_scheduler_readjust_num_partitions(options, options->num_partitions);
   return TRUE;
 }

--- a/lib/logscheduler.c
+++ b/lib/logscheduler.c
@@ -407,13 +407,13 @@ void
 _log_scheduler_readjust_num_partitions(LogSchedulerOptions *options, gint num_partitions)
 {
   gint max_threads = main_loop_worker_get_max_number_of_threads();
-
   if (num_partitions > max_threads)
     {
       msg_warning("The partitions() setting exceeds the maximum number of worker threads, "
                   "clamping to worker thread count for optimal performance",
                   evt_tag_int("partitions", num_partitions),
-                  evt_tag_int("max-worker-threads", max_threads));
+                  evt_tag_int("max-threads", max_threads),
+                  evt_tag_int("clamped-to", max_threads));
       num_partitions = max_threads;
     }
 

--- a/lib/logscheduler.c
+++ b/lib/logscheduler.c
@@ -230,21 +230,48 @@ _queue_thread(LogScheduler *self, LogSchedulerThreadState *thread_state, LogMess
 }
 
 static void
-_thread_state_init(LogScheduler *self, LogSchedulerThreadState *state)
+_thread_state_init(LogScheduler *self, LogSchedulerThreadState *state, gint thread_index)
 {
   worker_batch_callback_init(&state->batch_callback);
   state->batch_callback.func = _flush_batch;
   state->batch_callback.user_data = self;
 
+  state->batch_by_partition = g_new0(struct iv_list_head, self->options->num_partitions);
   for (gint i = 0; i < self->options->num_partitions; i++)
     INIT_IV_LIST_HEAD(&state->batch_by_partition[i]);
+
+}
+
+static LogSchedulerThreadState *
+_ensure_thread_state(LogScheduler *self, gint thread_index)
+{
+  LogSchedulerThreadState *state = &self->thread_states[thread_index];
+
+  /* Lazy initialization, only allocate batch_by_partition on first use */
+  if (G_UNLIKELY(state->batch_by_partition == NULL))
+    _thread_state_init(self, state, thread_index);
+
+  return state;
 }
 
 static void
-_init_thread_states(LogScheduler *self)
+_thread_state_clear(LogSchedulerThreadState *state)
+{
+  /* Lazy init means some still might be NULL */
+  if (state->batch_by_partition)
+    {
+      g_free(state->batch_by_partition);
+      state->batch_by_partition = NULL;
+    }
+}
+
+static void
+_free_thread_states(LogScheduler *self)
 {
   for (gint i = 0; i < self->num_threads; i++)
-    _thread_state_init(self, &self->thread_states[i]);
+    _thread_state_clear(&self->thread_states[i]);
+  g_free(self->thread_states);
+  self->thread_states = NULL;
 }
 
 static void
@@ -289,7 +316,7 @@ log_scheduler_push(LogScheduler *self, LogMessage *msg, const LogPathOptions *pa
       return;
     }
 
-  LogSchedulerThreadState *thread_state = &self->thread_states[thread_index];
+  LogSchedulerThreadState *thread_state = _ensure_thread_state(self, thread_index);
   _queue_thread(self, thread_state, msg, path_options);
 }
 
@@ -297,12 +324,14 @@ LogScheduler *
 log_scheduler_new(LogSchedulerOptions *options, LogPipe *front_pipe)
 {
   gint max_threads = main_loop_worker_get_max_number_of_threads();
-  LogScheduler *self = g_malloc0(sizeof(LogScheduler) + max_threads * sizeof(LogSchedulerThreadState));
+  LogScheduler *self = g_new0(LogScheduler, 1);
   self->num_threads = max_threads;
   self->options = options;
   self->front_pipe = log_pipe_ref(front_pipe);
 
-  _init_thread_states(self);
+  /* Allocate thread_states array but don't initialize yet (lazy init on first use) */
+  self->thread_states = g_new0(LogSchedulerThreadState, max_threads);
+
   _init_partitions(self);
   return self;
 }
@@ -312,6 +341,7 @@ log_scheduler_free(LogScheduler *self)
 {
   log_pipe_unref(self->front_pipe);
   _free_partitions(self);
+  _free_thread_states(self);
   g_free(self);
 }
 
@@ -344,9 +374,10 @@ log_scheduler_push(LogScheduler *self, LogMessage *msg, const LogPathOptions *pa
 LogScheduler *
 log_scheduler_new(LogSchedulerOptions *options, LogPipe *front_pipe)
 {
-  LogScheduler *self = g_malloc0(sizeof(LogScheduler) + 0 * sizeof(LogSchedulerThreadState));
+  LogScheduler *self = g_new0(LogScheduler, 1);
   self->options = options;
   self->front_pipe = log_pipe_ref(front_pipe);
+  self->thread_states = NULL;  /* Not used without iv_work_pool support */
 
   return self;
 }

--- a/lib/logscheduler.c
+++ b/lib/logscheduler.c
@@ -240,6 +240,11 @@ _thread_state_init(LogScheduler *self, LogSchedulerThreadState *state, gint thre
   for (gint i = 0; i < self->options->num_partitions; i++)
     INIT_IV_LIST_HEAD(&state->batch_by_partition[i]);
 
+  /* Spread initial partition assignment to avoid thundering herd on partition 0 */
+  if (self->options->num_partitions > 0)
+    state->last_partition = thread_index % self->options->num_partitions;
+  else
+    state->last_partition = 0;
 }
 
 static LogSchedulerThreadState *

--- a/lib/logscheduler.h
+++ b/lib/logscheduler.h
@@ -31,8 +31,6 @@
 #include <iv_list.h>
 #include <iv_event.h>
 
-#define LOGSCHEDULER_MAX_PARTITIONS 16
-
 typedef struct _LogSchedulerBatch
 {
   struct iv_list_head elements;
@@ -51,7 +49,7 @@ typedef struct _LogSchedulerPartition
 typedef struct _LogSchedulerThreadState
 {
   WorkerBatchCallback batch_callback;
-  struct iv_list_head batch_by_partition[LOGSCHEDULER_MAX_PARTITIONS];
+  struct iv_list_head *batch_by_partition;
 
   guint64 num_messages;
   gint last_partition;
@@ -69,7 +67,7 @@ typedef struct _LogScheduler
   LogSchedulerOptions *options;
   gint num_threads;
   LogSchedulerPartition *partitions;
-  LogSchedulerThreadState thread_states[];
+  LogSchedulerThreadState *thread_states;
 } LogScheduler;
 
 gboolean log_scheduler_init(LogScheduler *self);

--- a/lib/logscheduler.h
+++ b/lib/logscheduler.h
@@ -68,7 +68,7 @@ typedef struct _LogScheduler
   LogPipe *front_pipe;
   LogSchedulerOptions *options;
   gint num_threads;
-  LogSchedulerPartition partitions[LOGSCHEDULER_MAX_PARTITIONS];
+  LogSchedulerPartition *partitions;
   LogSchedulerThreadState thread_states[];
 } LogScheduler;
 
@@ -80,6 +80,7 @@ LogScheduler *log_scheduler_new(LogSchedulerOptions *options, LogPipe *front_pip
 void log_scheduler_free(LogScheduler *self);
 
 void log_scheduler_options_set_partition_key_ref(LogSchedulerOptions *options, LogTemplate *partition_key);
+void log_scheduler_options_set_num_partitions(LogSchedulerOptions *options, gint num_partitions);
 void log_scheduler_options_defaults(LogSchedulerOptions *options);
 gboolean log_scheduler_options_init(LogSchedulerOptions *options, GlobalConfig *cfg);
 void log_scheduler_options_destroy(LogSchedulerOptions *options);

--- a/lib/logscheduler.h
+++ b/lib/logscheduler.h
@@ -53,11 +53,13 @@ typedef struct _LogSchedulerThreadState
 
   guint64 num_messages;
   gint last_partition;
+  gint batch_countdown;
 } LogSchedulerThreadState;
 
 typedef struct _LogSchedulerOptions
 {
   gint num_partitions;
+  gint batch_size;
   LogTemplate *partition_key;
 } LogSchedulerOptions;
 
@@ -79,6 +81,7 @@ void log_scheduler_free(LogScheduler *self);
 
 void log_scheduler_options_set_partition_key_ref(LogSchedulerOptions *options, LogTemplate *partition_key);
 void log_scheduler_options_set_num_partitions(LogSchedulerOptions *options, gint num_partitions);
+void log_scheduler_options_set_batch_size(LogSchedulerOptions *options, gint batch_size);
 void log_scheduler_options_defaults(LogSchedulerOptions *options);
 gboolean log_scheduler_options_init(LogSchedulerOptions *options, GlobalConfig *cfg);
 void log_scheduler_options_destroy(LogSchedulerOptions *options);

--- a/news/feature-5654.md
+++ b/news/feature-5654.md
@@ -1,0 +1,4 @@
+`parallelize()`: Added `batch-size()` option
+
+`batch-size()` defines how many consecutive messages each input thread assigns to a single `parallelize()` worker.\
+This preserves ordering for those messages on the output side and can also improve the performance of `parallelize()`.


### PR DESCRIPTION
- LogScheduler internal data allocation is now fully dynamic, based on the configured workers() count
- Improved distribution of initial partition assignments
- Added `batch-size()` option to `parallelize()`
- Documentation PR: https://github.com/syslog-ng/syslog-ng.github.io/pull/307