### PR TITLE
Http responder content length fix

### DIFF
--- a/.github/workflows/PUBLISH-DOCKER-IMAGE.md
+++ b/.github/workflows/PUBLISH-DOCKER-IMAGE.md
@@ -1,0 +1,334 @@
+# Repeatable Docker Image Publishing
+
+This document explains how to use the enhanced `publish-docker-image.yml` workflow for reproducible Docker image builds.
+
+## Quick Reference
+
+**Most Common Use Cases:**
+
+| Scenario | pkg-type | pkg-version | apt-pkg-version | base-image | Use Case |
+|----------|----------|-------------------|---------------------|------------|----------|
+| **Publish latest stable** (RECOMMENDED) | `stable` | _empty_ | _empty_ | `debian:trixie` | Always use newest stable syslog-ng and base OS |
+| **Publish latest nightly** | `nightly` | _empty_ | _empty_ | `debian:trixie` | Development builds with cutting-edge code |
+| Rebuild with OS security patches only | `stable` | _empty_ | `4.5.0-1` | `debian:trixie` | Lock syslog-ng version, update base OS |
+| Test before publishing | any | any | any | any | Set `pkg-push: false` |
+
+**Key Parameters:**
+- `pkg-type`: Package repository type - `stable` or `nightly`
+- `pkg-version`: Controls Docker image **tags** (e.g., `4.5.0` → tag `balabit/syslog-ng:4.5.0`). Leave empty for latest.
+- `apt-pkg-version`: Controls **which APT package** gets installed (Debian format with revision, e.g., `4.5.0-1`). Leave empty for latest from repo.
+- `base-image`: Always pulls the latest of this tag (e.g., latest `debian:trixie`)
+
+**Version Format Difference:**
+```yaml
+pkg-version: '4.5.0'         # Docker tag format (no revision)
+apt-pkg-version: '4.5.0-1'   # Debian package format (includes -revision)
+```
+
+**Examples:**
+
+```yaml
+# Latest stable (most common)
+with:
+  pkg-type: stable
+  base-image: 'debian:trixie'
+
+# Latest nightly
+with:
+  pkg-type: nightly
+  base-image: 'debian:trixie'
+
+# Locked version with latest base OS
+with:
+  pkg-type: stable
+  pkg-version: '4.5.0'
+  apt-pkg-version: '4.5.0-1'
+  base-image: 'debian:trixie'
+```
+
+## Overview
+
+The workflow now supports **reproducible and flexible builds** that allow you to:
+- **Publish with latest syslog-ng version** and latest base OS (most common use case)
+- Re-publish stable Docker images with the same syslog-ng package version
+- Use updated base OS images to get latest security patches
+- Lock to specific package versions for true reproducibility
+- Manually trigger rebuilds via GitHub Actions UI
+
+## Use Cases
+
+### 1. Publish Latest Versions (RECOMMENDED)
+
+```yaml
+with:
+  pkg-type: stable
+  base-image: 'debian:trixie'
+  # All version parameters empty = latest stable syslog-ng + latest base OS
+```
+
+### 2. Rebuild Specific Version with Latest Base OS (Security Updates)
+
+**Use this when you need to keep a specific syslog-ng version but want the latest OS security patches.**
+
+```yaml
+with:
+  pkg-type: stable
+  pkg-version: '4.5.0'
+  apt-pkg-version: '4.5.0-1'  # Lock to specific APT package version
+  base-image: 'debian:trixie'
+  pkg-push: true
+```
+
+### 3. Publish Nightly Builds
+
+```yaml
+with:
+  pkg-type: nightly
+  base-image: 'debian:trixie'
+```
+
+### 4. Switch Base OS Distribution
+
+```yaml
+# Ubuntu instead of Debian
+with:
+  pkg-type: stable
+  pkg-version: '4.5.0'
+  apt-pkg-version: '4.5.0-1'
+  base-image: 'ubuntu:24.04'
+```
+
+### 5. Test Build Without Publishing
+
+```yaml
+with:
+  pkg-type: stable
+  pkg-version: '4.5.0'
+  base-image: 'debian:trixie'
+  pkg-push: false  # Test without pushing
+```
+
+### 6. Scheduled Weekly Rebuilds (Production)
+
+**Automated weekly builds with latest versions:**
+
+```yaml
+name: Weekly Docker Publish
+
+on:
+  schedule:
+    - cron: '0 12 * * 0'  # Every Sunday at 12:00 UTC
+  workflow_dispatch:
+
+jobs:
+  publish:
+    uses: ./.github/workflows/publish-docker-image.yml
+    with:
+      pkg-type: stable
+      base-image: 'debian:trixie'
+      pkg-push: true
+    secrets: inherit
+```
+
+Included as `.github/workflows/weekly-docker-publish.yml`
+
+### 7. Scheduled Monthly Security Rebuilds
+
+```yaml
+name: Monthly Security Rebuild
+
+on:
+  schedule:
+    - cron: '0 3 1 * *'  # 1st of each month
+  workflow_dispatch:
+
+jobs:
+  rebuild:
+    strategy:
+      matrix:
+        version: ['4.5.0', '4.6.0']
+        version-lock: ['4.5.0-1', '4.6.0-1']
+    uses: ./.github/workflows/publish-docker-image.yml
+    with:
+      pkg-type: stable
+      pkg-version: ${{ matrix.version }}
+      apt-pkg-version: ${{ matrix.version-lock }}
+      base-image: 'debian:trixie'
+      pkg-push: true
+    secrets: inherit
+```
+
+## Parameters Reference
+
+### Inputs
+
+| Parameter | Required | Type | Default | Description |
+|-----------|----------|------|---------|-------------|
+| `pkg-type` | Yes | string | - | Package type: `stable` or `nightly` |
+| `pkg-version` | No | string | _empty_ | Docker image tag version (e.g., `4.5.0`). **Leave empty to use latest version** (recommended for regular builds) |
+| `apt-pkg-version` | No | string | _empty_ | Exact Debian package version to install (e.g., `4.5.0-1` with revision). **Leave empty to install latest from repository** (recommended) |
+| `base-image` | No | string | `debian:trixie` | Base OS Docker image. Always pulls latest tag |
+| `pkg-push` | No | boolean | `true` | Push to Docker Hub. Set to `false` for testing |
+
+**💡 TIP:** For most use cases, leave both `pkg-version` and `apt-pkg-version` empty to automatically use the latest stable syslog-ng version.
+
+### Secrets
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `dockerhub-username` | Yes | Docker Hub username |
+| `dockerhub-password` | Yes | Docker Hub password/token |
+
+## How It Works
+
+### 1. Latest Version Behavior (Default)
+
+When `apt-pkg-version` is **not specified** (most common):
+
+```dockerfile
+# Installs latest syslog-ng from the repository
+apt-get install -y syslog-ng
+```
+
+This means:
+- ✅ Always gets the **newest syslog-ng** from the stable repository
+- ✅ Includes all latest features and bug fixes
+- ✅ Automatically updated when new versions are published
+- ✅ Perfect for CI/CD and regular releases
+
+### 2. Base Image Updates
+
+When you specify `base-image: 'debian:trixie'`, Docker pulls the **latest** `debian:trixie` image each time. This means:
+- Base OS security patches are automatically included
+- System libraries are updated
+- CVEs in base image are fixed
+
+### 3. Package Version Locking (Optional)
+
+The `apt-pkg-version` parameter pins the exact syslog-ng package version:
+
+```dockerfile
+# Without lock (installs latest from repository) - RECOMMENDED
+apt-get install -y syslog-ng
+
+# With lock (installs specific version) - For reproducibility
+apt-get install -y syslog-ng=4.5.0-1
+```
+
+**Use locking when:**
+- You need to rebuild with OS security updates only
+- You want guaranteed reproducibility
+- You're maintaining older versions
+
+**Don't use locking when:**
+- You want the latest features and fixes (most cases)
+- You're doing regular CI/CD builds
+- You want automatic updates
+
+### 4. Reproducibility
+
+To achieve true reproducibility:
+1. **Lock syslog-ng version**: Use `apt-pkg-version`
+2. **Document base image digest**: After build, note the base image digest for exact reproducibility
+3. **Version control**: Commit workflow files with specific parameters
+
+Example of capturing base image digest:
+```bash
+docker inspect debian:trixie | jq -r '.[0].RepoDigests[0]'
+# debian@sha256:abc123...
+```
+
+## Finding Package Versions
+
+### APT Package Version Format
+
+The `apt-pkg-version` parameter uses **Debian package version format**:
+
+```
+<upstream-version>-<debian-revision>
+```
+
+**Examples:**
+- `4.5.0-1` = syslog-ng version 4.5.0, Debian package revision 1
+- `4.5.0-2` = syslog-ng version 4.5.0, Debian package revision 2 (rebuild/patch)
+- `4.6.0-1ubuntu1` = syslog-ng version 4.6.0, Ubuntu-specific package build
+
+**Key Difference:**
+- `pkg-version: '4.5.0'` → Controls Docker image tag: `balabit/syslog-ng:4.5.0`
+- `apt-pkg-version: '4.5.0-1'` → APT installs: `apt-get install syslog-ng=4.5.0-1`
+
+### How to Find Available Versions
+
+To find actual package versions available in the repository:
+
+```bash
+# List available syslog-ng versions in repository
+curl -s https://ose-repo.syslog-ng.com/apt/dists/stable/debian-trixie/binary-amd64/Packages.gz \
+  | gunzip | grep -A5 "^Package: syslog-ng$" | grep "Version:"
+
+# Example output:
+# Version: 4.10.0-1
+# Version: 4.10.1-1
+# Version: 4.11.0-1
+
+# Or simpler - just download and view the plain text version:
+curl -s https://ose-repo.syslog-ng.com/apt/dists/stable/debian-trixie/binary-amd64/Packages \
+  | grep -A5 "^Package: syslog-ng$" | grep "Version:"
+```
+
+**Or check from within a container:**
+
+```bash
+# Show available versions
+apt-cache madison syslog-ng
+
+# Show currently installed version
+dpkg -l | grep syslog-ng
+```
+
+## Best Practices
+
+- **Weekly Security Rebuilds**: Use scheduled workflows to keep base OS updated
+- **Testing**: Always test with `pkg-push: false` before production
+- **Version Documentation**: Document locked versions in workflow comments
+- **CVE Monitoring**: Check GitHub Security tab for Trivy scan results
+- **Multi-Architecture**: Builds automatically create AMD64 and ARM64 images
+
+## Troubleshooting
+
+**Package Version Not Found**: Check available versions:
+`apt-cache madison syslog-ng` or verify distribution matches repository
+
+**Base Image Pull Failures**: Verify image name and architecture support
+
+**Build Time Increase**: Expected when base images update with security patches
+
+## Migration from Old Workflow
+
+**For regular releases** (leave version fields empty):
+```yaml
+with:
+  pkg-type: stable
+  base-image: 'debian:trixie'
+```
+
+**For version-locked rebuilds**:
+```yaml
+with:
+  pkg-type: stable
+  pkg-version: '4.5.0'
+  apt-pkg-version: '4.5.0-1'
+  base-image: 'debian:trixie'
+```
+
+---
+
+## Quick Decision Guide
+
+| Your Goal | Use This Configuration |
+|-----------|----------------------|
+| 🚀 **Regular releases with latest versions** | `pkg-type: stable`, leave version fields empty |
+| 🔒 **Locked version with OS security updates** | Set `pkg-version` and `apt-pkg-version` |
+| 🧪 **Test nightly builds** | `pkg-type: nightly`, leave version fields empty |
+| 🐧 **Different OS** | Change `base-image` to `ubuntu:24.04`, etc. |
+| 🧪 **Test without publishing** | Set `pkg-push: false` |

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,15 +1,23 @@
 name: Publish Docker image
 
-
 on:
   workflow_call:
     inputs:
       pkg-type:
         required: true
-        type: string  # stable / nightly
+        type: string # stable / nightly
       pkg-version:
         required: false
         type: string # <MAJOR>.<MINOR>.<PATCH>
+      apt-pkg-version:
+        required: false
+        type: string # Exact package version to install (e.g., 4.5.0-1), empty for latest
+        description: "Lock to specific package version for reproducible builds with updated base images"
+      base-image:
+        required: false
+        type: string # Base docker image (e.g., debian:trixie, ubuntu:24.04)
+        default: "debian:trixie"
+        description: "Base OS Docker image - update this to rebuild with latest base image"
       pkg-push:
         required: false
         type: boolean
@@ -19,7 +27,33 @@ on:
         required: true
       dockerhub-password:
         required: true
-
+  workflow_dispatch:
+    inputs:
+      pkg-type:
+        required: true
+        type: choice
+        options:
+          - stable
+          - nightly
+        description: "Package type to publish"
+      pkg-version:
+        required: false
+        type: string
+        description: "syslog-ng version tag (e.g., 4.5.0), empty for current tag"
+      apt-pkg-version:
+        required: false
+        type: string
+        description: "Lock to specific package version (e.g., 4.5.0-1) for reproducible rebuilds"
+      base-image:
+        required: false
+        type: string
+        default: "debian:trixie"
+        description: "Base OS Docker image (e.g., debian:trixie, ubuntu:24.04)"
+      pkg-push:
+        required: true
+        type: boolean
+        default: false
+        description: "Push to Docker Hub (use false for testing)"
 
 env:
   DOCKER_IMAGE_NAME: balabit/syslog-ng
@@ -33,7 +67,6 @@ jobs:
     steps:
       - name: Checkout syslog-ng source
         uses: actions/checkout@v4
-
 
       - name: Set up Docker
         # Build and load multi-platform images
@@ -61,7 +94,7 @@ jobs:
         with:
           images: ${{ env.DOCKER_IMAGE_NAME }}
           tags: type=match,pattern=syslog-ng-(.*),group=1
-          sep-tags: ','
+          sep-tags: ","
 
       - name: Extract metadata (syslog-ng version) from the given version TAG for Docker
         if: inputs.pkg-type == 'stable' && inputs.pkg-version != ''
@@ -70,7 +103,7 @@ jobs:
         with:
           images: ${{ env.DOCKER_IMAGE_NAME }}
           tags: type=match,pattern=syslog-ng-(.*),group=1,value=syslog-ng-${{ inputs.pkg-version }}
-          sep-tags: ','
+          sep-tags: ","
 
       - name: Compose Docker image tags
         id: tags
@@ -127,7 +160,10 @@ jobs:
           # So, as we are lucky, and these required only once, and only in a RUN docker command that can be dynamic
           # now generating these in the ${SRC_ROOT}/docker/Dockerfile based on the runner architecture (platforms: linux/amd64,linux/arm64)
           #build-args: PKG_TYPE=${{ inputs.pkg-type }} BASE_IMAGE=${{ matrix. }} CONTAINER_ARCH=${{ matrix. }} CONTAINER_NAME_SUFFIX=${{ matrix. }}
-          build-args: PKG_TYPE=${{ inputs.pkg-type }}
+          build-args: |
+            PKG_TYPE=${{ inputs.pkg-type }}
+            BASE_IMAGE=${{ inputs.base-image || 'debian:trixie' }}
+            APT_PACKAGE_VERSION=${{ inputs.apt-pkg-version || '' }}
           push: ${{ inputs.pkg-push }}
 
       - name: Scan docker image on CVEs (CRITICAL,HIGH to a sarif file) # https://aquasecurity.github.io/trivy/v0.54/docs/
@@ -135,9 +171,9 @@ jobs:
         with:
           image-ref: ${{ steps.tags.outputs.CVE_INPUT }}
 
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH"
 
           # DO NOT break the build yet if an issue is detected
           #exit-code: '1'
@@ -147,10 +183,10 @@ jobs:
         with:
           image-ref: ${{ steps.tags.outputs.CVE_INPUT }}
 
-          format: 'table'
+          format: "table"
           # TODO: replaced by https://github.com/aquasecurity/trivy-action/tree/master/?tab=readme-ov-file#using-trivy-to-generate-sbom ?!?
           #dependency-tree: true
-          severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+          severity: "CRITICAL,HIGH,MEDIUM,LOW"
         env:
           # Use the most reliable and quicker AWS ECR location for trivy DBs
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
@@ -160,4 +196,4 @@ jobs:
         if: ${{ inputs.pkg-push != false }}
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: "trivy-results.sarif"

--- a/.github/workflows/weekly-docker-publish.yml
+++ b/.github/workflows/weekly-docker-publish.yml
@@ -1,0 +1,28 @@
+name: Weekly Docker Publish
+
+# Publishes Docker images with latest syslog-ng and latest base OS every week
+# This ensures images always have the latest features and security patches
+
+permissions:
+  contents: read
+  packages: read
+
+on:
+  # Run every Sunday at 12:00 UTC
+  schedule:
+    - cron: "0 12 * * 0"
+
+  # Allow manual triggering
+  workflow_dispatch:
+
+jobs:
+  publish-latest:
+    name: Publish Latest
+    uses: ./.github/workflows/publish-docker-image.yml
+    with:
+      pkg-type: stable
+      base-image: "debian:trixie"
+      pkg-push: true
+    secrets:
+      dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      dockerhub-password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,7 @@ LABEL org.opencontainers.image.source="https://github.com/syslog-ng/syslog-ng"
 # redeclare ARGs so they are available after FROM
 ARG BASE_IMAGE
 ARG PKG_TYPE=stable
+ARG APT_PACKAGE_VERSION
 ARG CONTAINER_ARCH=amd64
 ARG CONTAINER_NAME_SUFFIX
 
@@ -54,8 +55,17 @@ RUN ARCH=$(arch) && \
   wget -qO - https://ose-repo.syslog-ng.com/apt/syslog-ng-ose-pub.asc | gpg --dearmor -o /usr/share/keyrings/ose-repo-archive-keyring.gpg && \
   echo "deb [signed-by=/usr/share/keyrings/ose-repo-archive-keyring.gpg arch=$CONTAINER_ARCH] https://ose-repo.syslog-ng.com/apt/ ${PKG_TYPE} ${DISTRO}-${CODENAME}$CONTAINER_NAME_SUFFIX" | tee --append /etc/apt/sources.list.d/syslog-ng-ose.list
 
-RUN apt-get update -qq && apt-get install -y \
-    libdbd-mysql libdbd-pgsql libdbd-sqlite3 syslog-ng libjemalloc2 \
+RUN apt-get update -qq && \
+    if [ -n "$APT_PACKAGE_VERSION" ]; then \
+      echo "Installing locked syslog-ng version: $APT_PACKAGE_VERSION"; \
+      SYSLOG_PKG="syslog-ng=${APT_PACKAGE_VERSION}"; \
+    else \
+      echo "Installing latest syslog-ng version"; \
+      SYSLOG_PKG="syslog-ng"; \
+    fi && \
+    apt-get install -y \
+      libdbd-mysql libdbd-pgsql libdbd-sqlite3 libjemalloc2 \
+      ${SYSLOG_PKG} \
     && rm -rf /var/lib/apt/lists/*
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Resolves: https://github.com/syslog-ng/syslog-ng/issues/5652
Doc PR: https://github.com/syslog-ng/syslog-ng.github.io/pull/304
TODO: https://github.com/syslog-ng/syslog-ng/issues/5656

Also,
- adds support for larger stats output
- modifies the default value of 
    - `scrape_freq_limit()` to `15`
    - `single-instance()` to `yes`
- fixes some other HTTP response formatting issues
- adds `evt_tag_strn()`