### PR TITLE
HTTP responder content length fix

### DIFF
--- a/lib/eventlog/src/evtlog.h
+++ b/lib/eventlog/src/evtlog.h
@@ -140,6 +140,7 @@ void evt_rec_free(EVTREC *e);
  * Return value: 0 to indicate failure and 1 for success
  **/
 EVTTAG *evt_tag_str(const char *tag, const char *value);
+EVTTAG *evt_tag_strn(const char *tag, const char *value, size_t len);
 EVTTAG *evt_tag_mem(const char *tag, const void *value, size_t len);
 EVTTAG *evt_tag_int(const char *tag, int value);
 EVTTAG *evt_tag_long(const char *tag, long long value);

--- a/lib/eventlog/src/evttags.c
+++ b/lib/eventlog/src/evttags.c
@@ -81,6 +81,58 @@ evt_tag_str(const char *tag, const char *value)
 }
 
 EVTTAG *
+evt_tag_strn(const char *tag, const char *value, size_t len)
+{
+  EVTTAG *p;
+  size_t value_len;
+  char *clipped_value;
+
+  /* neither tag nor value can be NULL */
+  assert(tag);
+  if (!value)
+    value = "(null)";
+
+  p = (EVTTAG *) malloc(sizeof(EVTTAG));
+  if (p == NULL)
+    return NULL;
+
+  value_len = strlen(value);
+  if (value_len > len) // need to clip the value and add "..." at the end
+    {
+      size_t clipped_len = len;
+      size_t clipped_buf_len = len + 4; /* len visible chars + "..." + '\0' */
+
+      clipped_value = malloc(clipped_buf_len);
+      if (clipped_value == NULL)
+        {
+          free(p);
+          return NULL;
+        }
+
+      if (clipped_len > 0)
+        memcpy(clipped_value, value, clipped_len);
+
+      size_t dots_len = clipped_buf_len - 1;
+
+      if (dots_len > 3)
+        dots_len = 3;
+
+      if (dots_len > 0)
+        {
+          size_t dots_start = clipped_buf_len - 1 - dots_len;
+          memset(clipped_value + dots_start, '.', dots_len);
+        }
+      clipped_value[clipped_buf_len - 1] = '\0';
+    }
+  else
+    clipped_value = strdup(value);
+
+  p->et_tag = strdup(tag);
+  p->et_value = clipped_value;
+  return p;
+}
+
+EVTTAG *
 evt_tag_mem(const char *tag, const void *value, size_t len)
 {
   char *buf = malloc(len + 1);
@@ -128,12 +180,21 @@ evt_tag_errno(const char *tag, int err)
 EVTTAG *
 evt_tag_printf(const char *tag, const char *format, ...)
 {
-  va_list ap;
-  char buf[1024];
+#define MAX_BUF_LEN 1024
+#define FULL_BUF_LEN (MAX_BUF_LEN + 3) /* +3 for possible truncation dots and null terminator */
+  char buf[FULL_BUF_LEN];
 
+  va_list ap;
   va_start(ap, format);
-  vsnprintf(buf, sizeof(buf), format, ap);
+  size_t n = vsnprintf(buf, MAX_BUF_LEN, format, ap);
   va_end(ap);
+  if (n >= MAX_BUF_LEN)
+    {
+      buf[FULL_BUF_LEN - 4] = '.';
+      buf[FULL_BUF_LEN - 3] = '.';
+      buf[FULL_BUF_LEN - 2] = '.';
+      buf[FULL_BUF_LEN - 1] = '\0';
+    }
   return evt_tag_str(tag, buf);
 }
 

--- a/lib/eventlog/tests/CMakeLists.txt
+++ b/lib/eventlog/tests/CMakeLists.txt
@@ -10,6 +10,14 @@ add_unit_test(CRITERION TARGET test_evt_tag_mem
   INCLUDES "${Eventlog_INCLUDE_DIR}"
   SOURCES test_evt_tag_mem.c)
 
+add_unit_test(CRITERION TARGET test_evt_tag_strn
+  INCLUDES "${Eventlog_INCLUDE_DIR}"
+  SOURCES test_evt_tag_strn.c)
+
+add_unit_test(CRITERION TARGET test_evt_tag_printf
+  INCLUDES "${Eventlog_INCLUDE_DIR}"
+  SOURCES test_evt_tag_printf.c)
+
 add_unit_test(TARGET test_evtsyslog
   INCLUDES "${Eventlog_INCLUDE_DIR}"
   SOURCES test_evtsyslog.c)

--- a/lib/eventlog/tests/CMakeLists.txt
+++ b/lib/eventlog/tests/CMakeLists.txt
@@ -8,15 +8,18 @@ add_unit_test(TARGET test_evtfmt
 
 add_unit_test(CRITERION TARGET test_evt_tag_mem
   INCLUDES "${Eventlog_INCLUDE_DIR}"
-  SOURCES test_evt_tag_mem.c)
+  SOURCES test_evt_tag_mem.c
+  DEPENDS eventlog)
 
 add_unit_test(CRITERION TARGET test_evt_tag_strn
   INCLUDES "${Eventlog_INCLUDE_DIR}"
-  SOURCES test_evt_tag_strn.c)
+  SOURCES test_evt_tag_strn.c
+  DEPENDS eventlog)
 
 add_unit_test(CRITERION TARGET test_evt_tag_printf
   INCLUDES "${Eventlog_INCLUDE_DIR}"
-  SOURCES test_evt_tag_printf.c)
+  SOURCES test_evt_tag_printf.c
+  DEPENDS eventlog)
 
 add_unit_test(TARGET test_evtsyslog
   INCLUDES "${Eventlog_INCLUDE_DIR}"

--- a/lib/eventlog/tests/Makefile.am
+++ b/lib/eventlog/tests/Makefile.am
@@ -3,7 +3,9 @@ lib_eventlog_tests_TESTS = \
 	lib/eventlog/tests/test_evtfmt \
 	lib/eventlog/tests/test_evtsyslog \
 	lib/eventlog/tests/test_evtsyslog_macros \
-	lib/eventlog/tests/test_evt_tag_mem
+	lib/eventlog/tests/test_evt_tag_mem \
+	lib/eventlog/tests/test_evt_tag_strn \
+	lib/eventlog/tests/test_evt_tag_printf
 
 EXTRA_DIST += lib/eventlog/tests/CMakeLists.txt
 
@@ -20,6 +22,9 @@ lib_eventlog_tests_test_evtsyslog_LDADD = $(top_builddir)/lib/eventlog/src/libev
 
 lib_eventlog_tests_test_evt_tag_mem_CFLAGS = $(TEST_CFLAGS)
 lib_eventlog_tests_test_evt_tag_mem_LDADD = $(TEST_LDADD)
+
+lib_eventlog_tests_test_evt_tag_printf_CFLAGS = $(TEST_CFLAGS)
+lib_eventlog_tests_test_evt_tag_printf_LDADD = $(TEST_LDADD)
 
 lib_eventlog_tests_test_evtsyslog_macros_SOURCES = lib/eventlog/tests/test_evtsyslog.c
 lib_eventlog_tests_test_evtsyslog_macros_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/lib/eventlog/src -DEVENTLOG_SYSLOG_MACROS=1

--- a/lib/eventlog/tests/Makefile.am
+++ b/lib/eventlog/tests/Makefile.am
@@ -21,10 +21,13 @@ lib_eventlog_tests_test_evtsyslog_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/lib/even
 lib_eventlog_tests_test_evtsyslog_LDADD = $(top_builddir)/lib/eventlog/src/libevtlog.la
 
 lib_eventlog_tests_test_evt_tag_mem_CFLAGS = $(TEST_CFLAGS)
-lib_eventlog_tests_test_evt_tag_mem_LDADD = $(TEST_LDADD)
+lib_eventlog_tests_test_evt_tag_mem_LDADD = $(TEST_LDADD) $(top_builddir)/lib/eventlog/src/libevtlog.la
+
+lib_eventlog_tests_test_evt_tag_strn_CFLAGS = $(TEST_CFLAGS)
+lib_eventlog_tests_test_evt_tag_strn_LDADD = $(TEST_LDADD) $(top_builddir)/lib/eventlog/src/libevtlog.la
 
 lib_eventlog_tests_test_evt_tag_printf_CFLAGS = $(TEST_CFLAGS)
-lib_eventlog_tests_test_evt_tag_printf_LDADD = $(TEST_LDADD)
+lib_eventlog_tests_test_evt_tag_printf_LDADD = $(TEST_LDADD) $(top_builddir)/lib/eventlog/src/libevtlog.la
 
 lib_eventlog_tests_test_evtsyslog_macros_SOURCES = lib/eventlog/tests/test_evtsyslog.c
 lib_eventlog_tests_test_evtsyslog_macros_CFLAGS = $(AM_CFLAGS) -I$(top_srcdir)/lib/eventlog/src -DEVENTLOG_SYSLOG_MACROS=1

--- a/lib/eventlog/tests/test_evt_tag_printf.c
+++ b/lib/eventlog/tests/test_evt_tag_printf.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include <evtlog.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+static void
+_assert_evt_tag_printf_str(const gchar *input, const gchar *expected)
+{
+  gchar *key = "test:evt_tag_printf";
+  EVTCONTEXT *ctx = evt_ctx_init("evt_tag_printf", LOG_AUTH);
+  EVTREC *event_rec = evt_rec_init(ctx, LOG_INFO, "");
+
+  evt_rec_add_tag(event_rec, evt_tag_printf(key, "%s", input));
+  gchar *formatted_result = evt_format(event_rec);
+
+  GString *expected_result = g_string_sized_new(64);
+  g_string_append_printf(expected_result, "; %s='%s'", key, expected);
+
+  cr_assert_str_eq(formatted_result, expected_result->str);
+
+  free(formatted_result);
+  g_string_free(expected_result, TRUE);
+  evt_ctx_free(ctx);
+}
+
+static void
+_assert_evt_tag_printf_int_pair(gint left, gint right, const gchar *expected)
+{
+  gchar *key = "test:evt_tag_printf";
+  EVTCONTEXT *ctx = evt_ctx_init("evt_tag_printf", LOG_AUTH);
+  EVTREC *event_rec = evt_rec_init(ctx, LOG_INFO, "");
+
+  evt_rec_add_tag(event_rec, evt_tag_printf(key, "%d %d", left, right));
+  gchar *formatted_result = evt_format(event_rec);
+
+  GString *expected_result = g_string_sized_new(64);
+  g_string_append_printf(expected_result, "; %s='%s'", key, expected);
+
+  cr_assert_str_eq(formatted_result, expected_result->str);
+
+  free(formatted_result);
+  g_string_free(expected_result, TRUE);
+  evt_ctx_free(ctx);
+}
+
+Test(evt_tag_printf, test_multiple_inputs)
+{
+#define LONG_INPUT_LEN 2000
+#define MAX_BUF_LEN 1024
+
+  gchar *long_input = malloc(LONG_INPUT_LEN + 1);
+  memset(long_input, 'a', LONG_INPUT_LEN);
+  long_input[LONG_INPUT_LEN] = '\0';
+
+  GString *expected_truncated = g_string_sized_new(1100);
+  g_string_append_len(expected_truncated, long_input, MAX_BUF_LEN - 1);
+  g_string_append(expected_truncated, "...");
+
+  _assert_evt_tag_printf_int_pair(5, 6, "5 6");
+  _assert_evt_tag_printf_str("short", "short");
+  _assert_evt_tag_printf_str(long_input, expected_truncated->str);
+
+  g_string_free(expected_truncated, TRUE);
+  free(long_input);
+
+#undef LONG_INPUT_LEN
+#undef MAX_BUF_LEN
+}

--- a/lib/eventlog/tests/test_evt_tag_strn.c
+++ b/lib/eventlog/tests/test_evt_tag_strn.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 One Identity
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include <evtlog.h>
+
+static void
+_assert_evt_tag_strn(const gchar *input, gsize len, const gchar *expected)
+{
+  gchar *key = "test:evt_tag_strn";
+  EVTCONTEXT *ctx = evt_ctx_init("evt_tag_strn", LOG_AUTH);
+  EVTREC *event_rec = evt_rec_init(ctx, LOG_INFO, "");
+
+  evt_rec_add_tag(event_rec, evt_tag_strn(key, input, len));
+  gchar *formatted_result = evt_format(event_rec);
+
+  GString *expected_result = g_string_sized_new(16);
+  g_string_append_printf(expected_result, "; %s='%s'", key, expected);
+
+  cr_assert_str_eq(formatted_result, expected_result->str);
+
+  free(formatted_result);
+  g_string_free(expected_result, TRUE);
+  evt_ctx_free(ctx);
+}
+
+Test(evt_tag_strn, test_multiple_inputs)
+{
+  _assert_evt_tag_strn("hello", 10, "hello");    /* 5 <= 10: no truncation */
+  _assert_evt_tag_strn("hello", 5,  "hello");    /* 5 <= 5: exact fit, no truncation */
+  _assert_evt_tag_strn("hello", 4,  "hell...");  /* 5 > 4: 4 visible chars + "..." */
+  _assert_evt_tag_strn("hello", 2,  "he...");    /* 5 > 2: 2 visible chars + "..." */
+  _assert_evt_tag_strn("hello", 1,  "h...");     /* 5 > 1: 1 visible char + "..." */
+  _assert_evt_tag_strn("hello", 0,  "...");      /* 5 > 0: 0 visible chars + "..." */
+  _assert_evt_tag_strn(NULL,    6,  "(null)");   /* "(null)" == 6: exact fit, no truncation */
+  _assert_evt_tag_strn(NULL,    3,  "(nu...");   /* "(null)" > 3: 3 visible chars + "..." */
+}

--- a/lib/logproto/logproto-http-scraper-responder-server.c
+++ b/lib/logproto/logproto-http-scraper-responder-server.c
@@ -246,7 +246,7 @@ log_proto_http_scraper_responder_options_init(LogProtoServerOptionsStorage *opti
   if (options->stat_type == 0)
     options->stat_type = STT_STATS;
   if (options->scrape_freq_limit == -1)
-    options->scrape_freq_limit = 0;
+    options->scrape_freq_limit = 15;
 }
 
 void

--- a/lib/logproto/logproto-http-scraper-responder-server.c
+++ b/lib/logproto/logproto-http-scraper-responder-server.c
@@ -81,10 +81,47 @@ _get_response_content_type(LogProtoHTTPServer *s)
     return g_string_new("text/plain");
 }
 
+#define USE_DEBUG_RESPONSE 0
+
+#if USE_DEBUG_RESPONSE
+static GString *
+_compose_debug_response_body(LogProtoHTTPScraperResponder *self)
+{
+  gchar *stat_format = _get_stat_format(self);
+
+  /* Generate test data > 100 MB to test size limit handling */
+  const gsize target_size = 100 * 1024 * 1024;
+  GString *response = g_string_sized_new(target_size);
+
+  for (gsize i = 0; response->len < target_size; i++)
+    if (strcmp(stat_format, "prometheus") == 0)
+      g_string_append_printf(response,
+                             "test_metric_%lu{label=\"value\",instance=\"test\"} 12345678.90 %lu\n",
+                             (unsigned long) i, (unsigned long) i);
+    else if (strcmp(stat_format, "csv") == 0)
+      g_string_append_printf(response,
+                             "src.pipe;debug.metric_%lu;instance;a;value;%lu\n",
+                             (unsigned long) i, (unsigned long) i);
+    else if (strcmp(stat_format, "kv") == 0)
+      g_string_append_printf(response,
+                             "src.pipe.debug.metric_%lu.instance.a.value=%lu\n",
+                             (unsigned long) i, (unsigned long) i);
+
+  msg_debug("http-server(): Generated test response body",
+            evt_tag_long("size", response->len));
+
+  return response;
+}
+#endif
+
 static GString *
 _compose_response_body(LogProtoHTTPServer *s)
 {
   LogProtoHTTPScraperResponder *self = (LogProtoHTTPScraperResponder *)s;
+
+#if USE_DEBUG_RESPONSE
+  return _compose_debug_response_body(self);
+#endif
 
   GString *stats = NULL;
   gboolean cancelled = FALSE;

--- a/lib/logproto/logproto-http-scraper-responder-server.c
+++ b/lib/logproto/logproto-http-scraper-responder-server.c
@@ -59,6 +59,28 @@ _generate_batched_response(const gchar *record, gpointer user_data)
   g_string_append_printf(*batch, "%s", record);
 }
 
+static gchar *
+_get_stat_format(LogProtoHTTPScraperResponder *self)
+{
+  gchar *stat_format = self->options->stat_format &&
+                       self->options->stat_format[0] ? self->options->stat_format : "prometheus";
+  return stat_format;
+}
+
+static GString *
+_get_response_content_type(LogProtoHTTPServer *s)
+{
+  LogProtoHTTPScraperResponder *self = (LogProtoHTTPScraperResponder *)s;
+
+  gchar *stat_format = _get_stat_format(self);
+  if (strcmp(stat_format, "prometheus") == 0)
+    return g_string_new("text/plain; version=0.0.4");
+  else if (strcmp(stat_format, "csv") == 0)
+    return g_string_new("text/csv");
+  else
+    return g_string_new("text/plain");
+}
+
 static GString *
 _compose_response_body(LogProtoHTTPServer *s)
 {
@@ -66,8 +88,7 @@ _compose_response_body(LogProtoHTTPServer *s)
 
   GString *stats = NULL;
   gboolean cancelled = FALSE;
-  char *stat_format = self->options->stat_format &&
-                      self->options->stat_format[0] ? self->options->stat_format : "prometheus";
+  gchar *stat_format = _get_stat_format(self);
 
   if (self->options->stat_type == STT_STATS)
     {
@@ -156,6 +177,7 @@ log_proto_http_scraper_responder_server_init(LogProtoHTTPScraperResponder *self,
   log_proto_http_server_init((LogProtoHTTPServer *)self, transport, options_storage);
   self->super.request_header_checker = _check_request_headers;
   self->super.response_body_composer = _compose_response_body;
+  self->super.response_content_type_composer = _get_response_content_type;
 
   self->super.super.super.super.free_fn = _log_proto_http_scraper_responder_server_free;
 

--- a/lib/logproto/logproto-http-scraper-responder-server.c
+++ b/lib/logproto/logproto-http-scraper-responder-server.c
@@ -209,6 +209,7 @@ log_proto_http_scraper_responder_options_defaults(LogProtoServerOptionsStorage *
 
   options->stat_type = 0;
   options->scrape_freq_limit = -1;
+  options->single_instance = TRUE;
 }
 
 void

--- a/lib/logproto/logproto-http-scraper-responder-server.c
+++ b/lib/logproto/logproto-http-scraper-responder-server.c
@@ -105,17 +105,17 @@ static gint
 _check_request_headers(LogProtoHTTPServer *s, gchar *buffer_start, gsize buffer_bytes)
 {
   LogProtoHTTPScraperResponder *self = (LogProtoHTTPScraperResponder *)s;
-  gint status = 200; // HTTP/1.1 200 OK
+  gint status = HTTP_STATUS_OK;
 
   g_mutex_lock(_mutex());
   iv_validate_now();
   time_t now = iv_now.tv_sec;
   time_t ellapsed = now - last_scrape_request_time;
   if (self->options->scrape_freq_limit && ellapsed < self->options->scrape_freq_limit)
-    status = 429; // HTTP/1.1 429 Too Many Requests
+    status = HTTP_STATUS_TOO_MANY_REQUESTS;
   last_scrape_request_time = now;
   g_mutex_unlock(_mutex());
-  if (status != 200)
+  if (status != HTTP_STATUS_OK)
     {
       msg_trace("Too frequent scraper requests, ignoring for now",
                 evt_tag_long("last-request", ellapsed),
@@ -129,7 +129,7 @@ _check_request_headers(LogProtoHTTPServer *s, gchar *buffer_start, gsize buffer_
     {
       msg_trace("Scraper request header did not match", evt_tag_str("header", header->str), evt_tag_str("expected-header",
                 self->options->scraper_request_hdr_pattern));
-      status = 400; // HTTP/1.1 400 Bad Request
+      status = HTTP_STATUS_BAD_REQUEST;
     }
   g_string_free(header, TRUE);
   g_pattern_spec_free(pattern);

--- a/lib/logproto/logproto-http-server.c
+++ b/lib/logproto/logproto-http-server.c
@@ -123,18 +123,19 @@ static gboolean
 _http_request_handler(LogProtoTextServer *s, LogProtoBufferedServerState *state,
                       const guchar *buffer_start, gsize buffer_bytes)
 {
-  gboolean result = FALSE;
   LogProtoHTTPServer *self = (LogProtoHTTPServer *)s;
+  gboolean result = FALSE;
 
-  GString *response = self->request_processor(self, state, buffer_start, buffer_bytes);
-  if (response)
+  GString *response_body = self->request_processor(self, state, buffer_start, buffer_bytes);
+  if (response_body)
     {
-      result = response->len > 0;
-      if (self->response_sender(self, response->str, response->len, self->options->super.close_after_send) >= 0)
-        msg_trace("http-server(): Sent response", evt_tag_str("http-server-response", response->str));
+      if (self->response_sender(self, response_body->str, response_body->len, self->options->super.close_after_send))
+        {
+          msg_trace("http-server(): Sent response", evt_tag_printf("response", "%.1024s", response_body->str));
+          result = TRUE;
+        }
+      g_string_free(response_body, TRUE);
     }
-  if (response)
-    g_string_free(response, TRUE);
   return result;
 }
 

--- a/lib/logproto/logproto-http-server.c
+++ b/lib/logproto/logproto-http-server.c
@@ -77,7 +77,7 @@ _compose_response_header(LogProtoHTTPServer *self, const gchar *data G_GNUC_UNUS
                          gboolean close_after_sent)
 {
   const gint maxContentNumLength = 5;
-  static const gchar close_str[] = "Connection: close\n";
+  static const gchar close_str[] = "Connection: close";
   static const gchar response_header_fmt[] = "%s\n"
                                              "Content-Type: text/plain; version=0.0.4\n"
                                              "Content-Length: %*lu\n"
@@ -96,7 +96,7 @@ static gssize
 _send_response(LogProtoHTTPServer *self, const gchar *data, gsize data_len, gboolean close_after_sent)
 {
   GString *response = self->response_header_composer(self, data, data_len, close_after_sent);
-  if (response && data && data > 0)
+  if (response && data && data_len > 0)
     g_string_append(response, data);
 
   gssize sent_bytes = -1;

--- a/lib/logproto/logproto-http-server.c
+++ b/lib/logproto/logproto-http-server.c
@@ -35,7 +35,7 @@ _compose_response_body(LogProtoHTTPServer *self)
 static gint
 _check_request_headers(LogProtoHTTPServer *self, gchar *buffer_start, gsize buffer_bytes)
 {
-  return 400; // HTTP/1.1 400 Bad Request
+  return HTTP_STATUS_BAD_REQUEST;
 }
 
 static GString *
@@ -47,17 +47,17 @@ _http_request_processor(LogProtoHTTPServer *self, LogProtoBufferedServerState *s
   gint status = self->request_header_checker(self, (gchar *)buffer_start, buffer_bytes);
   switch (status)
     {
-    case 200:
+    case HTTP_STATUS_OK:
       response_data = self->response_body_composer(self);
       break;
 
-    case 429: // HTTP/1.1 429 Too Many Requests
+    case HTTP_STATUS_TOO_MANY_REQUESTS:
       msg_trace("http-server(): Too many requests");
       response_data = g_string_new(http_too_many_request_msg);
       g_string_append(response_data, "\nContent-Length: 0\n\n");
       break;
 
-    case 400: // HTTP/1.1 400 Bad Request
+    case HTTP_STATUS_BAD_REQUEST:
     default:
     {
       GString *header = g_string_new_len((gchar *)buffer_start, buffer_bytes);

--- a/lib/logproto/logproto-http-server.c
+++ b/lib/logproto/logproto-http-server.c
@@ -25,6 +25,8 @@
 #include "messages.h"
 
 #include <unistd.h>
+#include <math.h>
+#include <errno.h>
 
 static GString *
 _compose_response_body(LogProtoHTTPServer *self)
@@ -103,20 +105,102 @@ _compose_response_header(LogProtoHTTPServer *self, const gchar *data G_GNUC_UNUS
   return response;
 }
 
-static gssize
+static gboolean
 _send_response(LogProtoHTTPServer *self, const gchar *data, gsize data_len, gboolean close_after_sent)
 {
+  gboolean result = FALSE;
+  const gsize max_chunk_size = 4096; // 4 KB - reasonable chunk size for writing to the transport
+  const gint max_retries = 100; // Max retries on EAGAIN before giving up
+  gint retry_count = 0;
+
   GString *response = self->response_header_composer(self, data, data_len, close_after_sent);
-  if (response && data && data_len > 0)
-    g_string_append(response, data);
+  g_assert(response != NULL);
 
-  gssize sent_bytes = -1;
-  if (response && response->len)
-    sent_bytes = log_transport_stack_write(&self->super.super.super.transport_stack, response->str, response->len);
+  if (log_transport_stack_write(&self->super.super.super.transport_stack, response->str, response->len) != response->len)
+    {
+      msg_error("http-server(): Failed to send response header",
+                evt_tag_long("header_size", response->len),
+                evt_tag_errno("error", errno));
+      goto exit;
+    }
+  else
+    msg_trace("http-server(): Sent response header", evt_tag_str("response_hdr", response->str));
 
-  if (response)
-    g_string_free(response, TRUE);
-  return sent_bytes;
+  if (data && data_len > 0)
+    {
+      gsize total_to_send = data_len;
+      gsize total_sent = 0;
+
+      while (total_sent < total_to_send && retry_count < max_retries)
+        {
+          gsize chunk_size = MIN(max_chunk_size, total_to_send - total_sent);
+          gssize sent_bytes = log_transport_stack_write(&self->super.super.super.transport_stack,
+                                                        (const gpointer) (data + total_sent),
+                                                        chunk_size);
+          if (sent_bytes < 0)
+            {
+              // Handle non-blocking socket flow control
+              if (errno == EAGAIN || errno == EWOULDBLOCK)
+                {
+                  retry_count++;
+                  msg_trace("http-server(): Socket buffer full, backing off",
+                            evt_tag_int("retry_count", retry_count),
+                            evt_tag_long("total_sent", total_sent),
+                            evt_tag_long("total_to_send", total_to_send));
+                  usleep(retry_count * 1000); // retry_count ms backoff
+                  continue;
+                }
+
+              msg_error("http-server(): Failed to send response chunk",
+                        evt_tag_long("total_size", total_to_send),
+                        evt_tag_long("bytes_sent_so_far", total_sent),
+                        evt_tag_long("chunk_size", chunk_size),
+                        evt_tag_long("chunk_bytes_sent", sent_bytes),
+                        evt_tag_errno("error", errno));
+              goto exit;
+            }
+
+          if (sent_bytes == 0)
+            {
+              msg_error("http-server(): Write returned 0, connection closed",
+                        evt_tag_long("total_sent", total_sent),
+                        evt_tag_long("total_to_send", total_to_send));
+              goto exit;
+            }
+
+          // Progress made - reset retry counter
+          retry_count = 0;
+          total_sent += sent_bytes;
+
+          if (sent_bytes < chunk_size)
+            msg_trace("http-server(): Partial chunk write, continuing",
+                      evt_tag_long("chunk_size", chunk_size),
+                      evt_tag_long("chunk_bytes_sent", sent_bytes),
+                      evt_tag_long("total_sent", total_sent),
+                      evt_tag_long("total_to_send", total_to_send));
+        }
+
+      if (total_sent == total_to_send)
+        {
+          msg_debug("http-server(): Response sent successfully",
+                    evt_tag_long("total_bytes", total_sent),
+                    evt_tag_long("num_chunks", (total_sent + max_chunk_size - 1) / max_chunk_size));
+          msg_trace("http-server(): Sent response", evt_tag_strn("response", data, 4096));
+          result = TRUE;
+        }
+      else if (retry_count >= max_retries)
+        msg_error("http-server(): Exceeded maximum retry attempts",
+                  evt_tag_int("max_retries", max_retries),
+                  evt_tag_long("bytes_sent", total_sent),
+                  evt_tag_long("bytes_to_send", total_to_send));
+      else
+        msg_error("http-server(): Incomplete response send",
+                  evt_tag_long("bytes_to_send", total_to_send),
+                  evt_tag_long("bytes_sent", total_sent));
+    }
+exit:
+  g_string_free(response, TRUE);
+  return result;
 }
 
 static gboolean
@@ -130,10 +214,7 @@ _http_request_handler(LogProtoTextServer *s, LogProtoBufferedServerState *state,
   if (response_body)
     {
       if (self->response_sender(self, response_body->str, response_body->len, self->options->super.close_after_send))
-        {
-          msg_trace("http-server(): Sent response", evt_tag_printf("response", "%.1024s", response_body->str));
-          result = TRUE;
-        }
+        result = TRUE;
       g_string_free(response_body, TRUE);
     }
   return result;

--- a/lib/logproto/logproto-http-server.c
+++ b/lib/logproto/logproto-http-server.c
@@ -73,22 +73,33 @@ _http_request_processor(LogProtoHTTPServer *self, LogProtoBufferedServerState *s
 }
 
 static GString *
+_get_response_content_type(LogProtoHTTPServer *self)
+{
+  return g_string_new("text/plain; charset=utf-8");
+}
+
+static GString *
 _compose_response_header(LogProtoHTTPServer *self, const gchar *data G_GNUC_UNUSED, gsize data_len,
                          gboolean close_after_sent)
 {
-  const gint maxContentNumLength = 5;
-  static const gchar close_str[] = "Connection: close";
+  static const gchar close_str[] = "Connection: close\n";
+  const gint max_content_num_length = 20; // max number of digits for gsize (64-bit unsigned) in decimal representation
+  const gint data_len_num_length = data_len > 0 ? (gint) (log10((double)data_len) + 1) : 1;
+  const gint max_resp_hdr_len = 150; // calculated based on the parts of a common header
   static const gchar response_header_fmt[] = "%s\n"
-                                             "Content-Type: text/plain; version=0.0.4\n"
+                                             "Content-Type: %s\n"
                                              "Content-Length: %*lu\n"
-                                             "%s\n"
+                                             "%s"
                                              "\n";
-  GString *response = g_string_sized_new(G_N_ELEMENTS(response_header_fmt) - 1 +
-                                         G_N_ELEMENTS(http_ok_msg) - 1 +
-                                         G_N_ELEMENTS(close_str) - 1 - 2 +
-                                         -4 + maxContentNumLength + (long) data_len);
-  g_string_printf(response, response_header_fmt, http_ok_msg, maxContentNumLength, (unsigned long) data_len,
+  GString *response = g_string_sized_new(max_resp_hdr_len);
+  GString *content_type = self->response_content_type_composer(self);
+
+  g_string_printf(response, response_header_fmt,
+                  http_ok_msg,
+                  content_type->str,
+                  MIN(data_len_num_length, max_content_num_length), (unsigned long) data_len,
                   close_after_sent ? close_str : "");
+  g_string_free(content_type, TRUE);
   return response;
 }
 
@@ -140,6 +151,7 @@ log_proto_http_server_init(LogProtoHTTPServer *self, LogTransport *transport,
   self->request_header_checker = _check_request_headers;
   self->response_header_composer = _compose_response_header;
   self->response_body_composer = _compose_response_body;
+  self->response_content_type_composer = _get_response_content_type;
   self->response_sender = _send_response;
 }
 

--- a/lib/logproto/logproto-http-server.c
+++ b/lib/logproto/logproto-http-server.c
@@ -43,8 +43,8 @@ _http_request_processor(LogProtoHTTPServer *self, LogProtoBufferedServerState *s
                         const guchar *buffer_start, gsize buffer_bytes)
 {
   GString *response_data = NULL;
-  gint status = self->request_header_checker(self, (gchar *)buffer_start, buffer_bytes);
 
+  gint status = self->request_header_checker(self, (gchar *)buffer_start, buffer_bytes);
   switch (status)
     {
     case 200:
@@ -54,7 +54,7 @@ _http_request_processor(LogProtoHTTPServer *self, LogProtoBufferedServerState *s
     case 429: // HTTP/1.1 429 Too Many Requests
       msg_trace("http-server(): Too many requests");
       response_data = g_string_new(http_too_many_request_msg);
-      g_string_append(response_data, "\n\n");
+      g_string_append(response_data, "\nContent-Length: 0\n\n");
       break;
 
     case 400: // HTTP/1.1 400 Bad Request
@@ -64,7 +64,7 @@ _http_request_processor(LogProtoHTTPServer *self, LogProtoBufferedServerState *s
       msg_trace("http-server(): Bad request",
                 evt_tag_str("header", header->str));
       response_data = g_string_new(http_bad_request_msg);
-      g_string_append(response_data, "\n\n");
+      g_string_append(response_data, "\nContent-Length: 0\n\n");
       g_string_free(header, TRUE);
       break;
     }

--- a/lib/logproto/logproto-http-server.h
+++ b/lib/logproto/logproto-http-server.h
@@ -68,6 +68,7 @@ struct _LogProtoHTTPServer
                                        gboolean close_after_sent);
   GString *(*response_body_composer)(LogProtoHTTPServer *self);
   gssize (*response_sender)(LogProtoHTTPServer *self, const gchar *data, gsize data_len, gboolean close_after_sent);
+  GString *(*response_content_type_composer)(LogProtoHTTPServer *self);
 };
 
 void log_proto_http_server_options_defaults(LogProtoServerOptionsStorage *options);
@@ -82,5 +83,4 @@ LogProtoServer *log_proto_http_server_new(LogTransport *transport,
                                           const LogProtoServerOptionsStorage *options);
 void log_proto_http_server_init(LogProtoHTTPServer *self, LogTransport *transport,
                                 const LogProtoServerOptionsStorage *options);
-
 #endif

--- a/lib/logproto/logproto-http-server.h
+++ b/lib/logproto/logproto-http-server.h
@@ -27,9 +27,16 @@
 #include "logproto/logproto-server.h"
 #include "logproto/logproto-text-server.h"
 
-static const gchar http_too_many_request_msg[] = "HTTP/1.1 429 Too Many Requests";
-static const gchar http_bad_request_msg[] = "HTTP/1.1 400 Bad Request";
+/* HTTP status codes */
+#define HTTP_STATUS_OK 200
+#define HTTP_STATUS_BAD_REQUEST 400
+#define HTTP_STATUS_TOO_MANY_REQUESTS 429
+#define HTTP_STATUS_INTERNAL_SERVER_ERROR 500
+
+/* HTTP status line messages */
 static const gchar http_ok_msg[] = "HTTP/1.1 200 OK";
+static const gchar http_bad_request_msg[] = "HTTP/1.1 400 Bad Request";
+static const gchar http_too_many_request_msg[] = "HTTP/1.1 429 Too Many Requests";
 
 typedef struct _LogProtoHTTPServerOptions
 {

--- a/lib/logproto/logproto-http-server.h
+++ b/lib/logproto/logproto-http-server.h
@@ -67,7 +67,7 @@ struct _LogProtoHTTPServer
   GString *(*response_header_composer)(LogProtoHTTPServer *self, const gchar *data, gsize data_len,
                                        gboolean close_after_sent);
   GString *(*response_body_composer)(LogProtoHTTPServer *self);
-  gssize (*response_sender)(LogProtoHTTPServer *self, const gchar *data, gsize data_len, gboolean close_after_sent);
+  gboolean (*response_sender)(LogProtoHTTPServer *self, const gchar *data, gsize data_len, gboolean close_after_sent);
   GString *(*response_content_type_composer)(LogProtoHTTPServer *self);
 };
 

--- a/lib/logproto/logproto-text-server.c
+++ b/lib/logproto/logproto-text-server.c
@@ -259,7 +259,8 @@ success:
     if (FALSE == self->extracted_raw_data_handler(self, state, buffer_start, buffer_bytes))
       {
         *msg_len = 0;
-        return TRUE;
+        self->super.io_status = G_IO_STATUS_ERROR;
+        return FALSE;
       }
 
   if (G_UNLIKELY(self->multi_line && multi_line_logic_keep_trailing_newline(self->multi_line)))

--- a/lib/logproto/tests/test-http-scraper-responder-server.c
+++ b/lib/logproto/tests/test-http-scraper-responder-server.c
@@ -60,6 +60,8 @@ get_inited_proto_http_scraper_server_options(void)
   // G=Full teardown of the base options (log_proto_server_options_destroy) will not work either as both
   // log_proto_server_options_init and log_proto_server_options_destroy are called only once, at suit init/teardown
   log_proto_http_scraper_responder_options_init(&proto_server_options, configuration);
+  log_proto_http_scraper_responder_options_set_scrape_freq_limit(&proto_server_options, 0);
+  log_proto_http_scraper_responder_options_set_single_instance(&proto_server_options, FALSE);
   log_proto_http_scraper_responder_options_set_scrape_pattern(&proto_server_options, "GET /metrics*");
   return (LogProtoHTTPScraperResponderOptionsStorage *)&proto_server_options;
 }
@@ -222,7 +224,7 @@ test_scrape_limit(LogTransportMockConstructor log_transport_mock_new)
   response = proto_http_server->request_processor(proto_http_server, NULL,
                                                   (const guchar *)mocked_request,
                                                   sizeof(mocked_request));
-  cr_assert_str_eq((const gchar *) response->str, "HTTP/1.1 429 Too Many Requests\n\n");
+  cr_assert_str_eq((const gchar *) response->str, "HTTP/1.1 429 Too Many Requests\nContent-Length: 0\n\n");
   g_string_free(response, TRUE);
 
   // do not have to wait yet as the fetch result will be the same, no matter if the time is up or not
@@ -276,7 +278,7 @@ test_scrape_pattern(LogTransportMockConstructor log_transport_mock_new)
   GString *response = proto_http_server->request_processor(proto_http_server, NULL,
                                                            (const guchar *)mocked_not_matching_request,
                                                            sizeof(mocked_not_matching_request));
-  cr_assert_str_eq((const gchar *) response->str, "HTTP/1.1 400 Bad Request\n\n");
+  cr_assert_str_eq((const gchar *) response->str, "HTTP/1.1 400 Bad Request\nContent-Length: 0\n\n");
   g_string_free(response, TRUE);
 
   // last fetch should be EOF (as result of the previous is dropped)

--- a/news/bugfix-5662.md
+++ b/news/bugfix-5662.md
@@ -1,0 +1,1 @@
+stats-exporter(): fixed the content-length value in the response header

--- a/news/other-5662.md
+++ b/news/other-5662.md
@@ -1,0 +1,6 @@
+stats-exporter(): applied changes arte:
+- any internal request or response processing errors which cannot be responded with a valid HTTP response, will now log the error and close the connection
+- the SCL module single-instance() option is synced correctly with the stats-exporter module's single-instance() option, so the default value must be `yes` in every case
+- the response content-type is set according to the requested stat-format()
+- added an internal chunked response solution, so large responses should not cause stalls anymore
+- set the default scrape-freq-limit() to 15

--- a/scl/stats-exporter/plugin.conf
+++ b/scl/stats-exporter/plugin.conf
@@ -23,7 +23,7 @@
 
 block source stats-exporter(
     scrape-pattern("GET /metrics*")
-    scrape-freq-limit(0)
+    scrape-freq-limit(15)
     single-instance(yes)
     stat-type("stats")
     stat-query("*")


### PR DESCRIPTION
Fixes: #5652
Doc PR: syslog-ng/syslog-ng.github.io#304
TODO: #5656

Also,

- adds support for larger stats output
- modifies the default value of
    - scrape_freq_limit() to 15
    - single-instance() to 
- fixes some other HTTP response formatting issues
- adds evt_tag_strn()
