### PR TITLE
syslog-ng-debun hung fix case of syslog-ng-ctl hung

### DIFF
--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -58,6 +58,7 @@ lsof="lsof -p"
 no_lsof_fallback() { echo "No lsof in path."; }
 pscmd="ps auxwwwwwf"
 pseao="ps -eao"
+pspoo() { ps -p "${1}" -o pid= -o ppid= ; }
 cpiopdL="cpio -pdL"
 findL () { find -L "$@" ; }
 dfk="df -k"
@@ -237,25 +238,50 @@ fi
 
 run_with_timeout () {
 	# Cross-platform timeout function
-	# run_with_timeout [timeout_sec] command
-	local timeout_sec
+	# run_with_timeout [-t timeout_sec] command
+	local timeout_sec=180
+
 	case "$1" in
-		'')        echo "Error: No command passed" >&4 ; return 1 ;;
-		*[!0-9.]*) timeout_sec=180 ;;
-		*)         timeout_sec="$1"; shift ;;
+		'-t') 
+			case "$2" in
+				''|*[!0-9]*)
+					echo "Error: run_with_timeout: -t requires an integer argument" >&4
+					return 1 ;;
+				*)	timeout_sec="$2" ;;
+			esac
+			shift ; shift ;;
 	esac
-	# Does not support parallel runs (use $$)
-	local timed_out_file="${tmpdir:-/tmp}/syslog-ng-debun_run-timeout.$$.flag"
+	if [ -z "$1" ] ;then
+		echo "Error: run_with_timeout: No command passed" >&4
+		return 1
+	fi
+
 	"$@" &
 	local cmd_pid=$!
-	( sleep "$timeout_sec" && touch "$timed_out_file" && kill "$cmd_pid" 2>/dev/null ) &
+	local cmd_fingerprint="$(pspoo ${cmd_pid} 2>/dev/null)"
+	local timed_out_file="${tmpdir:-/tmp}/syslog-ng-debun_run-timeout.${cmd_pid}.flag"
+
+	( 	local i=0
+		while [ "${i}" -lt "${timeout_sec}" ] ; do
+			sleep 1
+			i=$((i + 1))
+		done
+		touch "${timed_out_file}" 2>/dev/null
+		if [ "${cmd_fingerprint:-unset}" = "$(pspoo ${cmd_pid} 2>/dev/null)" ]; then
+			kill "${cmd_pid}" 2>/dev/null
+		fi
+	) &
 	local watchdog_pid=$!
-	wait "$cmd_pid" 2>/dev/null
+	local watchdog_fingerprint="$(pspoo ${watchdog_pid} 2>/dev/null)"
+
+	wait "${cmd_pid}" 2>/dev/null
 	local ret=$?
-	kill "$watchdog_pid" 2>/dev/null
-	wait "$watchdog_pid" 2>/dev/null
-	if [ -f "$timed_out_file" ]; then
-		rm -f "$timed_out_file"
+	if [ "${watchdog_fingerprint:-unset}" = "$(pspoo ${watchdog_pid} 2>/dev/null)" ]; then
+		kill "${watchdog_pid}" 2>/dev/null
+	fi
+	wait "${watchdog_pid}" >/dev/null 2>&1
+	if [ -f "${timed_out_file}" ]; then
+		rm -f "${timed_out_file}"
 		printf 'Warning: Command timeout reached: %ss: %s\n' "${timeout_sec}" "${*}" >&4
 		ret=124
 	fi

--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -237,8 +237,14 @@ fi
 
 run_timeout () {
   # Cross-platform timeout function
-  local timeout_sec="$1"
-  shift
+  # run_timeout [timeout_sec] command
+  local timeout_sec
+  case "$1" in
+    '')        return 1 ;;
+    *[!0-9.]*) timeout_sec=180 ;;
+    *)         timeout_sec="$1"; shift ;;
+  esac
+  # Does not support parallel runs (use $$)
   local timed_out_file="${tmpdir:-/tmp}/syslog-ng-debun_run-timeout.$$.flag"
   "$@" &
   local cmd_pid=$!

--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -269,6 +269,10 @@ run_with_timeout () {
 		touch "${timed_out_file}" 2>/dev/null
 		if [ "${cmd_fingerprint:-unset}" = "$(pspoo ${cmd_pid} 2>/dev/null)" ]; then
 			kill "${cmd_pid}" 2>/dev/null
+			sleep 2
+			if [ "${cmd_fingerprint:-unset}" = "$(pspoo ${cmd_pid} 2>/dev/null)" ]; then
+				kill -9 "${cmd_pid}" 2>/dev/null
+			fi
 		fi
 	) &
 	local watchdog_pid=$!

--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -240,7 +240,7 @@ run_timeout () {
   # run_timeout [timeout_sec] command
   local timeout_sec
   case "$1" in
-    '')        return 1 ;;
+    '')        echo "Error: No command passed" >> ${tmpdir}/syslog-ng.debun.txt ; return 1 ;;
     *[!0-9.]*) timeout_sec=180 ;;
     *)         timeout_sec="$1"; shift ;;
   esac
@@ -256,6 +256,7 @@ run_timeout () {
   wait "$watchdog_pid" 2>/dev/null
   if [ -f "$timed_out_file" ]; then
     rm -f "$timed_out_file"
+    echo "Warning: Command timeout reached: ${timeout_sec}s: $*" >> ${tmpdir}/syslog-ng.debun.txt
     ret=124
   fi
   return $ret

--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -12,7 +12,7 @@ LANG=en_US
 LC_ALL=C
 export LANG LC_ALL
 
-version="0.3.20.20220117"
+version="0.3.21.20260422"
 
 ### Check for "local" variable support
 if type local | grep builtin >/dev/null; then
@@ -236,30 +236,30 @@ else
 fi
 
 run_with_timeout () {
-  # Cross-platform timeout function
-  # run_with_timeout [timeout_sec] command
-  local timeout_sec
-  case "$1" in
-    '')        echo "Error: No command passed" >> ${tmpdir}/syslog-ng.debun.txt ; return 1 ;;
-    *[!0-9.]*) timeout_sec=180 ;;
-    *)         timeout_sec="$1"; shift ;;
-  esac
-  # Does not support parallel runs (use $$)
-  local timed_out_file="${tmpdir:-/tmp}/syslog-ng-debun_run-timeout.$$.flag"
-  "$@" &
-  local cmd_pid=$!
-  ( sleep "$timeout_sec" && touch "$timed_out_file" && kill "$cmd_pid" 2>/dev/null ) &
-  local watchdog_pid=$!
-  wait "$cmd_pid" 2>/dev/null
-  local ret=$?
-  kill "$watchdog_pid" 2>/dev/null
-  wait "$watchdog_pid" 2>/dev/null
-  if [ -f "$timed_out_file" ]; then
-    rm -f "$timed_out_file"
-    echo "Warning: Command timeout reached: ${timeout_sec}s: $*" >> ${tmpdir}/syslog-ng.debun.txt
-    ret=124
-  fi
-  return $ret
+	# Cross-platform timeout function
+	# run_with_timeout [timeout_sec] command
+	local timeout_sec
+	case "$1" in
+		'')        echo "Error: No command passed" >> ${tmpdir}/syslog-ng.debun.txt ; return 1 ;;
+		*[!0-9.]*) timeout_sec=180 ;;
+		*)         timeout_sec="$1"; shift ;;
+	esac
+	# Does not support parallel runs (use $$)
+	local timed_out_file="${tmpdir:-/tmp}/syslog-ng-debun_run-timeout.$$.flag"
+	"$@" &
+	local cmd_pid=$!
+	( sleep "$timeout_sec" && touch "$timed_out_file" && kill "$cmd_pid" 2>/dev/null ) &
+	local watchdog_pid=$!
+	wait "$cmd_pid" 2>/dev/null
+	local ret=$?
+	kill "$watchdog_pid" 2>/dev/null
+	wait "$watchdog_pid" 2>/dev/null
+	if [ -f "$timed_out_file" ]; then
+		rm -f "$timed_out_file"
+		echo "Warning: Command timeout reached: ${timeout_sec}s: $*" >> ${tmpdir}/syslog-ng.debun.txt
+		ret=124
+	fi
+	return $ret
 }
 
 debun_init () {

--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -267,26 +267,26 @@ run_with_timeout () {
 			sleep 1
 			i=$((i + 1))
 		done
-		touch "${timed_out_file}" 2>/dev/null
+		touch "${timed_out_file}" >/dev/null 2>&1
 		if [ "${cmd_fingerprint:-unset}" = "$(pspoo "${cmd_pid}" 2>/dev/null)" ]; then
-			kill "${cmd_pid}" 2>/dev/null
+			kill "${cmd_pid}" >/dev/null 2>&1
 			sleep 2
 			if [ "${cmd_fingerprint:-unset}" = "$(pspoo "${cmd_pid}" 2>/dev/null)" ]; then
-				kill -9 "${cmd_pid}" 2>/dev/null
+				kill -9 "${cmd_pid}" >/dev/null 2>&1
 			fi
 		fi
 	) &
 	local watchdog_pid=$!
 	local watchdog_fingerprint="$(pspoo "${watchdog_pid}" 2>/dev/null)"
 
-	wait "${cmd_pid}" 2>/dev/null
+	wait "${cmd_pid}" >/dev/null 2>&1
 	local ret=$?
 	if [ "${watchdog_fingerprint:-unset}" = "$(pspoo "${watchdog_pid}" 2>/dev/null)" ]; then
-		kill "${watchdog_pid}" 2>/dev/null
+		kill "${watchdog_pid}" >/dev/null 2>&1
 	fi
 	wait "${watchdog_pid}" >/dev/null 2>&1
 	if [ -f "${timed_out_file}" ]; then
-		rm -f "${timed_out_file}"
+		rm -f "${timed_out_file}" >/dev/null 2>&1
 		printf 'Warning: Command timeout reached: %ss: %s\n' "${timeout_sec}" "${*}" >&4
 		ret=124
 	fi

--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -235,9 +235,9 @@ else
 	syslogrealbin=${binprefix}/sbin/syslog-ng
 fi
 
-run_timeout () {
+run_with_timeout () {
   # Cross-platform timeout function
-  # run_timeout [timeout_sec] command
+  # run_with_timeout [timeout_sec] command
   local timeout_sec
   case "$1" in
     '')        echo "Error: No command passed" >> ${tmpdir}/syslog-ng.debun.txt ; return 1 ;;
@@ -778,10 +778,10 @@ acquire_syslog_stats () {
 	#handy-dandy delay magic, triggered when we'd step on our own foot
 	[ -f ${tmpdir}/syslog.stats.${tsdata} ] && sleep 5 && tsdata=$( timestamp )
 
-	run_timeout ${syslogngctlbin} stats > ${tmpdir}/syslog.stats.${tsdata} 2>&1
+	run_with_timeout ${syslogngctlbin} stats > ${tmpdir}/syslog.stats.${tsdata} 2>&1
 	echo ${syslogngctlbin} stats
 	tsdata=$( timestamp )
-	run_timeout ${syslogngctlbin} query get "*" > ${tmpdir}/syslog.query.all.${tsdata} 2>/dev/null
+	run_with_timeout ${syslogngctlbin} query get "*" > ${tmpdir}/syslog.query.all.${tsdata} 2>/dev/null
 	echo ${syslogngctlbin} query get "*"
 	if [ -x ${syslogngquerybin} ]; then
 		#if we reach this brach, then syslog.query.all - as generated above - will not contain any meaningful data
@@ -804,11 +804,11 @@ acquire_syslog_info () {
 		acquire_syslog_stats
 	fi
 
-	if run_timeout ${syslogngctlbin} show-license-info > ${tmpdir}/syslog.license-usage 2>&1; then
-		run_timeout ${syslogngctlbin} show-license-info --json > ${tmpdir}/syslog.license-usage.json 2>/dev/null
+	if run_with_timeout ${syslogngctlbin} show-license-info > ${tmpdir}/syslog.license-usage 2>&1; then
+		run_with_timeout ${syslogngctlbin} show-license-info --json > ${tmpdir}/syslog.license-usage.json 2>/dev/null
 	fi
 	echo ${syslogngctlbin} show-license-info
-	run_timeout ${syslogngctlbin} credentials status > ${tmpdir}/syslog.credentials.status 2>&1
+	run_with_timeout ${syslogngctlbin} credentials status > ${tmpdir}/syslog.credentials.status 2>&1
 	echo ${syslogngctlbin} credentials status
 
 	for i in ${sngallpids} ; do
@@ -955,8 +955,8 @@ acquire_syslog_nprv () {
 }
 
 acquire_running_syslog_config() {
-	if run_timeout ${syslogngctlbin} config >/dev/null 2>&1; then
-		run_timeout ${syslogngctlbin} config -p > "${tmpdir}/syslog-ng.ctl.running.conf" 2>&1
+	if run_with_timeout ${syslogngctlbin} config >/dev/null 2>&1; then
+		run_with_timeout ${syslogngctlbin} config -p > "${tmpdir}/syslog-ng.ctl.running.conf" 2>&1
 		[ -z "$saveprivatekeys" ] && remove_passwords_from_file "${tmpdir}/syslog-ng.ctl.running.conf"
 	fi
 }

--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -778,10 +778,10 @@ acquire_syslog_stats () {
 	#handy-dandy delay magic, triggered when we'd step on our own foot
 	[ -f ${tmpdir}/syslog.stats.${tsdata} ] && sleep 5 && tsdata=$( timestamp )
 
-	${syslogngctlbin} stats > ${tmpdir}/syslog.stats.${tsdata} 2>&1
+	run_timeout ${syslogngctlbin} stats > ${tmpdir}/syslog.stats.${tsdata} 2>&1
 	echo ${syslogngctlbin} stats
 	tsdata=$( timestamp )
-	${syslogngctlbin} query get "*" > ${tmpdir}/syslog.query.all.${tsdata} 2>/dev/null
+	run_timeout ${syslogngctlbin} query get "*" > ${tmpdir}/syslog.query.all.${tsdata} 2>/dev/null
 	echo ${syslogngctlbin} query get "*"
 	if [ -x ${syslogngquerybin} ]; then
 		#if we reach this brach, then syslog.query.all - as generated above - will not contain any meaningful data
@@ -804,11 +804,11 @@ acquire_syslog_info () {
 		acquire_syslog_stats
 	fi
 
-	if ${syslogngctlbin} show-license-info > ${tmpdir}/syslog.license-usage 2>&1; then
-		${syslogngctlbin} show-license-info --json > ${tmpdir}/syslog.license-usage.json 2>/dev/null
+	if run_timeout ${syslogngctlbin} show-license-info > ${tmpdir}/syslog.license-usage 2>&1; then
+		run_timeout ${syslogngctlbin} show-license-info --json > ${tmpdir}/syslog.license-usage.json 2>/dev/null
 	fi
 	echo ${syslogngctlbin} show-license-info
-	${syslogngctlbin} credentials status > ${tmpdir}/syslog.credentials.status 2>&1
+	run_timeout ${syslogngctlbin} credentials status > ${tmpdir}/syslog.credentials.status 2>&1
 	echo ${syslogngctlbin} credentials status
 
 	for i in ${sngallpids} ; do
@@ -955,8 +955,8 @@ acquire_syslog_nprv () {
 }
 
 acquire_running_syslog_config() {
-	if ${syslogngctlbin} config >/dev/null 2>&1; then
-		${syslogngctlbin} config -p > "${tmpdir}/syslog-ng.ctl.running.conf" 2>&1
+	if run_timeout ${syslogngctlbin} config >/dev/null 2>&1; then
+		run_timeout ${syslogngctlbin} config -p > "${tmpdir}/syslog-ng.ctl.running.conf" 2>&1
 		[ -z "$saveprivatekeys" ] && remove_passwords_from_file "${tmpdir}/syslog-ng.ctl.running.conf"
 	fi
 }

--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -240,7 +240,7 @@ run_with_timeout () {
 	# run_with_timeout [timeout_sec] command
 	local timeout_sec
 	case "$1" in
-		'')        echo "Error: No command passed" >> ${tmpdir}/syslog-ng.debun.txt ; return 1 ;;
+		'')        echo "Error: No command passed" >&4 ; return 1 ;;
 		*[!0-9.]*) timeout_sec=180 ;;
 		*)         timeout_sec="$1"; shift ;;
 	esac
@@ -256,7 +256,7 @@ run_with_timeout () {
 	wait "$watchdog_pid" 2>/dev/null
 	if [ -f "$timed_out_file" ]; then
 		rm -f "$timed_out_file"
-		echo "Warning: Command timeout reached: ${timeout_sec}s: $*" >> ${tmpdir}/syslog-ng.debun.txt
+		printf 'Warning: Command timeout reached: %ss: %s\n' "${timeout_sec}" "${*}" >&4
 		ret=124
 	fi
 	return $ret
@@ -274,7 +274,7 @@ debun_init () {
 	# Start redirections
 
 	#exec 3>&1 >${tmpdir}/syslog-ng.debun.txt 2>${tmpdir}/syslog-ng.debun.txt
-	exec 3>&1 >${tmpdir}/syslog-ng.debun.txt 2>&1
+	exec 3>&1 >${tmpdir}/syslog-ng.debun.txt 4>&1 2>&1
 	echo "Syslog-NG DEBUg buNdle generator"
 	sync
 	while [ ! -f ${tmpdir}/syslog-ng.debun.txt ] ; do sleep 1 ; done

--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -235,6 +235,26 @@ else
 	syslogrealbin=${binprefix}/sbin/syslog-ng
 fi
 
+run_timeout () {
+  # Cross-platform timeout function
+  local timeout_sec="$1"
+  shift
+  local timed_out_file="${tmpdir:-/tmp}/syslog-ng-debun_run-timeout.$$.flag"
+  "$@" &
+  local cmd_pid=$!
+  ( sleep "$timeout_sec" && touch "$timed_out_file" && kill "$cmd_pid" 2>/dev/null ) &
+  local watchdog_pid=$!
+  wait "$cmd_pid" 2>/dev/null
+  local ret=$?
+  kill "$watchdog_pid" 2>/dev/null
+  wait "$watchdog_pid" 2>/dev/null
+  if [ -f "$timed_out_file" ]; then
+    rm -f "$timed_out_file"
+    ret=124
+  fi
+  return $ret
+}
+
 debun_init () {
 	#Create temp dir, to place files into
 	host=$( uname -n )

--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -242,7 +242,7 @@ run_with_timeout () {
 	local timeout_sec=180
 
 	case "$1" in
-		'-t') 
+		'-t')
 			case "$2" in
 				''|*[!0-9]*)
 					echo "Error: run_with_timeout: -t requires an integer argument" >&4
@@ -251,36 +251,37 @@ run_with_timeout () {
 			esac
 			shift ; shift ;;
 	esac
-	if [ -z "$1" ] ;then
+	if [ -z "$1" ] ; then
 		echo "Error: run_with_timeout: No command passed" >&4
 		return 1
 	fi
 
 	"$@" &
 	local cmd_pid=$!
-	local cmd_fingerprint="$(pspoo ${cmd_pid} 2>/dev/null)"
+	local cmd_fingerprint="$(pspoo "${cmd_pid}" 2>/dev/null)"
 	local timed_out_file="${tmpdir:-/tmp}/syslog-ng-debun_run-timeout.${cmd_pid}.flag"
 
-	( 	local i=0
+	(
+		local i=0
 		while [ "${i}" -lt "${timeout_sec}" ] ; do
 			sleep 1
 			i=$((i + 1))
 		done
 		touch "${timed_out_file}" 2>/dev/null
-		if [ "${cmd_fingerprint:-unset}" = "$(pspoo ${cmd_pid} 2>/dev/null)" ]; then
+		if [ "${cmd_fingerprint:-unset}" = "$(pspoo "${cmd_pid}" 2>/dev/null)" ]; then
 			kill "${cmd_pid}" 2>/dev/null
 			sleep 2
-			if [ "${cmd_fingerprint:-unset}" = "$(pspoo ${cmd_pid} 2>/dev/null)" ]; then
+			if [ "${cmd_fingerprint:-unset}" = "$(pspoo "${cmd_pid}" 2>/dev/null)" ]; then
 				kill -9 "${cmd_pid}" 2>/dev/null
 			fi
 		fi
 	) &
 	local watchdog_pid=$!
-	local watchdog_fingerprint="$(pspoo ${watchdog_pid} 2>/dev/null)"
+	local watchdog_fingerprint="$(pspoo "${watchdog_pid}" 2>/dev/null)"
 
 	wait "${cmd_pid}" 2>/dev/null
 	local ret=$?
-	if [ "${watchdog_fingerprint:-unset}" = "$(pspoo ${watchdog_pid} 2>/dev/null)" ]; then
+	if [ "${watchdog_fingerprint:-unset}" = "$(pspoo "${watchdog_pid}" 2>/dev/null)" ]; then
 		kill "${watchdog_pid}" 2>/dev/null
 	fi
 	wait "${watchdog_pid}" >/dev/null 2>&1

--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -240,6 +240,7 @@ run_with_timeout () {
 	# Cross-platform timeout function
 	# run_with_timeout [-t timeout_sec] command
 	local timeout_sec=180
+	local kill_mode='TERM'
 
 	case "$1" in
 		'-t')
@@ -267,12 +268,14 @@ run_with_timeout () {
 			sleep 1
 			i=$((i + 1))
 		done
-		touch "${timed_out_file}" >/dev/null 2>&1
+		printf '%s\n' "${kill_mode}" > "${timed_out_file}" 2>/dev/null
 		if [ "${cmd_fingerprint:-unset}" = "$(pspoo "${cmd_pid}" 2>/dev/null)" ]; then
-			kill "${cmd_pid}" >/dev/null 2>&1
+			kill -s "${kill_mode}" "${cmd_pid}" >/dev/null 2>&1
 			sleep 2
 			if [ "${cmd_fingerprint:-unset}" = "$(pspoo "${cmd_pid}" 2>/dev/null)" ]; then
-				kill -9 "${cmd_pid}" >/dev/null 2>&1
+				kill_mode='KILL'
+				printf '%s\n' "${kill_mode}" > "${timed_out_file}" 2>/dev/null
+				kill -s "${kill_mode}" "${cmd_pid}" >/dev/null 2>&1
 			fi
 		fi
 	) &
@@ -282,12 +285,13 @@ run_with_timeout () {
 	wait "${cmd_pid}" >/dev/null 2>&1
 	local ret=$?
 	if [ "${watchdog_fingerprint:-unset}" = "$(pspoo "${watchdog_pid}" 2>/dev/null)" ]; then
-		kill "${watchdog_pid}" >/dev/null 2>&1
+		kill -s "${kill_mode}" "${watchdog_pid}" >/dev/null 2>&1
 	fi
 	wait "${watchdog_pid}" >/dev/null 2>&1
 	if [ -f "${timed_out_file}" ]; then
+		kill_mode=$(cat "${timed_out_file}" 2>/dev/null)
 		rm -f "${timed_out_file}" >/dev/null 2>&1
-		printf 'Warning: Command timeout reached: %ss: %s\n' "${timeout_sec}" "${*}" >&4
+		printf 'Warning: Command timeout reached: %ss (%s): %s\n' "${timeout_sec}" "${kill_mode:-unknown}" "${*}" >&4
 		ret=124
 	fi
 	return $ret

--- a/contrib/syslog-ng-debun
+++ b/contrib/syslog-ng-debun
@@ -818,7 +818,7 @@ acquire_syslog_stats () {
 		#if we reach this brach, then syslog.query.all - as generated above - will not contain any meaningful data
 		rm ${tmpdir}/syslog.query.all.${tsdata}
 		tsdata=$( timestamp )
-		${syslogngquerybin} sum "*" > ${tmpdir}/syslog.query.all.${tsdata} 2>/dev/null
+		run_with_timeout ${syslogngquerybin} sum "*" > ${tmpdir}/syslog.query.all.${tsdata} 2>/dev/null
 		echo ${syslogngquerybin} sum "*"
 	fi
 }

--- a/news/developer-note-5680.md
+++ b/news/developer-note-5680.md
@@ -1,0 +1,3 @@
+debun: fix possible hung issues related to syslog-ng-ctl
+
+


### PR DESCRIPTION
<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


 - Certain issues crated a situation where debug cannot be collected due syslog-ng-ctl cannot produce an output and hung.
 
- To solve this a wrapper function created to enforce timeout for commands.

- To try out the code move the syslog-ng-ctl and create a wrapper syslog-ng-ctl in its place:
`mv syslog-ng-ctl syslog-ng-ctl.original`
`vim syslog-ng-ctl` :
```
#!/bin/sh
atrap() { sleep 1000 ; }
#To test SIGTERM comment the trap, else SIGKILL 
trap 'atrap' TERM
sleep 250
./syslog-ng-ctl.original "${@}"
```

- Multiple platform provides timeout command to solve this, however I preferred to create a POSIX compatible cross platform solution.


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
