### PR TITLE
CI: fedora latest got the cmake version too that cannot build the old criterion anymore, use meson to build it

### DIFF
--- a/dbld/images/fedora-latest.dockerfile
+++ b/dbld/images/fedora-latest.dockerfile
@@ -20,7 +20,7 @@ RUN /dbld/builddeps add_copr_repo
 RUN /dbld/builddeps install_dnf_packages
 RUN /dbld/builddeps install_rpm_build_deps
 
-RUN /dbld/builddeps install_criterion_from_source
+RUN /dbld/builddeps install_criterion_from_source meson
 RUN /dbld/builddeps install_gradle
 
 VOLUME /source

--- a/dbld/packages.manifest
+++ b/dbld/packages.manifest
@@ -10,7 +10,7 @@ ca-certificates       	        [centos, almalinux, fedora, debian, opensuse, rhe
 
 # packages required for criterion compilation (with cmake or meson)
 cmake                           [centos, almalinux, fedora, debian, opensuse, rhel, rocky, ubuntu]
-meson                           [fedora-rawhide, debian-testing]
+meson                           [fedora, debian-testing]
 nanopb                          [debian-testing]
 protobuf-compiler               [debian-testing]
 gcc-c++                         [centos, almalinux, fedora, opensuse, rhel, rocky]


### PR DESCRIPTION
Proof: https://github.com/syslog-ng/syslog-ng/actions/runs/25102386526/job/73554750152