### PR TITLE
tls-verifier: use dedicated ASN1_STRING field accessors instead of direct member access

### DIFF
--- a/lib/transport/tls-verifier.c
+++ b/lib/transport/tls-verifier.c
@@ -220,10 +220,10 @@ tls_verify_certificate_name(X509 *cert, const gchar *host_name)
                 {
                   gchar dotted_ip[64] = {0};
                   int addr_family = AF_INET;
-                  if (gen_name->d.iPAddress->length == 16)
+                  if (ASN1_STRING_length(gen_name->d.iPAddress) == 16)
                     addr_family = AF_INET6;
 
-                  if (inet_ntop(addr_family, gen_name->d.iPAddress->data, dotted_ip, sizeof(dotted_ip)))
+                  if (inet_ntop(addr_family, ASN1_STRING_get0_data(gen_name->d.iPAddress), dotted_ip, sizeof(dotted_ip)))
                     {
                       g_strlcpy(pattern_buf, dotted_ip, sizeof(pattern_buf));
                       found = TRUE;


### PR DESCRIPTION
Fixes: https://github.com/syslog-ng/syslog-ng/issues/5674 by @pornmailbox
