### PR TITLE
dbld: Add ubuntu-resolute (26.04 LTS) to build system

### DIFF
--- a/.github/workflows/create-packages.yml
+++ b/.github/workflows/create-packages.yml
@@ -41,6 +41,7 @@ on:
             "ubuntu-jammy",
             "ubuntu-noble",
             "ubuntu-plucky",
+            "ubuntu-resolute",
             "rhel-8",
             "rhel-9",
             "rhel-10",

--- a/.github/workflows/dbld-images.yml
+++ b/.github/workflows/dbld-images.yml
@@ -65,6 +65,7 @@ jobs:
           - ubuntu-jammy
           - ubuntu-noble
           - ubuntu-plucky
+          - ubuntu-resolute
           - rhel-8
           - rhel-9
           - rhel-10
@@ -90,6 +91,9 @@ jobs:
             platform: ubuntu-22.04-arm
             arch: arm64
           - image: ubuntu-plucky
+            platform: ubuntu-22.04-arm
+            arch: arm64
+          - image: ubuntu-resolute
             platform: ubuntu-22.04-arm
             arch: arm64
           - image: rhel-8

--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -178,6 +178,7 @@ jobs:
             cc: gcc
 
     uses: ./.github/workflows/devshell-build.yml
+    name: Build @ ${{ matrix.image.name }} on ${{ matrix.platform }}
     with:
       build-tool: ${{ matrix.build-tool }}
       cc: ${{ matrix.cc }}

--- a/.github/workflows/devshell.yml
+++ b/.github/workflows/devshell.yml
@@ -54,6 +54,7 @@ jobs:
         # ubuntu-jammy        |   x   |           |  x  |   x   |   x    |       |   x   |   x  |     x     |
         # ubuntu-noble        |   x   |           |  x  |   x   |   x    |       |   x   |   x  |     x     |
         # ubuntu-plucky       |   x   |           |  x  |   x   |   x    |       |   x   |   x  |     x     |
+        # ubuntu-resolute     |   x   |           |  x  |   x   |   x    |       |   x   |   x  |     x     |
         # rhel-8              |   x   |           |  x  |   x   |   x    |       |   x   |   x  |     x     |
         # rhel-9              |   x   |           |  x  |   x   |   x    |       |   x   |   x  |     x     |
         # rhel-10             |   x   |           |  x  |   x   |   x    |       |   x   |   x  |     x     |
@@ -111,6 +112,7 @@ jobs:
             configure_flags: "--disable-ebpf"
             cmake_configure_flags: "-DENABLE_EBPF=OFF"
           - name: ubuntu-plucky
+          - name: ubuntu-resolute
           - name: rhel-8
             configure_flags: "--disable-ebpf --with-python=3.9"
             cmake_configure_flags: "-DENABLE_EBPF=OFF -DPYTHON_VERSION=3.9"

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -72,6 +72,7 @@ jobs:
         "ubuntu-jammy",
         "ubuntu-noble",
         "ubuntu-plucky",
+        "ubuntu-resolute",
         "rhel-8",
         "rhel-9",
         "rhel-10",

--- a/.github/workflows/test-deb-packages.yml
+++ b/.github/workflows/test-deb-packages.yml
@@ -30,6 +30,7 @@ jobs:
           - "ubuntu:jammy"
           - "ubuntu:noble"
           - "ubuntu:plucky"
+          - "ubuntu:resolute"
           # NOTE: These are RPM based distros, so they are tested in the test-rpm-packages.yml workflow
           # - "rhel-8"
           # - "rhel-9"

--- a/.github/workflows/upload-packages.yml
+++ b/.github/workflows/upload-packages.yml
@@ -24,6 +24,7 @@ on:
             "ubuntu-jammy",
             "ubuntu-noble",
             "ubuntu-plucky",
+            "ubuntu-resolute",
             "rhel-8",
             "rhel-9",
             "rhel-10",

--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ syslog-ng packages are released for the following distribution versions:
 
 | Distro version | sources.list component name | Arch | stable | nightly |
 |---|---|---|---|---|
+| Ubuntu 26.04    | ubuntu-resolute       | x86-64 | [stable](https://ose-repo.syslog-ng.com/apt/dists/stable/ubuntu-resolute/binary-amd64/)       | [nightly](https://ose-repo.syslog-ng.com/apt/dists/nightly/ubuntu-resolute/binary-amd64/) |
+| Ubuntu 26.04    | ubuntu-resolute-arm64 | arm64  | [stable](https://ose-repo.syslog-ng.com/apt/dists/stable/ubuntu-resolute-arm64/binary-arm64/) | [nightly](https://ose-repo.syslog-ng.com/apt/dists/nightly/ubuntu-resolute-arm64/binary-arm64/) |
 | Ubuntu 25.04    | ubuntu-plucky         | x86-64 | [stable](https://ose-repo.syslog-ng.com/apt/dists/stable/ubuntu-plucky/binary-amd64/)         | [nightly](https://ose-repo.syslog-ng.com/apt/dists/nightly/ubuntu-plucky/binary-amd64/) |
 | Ubuntu 25.04    | ubuntu-plucky-arm64   | arm64  | [stable](https://ose-repo.syslog-ng.com/apt/dists/stable/ubuntu-plucky-arm64/binary-arm64/)   | [nightly](https://ose-repo.syslog-ng.com/apt/dists/nightly/ubuntu-plucky-arm64/binary-arm64/) |
 | Ubuntu 24.04    | ubuntu-noble          | x86-64 | [stable](https://ose-repo.syslog-ng.com/apt/dists/stable/ubuntu-noble/binary-amd64/)          | [nightly](https://ose-repo.syslog-ng.com/apt/dists/nightly/ubuntu-noble/binary-amd64/) |

--- a/dbld/Makefile.am
+++ b/dbld/Makefile.am
@@ -47,6 +47,7 @@ EXTRA_DIST += \
 	dbld/images/ubuntu-jammy.dockerfile \
 	dbld/images/ubuntu-noble.dockerfile \
 	dbld/images/ubuntu-plucky.dockerfile \
+	dbld/images/ubuntu-resolute.dockerfile \
 	dbld/images/rhel-8.dockerfile \
 	dbld/images/rhel-9.dockerfile \
 	dbld/images/rhel-10.dockerfile \

--- a/dbld/build.manifest
+++ b/dbld/build.manifest
@@ -51,6 +51,7 @@ ubuntu-focal		python3,nocriterion,nomqtt,nogrpc,nobpf,notzdatalegacy
 ubuntu-jammy		python3,nobpf,notzdatalegacy
 ubuntu-noble		python3,nobpf,notzdatalegacy
 ubuntu-plucky		python3,notzdatalegacy
+ubuntu-resolute		python3,notzdatalegacy
 
 fedora				python3
 almalinux			python3

--- a/dbld/images/ubuntu-resolute.dockerfile
+++ b/dbld/images/ubuntu-resolute.dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:resolute
+ARG ARG_IMAGE_PLATFORM
+ARG COMMIT
+ARG JENKINS_URL
+
+LABEL maintainer="kira.syslogng@gmail.com"
+LABEL org.opencontainers.image.authors="kira.syslogng@gmail.com"
+LABEL COMMIT=${COMMIT}
+
+ENV OS_DISTRIBUTION=ubuntu
+ENV OS_DISTRIBUTION_CODE_NAME=resolute
+ENV IMAGE_PLATFORM ${ARG_IMAGE_PLATFORM}
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN=true
+ENV LANG C.UTF-8
+
+COPY images/entrypoint.sh /
+COPY . /dbld/
+
+RUN /dbld/builddeps update_packages
+RUN /dbld/builddeps install_dbld_dependencies
+RUN /dbld/builddeps install_apt_packages
+RUN /dbld/builddeps install_debian_build_deps
+
+VOLUME /source
+VOLUME /build
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/dbld/packages.manifest
+++ b/dbld/packages.manifest
@@ -54,8 +54,8 @@ which                           [fedora, opensuse, rhel, rocky]
 # eBPF related tools
 #############################################################################
 
-libbpf-dev                      [devshell, tarball, debian, ubuntu-plucky]
-bpftool                         [devshell, tarball, debian, ubuntu-plucky]
+libbpf-dev                      [devshell, tarball, debian, ubuntu-plucky, ubuntu-resolute]
+bpftool                         [devshell, tarball, debian, ubuntu-plucky, ubuntu-resolute]
 
 #############################################################################
 # Tarball related tools
@@ -121,7 +121,7 @@ libmongoc-dev                   [debian]
 
 # Our ivykis fork has uring support, let's use it in the devshell and the
 # packages we provide
-liburing-dev                    [debian, ubuntu-jammy, ubuntu-noble, ubuntu-plucky, devshell]
+liburing-dev                    [debian, ubuntu-jammy, ubuntu-noble, ubuntu-plucky, ubuntu-resolute, devshell]
 liburing-devel                  [opensuse, rhel, rocky]
 
 #############################################################################
@@ -184,7 +184,7 @@ snmptrapd                       [devshel, ubuntu, debian]
 dwarves                         [devshell]
 jq                              [devshell]
 curl                            [devshell]
-tzdata-legacy                   [ubuntu-noble, ubuntu-plucky, debian-trixie]
+tzdata-legacy                   [ubuntu-noble, ubuntu-plucky, ubuntu-resolute, debian-trixie]
 
 #############################################################################
 # Test requirements in devshell (and other platforms)

--- a/dbld/rules
+++ b/dbld/rules
@@ -23,6 +23,8 @@ BUILDER_IMAGES=	\
 	ubuntu-noble-arm64	\
 	ubuntu-plucky	\
 	ubuntu-plucky-arm64	\
+	ubuntu-resolute	\
+	ubuntu-resolute-arm64	\
 	rhel-8 \
 	rhel-8-arm64 \
 	rhel-9 \


### PR DESCRIPTION
Ubuntu Resolute is the next LTS after Noble. It inherits the same feature flags as Plucky.
