### PR TITLE
Feature/optional syslog awk

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -664,6 +664,12 @@ AC_ARG_ENABLE(all-modules,
     AS_HELP_STRING([--enable-all-modules], [Forcibly enable all modules. (default: auto)]),
     , enable_all_modules="auto")
 
+AC_ARG_ENABLE([scl-syslogconf-awk],
+  [AS_HELP_STRING([--disable-scl-syslogconf-awk],
+                  [Do not install scl/syslogconf/convert-syslogconf.awk])],
+  [],
+  [enable_scl_syslogconf_awk=yes])
+
 if test "x$enable_all_modules" != "xauto"; then
    state="$enable_all_modules"
 
@@ -2759,6 +2765,7 @@ AM_CONDITIONAL([HAVE_GETRANDOM], [test x$ac_cv_func_getrandom = xyes])
 AM_CONDITIONAL([HAVE_FMEMOPEN], [test x$ac_cv_func_fmemopen = xyes])
 AM_CONDITIONAL([HAVE_JAVAH], [test -n "$JAVAH_BIN"])
 AM_CONDITIONAL(ENABLE_IPV6, [test $enable_ipv6 = yes])
+AM_CONDITIONAL([ENABLE_SCL_SYSLOGCONF_AWK], [test "x$enable_scl_syslogconf_awk" = "xyes"])
 
 AM_CONDITIONAL(OS_TYPE_MACOS, [test $ostype = "Darwin"])
 AM_CONDITIONAL(OS_TYPE_FREEBSD, [test $ostype = "FreeBSD"])

--- a/news/feature-5702.md
+++ b/news/feature-5702.md
@@ -1,0 +1,7 @@
+`scl`: make syslogconf awk converter installation optional
+
+Add build options for both CMake and autotools to optionally omit
+installation of `scl/syslogconf/convert-syslogconf.awk`.
+
+The converter remains installed by default, preserving existing
+behavior for current users.

--- a/scl/CMakeLists.txt
+++ b/scl/CMakeLists.txt
@@ -54,8 +54,17 @@ set(SCL_DIRS
     azure
 )
 
+option(ENABLE_SCL_SYSLOGCONF_AWK "Install scl/syslogconf/convert-syslogconf.awk" ON)
+
 install(DIRECTORY ${SCL_DIRS} DESTINATION share/syslog-ng/include/scl
-        USE_SOURCE_PERMISSIONS)
+        USE_SOURCE_PERMISSIONS
+        PATTERN "convert-syslogconf.awk" EXCLUDE)
+
+if (ENABLE_SCL_SYSLOGCONF_AWK)
+    install(FILES syslogconf/convert-syslogconf.awk
+            DESTINATION share/syslog-ng/include/scl/syslogconf)
+endif()
+
 install(FILES scl.conf DESTINATION share/syslog-ng/include)
 
 if (NOT EXISTS ${CMAKE_INSTALL_PREFIX}/etc/syslog-ng.conf)

--- a/scl/Makefile.am
+++ b/scl/Makefile.am
@@ -71,6 +71,9 @@ scl-install-data-local:
 		$(install_sh_DATA) $(srcdir)/scl/scl.conf  $(DESTDIR)/$(config_includedir)/scl.conf; \
 	fi
 	(cd $(srcdir)/scl; tar cf - $(SCL_SUBDIRS)) | (cd $(DESTDIR)/$(scldir) && tar xf - --no-same-owner)
+if !ENABLE_SCL_SYSLOGCONF_AWK
+	rm -f $(DESTDIR)/$(scldir)/syslogconf/convert-syslogconf.awk
+endif
 	chmod -R u+rwX $(DESTDIR)/$(scldir)
 
 scl-uninstall-local:


### PR DESCRIPTION
The following PR intends to solve the following issue:

`convert-syslogconf.awk` requires an awk implementation at runtime,
commonly provided by gawk on Linux systems.

Some downstream users and distributions prefer to avoid depending on
awk/gawk for licensing, compliance, minimal-runtime, or packaging
reasons, especially when the converter is not needed in production
deployments.

This PR adds optional build-time controls to omit installation of the
legacy syslog.conf conversion helper while preserving the current
default behavior.
