### PR TITLE
java/hdfs: fix unreleased lock in send() when file open fails

### DIFF
--- a/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
+++ b/modules/java-modules/hdfs/src/main/java/org/syslog_ng/hdfs/HdfsDestination.java
@@ -240,14 +240,14 @@ public class HdfsDestination extends StructuredLogDestination {
         isOpened = false;
         String resolvedFileName = options.getFileNameTemplate().getResolvedString(logMessage);
         lock.lock();
-        HdfsFile hdfsfile = getHdfsFile(resolvedFileName);
-        if (hdfsfile == null) {
-            // Unable to open file
-            closeAll(true);
-            return ERROR;
-        }
-
         try {
+            HdfsFile hdfsfile = getHdfsFile(resolvedFileName);
+            if (hdfsfile == null) {
+                // Unable to open file
+                closeAll(true);
+                return ERROR;
+            }
+
             String formattedMessage = options.getTemplate().getResolvedString(logMessage);
 
             logger.debug("Outgoing message: " + formattedMessage);
@@ -262,9 +262,8 @@ public class HdfsDestination extends StructuredLogDestination {
             closeAll(false);
             return ERROR;
         } finally {
-          lock.unlock();
+            lock.unlock();
         }
-
 
         isOpened = true;
         return SUCCESS;

--- a/news/bugfix-5707.md
+++ b/news/bugfix-5707.md
@@ -1,0 +1,5 @@
+`java/hdfs`: fix unreleased lock in `send()` when file open fails
+
+If `getHdfsFile()` returned `null`, the lock acquired at the start of
+`send()` was never released, causing a permanent deadlock on all
+subsequent calls.


### PR DESCRIPTION
## Summary

Fixes CodeQL alert [java/unreleased-lock #1051](https://github.com/syslog-ng/syslog-ng/security/code-scanning/1051).

In `HdfsDestination.send()`, the lock was acquired unconditionally but the `finally { lock.unlock() }` block was only reached when `getHdfsFile()` returned a non-null value. If `getHdfsFile()` returned `null` (file open failure), the early `return ERROR` path bypassed the `finally` block, leaving the lock permanently acquired and deadlocking all subsequent `send()`, `flush()`, and `close()` calls.

## Fix

Moved `getHdfsFile()` and all subsequent logic inside the `try` block so the `finally { lock.unlock() }` covers all exit paths.
