### PR TITLE
Escaping option for usertty()

### DIFF
--- a/modules/afuser/CMakeLists.txt
+++ b/modules/afuser/CMakeLists.txt
@@ -18,3 +18,4 @@ add_module(
   SOURCES ${AFUSER_SOURCES}
 )
 
+add_test_subdirectory(tests)

--- a/modules/afuser/Makefile.am
+++ b/modules/afuser/Makefile.am
@@ -26,6 +26,8 @@ EXTRA_DIST				+=	\
 	modules/afuser/afuser-grammar.ym	\
 	modules/afuser/CMakeLists.txt
 
+include modules/afuser/tests/Makefile.am
+
 modules/afuser modules/afuser/ mod-afuser mod-usertty: \
 	modules/afuser/libafuser.la
 .PHONY: modules/afuser/ mod-afuser mod-usertty

--- a/modules/afuser/afuser-grammar.ym
+++ b/modules/afuser/afuser-grammar.ym
@@ -54,6 +54,7 @@ extern LogDriver *last_driver;
 
 %type   <ptr> dest_afuser
 
+%token KW_ESCAPING
 %token KW_USERTTY
 
 %%
@@ -75,6 +76,7 @@ afuser_opts
 
 afuser_opt
 	: KW_TIME_REOPEN '(' positive_integer ')' { afuser_dd_set_time_reopen(last_driver, $3); }
+	| KW_ESCAPING '(' yesno ')' { afuser_dd_set_escaping(last_driver, $3); }
 	;
 
 /* INCLUDE_RULES */

--- a/modules/afuser/afuser-parser.c
+++ b/modules/afuser/afuser-parser.c
@@ -31,6 +31,7 @@ int afuser_parse(CfgLexer *lexer, LogDriver **instance, gpointer arg);
 
 static CfgLexerKeyword afuser_keywords[] =
 {
+  { "escaping",              KW_ESCAPING },
   { "usertty",               KW_USERTTY },
 
   { NULL }

--- a/modules/afuser/afuser.c
+++ b/modules/afuser/afuser.c
@@ -24,6 +24,7 @@
 #include "afuser.h"
 #include "messages.h"
 #include "compat/getutent.h"
+#include "template/escaping.h"
 #include "timeutils/format.h"
 
 #include <string.h>
@@ -35,6 +36,7 @@ typedef struct _AFUserDestDriver
 {
   LogDestDriver super;
   GString *username;
+  gboolean escaping;
   time_t disable_until;
   time_t time_reopen;
 } AFUserDestDriver;
@@ -98,6 +100,14 @@ _utmp_entry_matches(UtmpEntry *ut, GString *username)
 G_LOCK_DEFINE_STATIC(utmp_lock);
 
 void
+afuser_dd_set_escaping(LogDriver *s, gboolean enable)
+{
+  AFUserDestDriver *self = (AFUserDestDriver *) s;
+
+  self->escaping = enable;
+}
+
+void
 afuser_dd_set_time_reopen(LogDriver *s, time_t time_reopen)
 {
   AFUserDestDriver *self = (AFUserDestDriver *) s;
@@ -117,11 +127,39 @@ _evt_tag_utmp_username(UtmpEntry *ut)
 }
 
 static void
+_format_message(AFUserDestDriver *self, LogMessage *msg, GString *formatted_message)
+{
+  GString *timestamp = g_string_sized_new(0);
+  gssize message_len;
+  const gchar *message = log_msg_get_value(msg, LM_V_MESSAGE, &message_len);
+
+  format_unix_time(&msg->timestamps[LM_TS_STAMP], timestamp, TS_FMT_FULL, -1, 0);
+  g_string_append_printf(formatted_message, "%s %s ",
+                         timestamp->str,
+                         log_msg_get_value(msg, LM_V_HOST, NULL));
+  if (self->escaping)
+    log_template_default_escape_method(formatted_message, message, message_len);
+  else
+    g_string_append_len(formatted_message, message, message_len);
+  g_string_append_c(formatted_message, '\n');
+
+  g_string_free(timestamp, TRUE);
+}
+
+void
+afuser_dd_format_message(LogDriver *s, LogMessage *msg, GString *formatted_message)
+{
+  AFUserDestDriver *self = (AFUserDestDriver *) s;
+
+  g_string_truncate(formatted_message, 0);
+  _format_message(self, msg, formatted_message);
+}
+
+static void
 afuser_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
 {
   AFUserDestDriver *self = (AFUserDestDriver *) s;
-  gchar buf[8192];
-  GString *timestamp;
+  GString *formatted_message;
   UtmpEntry *ut;
   time_t now;
 
@@ -129,13 +167,8 @@ afuser_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
   if (self->disable_until && self->disable_until > now)
     goto finish;
 
-  timestamp = g_string_sized_new(0);
-  format_unix_time(&msg->timestamps[LM_TS_STAMP], timestamp, TS_FMT_FULL, -1, 0);
-  g_snprintf(buf, sizeof(buf), "%s %s %s\n",
-             timestamp->str,
-             log_msg_get_value(msg, LM_V_HOST, NULL),
-             log_msg_get_value(msg, LM_V_MESSAGE, NULL));
-  g_string_free(timestamp, TRUE);
+  formatted_message = g_string_sized_new(0);
+  _format_message(self, msg, formatted_message);
 
   G_LOCK(utmp_lock);
   while ((ut = _fetch_utmp_entry()))
@@ -170,7 +203,7 @@ afuser_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
               self->disable_until = now + self->time_reopen;
               continue;
             }
-          if (write(fd, buf, strlen(buf)) < 0 && errno == EAGAIN)
+          if (write(fd, formatted_message->str, formatted_message->len) < 0 && errno == EAGAIN)
             {
               msg_notice("Writing to the user terminal has blocked for writing, disabling for time-reopen seconds",
                          evt_tag_str("user", self->username->str),
@@ -182,6 +215,7 @@ afuser_dd_queue(LogPipe *s, LogMessage *msg, const LogPathOptions *path_options)
     }
   _close_utmp();
   G_UNLOCK(utmp_lock);
+  g_string_free(formatted_message, TRUE);
 finish:
   log_dest_driver_queue_method(s, msg, path_options);
 }

--- a/modules/afuser/afuser.h
+++ b/modules/afuser/afuser.h
@@ -27,6 +27,8 @@
 #include "driver.h"
 
 LogDriver *afuser_dd_new(gchar *user, GlobalConfig *cfg);
+void afuser_dd_format_message(LogDriver *s, LogMessage *msg, GString *formatted_message);
+void afuser_dd_set_escaping(LogDriver *s, gboolean enable);
 void afuser_dd_set_time_reopen(LogDriver *s, time_t time_reopen);
 
 #endif

--- a/modules/afuser/tests/CMakeLists.txt
+++ b/modules/afuser/tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_unit_test(LIBTEST CRITERION TARGET test_afuser DEPENDS afuser)

--- a/modules/afuser/tests/Makefile.am
+++ b/modules/afuser/tests/Makefile.am
@@ -1,0 +1,12 @@
+check_PROGRAMS += \
+	${modules_afuser_tests_TESTS}
+
+modules_afuser_tests_TESTS = \
+	modules/afuser/tests/test_afuser
+
+modules_afuser_tests_test_afuser_CFLAGS = $(TEST_CFLAGS) -I$(top_srcdir)/modules/afuser
+modules_afuser_tests_test_afuser_LDADD = $(TEST_LDADD)
+modules_afuser_tests_test_afuser_LDFLAGS = \
+	-dlpreopen $(top_builddir)/modules/afuser/libafuser.la
+
+EXTRA_DIST += modules/afuser/tests/CMakeLists.txt

--- a/modules/afuser/tests/test_afuser.c
+++ b/modules/afuser/tests/test_afuser.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 One Identity
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ */
+
+#include <criterion/criterion.h>
+#include <string.h>
+
+#include "afuser.h"
+#include "apphook.h"
+#include "cfg.h"
+#include "libtest/config_parse_lib.h"
+#include "libtest/cr_template.h"
+#include "logmsg/logmsg.h"
+#include "logpipe.h"
+
+static GlobalConfig *cfg;
+
+static LogMessage *
+_create_test_message(const gchar *message)
+{
+  LogMessage *msg = create_empty_message();
+
+  msg->timestamps[LM_TS_STAMP].ut_sec = 0;
+  log_msg_set_value(msg, LM_V_HOST, "testhost", -1);
+  log_msg_set_value(msg, LM_V_MESSAGE, message, -1);
+  return msg;
+}
+
+static void
+_setup(void)
+{
+  app_startup();
+  configuration = cfg = cfg_new_snippet();
+}
+
+static void
+_teardown(void)
+{
+  cfg_free(cfg);
+  configuration = NULL;
+  app_shutdown();
+}
+
+TestSuite(afuser, .init = _setup, .fini = _teardown);
+
+Test(afuser, formats_raw_message_by_default)
+{
+  LogDriver *driver = afuser_dd_new("root", cfg);
+  LogMessage *msg = _create_test_message("\033[31mfoo\033[0m");
+  GString *formatted_message = g_string_sized_new(0);
+
+  afuser_dd_format_message(driver, msg, formatted_message);
+
+  cr_assert(strstr(formatted_message->str, "\033[31mfoo\033[0m\n") != NULL,
+            "formatted_message='%s'", formatted_message->str);
+
+  g_string_free(formatted_message, TRUE);
+  log_msg_unref(msg);
+  log_pipe_unref((LogPipe *) driver);
+}
+
+Test(afuser, formats_escaped_message_when_enabled)
+{
+  LogDriver *driver = afuser_dd_new("root", cfg);
+  LogMessage *msg = _create_test_message("\033[31mfoo\033[0m");
+  GString *formatted_message = g_string_sized_new(0);
+
+  afuser_dd_set_escaping(driver, TRUE);
+  afuser_dd_format_message(driver, msg, formatted_message);
+
+  cr_assert(strstr(formatted_message->str, "\\033[31mfoo\\033[0m\n") != NULL,
+            "formatted_message='%s'", formatted_message->str);
+
+  g_string_free(formatted_message, TRUE);
+  log_msg_unref(msg);
+  log_pipe_unref((LogPipe *) driver);
+}
+
+Test(afuser, parses_escaping_option)
+{
+  cfg_load_module(cfg, "afuser");
+
+  cr_assert(parse_config("destination d_test { usertty(\"root\" escaping(yes)); };",
+                         LL_CONTEXT_ROOT, NULL, NULL),
+            "Parsing the given configuration failed");
+}

--- a/news/feature-5713.md
+++ b/news/feature-5713.md
@@ -1,0 +1,4 @@
+`afuser`: add escaping() option to usertty() output
+
+The usertty() destination now supports an escaping() option, using the same
+template escaping behavior as templates.


### PR DESCRIPTION
The usertty() destination now supports an escaping() option, using the same template escaping behavior as templates.

Doc PR: https://github.com/syslog-ng/syslog-ng.github.io/pull/320
