### PR TITLE
otel: pin criterion-based C++ tests to C++17

### DIFF
--- a/modules/grpc/otel/tests/CMakeLists.txt
+++ b/modules/grpc/otel/tests/CMakeLists.txt
@@ -20,4 +20,18 @@ if (NOT APPLE)
     INCLUDES ${OTEL_PROTO_BUILDDIR}
     DEPENDS otel-cpp)
 
+  # Criterion's <criterion/alloc.h> still references std::allocator<void>::const_pointer,
+  # which was deprecated in C++17 and removed in C++20 (both libstdc++ and libc++ drop
+  # the std::allocator<void> specialization). Pin these criterion-based C++ tests to
+  # C++17 so the header keeps compiling regardless of the C++ standard otel-cpp itself
+  # is built with.
+  set_target_properties(
+    test_otel_protobuf_parser
+    test_otel_protobuf_formatter
+    test_syslog_ng_otlp
+    PROPERTIES
+      CXX_STANDARD 17
+      CXX_STANDARD_REQUIRED ON
+      CXX_EXTENSIONS OFF)
+
 endif ()


### PR DESCRIPTION
Criterion's <criterion/alloc.h> uses std::allocator<void>::const_pointer, removed in C++20, so the otel tests fail to compile when the gRPC modules select the C++20 standard.

