### PR TITLE
docker: Pin syslog-ng subpackages to base package version

### DIFF
--- a/docker/syslog-ng.deb.dockerfile
+++ b/docker/syslog-ng.deb.dockerfile
@@ -76,18 +76,36 @@ RUN ARCH=$(arch) && \
     *.xz)  CAT=xzcat ;; \
     *)     CAT=cat ;; \
   esac && \
-  SYSLOG_PKGS="$($CAT "$OSE_PKGS_FILE" \
-      | awk '/^Package: / { print $2 }' \
+  # Materialise (name, version) pairs from the OSE Packages index once so
+  # we can resolve a single target version and filter the subpackage set
+  # against it. Pinning the whole set to a single version is required
+  # because nightly builds occasionally don't republish every subpackage
+  # in lock-step (e.g. when a module is added / removed / temporarily
+  # skipped). The strict `Depends: syslog-ng (= <ver>)` of any stale
+  # leftover would otherwise drag in a mismatched base package and make
+  # apt's resolution unsatisfiable.
+  ALL_PKGS="$($CAT "$OSE_PKGS_FILE" | awk 'BEGIN { RS=""; FS="\n" } { name=""; version=""; for (i=1;i<=NF;i++) { if ($i ~ /^Package: /) name=substr($i,10); if ($i ~ /^Version: /) version=substr($i,10) } if (name!="" && version!="") print name " " version }')" && \
+  if [ -n "$PACKAGE_VERSION" ]; then \
+    RESOLVED_VERSION="$PACKAGE_VERSION"; \
+    echo "Installing locked syslog-ng version: $RESOLVED_VERSION"; \
+  else \
+    RESOLVED_VERSION="$(echo "$ALL_PKGS" | awk '$1 == "syslog-ng" { print $2 }' | sort -V -r | head -n1)"; \
+    [ -n "$RESOLVED_VERSION" ] || { echo "ERROR: could not resolve newest syslog-ng version from OSE Packages index" >&2; exit 1; }; \
+    echo "Installing newest syslog-ng version: $RESOLVED_VERSION"; \
+  fi && \
+  # Enumerate the base package + every syslog-ng-mod-* package that
+  # exists at the resolved version. Java-related modules (java,
+  # java-common-lib, hdfs) are excluded to keep the image lean — pulling
+  # OpenJDK would roughly double the image size. Modules without a build
+  # at the resolved version (e.g. ones intentionally dropped this round)
+  # are simply not enumerated, which is the correct behaviour.
+  SYSLOG_PKGS="$(echo "$ALL_PKGS" \
+      | awk -v ver="$RESOLVED_VERSION" '$2 == ver { print $1 }' \
       | grep -E '^(syslog-ng|syslog-ng-mod-.*)$' \
       | grep -Ev '^syslog-ng-mod-(java|java-common-lib|hdfs)$' \
       | sort -u)" && \
-  if [ -z "$SYSLOG_PKGS" ]; then echo "ERROR: no syslog-ng packages found in OSE Packages index" >&2; exit 1; fi && \
-  if [ -n "$PACKAGE_VERSION" ]; then \
-    echo "Installing locked syslog-ng version: $PACKAGE_VERSION"; \
-    SYSLOG_PKGS="$(echo "$SYSLOG_PKGS" | sed "s/\$/=${PACKAGE_VERSION}/")"; \
-  else \
-    echo "Installing latest syslog-ng version (all modules)"; \
-  fi && \
+  if [ -z "$SYSLOG_PKGS" ]; then echo "ERROR: no syslog-ng packages found at version $RESOLVED_VERSION in OSE Packages index" >&2; exit 1; fi && \
+  SYSLOG_PKGS="$(echo "$SYSLOG_PKGS" | sed "s/\$/=${RESOLVED_VERSION}/")" && \
   apt-get install -y \
     libdbd-mysql libdbd-pgsql libdbd-sqlite3 libjemalloc2 \
     $SYSLOG_PKGS \

--- a/docker/syslog-ng.rpm.dockerfile
+++ b/docker/syslog-ng.rpm.dockerfile
@@ -86,22 +86,38 @@ RUN set -eu -o pipefail && \
     OSE_REPO_ID="$(grep -oE '^\[[^]]+\]' /etc/yum.repos.d/syslog-ng-ose.repo | head -n1 | tr -d '[]')" && \
     [ -n "$OSE_REPO_ID" ] || { echo "ERROR: could not determine OSE repo id" >&2; exit 1; } && \
     echo "Using OSE repo id: $OSE_REPO_ID" && \
-    # Enumerate the base package + every published syslog-ng-* subpackage so
-    # the image ships with all available modules. -devel / -debug* are
-    # excluded (build-time / debugging artefacts, not runtime). The java
-    # subpackage is also excluded to keep the image lean — pulling OpenJDK
-    # would roughly double the image size.
-    SYSLOG_PKGS="$(dnf -q repoquery --repo="$OSE_REPO_ID" --queryformat='%{name}\n' 'syslog-ng' 'syslog-ng-*' \
+    # Resolve the exact EVR to install. If the caller pinned PACKAGE_VERSION,
+    # honour it; otherwise lock onto the newest EVR of the base `syslog-ng`
+    # package currently in the repo. Pinning the entire subpackage set to a
+    # single EVR is required because nightly builds occasionally don't
+    # republish every subpackage in lock-step (e.g. when a subpackage is
+    # added / removed / temporarily skipped). The strict
+    # `Requires: syslog-ng(x86-64) = <EVR>` of any stale leftover would then
+    # drag in a mismatched base package and make the transaction
+    # unresolvable. Always pinning side-steps that entirely.
+    if [ -n "${PACKAGE_VERSION:-}" ]; then \
+        RESOLVED_VERSION="${PACKAGE_VERSION}"; \
+        echo "Installing locked syslog-ng version: ${RESOLVED_VERSION}"; \
+    else \
+        RESOLVED_VERSION="$(dnf -q repoquery --repo="$OSE_REPO_ID" --latest-limit=1 \
+            --queryformat='%{evr}\n' 'syslog-ng' | head -n1)"; \
+        [ -n "$RESOLVED_VERSION" ] || { echo "ERROR: could not resolve newest syslog-ng EVR from OSE repo" >&2; exit 1; }; \
+        echo "Installing newest syslog-ng version: ${RESOLVED_VERSION}"; \
+    fi && \
+    # Enumerate the base package + every syslog-ng-* subpackage that exists
+    # at the resolved EVR. -devel / -debug* are excluded (build-time /
+    # debugging artefacts, not runtime). The java subpackage is also
+    # excluded to keep the image lean — pulling OpenJDK would roughly
+    # double the image size. Subpackages that don't have a build at the
+    # resolved EVR (e.g. ones intentionally dropped this round) are simply
+    # not enumerated, which is the correct behaviour.
+    SYSLOG_PKGS="$(dnf -q repoquery --repo="$OSE_REPO_ID" --queryformat='%{name} %{evr}\n' 'syslog-ng' 'syslog-ng-*' \
+        | awk -v ver="$RESOLVED_VERSION" '$2 == ver { print $1 }' \
         | grep -Ev -- '-(devel|debuginfo|debugsource)$' \
         | grep -Ev '^syslog-ng-java$' \
         | sort -u)" && \
-    if [ -z "$SYSLOG_PKGS" ]; then echo "ERROR: no syslog-ng packages found in OSE repo" >&2; exit 1; fi && \
-    if [ -n "${PACKAGE_VERSION:-}" ]; then \
-        echo "Installing locked syslog-ng version: ${PACKAGE_VERSION}"; \
-        SYSLOG_PKGS="$(echo "$SYSLOG_PKGS" | sed "s/\$/-${PACKAGE_VERSION}/")"; \
-    else \
-        echo "Installing latest syslog-ng version (all modules)"; \
-    fi && \
+    if [ -z "$SYSLOG_PKGS" ]; then echo "ERROR: no syslog-ng packages found at EVR ${RESOLVED_VERSION} in OSE repo" >&2; exit 1; fi && \
+    SYSLOG_PKGS="$(echo "$SYSLOG_PKGS" | sed "s/\$/-${RESOLVED_VERSION}/")" && \
     dnf -y install --setopt=install_weak_deps=False \
         $SYSLOG_PKGS jemalloc && \
     # dnf-plugins-core was only needed to flip CRB on; drop it again so it


### PR DESCRIPTION
Nightly OSE repos can contain subpackages from different build rounds (e.g. yesterday's `-slog` lingering after today's drop). Their strict `Requires/Depends: syslog-ng = <ver>` then conflicts with the current base package and makes the dnf/apt transaction unresolvable.

Test run: https://github.com/syslog-ng/syslog-ng/actions/runs/27288952422/job/80603936484