### PR TITLE
logreader: Honour the prepare()-set idle_timeout in the LPPA_SUSPEND branch

### DIFF
--- a/lib/logreader.c
+++ b/lib/logreader.c
@@ -138,11 +138,17 @@ log_reader_stop_watches(LogReader *self)
 }
 
 static void
-log_reader_disable_watches(LogReader *self)
+log_reader_disable_watches_keep_idle_timer(LogReader *self)
 {
   g_assert(self->watches_running);
   if (self->poll_events)
     poll_events_suspend_watches(self->poll_events);
+}
+
+static void
+log_reader_disable_watches(LogReader *self)
+{
+  log_reader_disable_watches_keep_idle_timer(self);
   log_reader_stop_idle_timer(self);
 }
 
@@ -154,6 +160,16 @@ static void
 log_reader_suspend_until_awoken(LogReader *self)
 {
   log_reader_disable_watches(self);
+  self->suspended = TRUE;
+}
+
+/* Same as log_reader_suspend_until_awoken() but leaves the idle_timer
+ * registered, so a watchdog timeout passed in via log_proto_server_poll_prepare()
+ * can still wake the reader if no wakeup callback fires within that window. */
+static void
+log_reader_suspend_until_awoken_or_timeout(LogReader *self)
+{
+  log_reader_disable_watches_keep_idle_timer(self);
   self->suspended = TRUE;
 }
 
@@ -327,7 +343,7 @@ log_reader_update_watches(LogReader *self)
       log_reader_force_check_in_next_poll(self);
       break;
     case LPPA_SUSPEND:
-      log_reader_suspend_until_awoken(self);
+      log_reader_suspend_until_awoken_or_timeout(self);
       break;
     default:
       g_assert_not_reached();


### PR DESCRIPTION
Inside log_reader_update_watches() the inner make's `prepare()` may set a non-zero idle_timeout to bound a suspended state (e.g. the ALTP server uses it as an ack-timeout watchdog while in LPRSS_WAIT_FOR_ACK). The idle_timer is then registered, but the LPPA_SUSPEND branch routed through log_reader_suspend_until_awoken() -> log_reader_disable_watches() which unconditionally called log_reader_stop_idle_timer(), killing the timer microseconds after registering it. The watchdog could therefore never fire on the SUSPEND prepare-action, only on LPPA_POLL_IO.
