### PR TITLE
autogen.sh: detect .git as a gitfile, not only a directory

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -59,7 +59,7 @@ autogen_submodules()
 		fi
 	done
 
-	if [ -n "$GIT" ] && [ -f .gitmodules ] && [ -d .git ] && [ $submod_initialized = 0 ]; then
+	if [ -n "$GIT" ] && [ -f .gitmodules ] && [ -e .git ] && [ $submod_initialized = 0 ]; then
 		# only clone submodules if none of them present
 		git submodule update --init --recursive
 	fi


### PR DESCRIPTION
The submodule auto-init in autogen_submodules() was guarded by [ -d .git ], which is false whenever .git is a gitfile (i.e. when this tree is consumed as a submodule, or used via `git worktree add`). In that case the helper falls through to the per-submodule loop with lib/ivykis` empty and bails out with "Don't know how to bootstrap submodule 'lib/ivykis'".
