### PR TITLE
format-json: add --order to control the order of emitted keys

### DIFF
--- a/lib/value-pairs/value-pairs.c
+++ b/lib/value-pairs/value-pairs.c
@@ -441,6 +441,21 @@ vp_foreach_helper(const gchar *name, gpointer ndx_as_pointer, gpointer data)
 }
 
 
+static void
+vp_foreach_in_insertion_order(VPResults *results, gpointer helper_args)
+{
+  for (guint i = 0; i < results->values->len; i++)
+    {
+      VPResultValue *rv = &g_array_index(results->values, VPResultValue, i);
+
+      if (GPOINTER_TO_INT(g_tree_lookup(results->result_tree, rv->name->str)) != (gint) i)
+        continue;
+
+      if (vp_foreach_helper(rv->name->str, GINT_TO_POINTER(i), helper_args))
+        break;
+    }
+}
+
 gboolean
 value_pairs_foreach_sorted (ValuePairs *vp, VPForeachFunc func,
                             GCompareFunc compare_func,
@@ -454,7 +469,7 @@ value_pairs_foreach_sorted (ValuePairs *vp, VPForeachFunc func,
   ScratchBuffersMarker mark;
 
   scratch_buffers_mark(&mark);
-  vp_results_init(&results, compare_func);
+  vp_results_init(&results, compare_func ? compare_func : (GCompareFunc) strcmp);
   args[5] = &results;
 
   /*
@@ -470,7 +485,10 @@ value_pairs_foreach_sorted (ValuePairs *vp, VPForeachFunc func,
   g_ptr_array_foreach(vp->vpairs, (GFunc)vp_pairs_foreach, args);
 
   /* Aaand we run it through the callback! */
-  g_tree_foreach(results.result_tree, (GTraverseFunc)vp_foreach_helper, helper_args);
+  if (compare_func)
+    g_tree_foreach(results.result_tree, (GTraverseFunc)vp_foreach_helper, helper_args);
+  else
+    vp_foreach_in_insertion_order(&results, helper_args);
   vp_results_deinit(&results);
   scratch_buffers_reclaim_marked(mark);
 
@@ -871,19 +889,152 @@ vp_walk_cmp(const gchar *s1, const gchar *s2)
 }
 
 /*******************************************************************************
+ * vp_order_tree
+ *
+ * Used by the as-written walk: name-value pairs are inserted in their
+ * first-seen order, then replayed depth-first so that keys sharing a prefix
+ * stay contiguous, as the walker requires.
+ *******************************************************************************/
+
+typedef struct _VPOrderNode
+{
+  gchar *key;
+  GHashTable *index;
+  GPtrArray *children;
+  gboolean has_value;
+  LogMessageValueType type;
+  gchar *value;
+  gsize value_len;
+} VPOrderNode;
+
+static VPOrderNode *
+vp_order_node_new(const gchar *key)
+{
+  VPOrderNode *node = g_new0(VPOrderNode, 1);
+  node->key = g_strdup(key);
+  node->children = g_ptr_array_new();
+  return node;
+}
+
+static void
+vp_order_node_free(VPOrderNode *node)
+{
+  for (guint i = 0; i < node->children->len; i++)
+    vp_order_node_free(g_ptr_array_index(node->children, i));
+  g_ptr_array_free(node->children, TRUE);
+  if (node->index)
+    g_hash_table_destroy(node->index);
+  g_free(node->key);
+  g_free(node->value);
+  g_free(node);
+}
+
+static void
+vp_order_tree_insert(VPOrderNode *root, GPtrArray *tokens,
+                     LogMessageValueType type, const gchar *value, gsize value_len)
+{
+  VPOrderNode *node = root;
+
+  for (guint i = 0; i < tokens->len; i++)
+    {
+      const gchar *segment = g_ptr_array_index(tokens, i);
+      VPOrderNode *child = node->index ? g_hash_table_lookup(node->index, segment) : NULL;
+
+      if (!child)
+        {
+          child = vp_order_node_new(segment);
+          if (!node->index)
+            node->index = g_hash_table_new(g_str_hash, g_str_equal);
+          g_hash_table_insert(node->index, child->key, child);
+          g_ptr_array_add(node->children, child);
+        }
+      node = child;
+    }
+
+  node->has_value = TRUE;
+  node->type = type;
+  g_free(node->value);
+  node->value = g_malloc(value_len + 1);
+  memcpy(node->value, value, value_len);
+  node->value[value_len] = '\0';
+  node->value_len = value_len;
+}
+
+static void
+vp_order_tree_emit(VPOrderNode *node, GString *prefix, vp_walk_state_t *state, gboolean *result)
+{
+  for (guint i = 0; i < node->children->len && *result; i++)
+    {
+      VPOrderNode *child = g_ptr_array_index(node->children, i);
+      gsize prefix_len = prefix->len;
+
+      if (prefix_len)
+        g_string_append_c(prefix, state->key_delimiter);
+      g_string_append(prefix, child->key);
+
+      if (child->has_value &&
+          value_pairs_walker(prefix->str, child->type, child->value, child->value_len, state))
+        *result = FALSE;
+
+      if (*result)
+        vp_order_tree_emit(child, prefix, state, result);
+
+      g_string_truncate(prefix, prefix_len);
+    }
+}
+
+typedef struct
+{
+  VPOrderNode *root;
+  vp_walk_state_t *state;
+} VPOrderBuilder;
+
+static gboolean
+vp_order_collect(const gchar *name, LogMessageValueType type,
+                 const gchar *value, gsize value_len, gpointer user_data)
+{
+  VPOrderBuilder *builder = (VPOrderBuilder *) user_data;
+  GPtrArray *tokens = vp_walker_split_name_to_tokens(builder->state, name);
+
+  if (tokens)
+    {
+      vp_order_tree_insert(builder->root, tokens, type, value, value_len);
+      g_ptr_array_foreach(tokens, (GFunc) g_free, NULL);
+      g_ptr_array_free(tokens, TRUE);
+    }
+
+  return FALSE;
+}
+
+/*******************************************************************************
  * Public API
  *******************************************************************************/
 
+static void
+vp_walk_as_written(ValuePairs *vp, vp_walk_state_t *state,
+                   LogMessage *msg, LogTemplateEvalOptions *options, gboolean *result)
+{
+  VPOrderNode *root = vp_order_node_new(NULL);
+  VPOrderBuilder builder = { root, state };
+  GString *prefix = g_string_sized_new(64);
+
+  value_pairs_foreach_sorted(vp, vp_order_collect, NULL, msg, options, &builder);
+  vp_order_tree_emit(root, prefix, state, result);
+
+  g_string_free(prefix, TRUE);
+  vp_order_node_free(root);
+}
+
 gboolean
-value_pairs_walk(ValuePairs *vp,
-                 VPWalkCallbackFunc obj_start_func,
-                 VPWalkValueCallbackFunc process_value_func,
-                 VPWalkCallbackFunc obj_end_func,
-                 LogMessage *msg, LogTemplateEvalOptions *options,
-                 gchar key_delimiter, gpointer user_data)
+value_pairs_walk_ordered(ValuePairs *vp,
+                         VPWalkCallbackFunc obj_start_func,
+                         VPWalkValueCallbackFunc process_value_func,
+                         VPWalkCallbackFunc obj_end_func,
+                         LogMessage *msg, LogTemplateEvalOptions *options,
+                         gchar key_delimiter, ValuePairsOrder order, gpointer user_data)
 {
   vp_walk_state_t state;
-  gboolean result;
+  gboolean result = TRUE;
 
   state.user_data = user_data;
   state.obj_start = obj_start_func;
@@ -893,14 +1044,30 @@ value_pairs_walk(ValuePairs *vp,
   vp_stack_init(&state.stack);
 
   state.obj_start(NULL, NULL, NULL, NULL, NULL, user_data);
-  result = value_pairs_foreach_sorted(vp, value_pairs_walker,
-                                      (GCompareFunc)vp_walk_cmp, msg,
-                                      options, &state);
+  if (order == VP_ORDER_AS_WRITTEN)
+    vp_walk_as_written(vp, &state, msg, options, &result);
+  else
+    {
+      GCompareFunc compare_func = order == VP_ORDER_ASCENDING ? (GCompareFunc) strcmp : (GCompareFunc) vp_walk_cmp;
+      result = value_pairs_foreach_sorted(vp, value_pairs_walker, compare_func, msg, options, &state);
+    }
   vp_walker_stack_unwind_all_containers(&state);
   state.obj_end(NULL, NULL, NULL, NULL, NULL, user_data);
   vp_stack_destroy(&state.stack);
 
   return result;
+}
+
+gboolean
+value_pairs_walk(ValuePairs *vp,
+                 VPWalkCallbackFunc obj_start_func,
+                 VPWalkValueCallbackFunc process_value_func,
+                 VPWalkCallbackFunc obj_end_func,
+                 LogMessage *msg, LogTemplateEvalOptions *options,
+                 gchar key_delimiter, gpointer user_data)
+{
+  return value_pairs_walk_ordered(vp, obj_start_func, process_value_func, obj_end_func,
+                                  msg, options, key_delimiter, VP_ORDER_DESCENDING, user_data);
 }
 
 gboolean

--- a/lib/value-pairs/value-pairs.c
+++ b/lib/value-pairs/value-pairs.c
@@ -618,7 +618,8 @@ vp_walker_stack_unwind_containers_until(vp_walk_state_t *state,
     {
       vp_walk_stack_data_t *p;
 
-      if (name && strncmp(name, t->prefix, t->prefix_len) == 0)
+      if (name && strncmp(name, t->prefix, t->prefix_len) == 0 &&
+          (name[t->prefix_len] == state->key_delimiter || name[t->prefix_len] == '\0'))
         {
           /* This one matched, put it back, PUT IT BACK! */
           vp_stack_push(&state->stack, t);

--- a/lib/value-pairs/value-pairs.h
+++ b/lib/value-pairs/value-pairs.h
@@ -34,6 +34,13 @@
 
 typedef struct _ValuePairs ValuePairs;
 
+typedef enum
+{
+  VP_ORDER_DESCENDING,
+  VP_ORDER_ASCENDING,
+  VP_ORDER_AS_WRITTEN,
+} ValuePairsOrder;
+
 typedef gboolean
 (*VPForeachFunc) (const gchar *name, LogMessageValueType type, const gchar *value,
                   gsize value_len, gpointer user_data);
@@ -74,6 +81,13 @@ gboolean value_pairs_walk(ValuePairs *vp,
                           LogMessage *msg, LogTemplateEvalOptions *options,
                           gchar key_delimiter,
                           gpointer user_data);
+gboolean value_pairs_walk_ordered(ValuePairs *vp,
+                                  VPWalkCallbackFunc obj_start_func,
+                                  VPWalkValueCallbackFunc process_value_func,
+                                  VPWalkCallbackFunc obj_end_func,
+                                  LogMessage *msg, LogTemplateEvalOptions *options,
+                                  gchar key_delimiter, ValuePairsOrder order,
+                                  gpointer user_data);
 
 ValuePairs *value_pairs_new(GlobalConfig *cfg);
 ValuePairs *value_pairs_new_default(GlobalConfig *cfg);

--- a/modules/json/format-json.c
+++ b/modules/json/format-json.c
@@ -39,7 +39,31 @@ typedef struct _TFJsonState
   TFSimpleFuncState super;
   ValuePairs *vp;
   gchar key_delimiter;
+  ValuePairsOrder order;
 } TFJsonState;
+
+static gboolean
+_parse_order(const gchar *option_name,
+             const gchar *value,
+             gpointer data,
+             GError **error)
+{
+  TFJsonState *state = (TFJsonState *) data;
+
+  if (strcmp(value, "descending") == 0)
+    state->order = VP_ORDER_DESCENDING;
+  else if (strcmp(value, "ascending") == 0)
+    state->order = VP_ORDER_ASCENDING;
+  else if (strcmp(value, "as-written") == 0)
+    state->order = VP_ORDER_AS_WRITTEN;
+  else
+    {
+      g_set_error(error, G_OPTION_ERROR, G_OPTION_ERROR_BAD_VALUE,
+                  "$(format-json) --order only accepts 'descending', 'ascending' or 'as-written', found: '%s'", value);
+      return FALSE;
+    }
+  return TRUE;
+}
 
 static gboolean
 _parse_key_delimiter(const gchar *option_name,
@@ -70,10 +94,12 @@ tf_json_prepare(LogTemplateFunction *self, gpointer s, LogTemplate *parent,
   gboolean transform_initial_dot = TRUE;
 
   state->key_delimiter = '.';
+  state->order = VP_ORDER_DESCENDING;
   GOptionEntry format_json_options[] =
   {
     { "leave-initial-dot", 0, G_OPTION_FLAG_REVERSE, G_OPTION_ARG_NONE, &transform_initial_dot, NULL, NULL },
     { "key-delimiter", 0, 0, G_OPTION_ARG_CALLBACK, _parse_key_delimiter, NULL, NULL },
+    { "order", 0, 0, G_OPTION_ARG_CALLBACK, _parse_order, NULL, NULL },
     { NULL },
   };
 
@@ -410,9 +436,9 @@ tf_json_append(TFJsonState *state, GString *result, LogMessage *msg, LogTemplate
   invocation_state.buffer = result;
   invocation_state.template_options = options->opts;
 
-  return value_pairs_walk(state->vp,
-                          tf_json_obj_start, tf_json_value, tf_json_obj_end,
-                          msg, options, state->key_delimiter, &invocation_state);
+  return value_pairs_walk_ordered(state->vp,
+                                  tf_json_obj_start, tf_json_value, tf_json_obj_end,
+                                  msg, options, state->key_delimiter, state->order, &invocation_state);
 }
 
 static void
@@ -472,9 +498,15 @@ tf_flat_json_append(TFJsonState *state, GString *result, LogMessage *msg, LogTem
 
   g_string_append_c(invocation_state.buffer, '{');
 
+  GCompareFunc compare_func = (GCompareFunc) tf_flat_value_pairs_sort;
+  if (state->order == VP_ORDER_ASCENDING)
+    compare_func = (GCompareFunc) strcmp;
+  else if (state->order == VP_ORDER_AS_WRITTEN)
+    compare_func = NULL;
+
   gboolean success = value_pairs_foreach_sorted(state->vp,
                                                 tf_flat_json_value,
-                                                (GCompareFunc) tf_flat_value_pairs_sort, msg, options,
+                                                compare_func, msg, options,
                                                 &invocation_state);
 
   g_string_append_c(invocation_state.buffer, '}');

--- a/modules/json/tests/test_format_json.c
+++ b/modules/json/tests/test_format_json.c
@@ -474,3 +474,43 @@ Test(format_json, test_format_json_key_value_with_spaces)
   assert_template_format("$(format-json foo1= alma foo2 =korte foo3 = szilva foo4 = \" meggy \")",
                          "{\"foo4\":\" meggy \",\"foo3\":\"szilva\",\"foo2\":\"korte\",\"foo1\":\"alma\"}");
 }
+
+Test(format_json, test_format_json_order)
+{
+  cfg_set_version_without_validation(configuration, VERSION_VALUE_4_0);
+
+  assert_template_format("$(format-json a=1 b=2)",
+                         "{\"b\":\"2\",\"a\":\"1\"}");
+  assert_template_format("$(format-json --order=descending a=1 b=2)",
+                         "{\"b\":\"2\",\"a\":\"1\"}");
+
+  assert_template_format("$(format-json --order=ascending a=1 b=2)",
+                         "{\"a\":\"1\",\"b\":\"2\"}");
+  assert_template_format("$(format-json --order=ascending --scope rfc3164)",
+                         "{\"DATE\":\"Feb 11 10:34:56\",\"FACILITY\":\"local3\",\"HOST\":\"bzorp\",\"MESSAGE\":\"árvíztűrőtükörfúrógép\",\"PID\":\"23323\",\"PRIORITY\":\"err\",\"PROGRAM\":\"syslog-ng\"}");
+
+  assert_template_format("$(format-json --order=as-written b=1 a=2 last=3)",
+                         "{\"b\":\"1\",\"a\":\"2\",\"last\":\"3\"}");
+  assert_template_format("$(format-json --order=as-written msg.b=1 msg.a=2 host=h)",
+                         "{\"msg\":{\"b\":\"1\",\"a\":\"2\"},\"host\":\"h\"}");
+
+  /* a flat key must not be absorbed into a container that is a string prefix of it */
+  assert_template_format("$(format-json --order=ascending msg.a=1 msgx=2)",
+                         "{\"msg\":{\"a\":\"1\"},\"msgx\":\"2\"}");
+  assert_template_format("$(format-json --order=as-written msg.a=1 msgx=2)",
+                         "{\"msg\":{\"a\":\"1\"},\"msgx\":\"2\"}");
+
+  /* multiple nesting levels keep first-seen order at every level */
+  assert_template_format("$(format-json --order=as-written a.b.c=1 a.b.d=2 a.e=3 f=4)",
+                         "{\"a\":{\"b\":{\"c\":\"1\",\"d\":\"2\"},\"e\":\"3\"},\"f\":\"4\"}");
+  assert_template_format("$(format-json --order=ascending a.b.x=1 a.bb=2)",
+                         "{\"a\":{\"b\":{\"x\":\"1\"},\"bb\":\"2\"}}");
+
+  assert_template_format("$(format-flat-json --order=ascending b=1 a=2 c=3)",
+                         "{\"a\":\"2\",\"b\":\"1\",\"c\":\"3\"}");
+  assert_template_format("$(format-flat-json --order=as-written b=1 a=2 c=3)",
+                         "{\"b\":\"1\",\"a\":\"2\",\"c\":\"3\"}");
+
+  assert_template_failure("$(format-json --order=nonsense a=1)",
+                          "--order only accepts");
+}

--- a/news/bugfix-5736.md
+++ b/news/bugfix-5736.md
@@ -1,0 +1,2 @@
+`format-json`: Fixed nested `$(format-json)` so a key is no longer placed inside an object whose name is only a
+string prefix of it, for example `hostname` is no longer absorbed into a `host.*` object.

--- a/news/feature-5736.md
+++ b/news/feature-5736.md
@@ -1,0 +1,3 @@
+`format-json`: Added the `--order` option to `$(format-json)` and `$(format-flat-json)` to control the order of
+the emitted keys. It accepts `descending` (the unchanged default), `ascending`, and `as-written`, the latter
+keeping the keys in their first-seen order instead of sorting them.


### PR DESCRIPTION
## Problem

`$(format-json)` and `$(format-flat-json)` always emit keys in reverse lexical order, with no way to change it. Some consumers need a specific order, for example keeping a known key like `MSG` last so metadata and payload can be split by byte offset without parsing the whole document. See #5731.

## What this does

Adds an opt-in `--order` argument to both functions:

- `--order=descending` - the current behavior, still the default, unchanged
- `--order=ascending`
- `--order=as-written` - keep the keys in their first-seen order instead of sorting them

`ascending` and `descending` only swap the comparator. `as-written` is the new path: a NULL comparator in `value_pairs_foreach_sorted` now means insertion order (deduped through the existing array plus tree), and for the nested `$(format-json)` an ordered tree replays the pairs depth-first so that keys sharing a prefix stay contiguous, which the walker requires.

## Bug found along the way

The first commit is a separate fix. The container walker (`vp_walker_stack_unwind_containers_until`) decided whether to keep an object open with a plain `strncmp` and no delimiter-boundary check, so a flat key could be absorbed into an object whose name is only a string prefix of it (for example `hostname` ending up inside a `host.*` object). The default descending order happened to dodge it for most key shapes, but the new orders surface it. The fix keeps a container open only for a genuine child or for a key that is exactly the container's own path, so the default output stays the same for every input except these mis-nestings.

## Notes

- A name used both as a value and as an object prefix (nv-pairs `a` and `a.b`, say) is contradictory and has no valid JSON form. The default order already handles this in a surprising, undocumented way, so defining one behavior for it is tracked separately in #5737 and kept out of this PR to keep the scope on ordering.
- Tests in `test_format_json.c` cover all three orders, multiple nesting levels, and the prefix-collision case.

News entries are included (`news/feature-5736.md`, `news/bugfix-5736.md`).
