### PR TITLE
AWS CloudWatch Logs HLC destination

### DIFF
--- a/news/feature-5738.md
+++ b/news/feature-5738.md
@@ -1,0 +1,4 @@
+`cloudwatchlogshlc`: Added CloudWatch Logs HLC destination
+
+New SCL destination that sends logs to the AWS CloudWatch Logs HTTP Log Collector (HLC)
+endpoint using bearer token authentication. No AWS SDK dependency required.

--- a/scl/CMakeLists.txt
+++ b/scl/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SCL_DIRS
     cim
     checkpoint
     cisco
+    cloudwatchlogshlc
     collectd
     default-network-drivers
     darwinosl

--- a/scl/cloudwatchlogshlc/cloudwatchlogshlc.conf
+++ b/scl/cloudwatchlogshlc/cloudwatchlogshlc.conf
@@ -1,0 +1,101 @@
+#############################################################################
+# Copyright (c) 2025 One Identity LLC
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 as published
+# by the Free Software Foundation, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+#
+# As an additional exemption you are allowed to compile & link against the
+# OpenSSL libraries as published by the OpenSSL project. See the file
+# COPYING for details.
+#
+#############################################################################
+
+# CloudWatch Logs HLC (HTTP Log Collector) destination
+#
+# Sends logs to the CloudWatch Logs HLC endpoint using bearer token authentication.
+# No AWS SDK needed - uses the standard HTTP endpoint with a bearer token.
+#
+# Reference: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_HLC_Endpoint.html
+#
+# Usage example:
+#   log {
+#       source { system(); };
+#       destination {
+#           cloudwatch_logs_hlc(
+#               region("us-east-1")
+#               log_group("my-log-group")
+#               log_stream("my-log-stream")
+#               bearer_token("ACWL...")
+#           );
+#       };
+#   };
+
+@requires json-plugin
+
+block destination cloudwatch_logs_hlc(
+  region()
+  log_group()
+  log_stream()
+  bearer_token()
+
+  # Optional entity association parameters
+  entity_name("")
+  entity_environment("")
+
+  # Event formatting
+  event("${MSG}")
+  host("${HOST}")
+  source_field("${PROGRAM}")
+  time("${S_UNIXTIME}.${S_MSEC}")
+
+  # Batching and performance tuning
+  batch_lines(100)
+  batch_bytes(512kB)
+  batch_timeout(5)
+  workers(4)
+  timeout(30)
+
+  # TLS
+  use_system_cert_store(yes)
+
+  # Extra headers (e.g., for additional metadata)
+  extra_headers("")
+
+  ...)
+{
+
+@requires http "The cloudwatch-logs-hlc() driver depends on the syslog-ng http module, please install the syslog-ng-mod-http (Debian & derivatives) or the syslog-ng-http (RHEL & co) package"
+
+  http(
+    url("https://logs.`region`.amazonaws.com/services/collector/event?logGroup=`log_group`&logStream=`log_stream`&entityName=`entity_name`&entityEnvironment=`entity_environment`")
+    method("POST")
+    headers(
+      "Authorization: Bearer `bearer_token`"
+      "Content-Type: application/json"
+      "Connection: keep-alive"
+      `extra_headers`
+    )
+    body('$(format-json --scope none
+              event="`event`"
+              time="`time`"
+              host="`host`"
+              source="`source_field`")')
+    batch-lines(`batch_lines`)
+    batch-bytes(`batch_bytes`)
+    batch-timeout(`batch_timeout`)
+    workers(`workers`)
+    timeout(`timeout`)
+    use_system_cert_store(`use_system_cert_store`)
+    `__VARARGS__`
+  );
+};


### PR DESCRIPTION
## Problem

syslog-ng has no built-in destination for AWS CloudWatch Logs. Users who want to send logs to CloudWatch must manually configure the `http()` driver with the correct endpoint URL, authorization headers, and JSON body format for the HLC (HTTP Log Collector) protocol.

## Solution

Added a new SCL destination driver `cloudwatch_logs_hlc()` that wraps the existing `http()` driver with the correct configuration for the [CloudWatch Logs HLC endpoint](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_HLC_Endpoint.html). Uses bearer token authentication over HTTPS — no AWS SDK dependency needed.

This follows the same pattern as other cloud SCL destinations (Splunk HEC, Sumo Logic, Logscale, etc.)

## Configuration example

```conf
@version: 4.2
@include "scl.conf"

source s_local {
    file("/var/log/messages");
};

destination d_cloudwatch {
    cloudwatch_logs_hlc(
        region("us-east-1")
        log_group("my-log-group")
        log_stream("my-log-stream")
        bearer_token("ACWL...")
    );
};

log {
    source(s_local);
    destination(d_cloudwatch);
};
```

## Parameters

| Parameter | Required | Default | Description |
|-----------|----------|---------|-------------|
| `region` | Yes | — | AWS region (e.g., `us-east-1`) |
| `log_group` | Yes | — | CloudWatch log group name |
| `log_stream` | Yes | — | CloudWatch log stream name |
| `bearer_token` | Yes | — | Bearer token (starts with `ACWL`) |
| `entity_name` | No | `""` | Service entity name for CloudWatch Logs related telemetry |
| `entity_environment` | No | `""` | Service environment (e.g., `production`) |
| `event` | No | `${MSG}` | Log event content |
| `host` | No | `${HOST}` | Source hostname |
| `source_field` | No | `${PROGRAM}` | Source identifier |
| `time` | No | `${S_UNIXTIME}.${S_MSEC}` | Epoch timestamp |
| `batch_lines` | No | `100` | Max events per batch |
| `batch_bytes` | No | `512kB` | Max batch size |
| `batch_timeout` | No | `5` | Flush timeout in seconds |
| `workers` | No | `4` | HTTP worker threads |
| `timeout` | No | `30` | HTTP request timeout |

## Testing

- `make style-check`: PASS (0 badly formatted files)
- Configuration syntax validation: PASS
- Live end-to-end test sending messages to CloudWatch Logs (us-west-2): PASS
- Verified delivery via `aws logs get-log-events`: all messages received with correct JSON structure

## Checklist

- [x] Read the [Contribution guideline](https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md)
- [x] Tests pass (style-check: 0 issues)
- [x] News file added (`news/feature-5738.md`)
