### PR TITLE
control: reject malformed STATS/QUERY commands instead of aborting on CRLF input

### DIFF
--- a/lib/control/control-connection.c
+++ b/lib/control/control-connection.c
@@ -239,6 +239,8 @@ control_connection_io_input(void *s)
       gint nl_pos = nl - self->input_buffer->str;
       /* command doesn't contain NL, strip it */
       g_string_assign_len(command, self->input_buffer->str, nl_pos);
+      if (command->len > 0 && command->str[command->len - 1] == '\r')
+        g_string_truncate(command, command->len - 1);
       /* cleanup the input buffer */
       secret_storage_wipe(self->input_buffer->str, nl_pos);
       g_string_truncate(self->input_buffer, 0);

--- a/lib/control/tests/test_control_cmds.c
+++ b/lib/control/tests/test_control_cmds.c
@@ -214,6 +214,35 @@ Test(control_cmds, test_stats)
   g_strfreev(stats_result);
 }
 
+Test(control_cmds, test_stats_crlf)
+{
+  StatsCounterItem *counter = NULL;
+  gchar **stats_result;
+  const gchar *response;
+
+  stats_lock();
+  StatsClusterKey sc_key;
+  stats_cluster_logpipe_key_legacy_set(&sc_key, SCS_CENTER, "id", "received" );
+  stats_register_counter(0, &sc_key, SC_TYPE_PROCESSED, &counter);
+  stats_unlock();
+
+  _run_command("STATS CSV\r", &response);
+
+  stats_result = g_strsplit(response, "\n", 2);
+  cr_assert_str_eq(stats_result[0], "SourceName;SourceId;SourceInstance;State;Type;Number",
+                   "Bad reply");
+  g_strfreev(stats_result);
+}
+
+Test(control_cmds, test_stats_invalid_arguments)
+{
+  const gchar *response;
+
+  _run_command("STATS", &response);
+  cr_assert(first_line_eq(response, "FAIL Invalid arguments received"),
+            "Bad reply: [%s]", response);
+}
+
 Test(control_cmds, test_reset_stats)
 {
   StatsCounterItem *counter = NULL;

--- a/lib/stats/stats-control.c
+++ b/lib/stats/stats-control.c
@@ -79,9 +79,15 @@ control_connection_send_stats(ControlConnection *cc, GString *command, gpointer 
 {
   gchar **cmds = g_strsplit(command->str, " ", 3);
   gsize cmd_ndx = 0;
-  g_assert(g_str_equal(cmds[cmd_ndx], "STATS"));
+
+  if (!cmds[cmd_ndx] || !g_str_equal(cmds[cmd_ndx], "STATS") || !cmds[cmd_ndx + 1])
+    {
+      control_connection_send_reply(cc, g_string_new("FAIL Invalid arguments received"));
+      g_strfreev(cmds);
+      return;
+    }
+
   ++cmd_ndx;
-  g_assert(cmds[cmd_ndx] != NULL && "STATS command must have at least one format argument");
 
   GString *response = NULL;
   gpointer args[] = {cc, &response};
@@ -101,7 +107,15 @@ control_connection_send_stats(ControlConnection *cc, GString *command, gpointer 
   else
     {
       gboolean csv = strcmp(cmds[cmd_ndx], "CSV") == 0;
-      g_assert(csv || strcmp(cmds[cmd_ndx], "KV") == 0);
+      gboolean kv = strcmp(cmds[cmd_ndx], "KV") == 0;
+
+      if (!csv && !kv)
+        {
+          control_connection_send_reply(cc, g_string_new("FAIL Invalid arguments received"));
+          g_strfreev(cmds);
+          return;
+        }
+
       gboolean without_header = g_strcmp0(cmds[cmd_ndx + 1], "WITHOUT_HEADER") == 0;
       if (without_header)
         ++cmd_ndx;

--- a/lib/stats/stats-query-commands.c
+++ b/lib/stats/stats-query-commands.c
@@ -225,7 +225,12 @@ stats_execute_query_command(const gchar *command, gpointer user_data, gboolean *
   GString *result = g_string_new("");
   gchar **cmds = g_strsplit(command, " ", 4);
 
-  g_assert(g_str_equal(cmds[CMD_STR], "QUERY"));
+  if (!cmds[CMD_STR] || !g_str_equal(cmds[CMD_STR], "QUERY"))
+    {
+      g_string_assign(result, "FAIL Invalid arguments received");
+      g_strfreev(cmds);
+      return result;
+    }
 
   _dispatch_query(_command_str_to_id(cmds[QUERY_CMD_STR]), cmds[QUERY_OUT_FMT_STR], cmds[QUERY_FILTER_STR], result);
 

--- a/news/bugfix-5742.md
+++ b/news/bugfix-5742.md
@@ -1,0 +1,5 @@
+`control`: reject malformed STATS/QUERY commands instead of aborting
+
+Malformed control socket input (e.g. CRLF line endings or missing STATS
+format argument) could abort syslog-ng via g_assert. Strip trailing CR
+and return FAIL for invalid commands.


### PR DESCRIPTION
Fix a DOS bug on the control Unix socket: malformed STATS (and QUERY) commands could abort syslog-ng instead of returning an error.

Two related issues:
- CRLF line endings - the control parser stripped \n but left a trailing \r, so STATS\r\n was handled as STATS\r. Command lookup still matched (strncmp), but the STATS handler asserted on strict string equality and crashed the daemon.
- g_assert for protocol validation - missing or invalid STATS arguments (e.g. bare STATS without CSV/KV/PROMETHEUS) also triggered g_assert and aborted the process. Other control commands (e.g. LOG) already return FAIL Invalid arguments received.

This showed up in production with a monitoring agent ([alligator](https://github.com/alligatormon/alligator/blob/1.14.191/src/parsers/syslog-ng.c#L78)) that queries syslog-ng statistics over the control socket using a legacy command form (STATS\n). On some hosts the agent sends CRLF-terminated lines; on current syslog-ng that caused a reproducible crash:
```
Control command thread has started; control_command='STATS\x0d'
ERROR:lib/stats/stats-control.c:82:control_connection_send_stats: assertion failed: (g_str_equal(cmds[cmd_ndx], "STATS"))
Aborted (core dumped)
```
Any client that can reach the control socket could crash syslog-ng with a single malformed line - a local DoS.


Changes is:
lib/control/control-connection.c - strip trailing \r after extracting a control line (CRLF normalization).
lib/stats/stats-control.c - replace g_assert in control_connection_send_stats() with FAIL Invalid arguments received for malformed commands.
lib/stats/stats-query-commands.c - same for invalid QUERY command names.
lib/control/tests/test_control_cmds.c - add tests for CRLF input and invalid STATS arguments.

Note: the official client (syslog-ng-ctl) sends STATS CSV\n and is unaffected. Legacy clients should migrate to STATS CSV\n (or STATS KV\n / STATS PROMETHEUS\n); this patch ensures bad input does not take down the daemon.