### PR TITLE
CI: fix macos and freebsd builds

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -78,6 +78,7 @@ jobs:
             --enable-slog
             --disable-java
             --disable-java-modules
+            --disable-mongodb
           "
           CMAKE_CONFIGURE_FLAGS="
             `[ $CC = clang ] && echo '-DENABLE_FORCE_GNU99=ON' || true`
@@ -95,6 +96,7 @@ jobs:
             -DENABLE_JOURNALD=OFF
             -DENABLE_JAVA=OFF
             -DENABLE_JAVA_MODULES=OFF
+            -DENABLE_MONGODB=OFF
           "
           PKGCONF_PATH=$(pkgconf --variable pc_path pkgconf)
           export PKG_CONFIG_PATH="${PKGCONF_PATH}:$PKG_CONFIG_PATH"
@@ -154,7 +156,7 @@ jobs:
               echo "pkg catalogue OK; using default repo configuration."
             fi
 
-            pkg install -y autoconf autoconf-archive automake bison cmake flex git gperf glib json-c libtool pcre2 pkgconf gradle grpc hiredis libdbi libdbi-drivers libmaxminddb libnet libpaho-mqtt3 librdkafka libesmtp mongo-c-driver net-snmp openjdk25 rabbitmq-c riemann-c-client
+            pkg install -y autoconf autoconf-archive automake bison cmake flex git gperf glib json-c libtool pcre2 pkgconf gradle grpc hiredis libdbi libdbi-drivers libmaxminddb libnet libpaho-mqtt3 librdkafka libesmtp net-snmp openjdk25 rabbitmq-c riemann-c-client
             # For testing
             pkg install -y criterion libxml2 qpdf
             if  [ "${{ matrix.build-tool }}" = "autotools" ]; then

--- a/configure.ac
+++ b/configure.ac
@@ -981,7 +981,13 @@ case "$ostype" in
 		MODULE_LDFLAGS="-avoid-version -module -no-undefined"
 		;;
 	Darwin)
-		MODULE_LDFLAGS="-avoid-version -dylib -no-undefined"
+		# Note: -no-undefined is intentionally omitted here. syslog-ng modules are
+		# dylibs that reference symbols from libsyslog-ng.dylib, so they legitimately
+		# have undefined symbols that are resolved at load time. Omitting -no-undefined
+		# lets libtool emit -undefined dynamic_lookup -no_fixup_chains, which is
+		# required by the Apple linker (ld-1267+, macOS 26/Xcode 26.5) that no longer
+		# allows undefined symbols in dylibs by default.
+		MODULE_LDFLAGS="-avoid-version -dylib"
         TEST_NO_INSTALL_FLAG="-no-fast-install"
         # This flag might be a security issue, do not use in production code, unfortunately we still need it for criterion tests and the current mocking solution
         if test "x$enable_tests" = "xyes"; then


### PR DESCRIPTION
- temporarily turn off the mongo-c module for FreeBSD builds
- fix linker errors on the latest macOS versions