### PR TITLE
diskq: remove empty queue files when their destination is reaped

### DIFF
--- a/modules/diskq/diskq-grammar.ym
+++ b/modules/diskq/diskq-grammar.ym
@@ -70,6 +70,7 @@ DiskQueueOptions *last_options;
 %token KW_DIR
 %token KW_TRUNCATE_SIZE_RATIO
 %token KW_PREALLOC
+%token KW_REMOVE_IF_EMPTY
 
 
 %%
@@ -104,6 +105,7 @@ dest_diskq_option
         | KW_DIR '(' string ')'                          { disk_queue_options_set_dir(last_options, $3); free($3); }
         | KW_TRUNCATE_SIZE_RATIO '(' float_between_0_and_1 ')' { disk_queue_options_set_truncate_size_ratio(last_options, $3); }
         | KW_PREALLOC '(' yesno ')'                      { disk_queue_options_set_prealloc(last_options, $3); }
+        | KW_REMOVE_IF_EMPTY '(' yesno ')'               { disk_queue_options_set_remove_if_empty(last_options, $3); }
         ;
 
 diskq_global_options

--- a/modules/diskq/diskq-options.c
+++ b/modules/diskq/diskq-options.c
@@ -83,6 +83,12 @@ disk_queue_options_set_prealloc(DiskQueueOptions *self, gboolean prealloc)
 }
 
 void
+disk_queue_options_set_remove_if_empty(DiskQueueOptions *self, gboolean remove_if_empty)
+{
+  self->remove_if_empty = remove_if_empty;
+}
+
+void
 disk_queue_options_check_plugin_settings(DiskQueueOptions *self)
 {
   if (self->reliable)
@@ -135,6 +141,7 @@ disk_queue_options_set_default_options(DiskQueueOptions *self)
   self->dir = g_strdup(get_installation_path_for(SYSLOG_NG_PATH_LOCALSTATEDIR));
   self->truncate_size_ratio = -1;
   self->prealloc = -1;
+  self->remove_if_empty = FALSE;
 }
 
 void

--- a/modules/diskq/diskq-options.h
+++ b/modules/diskq/diskq-options.h
@@ -41,6 +41,7 @@ typedef struct _DiskQueueOptions
   gchar *dir;
   gdouble truncate_size_ratio;
   gboolean prealloc;
+  gboolean remove_if_empty;
 } DiskQueueOptions;
 
 void disk_queue_options_front_cache_size_set(DiskQueueOptions *self, gint front_cache_size);
@@ -53,6 +54,7 @@ void disk_queue_options_check_plugin_settings(DiskQueueOptions *self);
 void disk_queue_options_set_dir(DiskQueueOptions *self, const gchar *dir);
 void disk_queue_options_set_truncate_size_ratio(DiskQueueOptions *self, gdouble truncate_size_ratio);
 void disk_queue_options_set_prealloc(DiskQueueOptions *self, gboolean prealloc);
+void disk_queue_options_set_remove_if_empty(DiskQueueOptions *self, gboolean remove_if_empty);
 void disk_queue_options_set_default_options(DiskQueueOptions *self);
 void disk_queue_options_destroy(DiskQueueOptions *self);
 

--- a/modules/diskq/diskq-parser.c
+++ b/modules/diskq/diskq-parser.c
@@ -44,6 +44,7 @@ static CfgLexerKeyword diskq_keywords[] =
   { "dir",               KW_DIR },
   { "truncate_size_ratio", KW_TRUNCATE_SIZE_RATIO },
   { "prealloc",          KW_PREALLOC },
+  { "remove_if_empty",   KW_REMOVE_IF_EMPTY },
   { "stats",             KW_STATS },
   { "freq",              KW_FREQ },
   { NULL }

--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -22,6 +22,8 @@
  */
 
 #include <math.h>
+#include <errno.h>
+#include <unistd.h>
 
 #include "diskq.h"
 #include "diskq-config.h"
@@ -173,6 +175,29 @@ exit:
   return queue;
 }
 
+static gboolean
+_discard_empty_queue_file(GlobalConfig *cfg, LogQueue *queue, const gchar *filename)
+{
+  if (!filename)
+    return FALSE;
+
+  if (unlink(filename) < 0 && errno != ENOENT)
+    {
+      msg_error("Failed to remove empty disk-buffer file",
+                evt_tag_str("filename", filename),
+                evt_tag_error(EVT_TAG_OSERROR));
+      return FALSE;
+    }
+
+  if (queue->persist_name && cfg && cfg->state)
+    persist_state_remove_entry(cfg->state, queue->persist_name);
+
+  msg_debug("Removed empty disk-buffer file",
+            evt_tag_str("filename", filename));
+
+  return TRUE;
+}
+
 void
 _release_queue(LogDestDriver *dd, LogQueue *queue)
 {
@@ -180,7 +205,21 @@ _release_queue(LogDestDriver *dd, LogQueue *queue)
   gboolean persistent;
 
   log_queue_disk_stop(queue, &persistent);
-  diskq_global_metrics_file_released(log_queue_disk_get_filename(queue));
+
+  const gchar *filename = log_queue_disk_get_filename(queue);
+  diskq_global_metrics_file_released(filename);
+
+  if (!persistent)
+    {
+      /* the file and its persist entry have to go together: an entry naming a
+       * deleted file lets this destination reattach to a filename that another
+       * queue has been given in the meantime */
+      if (_discard_empty_queue_file(cfg, queue, filename))
+        {
+          log_queue_unref(queue);
+          return;
+        }
+    }
 
   if (queue->persist_name)
     {

--- a/modules/diskq/diskq.c
+++ b/modules/diskq/diskq.c
@@ -176,10 +176,17 @@ exit:
 }
 
 static gboolean
+_is_remove_if_empty_enabled(LogQueue *queue)
+{
+  LogQueueDisk *disk_queue = (LogQueueDisk *) queue;
+
+  return qdisk_get_options(disk_queue->qdisk)->remove_if_empty;
+}
+
+static gboolean
 _discard_empty_queue_file(GlobalConfig *cfg, LogQueue *queue, const gchar *filename)
 {
-  if (!filename)
-    return FALSE;
+  g_assert(filename);
 
   if (unlink(filename) < 0 && errno != ENOENT)
     {
@@ -209,7 +216,7 @@ _release_queue(LogDestDriver *dd, LogQueue *queue)
   const gchar *filename = log_queue_disk_get_filename(queue);
   diskq_global_metrics_file_released(filename);
 
-  if (!persistent)
+  if (!persistent && _is_remove_if_empty_enabled(queue))
     {
       /* the file and its persist entry have to go together: an entry naming a
        * deleted file lets this destination reattach to a filename that another

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -535,10 +535,13 @@ _stop(LogQueueDisk *s, gboolean *persistent)
   LogQueueDiskNonReliable *self = (LogQueueDiskNonReliable *) s;
 
   gboolean result = FALSE;
+  gboolean has_messages = TRUE;
 
-  if (qdisk_stop(s->qdisk, self->front_cache, self->backlog, self->flow_control_window))
+  *persistent = TRUE;
+
+  if (qdisk_stop(s->qdisk, self->front_cache, self->backlog, self->flow_control_window, &has_messages))
     {
-      *persistent = TRUE;
+      *persistent = has_messages;
       result = TRUE;
     }
 
@@ -552,7 +555,7 @@ _stop(LogQueueDisk *s, gboolean *persistent)
 static gboolean
 _stop_corrupted(LogQueueDisk *s)
 {
-  return qdisk_stop(s->qdisk, NULL, NULL, NULL);
+  return qdisk_stop(s->qdisk, NULL, NULL, NULL, NULL);
 }
 
 static inline void

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -447,10 +447,13 @@ _stop(LogQueueDisk *s, gboolean *persistent)
   LogQueueDiskReliable *self = (LogQueueDiskReliable *) s;
 
   gboolean result = FALSE;
+  gboolean has_messages = TRUE;
 
-  if (qdisk_stop(s->qdisk, NULL, NULL, NULL))
+  *persistent = TRUE;
+
+  if (qdisk_stop(s->qdisk, NULL, NULL, NULL, &has_messages))
     {
-      *persistent = TRUE;
+      *persistent = has_messages;
       result = TRUE;
     }
 

--- a/modules/diskq/logqueue-disk.c
+++ b/modules/diskq/logqueue-disk.c
@@ -60,7 +60,9 @@ log_queue_disk_stop(LogQueue *s, gboolean *persistent)
 
   if (!qdisk_started(self->qdisk))
     {
-      *persistent = FALSE;
+      /* nothing was measured here and the file may hold messages from an
+       * earlier run, so we report it as one to keep */
+      *persistent = TRUE;
       return TRUE;
     }
 

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1754,9 +1754,7 @@ qdisk_stop(QDisk *self, GQueue *front_cache, GQueue *backlog, GQueue *flow_contr
     result = _save_state(self, front_cache, backlog, flow_control_window);
 
   if (has_messages)
-    {
-      *has_messages = result ? (_number_of_messages(self) != 0) : TRUE;
-    }
+    *has_messages = result ? (_number_of_messages(self) != 0) : TRUE;
 
   _close_file(self);
 

--- a/modules/diskq/qdisk.c
+++ b/modules/diskq/qdisk.c
@@ -1745,12 +1745,18 @@ qdisk_start(QDisk *self, GQueue *front_cache, GQueue *backlog, GQueue *flow_cont
 }
 
 gboolean
-qdisk_stop(QDisk *self, GQueue *front_cache, GQueue *backlog, GQueue *flow_control_window)
+qdisk_stop(QDisk *self, GQueue *front_cache, GQueue *backlog, GQueue *flow_control_window,
+           gboolean *has_messages)
 {
   gboolean result = TRUE;
 
   if (!self->options->read_only)
     result = _save_state(self, front_cache, backlog, flow_control_window);
+
+  if (has_messages)
+    {
+      *has_messages = result ? (_number_of_messages(self) != 0) : TRUE;
+    }
 
   _close_file(self);
 

--- a/modules/diskq/qdisk.h
+++ b/modules/diskq/qdisk.h
@@ -70,7 +70,8 @@ void qdisk_empty_backlog(QDisk *self);
 gint64 qdisk_get_next_tail_position(QDisk *self);
 gint64 qdisk_get_next_head_position(QDisk *self);
 gboolean qdisk_start(QDisk *self, GQueue *front_cache, GQueue *backlog, GQueue *flow_control_window);
-gboolean qdisk_stop(QDisk *self, GQueue *front_cache, GQueue *backlog, GQueue *flow_control_window);
+gboolean qdisk_stop(QDisk *self, GQueue *front_cache, GQueue *backlog, GQueue *flow_control_window,
+                    gboolean *has_messages);
 void qdisk_reset_file_if_empty(QDisk *self);
 gboolean qdisk_started(QDisk *self);
 void qdisk_free(QDisk *self);

--- a/modules/diskq/tests/CMakeLists.txt
+++ b/modules/diskq/tests/CMakeLists.txt
@@ -5,3 +5,4 @@ add_unit_test(CRITERION LIBTEST TARGET test_diskq_truncate DEPENDS m disk-buffer
 add_unit_test(CRITERION LIBTEST TARGET test_qdisk DEPENDS disk-buffer)
 add_unit_test(CRITERION LIBTEST TARGET test_logqueue_disk DEPENDS disk-buffer)
 add_unit_test(CRITERION LIBTEST TARGET test_diskq_counters DEPENDS disk-buffer)
+add_unit_test(CRITERION LIBTEST TARGET test_diskq_release DEPENDS disk-buffer)

--- a/modules/diskq/tests/Makefile.am
+++ b/modules/diskq/tests/Makefile.am
@@ -9,7 +9,8 @@ modules_diskq_tests_TESTS = \
   modules/diskq/tests/test_reliable_backlog \
   modules/diskq/tests/test_qdisk \
   modules/diskq/tests/test_logqueue_disk \
-  modules/diskq/tests/test_diskq_counters
+  modules/diskq/tests/test_diskq_counters \
+  modules/diskq/tests/test_diskq_release
 
 check_PROGRAMS += ${modules_diskq_tests_TESTS}
 
@@ -62,4 +63,11 @@ modules_diskq_tests_test_diskq_counters_LDFLAGS = $(DISKQ_TEST_LD_FLAGS)
 modules_diskq_tests_test_diskq_counters_LDADD = $(DISKQ_TEST_LD_ADD)
 modules_diskq_tests_test_diskq_counters_SOURCES = \
 	modules/diskq/tests/test_diskq_counters.c \
+	modules/diskq/tests/test_diskq_tools.h
+
+modules_diskq_tests_test_diskq_release_CFLAGS = $(DISKQ_TEST_C_FLAGS)
+modules_diskq_tests_test_diskq_release_LDFLAGS = $(DISKQ_TEST_LD_FLAGS)
+modules_diskq_tests_test_diskq_release_LDADD = $(DISKQ_TEST_LD_ADD)
+modules_diskq_tests_test_diskq_release_SOURCES = \
+	modules/diskq/tests/test_diskq_release.c \
 	modules/diskq/tests/test_diskq_tools.h

--- a/modules/diskq/tests/test_diskq_release.c
+++ b/modules/diskq/tests/test_diskq_release.c
@@ -12,7 +12,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * As an additional exemption you are allowed to compile & link against the
  * OpenSSL libraries as published by the OpenSSL project. See the file
@@ -21,7 +21,6 @@
  */
 
 #include <criterion/criterion.h>
-#include <unistd.h>
 #include <sys/stat.h>
 #include <glib/gstdio.h>
 
@@ -36,14 +35,48 @@
 #define PERSIST_FILE "test_diskq_release.persist"
 #define QUEUE_PERSIST_NAME "test_diskq_release_queue"
 
+static gchar *base_dir;
+static gchar *workspace_dir;
+
 static void
 setup(void)
 {
   app_startup();
 
+  base_dir = g_get_current_dir();
+  workspace_dir = NULL;
+
   configuration = cfg_new_snippet();
   configuration->stats_options.level = STATS_LEVEL1;
   diskq_global_metrics_init();
+}
+
+/* the queue file, the persist file and the dirlock all land in the workspace,
+ * and distcheck fails on anything left in the build directory */
+static void
+_leave_workspace(void)
+{
+  cr_assert_eq(g_chdir(base_dir), 0, "failed to return to the build directory: %s", base_dir);
+
+  if (!workspace_dir)
+    return;
+
+  GDir *dir = g_dir_open(workspace_dir, 0, NULL);
+  cr_assert_not_null(dir, "failed to open the workspace: %s", workspace_dir);
+
+  const gchar *entry;
+  while ((entry = g_dir_read_name(dir)))
+    {
+      gchar *path = g_build_filename(workspace_dir, entry, NULL);
+      cr_assert_eq(g_unlink(path), 0, "failed to remove a file left in the workspace: %s", path);
+      g_free(path);
+    }
+  g_dir_close(dir);
+
+  cr_assert_eq(g_rmdir(workspace_dir), 0, "failed to remove the workspace: %s", workspace_dir);
+
+  g_free(workspace_dir);
+  workspace_dir = NULL;
 }
 
 static void
@@ -53,17 +86,25 @@ teardown(void)
     persist_state_cancel(configuration->state);
   cfg_free(configuration);
   app_shutdown();
+
+  _leave_workspace();
+  g_free(base_dir);
 }
 
 TestSuite(diskq_release, .init = setup, .fini = teardown);
 
 /* tests share the working directory of the binary, so each one needs its own
- * persist file and spool dir to survive a parallel run */
+ * persist file and spool dir to survive a parallel run. the workspace is
+ * created relative to the build directory rather than to the current one, so
+ * that the suite does not nest its workspaces when Criterion runs without
+ * forking and the process keeps the previous test's directory */
 static void
 _enter_workspace(const gchar *name)
 {
-  cr_assert_eq(g_mkdir_with_parents(name, 0700), 0, "failed to create the workspace: %s", name);
-  cr_assert_eq(g_chdir(name), 0, "failed to enter the workspace: %s", name);
+  workspace_dir = g_build_filename(base_dir, name, NULL);
+
+  cr_assert_eq(g_mkdir_with_parents(workspace_dir, 0700), 0, "failed to create the workspace: %s", workspace_dir);
+  cr_assert_eq(g_chdir(workspace_dir), 0, "failed to enter the workspace: %s", workspace_dir);
 
   configuration->state = persist_state_new(PERSIST_FILE);
   cr_assert(persist_state_start(configuration->state), "failed to start the persist state");
@@ -71,7 +112,7 @@ _enter_workspace(const gchar *name)
 }
 
 static LogDestDriver *
-_dummy_dd_new(gboolean reliable, gint front_cache_size)
+_dummy_dd_new(gboolean reliable, gint front_cache_size, gboolean remove_if_empty)
 {
   LogDestDriver *self = g_new0(LogDestDriver, 1);
   log_dest_driver_init_instance(self, configuration);
@@ -82,6 +123,7 @@ _dummy_dd_new(gboolean reliable, gint front_cache_size)
   disk_queue_options_reliable_set(options, reliable);
   disk_queue_options_front_cache_size_set(options, front_cache_size);
   disk_queue_options_set_dir(options, ".");
+  disk_queue_options_set_remove_if_empty(options, remove_if_empty);
   cr_assert(log_driver_add_plugin(&self->super, (LogDriverPlugin *) plugin));
   cr_assert(log_pipe_init(&self->super.super));
 
@@ -129,10 +171,10 @@ _entry_survives_a_reload(void)
 
 /* acquire a queue, optionally feed it, release it, report what became of its file */
 static void
-_acquire_feed_release(gboolean reliable, gint front_cache_size, gint messages,
+_acquire_feed_release(gboolean reliable, gint front_cache_size, gint messages, gboolean remove_if_empty,
                       gchar **filename, gboolean *file_survived, gboolean *entry_survived)
 {
-  LogDestDriver *driver = _dummy_dd_new(reliable, front_cache_size);
+  LogDestDriver *driver = _dummy_dd_new(reliable, front_cache_size, remove_if_empty);
 
   /* releasing consumes two references: ours and the one on the driver's list */
   LogQueue *queue = log_queue_ref(log_dest_driver_acquire_queue(driver, QUEUE_PERSIST_NAME, STATS_LEVEL0, NULL, NULL));
@@ -164,10 +206,25 @@ Test(diskq_release, test_empty_reliable_queue_file_is_removed_with_its_persist_e
   gboolean file_survived, entry_survived;
 
   _enter_workspace("empty_reliable");
-  _acquire_feed_release(TRUE, 0, 0, &filename, &file_survived, &entry_survived);
+  _acquire_feed_release(TRUE, 0, 0, TRUE, &filename, &file_survived, &entry_survived);
 
   cr_assert_not(file_survived, "an empty reliable queue file was left behind: %s", filename);
   cr_assert_not(entry_survived, "the persist entry outlived the file it names");
+
+  g_free(filename);
+}
+
+/* the option is opt-in, so without it an empty file is kept exactly as before */
+Test(diskq_release, test_empty_queue_file_is_kept_without_remove_if_empty)
+{
+  gchar *filename = NULL;
+  gboolean file_survived, entry_survived;
+
+  _enter_workspace("empty_without_remove_if_empty");
+  _acquire_feed_release(TRUE, 0, 0, FALSE, &filename, &file_survived, &entry_survived);
+
+  cr_assert(file_survived, "an empty queue file was removed without remove-if-empty(yes): %s", filename);
+  cr_assert(entry_survived, "the persist entry was dropped without remove-if-empty(yes)");
 
   g_free(filename);
 }
@@ -178,12 +235,11 @@ Test(diskq_release, test_reliable_queue_file_holding_a_message_is_kept)
   gboolean file_survived, entry_survived;
 
   _enter_workspace("reliable_with_message");
-  _acquire_feed_release(TRUE, 0, 1, &filename, &file_survived, &entry_survived);
+  _acquire_feed_release(TRUE, 0, 1, TRUE, &filename, &file_survived, &entry_survived);
 
   cr_assert(file_survived, "a reliable queue file holding a message was removed: %s", filename);
   cr_assert(entry_survived, "the persist entry for a kept file was dropped");
 
-  unlink(filename);
   g_free(filename);
 }
 
@@ -193,7 +249,7 @@ Test(diskq_release, test_empty_non_reliable_queue_file_is_removed_with_its_persi
   gboolean file_survived, entry_survived;
 
   _enter_workspace("empty_non_reliable");
-  _acquire_feed_release(FALSE, 0, 0, &filename, &file_survived, &entry_survived);
+  _acquire_feed_release(FALSE, 0, 0, TRUE, &filename, &file_survived, &entry_survived);
 
   cr_assert_not(file_survived, "an empty non-reliable queue file was left behind: %s", filename);
   cr_assert_not(entry_survived, "the persist entry outlived the file it names");
@@ -207,12 +263,11 @@ Test(diskq_release, test_non_reliable_queue_file_holding_a_message_is_kept)
   gboolean file_survived, entry_survived;
 
   _enter_workspace("non_reliable_with_message");
-  _acquire_feed_release(FALSE, 0, 1, &filename, &file_survived, &entry_survived);
+  _acquire_feed_release(FALSE, 0, 1, TRUE, &filename, &file_survived, &entry_survived);
 
   cr_assert(file_survived, "a non-reliable queue file holding a message was removed: %s", filename);
   cr_assert(entry_survived, "the persist entry for a kept file was dropped");
 
-  unlink(filename);
   g_free(filename);
 }
 
@@ -225,12 +280,11 @@ Test(diskq_release, test_non_reliable_queue_file_holding_only_a_front_cached_mes
   gboolean file_survived, entry_survived;
 
   _enter_workspace("non_reliable_front_cache");
-  _acquire_feed_release(FALSE, 16, 1, &filename, &file_survived, &entry_survived);
+  _acquire_feed_release(FALSE, 16, 1, TRUE, &filename, &file_survived, &entry_survived);
 
   cr_assert(file_survived,
             "a non-reliable queue file holding a front-cached message was removed: %s", filename);
   cr_assert(entry_survived, "the persist entry for a kept file was dropped");
 
-  unlink(filename);
   g_free(filename);
 }

--- a/modules/diskq/tests/test_diskq_release.c
+++ b/modules/diskq/tests/test_diskq_release.c
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2026 One Identity LLC.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+ *
+ * As an additional exemption you are allowed to compile & link against the
+ * OpenSSL libraries as published by the OpenSSL project. See the file
+ * COPYING for details.
+ *
+ */
+
+#include <criterion/criterion.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <glib/gstdio.h>
+
+#include "libtest/queue_utils_lib.h"
+
+#include "diskq.h"
+#include "diskq-global-metrics.h"
+#include "logqueue-disk.h"
+#include "apphook.h"
+#include "persist-state.h"
+
+#define PERSIST_FILE "test_diskq_release.persist"
+#define QUEUE_PERSIST_NAME "test_diskq_release_queue"
+
+static void
+setup(void)
+{
+  app_startup();
+
+  configuration = cfg_new_snippet();
+  configuration->stats_options.level = STATS_LEVEL1;
+  diskq_global_metrics_init();
+}
+
+static void
+teardown(void)
+{
+  if (configuration->state)
+    persist_state_cancel(configuration->state);
+  cfg_free(configuration);
+  app_shutdown();
+}
+
+TestSuite(diskq_release, .init = setup, .fini = teardown);
+
+/* tests share the working directory of the binary, so each one needs its own
+ * persist file and spool dir to survive a parallel run */
+static void
+_enter_workspace(const gchar *name)
+{
+  cr_assert_eq(g_mkdir_with_parents(name, 0700), 0, "failed to create the workspace: %s", name);
+  cr_assert_eq(g_chdir(name), 0, "failed to enter the workspace: %s", name);
+
+  configuration->state = persist_state_new(PERSIST_FILE);
+  cr_assert(persist_state_start(configuration->state), "failed to start the persist state");
+  cr_assert(cfg_init(configuration), "failed to initialize the configuration");
+}
+
+static LogDestDriver *
+_dummy_dd_new(gboolean reliable, gint front_cache_size)
+{
+  LogDestDriver *self = g_new0(LogDestDriver, 1);
+  log_dest_driver_init_instance(self, configuration);
+
+  DiskQDestPlugin *plugin = diskq_dest_plugin_new();
+  DiskQueueOptions *options = diskq_get_options(plugin);
+  disk_queue_options_capacity_bytes_set(options, MIN_CAPACITY_BYTES);
+  disk_queue_options_reliable_set(options, reliable);
+  disk_queue_options_front_cache_size_set(options, front_cache_size);
+  disk_queue_options_set_dir(options, ".");
+  cr_assert(log_driver_add_plugin(&self->super, (LogDriverPlugin *) plugin));
+  cr_assert(log_pipe_init(&self->super.super));
+
+  return self;
+}
+
+static void
+_dummy_dd_free(LogDestDriver *self)
+{
+  cr_assert(log_pipe_deinit(&self->super.super));
+  log_pipe_unref(&self->super.super);
+}
+
+static gboolean
+_file_exists(const gchar *filename)
+{
+  struct stat st;
+  return stat(filename, &st) == 0;
+}
+
+static gchar *
+_persist_entry_value(void)
+{
+  gsize length = 0;
+  guint8 version = 0;
+  return persist_state_lookup_string(configuration->state, QUEUE_PERSIST_NAME, &length, &version);
+}
+
+/* removing an entry only clears its in_use flag and a lookup would set it
+ * again, so the entry is only observable as gone after a commit and reload */
+static gboolean
+_entry_survives_a_reload(void)
+{
+  cr_assert(persist_state_commit(configuration->state), "failed to commit the persist state");
+  persist_state_free(configuration->state);
+
+  configuration->state = persist_state_new(PERSIST_FILE);
+  cr_assert(persist_state_start(configuration->state), "failed to reload the persist state");
+
+  gsize size = 0;
+  guint8 version = 0;
+
+  return persist_state_lookup_entry(configuration->state, QUEUE_PERSIST_NAME, &size, &version) != 0;
+}
+
+/* acquire a queue, optionally feed it, release it, report what became of its file */
+static void
+_acquire_feed_release(gboolean reliable, gint front_cache_size, gint messages,
+                      gchar **filename, gboolean *file_survived, gboolean *entry_survived)
+{
+  LogDestDriver *driver = _dummy_dd_new(reliable, front_cache_size);
+
+  /* releasing consumes two references: ours and the one on the driver's list */
+  LogQueue *queue = log_queue_ref(log_dest_driver_acquire_queue(driver, QUEUE_PERSIST_NAME, STATS_LEVEL0, NULL, NULL));
+  cr_assert_not_null(queue, "failed to acquire a disk-buffer queue");
+
+  *filename = g_strdup(log_queue_disk_get_filename(queue));
+  cr_assert(_file_exists(*filename), "the queue file was not created: %s", *filename);
+
+  gchar *recorded = _persist_entry_value();
+  cr_assert_not_null(recorded, "acquiring the queue recorded no persist entry");
+  cr_assert_str_eq(recorded, *filename, "the persist entry names a different file than the queue uses");
+  g_free(recorded);
+
+  if (messages > 0)
+    feed_some_messages(queue, messages);
+
+  log_dest_driver_release_queue(driver, queue);
+
+  *file_survived = _file_exists(*filename);
+
+  _dummy_dd_free(driver);
+
+  *entry_survived = _entry_survives_a_reload();
+}
+
+Test(diskq_release, test_empty_reliable_queue_file_is_removed_with_its_persist_entry)
+{
+  gchar *filename = NULL;
+  gboolean file_survived, entry_survived;
+
+  _enter_workspace("empty_reliable");
+  _acquire_feed_release(TRUE, 0, 0, &filename, &file_survived, &entry_survived);
+
+  cr_assert_not(file_survived, "an empty reliable queue file was left behind: %s", filename);
+  cr_assert_not(entry_survived, "the persist entry outlived the file it names");
+
+  g_free(filename);
+}
+
+Test(diskq_release, test_reliable_queue_file_holding_a_message_is_kept)
+{
+  gchar *filename = NULL;
+  gboolean file_survived, entry_survived;
+
+  _enter_workspace("reliable_with_message");
+  _acquire_feed_release(TRUE, 0, 1, &filename, &file_survived, &entry_survived);
+
+  cr_assert(file_survived, "a reliable queue file holding a message was removed: %s", filename);
+  cr_assert(entry_survived, "the persist entry for a kept file was dropped");
+
+  unlink(filename);
+  g_free(filename);
+}
+
+Test(diskq_release, test_empty_non_reliable_queue_file_is_removed_with_its_persist_entry)
+{
+  gchar *filename = NULL;
+  gboolean file_survived, entry_survived;
+
+  _enter_workspace("empty_non_reliable");
+  _acquire_feed_release(FALSE, 0, 0, &filename, &file_survived, &entry_survived);
+
+  cr_assert_not(file_survived, "an empty non-reliable queue file was left behind: %s", filename);
+  cr_assert_not(entry_survived, "the persist entry outlived the file it names");
+
+  g_free(filename);
+}
+
+Test(diskq_release, test_non_reliable_queue_file_holding_a_message_is_kept)
+{
+  gchar *filename = NULL;
+  gboolean file_survived, entry_survived;
+
+  _enter_workspace("non_reliable_with_message");
+  _acquire_feed_release(FALSE, 0, 1, &filename, &file_survived, &entry_survived);
+
+  cr_assert(file_survived, "a non-reliable queue file holding a message was removed: %s", filename);
+  cr_assert(entry_survived, "the persist entry for a kept file was dropped");
+
+  unlink(filename);
+  g_free(filename);
+}
+
+/* the message is in the front cache, not in the qdisk part, so the qdisk length
+ * is zero while the file is not empty. stopping serializes the cache into the
+ * file, and the count that decides has to include it */
+Test(diskq_release, test_non_reliable_queue_file_holding_only_a_front_cached_message_is_kept)
+{
+  gchar *filename = NULL;
+  gboolean file_survived, entry_survived;
+
+  _enter_workspace("non_reliable_front_cache");
+  _acquire_feed_release(FALSE, 16, 1, &filename, &file_survived, &entry_survived);
+
+  cr_assert(file_survived,
+            "a non-reliable queue file holding a front-cached message was removed: %s", filename);
+  cr_assert(entry_survived, "the persist entry for a kept file was dropped");
+
+  unlink(filename);
+  g_free(filename);
+}

--- a/modules/diskq/tests/test_qdisk.c
+++ b/modules/diskq/tests/test_qdisk.c
@@ -139,7 +139,7 @@ Test(qdisk, test_qdisk_started)
   qdisk_start(qdisk, NULL, NULL, NULL);
   cr_assert(qdisk_started(qdisk));
 
-  qdisk_stop(qdisk, NULL, NULL, NULL);
+  qdisk_stop(qdisk, NULL, NULL, NULL, NULL);
   cr_assert_not(qdisk_started(qdisk));
 
   cleanup_qdisk(filename, qdisk);
@@ -162,7 +162,7 @@ Test(qdisk, qdisk_basic_push_pop)
 
   cr_assert_eq(qdisk_get_length(qdisk), 0);
 
-  qdisk_stop(qdisk, NULL, NULL, NULL);
+  qdisk_stop(qdisk, NULL, NULL, NULL, NULL);
   cleanup_qdisk(filename, qdisk);
 }
 
@@ -196,7 +196,7 @@ Test(qdisk, qdisk_is_space_avail)
   /* 1 byte of empty space (between backlog and write head) is reserved */
   cr_assert(qdisk_is_space_avail(qdisk, 100 - 1));
 
-  qdisk_stop(qdisk, NULL, NULL, NULL);
+  qdisk_stop(qdisk, NULL, NULL, NULL, NULL);
   g_string_free(data, TRUE);
   cleanup_qdisk(filename, qdisk);
 }
@@ -219,7 +219,7 @@ Test(qdisk, qdisk_remove_head)
 
   cr_assert_not(qdisk_remove_head(qdisk));
 
-  qdisk_stop(qdisk, NULL, NULL, NULL);
+  qdisk_stop(qdisk, NULL, NULL, NULL, NULL);
   cleanup_qdisk(filename, qdisk);
 }
 
@@ -257,7 +257,7 @@ Test(qdisk, qdisk_basic_ack_rewind)
   cr_assert_eq(qdisk_get_backlog_count(qdisk), 0);
   cr_assert_eq(qdisk_get_backlog_head(qdisk), qdisk_get_reader_head(qdisk));
 
-  qdisk_stop(qdisk, NULL, NULL, NULL);
+  qdisk_stop(qdisk, NULL, NULL, NULL, NULL);
   cleanup_qdisk(filename, qdisk);
 }
 
@@ -280,7 +280,7 @@ Test(qdisk, qdisk_empty_backlog)
 
   cr_assert_eq(qdisk_get_backlog_head(qdisk), qdisk_get_reader_head(qdisk));
 
-  qdisk_stop(qdisk, NULL, NULL, NULL);
+  qdisk_stop(qdisk, NULL, NULL, NULL, NULL);
   cleanup_qdisk(filename, qdisk);
 }
 
@@ -298,7 +298,7 @@ Test(qdisk, allow_writing_more_than_max_size_when_last_message_does_not_fit)
 
   cr_assert_geq(qdisk_get_file_size(qdisk), qdisk_get_maximum_size(qdisk));
 
-  qdisk_stop(qdisk, NULL, NULL, NULL);
+  qdisk_stop(qdisk, NULL, NULL, NULL, NULL);
   cleanup_qdisk(filename, qdisk);
 }
 
@@ -322,7 +322,7 @@ Test(qdisk, do_not_allow_diskq_to_exceed_max_size_if_last_message_fits)
   push_dummy_record(qdisk, 4);
   cr_assert_leq(qdisk_get_file_size(qdisk), qdisk_get_maximum_size(qdisk));
 
-  qdisk_stop(qdisk, NULL, NULL, NULL);
+  qdisk_stop(qdisk, NULL, NULL, NULL, NULL);
   g_string_free(data, TRUE);
   cleanup_qdisk(filename, qdisk);
 }
@@ -351,7 +351,7 @@ Test(qdisk, completely_full_and_then_emptied_qdisk_should_update_positions_prope
   cr_assert(push_dummy_record(qdisk, record_len));
   cr_assert(reliable_pop_record_without_backlog(qdisk, popped_data));
 
-  qdisk_stop(qdisk, NULL, NULL, NULL);
+  qdisk_stop(qdisk, NULL, NULL, NULL, NULL);
   g_string_free(popped_data, TRUE);
   cleanup_qdisk(filename, qdisk);
 }
@@ -378,7 +378,7 @@ Test(qdisk, prealloc)
                "qdisk size mismatch: actual=%"G_GINT64_FORMAT" expected=%"G_GINT64_FORMAT,
                actual, (gint64) MIN_CAPACITY_BYTES);
 
-  qdisk_stop(qdisk, NULL, NULL, NULL);
+  qdisk_stop(qdisk, NULL, NULL, NULL, NULL);
   cleanup_qdisk(filename, qdisk);
 }
 
@@ -515,7 +515,7 @@ Test(qdisk, get_empty_space_non_wrapped)
   // |---|------ ... --------------|---------|
   //      ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  cr_assert(qdisk_stop(qdisk, NULL, NULL, NULL));
+  cr_assert(qdisk_stop(qdisk, NULL, NULL, NULL, NULL));
   cleanup_qdisk(filename, qdisk);
 }
 
@@ -575,7 +575,7 @@ Test(qdisk, get_empty_space_wrapped)
   // 0   RESERVED                  DBS=W     B
   // |---|------ ... --------------|---------|
 
-  cr_assert(qdisk_stop(qdisk, NULL, NULL, NULL));
+  cr_assert(qdisk_stop(qdisk, NULL, NULL, NULL, NULL));
   cleanup_qdisk(filename, qdisk);
 }
 

--- a/news/bugfix-5749.md
+++ b/news/bugfix-5749.md
@@ -1,0 +1,5 @@
+`disk-buffer`: remove empty queue files when their destination is reaped
+
+A disk-buffer file whose destination has been torn down by `time-reap()` is now removed, together with its persist
+entry, when it holds no messages. Previously every expansion of a templated destination left a queue file behind
+permanently, which could exhaust the 10000 entry filename namespace on a long-running instance.

--- a/news/bugfix-5749.md
+++ b/news/bugfix-5749.md
@@ -1,5 +1,0 @@
-`disk-buffer`: remove empty queue files when their destination is reaped
-
-A disk-buffer file whose destination has been torn down by `time-reap()` is now removed, together with its persist
-entry, when it holds no messages. Previously every expansion of a templated destination left a queue file behind
-permanently, which could exhaust the 10000 entry filename namespace on a long-running instance.

--- a/news/feature-5749.md
+++ b/news/feature-5749.md
@@ -1,0 +1,4 @@
+`disk-buffer`: added the `remove-if-empty()` option, which removes a queue file and its persist entry when the
+destination that owns it is torn down by `time-reap()` and the queue holds no messages. It defaults to `no`, and it is
+meant for templated destinations whose expansions never come back, such as a path built from a receive-time date macro,
+where every date roll would otherwise leave queue files behind permanently.


### PR DESCRIPTION
## The problem

When a destination's filename is templated, each expansion gets its own `LogQueue` and its own disk-buffer file. When that destination is torn down by `time-reap()`, the queue file is left on disk and its persist entry is retained, **even when the queue is empty and every message it ever held has been delivered**.

With a receive-time date macro in the path, which is an ordinary way to write per-day files, the destination set turns over completely at every date roll. Every one of yesterday's destinations leaves an empty queue file behind, permanently, and nothing in the tree ever removes one. `qdisk_get_next_filename()` allocates out of a 10,000-entry namespace, so a spool accumulating a few hundred files a day walks into that ceiling on a schedule.

We hit it on a central-log receiver collecting from a fleet into `${PROGRAM}/${R_YEAR}-${R_MONTH}-${R_DAY}.log` with a reliable disk-buffer: roughly 300 to 500 new queue files a day, of which all but a handful were empty and unreachable. Occupancy reached 6,500 of 10,000 slots. Sweeping them by hand is possible (we do it, with an age floor and a measured-emptiness predicate) but it is a workaround for something the queue itself is in the best position to decide.

## The hook already exists and is dead code

`log_queue_disk_stop()` takes a `gboolean *persistent` out-parameter that answers exactly the question "should this queue be kept?". Both `_stop()` implementations set it to `TRUE` unconditionally on success, and **not one caller in the tree reads it**: `_release_queue()` in `diskq.c`, `diskq-global-metrics.c`, all three sites in `dqtool.c`, `_restart_diskq()` in `logqueue-disk.c`, and every test call site all discard it.

The primitives for the real decision exist too. `_number_of_messages()` in `qdisk.c` already computes the complete count, and it is the number `dqtool info` prints.

## The change

1. `qdisk_stop()` gains an optional `gboolean *has_messages` out-parameter, computed **after** `_save_state()` has written the in-memory queues back into the file and **before** `_close_file()` unmaps the header. It reports `TRUE` when saving the state failed, because then nothing was measured.
2. Both `_stop()` implementations pass that through as `*persistent`.
3. `_release_queue()` unlinks the queue file and removes its persist entry when `persistent` comes back `FALSE`, then drops the queue instead of stashing it in `cfg_persist_config`.

Emptiness, rather than "the destination is gone", is the predicate on purpose: syslog-ng cannot know whether `2026-08-07` will ever re-expand, and it does not need to. At teardown the queue either holds messages or it does not, and an empty disk buffer has nothing worth preserving, `reliable(yes)` included. A queue holding even one message is kept, entry included.

## What the count has to include, because the obvious helper is not enough

`qdisk_is_file_empty()` tests `hdr->length == 0 && hdr->backlog_len == 0`. For a non-reliable queue that is **not** the whole file: `_save_state()` serializes the front cache, the backlog and the flow-control window into it and records their counts in `hdr->front_cache_pos`, `hdr->backlog_pos` and `hdr->flow_control_window_pos`, none of which `qdisk_is_file_empty()` looks at. A predicate built on it deletes a non-reliable file holding a front-cached message.

So the patch uses `_number_of_messages()`, which is mode-aware and counts those positions. `test_non_reliable_queue_file_holding_only_a_front_cached_message_is_kept` is that case, and it fails if the predicate is switched to `qdisk_is_file_empty()`.

I have deliberately not changed `qdisk_is_file_empty()` itself, though its other two callers (`_autodetect_capacity_bytes()` and `qdisk_reset_file_if_empty()`) may want the same scrutiny. That felt like a separate question from this one.

## `persistent`'s contract, and the two ways it could have gone wrong

Because a `FALSE` now authorizes deleting a file, the contract has to be that `FALSE` means "stopped successfully and measured empty", and nothing weaker. Two existing paths could produce something weaker, and both are handled here:

- **`log_queue_disk_stop()` on a queue that was never started** returned `*persistent = FALSE`. Nothing was measured there, and the file may hold messages from a previous run, so it now reports `TRUE`.
- **Both `_stop()` implementations left `*persistent` untouched when `qdisk_stop()` failed**, so the caller read an uninitialized `gboolean`. They now default it to `TRUE` before doing anything.

Neither was a bug while every caller ignored the value. Both would have been one afterwards.

## Why the unlink and the persist entry have to move together

Leaving a persist entry that names a file which no longer exists is worse than leaving the file. We measured this in a container, on 4.8.1, with a shortened `time-reap`:

- Delete an empty reaped queue file and let the **same** destination re-expand: clean, it files normally.
- Delete it, let a **different** destination mint a queue and take the freed filename, then let the original destination return: the original follows its stale persist entry onto that filename, and two live destinations end up sharing one queue file. One `.rqf` on disk where two were expected, the file's content changing under the second attach, two persist entries naming one filename at shutdown, and **nothing logged at any severity**.

That is the failure mode this patch has to avoid creating, and it is why `_release_queue()` drops the entry in the same step rather than relying on a later cleanup.

## Alternative shape

If you would rather not change the default behavior, this fits behind a disk-buffer option cleanly (the decision is one boolean in `_release_queue()`), and I am happy to redo it that way. My argument for the default is that the current behavior has no upside: the file is empty, it is unreachable, and nothing in the tree will ever open it again.

## Tests

New `modules/diskq/tests/test_diskq_release.c`, registered in both the Makefile.am and CMake test lists. It drives a real `LogDestDriver` with a real persist state through acquire, feed, release, and asserts what became of the file and the entry:

- an empty reliable queue file is removed with its persist entry
- a reliable queue file holding one message is kept, entry included
- an empty non-reliable queue file is removed with its persist entry
- a non-reliable queue file holding one message is kept, entry included
- a non-reliable queue file holding only a front-cached message is kept

The "holding a message is kept" arms are the ones that must never regress, so they are asserted for both queue types.

**The test was run against unmodified upstream sources as a control**, with only the new test file and its build registration added. It compiles there with zero warnings, and over 16 trials (8 serial, 8 parallel) it reports `Passing: 3, Failing: 2, Crashing: 0` every time: the two "is removed" tests fail, naming the file that was left behind, and the three "is kept" tests pass. The failures are assertion failures rather than crashes, and they reach 14 of their 15 assertions before failing, so they run the whole scenario and fail only at the check that distinguishes the new behavior.

That control is a behavioral one over the diskq change as a whole rather than a per-hunk bisect.

## Build and test

Built and tested in a `debian:trixie` container (Debian 13.6, aarch64, gcc 14.2.0, CMake 3.31.6, Criterion 2.4.1, glib 2.84.4, libivykis 0.43.2), out of tree, from this branch on top of `ab74617`:

```
cmake -B /build -S . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DIVYKIS_SOURCE=system \
      -DDISABLE_ALL_MODULES=ON -DENABLE_TESTING=ON -DBUILD_TESTING=ON -DENABLE_FORCE_GNU99=ON
cmake --build /build -j
```

Build succeeds with **zero compiler warnings**. The diskq test binaries were run with the environment `cmake/set_testing.cmake` puts in `CTEST_ENVIRONMENT` (`G_SLICE=always-malloc,debug-blocks`, `G_DEBUG=fatal-warnings,fatal-criticals,gc-friendly`):

| Test binary | Synthesis |
|---|---|
| `test_diskq` | Tested: 8, Passing: 8 |
| `test_diskq_full` | Tested: 2, Passing: 2 |
| `test_diskq_truncate` | Tested: 9, Passing: 9 |
| `test_reliable_backlog` | Tested: 2, Passing: 2 |
| `test_qdisk` | Tested: 12, Passing: 12 |
| `test_logqueue_disk` | Tested: 4, Passing: 4 |
| `test_diskq_release` (new) | Tested: 5, Passing: 5 |
| `test_diskq_counters` | Tested: 2, Passing: 0, and identically so without this patch, see below |

The new binary was run **46 times at Criterion's default parallelism and 10 times serially, 5 of 5 every time**, rather than once. The count is worth stating because each of these five tests creates a persist file and a spool directory, and Criterion runs them in the working directory of the binary: a single green run cannot distinguish a suite that is isolated from one that merely avoided a collision. Each test therefore works in a directory of its own.

**`test_diskq_counters` fails identically with and without this patch**, on the same commit, in the same container, with byte-identical Criterion output: I built a pristine baseline with the modified files replaced by their `HEAD` versions and the new test removed, and it crashes 2/2 at the same two lines. It is a pre-existing interaction between this environment and the `G_DEBUG=fatal-warnings,fatal-criticals` that `set_testing.cmake` exports (it passes 2/2 with `G_DEBUG` unset), and this patch does not affect it. I have not tried to fix it here.

Style: `scripts/style-checker.sh check` with astyle 3.6.13 (the version pinned in `dbld/builddeps`; Debian's 3.1 predates the `--max-continuation-indent` in `.astylerc` and cannot check this tree) reports **0 badly formatted files**, with all changed files confirmed present in the scan as `Unchanged`.

## Related

- #5747, a file-descriptor leak in `_release_dirlock()`, is **independent** of this: the leaked descriptor is on the dirlock, `_release_dirlock()` does unlock it, and there is no coupling by which the leak prevents queue-file cleanup. They interact only in consequence: once the namespace is full, every allocation attempt fails and leaks, which is how a slow accumulation turns into a fast one.
- #5748, on `qdisk_get_next_filename()` scanning 10,000 slots while the filename format addresses 100,000. Fixing this PR makes that mostly moot for the templated-destination case, which is why it is filed separately rather than bundled here.
