### PR TITLE
cmake: define the libcap interface when caps are disabled

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -387,12 +387,15 @@ target_link_libraries(syslog-ng
     ${Libsystemd_LIBRARIES}
     ${LIBUNWIND_LIBRARIES}
     resolv
-    libcap
     OpenSSL::SSL
     OpenSSL::Crypto
     Threads::Threads
     secret-storage
 )
+
+if(SYSLOG_NG_ENABLE_LINUX_CAPS)
+  target_link_libraries(syslog-ng PUBLIC libcap)
+endif()
 
 set_target_properties(syslog-ng
     PROPERTIES VERSION ${SYSLOG_NG_VERSION}


### PR DESCRIPTION
-DENABLE_LINUX_CAPS=OFF currently fails to link because
lib/CMakeLists.txt references the libcap target unconditionally.

Normally this works because FindLIBCAP.cmake always defines an
INTERFACE target, even when libcap is not installed. However,
enable_caps.cmake returns early when capabilities are disabled,
so find_package(LIBCAP) is never reached and the target is not
created.

CMake consequently treats libcap as a regular library name and
adds -llibcap to the link command.

Define the same empty interface in the disabled branch so the target
always exists.

Reproduced and verified with a cross-build of syslog-ng 4.12.0 for
powerpc_8548 (musl, no libcap) using -DENABLE_LINUX_CAPS=OFF.
The build fails without the change and completes successfully with it.