### PR TITLE
pdbtool: keep the source directory out of shipped binaries

### DIFF
--- a/modules/correlation/pdb-file.c
+++ b/modules/correlation/pdb-file.c
@@ -82,21 +82,10 @@ exit:
 }
 
 static const gchar *
-_get_xsddir_in_build(void)
-{
-  static gchar path[256];
-
-  g_snprintf(path, sizeof(path), "%s/doc/xsd", SYSLOG_NG_PATH_TOPSRC_DIR);
-  return path;
-}
-
-static const gchar *
 _get_xsddir_in_production(void)
 {
   return get_installation_path_for(SYSLOG_NG_PATH_XSDDIR);
 }
-
-typedef const gchar *(*PdbGetXsdDirFunc) (void);
 
 static gchar *
 _get_xsd_file(gint version, PdbGetXsdDirFunc get_xsd_dir)
@@ -104,8 +93,8 @@ _get_xsd_file(gint version, PdbGetXsdDirFunc get_xsd_dir)
   return g_strdup_printf("%s/patterndb-%d.xsd", get_xsd_dir(), version);
 }
 
-static gboolean
-_pdb_file_validate(const gchar *filename, GError **error, PdbGetXsdDirFunc get_xsd_dir)
+gboolean
+pdb_file_validate(const gchar *filename, GError **error, PdbGetXsdDirFunc get_xsd_dir)
 {
   gchar *xmllint_cmdline;
   gint version;
@@ -118,6 +107,9 @@ _pdb_file_validate(const gchar *filename, GError **error, PdbGetXsdDirFunc get_x
   version = pdb_file_detect_version(filename, error);
   if (!version)
     return FALSE;
+
+  if (!get_xsd_dir)
+    get_xsd_dir = _get_xsddir_in_production;
 
   xsd_file = _get_xsd_file(version, get_xsd_dir);
   if (!is_file_regular(xsd_file))
@@ -152,18 +144,6 @@ _pdb_file_validate(const gchar *filename, GError **error, PdbGetXsdDirFunc get_x
   g_free(xmllint_cmdline);
   g_free(stderr_content);
   return TRUE;
-}
-
-gboolean
-pdb_file_validate(const gchar *filename, GError **error)
-{
-  return _pdb_file_validate(filename, error, _get_xsddir_in_production);
-}
-
-gboolean
-pdb_file_validate_in_tests(const gchar *filename, GError **error)
-{
-  return _pdb_file_validate(filename, error, _get_xsddir_in_build);
 }
 
 GPtrArray *

--- a/modules/correlation/pdb-file.h
+++ b/modules/correlation/pdb-file.h
@@ -26,9 +26,11 @@
 
 #include "syslog-ng.h"
 
+typedef const gchar *(*PdbGetXsdDirFunc) (void);
+
 gint pdb_file_detect_version(const gchar *pdbfile, GError **error);
-gboolean pdb_file_validate(const gchar *filename, GError **error);
-gboolean pdb_file_validate_in_tests(const gchar *filename, GError **error);
+/* get_xsd_dir may be NULL to validate against the installed XSD directory */
+gboolean pdb_file_validate(const gchar *filename, GError **error, PdbGetXsdDirFunc get_xsd_dir);
 GPtrArray *pdb_get_filenames(const gchar *dir_path, gboolean recursive, gchar *pattern, GError **error);
 void pdb_sort_filenames(GPtrArray *filenames);
 

--- a/modules/correlation/pdbtool/pdbtool.c
+++ b/modules/correlation/pdbtool/pdbtool.c
@@ -848,7 +848,7 @@ pdbtool_test(int argc, char *argv[])
         {
           GError *error = NULL;
 
-          if (!pdb_file_validate(argv[arg_pos], &error))
+          if (!pdb_file_validate(argv[arg_pos], &error, NULL))
             {
               fprintf(stderr, "%s: error validating pdb file: %s\n", argv[arg_pos], error->message);
               g_clear_error(&error);

--- a/modules/correlation/tests/test_patterndb.c
+++ b/modules/correlation/tests/test_patterndb.c
@@ -60,13 +60,19 @@ _emit_func(LogMessage *msg, gpointer user_data)
   g_ptr_array_add(messages, log_msg_ref(msg));
 }
 
+static const gchar *
+_get_xsddir_in_build(void)
+{
+  return SYSLOG_NG_PATH_TOPSRC_DIR "/doc/xsd";
+}
+
 static void
 assert_pdb_file_valid(const gchar *filename_)
 {
   GError *error = NULL;
   gboolean success;
 
-  success = pdb_file_validate_in_tests(filename_, &error);
+  success = pdb_file_validate(filename_, &error, _get_xsddir_in_build);
   cr_assert(success, "Error validating patterndb, error=%s\n", error ? error->message : "unknown");
   g_clear_error(&error);
 }


### PR DESCRIPTION
`SYSLOG_NG_PATH_TOPSRC_DIR` is set from the absolute source path
(`configure.ac` via `$abs_topsrcdir`, `CMakeLists.txt` via
`PROJECT_SOURCE_DIR`). The only code using it is `_get_xsddir_in_build()`
in `modules/correlation/pdb-file.c`, which is reachable only through
`pdb_file_validate_in_tests()`, and that is called only from
`modules/correlation/tests/test_patterndb.c`.

It nevertheless ends up in `libcorrelation.so` and `pdbtool`, so the
released binaries contain the absolute path of the build machine. The
OpenWrt package CI reports both files as containing a hardcoded build
path.

Pass the directory in from the caller, so the test provides it and the
shipped code no longer references the macro. No build system changes are
needed, since the test already sees `syslog-ng-config.h`.

Verified on a cross-build of 4.12.0 for powerpc_8548: before the change,
both binaries contain the source path; after it, neither does. The
production lookup through `SYSLOG_NG_PATH_XSDDIR` is unchanged.