### PR TITLE
dbld: Handle dnf5-relocated Fedora repo files in workaround_rpm_repos

### DIFF
--- a/dbld/builddeps
+++ b/dbld/builddeps
@@ -101,10 +101,19 @@ function workaround_rpm_repos() {
     case "${OS_DISTRIBUTION}" in
         fedora)
             # Workaround for often getting 503 from mirrors.fedoraproject.org.
-            sed -i -e "/baseurl/c\baseurl=${MIRROR_URL}/releases/\$releasever/Everything/\$basearch/os/" /etc/yum.repos.d/fedora.repo
-            sed -i -e "/baseurl/c\baseurl=${MIRROR_URL}/updates/\$releasever/Everything/\$basearch/" /etc/yum.repos.d/fedora-updates.repo
+            # Repo file locations moved between Fedora releases (dnf5), so let
+            # dnf5 itself resolve/persist the override instead of guessing paths.
+            BASE_REPO_ID=fedora
+            BASE_REPO_PATH="${MIRROR_URL}/releases/\$releasever/Everything/\$basearch/os/"
+            if dnf5 repolist --all 2>/dev/null | awk '{print $1}' | grep -qx rawhide; then
+                BASE_REPO_ID=rawhide
+                BASE_REPO_PATH="${MIRROR_URL}/development/rawhide/Everything/\$basearch/os/"
+            fi
+
+            dnf5 config-manager setopt "${BASE_REPO_ID}.baseurl=${BASE_REPO_PATH}"
+            dnf5 config-manager setopt "updates.baseurl=${MIRROR_URL}/updates/\$releasever/Everything/\$basearch/"
             # we don't need h264 codecs
-            sed -i -e "/enabled/c\enabled=0" /etc/yum.repos.d/fedora-cisco-openh264.repo
+            dnf5 config-manager setopt fedora-cisco-openh264.enabled=0
             ;;
     esac
 }


### PR DESCRIPTION
<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->
Fedora is transitioning from storing repositories in a legacy yum directory to native dnf5. This PR adapts the changes to builddeps.

<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
