### PR TITLE
logwriter: fix reconnect hang on deferred reopen

### DIFF
--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -237,6 +237,12 @@ log_writer_work_finished(gpointer s, gpointer arg)
   main_loop_assert_main_thread();
   self->waiting_for_throttle = FALSE;
 
+  msg_trace("log_writer_work_finished",
+            evt_tag_int("pending_proto_present", self->pending_proto_present),
+            evt_tag_int("work_result", self->work_result),
+            evt_tag_int("proto_is_set", self->proto != NULL),
+            evt_tag_int("watches_running", self->watches_running));
+
   if (self->pending_proto_present)
     {
       /* pending proto is only set in the main thread, so no need to
@@ -277,6 +283,10 @@ log_writer_work_finished(gpointer s, gpointer arg)
     {
       /* reenable polling the source, but only if we're still initialized */
       log_writer_start_watches(self);
+    }
+  else if ((self->super.flags & PIF_INITIALIZED) && !self->watches_running)
+    {
+      log_pipe_notify(self->control, NC_REOPEN_REQUIRED, self);
     }
 }
 
@@ -1138,6 +1148,10 @@ log_writer_format_log(LogWriter *self, LogMessage *lm, GString *result)
 static void
 log_writer_broken(LogWriter *self, gint notify_code)
 {
+  msg_trace("log_writer_broken",
+            evt_tag_int("notify_code", notify_code),
+            evt_tag_int("proto_is_set", self->proto != NULL),
+            evt_tag_int("watches_running", self->watches_running));
   log_writer_stop_watches(self);
   log_pipe_notify(self->control, notify_code, self);
 }
@@ -1808,6 +1822,11 @@ log_writer_reopen_deferred(gpointer s)
   gpointer *args = (gpointer *) s;
   LogWriter *self = args[0];
   LogProtoClient *proto = args[1];
+
+  msg_trace("log_writer_reopen_deferred",
+            evt_tag_int("proto_is_set", proto != NULL),
+            evt_tag_int("io_job_working", self->io_job.working),
+            evt_tag_int("watches_running", self->watches_running));
 
   if (!proto)
     {

--- a/lib/logwriter.c
+++ b/lib/logwriter.c
@@ -22,6 +22,8 @@
  *
  */
 
+#define LOGWRITER_TEST_PRIVATE
+
 #include "logwriter.h"
 #include "messages.h"
 #include "stats/stats-registry.h"
@@ -2122,4 +2124,30 @@ gboolean
 log_writer_options_process_flag(LogWriterOptions *options, const gchar *flag)
 {
   return cfg_process_flag(log_writer_flag_handlers, options, flag);
+}
+
+void
+log_writer_test_set_io_job_working(LogWriter *self, gboolean working)
+{
+  self->io_job.working = working;
+}
+
+void
+log_writer_test_call_reopen_deferred(LogWriter *self, LogProtoClient *proto)
+{
+  gpointer args[] = { self, proto };
+  log_writer_reopen_deferred(args);
+}
+
+void
+log_writer_test_simulate_io_job_completion(LogWriter *self, LogProtoStatus work_result)
+{
+  self->work_result = work_result;
+  log_writer_work_finished(self, NULL);
+}
+
+gboolean
+log_writer_test_get_watches_running(LogWriter *self)
+{
+  return self->watches_running;
 }

--- a/lib/logwriter.h
+++ b/lib/logwriter.h
@@ -98,4 +98,13 @@ void log_writer_options_destroy(LogWriterOptions *options);
 void log_writer_options_set_mark_mode(LogWriterOptions *options, const gchar *mark_mode);
 gboolean log_writer_options_process_flag(LogWriterOptions *options, const gchar *flag);
 
+#ifdef LOGWRITER_TEST_PRIVATE
+
+void log_writer_test_set_io_job_working(LogWriter *self, gboolean working);
+void log_writer_test_call_reopen_deferred(LogWriter *self, LogProtoClient *proto);
+void log_writer_test_simulate_io_job_completion(LogWriter *self, LogProtoStatus work_result);
+gboolean log_writer_test_get_watches_running(LogWriter *self);
+
+#endif
+
 #endif

--- a/lib/tests/test_logwriter.c
+++ b/lib/tests/test_logwriter.c
@@ -23,6 +23,8 @@
 
 #include <criterion/criterion.h>
 
+#define LOGWRITER_TEST_PRIVATE
+
 #include "logwriter.h"
 #include "logmsg/logmsg.h"
 #include "template/templates.h"
@@ -228,6 +230,89 @@ Test(logwriter, test_logwriter)
     _assert_logwriter_output(test_cases[i]);
 
   msg_format_options_destroy(&parse_options);
+  app_shutdown();
+  iv_deinit();
+  cfg_free(configuration);
+}
+
+/* Regression test for a reconnect hang: log_writer_reopen_deferred() can
+ * defer applying a NULL LogProtoClient while the writer's I/O job is still
+ * in flight (e.g. a connection break detected concurrently with an
+ * in-progress write). When that job later completes,
+ * log_writer_work_finished() must not silently leave the writer with no
+ * proto and no watches running -- it has to request a reconnect,
+ * otherwise nothing would ever wake the writer up again. */
+
+typedef struct _MockControlPipe
+{
+  LogPipe super;
+  gint notify_count;
+  gint last_notify_code;
+} MockControlPipe;
+
+static gint
+_mock_control_pipe_notify(LogPipe *s, gint notify_code, gpointer user_data)
+{
+  MockControlPipe *self = (MockControlPipe *) s;
+
+  self->notify_count++;
+  self->last_notify_code = notify_code;
+  return NR_OK;
+}
+
+static MockControlPipe *
+_mock_control_pipe_new(GlobalConfig *cfg)
+{
+  MockControlPipe *self = g_new0(MockControlPipe, 1);
+
+  log_pipe_init_instance(&self->super, cfg);
+  self->super.notify = _mock_control_pipe_notify;
+  self->last_notify_code = -1;
+  return self;
+}
+
+Test(logwriter, test_logwriter_requests_reconnect_after_reopen_deferred_during_active_io_job)
+{
+  configuration = cfg_new_snippet();
+  app_startup();
+
+  LogWriterOptions opt = {0};
+  log_writer_options_defaults(&opt);
+  log_writer_options_init(&opt, configuration, LWO_NO_STATS);
+
+  LogQueue *queue = log_queue_fifo_new(1000, NULL, STATS_LEVEL0, NULL, NULL);
+  LogWriter *writer = log_writer_new(0, configuration);
+  MockControlPipe *control = _mock_control_pipe_new(configuration);
+
+  log_writer_set_options(writer, &control->super, &opt, NULL, NULL);
+  log_writer_set_queue(writer, queue);
+  cr_assert(log_pipe_init((LogPipe *) writer), "LogWriter initialization failed");
+
+  /* A connection break arrives while the writer's I/O job is still
+   * considered in flight -- log_writer_reopen_deferred() must take the
+   * deferred branch instead of applying the NULL proto immediately. */
+  log_writer_test_set_io_job_working(writer, TRUE);
+  log_writer_test_call_reopen_deferred(writer, NULL);
+  cr_assert_not(log_writer_test_get_watches_running(writer),
+                "watches must not be running while a reopen is still deferred");
+
+  /* The in-flight job now completes. This applies the deferred NULL proto
+   * and used to leave the writer stuck forever with no proto and no
+   * watches running -- it must request a reconnect instead. */
+  log_writer_test_simulate_io_job_completion(writer, LPS_SUCCESS);
+
+  cr_assert_eq(control->notify_count, 1,
+               "expected exactly one notification requesting a reconnect after the deferred NULL proto was applied");
+  cr_assert_eq(control->last_notify_code, NC_REOPEN_REQUIRED,
+               "log_writer_work_finished() must request a reconnect (NC_REOPEN_REQUIRED) after applying a deferred "
+               "NULL proto, otherwise the writer is left stuck with no fd watch and no timer to wake it up again");
+
+  cr_expect(log_pipe_deinit((LogPipe *) writer));
+  log_pipe_unref((LogPipe *) writer);
+  log_pipe_unref(&control->super);
+  log_queue_unref(queue);
+  log_writer_options_destroy(&opt);
+
   app_shutdown();
   iv_deinit();
   cfg_free(configuration);

--- a/modules/afsocket/afsocket-dest.c
+++ b/modules/afsocket/afsocket-dest.c
@@ -350,6 +350,9 @@ afsocket_dd_start_connect(AFSocketDestDriver *self)
 
   main_loop_assert_main_thread();
 
+  msg_trace("afsocket_dd_start_connect",
+            evt_tag_int("log_writer_opened", log_writer_opened(self->writer)));
+
   if (log_writer_opened(self->writer))
     return TRUE;
 
@@ -760,6 +763,9 @@ afsocket_dd_notify(LogPipe *s, gint notify_code, gpointer user_data)
   AFSocketDestDriver *self = (AFSocketDestDriver *) s;
   gchar buf[MAX_SOCKADDR_STRING];
 
+  msg_trace("afsocket_dd_notify",
+            evt_tag_int("notify_code", notify_code));
+
   switch (notify_code)
     {
     case NC_CLOSE:
@@ -770,6 +776,9 @@ afsocket_dd_notify(LogPipe *s, gint notify_code, gpointer user_data)
                  evt_tag_int("fd", self->fd),
                  evt_tag_str("server", g_sockaddr_format(self->dest_addr, buf, sizeof(buf), GSA_FULL)),
                  evt_tag_int("time_reopen", self->writer_options.time_reopen));
+      afsocket_dd_start_reconnect_timer(self);
+      break;
+    case NC_REOPEN_REQUIRED:
       afsocket_dd_start_reconnect_timer(self);
       break;
     default:


### PR DESCRIPTION
<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->

Fixes a hang where a logwriter reconnect could get stuck if a reopen was deferred while an I/O job was active. Includes a regression test.
<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
