### PR TITLE
diskq: fix message memory-accounting drift

### DIFF
--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -660,6 +660,8 @@ log_msg_unset_value(LogMessage *self, NVHandle handle)
     {
       self->payload = nv_table_clone(self->payload, 0);
       log_msg_set_flag(self, LF_STATE_OWN_PAYLOAD);
+      self->allocated_bytes += self->payload->size;
+      stats_counter_add(count_allocated_bytes, self->payload->size);
     }
 
   while (!nv_table_unset_value(self->payload, handle))

--- a/lib/logmsg/logmsg.c
+++ b/lib/logmsg/logmsg.c
@@ -728,6 +728,8 @@ log_msg_set_value_indirect_with_type(LogMessage *self, NVHandle handle,
     {
       self->payload = nv_table_clone(self->payload, name_len + 1);
       log_msg_set_flag(self, LF_STATE_OWN_PAYLOAD);
+      self->allocated_bytes += self->payload->size;
+      stats_counter_add(count_allocated_bytes, self->payload->size);
     }
 
   NVReferencedSlice referenced_slice =
@@ -740,6 +742,7 @@ log_msg_set_value_indirect_with_type(LogMessage *self, NVHandle handle,
   while (!nv_table_add_value_indirect(self->payload, handle, name, name_len, &referenced_slice, type, &new_entry))
     {
       /* error allocating string in payload, reallocate */
+      guint32 old_size = self->payload->size;
       if (!nv_table_realloc(self->payload, &self->payload))
         {
           /* error growing the payload, skip without storing the value */
@@ -748,6 +751,9 @@ log_msg_set_value_indirect_with_type(LogMessage *self, NVHandle handle,
                    evt_tag_str("ref-name", log_msg_get_value_name(ref_handle, NULL)));
           break;
         }
+      guint32 new_size = self->payload->size;
+      self->allocated_bytes += (new_size - old_size);
+      stats_counter_add(count_allocated_bytes, new_size-old_size);
       stats_counter_inc(count_payload_reallocs);
     }
 

--- a/lib/tests/test_clone_logmsg.c
+++ b/lib/tests/test_clone_logmsg.c
@@ -138,3 +138,50 @@ ParameterizedTest(CloneLogMessageParam *param, clone_logmsg, test_cloning_with_l
   log_msg_unref(log_message);
   log_msg_unref(original_log_message);
 }
+
+Test(clone_logmsg, test_unset_value_accounts_for_newly_owned_payload_like_set_value_does)
+{
+  const gchar *msg_str =
+    "<7>1 2006-10-29T01:59:59.156+01:00 mymachine.example.com evntslog - ID47 "
+    "[exampleSDID@0 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"] BOMAn application event log entry...";
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+  LogMessage *original, *clone_for_unset, *clone_for_set;
+  NVHandle handle;
+
+  parse_options.flags = LP_SYSLOG_PROTOCOL;
+  path_options.ack_needed = FALSE;
+
+  handle = log_msg_get_value_handle(".SDATA.exampleSDID@0.iut");
+
+  original = msg_format_parse(&parse_options, (const guchar *) msg_str, strlen(msg_str));
+  clone_for_unset = log_msg_clone_cow(original, &path_options);
+  cr_assert_not((clone_for_unset->flags & LF_STATE_OWN_PAYLOAD),
+                "test precondition: a fresh clone must not yet own its payload");
+
+  gsize allocated_bytes_before_unset = clone_for_unset->allocated_bytes;
+  log_msg_unset_value(clone_for_unset, handle);
+  cr_assert((clone_for_unset->flags & LF_STATE_OWN_PAYLOAD),
+            "test precondition: unset_value() must have taken payload ownership");
+
+  cr_assert_gt(clone_for_unset->allocated_bytes, allocated_bytes_before_unset,
+               "log_msg_unset_value() must add the newly-owned payload's size to allocated_bytes");
+
+  log_msg_unref(clone_for_unset);
+  log_msg_unref(original);
+
+  original = msg_format_parse(&parse_options, (const guchar *) msg_str, strlen(msg_str));
+  clone_for_set = log_msg_clone_cow(original, &path_options);
+  cr_assert_not((clone_for_set->flags & LF_STATE_OWN_PAYLOAD),
+                "test precondition: a fresh clone must not yet own its payload");
+
+  gsize allocated_bytes_before_set = clone_for_set->allocated_bytes;
+  log_msg_set_value(clone_for_set, handle, "5", -1);
+  cr_assert((clone_for_set->flags & LF_STATE_OWN_PAYLOAD),
+            "test precondition: set_value() must have taken payload ownership");
+
+  cr_assert_gt(clone_for_set->allocated_bytes, allocated_bytes_before_set,
+               "sanity check: set_value()'s ownership-transition accounting must work");
+
+  log_msg_unref(clone_for_set);
+  log_msg_unref(original);
+}

--- a/lib/tests/test_clone_logmsg.c
+++ b/lib/tests/test_clone_logmsg.c
@@ -185,3 +185,35 @@ Test(clone_logmsg, test_unset_value_accounts_for_newly_owned_payload_like_set_va
   log_msg_unref(clone_for_set);
   log_msg_unref(original);
 }
+
+Test(clone_logmsg, test_set_value_indirect_accounts_for_newly_owned_payload_like_set_value_does)
+{
+  const gchar *msg_str =
+    "<7>1 2006-10-29T01:59:59.156+01:00 mymachine.example.com evntslog - ID47 "
+    "[exampleSDID@0 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"] BOMAn application event log entry...";
+  LogPathOptions path_options = LOG_PATH_OPTIONS_INIT;
+  LogMessage *original, *clone;
+  NVHandle ref_handle, indirect_handle;
+
+  parse_options.flags = LP_SYSLOG_PROTOCOL;
+  path_options.ack_needed = FALSE;
+
+  ref_handle = LM_V_MESSAGE;
+  indirect_handle = log_msg_get_value_handle("newindirectvalue");
+
+  original = msg_format_parse(&parse_options, (const guchar *) msg_str, strlen(msg_str));
+  clone = log_msg_clone_cow(original, &path_options);
+  cr_assert_not((clone->flags & LF_STATE_OWN_PAYLOAD),
+                "test precondition: a fresh clone must not yet own its payload");
+
+  gsize allocated_bytes_before = clone->allocated_bytes;
+  log_msg_set_value_indirect(clone, indirect_handle, ref_handle, 0, 3);
+  cr_assert((clone->flags & LF_STATE_OWN_PAYLOAD),
+            "test precondition: set_value_indirect() must have taken payload ownership");
+
+  cr_assert_gt(clone->allocated_bytes, allocated_bytes_before,
+               "log_msg_set_value_indirect_with_type() must add the newly-owned payload's size to allocated_bytes");
+
+  log_msg_unref(clone);
+  log_msg_unref(original);
+}

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -267,6 +267,8 @@ _pop_head_flow_control_window(LogQueueDiskNonReliable *self, LogPathOptions *pat
 static inline void
 _push_tail_backlog(LogQueueDiskNonReliable *self, LogMessage *msg, LogPathOptions *path_options)
 {
+  log_msg_write_protect(msg);
+
   log_msg_ref(msg);
   g_queue_push_tail(self->backlog, msg);
   g_queue_push_tail(self->backlog, LOG_PATH_OPTIONS_TO_POINTER(path_options));

--- a/modules/diskq/logqueue-disk-non-reliable.c
+++ b/modules/diskq/logqueue-disk-non-reliable.c
@@ -441,6 +441,8 @@ _push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
         }
     }
 
+  log_msg_write_protect(msg);
+
   g_mutex_lock(&s->lock);
 
   /* we push messages into queue segments in the following order: flow_control_window, disk, front_cache */

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -271,6 +271,7 @@ _pop_head(LogQueue *s, LogPathOptions *path_options)
         qdisk_corrupt = TRUE;
 
       /* push to backlog */
+      log_msg_write_protect(msg);
       log_msg_ref(msg);
       _push_to_memory_queue_tail(self->backlog, position, msg, path_options);
       log_queue_memory_usage_add(s, log_msg_get_size(msg));

--- a/modules/diskq/logqueue-disk-reliable.c
+++ b/modules/diskq/logqueue-disk-reliable.c
@@ -373,6 +373,8 @@ _push_tail(LogQueue *s, LogMessage *msg, const LogPathOptions *path_options)
 
   scratch_buffers_reclaim_marked(marker);
 
+  log_msg_write_protect(msg);
+
   if (_is_reserved_buffer_size_reached(self))
     {
       /*


### PR DESCRIPTION
<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->

log_msg_unset_value() and log_msg_set_value_indirect_with_type() take ownership of a shared payload (like set_value_with_type() does) but never counted the clone toward allocated_bytes/count_allocated_bytes. Disk-buffer queues also never write-protected messages kept alive in front_cache/flow_control_window/backlog, unlike logqueue-fifo.c, allowing in-place mutation to drift memory_usage accounting. Adds the missing accounting and write-protection.
<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
