### PR TITLE
affile: Fix return value in logrotate transient reopen retry

### DIFF
--- a/modules/affile/affile-dest.c
+++ b/modules/affile/affile-dest.c
@@ -273,7 +273,7 @@ affile_dw_logrotate(AFFileDestWriter *self, gpointer user_data)
               gpointer result = main_loop_call((MainLoopTaskFunc) affile_dw_reopen, (gpointer) self, TRUE);
               FileOpenerResult success = GPOINTER_TO_INT(result);
               logrotate_options->pending = ((FileOpenerResult) success != FILE_OPENER_RESULT_SUCCESS);
-              return success;
+              return (success == FILE_OPENER_RESULT_SUCCESS);
             }
           else
             {


### PR DESCRIPTION
The main_loop_call retry path returned the raw FileOpenerResult enum (SUCCESS=0) as a gboolean, making success look like FALSE to the caller. This caused NR_ERROR to be returned on a successful reopen, incorrectly suspending the writer for time_reopen (60s) and causing the logrotate functional test to time out intermittently.
