### PR TITLE
crypto: Stop OpenSSL thread state on teardown

### DIFF
--- a/lib/apphook.c
+++ b/lib/apphook.c
@@ -291,6 +291,7 @@ app_shutdown(void)
   dns_caching_thread_deinit();
   dns_caching_global_deinit();
   hostname_global_deinit();
+  crypto_thread_deinit();
   crypto_deinit();
   msg_deinit();
 
@@ -355,4 +356,5 @@ app_thread_stop(void)
   dns_caching_thread_deinit();
   scratch_buffers_allocator_deinit();
   timeutils_cache_deinit();
+  crypto_thread_deinit();
 }

--- a/lib/crypto.c
+++ b/lib/crypto.c
@@ -59,6 +59,14 @@ crypto_deinit(void)
 }
 
 void
+crypto_thread_deinit(void)
+{
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+  OPENSSL_thread_stop();
+#endif
+}
+
+void
 crypto_init(void)
 {
   openssl_init();

--- a/lib/crypto.h
+++ b/lib/crypto.h
@@ -27,6 +27,7 @@
 #include "syslog-ng.h"
 
 void crypto_init(void);
+void crypto_thread_deinit(void);
 void crypto_deinit(void);
 
 #endif

--- a/news/bugfix-5775.md
+++ b/news/bugfix-5775.md
@@ -1,0 +1,1 @@
+`crypto`: Fixed intermittent crashes during OpenSSL thread cleanup when syslog-ng shut down or restarted.


### PR DESCRIPTION
RHEL 9 reported intermittent syslog-ng crashes in OpenSSL thread cleanup after ALTP/TLS restart tests completed message delivery.
