### PR TITLE
http: reset batch after header callback failure

### DIFF
--- a/modules/http/http-worker.c
+++ b/modules/http/http-worker.c
@@ -578,6 +578,17 @@ _finish_request_body(HTTPDestinationWorker *self)
 }
 
 static void
+_reset_request(HTTPDestinationWorker *self)
+{
+  _reinit_request_headers(self);
+  _reinit_request_body(self);
+  _reinit_response_headers(self);
+
+  log_msg_unref(self->msg_for_templated_url);
+  self->msg_for_templated_url = NULL;
+}
+
+static void
 _debug_response_info(HTTPDestinationWorker *self, const gchar *url, glong http_code)
 {
   HTTPDestinationDriver *owner = (HTTPDestinationDriver *) self->super.owner;
@@ -875,7 +886,10 @@ _flush(LogThreadedDestWorker *s, LogThreadedFlushMode mode)
   if (!_try_format_request_headers(self, &error))
     {
       if (!_format_request_headers_catch_error(&error))
-        return LTR_NOT_CONNECTED;
+        {
+          _reset_request(self);
+          return LTR_NOT_CONNECTED;
+        }
     }
 
   target = http_load_balancer_choose_target(owner->load_balancer, &self->lbc);
@@ -918,12 +932,7 @@ _flush(LogThreadedDestWorker *s, LogThreadedFlushMode mode)
       url = alt_url;
     }
 
-  _reinit_request_headers(self);
-  _reinit_request_body(self);
-  _reinit_response_headers(self);
-
-  log_msg_unref(self->msg_for_templated_url);
-  self->msg_for_templated_url = NULL;
+  _reset_request(self);
 
   return retval;
 }

--- a/modules/http/tests/test_http-signal_slot.c
+++ b/modules/http/tests/test_http-signal_slot.c
@@ -70,6 +70,7 @@ _generate_message(HTTPDestinationDriver *dd, const gchar *msg_str)
 }
 
 gboolean signal_slot_executed;
+guint signal_slot_execution_count;
 
 static void
 _sleep_msec(long msec)
@@ -100,6 +101,16 @@ _check(const gchar *expected_body, HttpHeaderRequestSignalData *data)
   cr_assert_str_eq(data->request_body->str, expected_body);
 
   notify_signal_slot_finish();
+}
+
+static void
+_fail_header_request_and_check_retried_body(const gchar *expected_body, HttpHeaderRequestSignalData *data)
+{
+  cr_assert_str_eq(data->request_body->str, expected_body);
+
+  data->result = HTTP_SLOT_CRITICAL_ERROR;
+  if (++signal_slot_execution_count == 2)
+    notify_signal_slot_finish();
 }
 
 Test(test_http_signal_slot, basic)
@@ -146,6 +157,29 @@ Test(test_http_signal_slot, batch_with_prefix_suffix)
   SignalSlotConnector *ssc = driver->super.super.super.signal_slot_connector;
 
   CONNECT(ssc, signal_http_header_request, _check, "[1,2]");
+
+  cr_assert(log_pipe_init((LogPipe *)driver));
+  cr_assert(log_pipe_post_config_init((LogPipe *)driver));
+
+  _generate_message(driver, "1");
+  _generate_message(driver, "2");
+
+  wait_for_signal_slot_to_finish();
+}
+
+Test(test_http_signal_slot, batch_is_reinitialized_after_critical_header_error)
+{
+  http_dd_set_body_prefix((LogDriver *)driver, "[");
+  http_dd_set_body_suffix((LogDriver *)driver, "]");
+  http_dd_set_delimiter((LogDriver *)driver, ",");
+  log_threaded_dest_driver_set_batch_lines((LogDriver *)driver, 2);
+  log_threaded_dest_driver_set_batch_timeout((LogDriver *)driver, 1000);
+  log_threaded_dest_driver_set_time_reopen((LogDriver *)driver, 1);
+
+  SignalSlotConnector *ssc = driver->super.super.super.signal_slot_connector;
+
+  signal_slot_execution_count = 0;
+  CONNECT(ssc, signal_http_header_request, _fail_header_request_and_check_retried_body, "[1,2]");
 
   cr_assert(log_pipe_init((LogPipe *)driver));
   cr_assert(log_pipe_post_config_init((LogPipe *)driver));

--- a/news/bugfix-5777.md
+++ b/news/bugfix-5777.md
@@ -1,0 +1,2 @@
+`http`: Fixed a bug where a message retried after a critical header callback failure was appended to the
+already-finished request body. All per-request state is now reset before returning on such errors.


### PR DESCRIPTION
A critical header callback error returned before request cleanup, so retried messages were appended to the already-finished body. Reset all per-request state before returning and cover the retry with a batched regression test.

<!--
Thank you for contributing to syslog-ng. Please make sure you:
- Read our Contribution guideline: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md
- Checked that tests pass (including stylechecks: `make style-check`)
- Wrote a news file, if applicable: https://github.com/syslog-ng/syslog-ng/tree/master/news
-->


<!--
PR description
In the description, please explain the problem your pull request intends to solve, and a give general overview of the implementation.
For more information, see: https://github.com/syslog-ng/syslog-ng/blob/master/CONTRIBUTING.md#pr-description
-->
